### PR TITLE
Explicitly mention subtypes for arrays and maps

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4707,9 +4707,13 @@ name.</p>
                      <termref
                         def="dt-map"
                         >map</termref>, and (b) every
-                     entry in <var>M</var> has a key that matches <code>K</code> and an associated value that matches <code>V</code>. For example,
+                     entry in <var>M</var> has a key that is a <termref def="dt-subtype"
+                     >subtype</termref> of <code>K</code> and an associated value that is a <termref def="dt-subtype"
+                     >subtype</termref> of <code>V</code>. For example,
                      <code>map(xs:integer, element(employee))</code> matches a map if all the keys in the map are integers, and all the associated
-                     values are <code>employee</code> elements. Note that a map (like a sequence) carries no intrinsic type information separate
+                     values are <code>employee</code> elements. Map tests are described in more detail in <specref ref="id-itemtype-subtype"/> (4.c to 4.g).</p>
+                  <p>
+                     Note that a map (like a sequence) carries no intrinsic type information separate
                      from the types of its entries, and the type of existing entries in a map does not constrain the type of new entries that can be
                      added to the map.</p>
                   <note>
@@ -4729,7 +4733,8 @@ name.</p>
                </item>
                <item>
                   <p>The <code>ItemType</code>
-                     <code>array(T)</code> matches any array in which the type of every member is <code>T</code>.</p>
+                     <code>array(T)</code> matches any array in which the type of every member is a <termref def="dt-subtype"
+                     >subtype</termref> of <code>T</code>. Array tests are described in more detail in <specref ref="id-itemtype-subtype"/> (4.h to 4.l).</p>
                </item>
                <item>
                   <p>The <code>ItemType</code>


### PR DESCRIPTION
Reword section 3.6.4 for map and array type tests to explicitly mention sub typing and link to the relevant section.

I believe, it is important to add examples for subtypes of arrays and maps. Can someone advise how and where to add them?

map subtype example (could be added to 3.7.2.4 d.):

```xml
<note>
  <p><code>map(xs:integer, element(fruit))</code> is a subtype of <code>map(xs:anyAtomic, node())</code></p>
</note>
```

array subtype example (could be added to 3.7.2.4 i.):

```xml
<note>
  <p><code>array(xs:positiveInteger)</code> is a subtype of <code>array(xs:decimal)</code></p>
</note>
```
