### PR TITLE
Fix error in input paths for XSLT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -293,8 +293,8 @@ task xslt_grammar(
   description: "Build the grammar files for XSLT 4.0"
 ) {
   inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/xslt-40/src")
-  inputs.files fileTree(dir: "${projectDir}/xslt-40/style")
+  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/src")
+  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/style")
   inputs.files fileTree(dir: "${projectDir}/specifications/grammar-40")
   outputs.file "${buildDir}/xslt-40/src/xslt-40-assembled.xml"
 


### PR DESCRIPTION
The XSLT 4.0 spec didn't build correctly because the input paths in the build script were missing the /specification/ directory :-(