### PR TITLE
Don't attempt to upgrade the host

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
             - "9c:ea:35:11:e9:9f:73:a3:a9:28:44:6b:fd:34:04:62"
 
       - run: sudo apt-get update
-      - run: sudo apt-get dist-upgrade
       - run: sudo apt-get install graphviz tidy
 
       - checkout


### PR DESCRIPTION
The CI script shouldn't attempt to upgrade the host. CircleCI have customized some of the packages so upgrading doesn't work. And it shouldn't really be necessary anyway.