### PR TITLE
Create a schema-for-xslt40.xsd file for the current draft spec.

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -768,8 +768,12 @@ of problems processing the schema using various tools
                       maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="array" type="xsl:expression"/>
+          <xs:attribute name="map" type="xsl:expression"/>
           <xs:attribute name="separator" type="xs:string"/>
           <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_array" type="xs:string"/>
+          <xs:attribute name="_map" type="xs:string"/>
           <xs:attribute name="_separator" type="xs:string"/>
           <xs:assert test="every $e in subsequence(xsl:sort, 2)
                            satisfies empty($e/(@stable | @_stable))">
@@ -783,7 +787,7 @@ of problems processing the schema using various tools
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
-          <xs:assert test="exists(@select | @_select)"/>
+          <xs:assert test="exists(@select | @_select | @array | @_array | @map | @_map)"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -800,6 +804,8 @@ of problems processing the schema using various tools
                       maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="array" type="xsl:expression"/>
+          <xs:attribute name="map" type="xsl:expression"/>
           <xs:attribute name="group-by" type="xsl:expression"/>
           <xs:attribute name="group-adjacent" type="xsl:expression"/>
           <xs:attribute name="group-starting-with" type="xsl:pattern"/>
@@ -808,6 +814,8 @@ of problems processing the schema using various tools
           <xs:attribute name="composite" type="xsl:yes-or-no"/>
           <xs:attribute name="collation" type="xsl:avt"/>
           <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_array" type="xs:string"/>
+          <xs:attribute name="_map" type="xs:string"/>
           <xs:attribute name="_group-by" type="xs:string"/>
           <xs:attribute name="_group-adjacent" type="xs:string"/>
           <xs:attribute name="_group-starting-with" type="xs:string"/>
@@ -815,7 +823,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_break-when" type="xs:string"/>
           <xs:attribute name="_composite" type="xs:string"/>
           <xs:attribute name="_collation" type="xs:string"/>
-          <xs:assert test="exists(@select | @_select)"/>
+          <xs:assert test="exists(@select | @_select | @array | @_array | @map | @_map)"/>
           <xs:assert test="every $e in subsequence(xsl:sort, 2)
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
@@ -1104,8 +1112,12 @@ of problems processing the schema using various tools
                       maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="array" type="xsl:expression"/>
+          <xs:attribute name="map" type="xsl:expression"/>
           <xs:attribute name="_select" type="xs:string"/>
-          <xs:assert test="exists(@select | @_select)"/>
+          <xs:attribute name="_array" type="xs:string"/>
+          <xs:attribute name="_map" type="xs:string"/>
+          <xs:assert test="exists(@select | @_select | @array | @_array | @map | @_map)"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -1143,6 +1155,25 @@ of problems processing the schema using various tools
           <xs:attribute name="key" type="xsl:expression"/>
           <xs:attribute name="_key" type="xs:string"/>
           <xs:assert test="exists(@key | @_key)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="match" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="false">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+              <xs:element ref="xsl:fallback"/>
+            </xs:choice>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="pattern" type="xsl:pattern"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_pattern" type="xs:string"/>
+          <xs:assert test="exists(@pattern | @_pattern)"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -1851,20 +1882,6 @@ of problems processing the schema using various tools
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-  </xs:element>
-
-  <xs:element name="test" substitutionGroup="xsl:instruction">
-    <xs:complexType>
-      <xs:complexContent mixed="false">
-        <xs:extension base="xsl:element-only-versioned-element-type">
-          <xs:attribute name="select" type="xsl:expression"/>
-          <xs:attribute name="match" type="xsl:pattern"/>
-          <xs:attribute name="_select" type="xs:string"/>
-          <xs:attribute name="_match" type="xs:string"/>
-          <xs:assert test="exists(@match | @_match)"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -21,65 +21,65 @@
   <xs:annotation>
     <xs:documentation>
       <p>
-         This is an XSD 1.1 schema for XSLT 4.0 stylesheets. It defines all the
-         elements that appear in the XSLT namespace; it also provides hooks that
-         allow the inclusion of user-defined literal result elements, extension
-         instructions, and top-level data elements.
+        This is an XSD 1.1 schema for XSLT 4.0 stylesheets. It defines all the
+        elements that appear in the XSLT namespace; it also provides hooks that
+        allow the inclusion of user-defined literal result elements, extension
+        instructions, and top-level data elements.
       </p>
       <p>
-         This schema is available for use under the conditions of the W3C Software
-         License published at
-         http://www.w3.org/Consortium/Legal/copyright-software-19980720
+        This schema is available for use under the conditions of the W3C Software
+        License published at
+        http://www.w3.org/Consortium/Legal/copyright-software-19980720
       </p>
       <p>
-         The schema is organized as follows:
+        The schema is organized as follows:
       </p>
       <ul>
         <li>
-           PART A: definitions of complex types and model groups used as the basis
-           for element definitions
+          PART A: definitions of complex types and model groups used as the basis
+          for element definitions
         </li>
         <li>
-           PART B: definitions of individual XSLT elements
+          PART B: definitions of individual XSLT elements
         </li>
         <li>
-           PART C: definitions for literal result elements
+          PART C: definitions for literal result elements
         </li>
         <li>
-           PART D: definitions of simple types used in attribute definitions
+          PART D: definitions of simple types used in attribute definitions
         </li>
       </ul>
       <p>
-         The schema has a number of limitations:
+        The schema has a number of limitations:
       </p>
       <ul>
         <li>
-           The XSLT specification allows additional elements and attributes to be
-           present where forwards compatibility is invoked. This schema does not.
+          The XSLT specification allows additional elements and attributes to be
+          present where forwards compatibility is invoked. This schema does not.
         </li>
         <li>
-           The XSLT specification allows arbitrary content in a part of the
-           stylesheet that is excluded by virtue of a use-when attribute. This
-           schema does not.
+          The XSLT specification allows arbitrary content in a part of the
+          stylesheet that is excluded by virtue of a use-when attribute. This
+          schema does not.
         </li>
         <li>
-           The handling of literal result elements in this schema is imperfect;
-           although various options are allowed, none matches the specification
-           exactly. For example, the content of a literal result element uses lax
-           validation, which permits child elements in the XSLT namespace that have
-           no declaration in this schema.
+          The handling of literal result elements in this schema is imperfect;
+          although various options are allowed, none matches the specification
+          exactly. For example, the content of a literal result element uses lax
+          validation, which permits child elements in the XSLT namespace that have
+          no declaration in this schema.
         </li>
         <li>
-           The schema makes no attempt to check XPath expressions for syntactic or
-           semantic correctness, nor to check that component references are
-           resolved (for example that a template named in xsl:call-template has a
-           declaration). Doing this in general requires cross-document validation,
-           which is beyond the scope of XSD.
+          The schema makes no attempt to check XPath expressions for syntactic or
+          semantic correctness, nor to check that component references are
+          resolved (for example that a template named in xsl:call-template has a
+          declaration). Doing this in general requires cross-document validation,
+          which is beyond the scope of XSD.
         </li>
         <li>
-           The schema imports the schema for XSD 1.0 schema documents. In
-           stylesheets that contain an inline XSD 1.1 schema, this import should be
-           replaced with one for the schema for XSD 1.1 schema documents.
+          The schema imports the schema for XSD 1.0 schema documents. In
+          stylesheets that contain an inline XSD 1.1 schema, this import should be
+          replaced with one for the schema for XSD 1.1 schema documents.
         </li>
       </ul>
     </xs:documentation>
@@ -106,8 +106,8 @@ of problems processing the schema using various tools
   <xs:annotation>
     <xs:documentation>
       <p>
-         PART A: definitions of complex types and model groups used as the basis
-         for element definitions
+        PART A: definitions of complex types and model groups used as the basis
+        for element definitions
       </p>
     </xs:documentation>
   </xs:annotation>
@@ -117,9 +117,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This complex type provides a generic supertype for all XSLT elements; it
-           contains the definitions of the standard attributes that may appear on
-           any element.
+          This complex type provides a generic supertype for all XSLT elements; it
+          contains the definitions of the standard attributes that may appear on
+          any element.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -148,14 +148,14 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This complex type provides a generic supertype for all XSLT elements
-           with the exception of xsl:output; it contains the definitions of the
-           version attribute that may appear on any element.
+          This complex type provides a generic supertype for all XSLT elements
+          with the exception of xsl:output; it contains the definitions of the
+          version attribute that may appear on any element.
         </p>
         <p>
-           The xsl:output does not use this definition because, although it has a
-           version attribute, the syntax and semantics of this attribute are
-           unrelated to the standard version attribute allowed on other elements.
+          The xsl:output does not use this definition because, although it has a
+          version attribute, the syntax and semantics of this attribute are
+          unrelated to the standard version attribute allowed on other elements.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -179,8 +179,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This complex type provides a generic supertype for all XSLT elements
-           that allow a sequence constructor as their content.
+          This complex type provides a generic supertype for all XSLT elements
+          that allow a sequence constructor as their content.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -197,7 +197,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This complex type allows a sequence constructor and a select attribute.
+          This complex type allows a sequence constructor and a select attribute.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -213,8 +213,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This complex type allows a sequence constructor or a select attribute,
-           but not both.
+          This complex type allows a sequence constructor or a select attribute,
+          but not both.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -234,8 +234,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This complex type provides a generic supertype for all XSLT elements
-           that allow a sequence constructor as their content.
+          This complex type provides a generic supertype for all XSLT elements
+          that allow a sequence constructor as their content.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -253,8 +253,8 @@ of problems processing the schema using various tools
   <xs:annotation>
     <xs:documentation>
       <p>
-         PART B: definitions of individual XSLT elements Elements are listed in
-         alphabetical order.
+        PART B: definitions of individual XSLT elements Elements are listed in
+        alphabetical order.
       </p>
     </xs:documentation>
   </xs:annotation>
@@ -264,11 +264,11 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This element appears as a child of xsl:use-package and defines any
-           variations that the containing package wishes to make to the visibility
-           of components made available from a library package. For example, it may
-           indicate that some of the public components in the library package are
-           not to be made available to the containing package.
+          This element appears as a child of xsl:use-package and defines any
+          variations that the containing package wishes to make to the visibility
+          of components made available from a library package. For example, it may
+          indicate that some of the public components in the library package are
+          not to be made available to the containing package.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -382,9 +382,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if an xsl:sort element other than the first
-                   in a sequence of sibling xsl:sort elements has a stable
-                   attribute.
+                  It is a static error if an xsl:sort element other than the first
+                  in a sequence of sibling xsl:sort elements has a stable
+                  attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -428,8 +428,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -566,8 +566,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -595,8 +595,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -619,8 +619,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -684,8 +684,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -727,9 +727,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This element appears as a child of xsl:use-package and defines the
-           visibility of components that are made available (or not) by this
-           package to other using packages.
+          This element appears as a child of xsl:use-package and defines the
+          visibility of components that are made available (or not) by this
+          package to other using packages.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -768,9 +768,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if an xsl:sort element other than the first
-                   in a sequence of sibling xsl:sort elements has a stable
-                   attribute.
+                  It is a static error if an xsl:sort element other than the first
+                  in a sequence of sibling xsl:sort elements has a stable
+                  attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -811,9 +811,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if an xsl:sort element other than the first
-                   in a sequence of sibling xsl:sort elements has a stable
-                   attribute.
+                  It is a static error if an xsl:sort element other than the first
+                  in a sequence of sibling xsl:sort elements has a stable
+                  attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -825,9 +825,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   These four attributes are mutually exclusive: it is a static
-                   error if none of these four attributes is present or if more
-                   than one of them is present.
+                  These four attributes are mutually exclusive: it is a static
+                  error if none of these four attributes is present or if more
+                  than one of them is present.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -838,9 +838,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is an error to specify the collation attribute or the
-                   composite attribute if neither the group-by attribute nor
-                   group-adjacent attribute is specified.
+                  It is an error to specify the collation attribute or the
+                  composite attribute if neither the group-by attribute nor
+                  group-adjacent attribute is specified.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -904,7 +904,7 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   A parameter for a function must have no default value.
+                  A parameter for a function must have no default value.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -913,7 +913,7 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   A parameter for a function must have no visibility attribute.
+                  A parameter for a function must have no visibility attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -922,7 +922,7 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   A parameter for a function must have no required attribute.
+                  A parameter for a function must have no required attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -993,9 +993,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   XTSE0215: It is a static error if an xsl:import-schema element
-                   that contains an xs:schema element has a schema-location
-                   attribute
+                  XTSE0215: It is a static error if an xsl:import-schema element
+                  that contains an xs:schema element has a schema-location
+                  attribute
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1294,9 +1294,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if the value attribute of xsl:number is
-                   present unless the select, level, count, and from attributes are
-                   all absent.
+                  It is a static error if the value attribute of xsl:number is
+                  present unless the select, level, count, and from attributes are
+                  all absent.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1391,9 +1391,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This element appears as a child of xsl:use-package and defines any
-           overriding definitions of components that the containing package wishes
-           to make to the components made available from a library package.
+          This element appears as a child of xsl:use-package and defines any
+          overriding definitions of components that the containing package wishes
+          to make to the components made available from a library package.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -1442,9 +1442,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Declaration of the xsl:param element, used both defining function
-           parameters, template parameters, parameters to xsl:iterate, and global
-           stylesheet parameters.
+          Declaration of the xsl:param element, used both defining function
+          parameters, template parameters, parameters to xsl:iterate, and global
+          stylesheet parameters.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -1468,8 +1468,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   When the attribute static="yes" is specified, the xsl:param
-                   element must have empty content.
+                  When the attribute static="yes" is specified, the xsl:param
+                  element must have empty content.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1497,9 +1497,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if an xsl:sort element other than the first
-                   in a sequence of sibling xsl:sort elements has a stable
-                   attribute.
+                  It is a static error if an xsl:sort element other than the first
+                  in a sequence of sibling xsl:sort elements has a stable
+                  attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1592,8 +1592,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1647,8 +1647,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
+                  The type and validation attributes are mutually exclusive (if
+                  one is present, the other must be absent).
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1700,8 +1700,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   An xsl:template element must have either a match attribute or a
-                   name attribute, or both.
+                  An xsl:template element must have either a match attribute or a
+                  name attribute, or both.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1712,8 +1712,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   An xsl:template element that has no match attribute must have no
-                   mode attribute and no priority attribute.
+                  An xsl:template element that has no match attribute must have no
+                  mode attribute and no priority attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1722,8 +1722,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   An xsl:template element that has no name attribute must have no
-                   visibility attribute
+                  An xsl:template element that has no name attribute must have no
+                  visibility attribute
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1734,10 +1734,10 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   If the visibility attribute is present with the value abstract
-                   then (a) the sequence constructor defining the template body
-                   must be empty: that is, the only permitted children are
-                   xsl:context-item and xsl:param
+                  If the visibility attribute is present with the value abstract
+                  then (a) the sequence constructor defining the template body
+                  must be empty: that is, the only permitted children are
+                  xsl:context-item and xsl:param
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1746,8 +1746,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   If the visibility attribute is present with the value abstract
-                   then there must be no match attribute.
+                  If the visibility attribute is present with the value abstract
+                  then there must be no match attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1756,7 +1756,7 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   A parameter for a template must have no visibility attribute.
+                  A parameter for a template must have no visibility attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1799,11 +1799,11 @@ of problems processing the schema using various tools
           <xs:annotation>
             <xs:documentation>
               <p>
-                 The version attribute indicates the version of XSLT that the
-                 stylesheet module requires. The attribute is required, unless the
-                 xsl:stylesheet element is a child of an xsl:package element, in
-                 which case it is optional: the default is then taken from the
-                 parent xsl:package element.
+                The version attribute indicates the version of XSLT that the
+                stylesheet module requires. The attribute is required, unless the
+                xsl:stylesheet element is a child of an xsl:package element, in
+                which case it is optional: the default is then taken from the
+                parent xsl:package element.
               </p>
             </xs:documentation>
           </xs:annotation>
@@ -1837,8 +1837,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The static attribute must not be present on an xsl:variable or
-                   xsl:param element unless it is a top-level element.
+                  The static attribute must not be present on an xsl:variable or
+                  xsl:param element unless it is a top-level element.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1849,15 +1849,15 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   XTSE0808: It is a static error if a namespace prefix is used
-                   within the [xsl:]exclude-result-prefixes attribute and there is
-                   no namespace binding in scope for that prefix.
+                  XTSE0808: It is a static error if a namespace prefix is used
+                  within the [xsl:]exclude-result-prefixes attribute and there is
+                  no namespace binding in scope for that prefix.
                 </p>
                 <p>
-                   XTSE0809: It is a static error if the value #default is used
-                   within the [xsl:]exclude-result-prefixes attribute and the
-                   parent element of the [xsl:]exclude-result-prefixes attribute
-                   has no default namespace.
+                  XTSE0809: It is a static error if the value #default is used
+                  within the [xsl:]exclude-result-prefixes attribute and the
+                  parent element of the [xsl:]exclude-result-prefixes attribute
+                  has no default namespace.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1894,10 +1894,10 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This element appears as a child of xsl:package and defines a dependency
-           of the containing package on another package, identified by URI in the
-           name attribute. The package-version attribute indicates which version of
-           the library package is required, or may indicate a range of versions.
+          This element appears as a child of xsl:package and defines a dependency
+          of the containing package on another package, identified by URI in the
+          name attribute. The package-version attribute indicates which version of
+          the library package is required, or may indicate a range of versions.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -1934,14 +1934,14 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Declaration of the xsl:variable element, used both for local and global
-           variable bindings.
+          Declaration of the xsl:variable element, used both for local and global
+          variable bindings.
         </p>
         <p>
-           This definition takes advantage of the ability in XSD 1.1 for an element
-           to belong to more than one substitution group. A global variable is a
-           declaration, while a local variable can appear as an instruction in a
-           sequence constructor.
+          This definition takes advantage of the ability in XSD 1.1 for an element
+          to belong to more than one substitution group. A global variable is a
+          declaration, while a local variable can appear as an instruction in a
+          sequence constructor.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -1964,9 +1964,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   When the static attribute is present with the value yes, the
-                   visibility attribute must not have a value other than private or
-                   final.
+                  When the static attribute is present with the value yes, the
+                  visibility attribute must not have a value other than private or
+                  final.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1977,9 +1977,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   When the attribute static="yes" is specified, the xsl:variable
-                   element must have empty content, and the select attribute must
-                   be present to define the value of the variable.
+                  When the attribute static="yes" is specified, the xsl:variable
+                  element must have empty content, and the select attribute must
+                  be present to define the value of the variable.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -2025,16 +2025,16 @@ of problems processing the schema using various tools
   <xs:annotation>
     <xs:documentation>
       <p>
-         PART C: definition of literal result elements There are three ways to
-         define the literal result elements permissible in a stylesheet. (a) do
-         nothing. This allows any element to be used as a literal result element,
-         provided it is not in the XSLT namespace (b) declare all permitted literal
-         result elements as members of the xsl:literal-result-element substitution
-         group (c) redefine the model group xsl:result-elements to accommodate all
-         permitted literal result elements. Literal result elements are allowed to
-         take certain attributes in the XSLT namespace. These are defined in the
-         attribute group literal-result-element-attributes, which can be included
-         in the definition of any literal result element.
+        PART C: definition of literal result elements There are three ways to
+        define the literal result elements permissible in a stylesheet. (a) do
+        nothing. This allows any element to be used as a literal result element,
+        provided it is not in the XSLT namespace (b) declare all permitted literal
+        result elements as members of the xsl:literal-result-element substitution
+        group (c) redefine the model group xsl:result-elements to accommodate all
+        permitted literal result elements. Literal result elements are allowed to
+        take certain attributes in the XSLT namespace. These are defined in the
+        attribute group literal-result-element-attributes, which can be included
+        in the definition of any literal result element.
       </p>
     </xs:documentation>
   </xs:annotation>
@@ -2079,7 +2079,7 @@ of problems processing the schema using various tools
   <xs:annotation>
     <xs:documentation>
       <p>
-         PART D: definitions of simple types used in stylesheet attributes
+        PART D: definitions of simple types used in stylesheet attributes
       </p>
     </xs:documentation>
   </xs:annotation>
@@ -2089,9 +2089,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The use-accumulators attribute of xsl:source-document, xsl:merge-source,
-           or xsl:global-context-item: either a list, each member being a QName; or
-           the value #all
+          The use-accumulators attribute of xsl:source-document, xsl:merge-source,
+          or xsl:global-context-item: either a list, each member being a QName; or
+          the value #all
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2111,10 +2111,10 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           This type is used for all attributes that allow an attribute value
-           template. The general rules for the syntax of attribute value templates,
-           and the specific rules for each such attribute, are described in the
-           XSLT 4.0 Working Group Draft.
+          This type is used for all attributes that allow an attribute value
+          template. The general rules for the syntax of attribute value templates,
+          and the specific rules for each such attribute, are described in the
+          XSLT 4.0 Working Group Draft.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2125,7 +2125,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A string containing exactly one character.
+          A string containing exactly one character.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2134,11 +2134,11 @@ of problems processing the schema using various tools
     </xs:restriction>
   </xs:simpleType>
 
-   <xs:simpleType name="component-kind-type">
+  <xs:simpleType name="component-kind-type">
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes a kind of component within a package.
+          Describes a kind of component within a package.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2156,8 +2156,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The default-mode attribute of xsl:stylesheet, xsl:transform, xsl:package
-           (or any other xsl:* element): either a QName or #unnamed.
+          The default-mode attribute of xsl:stylesheet, xsl:transform, xsl:package
+          (or any other xsl:* element): either a QName or #unnamed.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2174,7 +2174,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           An XPath 4.0 expression.
+          An XPath 4.0 expression.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2187,7 +2187,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           An XPath 4.0 ItemType
+          An XPath 4.0 ItemType
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2200,7 +2200,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes how type annotations in source documents are handled.
+          Describes how type annotations in source documents are handled.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2215,7 +2215,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The level attribute of xsl:number: one of single, multiple, or any.
+          The level attribute of xsl:number: one of single, multiple, or any.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2230,8 +2230,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The mode attribute of xsl:apply-templates: either a QName, or #current,
-           or #unnamed, or #default.
+          The mode attribute of xsl:apply-templates: either a QName, or #current,
+          or #unnamed, or #default.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2250,8 +2250,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The mode attribute of xsl:template: either a list, each member being
-           either a QName or #default or #unnamed; or the value #all
+          The mode attribute of xsl:template: either a list, each member being
+          either a QName or #default or #unnamed; or the value #all
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2276,8 +2276,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   XTSE0550: It is a static error if the same token is included
-                   more than once in the list.
+                  XTSE0550: It is a static error if the same token is included
+                  more than once in the list.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -2296,8 +2296,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A list of NameTests, as defined in the XPath 4.0 Working Group Draft. Each
-           NameTest is either a QName, or "*", or "prefix:*", or "*:localname"
+          A list of NameTests, as defined in the XPath 4.0 Working Group Draft. Each
+          NameTest is either a QName, or "*", or "prefix:*", or "*:localname"
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2324,8 +2324,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes the action to be taken when there are several template rules
-           to match an item in a given mode.
+          Describes the action to be taken when there are several template rules
+          to match an item in a given mode.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2339,8 +2339,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes the action to be taken when there is no template rule to match
-           an item in a given mode.
+          Describes the action to be taken when there is no template rule to match
+          an item in a given mode.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2376,8 +2376,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The method attribute of xsl:output: Either one of the recognized names
-           "xml", "xhtml", "html", "text", or a QName that must include a prefix.
+          The method attribute of xsl:output: Either one of the recognized names
+          "xml", "xhtml", "html", "text", or a QName that must include a prefix.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2402,10 +2402,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A match pattern as defined in the XSLT 4.0 Working Group Draft. The syntax
-           for patterns is a restricted form of the syntax for XPath 4.0
-           expressions. Change since XSLT 4.0: Patterns may now match any item (not
-           only nodes)
+          A match pattern as defined in the XSLT 4.0 Working Group Draft. The syntax
+          for patterns is a restricted form of the syntax for XPath 4.0
+          expressions.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2416,8 +2415,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Either a namespace prefix, or #default. Used in the xsl:namespace-alias
-           element.
+          Either a namespace prefix, or #default. Used in the xsl:namespace-alias
+          element.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2434,9 +2433,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A list of QNames. Used in the [xsl:]use-attribute-sets attribute of
-           various elements, and in the cdata-section-elements attribute of
-           xsl:output
+          A list of QNames. Used in the [xsl:]use-attribute-sets attribute of
+          various elements, and in the cdata-section-elements attribute of
+          xsl:output
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2447,20 +2446,20 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           An extended QName. This schema does not use the built-in type xs:QName,
-           but rather defines its own QName type. This may be either a local name,
-           or a prefixed QName, or a name written using the extended QName notation
-           Q{uri}local
+          An extended QName. This schema does not use the built-in type xs:QName,
+          but rather defines its own QName type. This may be either a local name,
+          or a prefixed QName, or a name written using the extended QName notation
+          Q{uri}local
         </p>
         <p>
-           Although xs:QName would define the correct validation on these
-           attributes, a schema processor would expand unprefixed QNames
-           incorrectly when constructing the PSVI, because (as defined in XML
-           Schema errata) an unprefixed xs:QName is assumed to be in the default
-           namespace, which is not the correct assumption for XSLT. The datatype is
-           therefore defined as a union of NCName and QName, so that an unprefixed
-           name will be validated as an NCName and will therefore not be treated as
-           having the semantics of an unprefixed xs:QName.
+          Although xs:QName would define the correct validation on these
+          attributes, a schema processor would expand unprefixed QNames
+          incorrectly when constructing the PSVI, because (as defined in XML
+          Schema errata) an unprefixed xs:QName is assumed to be in the default
+          namespace, which is not the correct assumption for XSLT. The datatype is
+          therefore defined as a union of NCName and QName, so that an unprefixed
+          name will be validated as an NCName and will therefore not be treated as
+          having the semantics of an unprefixed xs:QName.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2477,7 +2476,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A subtype of EQNames that excludes no-namespace names
+          A subtype of EQNames that excludes no-namespace names
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2490,8 +2489,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The description of a datatype, conforming to the SequenceType production
-           defined in the XPath 4.0 Working Group Draft.
+          The description of a datatype, conforming to the SequenceType production
+          defined in the XPath 4.0 Working Group Draft
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2504,8 +2503,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes the category to which a function belongs, with regards to its
-           streaming behavior.
+          Describes the category to which a function belongs, with regards to its
+          streaming behavior.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2528,7 +2527,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes whether a mode is designed to match typed or untyped nodes.
+          Describes whether a mode is designed to match typed or untyped nodes.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2553,7 +2552,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes different ways of type-annotating an element or attribute.
+          Describes different ways of type-annotating an element or attribute.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2567,7 +2566,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes different ways of type-annotating an element or attribute.
+          Describes different ways of type-annotating an element or attribute.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2583,7 +2582,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes the visibility of a component within a package.
+          Describes the visibility of a component within a package.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2600,7 +2599,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Describes the visibility of a component within a package.
+          Describes the visibility of a component within a package.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2616,8 +2615,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           One of the values "yes" or "no": the values "true" or "false", or "1" or
-           "0" are accepted as synonyms.
+          One of the values "yes" or "no": the values "true" or "false", or "1" or
+          "0" are accepted as synonyms.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2635,8 +2634,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           One of the values "yes" or "no" or "omit". The values "true" or "false",
-           or "1" or "0" are accepted as synonyms of "yes" and "no" respectively.
+          One of the values "yes" or "no" or "omit". The values "true" or "false",
+          or "1" or "0" are accepted as synonyms of "yes" and "no" respectively.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2655,8 +2654,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           One of the values "yes" or "no" or "omit". The values "true" or "false",
-           or "1" or "0" are accepted as synonyms of "yes" and "no" respectively.
+          One of the values "yes" or "no" or "omit". The values "true" or "false",
+          or "1" or "0" are accepted as synonyms of "yes" and "no" respectively.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2675,7 +2674,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A digit that has the numerical value zero.
+          A digit that has the numerical value zero.
         </p>
       </xs:documentation>
     </xs:annotation>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -21,7 +21,7 @@
   <xs:annotation>
     <xs:documentation>
       <p>
-         This is an XSD 1.1 schema for XSLT 3.0 stylesheets. It defines all the
+         This is an XSD 1.1 schema for XSLT 4.0 stylesheets. It defines all the
          elements that appear in the XSLT namespace; it also provides hooks that
          allow the inclusion of user-defined literal result elements, extension
          instructions, and top-level data elements.
@@ -2114,7 +2114,7 @@ of problems processing the schema using various tools
            This type is used for all attributes that allow an attribute value
            template. The general rules for the syntax of attribute value templates,
            and the specific rules for each such attribute, are described in the
-           XSLT 2.1 Recommendation.
+           XSLT 4.0 Working Group Draft.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2174,7 +2174,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           An XPath 2.0 expression.
+           An XPath 4.0 expression.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2187,7 +2187,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           An XPath 2.1 ItemType
+           An XPath 4.0 ItemType
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2296,7 +2296,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A list of NameTests, as defined in the XPath 2.0 Recommendation. Each
+           A list of NameTests, as defined in the XPath 4.0 Working Group Draft. Each
            NameTest is either a QName, or "*", or "prefix:*", or "*:localname"
         </p>
       </xs:documentation>
@@ -2402,9 +2402,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A match pattern as defined in the XSLT 2.1 Recommendation. The syntax
-           for patterns is a restricted form of the syntax for XPath 2.0
-           expressions. Change since XSLT 2.0: Patterns may now match any item (not
+           A match pattern as defined in the XSLT 4.0 Working Group Draft. The syntax
+           for patterns is a restricted form of the syntax for XPath 4.0
+           expressions. Change since XSLT 4.0: Patterns may now match any item (not
            only nodes)
         </p>
       </xs:documentation>
@@ -2491,7 +2491,7 @@ of problems processing the schema using various tools
       <xs:documentation>
         <p>
            The description of a datatype, conforming to the SequenceType production
-           defined in the XPath 2.0 Recommendation
+           defined in the XPath 4.0 Working Group Draft.
         </p>
       </xs:documentation>
     </xs:annotation>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -94,7 +94,7 @@ of problems processing the schema using various tools
   <xs:import namespace="http://www.w3.org/XML/1998/namespace"/>
   <!--schemaLocation="http://www.w3.org/2001/xml.xsd"-->
 
-  <!-- 
+  <!--
     An XSLT stylesheet may contain an in-line schema within an xsl:import-schema element,
     so the Schema for schemas needs to be imported. We use the XSD 1.1 version.
 -->
@@ -192,7 +192,7 @@ of problems processing the schema using various tools
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  
+
   <xs:complexType name="sequence-constructor-and-select">
     <xs:annotation>
       <xs:documentation>
@@ -208,7 +208,7 @@ of problems processing the schema using various tools
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  
+
   <xs:complexType name="sequence-constructor-or-select">
     <xs:annotation>
       <xs:documentation>
@@ -224,7 +224,7 @@ of problems processing the schema using various tools
                   minOccurs="0"
                   maxOccurs="unbounded"/>
         <xs:anyAttribute namespace="##other" processContents="lax"/>
-        <xs:assert test="not(exists(@select | @_select) and 
+        <xs:assert test="not(exists(@select | @_select) and
           (exists(* except xsl:fallback) or exists(text()[normalize-space()])))"/>
       </xs:restriction>
     </xs:complexContent>
@@ -259,7 +259,7 @@ of problems processing the schema using various tools
     </xs:documentation>
   </xs:annotation>
   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-  
+
   <xs:element name="accept">
     <xs:annotation>
       <xs:documentation>
@@ -288,7 +288,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="accumulator" substitutionGroup="xsl:declaration">
     <xs:complexType>
       <xs:complexContent>
@@ -377,7 +377,7 @@ of problems processing the schema using various tools
           <xs:attribute name="mode" type="xsl:mode"/>
           <xs:attribute name="_select" type="xs:string"/>
           <xs:attribute name="_mode" type="xs:string"/>
-          <xs:assert test="every $e in subsequence(xsl:sort, 2) 
+          <xs:assert test="every $e in subsequence(xsl:sort, 2)
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
               <xs:documentation>
@@ -393,7 +393,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="assert" substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent mixed="true">
@@ -524,7 +524,7 @@ of problems processing the schema using various tools
   <xs:element name="comment"
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor-or-select"/>
-  
+
   <xs:element name="context-item">
     <xs:complexType>
       <xs:complexContent>
@@ -722,7 +722,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="expose">
     <xs:annotation>
       <xs:documentation>
@@ -763,7 +763,7 @@ of problems processing the schema using various tools
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
           <xs:attribute name="_select" type="xs:string"/>
-          <xs:assert test="every $e in subsequence(xsl:sort, 2) 
+          <xs:assert test="every $e in subsequence(xsl:sort, 2)
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
               <xs:documentation>
@@ -806,7 +806,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_composite" type="xs:string"/>
           <xs:attribute name="_collation" type="xs:string"/>
           <xs:assert test="exists(@select | @_select)"/>
-          <xs:assert test="every $e in subsequence(xsl:sort, 2) 
+          <xs:assert test="every $e in subsequence(xsl:sort, 2)
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
               <xs:documentation>
@@ -818,9 +818,9 @@ of problems processing the schema using various tools
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
-          <xs:assert test="count(((@group-by|@_group-by)[1], 
-                                  (@group-adjacent|@_group-adjacent)[1], 
-                                  (@group-starting-with|@_group-starting-with)[1], 
+          <xs:assert test="count(((@group-by|@_group-by)[1],
+                                  (@group-adjacent|@_group-adjacent)[1],
+                                  (@group-starting-with|@_group-starting-with)[1],
                                   (@group-ending-with|@_group-ending-with)[1])) = 1">
             <xs:annotation>
               <xs:documentation>
@@ -832,8 +832,8 @@ of problems processing the schema using various tools
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
-          <xs:assert test="if (exists(@collation|@_collation) or exists(@composite|@_composite)) 
-                           then (exists(@group-by|@_group-by) or exists(@group-adjacent|@_group-adjacent)) 
+          <xs:assert test="if (exists(@collation|@_collation) or exists(@composite|@_composite))
+                           then (exists(@group-by|@_group-by) or exists(@group-adjacent|@_group-adjacent))
                            else true()">
             <xs:annotation>
               <xs:documentation>
@@ -899,7 +899,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_identity-sensitive" type="xs:string"/>
           <xs:attribute name="_cache" type="xs:string"/>
           <xs:assert test="exists(@name | @_name)"/>
-          <xs:assert test="every $e in xsl:param 
+          <xs:assert test="every $e in xsl:param
                            satisfies (empty($e/(@select | @_select)) and empty($e/child::node()))">
             <xs:annotation>
               <xs:documentation>
@@ -931,7 +931,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="global-context-item" substitutionGroup="xsl:declaration">
     <xs:complexType>
       <xs:complexContent>
@@ -952,7 +952,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
 
   <xs:element name="if" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1056,11 +1056,11 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="map"
               type="xsl:sequence-constructor"
               substitutionGroup="xsl:instruction"/>
-  
+
   <xs:element name="map-entry" substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent mixed="true">
@@ -1223,7 +1223,7 @@ of problems processing the schema using various tools
           <xs:assert test="exists(@stylesheet-prefix | @_stylesheet-prefix)"/>
           <xs:assert test="exists(@result-prefix | @_result-prefix)"/>
           <xs:assert test="every $prefix in (@stylesheet-prefix, @result-prefix)
-                                                /normalize-space(.)[. ne '#default'] 
+                                                /normalize-space(.)[. ne '#default']
                            satisfies $prefix = in-scope-prefixes(.)"/>
         </xs:extension>
       </xs:complexContent>
@@ -1287,9 +1287,9 @@ of problems processing the schema using various tools
           <xs:attribute name="_start-at" type="xs:string"/>
           <xs:attribute name="_grouping-separator" type="xs:string"/>
           <xs:attribute name="_grouping-size" type="xs:string"/>
-          <xs:assert test="if (exists(@value | @_value)) 
-                           then empty((@select | @_select, @count | @_count, @from | @_from)) 
-                            and (exists(@_level) or normalize-space(@level)='single') 
+          <xs:assert test="if (exists(@value | @_value))
+                           then empty((@select | @_select, @count | @_count, @from | @_from))
+                            and (exists(@_level) or normalize-space(@level)='single')
                            else true()">
             <xs:annotation>
               <xs:documentation>
@@ -1307,11 +1307,11 @@ of problems processing the schema using various tools
   </xs:element>
 
   <xs:element name="on-completion" type="xsl:sequence-constructor-or-select"/>
-  
+
   <xs:element name="on-empty"
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor-or-select"/>
-  
+
   <xs:element name="on-non-empty"
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor-or-select"/>
@@ -1386,7 +1386,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="override">
     <xs:annotation>
       <xs:documentation>
@@ -1411,7 +1411,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-    
+
   <xs:element name="package">
     <xs:complexType>
       <xs:complexContent>
@@ -1462,8 +1462,8 @@ of problems processing the schema using various tools
           <xs:attribute name="_tunnel" type="xs:string"/>
           <xs:attribute name="_static" type="xs:string"/>
           <xs:assert test="exists(@name | @_name)"/>
-          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1')) 
-                           then empty((*,text())) 
+          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1'))
+                           then empty((*,text()))
                            else true()">
             <xs:annotation>
               <xs:documentation>
@@ -1479,7 +1479,7 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-  
+
 
   <xs:element name="perform-sort" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1492,7 +1492,7 @@ of problems processing the schema using various tools
                       maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
-          <xs:assert test="every $e in subsequence(xsl:sort, 2) 
+          <xs:assert test="every $e in subsequence(xsl:sort, 2)
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
               <xs:documentation>
@@ -1602,7 +1602,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="sequence"
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor-or-select"/>
@@ -1627,7 +1627,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="source-document" substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent>
@@ -1672,7 +1672,7 @@ of problems processing the schema using various tools
 
   <xs:element name="stylesheet" substitutionGroup="xsl:transform"/>
 
-  
+
   <xs:element name="template" substitutionGroup="xsl:declaration">
     <xs:complexType>
       <xs:complexContent mixed="true">
@@ -1706,8 +1706,8 @@ of problems processing the schema using various tools
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
-          <xs:assert test="if (empty(@match | @_match)) 
-                           then (empty(@mode | @_mode) and empty(@priority | @_priority)) 
+          <xs:assert test="if (empty(@match | @_match))
+                           then (empty(@mode | @_mode) and empty(@priority | @_priority))
                            else true()">
             <xs:annotation>
               <xs:documentation>
@@ -1728,8 +1728,8 @@ of problems processing the schema using various tools
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
-          <xs:assert test="if (normalize-space(@visibility) = 'abstract') 
-                           then empty(* except (xsl:context-item, xsl:param)) 
+          <xs:assert test="if (normalize-space(@visibility) = 'abstract')
+                           then empty(* except (xsl:context-item, xsl:param))
                            else true()">
             <xs:annotation>
               <xs:documentation>
@@ -1832,7 +1832,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_input-type-annotations" type="xs:string"/>
           <!--* The 'static' attribute may be used on 'param' and 'variable'
               * only when they are top-level elements. *-->
-          <xs:assert test="every $v in (.//xsl:param, .//xsl:variable)[exists(@static | @_static)] 
+          <xs:assert test="every $v in (.//xsl:param, .//xsl:variable)[exists(@static | @_static)]
                            satisfies $v[parent::xsl:stylesheet or parent::xsl:transform or parent::xsl:override]">
             <xs:annotation>
               <xs:documentation>
@@ -1843,8 +1843,8 @@ of problems processing the schema using various tools
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
-          <xs:assert test="every $prefix in (@exclude-result-prefixes[not(. = '#all')], 
-                                             @extension-element-prefixes) 
+          <xs:assert test="every $prefix in (@exclude-result-prefixes[not(. = '#all')],
+                                             @extension-element-prefixes)
                            satisfies ((if ($prefix = '#default') then '' else $prefix) = in-scope-prefixes(.))">
             <xs:annotation>
               <xs:documentation>
@@ -1889,7 +1889,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="use-package" substitutionGroup="xsl:declaration">
     <xs:annotation>
       <xs:documentation>
@@ -1957,9 +1957,9 @@ of problems processing the schema using various tools
           <xs:attribute name="_visibility" type="xs:string"/>
           <xs:attribute name="_static" type="xs:string"/>
           <xs:assert test="exists(@name | @_name)"/>
-          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1')) 
-                           then (exists(@_visibility) or normalize-space(@visibility) 
-                                       = ('', 'private', 'final')) 
+          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1'))
+                           then (exists(@_visibility) or normalize-space(@visibility)
+                                       = ('', 'private', 'final'))
                            else true()">
             <xs:annotation>
               <xs:documentation>
@@ -1971,8 +1971,8 @@ of problems processing the schema using various tools
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
-          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1')) 
-                           then (empty((*, text())) and exists(@select | @_select)) 
+          <xs:assert test="if (normalize-space(@static) = ('yes', 'true', '1'))
+                           then (empty((*, text())) and exists(@select | @_select))
                            else true()">
             <xs:annotation>
               <xs:documentation>
@@ -2000,7 +2000,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="where-populated"
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor"/>
@@ -2105,8 +2105,8 @@ of problems processing the schema using various tools
         </xs:restriction>
       </xs:simpleType>
     </xs:union>
-  </xs:simpleType> 
-  
+  </xs:simpleType>
+
   <xs:simpleType name="avt">
     <xs:annotation>
       <xs:documentation>
@@ -2120,7 +2120,7 @@ of problems processing the schema using various tools
     </xs:annotation>
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
-  
+
   <xs:simpleType name="char">
     <xs:annotation>
       <xs:documentation>
@@ -2133,7 +2133,7 @@ of problems processing the schema using various tools
       <xs:length value="1"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
    <xs:simpleType name="component-kind-type">
     <xs:annotation>
       <xs:documentation>
@@ -2151,7 +2151,7 @@ of problems processing the schema using various tools
       <xs:enumeration value="*"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="default-mode-type">
     <xs:annotation>
       <xs:documentation>
@@ -2319,7 +2319,7 @@ of problems processing the schema using various tools
       </xs:simpleType>
     </xs:list>
   </xs:simpleType>
-  
+
   <xs:simpleType name="on-multiple-match-type">
     <xs:annotation>
       <xs:documentation>
@@ -2334,7 +2334,7 @@ of problems processing the schema using various tools
       <xs:enumeration value="fail"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="on-no-match-type">
     <xs:annotation>
       <xs:documentation>
@@ -2472,7 +2472,7 @@ of problems processing the schema using various tools
       </xs:simpleType>
     </xs:union>
   </xs:simpleType>
-  
+
   <xs:simpleType name="EQName-in-namespace">
     <xs:annotation>
       <xs:documentation>
@@ -2485,7 +2485,7 @@ of problems processing the schema using various tools
       <xs:pattern value="Q\{.+\}.+|\i\c*:.+"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="sequence-type">
     <xs:annotation>
       <xs:documentation>
@@ -2499,7 +2499,7 @@ of problems processing the schema using various tools
       <xs:pattern value=".+"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="streamability-type">
     <xs:annotation>
       <xs:documentation>
@@ -2523,7 +2523,7 @@ of problems processing the schema using various tools
       </xs:simpleType>
     </xs:union>
   </xs:simpleType>
-  
+
   <xs:simpleType name="typed-type">
     <xs:annotation>
       <xs:documentation>
@@ -2578,7 +2578,7 @@ of problems processing the schema using various tools
       <xs:enumeration value="strip"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="visibility-type">
     <xs:annotation>
       <xs:documentation>
@@ -2595,7 +2595,7 @@ of problems processing the schema using various tools
       <xs:enumeration value="hidden"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="visibility-not-hidden-type">
     <xs:annotation>
       <xs:documentation>
@@ -2630,7 +2630,7 @@ of problems processing the schema using various tools
       <xs:enumeration value="0"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="yes-or-no-or-maybe">
     <xs:annotation>
       <xs:documentation>
@@ -2670,7 +2670,7 @@ of problems processing the schema using various tools
       <xs:enumeration value="omit"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <xs:simpleType name="zero-digit">
     <xs:annotation>
       <xs:documentation>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -124,7 +124,9 @@ of problems processing the schema using various tools
       </xs:documentation>
     </xs:annotation>
     <xs:attribute name="default-collation" type="xsl:uri-list"/>
+    <xs:attribute name="default-element-namespace" type="xs:anyURI"/>
     <xs:attribute name="default-mode" type="xsl:default-mode-type"/>
+    <xs:attribute name="default-type-namespace" type="xs:anyURI"/>
     <xs:attribute name="default-validation"
                   type="xsl:validation-strip-or-preserve"
                   default="strip"/>
@@ -134,7 +136,9 @@ of problems processing the schema using various tools
     <xs:attribute name="use-when" type="xsl:expression"/>
     <xs:attribute name="xpath-default-namespace" type="xs:anyURI"/>
     <xs:attribute name="_default-collation" type="xs:string"/>
+    <xs:attribute name="_default-element-namespace" type="xs:string"/>
     <xs:attribute name="_default-mode" type="xs:string"/>
+    <xs:attribute name="_default-type-namespace" type="xs:string"/>
     <xs:attribute name="_default-validation" type="xs:string"/>
     <xs:attribute name="_exclude-result-prefixes" type="xs:string"/>
     <xs:attribute name="_expand-text" type="xs:string"/>
@@ -375,8 +379,10 @@ of problems processing the schema using various tools
           </xs:choice>
           <xs:attribute name="select" type="xsl:expression" default="child::node()"/>
           <xs:attribute name="mode" type="xsl:mode"/>
+          <xs:attribute name="separator" type="xs:string"/>
           <xs:attribute name="_select" type="xs:string"/>
           <xs:attribute name="_mode" type="xs:string"/>
+          <xs:attribute name="_separator" type="xs:string"/>
           <xs:assert test="every $e in subsequence(xsl:sort, 2)
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
@@ -762,7 +768,9 @@ of problems processing the schema using various tools
                       maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="separator" type="xs:string"/>
           <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_separator" type="xs:string"/>
           <xs:assert test="every $e in subsequence(xsl:sort, 2)
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
@@ -796,6 +804,7 @@ of problems processing the schema using various tools
           <xs:attribute name="group-adjacent" type="xsl:expression"/>
           <xs:attribute name="group-starting-with" type="xsl:pattern"/>
           <xs:attribute name="group-ending-with" type="xsl:pattern"/>
+          <xs:attribute name="break-when" type="xsl:expression"/>
           <xs:attribute name="composite" type="xsl:yes-or-no"/>
           <xs:attribute name="collation" type="xsl:avt"/>
           <xs:attribute name="_select" type="xs:string"/>
@@ -803,6 +812,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_group-adjacent" type="xs:string"/>
           <xs:attribute name="_group-starting-with" type="xs:string"/>
           <xs:attribute name="_group-ending-with" type="xs:string"/>
+          <xs:attribute name="_break-when" type="xs:string"/>
           <xs:attribute name="_composite" type="xs:string"/>
           <xs:attribute name="_collation" type="xs:string"/>
           <xs:assert test="exists(@select | @_select)"/>
@@ -932,6 +942,45 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
+  <xs:element name="function-library" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent mixed="false">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:function-namespace" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="namespace" type="xs:anyURI"/>
+          <xs:attribute name="schema-location" type="xs:anyURI"/>
+          <xs:attribute name="_namespace" type="xs:string"/>
+          <xs:attribute name="_schema-location" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="function-namespace">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+          This element appears as a child of xsl:function-library.
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="uri" type="xs:anyURI"/>
+          <xs:attribute name="prefix" type="xs:NCName"/>
+          <xs:attribute name="exclude" type="xsl:ncnames"/>
+          <xs:attribute name="_uri" type="xs:string"/>
+          <xs:attribute name="_prefix" type="xs:string"/>
+          <xs:attribute name="_exclude" type="xs:string"/>
+          <xs:assert test="exists(@uri | @_uri)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
   <xs:element name="global-context-item" substitutionGroup="xsl:declaration">
     <xs:complexType>
       <xs:complexContent>
@@ -953,13 +1002,16 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-
   <xs:element name="if" substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent mixed="true">
         <xs:extension base="xsl:sequence-constructor">
           <xs:attribute name="test" type="xsl:expression"/>
+          <xs:attribute name="then" type="xsl:expression"/>
+          <xs:attribute name="else" type="xsl:expression"/>
           <xs:attribute name="_test" type="xs:string"/>
+          <xs:attribute name="_then" type="xs:string"/>
+          <xs:attribute name="_else" type="xs:string"/>
           <xs:assert test="exists(@test | @_test)"/>
         </xs:extension>
       </xs:complexContent>
@@ -1012,6 +1064,29 @@ of problems processing the schema using various tools
           <xs:attribute name="href" type="xs:anyURI"/>
           <xs:attribute name="_href" type="xs:string"/>
           <xs:assert test="exists(@href | @_href)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="item-type" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent mixed="false">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="as" type="xsl:item-type"/>
+          <xs:attribute name="visibility">
+            <xs:simpleType>
+              <xs:restriction base="xsl:visibility-type">
+                <xs:enumeration value="private"/>
+                <xs:enumeration value="final"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -1167,7 +1242,11 @@ of problems processing the schema using various tools
     <xs:complexType>
       <xs:complexContent mixed="false">
         <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:template" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
           <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="as" type="xsl:sequence-type"/>
           <xs:attribute name="streamable" type="xsl:yes-or-no" default="no"/>
           <xs:attribute name="use-accumulators" type="xsl:accumulator-names"/>
           <xs:attribute name="on-no-match" type="xsl:on-no-match-type" default="shallow-skip"/>
@@ -1187,6 +1266,7 @@ of problems processing the schema using various tools
             </xs:simpleType>
           </xs:attribute>
           <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
           <xs:attribute name="_streamable" type="xs:string"/>
           <xs:attribute name="_on-no-match" type="xs:string"/>
           <xs:attribute name="_on-multiple-match" type="xs:string"/>
@@ -1198,7 +1278,6 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-
 
   <xs:element name="namespace" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1230,7 +1309,6 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-
   <xs:element name="next-iteration" substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent mixed="true">
@@ -1242,7 +1320,6 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-
 
   <xs:element name="next-match" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1316,7 +1393,7 @@ of problems processing the schema using various tools
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor-or-select"/>
 
-  <xs:element name="otherwise" type="xsl:sequence-constructor"/>
+  <xs:element name="otherwise" type="xsl:sequence-constructor-or-select"/>
 
   <xs:element name="output" substitutionGroup="xsl:declaration">
     <xs:complexType>
@@ -1478,8 +1555,6 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-
-
 
   <xs:element name="perform-sort" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1672,6 +1747,21 @@ of problems processing the schema using various tools
 
   <xs:element name="stylesheet" substitutionGroup="xsl:transform"/>
 
+  <xs:element name="switch" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:when" maxOccurs="unbounded"/>
+            <xs:element ref="xsl:otherwise" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:assert test="exists(@select | @_select)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
 
   <xs:element name="template" substitutionGroup="xsl:declaration">
     <xs:complexType>
@@ -1766,6 +1856,20 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
+  <xs:element name="test" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="false">
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="match" type="xsl:pattern"/>
+          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_match" type="xs:string"/>
+          <xs:assert test="exists(@match | @_match)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+
   <xs:complexType name="text-element-base-type">
     <xs:simpleContent>
       <xs:restriction base="xsl:versioned-element-type">
@@ -1789,7 +1893,6 @@ of problems processing the schema using various tools
   <xs:element name="text"
               substitutionGroup="xsl:instruction"
               type="xsl:text-element-type"/>
-
 
   <xs:complexType name="transform-element-base-type">
     <xs:complexContent>
@@ -1992,7 +2095,7 @@ of problems processing the schema using various tools
   <xs:element name="when">
     <xs:complexType>
       <xs:complexContent mixed="true">
-        <xs:extension base="xsl:sequence-constructor">
+        <xs:extension base="xsl:sequence-constructor-or-select">
           <xs:attribute name="test" type="xsl:expression"/>
           <xs:attribute name="_test" type="xs:string"/>
           <xs:assert test="exists(@test | @_test)"/>
@@ -2073,7 +2176,6 @@ of problems processing the schema using various tools
       <xs:any namespace="##local" processContents="lax"/>
     </xs:choice>
   </xs:group>
-
 
   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
   <xs:annotation>
@@ -2318,6 +2420,10 @@ of problems processing the schema using various tools
         </xs:union>
       </xs:simpleType>
     </xs:list>
+  </xs:simpleType>
+
+  <xs:simpleType name="ncnames">
+    <xs:list itemType="xs:NCName"/>
   </xs:simpleType>
 
   <xs:simpleType name="on-multiple-match-type">


### PR DESCRIPTION
Note: schema-for-xslt30.xsd is still referenced by other source files, such as xslt-first-cut.xml, so it has not been removed.