### PR TITLE
Fix typo in spec reference

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14663,7 +14663,7 @@ else
          <p>If <code>$arg</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>The input must be a namespace-well-formed external general parsed entity. More
             specifically, it must be a string conforming to the production rule <xnt
-               spec="xml" ref="NT-extParsedEnt">extParsedEnt</xnt> in <bibref ref="xml"
+               spec="XML" ref="NT-extParsedEnt">extParsedEnt</xnt> in <bibref ref="xml"
                />, it must contain
             no entity references other than references to predefined entities, and it must satisfy
             all the rules of <bibref


### PR DESCRIPTION
Spec identifiers are case sensitive.