### PR TITLE
Variadicity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -293,8 +293,8 @@ task xslt_grammar(
   description: "Build the grammar files for XSLT 4.0"
 ) {
   inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/xslt-40/src")
-  inputs.files fileTree(dir: "${projectDir}/xslt-40/style")
+  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/src")
+  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/style")
   inputs.files fileTree(dir: "${projectDir}/specifications/grammar-40")
   outputs.file "${buildDir}/xslt-40/src/xslt-40-assembled.xml"
 

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -664,11 +664,22 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:optional>
     <g:string>function</g:string>
     <g:ref name="_Function_QName_or_EQName" unfold="yes"/>   
-    <g:ref name="FunctionSignature"/>
+    <g:ref name="FunctionFamilySignature"/>
     <g:choice name="FunctionDeclBody">
       <g:ref name="FunctionBody" if="xquery40"/>
       <g:ref name="External"/>
     </g:choice>
+  </g:production>
+  
+  <g:production name="FunctionFamilySignature">
+    <g:string>(</g:string>
+    <g:optional name="OptionalFamilyParamList">
+      <g:ref name="FamilyParamList"/>
+    </g:optional>
+    <g:string>)</g:string>
+    <g:optional name="optionFuncFamilyType">
+      <g:ref name="TypeDeclaration"/>
+    </g:optional>
   </g:production>
   
   <g:production name="FunctionSignature">
@@ -679,6 +690,26 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>)</g:string>
     <g:optional name="optionFuncType">
       <g:ref name="TypeDeclaration"/>
+    </g:optional>
+  </g:production>
+  
+  <g:production name="FamilyParamList" if=" xpath40 xquery40 ">
+    <g:ref name="ParamWithDefault"/>
+    <g:zeroOrMore name="FamilyParamListTail">
+      <g:string>,</g:string>
+      <g:ref name="ParamWithDefault"/>
+    </g:zeroOrMore>
+  </g:production>
+  
+  <g:production name="ParamWithDefault" if=" xpath40 xquery40 ">
+    <g:string>$</g:string>
+    <g:ref name="_QName_or_EQName" unfold="yes"/>
+    <g:optional name="OptionalTypeDeclarationForParamWithDefault">
+      <g:ref name="TypeDeclaration"/>
+    </g:optional>
+    <g:optional name="OptionalDefaultForParam">
+      <g:string>:=</g:string>
+      <g:ref name="ExprSingle"/>
     </g:optional>
   </g:production>
 
@@ -1860,9 +1891,9 @@ ErrorVal ::= "$" VarName
   </g:production>
   
   <g:production name="KeywordArgument" if="xpath40 xquery40 xslt40-patterns">
-    <g:ref name="NCName"/>
-    <g:string>:=</g:string>
-    <g:ref name="ExprSingle"/> 
+    <g:ref name="EQName"/>
+    <g:string>:</g:string>
+    <g:ref name="Argument"/> 
   </g:production>
 
   <g:production name="PredicateList" condition="&gt; 0">

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -34,7 +34,7 @@ precision.</p></item></olist></item>
 <div2 id="mapping">
 <head>Operator Mapping</head> <p>The operator mapping tables in this section list the
 combinations of types for which the various operators of &language;
-are defined. <termdef term="operator function" id="dt-operator-function">For each operator and valid combination of operand types, the operator mapping tables specify a result type and an <term>operator function</term> that implements the semantics of the operator for the given types.</termdef> The definitions of the operator functions are given in  <bibref ref="xpath-functions-31"/>. The result of an operator may be the raising of an error by its operator function, as defined in <bibref ref="xpath-functions-31"/>. The operator function fully defines the semantics of a given operator for the case where the operands are single atomic values of the types given in the table. For the definition of each operator (including its
+are defined. <termdef term="operator function" id="dt-operator-function">For each operator and valid combination of operand types, the operator mapping tables specify a result type and an <term>operator function</term> that implements the semantics of the operator for the given types.</termdef> The definitions of the operator functions are given in  <bibref ref="xpath-functions-40"/>. The result of an operator may be the raising of an error by its operator function, as defined in <bibref ref="xpath-functions-40"/>. The operator function fully defines the semantics of a given operator for the case where the operands are single atomic values of the types given in the table. For the definition of each operator (including its
 behavior for empty sequences or sequences of length greater than one),
 see the descriptive material in the main part of this
 document.</p>
@@ -1063,7 +1063,7 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
 
 </olist>
 
-<note><p>Additional <termref def="dt-implementation-defined">implementation-defined</termref> items are listed in <bibref ref="xpath-datamodel-31"/> and <bibref ref="xpath-functions-31"/>.</p></note></div1>
+<note><p>Additional <termref def="dt-implementation-defined">implementation-defined</termref> items are listed in <bibref ref="xpath-datamodel-31"/> and <bibref ref="xpath-functions-40"/>.</p></note></div1>
 <div1 id="id-references">
 <head>References</head>
 <div2 id="id-normative-references">
@@ -1145,7 +1145,7 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
 
 <bibl id="xpath-datamodel-31" key="XQuery and XPath Data Model (XDM) 3.1"/>
 
-<bibl id="xpath-functions-31" key="XQuery and XPath Functions and Operators 3.1"/>
+<bibl id="xpath-functions-40" key="XQuery and XPath Functions and Operators 4.0"/>
 
 <bibl id="xslt-xquery-serialization-31" key="XSLT and XQuery Serialization 3.1"/>
 

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -90,7 +90,7 @@
                     implementation.</p>
             </item>
             <item>
-                <p>An implementation of all functions defined in <bibref ref="xpath-functions-31"/>,
+                <p>An implementation of all functions defined in <bibref ref="xpath-functions-40"/>,
                     and a definition of every item specified to be <termref
                         def="dt-implementation-defined">implementation-defined</termref>, unless
                     that function or item is part of an optional feature that is not provided by the
@@ -257,7 +257,7 @@
                 a function.</p>
 
             <p>If an implementation provides the Higher-Order Function Feature, then it <termref def="must">MUST</termref> provide
-                    all <xtermref spec="FO31" ref="dt-higher-order"/> functions defined in <bibref ref="xpath-functions-31"/>.
+                    all <xtermref spec="FO31" ref="dt-higher-order"/> functions defined in <bibref ref="xpath-functions-40"/>.
                 If an implementation does not provide the Higher
                 Order Function Feature, a <termref def="dt-static-error">static error</termref> is
                 raised <errorref class="ST" code="0017"/> if any of these functions is present in a

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -108,8 +108,8 @@
       <error spec="XP" code="0017" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> if the <termref
                def="dt-expanded-qname">expanded QName</termref> and number of arguments in a <phrase
-               diff="add">static</phrase> function call do not match the name and arity of a
-               <termref def="dt-known-func-signatures">function signature</termref> in the <termref
+               diff="add">static</phrase> function call do not match the name and arity range of a
+               <termref def="dt-declared-function">declared function</termref> in the <termref
                def="dt-static-context">static context</termref>.</p>
       </error>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -707,8 +707,7 @@ inferred by static type inference as discussed in  <specref
                         >expanded QName</termref> and the overlapping
                      arity ranges (even if the signatures are consistent).</phrase></p>
  
-    <p>The entries in the known static functions define the set of 
-     declared functions that are available to be called from a 
+    <p>The declared functions are available to be called from a 
     <termref
                         def="dt-static-function-call"
                         >static function call</termref>,

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -438,42 +438,23 @@ whitespace normalized according to the rules for the <code>xs:anyURI</code> type
 
                <item diff="chg" at="A">
                   <p>
-                     <termdef id="dt-function-name-resolver" term="function name resolver">
-                        <term>Function name resolver.</term> This is an algorithm that takes as input
-                        a lexical QName and arity, and delivers as its result an expanded QName.</termdef> 
-                        The expanded QName and arity must uniquely identify a function signature in the
-                        <termref def="dt-known-func-signatures"/>, or a static error is reported.
-                        This algorithm
-                        is used when function names are resolved statically, specifically when they
-                        appear in static function calls or function references. The 
+                     <termdef id="dt-default-function-namespace" term="default function namespace">
+                        <term>Default function namespace.</term> This is an algorithm that takes as input
+                        an unprefixed QName and arity used in a context where a function name is expected, and delivers 
+                        as its result a namespace URI.</termdef> 
+                  </p>
+                  <p>
+                        In its simplest form its value is simply a whitespace-normalized <code>xs:anyURI</code>
+                        value (most commonly, the URI <code>http://www.w3.org/2005/xpath-functions</code>)
+                        to be used as the default namespace for unprefixed function names. However, the use of a more
+                        complex algorithm is not precluded, for example an algorithm which searches multiple namespaces for
+                        a matching name.
                   </p>
                   <p role="xquery">
-                     In XQuery, the function name resolver works as follows:
-                  </p>
-                  <olist role="xquery">
-                     <item><p>If the lexical QName has no prefix, it is interpreted as a local name and
-                     expanded using the default function namespace. The default function namespace can be
-                     declared in the prolog in a <term>default function namespace declaration</term>:
-                     see <specref ref="id-default-namespace"/>.</p></item>
-                     <item><p>If the lexical QName has a prefix, the prefix is resolved to a URI using 
-                     the <termref def="dt-static-namespaces"/>.</p></item>
-                  </olist>
-                  <note role="xpath">
-                     <p>Different host languages or APIs may adopt different strategies for resolving unprefixed
-                     function names. Possible approaches include (but are not limited to):</p>
-                     <olist>
-                        <item><p>Treating all unprefixed names as references to functions in the namespace
-                        <code>http://www.w3.org/2005/xpath-functions</code>.</p></item>
-                        <item><p>Treating all unprefixed names as references to functions in a default
-                           namespace established in some way determined by the host language or API.</p></item>
-                        <item><p>Searching multiple namespaces, with some strategy for resolving conflicts.</p></item>
-                        <item><p>Giving different precedence to functions declared in different ways, for example
-                        giving locally-declared functions precedence over globally-declared functions.</p></item>
-                        <item><p>Resolving particular magic names (such as <code>xsl:original</code>) using host-language
-                        defined rules.</p></item>
-                     </olist>
-                     
-                  </note>
+                     In XQuery, a default function namespace can be
+                     declared in the prolog in a <term>default function namespace declaration</term>
+                     (see <specref ref="id-default-namespace"/>); in the absence of such a declaration, the namespace
+                     <code>http://www.w3.org/2005/xpath-functions</code> is used.</p>
                </item>
 
 
@@ -646,18 +627,88 @@ inferred by static type inference as discussed in  <specref
                </item>
 
 
-               <item>
+               <item diff="chg" at="variadicity">
                   <p>
-                     <termdef id="dt-known-func-signatures"
-                        term="statically known function signatures">
-                        <term>Statically known function signatures.</term>
-        This is a mapping from (expanded QName, arity) to 
-        <xtermref
-                           spec="DM31" ref="dt-signature"
-                        />. 
-    </termdef>
-    The entries in this mapping define the set of 
-     functions that are available to be called from a 
+                     <termdef id="dt-declared-functions"
+                        term="declared functions">
+                        <term>Declared functions.</term> This is a set of 
+                        <termref def="dt-declared-function">declared functions</termref>.</termdef></p>
+                  
+                  <p><termdef id="dt-declared-function" term="declared function">A <term>declared function</term>
+                     contains the information needed to evaluate a static function call. It may be derived
+                     from an actual declaration in a host language such as XQuery or XSLT, or it may represent
+                     a built-in function, or it may represent information registered with the 
+                     processor using some <termref def="dt-implementation-defined"/> API.</termdef></p>
+                  
+                  <p>The properties of a <termref def="dt-declared-function"/> include:</p>
+                  
+                  <ulist>
+                     <item><p>The function name, which is an <termref def="dt-expanded-qname"/>.</p></item>
+                     <item><p>A (possibly empty) list of required parameters, each having:</p>
+                        <ulist>
+                           <item><p>a parameter name (an <termref def="dt-expanded-qname"/>)</p></item>
+                           <item><p>a required type (a <termref def="dt-sequence-type"/>)</p></item>
+                        </ulist>
+                     </item>
+                     <item><p>A (possibly empty) list of optional parameters, each having:</p>
+                        <ulist>
+                           <item><p>a parameter name (an <termref def="dt-expanded-qname"/>)</p></item>
+                           <item><p>a required type (a <termref def="dt-sequence-type"/>)</p></item>
+                           <item><p>a default value (a <termref def="dt-sequence-type"/>)</p></item>
+                        </ulist>
+                     </item>
+                     <item><p>A return type (a <termref def="dt-sequence-type"/>)</p></item>
+                     <item><p>A (possibly empty) set of <term>function annotations</term></p>
+                        <p role="xquery">In XQuery, function annotations are described in <specref ref="id-annotations"/>.</p></item>
+                     <item><p>An implementation. The function implementation contains the logic that enables the function
+                     result to be computed from the supplied parameters and information in the dynamic context.</p></item>
+                  </ulist>
+                  
+                  <p>The names of the parameters must be distinct.</p>
+                  
+                  <note><p>Despite the name, a <termref def="dt-declared-function"/> is not actually a <xtermref
+                     spec="DM31" ref="dt-function-item"
+                     >function</xtermref> (or <term>function item</term>) in the sense of the XDM data model. Rather, it provides information about
+                     a family of functions which can be obtained, for example, by means of a <termref def="dt-named-function-ref"/>.</p></note>
+                  
+                  <p>Declared functions can be categorized as:</p>
+                  <ulist>
+                     <item><p>User-written functions, implemented in a host language such as XQuery or XSLT.</p></item>
+                     <item><p>Built-in functions, for example functions specified in <bibref ref="xpath-functions-40"/>,
+                     and <termref def="dt-constructor-function">constructor functions</termref> for built-in and user-defined
+                     types.</p></item>
+                     <item><p>External functions, for example functions implemented in a general-purpose programming
+                     language such as Java or Python.</p></item>
+                  </ulist>
+                  
+                  <p>However, this is not a hard-and-fast distinction. For example, the processor might implement built-in functions
+                     using the same mechanisms as user-written functions or external functions.</p>
+                  
+                  <p><termdef id="dt-arity-range" term="arity range">A <termref def="dt-declared-function"/> has an <term>arity range</term>
+                     which is a range of consecutive non-negative integers. If the declared function has <var>M</var> required parameters
+                     and <var>N</var> optional parameters, then its arity range is from <var>M</var> to <var>M</var>+<var>N</var>
+                     inclusive.</termdef></p>
+                  <p>The static context may contain several <termref def="dt-declared-function">declared functions</termref> with the
+                     same name, but the <termref def="dt-arity-range">arity ranges</termref> of two such declared functions must not 
+                     overlap. For example, it is acceptable to have a declared function with two required parameters and no optional
+                     parameters, and another declared function (with the same name) that has three required parameters and one optional
+                     parameter. It is not acceptable to have a declared function with one required parameter and another (with the same name)
+                     having three optional parameters.</p>
+                  <p><phrase role="xquery"
+                     >It is a <termref def="dt-static-error">static error</termref>
+                     <errorref class="ST" code="0034"
+                     /> if two declared functions have the same
+                     <termref def="dt-expanded-qname"
+                        >expanded QName</termref> and overlapping
+                     arity ranges (even if the signatures are consistent).</phrase>
+                  <phrase role="xpath"
+                     >Implementations must ensure that no two declared functions have the same <termref
+                        def="dt-expanded-qname"
+                        >expanded QName</termref> and the overlapping
+                     arity ranges (even if the signatures are consistent).</phrase></p>
+ 
+    <p>The entries in the known static functions define the set of 
+     declared functions that are available to be called from a 
     <termref
                         def="dt-static-function-call"
                         >static function call</termref>,
@@ -665,24 +716,12 @@ inferred by static type inference as discussed in  <specref
     <termref
                         def="dt-named-function-ref"
                         >named function reference</termref>.
-    Each such function is uniquely identified by its 
-    <termref
-                        def="dt-expanded-qname"
-                        >expanded QName</termref>
-    and arity (number of parameters).
-     Given a statically known function's expanded QName and arity,
-    this component supplies the function's 
-    <xtermref
-                        spec="DM31" ref="dt-signature"
-                        >signature</xtermref>,
-    which specifies various static properties of the function,
-    including types<phrase
-                        role="xquery">
-    and annotations</phrase>. 
+    
 </p>
 
 
-                  <p>The <phrase>statically known</phrase> function signatures include the signatures of functions from a variety of sources, including
+                  <p>The declared functions typically 
+                     include functions from a variety of sources, including
                      the <phrase role="xpath"><termref def="dt-built-in-function">built-in functions</termref>.</phrase>
                          <phrase role="xquery"><termref
                         def="dt-built-in-function"
@@ -695,18 +734,7 @@ inferred by static type inference as discussed in  <specref
 implementation or via an implementation-defined API (see <specref
                         ref="id-xq-static-context-components"/>).</phrase>
 
-<phrase role="xquery"
-                           >It is a <termref def="dt-static-error">static error</termref>
-                        <errorref class="ST" code="0034"
-                           /> if two such functions have the same
-<termref def="dt-expanded-qname"
-                           >expanded QName</termref> and the same
-arity (even if the signatures are consistent).</phrase>
-                     <phrase role="xpath"
-                           >Implementations must ensure that no two functions have the same <termref
-                           def="dt-expanded-qname"
-                        >expanded QName</termref> and the same
-arity (even if the signatures are consistent).</phrase>
+
                   </p>
 
                </item>
@@ -1236,7 +1264,7 @@ the number of items in the sequence obtained by evaluating <code
                </item>
 
                <item>
-                  <p>
+                  <p diff="chg" at="variadicity">
                      <termdef term="named functions" id="dt-named-functions">
                         <term>Named functions</term>.
         This is a mapping from (expanded QName, arity) to 
@@ -1244,7 +1272,37 @@ the number of items in the sequence obtained by evaluating <code
                            spec="DM31" ref="dt-function-item"
                         >function</xtermref>.
       </termdef>
-      It supplies a function for each signature in 
+      It contains:</p>
+                  <ulist>
+                     <item><p>For each <termref def="dt-declared-function"/> in the <termref def="dt-declared-functions"/>,
+                     and for each integer <code>A</code> in the <termref def="dt-arity-range"/> of that declared function,
+                        a <xtermref spec="DM31" ref="dt-function-item">function item</xtermref> equivalent to that
+                     obtained using the <termref def="dt-named-function-ref"/> <code>N#A</code>, where <var>N</var>
+                     is the name of the declared function.</p></item>
+                     <item><p>Optionally, an <termref def="dt-implementation-defined"/> set of additional named
+                        <xtermref spec="DM31" ref="dt-function-item">function items</xtermref>.</p></item>
+                  </ulist>
+                  <p>The named functions in the dynamic context are used primarily by the <code>fn:function-lookup</code>
+                  function.</p>
+                  <p>Each function must be uniquely identified by its name and arity.</p>
+                  <note><p>The reason for allowing named functions to be available dynamically beyond those that are
+                  available statically is primarily to allow for cases where the run-time execution
+                  environment is significantly different from the compile-time environment. This could happen, for example,
+                  if a stylesheet or query is compiled within a web server and then executed in the web browser.
+                  The <code>fn:function-lookup</code> function allows dynamic discovery of resources that were not
+                  available statically.</p></note>
+                  
+                  <p><termdef id="dt-external-function" term="external function">
+                     <term>External functions</term> are functions that are implemented outside the query
+                     environment.</termdef> For example, an implementation might provide a set of 
+                     <termref
+                        def="dt-implementation-defined"
+                        >implementation-defined</termref>
+                     external functions in addition to the core function library described in <bibref
+                        ref="xpath-functions-40"/>.
+                     </p>
+                  
+  <!--                supplies a function for each signature in 
       <termref
                         def="dt-known-func-signatures"
                         >
@@ -1258,16 +1316,7 @@ the number of items in the sequence obtained by evaluating <code
       
       <termref
                         def="dt-external-function">external functions</termref>.
-      <termdef
-                        id="dt-external-function" term="external function">
-                        <term>External functions</term> are functions that are implemented outside the query
-        environment.</termdef> For example, an implementation might provide a set of 
-        <termref
-                        def="dt-implementation-defined"
-                        >implementation-defined</termref>
-        external functions in addition to the core function library described in <bibref
-                        ref="xpath-functions-31"/>. 
-      <termdef
+      
                         id="dt-implementation-defined-function"
                         term="implementation-defined function"
                            >An <term>implementation-defined function</term> is an <termref
@@ -1282,7 +1331,7 @@ the number of items in the sequence obtained by evaluating <code
                               >external function</termref> defined by the <termref
                               def="dt-host-language">host language</termref>.</termdef>
                      </phrase>
-                  </p>
+                  </p>-->
                </item>
 
                <item>
@@ -2131,8 +2180,8 @@ or more of these constraints is not satisfied.</p>
                <item>
                   <p>Every element name, attribute name, or schema type name referenced in <termref
                         def="dt-in-scope-variables">in-scope variables</termref> or <termref
-                        def="dt-known-func-signatures"
-                        >statically known function signatures</termref> must be in the <termref
+                           def="dt-declared-functions"
+                        >declared functions</termref> must be in the <termref
                         def="dt-issd"
                         >in-scope schema definitions</termref>, unless it is an element name referenced as part of an <nt
                         def="ElementTest"
@@ -2258,10 +2307,7 @@ The prefix <code>xmlns</code> must not be bound to any namespace URI, and no pre
                   <p>
       For each 
       <code>(expanded QName, arity) -&gt; FunctionTest</code>
-      entry in 
-      <termref
-                        def="dt-known-func-signatures"
-                        >statically known function signatures</termref>,
+      entry in the <termref def="dt-declared-functions"/>,
       there must exist an 
       <code>(expanded QName, arity) -&gt; function</code>
       entry in 
@@ -2568,7 +2614,7 @@ not required, but is permitted, to evaluate any other operands.</p>
 function</termref> or operator.  For example,
 the <code>div</code> operator raises an error if its operands are <code>xs:decimal</code> values and its second operand
 is equal to zero. Errors raised by built-in functions and operators are defined in <bibref
-                  ref="xpath-functions-31"/>.</p>
+                  ref="xpath-functions-40"/>.</p>
 
             <p>A dynamic error can also be raised explicitly by calling the
 <code>fn:error</code> function, which always raises a dynamic error and never
@@ -5015,7 +5061,7 @@ name.</p>
 		                whose value is also a singleton <code>xs:double</code> value.</p>
 
 
-               <p>If the list of fields ends with <code>",*"</code> then the tuple test is said to be
+               <p>If the list of fields ends with <code>",*"</code> then the record test is said to be
 		                <term>extensible</term>. For example, the <code>RecordTest</code>
                   <code>record(e as element(Employee), *)</code>
 		             matches a map if it has an entry with key <code>"e"</code> whose value matches <code>element(Employee)</code>,
@@ -6546,10 +6592,12 @@ At evaluation time, the value of a variable reference is the value to which the 
          <p>Functions in &language; take two forms:</p>
          
          <ulist>
-            <item role="xpath"><p>Static functions are named constructs in the <specref ref="static_context"/>,
+            <item role="xpath"><p><termref def="dt-declared-functions">Declared functions</termref> are named 
+               constructs in the <specref ref="static_context"/>,
             typically originating either as built-in functions made available by the implementation,
             or as user-defined functions declared using the constructs of the host language.</p></item>
-            <item role="xquery"><p>Static functions are named constructs in the <specref ref="static_context"/>,
+            <item role="xquery"><p><termref def="dt-declared-functions">Declared functions</termref> 
+               are named constructs in the <specref ref="static_context"/>,
                typically originating either as built-in functions made available by the implementation,
                or as user-defined functions declared in the query prolog.</p></item>
             <item><p>Dynamic functions are XDM items: values that can be bound to variables, passed as
@@ -6557,21 +6605,18 @@ At evaluation time, the value of a variable reference is the value to which the 
             XDM values.</p></item>
          </ulist>
          
-         <p>Static and dynamic functions, and the mechanisms for calling them, are described in the
+         <p>Declared and dynamic functions, and the mechanisms for calling them, are described in the
          following sections.</p>
          
             <div3 id="id-static-functions" diff="add" at="A">
-               <head>Static Functions</head>
-               <note><p>TODO: Corresponding changes are needed in <specref ref="static_context"/>.</p></note>
-               <note><p>TODO: define mechanisms in XQuery and XSLT that take advantage of these mechanism
-               for user-defined functions.</p></note>
-               <p>The static context for an expression includes a set of named functions. Each function in
-               the static context can be identified given knowledge of its name and arity. Every function
+               <head>Declared Functions</head>
+               <p>The static context for an expression includes a set of <termref def="dt-declared-functions"/>. Every declared function
                in the static context has a name (which is a QName) and a range of permitted arities for
-               calls on that function. Two functions having the same name must not have overlapping arity ranges:
-               the rules are defined more precisely below.</p>
+               calls on that function. Two function families having the same name must not have overlapping arity ranges.
+               This means that for a given static function call, it is possible to identify the target function
+               in the static context unambiguously from knowledge of the function name and the number of supplied arguments.</p>
                
-               <p>Functions in the static context may include any or all of the following:</p>
+               <p>Declared functions in the static context may include any or all of the following:</p>
                <ulist>
                   <item><p>Built-in functions defined in these specifications or in a host language
                   referencing these specifications.</p></item>
@@ -6584,7 +6629,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                <p>
                   <termdef term="built-in function" id="dt-built-in-function">The 
                      <term>built-in functions</term>  are 
-                     the functions defined in <bibref ref="xpath-functions-31"/>in the 
+                     the functions defined in <bibref ref="xpath-functions-40"/>in the 
                      <code>http://www.w3.org/2005/xpath-functions</code>,
                      <code>http://www.w3.org/2001/XMLSchema</code>,
                      <code>http://www.w3.org/2005/xpath-functions/math</code>,
@@ -6609,7 +6654,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                         context</termref>.</phrase>
                </p>
                
-               <p>Static functions may be variadic. If a function is variadic, the number of arguments appearing
+               <!--<p>Static functions may be variadic. If a function is variadic, the number of arguments appearing
                in a function call may differ from the number of parameters declared in the function signature.
                Different kinds of variadic functions are defined, distinguished by the value of the annotation
                <code>%variadic</code>, which is present on all static functions, and takes one of four values:</p>
@@ -6650,9 +6695,9 @@ At evaluation time, the value of a variable reference is the value to which the 
                      as a <term>Record Test</term>, which then allows static type checking. However, there
                      is no requirement to use such a type.</p>
                   </item>
-               </ulist>
+               </ulist>-->
                
-               <p>A function has a <term>declared arity</term> which is the number of parameters
+               <!--<p>A function has a <term>declared arity</term> which is the number of parameters
                defined in the function declaration. This value, together with the value of the
                <code>variadic</code> annotation, determine the number of positional arguments
                and keyword arguments that may appear in a function call. Specifically, for each function
@@ -6736,12 +6781,12 @@ At evaluation time, the value of a variable reference is the value to which the 
                
                <p>In consequence, a function call with a known number of positional arguments and a known
                number of keyword arguments can never match more than one function in the static context.</p>
-               
+               -->
                <p>Similarly, a named function reference such as <code>fn#3</code> is a reference to a
-               function in the static context with name <code>fn</code> having <code>MinP ≤ 3 and MaxP ≥ 3</code>,
+               function in the static context with name <code>fn</code> and arity 3,
                and there can be at most one such function.</p>
                
-               <p>Taking examples from the standard function library:</p>
+               <!--<p>Taking examples from the standard function library:</p>
                <ulist>
                   <item><p>The function <code>fn:position</code> takes no arguments. It has
                      <var>MinA</var>=0, <var>MaxA</var>=0, <var>MinP</var>=0, <var>MaxP</var>=0, 
@@ -6776,35 +6821,32 @@ At evaluation time, the value of a variable reference is the value to which the 
                      <p>The function thus has <var>MinA</var>=1, <var>MaxA</var>=unbounded, <var>MinP</var>=1, 
                         <var>MaxP</var>=2, <var>MinK</var>=0, <var>MaxK</var>=unbounded.</p>
                      </item>
-               </ulist>
+               </ulist>-->
                
-               <p>A static function call is bound to a function in the static context by matching the name
-               and arity. If the function call has <code>P</code> positional arguments followed by
-                  <code>K</code> keyword arguments, then the static context must include a function 
-                  whose name matches the name in the function call, and that satisfies all the following
-                  conditions:</p>
-                  <ulist>
-                     <item><p><code>MinA ≤ P + K</code></p></item>
-                     <item><p><code>MaxA ≥ P + K</code></p></item>    
-                     <item><p><code>MinP ≤ P</code></p></item>
-                     <item><p><code>MaxP ≥ P</code></p></item>
-                     <item><p><code>MinK ≤ K</code></p></item>
-                     <item><p><code>MaxK ≥ K</code></p></item>                                     
-                  </ulist>
-                  
+               <p>A static function call is bound to a declared function in the static context by matching the name
+               and arity. If the function call has <var>P</var> positional arguments followed by
+                  <var>K</var> keyword arguments, then the required arity is <var>P+K</var>, and the static context 
+                  must include a declared function whose name matches the name in the function call, and whose arity range 
+               includes this required arity. This is the function chosen for execution.
+               The function is evaluated by executing its implementation, with
+               a dynamic context that provides values for all the declared parameters, initialized
+               as described in <specref ref="id-eval-static-function-call"/> below.</p>
+               
+             
+ 
                
                <p>Similarly, a function reference of the form <code>f#N</code> binds to a function in the
-                  static context whose name matches <var>f</var> where <code>MinP ≤ N and MaxP ≥ N</code>.
+                  static context whose name matches <var>f</var> given the required arity <code>N</code>.
                The result of evaluating a function reference is a (dynamic) function which can be invoked
-               using a dynamic function call. Dynamic functions are never variadic and their arguments
+               using a dynamic function call. Dynamic functions have a fixed arity and their arguments
                are always supplied positionally. For example, the function reference <code>fn:concat#3</code>
                returns a function with arity 3, which is always invoked by supplying three positional
                arguments, and whose effect is the same as a static call on <code>fn:concat</code> with
-               three positional arguments. The arity must not exceed the number of arguments that
+               three positional arguments. <!--The arity must not exceed the number of arguments that
                can be supplied positionally. Therefore, in the case of a function reference to a map-variadic functions
                such as <code>fn:serialize#2</code>, a dynamic call must supply the map-valued argument
                (the serialization parameters) in the form of a map; the function reference <code>fn:serialize#3</code>
-               is an error, because <var>MaxP</var> = 2.</p>
+               is an error, because <var>MaxP</var> = 2.--></p>
                
                <p>The detailed rules for evaluating static function calls and function references are defined
                in subsequent sections.</p>
@@ -6825,20 +6867,27 @@ At evaluation time, the value of a variable reference is the value to which the 
             </scrap>
             <p><termdef term="static function call" id="dt-static-function-call">A <term>static function call</term> 
                consists of an EQName followed by a parenthesized list of zero or more arguments.</termdef></p>
-            <p diff="add" at="A">In general, the argument list consists of zero or more positional arguments,
+            <p diff="add" at="A">The argument list consists of zero or more positional arguments,
                followed by zero or more keyword arguments.</p>
-            <p><termdef term="argument expression" id="dt-arg-expr">A <phrase diff="add" at="A">positional</phrase> 
-               argument to a function call is either an
-               <term>argument expression</term> or an ArgumentPlaceholder ("?").</termdef></p>
-            <p diff="add" at="A">A keyword argument takes the form <code>name := expr</code>. The effect of positional and keyword
-               arguments is described below.</p>
-            <p>If the EQName in a static function call is a <termref def="dt-qname"
-               >lexical QName</termref>, it is expanded by invoking the <termref def="dt-function-name-resolver"/> 
+            <note><p>In some circumstances, it is necessary to include whitespace before or after the
+            separating colon in a <code>KeywordArgument</code> to ensure that it is parsed as intended. See the
+               note in <specref ref="id-map-constructors"/> for details of how this applies in map constructors.
+            The situation for function calls is similar, except that an argument written as <code>a:b</code>
+            would be misinterpreted as a QName (probably with an undeclared prefix) rather than automatically 
+            being a syntax error.</p></note>
+            <p><termdef term="argument expression" id="dt-arg-expr">An argument to a function call is either an
+               <term>argument expression</term> or an ArgumentPlaceholder ("?"); in both cases it may
+            either be supplied positionally, or identified by a name (called a keyword).</termdef></p>
+            <p>This section is concerned with static function calls in which none of the arguments are
+               <code>ArgumentPlaceHolders</code>. Calls using one or more <code>ArgumentPlaceHolders</code> are covered in the 
+               section <specref ref="id-partial-function-application"/>.</p>
+            <p>If the EQName in a static function call is an unprefixed <termref def="dt-qname"
+               >lexical QName</termref>, it is expanded by invoking the <termref def="dt-default-function-namespace"/> 
                in the <termref def="dt-static-context">static context</termref>.
             </p>
             <p><phrase diff="del" at="A">In other cases, </phrase>The <termref def="dt-expanded-qname"
-               >expanded QName</termref> and number of arguments in the static function call 
-               must match the name and arity range of a <termref def="dt-known-func-signatures">function signature</termref> 
+               >expanded QName</termref> used as the function name, and the number of arguments in the static function call 
+               (the required arity) must match the name and arity range of a <termref def="dt-declared-function"/> 
                in the <termref def="dt-static-context">static context</termref> 
                <phrase>using the rules defined in the previous section</phrase>; if there is no match, a
                <termref def="dt-static-error">static error</termref> is raised <errorref class="ST" code="0017"/>.
@@ -6924,13 +6973,27 @@ At evaluation time, the value of a variable reference is the value to which the 
                </item>
                <item diff="add" at="A">
                   <p>
+                     <code role="parse-test">fn:sort(//employee, key: ->{xs:decimal(salary)})</code> is a static function 
+                     call with one positional argument and one keyword argument. 
+                     The corresponding function declaration defines three parameters,
+                     a required parameter <code>$input</code>, an optional parameter <code>$collation</code>,
+                     and an optional parameter <code>$key</code>
+                     This call supplies values for the first and third parameters, leaving the second parameter (<code>$collation</code>)
+                     to take its default value. The default value of the <code>$collation</code> parameter
+                     is given as <code>fn:default-collation()</code>, so the value supplied to the function is the
+                     default collation from the dynamic context of the caller. It is equivalent to the call 
+                     <code>fn:sort(//employee, fn:default-collation(), ->{xs:decimal(salary)})</code>.
+                  </p>
+               </item>
+               <!--<item diff="add" at="A">
+                  <p>
                      <code role="parse-test"
                         >fn:serialize($value, method: 'json', indent: true())</code> is a static function call
                      with three arguments. This function is declared as map-variadic, so it is effectively
                      called supplying <code>$value</code> for the first parameter, and 
                      <code>map{'method':'json', 'indent':true()}</code> for the second.</p>
-               </item>
-               <item diff="add" at="A">
+               </item>-->
+               <!--<item diff="add" at="A">
                   <p>
                      <code role="parse-test"
                         >fn:codepoints-to-string(66, 65, 67, 72)</code> is a static function call with
@@ -6940,8 +7003,12 @@ At evaluation time, the value of a variable reference is the value to which the 
                      the single-argument call <code>fn:codepoints-to-string((66, 65, 67, 72))</code>: it returns "BACH".
                      The call could also be written with two arguments: 
                      <code>fn:codepoints-to-string((66, 65), (67, 72)))</code>.</p>
-               </item>
+               </item>-->
             </ulist>
+            
+            <p>An <code>EQName</code> in a <code>KeywordArgument</code> is expanded to a QName value; if there
+            is no prefix, then the name is in no namespace (otherwise the prefix is resolved in the usual way).
+            The keywords used in a function call (after expansion to QNames) must be distinct [TODO: error condition].</p>
          </div4> 
          
          <div4 id="id-eval-static-function-call" diff="chg" at="A">
@@ -6961,41 +7028,31 @@ At evaluation time, the value of a variable reference is the value to which the 
 
                <olist>
 
-<!--                  <item diff="chg" at="A">
-                     <p>
-                        <termdef term="arity" id="dt-argumentlist-arity">
-                           The <term>arity</term> of an <code>ArgumentList</code>
-                            is the number of arguments in the <code>ArgumentList</code>,
-                           including both positional and keyword arguments.
-                          </termdef>
-                     </p>
-                  </item>-->
 
                   <item>
                      <p>
-                          The function <var>F</var> to be called is obtained as follows:
+                          The <termref def="dt-declared-function"/> <var>FF</var> to be used is found in the static context.
                         </p>
                      
+                     <p>The <term>required arity</term> is the total number of arguments in the
+                        function call, including both positional and keyword arguments.</p>
+                     
                            <p>
-                              Using the expanded QName corresponding to <var>FC</var>'s <code>EQName</code>,
-                              and the arity of <var>FC</var>'s <code>ArgumentList</code>,
-                              the corresponding function is looked up
-                              in the <termref def="dt-named-functions"
-                                 >named functions</termref> component of <var>DC</var>.
+                              There can be at most one declared function <var>FF</var> in the <termref def="dt-named-functions"
+                                 >named functions</termref> component of <var>DC</var> whose function name
+                              matches the expanded QName in <var>FC</var> and whose arity range
+                              and the arity of <var>FC</var>'s <code>ArgumentList</code>.
                            </p>
-                     <p>If <var>P</var> is the number of positional arguments in the function call, 
-                        and <var>K</var> is the number of keyword arguments in the function call,
-                        there must be exactly one function in the static context whose name matches
-                              the name in the function call, and that has 
-                        <code>MinP ≤ P and MaxP ≥ P and MinK ≤ K and MaxK ≥ K</code>.
-                        Let <var>F</var> denote the function obtained.
-                              
-                           </p>
+                     
+                     <p>If there is no such declared function, a static error <errorref
+                        class="ST" code="0017"/> is raised.</p>
+                     
+                     
  
                      
                   </item>
 
-                  <item>
+                  <!--<item>
                      <p>
                         <termdef term="argument value" id="dt-arg-value">
                            <termref def="dt-arg-expr"
@@ -7004,88 +7061,53 @@ At evaluation time, the value of a variable reference is the value to which the 
                            def="dt-implementation-dependent"
                         >implementation-dependent</termref> and it is not required that an argument be evaluated 
                         if the function can evaluate its body without evaluating that argument.</p>
-                  </item>
+                  </item>-->
             
                   <item>
-                     <p>Argument values are mapped to parameters in the function declaration as follows:</p>
+                     <p>Each parameter in the declaration of <var>FF</var> is associated with an argument
+                     expression as follows:</p>
                      <olist>
-                        <item><p>For non-variadic functions:</p>
-                        <olist>
-                           <item><p>A positional argument in position <var>N</var> corresponds to
-                           the parameter in position <var>N</var>.</p></item>
-                           <item><p>A keyword argument with keyword <var>K</var> corresponds to
-                              the parameter with name <var>K</var>.</p></item>
-                        </olist>
-                        <p>There must be exactly one argument corresponding to each parameter in the function
-                        declaration.</p>
-                        </item>
-                        <item><p>For bounded-variadic functions:</p>
-                           <olist>
-                              <item><p>A positional argument in position <var>N</var> corresponds to
-                                 the parameter in position <var>N</var>.</p></item>
-                              <item><p>A keyword argument with keyword <var>K</var> corresponds to
-                                 the parameter with name <var>K</var>.</p></item>
-                           </olist>
-                           <p>There must be at most one argument corresponding to each parameter in the function
-                              declaration.</p>
-                           <p>Any parameter for which there is no corresponding argument must be declared as
-                           optional, and the default value for that parameter is then used.</p>
-                           <p>TODO: define how the default value is evaluated, ie. what context is used.</p>
-                        </item>
-                        <item><p>For sequence-variadic functions:</p>
-                           <p>Let the number of declared parameters be <var>N</var>.</p>
-                           <olist>
-                              <item><p>All arguments must be positional.</p></item>
-                              <item><p>A positional argument with position <var>M</var>, 
-                                 (<var>M</var> &lt; <var>N</var>) corresponds to
-                                 the parameter in position <var>M</var>.</p></item>
-                              <item><p>The values of arguments in positions greater than
-                                 or equal to <var>N</var> are concatenated into a sequence,
-                                 and the resulting sequence is supplied as the value of
-                                 parameter <var>N</var>. If there are no such arguments (that is,
-                              if <var>N-1</var> arguments are supplied), then the value supplied
-                              for parameter <var>N</var> is an empty sequence.</p></item>
-                           </olist>
-                           
-                        </item>
-                        <item>
-                           <p>For map-variadic functions:</p>
-                           <p>Let the number of declared parameters be <var>N</var>.</p>
-                           
-                           <olist>
-                              <item><p>A positional argument in position <var>M</var> 
-                                 (<var>M</var> &lt; <var>N</var>) corresponds to
-                                 the parameter in position <var>M</var>.</p></item>
-                              <item><p>If there is a positional argument in position <var>N</var>,
-                                 this corresponds to the parameter in position <var>N</var>,
-                              and there must then be no keyword arguments.</p></item>
-                              <item><p>The values of keyword arguments are assembled into a map.
-                              For each keyword argument, the map has an entry whose name is
-                              the keyword (as an instance of <code>xs:string</code>) and whose
-                              corresponding value is the argument value. The resulting map
-                              is supplied as the value of parameter <var>N</var>.</p></item>
-                              <item><p>If there are no keyword arguments, and if there is
-                                 no positional argument in position <var>N</var>, then the 
-                                 value supplied for parameter <var>N</var> is an empty map.</p></item>
-                              
-                           </olist>
-                           
-                        </item>
+                        <item><p>If there are <var>N</var> positional arguments in the function call,
+                           the corresponding argument expressions are associated pairwise with the first <var>N</var>
+                           parameters in the declaration. For this purpose the required parameters and optional parameters
+                        in the declared function are concatenated into a single list, in order.</p></item>
+                        <item><p>Any keyword arguments in the function call are then matched against
+                           the names of the parameters (whether required or optional) in the declared function. Each keyword must match
+                        the name of a declared parameter, and this must be one that has not already
+                        been associated with a positional argument. [TODO: error condition]. 
+                        The expression supplied in the keyword
+                        argument is then associated with the corresponding parameter.</p></item>
+                        <item><p>Any parameters that have not been associated with any argument expression
+                        by applying the above rules (which are necessarily optional parameters) are then associated 
+                        with the default expression for the relevant parameter in the declared function.</p></item>
                      </olist>
-                  </item>
-            
-   
+                  </item>   
+  
 
                   <item>
                      <p>
-                          Each argument value computed by the above rules is converted
-                          to the corresponding parameter type in <var>F</var>'s signature
-                          by applying the <termref def="dt-coercion-rules">coercion rules</termref>, resulting in a <termref
-                           def="dt-arg-value"
-                        >converted argument value</termref>.
-                     </p>
+                          Each argument expression established by the above rules is evaluated with respect to DC.
+                          The order of argument evaluation is <termref def="dt-implementation-dependent"/> and it is not
+                        required that an argument be evaluated if the function can evaluate its body without evaluating
+                        that argument.</p>
+                     
+                     <note><p>All argument expressions, including default value expressions, are evaluated in the dynamic
+                     context of the function call. It is therefore possible to use a default value expression such as 
+                     <code>.</code>, or <code>/</code>, or <code>fn:current-dateTime()</code>, whose value depends on the
+                     dynamic context of the function call.</p></note>
+                     
+                     <p>If the expression used for the default value of a parameter has no dependencies on the dynamic
+                     context, then an implementation <rfc2119>may</rfc2119> choose to reuse the same value on repeated
+                     function calls rather than re-evaluating it each time.</p>
+                     
+                     <note><p>This is relevant, for example, if the expression constructs new nodes.</p></note>
+ 
 
                   </item>
+                     
+                     <item><p>The result of evaluating the argument expression is converted to the required type (the
+                     declared type associated with the corresponding parameter in the function declaration, defaulting
+                     to <code>item()*</code>) by applying the <termref def="dt-coercion-rules"/>.</p></item>
                   
                   
 
@@ -7094,7 +7116,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                  <ulist>
                                     <item>
                                        <p>
-                                          <var>F</var>'s implementation is invoked
+                                          <var>FF</var>'s implementation is invoked
                                       in an implementation-dependent way.
                                       The processor makes the following information
                                       available to that invocation:
@@ -7106,12 +7128,12 @@ At evaluation time, the value of a variable reference is the value to which the 
                                           </item>
                                           <item>
                                              <p>
-                                                <var>F</var>'s nonlocal variable bindings; and</p>
+                                                An empty set of nonlocal variable bindings; and</p>
                                           </item>
                                           <item>
                                              <p>
                                           a static context and dynamic context.
-                                          If <var>F</var>'s implementation is associated with a static and a dynamic context,
+                                          If <var>FF</var>'s implementation is associated with a static and a dynamic context,
                                           then these are supplied,
                                           otherwise <var>SC</var> and <var>DC</var> are supplied.
                                         </p>
@@ -7136,7 +7158,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                     </item>
                                     <item>
                                        <p>
-                                      The result is either an instance of <var>F</var>'s return type
+                                      The result is either an instance of <var>FF</var>'s return type
                                       or a dynamic error.
                                       This result is then the result of evaluating <var>FC</var>.
                                     </p>
@@ -7145,7 +7167,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                        <p>
                                       Errors raised by built-in functions are defined in
                                       <bibref
-                                             ref="xpath-functions-31"
+                                             ref="xpath-functions-40"
                                           />.
                                     </p>
                                     </item>
@@ -7176,14 +7198,16 @@ At evaluation time, the value of a variable reference is the value to which the 
                                           spec="FO31" ref="func-base-uri"
                                           />.  Use of <code>SC</code> and <code>DC</code> and errors raised by this function are all defined in 
                                   <bibref
-                                          ref="xpath-functions-31"/>.</p>
+                                          ref="xpath-functions-40"/>.</p>
 
                                     <eg role="parse-test"><![CDATA[fn:base-uri()]]></eg>
 
                                  </example>
-                              </item>
+                             
+                  </item>
 
-                           </olist>
+               
+               </olist>
 
             
                </div4>
@@ -7192,7 +7216,9 @@ At evaluation time, the value of a variable reference is the value to which the 
          
          <div3 id="id-dynamic-functions">
             <head>Dynamic Functions</head>
-            <p>A dynamic function (or <term>function</term>, or <term>function item</term>) is an XDM
+
+            <p>A dynamic function (or <xtermref spec="DM31" ref="dt-function-item"
+               >function</xtermref>, or <term>function item</term>) is an XDM
             value that can be bound to a variable, or manipulated in various ways by &language; expressions.
             The most significant such expression is a <term>dynamic function call</term>, which supplies
             values of arguments and evaluates the function to produce a result.</p>
@@ -7272,10 +7298,11 @@ At evaluation time, the value of a variable reference is the value to which the 
                      <p>
                           Each argument value is converted
                           to the corresponding parameter type in <var>F</var>'s signature
-                          by applying the <termref def="dt-coercion-rules">coercion rules</termref>, resulting in a <termref
+                          by applying the <termref def="dt-coercion-rules">coercion rules</termref>, resulting in a
+                        <term>converted argument value</term><!--<termref
                            def="dt-arg-value"
-                        >converted argument value</termref>. The correspondence of arguments to parameters
-                        is by matching position.
+                        >converted argument value</termref>-->. <!--The correspondence of arguments to parameters
+                        is by matching position.-->
                      </p>
 
                   </item>
@@ -7456,9 +7483,9 @@ return $vat()
                                   a <termref
                                        def="dt-built-in-function">built-in function</termref>
                                     <phrase role="xquery">or an <termref def="dt-external-function"
-                                          >external function</termref>
+                                          >external function</termref>,
                                     </phrase>
-                                    <phrase role="xpath">or a <termref
+                                    <!--<phrase role="xpath">or a <termref
                                           def="dt-host-language-function"
                                           >host language function</termref>
                                     </phrase>
@@ -7466,7 +7493,7 @@ return $vat()
                                   <termref
                                        def="dt-partially-applied-function"
                                        >partial application</termref>
-                                       of such a function), the implementation of the function is
+                                       of such a function)--> the implementation of the function is
                                        evaluated, and the result is converted
                                        to the declared return type, in the same way as for a 
                                        static function call (see <specref ref="id-function-calls"/>).</p>
@@ -7498,7 +7525,7 @@ return $vat()
                <p>The function <var>F</var> to be partially applied is determined in the same way as for a 
                   (static or dynamic) function call without placeholders, as described in the preceding sections.
                   For this purpose an <code>ArgumentPlaceHolder</code> contributes to the count of
-               positional arguments.</p>
+                  arguments.</p>
                   </item>
 
                   
@@ -7506,7 +7533,9 @@ return $vat()
                      <p>Arguments other than placeholders are evaluated, mapped to corresponding
                      parameters in the function signature of <var>F</var>, and converted to the required
                      type of the parameter, using the rules for static and dynamic function calls as 
-                     appropriate.</p>
+                     appropriate. <phrase diff="add" at="variadicity">In the case of static function calls,
+                     this includes optional parameters for which no argument expression is supplied in the
+                     call.</phrase></p>
                   </item>
 
 
@@ -7527,10 +7556,10 @@ return $vat()
                               is a function created by  <termref
                                     def="dt-partial-function-application"
                                     >partial function application</termref>.</termdef>
-                              <termdef term="fixed position" id="dt-fixed-position"
+                              <termdef term="fixed position" id="dt-fixed-position" diff="chg" at="variadicity"
                                     >In a partial function application, a <term>supplied parameter</term>
-                              is a parameter for which the <code>ArgumentList</code> includes
-                              a corresponding argument (as distinct from a placeholder).</termdef>
+                              is any parameter other than one for which the <code>ArgumentList</code> includes
+                              a placeholder.</termdef>
                               A partial function application need not have any supplied parameters.  A <termref
                                  def="dt-partially-applied-function"
                                  >partially applied function</termref> has
@@ -7655,14 +7684,13 @@ return $a("A")]]></eg>
             <p>The name and arity of the required function are known statically.</p>
           
             <p diff="chg" at="A">If the EQName is a <termref def="dt-qname">lexical QName</termref>, it is expanded using the 
-               <termref def="dt-function-name-resolver"/> in the <termref def="dt-static-context">static context</termref>.</p>
+               <termref def="dt-default-function-namespace"/> in the <termref def="dt-static-context">static context</termref>.</p>
             
-            <p>The expanded QName and arity must correspond to a function
-               signature present in the <termref def="dt-static-context">static context</termref>.
-            <phrase diff="add" at="A">More specifically, for a named function reference <code>F#N</code>,
-               there must be a function in the static context
-               whose name matches <code>F</code>, and that has 
-               <code>MinP ≤ N and MaxP ≥ N</code></phrase>.</p>
+            <p>The expanded QName and arity must correspond to a <termref def="dt-declared-function"/>
+               present in the <termref def="dt-static-context">static context</termref>.
+            <phrase diff="add" at="variadicity">More specifically, for a named function reference <code>F#N</code>,
+               there must be a declared function in the static context
+               whose name matches <var>F</var>, and whose <termref def="dt-arity-range"/> includes <var>N</var></phrase>.</p>
             
             <p>If the function is
           context dependent, then the returned function is associated
@@ -7695,6 +7723,13 @@ return $a("A")]]></eg>
                >named functions</termref> component
             of the dynamic context.
             </p>
+            
+            <note diff="add" at="variadicity"><p>Consider the declared function <code>fn:format-date</code>
+            with an arity range of 2 to 5. The named function reference <code>fn:format-date#3</code>
+            returns a (dynamic) function whose three arguments correspond to the first three arguments
+            of <code>fn:format-date</code>; the remaining two arguments will take their default values.
+               To obtain a 3-argument function that binds to arguments 1, 2, and 5 of <code>fn:format-date</code>,
+            use the partial function application <code>format-date(?, ?, place:?)</code>.</p></note>
 
             <p>
             Furthermore, if the function returned by the evaluation of
@@ -10640,7 +10675,7 @@ together with the <termref def="dt-operator-function"
                >operator functions</termref>
 that define the semantics of the operator for each
 type combination, including the dynamic errors that can be raised by the operator. The definitions of the operator functions are found in <bibref
-               ref="xpath-functions-31"/>.</p>
+               ref="xpath-functions-40"/>.</p>
          <p>If the types of the operands, after evaluation, are not a valid combination for the given operator, according to the rules in <specref
                ref="mapping"/>, a <termref def="dt-type-error"
                >type error</termref> is raised <errorref class="TY" code="0004"/>.</p>
@@ -10822,7 +10857,7 @@ listed in <specref
                   >operator functions</termref> that define
 the semantics of the operator for each type combination. The
 definitions of the operator functions are found in <bibref
-                  ref="xpath-functions-31"/>.</p>
+                  ref="xpath-functions-40"/>.</p>
 
             <p>Informally, if both atomized operands consist of exactly one atomic
 value, then the result of the comparison is <code>true</code> if the value of the
@@ -11364,7 +11399,7 @@ following expression must raise a <termref def="dt-dynamic-error"
 function named <code>fn:not</code> that takes a general sequence as
 parameter and returns a boolean value.  The <code>fn:not</code> function
 is defined in <bibref
-               ref="xpath-functions-31"
+               ref="xpath-functions-40"
                />. The
 <code>fn:not</code> function reduces its parameter to an <termref
                def="dt-ebv"
@@ -16976,7 +17011,7 @@ Also, within a <termref def="dt-path-expression"
          </note>
          <note>
             <p>The <code>fn:id</code> and <code>fn:idref</code> functions are described in <bibref
-                  ref="xpath-functions-31"/> as returning their results in <termref
+                  ref="xpath-functions-40"/> as returning their results in <termref
                   def="dt-document-order"
                   >document order</termref>. Since ordering mode is a feature of XQuery, relaxation of the ordering requirement for function results when ordering mode is <code>unordered</code> is a feature of XQuery rather than of the functions themselves.</p>
          </note>
@@ -18042,8 +18077,7 @@ usa:zipcode?)</code>.</p>
                   in a cast expression, an unqualified name is resolved using the 
                   <termref def="dt-def-type-ns" diff="chg" at="A">default type namespace</termref>,
                   while an unqualified name in a constructor function call is resolved using the
-                  <termref def="dt-function-name-resolver"/> which will typically assume a default
-                  namespace.
+                  <termref def="dt-default-function-namespace"/> which will often be inappropriate.
                </p>
   
             </note>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6609,9 +6609,11 @@ At evaluation time, the value of a variable reference is the value to which the 
          
             <div3 id="id-static-functions" diff="add" at="A">
                <head>Declared Functions</head>
-               <p>The static context for an expression includes a set of <termref def="dt-declared-functions"/>. Every declared function
-               in the static context has a name (which is a QName) and a range of permitted arities for
-               calls on that function. Two function families having the same name must not have overlapping arity ranges.
+               <p>The <termref def="dt-static-context"/> for an expression includes a set 
+                  of <termref def="dt-declared-functions"/>. Every declared function
+               in the static context has a name (which is an <termref def="dt-expanded-qname"/>) and 
+                  an <termref def="dt-arity-range"/>, which is a range of permitted arities for
+               calls on that function. Two declared functions having the same name must not have overlapping arity ranges.
                This means that for a given static function call, it is possible to identify the target function
                in the static context unambiguously from knowledge of the function name and the number of supplied arguments.</p>
                
@@ -6781,9 +6783,9 @@ At evaluation time, the value of a variable reference is the value to which the 
                <p>In consequence, a function call with a known number of positional arguments and a known
                number of keyword arguments can never match more than one function in the static context.</p>
                -->
-               <p>Similarly, a named function reference such as <code>fn#3</code> is a reference to a
+               <!--<p>Similarly, a named function reference such as <code>fn#3</code> is a reference to a
                function in the static context with name <code>fn</code> and arity 3,
-               and there can be at most one such function.</p>
+               and there can be at most one such function.</p>-->
                
                <!--<p>Taking examples from the standard function library:</p>
                <ulist>
@@ -6822,10 +6824,12 @@ At evaluation time, the value of a variable reference is the value to which the 
                      </item>
                </ulist>-->
                
-               <p>A static function call is bound to a declared function in the static context by matching the name
+               <p>A <termref def="dt-static-function-call"/> is bound to a <termref def="dt-declared-function"/> 
+                  in the static context by matching the name
                and arity. If the function call has <var>P</var> positional arguments followed by
                   <var>K</var> keyword arguments, then the required arity is <var>P+K</var>, and the static context 
-                  must include a declared function whose name matches the name in the function call, and whose arity range 
+                  must include a declared function whose name matches the <termref def="dt-expanded-qname"/> 
+                  in the function call, and whose <termref def="dt-arity-range"/> 
                includes this required arity. This is the function chosen for execution.
                The function is evaluated by executing its implementation, with
                a dynamic context that provides values for all the declared parameters, initialized
@@ -6834,8 +6838,8 @@ At evaluation time, the value of a variable reference is the value to which the 
              
  
                
-               <p>Similarly, a function reference of the form <code>f#N</code> binds to a function in the
-                  static context whose name matches <var>f</var> given the required arity <code>N</code>.
+               <p>Similarly, a function reference of the form <code>F#N</code> binds to a function in the
+                  static context whose name matches <var>F</var> given the required arity <code>N</code>.
                The result of evaluating a function reference is a (dynamic) function which can be invoked
                using a dynamic function call. Dynamic functions have a fixed arity and their arguments
                are always supplied positionally. For example, the function reference <code>fn:concat#3</code>
@@ -6875,13 +6879,15 @@ At evaluation time, the value of a variable reference is the value to which the 
             would be misinterpreted as a QName (probably with an undeclared prefix) rather than automatically 
             being a syntax error.</p></note>
             <p><termdef term="argument expression" id="dt-arg-expr">An argument to a function call is either an
-               <term>argument expression</term> or an ArgumentPlaceholder ("?"); in both cases it may
+               <term>argument expression</term> or an <nt def="ArgumentPlaceholder">ArgumentPlaceholder</nt> 
+               (<code>?</code>); in both cases it may
             either be supplied positionally, or identified by a name (called a keyword).</termdef></p>
             <p>This section is concerned with static function calls in which none of the arguments are
-               <code>ArgumentPlaceHolders</code>. Calls using one or more <code>ArgumentPlaceHolders</code> are covered in the 
+               <nt def="ArgumentPlaceholder">ArgumentPlaceholders</nt>. 
+               Calls using one or more <nt def="ArgumentPlaceholder">ArgumentPlaceholders</nt> are covered in the 
                section <specref ref="id-partial-function-application"/>.</p>
             <p>If the EQName in a static function call is an unprefixed <termref def="dt-qname"
-               >lexical QName</termref>, it is expanded by invoking the <termref def="dt-default-function-namespace"/> 
+               >lexical QName</termref>, it is expanded using the <termref def="dt-default-function-namespace"/> 
                in the <termref def="dt-static-context">static context</termref>.
             </p>
             <p><phrase diff="del" at="A">In other cases, </phrase>The <termref def="dt-expanded-qname"
@@ -6891,12 +6897,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                <phrase>using the rules defined in the previous section</phrase>; if there is no match, a
                <termref def="dt-static-error">static error</termref> is raised <errorref class="ST" code="0017"/>.
                </p>
-            <p>
-               <termdef term="partial function application" id="dt-partial-function-application">
-                  A static or <termref def="dt-dynamic-function-invocation">dynamic</termref>
-                  function call is a <term>partial function application</term>
-                  if one or more arguments is an ArgumentPlaceholder.</termdef>
-            </p>
+            
             
             <p>Evaluation of static function calls is described in <specref ref="id-eval-static-function-call"/>,
                while evaluation of dynamic function calls is described in 
@@ -7014,7 +7015,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                <head>Evaluating Static Function Calls</head>
             
             <p>This section applies to static function calls where none of the
-            arguments is an <code>ArgumentPlaceHolder</code>. For function calls involving
+            arguments is an <code>ArgumentPlaceholder</code>. For function calls involving
             placeholders, see <specref ref="id-partial-function-application"/>.</p>
 
                <p>
@@ -7037,10 +7038,10 @@ At evaluation time, the value of a variable reference is the value to which the 
                         function call, including both positional and keyword arguments.</p>
                      
                            <p>
-                              There can be at most one declared function <var>FF</var> in the <termref def="dt-named-functions"
-                                 >named functions</termref> component of <var>DC</var> whose function name
-                              matches the expanded QName in <var>FC</var> and whose arity range
-                              and the arity of <var>FC</var>'s <code>ArgumentList</code>.
+                              There can be at most one declared function <var>FF</var> in the <termref def="dt-declared-functions"
+                                 >declared functions</termref> component of <var>SC</var> whose function name
+                              matches the expanded QName in <var>FC</var> and whose <termref def="dt-arity-range"/>
+                              includes the arity of <var>FC</var>'s <code>ArgumentList</code>.
                            </p>
                      
                      <p>If there is no such declared function, a static error <errorref
@@ -7250,7 +7251,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                <head>Evaluating Dynamic Function Calls</head>
             
             <p>This section applies to dynamic function calls whose arguments do not include
-            an <code>ArgumentPlaceHolder</code>. For function calls that include a placeholder,
+            an <code>ArgumentPlaceholder</code>. For function calls that include a placeholder,
             see <specref ref="id-partial-function-application"/>.</p>
 
                <p>
@@ -7511,8 +7512,13 @@ return $vat()
             <div4 id="id-partial-function-application">
                <head>Partial Function Application</head>
                
-               <p>A partial function application is a static or dynamic function call
-               in which one or more of the arguments is supplied as an <code>ArgumentPlaceHolder</code>.</p>
+               <p>
+                  <termdef term="partial function application" id="dt-partial-function-application">
+                     A static or <termref def="dt-dynamic-function-invocation">dynamic</termref>
+                     function call is a <term>partial function application</term>
+                     if one or more arguments is an ArgumentPlaceholder.</termdef>
+               </p>
+               
                
                <p>The result of a partial function application is a (dynamic) function, whose
                arity is equal to the number of placeholders in the call.</p>
@@ -7523,7 +7529,7 @@ return $vat()
                   <item>
                <p>The function <var>F</var> to be partially applied is determined in the same way as for a 
                   (static or dynamic) function call without placeholders, as described in the preceding sections.
-                  For this purpose an <code>ArgumentPlaceHolder</code> contributes to the count of
+                  For this purpose an <code>ArgumentPlaceholder</code> contributes to the count of
                   arguments.</p>
                   </item>
 
@@ -7533,7 +7539,7 @@ return $vat()
                      parameters in the function signature of <var>F</var>, and converted to the required
                      type of the parameter, using the rules for static and dynamic function calls as 
                      appropriate. <phrase diff="add" at="variadicity">In the case of static function calls,
-                     this includes optional parameters for which no argument expression is supplied in the
+                     this includes optional parameters for which no argument expression or placeholder is supplied in the
                      call.</phrase></p>
                   </item>
 
@@ -7678,7 +7684,8 @@ return $a("A")]]></eg>
             <p>
                <termdef term="named function reference" id="dt-named-function-ref">
           A <term>named function reference</term> is an expression
-          which evaluates to a <termref def="dt-named-func">named function</termref>.</termdef></p>
+                  which evaluates to a dynamic <xtermref spec="DM31" ref="dt-function-item"
+                     >function</xtermref>.</termdef></p>
             
             <p>The name and arity of the required function are known statically.</p>
           
@@ -7689,38 +7696,38 @@ return $a("A")]]></eg>
                present in the <termref def="dt-static-context">static context</termref>.
             <phrase diff="add" at="variadicity">More specifically, for a named function reference <code>F#N</code>,
                there must be a declared function in the static context
-               whose name matches <var>F</var>, and whose <termref def="dt-arity-range"/> includes <var>N</var></phrase>.</p>
+               whose name matches <var>F</var>, and whose <termref def="dt-arity-range"/> includes <var>N</var></phrase>.
+               Call this declared function <var>DF</var>.</p>
             
             <p>If the function is
           context dependent, then the returned function is associated
           with the static context of the named function reference and
           the dynamic context in which it is evaluated.</p>
             
-          <p>
-               <termdef term="named function" id="dt-named-func"
-                     >A <term>named function</term> is a function defined in the
-          static context for the <phrase
-                     role="xquery">query</phrase>
-                  <phrase role="xpath"
-                  >expression</phrase>. 
-          To uniquely identify a particular named function, both its name as an expanded QName
-          and its arity are required.</termdef>
-            </p>
-
+ 
            
             <p>If the <termref def="dt-expanded-qname"
-                  >expanded QName</termref> and arity in a named function reference do not match the name and arity of a function signature in the
+                  >expanded QName</termref> and arity in a named function reference do not match the 
+               name and <termref def="dt-arity-range"/> of a <termref def="dt-declared-function"/> in the
           static context, a static error is raised <errorref
                   class="ST" code="0017"/>.</p>
 
-            <p>
+            <p diff="chg" at="variadicity">
             The value of a <code>NamedFunctionRef</code>
-            is the function obtained by looking up
-            the expanded QName and arity
-            in the <termref
-                  def="dt-named-functions"
-               >named functions</termref> component
-            of the dynamic context.
+               is a <xtermref spec="DM31" ref="dt-function-item">function</xtermref> <var>FI</var> 
+               obtained from <var>DF</var>
+               as follows:
+               <ulist>
+                  <item><p>The name of <var>FI</var> is the name of <var>DF</var>.</p></item>
+                  <item><p>The parameter names of <var>FI</var> are the first <var>A</var> parameter names of <var>DF</var>,
+                  where <var>A</var> is the required arity.</p></item>
+                  <item><p>The signature of <var>FI</var> is formed from the required types of the 
+                     first <var>A</var> parameters of <var>DF</var>, and the function result type of <var>DF</var>.</p></item>
+                  <item><p>The implementation of <var>FI</var> is the implementation of <var>DF</var>.</p></item>
+                  <item><p>The nonlocal variable bindings of <var>FI</var> comprise bindings of the names of parameters of <var>DF</var>
+                  beyond the <var>A</var>'th parameter, to their respective default values. The evaluation of the expressions
+                  that define these default values occurs in the dynamic context of the named function reference.</p></item>
+               </ulist>
             </p>
             
             <note diff="add" at="variadicity"><p>Consider the declared function <code>fn:format-date</code>

--- a/specifications/xquery-40/src/introduction.xml
+++ b/specifications/xquery-40/src/introduction.xml
@@ -92,7 +92,7 @@
 
 		<item>
 			<p>The built-in function library and the operators supported by &language; are defined
-				in <bibref ref="xpath-functions-31"/>.</p>
+				in <bibref ref="xpath-functions-40"/>.</p>
 		</item>
 
 		<item role="xquery">

--- a/specifications/xquery-40/src/mime-type.xml
+++ b/specifications/xquery-40/src/mime-type.xml
@@ -197,7 +197,7 @@ declaration</termref> as part of its <termref def="dt-version-declaration">versi
 
     accessed, processed and returned as results. XQuery expressions can invoke any of the functions defined in
 
-<bibref ref="xpath-functions-31"/>. For example, the
+<bibref ref="xpath-functions-40"/>. For example, the
 
 <code>fn:doc()</code> and <code>fn:doc-available()</code> functions  allow local filesystem probes as well as
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -388,7 +388,7 @@ declaration">A
           declaration</term> adds a decimal format to the <termref def="dt-static-decimal-formats"
             >statically known decimal formats</termref>, which define the properties used to format
         numbers using the <code>fn:format-number()</code> function</termdef>, as described in
-      <bibref ref="xpath-functions-31"/>. 
+      <bibref ref="xpath-functions-40"/>. 
       
       If the form <code>decimal-format EQName</code> is used, then the declaration 
         defines the properties of the decimal format whose name is <code>EQName</code>, while the form <code>default decimal-format</code> 
@@ -562,7 +562,7 @@ return (
         public variable declarations, public function declarations<phrase diff="add" at="A">, 
           and public item type declarations</phrase> from one or more <termref
           def="dt-library-module">library modules</termref> into the <termref
-          def="dt-known-func-signatures">statically known function signatures</termref>, <termref
+          def="dt-declared-functions"/>, <termref
           def="dt-in-scope-variables">in-scope variables</termref><phrase diff="add" at="A">,
           or <termref def="dt-item-type-aliases"/></phrase> of the importing <termref
           def="dt-module">module</termref>.</termdef> Each module import names a <termref
@@ -575,7 +575,7 @@ return (
 
     <p>If a module <code>A</code> imports module <code>B</code>, the static context of module
         <code>A</code> will contain the <termref def="dt-issd">in-scope schema definitions</termref>
-      and <termref def="dt-known-func-signatures">statically known function signatures</termref> of
+      and <termref def="dt-declared-functions"/> of
       module <code>B</code>, and the dynamic context of module <code>A</code> will contain the
         <termref def="dt-variable-values">variable values</termref> and <termref
         def="dt-named-functions">named functions</termref> of module <code>B</code>, with the
@@ -961,8 +961,7 @@ return $i/xx:bing]]>
         <p>A <term>default function namespace declaration</term> declares a namespace URI that is
           associated with unprefixed function names in static function calls and function
           declarations.</p>
-        <p diff="chg" at="A">The <termref def="dt-function-name-resolver">function
-        name resolver</termref> for XQuery resolves such function names using this default namespace.</p>
+ 
          <p>A <termref def="dt-prolog">Prolog</termref> may contain at most one
           default function namespace declaration <errorref class="ST" code="0066"/>. If the
           <code>StringLiteral</code> in a default function namespace declaration is a zero-length string, the
@@ -1377,34 +1376,40 @@ declare context item as element(env:Envelope) external;</eg>
 
   <div2 id="FunctionDeclns">
     <head>Function Declaration</head>
-    <p>In addition to the <termref def="dt-built-in-function">built-in functions</termref>, XQuery
-      allows users to declare functions of their own. A function declaration specifies the name of
+    <p diff="chg" at="variadicity">In addition to the <termref def="dt-built-in-function">built-in functions</termref>, XQuery
+      allows users to declare functions of their own. A function declaration declares a family of functions
+      having the same name and similar parameters. The declaration specifies the name of
       the function, the names and datatypes of the parameters, and the datatype of the result. All
-      datatypes are specified using the syntax described in <specref ref="id-types"/>. A function
-      declaration causes the declared function to be added to the <termref
-        def="dt-known-func-signatures">statically known function signatures</termref> and the
-        <termref def="dt-named-functions">named functions</termref> of the <termref def="dt-module"
-        >module</termref> in which it appears.</p>
+      datatypes are specified using the syntax described in <specref ref="id-types"/>.</p>
+    
+      <p>Including a function declaration in the query causes a corresponding <termref def="dt-declared-function"/> to be
+        added to the <termref def="dt-declared-functions"/> of the <termref def="dt-static-context"/>.
+        The associated functions also become available in the
+        <termref def="dt-named-functions">named functions</termref> of the <termref def="dt-dynamic-context"/>.</p>
+    
+ 
+ 
 
-    <scrap>
+    <scrap diff="chg" at="variadicity">
       <head></head>
       <prodrecap ref="AnnotatedDecl"/>
       <prodrecap ref="Annotation"/>
       <prodrecap id="FunctionDecl" ref="FunctionDecl"/>
-      <prodrecap id="ParamList" ref="ParamList"/>
-      <prodrecap id="Param" ref="Param"/>
+      <prodrecap id="FunctionFamilySignature" ref="FunctionFamilySignature"/>
+      <prodrecap id="FamilyParamList" ref="FamilyParamList"/>
+      <prodrecap id="ParamWithDefault" ref="ParamWithDefault"/>
       <prodrecap id="FunctionBody" ref="FunctionBody"/>
       <prodrecap ref="TypeDeclaration"/>
       <prodrecap ref="EnclosedExpr"/>
     </scrap>
 
-    <p> A function declaration specifies whether a function is <termref def="dt-udf"
-        >user-defined</termref> or <termref def="dt-external-function">external</termref>.</p>
+    <p> A function declaration specifies whether a function <phrase diff="add" at="variadicity">family</phrase> 
+      is <termref def="dt-udf">user-defined</termref> or <termref def="dt-external-function">external</termref>.</p>
 
     <p>
       <termdef id="dt-udf" term="user-defined function">
         <term>User defined functions</term> are functions that contain a <term>function body</term>,
-        which provides the implementation of the function as <phrase diff="del" at="####">an XQuery expression</phrase><phrase diff="add" at="####">a <termref def="dt-content-expression">content expression</termref></phrase>.</termdef> The
+        which provides the implementation of the function as a <termref def="dt-content-expression">content expression</termref>.</termdef> The
         <termref def="dt-static-context">static context</termref> for a function body includes all
       functions, variables, and namespaces that are declared or imported anywhere in the <termref
         def="dt-prolog">Prolog</termref>, including the function being declared. Its <termref
@@ -1414,6 +1419,18 @@ declare context item as element(env:Envelope) external;</eg>
       However, its <termref def="dt-context-item-static-type">context item static type</termref> component is <xtermref spec="DM31" ref="dt-absent"/>,
       and an implementation should raise a static error <errorref class="ST" code="0008"/> if an expression depends on the context item.
     </p>
+    
+    <p diff="add" at="variadicity">The function declaration includes a list of zero or more function parameters. A parameter is
+    optional if a default value is supplied using the construct <code>:= ExprSingle</code>; otherwise it is required. If a parameter
+    is optional, then all subsequent parameters in the list must also be optional. In other words, the parameter list includes
+    zero or more required parameters followed by zero or more optional parameters.</p>
+    
+    <p>The number of arguments that may be supplied in a call to this family of functions is this in the range <var>M</var> to <var>N</var>,
+    where <var>M</var> is the number of required parameters, and <var>N</var> is the total number of parameters (whether required or optional).
+    This is refered to as the <term>arity range</term> of the function family.</p>
+    
+    <p>The static context may include more than one declared function with the same name, but their arity ranges must not overlap. [TODO: define
+    error condition].</p>
 
     <p>
       In function declarations, <termref def="dt-external-function">external functions</termref> are identified by the keyword
@@ -1430,12 +1447,11 @@ declare context item as element(env:Envelope) external;</eg>
       function is public. <termdef id="dt-private-function" term="private function">A <term>private
           function</term> is a function with a <code>%private</code> annotation. A private function
         is hidden from <termref def="dt-module-import">module import</termref>, which can not import
-        it into the <termref def="dt-known-func-signatures">statically known function
-          signatures</termref> of another module. </termdef>
+        it into the <termref def="dt-declared-functions"/> of another module. </termdef>
       <termdef id="dt-public-function" term="public function">A <term>public function</term> is a
         function without a <code>%private</code> annotation. A public function is accessible to
           <termref def="dt-module-import">module import</termref>, which can import it into the
-          <termref def="dt-known-func-signatures">statically known function signatures</termref> of
+        <termref def="dt-declared-functions"/> of
         another module. </termdef> Using <code>%public</code> and <code>%private</code> annotations
       in a main module is not an error, but it does not affect module imports, since a main module
       cannot be imported. It is a <termref def="dt-static-error">static error</termref>
@@ -1522,14 +1538,24 @@ declare context item as element(env:Envelope) external;</eg>
     <p>If a function parameter is declared using a name but no type, its default type is
         <code>item()*</code>. If the result type is omitted from a function declaration, its default
       result type is <code>item()*</code>.</p>
+    
+    <p diff="add" at="variadicity">The function body defines the implementation of the <termref def="dt-declared-function"/>. 
+      The rules for static function calls (see <specref ref="id-eval-static-function-call"/>)
+    ensure that, a value is available for each parameter, whether required or optional.
+    </p>
     <p>The parameters of a function declaration are considered to be variables whose scope is the
       function body. It is an <termref def="dt-static-error">static error</termref>
       <errorref class="ST" code="0039"/> for a function declaration to have more than one parameter
       with the same name. The type of a function parameter can be any type that can be expressed as
       a <termref def="dt-sequence-type">sequence type</termref>.</p>
 
-    <p> A <code>FunctionDecl</code> defines a function with the following properties: </p>
+    <p> A <code>FunctionDecl</code> thus defines a <phrase diff="chg" at="variadicity">set of functions</phrase> with the following properties: </p>
     <ulist>
+      <item diff="add" at="variadicity">
+        <p>There is one function for each arity <var>A</var> within the <term>arity range</term> of 
+          the <termref def="dt-declared-function"/>. The properties of the function with arity <var>A</var>
+        are given below.</p>
+      </item>
       <item>
         <p>
           <term>name</term>: The <code>EQName</code> of the <code>FunctionDecl</code>, expanded (if
@@ -1540,7 +1566,7 @@ declare context item as element(env:Envelope) external;</eg>
 
       <item>
         <p>
-          <term>parameter names</term>: The <code>EQName</code>s in the <code>ParamList</code>,
+          <term>parameter names</term>: The <code>EQName</code>s of the first <var>A</var> parameters in the <code>FamilyParamList</code>,
           expanded (if necessary) using the <termref def="dt-static-namespaces">statically known
             namespaces</termref> of the module's static context. </p>
       </item>
@@ -1549,7 +1575,7 @@ declare context item as element(env:Envelope) external;</eg>
         <p>
           <term>signature</term>: A <code>FunctionTest</code> built from the
             <code>SequenceType</code>s (explicit or implicit) in the <code>FunctionDecl</code> and
-          its <code>ParamList</code>, and from any <code>Annotation</code>s preceding the
+          of the first <var>A</var> parameters in its <code>FamilyParamList</code>, and from any <code>Annotation</code>s preceding the
             <code>FunctionDecl</code>. </p>
       </item>
 
@@ -1566,6 +1592,10 @@ declare context item as element(env:Envelope) external;</eg>
       </item>
 
     </ulist>
+    
+    <p diff="add" at="variadicity">[TODO: The above doesn't formally capture the fact that for those functions below the maximum arity,
+      i.e. functions called with one or more optional arguments omitted, the semantics are to execute the function
+      body with additional variable bindings in scope, representing the omitted arguments with their default values.]</p>
 
     <p>The following example illustrates the declaration and use of a local function that accepts a
       sequence of <code>employee</code> elements, summarizes them by department, and returns a
@@ -1617,6 +1647,7 @@ local:depth(fn:doc("partlist.xml"))
 
     <!-- ============================================================ -->
 
+<p diff="add" at="variadicity">[TODO: add an example of a function with an optional parameter.]</p>
 
     <!-- ============================================================ -->
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1403,7 +1403,7 @@ declare context item as element(env:Envelope) external;</eg>
       <prodrecap ref="EnclosedExpr"/>
     </scrap>
 
-    <p> A function declaration specifies whether a function <phrase diff="add" at="variadicity">family</phrase> 
+    <p> A function declaration specifies whether the implementation of the function 
       is <termref def="dt-udf">user-defined</termref> or <termref def="dt-external-function">external</termref>.</p>
 
     <p>
@@ -1427,7 +1427,29 @@ declare context item as element(env:Envelope) external;</eg>
     
     <p>The number of arguments that may be supplied in a call to this family of functions is this in the range <var>M</var> to <var>N</var>,
     where <var>M</var> is the number of required parameters, and <var>N</var> is the total number of parameters (whether required or optional).
-    This is refered to as the <term>arity range</term> of the function family.</p>
+    This is refered to as the <termref def="dt-arity-range"/> of the <termref def="dt-declared-function"/>.</p>
+    
+    <p>The properties of the <termref def="dt-declared-function"/> <var>F</var> are derived from the syntax of the
+    function declaration as follows:</p>
+    
+    <ulist>
+      <item><p>The name of <var>F</var> is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
+      that follows the keyword <code>function</code>.</p></item>
+      <item><p>The parameters of <var>F</var> are derived from the <code>ParamWithDefault</code> entries in the
+      <code>FamilyParamList</code>:</p>
+        <ulist>
+          <item><p>The parameter name is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
+          that follows the <code>$</code> symbol.</p></item>
+          <item><p>The required type of the parameter is given by the <code>TypeDeclaration</code>, defaulting to <code>item()*</code>.</p></item>
+          <item><p>The default value of the parameter is given by the expression that follows the <code>:=</code> symbol; if there
+          is no default value, then the parameter is a required parameter.</p></item>
+        </ulist>
+      </item>
+      <item><p>The return type of the function is given by the final <code>TypeDeclaration</code> that follows the <code>FamilyParamList</code>
+        if present, defaulting to <code>item()*</code>.</p></item>
+      <item><p>The function annotations are derived from the annotations that follow the <code>%</code> symbol, if present.</p></item>
+      <item><p>The implementation of the function is given by the enclosed expression.</p></item>
+    </ulist>
     
     <p>The static context may include more than one declared function with the same name, but their arity ranges must not overlap. [TODO: define
     error condition].</p>
@@ -1541,7 +1563,7 @@ declare context item as element(env:Envelope) external;</eg>
     
     <p diff="add" at="variadicity">The function body defines the implementation of the <termref def="dt-declared-function"/>. 
       The rules for static function calls (see <specref ref="id-eval-static-function-call"/>)
-    ensure that, a value is available for each parameter, whether required or optional.
+    ensure that a value is available for each parameter, whether required or optional.
     </p>
     <p>The parameters of a function declaration are considered to be variables whose scope is the
       function body. It is an <termref def="dt-static-error">static error</termref>
@@ -1549,7 +1571,8 @@ declare context item as element(env:Envelope) external;</eg>
       with the same name. The type of a function parameter can be any type that can be expressed as
       a <termref def="dt-sequence-type">sequence type</termref>.</p>
 
-    <p> A <code>FunctionDecl</code> thus defines a <phrase diff="chg" at="variadicity">set of functions</phrase> with the following properties: </p>
+    <!--<p diff="chg" at="variadicity"> A <code>FunctionDecl</code> thus defines a <termref def="dt-declared-function"/> 
+      with the following properties: </p>
     <ulist>
       <item diff="add" at="variadicity">
         <p>There is one function for each arity <var>A</var> within the <term>arity range</term> of 
@@ -1591,12 +1614,12 @@ declare context item as element(env:Envelope) external;</eg>
           <term>nonlocal variable bindings</term>: Empty. </p>
       </item>
 
-    </ulist>
+    </ulist>-->
     
-    <p diff="add" at="variadicity">[TODO: The above doesn't formally capture the fact that for those functions below the maximum arity,
+    <!--<p diff="add" at="variadicity">[TODO: The above doesn't formally capture the fact that for those functions below the maximum arity,
       i.e. functions called with one or more optional arguments omitted, the semantics are to execute the function
       body with additional variable bindings in scope, representing the omitted arguments with their default values.]</p>
-
+-->
     <p>The following example illustrates the declaration and use of a local function that accepts a
       sequence of <code>employee</code> elements, summarizes them by department, and returns a
       sequence of <code>dept</code> elements.</p>

--- a/specifications/xquery-40/src/xpath-backwards-compat.xml
+++ b/specifications/xquery-40/src/xpath-backwards-compat.xml
@@ -40,7 +40,7 @@
             <code>xs:untypedAtomic</code>.</p>
 
         <p>Incompatibilities in the behavior of individual functions are not listed here, but are
-            included in an appendix of <bibref ref="xpath-functions-31"/>.</p>
+            included in an appendix of <bibref ref="xpath-functions-40"/>.</p>
 
         <p>Since both XPath 1.0 and <phrase diff="chg" at="bug28782">XPath 3.1</phrase> leave some aspects of the specification
             implementation-defined, there may be incompatibilities in the behavior of a particular

--- a/specifications/xquery-40/src/xquery-header.xml
+++ b/specifications/xquery-40/src/xquery-header.xml
@@ -116,7 +116,7 @@ as modeling the tree structure of XML, the data model also includes
 atomic values, function items, and sequences.  This version of XPath
 supports JSON as well as XML, adding maps and arrays to the data model
 and supporting them with new expressions in the
-language and new functions in <bibref ref="xpath-functions-31"/>.  
+language and new functions in <bibref ref="xpath-functions-40"/>.  
 These are the most important new features in &language;:
 
 <olist>
@@ -142,7 +142,7 @@ sources.</p>
 together with XML and HTML. &language; extends XQuery to 
 support JSON as well as XML, adding maps and arrays to the data model
 and supporting them with new expressions in the
-language and new functions in <bibref ref="xpath-functions-31"/>. 
+language and new functions in <bibref ref="xpath-functions-40"/>. 
 A list of changes made since XQuery 3.1 can be found in <specref ref="id-revision-log"/>. 
 These are the most important new features in &language;:
 </p>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -17,8 +17,6 @@
       <fos:variable name="item3" select="$po/line-item[3]"/>
    </fos:global-variables>
 
-
-
    <fos:function name="current">
       <fos:signatures>
          <fos:proto name="current" return-type="item()"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -1459,6 +1459,8 @@
 
                <p>When a transformation is invoked by calling an <termref def="dt-initial-function"/>, the entire transformation executes in <termref def="dt-temporary-output-state"/>, which means that calls on
                      <elcode>xsl:result-document</elcode> are not permitted.</p>
+               
+               <p>[TODO: Generalize the above description to allow for the possibility of keyword-based and optional arguments.]</p>
 
             </div3>
             <div3 id="post-processing">
@@ -16031,8 +16033,11 @@ and <code>version="1.0"</code> otherwise.</p>
                      <rfc2119>must not</rfc2119> have a <code>select</code> attribute.</p>
 
                <p diff="add" at="A">The static context for evaluating the default value depends on where the
-               relevant expression appears in the stylesheet, in the usual way. The dynamic context is different
-               for different kinds of parameter:</p>
+               relevant expression appears in the stylesheet, in the usual way. Note however that
+               for <elcode>xsl:param</elcode> elements defining <termref def="dt-function-parameter">function parameters</termref>,
+                  the static context does not include variables bound in preceding-sibling <elcode>xsl:param</elcode> elements.</p>
+               
+               <p diff="add" at="A">The dynamic context is different for different kinds of parameter:</p>
                
                <ulist diff="add" at="A">
                   <item><p>For <termref def="dt-stylesheet-parameter">stylesheet parameters</termref>, the 
@@ -16070,9 +16075,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      parameters, or on the evaluation context, in which case the default must
                      effectively be evaluated on each invocation.</p>
                   
-                  <p diff="add" at="variadicity">TODO: For function parameters with defaults, we probably don't want to allow the default
-                  for one parameter to depend on the value of another; but we allow it for template parameters,
-                  so perhaps we should be consistent.</p>
+ 
                </note>
 
                <p><termdef id="dt-explicit-default" term="explicit default">An <term>explicit
@@ -18169,8 +18172,8 @@ and <code>version="1.0"</code> otherwise.</p>
  
                
                <p diff="add" at="A">For example, the following <elcode>xsl:function</elcode> declaration
-               declares a family of two functions, both named <code>f:compare</code>, one having arity 2 and one having
-               arity 3. The effect of calling <code>f:compare($a, $b)</code> is the same as the effect
+               declares a function, named <code>f:compare</code>, with an arity range of (2 to 3). 
+                  The effect of calling <code>f:compare($a, $b)</code> is the same as the effect
                of calling <code>f:compare($a, $b, map{"order":"ascending"})</code>.</p>
                
                <eg><![CDATA[

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -535,6 +535,25 @@
 
 
                </item>
+               <item>
+                  <p>
+                     <termdef id="dt-declared-function" term="declared function">The term
+                        <term>declared function</term> is defined in <xspecref spec="XP40" ref="static_context"/>. 
+                        In refers to the definition of a function that can be called from within an XPath
+                        expression: in the case of XSLT it typically means either a <termref def="dt-stylesheet-function"/>,
+                        or a built-in function such as those defined in <bibref ref="xpath-functions-40"/></termdef>
+                  </p>
+                  <p>
+                     <termdef id="dt-arity-range" term="arity range">A <termref def="dt-declared-function"/>
+                        has an <term>arity range</term> which defines the minimum and maximum number of arguments
+                        that must be supplied in a call to the function. The static context can contain multiple
+                        <term>declared functions</term> with the same name, provided that their <term>arity ranges</term>
+                        do not overlap.</termdef>
+                      
+                  </p>
+                  
+                  
+               </item>
             </ulist>
             
          </div2>
@@ -3702,7 +3721,8 @@
                      template, accumulator, attribute set, global
                      variable, key, or mode), the <termref def="dt-expanded-qname">expanded
                         QName</termref> of the component (namespace URI plus local name), and in the
-                     case of stylesheet functions, the <termref def="dt-arity">arity</termref>.</termdef></p>
+                     case of stylesheet functions, <phrase diff="chg" at="variadicity">the upper
+                     bound of the <termref def="dt-arity-range"/></phrase>.</termdef></p>
 
                <note>
                   <p>In the case of the <termref def="dt-unnamed-mode"/>,
@@ -4551,45 +4571,6 @@
                      and a <code>match</code> attribute, then it defines both a named component and
                      a template rule, and both sections apply.</p>
                   
-                  <p diff="add" at="A">An <elcode>xsl:function</elcode> declaration that includes optional
-                  parameters declares a number of functions, differing in arity. A function
-                  declaration appearing within <elcode>xsl:override</elcode> may similarly
-                  declare several functions differing in arity: these are considered individually
-                  when considering which functions from the used package are overridden.</p>
-                  
-                  <note diff="add" at="A">
-                     <p>Suppose the used package contains an <elcode>xsl:function</elcode>
-                     declaration with name <code>f:x</code>, having two required parameters, 
-                        followed by an optional parameter whose default value is an empty sequence. 
-                        It thus declares two components,
-                     <code>f:x#2</code> and <code>f:x#3</code>. A call on <code>f:x(a, b)</code>
-                     is evaluated as a call on <code>f:x(a, b, ())</code>.</p>
-                     <p>If an <code>xsl:override</code> element includes an <elcode>xsl:function</elcode>
-                     declaration for <code>f:x</code> with two parameters, both mandatory, then this
-                     overrides <code>f:x#2</code> but does not override <code>f:x#3</code>, which remains
-                     available in its original form.</p>
-                     <p>If the <code>xsl:override</code> element includes an <elcode>xsl:function</elcode>
-                        declaration for <code>f:x</code> with three parameters, all mandatory, then this
-                        overrides <code>f:x#3</code> but does not override <code>f:x#2</code>. A call on <code>f:x(a, b)</code>
-                        is evaluated as a call on <code>f:x(a, b, ())</code>, which invokes the overriding
-                     version of <code>f:x#3</code>. If the overriding declaration was intended to make the
-                     optional parameter mandatory, then it failed to achieve this effect.</p>
-                     <p>If the <code>xsl:override</code> element includes an <elcode>xsl:function</elcode>
-                        declaration for <code>f:x</code> with three parameters, where the first two are required
-                        and the third is optional, then this
-                        overrides both <code>f:x#2</code> and <code>f:x#3</code>.</p>
-                     <p>If the <code>xsl:override</code> element includes an <elcode>xsl:function</elcode>
-                        declaration for <code>f:x</code> with three parameters, where the first is required
-                        and the last two are declared optional, then this is an error: the declaration
-                        is attempting to override <code>f:x#1</code>, but there is no such component.</p>
-                     
-                  </note>
-                  
-                  <note diff="add" at="variadicity">
-                     <p>TODO: the above rules seem tortuous. It's probably better to simplify them
-                     so the xsl:function declaration must more closely match the overridden xsl:function.</p>
-                  </note>
-                  
                   
 
 
@@ -4671,12 +4652,16 @@
                            </item>
                         </olist>
                      </item>
-                     <item>
-                        <p>Two functions with the same name and arity are compatible if and only if
+                     <item diff="chg" at="variadicity">
+                        <p>Two functions with the same symbolic identifier are compatible if and only if
                            they satisfy all the following rules:</p>
                         <olist>
                            <item>
-                              <p>The declared types of the arguments 
+                              <p>They have the same <termref def="dt-arity-range"/>
+                              (which implies they have the same number of required and optional parameters)</p>
+                           </item>
+                           <item>
+                              <p>The declared types of the parameters 
                                  (defaulting to <code>item()*</code>) are pairwise <termref def="dt-identical-types">identical</termref>.</p>
                            </item>
                            <item>
@@ -4696,9 +4681,10 @@
                            </item>
                         </olist>
                         
-                        <p diff="add" at="variadicity">It is <rfc2119>recommended</rfc2119>, but not <rfc2119>required</rfc2119>,
+                        <p>It is <rfc2119>recommended</rfc2119>
                         that the parameter names on the overriding function should be the same as on the overridden function.
-                        (This is to maintain backwards compatibility with XSLT 3.0.) If the parameter names are not the same,
+                        (However, in order to maintain backwards compatibility with XSLT 3.0, 
+                        this is not <rfc2119>required</rfc2119>.) If the parameter names are not the same,
                         then the parameter names on the overriding function are effectively replaced with the names declared
                         on the overridden function, so that any static function calls using keyword arguments to set the values
                         of arguments must use the names defined on the overridden function.</p>
@@ -14535,7 +14521,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <rfc2119>must</rfc2119> have no children. That is, the <code>then</code> attribute and the
                contained sequence constructor are mutually exclusive.</p>
             <p>The result of the <elcode>xsl:if</elcode> instruction depends on the <xtermref
-               spec="XP40" ref="dt-ebv">effective boolean value</xtermref> of the expression in
+               spec="XP30" ref="dt-ebv">effective boolean value</xtermref> of the expression in
                the <code>test</code> attribute. The rules for determining the effective boolean
                value of an expression are given in <bibref ref="xpath-30"/>: they are the same as
                the rules used for XPath conditional expressions.</p>
@@ -14610,7 +14596,7 @@ and <code>version="1.0"</code> otherwise.</p>
                elements is satisfied. If none of the <elcode>xsl:when</elcode> elements is
                satisfied, then the <elcode>xsl:otherwise</elcode> element is considered, as
                described below.</p>
-            <p>An <elcode>xsl:when</elcode> element is satisfied if the <xtermref spec="XP40"
+            <p>An <elcode>xsl:when</elcode> element is satisfied if the <xtermref spec="XP30"
                ref="dt-ebv">effective boolean value</xtermref> of the <termref
                   def="dt-expression">expression</termref> in its <code>test</code> attribute is
                <code>true</code>. The rules for determining the effective boolean value of an
@@ -18101,41 +18087,55 @@ and <code>version="1.0"</code> otherwise.</p>
          </div2>
          <div2 id="stylesheet-functions">
             <head>Stylesheet Functions</head>
-            <p>
+            <p diff="add" at="variadicity">
                <termdef id="dt-stylesheet-function" term="stylesheet function">An
                      <elcode>xsl:function</elcode> declaration declares the name, parameters, and
                   implementation of a family of <term>stylesheet functions</term> that can be called from any
                   XPath <termref def="dt-expression">expression</termref> within the <termref def="dt-stylesheet">stylesheet</termref>
-                  (subject to visibility
-                  rules).</termdef>
+                  (subject to visibility rules).</termdef>
             </p>
             <?element xsl:function?>
-            <p>The <elcode>xsl:function</elcode> declaration defines a family of 
-               <termref def="dt-stylesheet-function">stylesheet functions</termref> that can be called from
-               any XPath <termref def="dt-expression">expression</termref> used in the <termref def="dt-stylesheet">stylesheet</termref> (including an XPath expression used
-               within a predicate in a <termref def="dt-pattern">pattern</termref>). The
-                  <code>name</code> attribute specifies the name of the function. The value of the
-                  <code>name</code> attribute is an <termref def="dt-eqname">EQName</termref>, which is expanded as described in
-                  <specref ref="qname"/>.</p>
+            <p diff="add" at="variadicity">The effect of an <elcode>xsl:function</elcode> declaration is to add a 
+               <termref def="dt-declared-function"/>
+               to the static context for all XPath <termref def="dt-expression">expressions</termref> 
+               used in the <termref def="dt-stylesheet">stylesheet</termref> (including an XPath expression used
+               within a predicate in a <termref def="dt-pattern">pattern</termref>).</p>
             
-            <p diff="add" at="A">More specifically, the function family contains a set of 
-               <termref def="dt-stylesheet-function">stylesheet functions</termref> having the same name but 
-            different <termref def="dt-arity"/>: see <specref ref="xsl-function-name"/> below.</p>
-            <p>An <elcode>xsl:function</elcode> declaration can only appear as a <termref def="dt-top-level"/> element in a stylesheet module.</p>
-
             <p>The content of the <elcode>xsl:function</elcode> element consists of zero or more
-                  <elcode>xsl:param</elcode> elements that specify the formal parameters of the
+               <elcode>xsl:param</elcode> elements that specify the formal parameters of the
                function, followed by a <termref def="dt-sequence-constructor">sequence
                   constructor</termref> that defines the value to be returned by the function.</p>
+            
+            
+            <p>The children and attributes of the <elcode>xsl:function</elcode> declaration translate directly
+               into properties of the <termref def="dt-declared-function"/>:</p>
+            
+            <ulist>
+               <item><p>The <code>xsl:function/@name</code> attribute defines the function's name.</p></item>
+               <item><p>The <code>xsl:param</code> children define the function's parameters:</p>
+                  <ulist>
+                     <item><p>The <code>xsl:param/@name</code> attribute defines the name of the parameter.</p></item>
+                     <item><p>The <code>xsl:param/@required</code> attribute determines whether the parameter is mandatory or optional.</p></item>
+                     <item><p>The <code>xsl:param/@as</code> attribute determines the required type of the parameter.</p></item>
+                     <item><p>The <code>xsl:param/@select</code> attribute determines a default value for an optional parameter.</p></item>
+                  </ulist>
+               </item>
+               <item><p>The <code>xsl:function/@as</code> attribute defines the return type of the function.</p></item>               
+               <item><p>The implementation of the function is defined by the <termref def="dt-sequence-constructor"/> content
+               of the <elcode>xsl:function</elcode> element.</p></item>
+            </ulist>
+               
+ 
+            
+      
+            <p>An <elcode>xsl:function</elcode> declaration can only appear as a <termref def="dt-top-level"/> element in a stylesheet module.</p>
 
-            <div3 id="xsl-function-name">
+            
+            <div3 id="xsl-function-name" diff="chg" at="variadicity">
                <head>Function Name and Arity</head>
 
                <p>The name of the function is given by the <code>name</code>
-                  attribute; the parameters are defined by child <elcode>xsl:param</elcode> elements;
-                  and the return type is defined by the <code>as</code> attribute. Together these
-                  definitions constitute the <emph>function signature</emph> of each of the functions
-                  in the function family.</p>
+                  attribute.</p>
                
                <p>
                   <error spec="XT" type="static" class="SE" code="0740">
@@ -18151,33 +18151,22 @@ and <code>version="1.0"</code> otherwise.</p>
                   </p>
                </note>
                
+               <p>The function parameters are defined by child <elcode>xsl:param</elcode> elements. The parameters must have distinct names.
+                  The list of parameters must contain zero or more required parameters, followed by zero or more optional parameters.
+                  A parameter is optional if it has the attribute <code>required="no"</code>; otherwise, it is required.</p>
                
-               <p diff="chg" at="A">
-                  <termdef id="dt-arity" term="arity">The <term>arity</term> of a stylesheet
-                     function is the number of arguments that must be supplied when calling
-                     the function.</termdef></p>
-
-               <p diff="add" at="A">A function parameter may be declared to be optional by specifying <code>required="no"</code>
-               on the <elcode>xsl:param</elcode> element. An optional parameter <rfc2119>must</rfc2119> have
-               a <code>select</code> attribute or a contained sequence constructor to define its default
-               value. A function parameter <rfc2119>must not</rfc2119> be declared optional unless all
-               subsequent function parameters are also declared optional: that is, the sequence of <elcode>xsl:param</elcode>
-               elements comprises a sequence of required parameters followed by a sequence of optional parameters.</p>
-               
-               <p diff="add" at="A">The <elcode>xsl:function</elcode> declaration declares a set of 
-                  <termref def="dt-stylesheet-function">stylesheet functions</termref> having the same name,
-               and with arities in the range <var>M</var> to <var>N</var> inclusive, where <var>M</var>
-               is the number of required parameters and <var>N</var> is the total number of parameters
-               (required or optional).</p>
-               
-               <p diff="add" at="A">The body of the <elcode>xsl:function</elcode> declaration (if the <code>visibility</code>
-               is not <code>abstract</code>) defines the implementation of the function with maximum arity
-               <var>N</var>, that is the function with all arguments supplied. The implementation of
-               a function with lower arity <var>R</var> is defined as the result of invoking the function with
-               arity <var>R+1</var> with the first <var>R</var> arguments supplied unchanged,
-               and the additional argument obtained by evaluating the <code>select</code> expression
-               or the contained sequence constructor of the corresponding <elcode>xsl:param</elcode>
-               element.</p>
+               <p>The default value for an optional parameter can be defined using the <code>select</code> attribute or the 
+               contained <termref def="dt-sequence-constructor"/> of the <elcode>xsl:param</elcode> element. These must be absent
+               for a required parameter. If an optional parameter has no <code>select</code> attribute and the contained sequence
+               constructor is empty, then the default value will be an empty sequence. This will lead to a type error if the
+               required type of the parameter does not permit an empty sequence.</p>
+                  
+               <p>The <termref def="dt-declared-function"/> derived from the 
+                  <elcode>xsl:function</elcode> declaration has an <termref def="dt-arity-range"/>
+                  from <var>M</var> to <var>M</var>+<var>N</var>, where <var>M</var> is the number of required parameters
+                  and <var>N</var> is the number of optional parameters. The arity range constrains the number of arguments
+               that may appear in a call to this function.</p> 
+ 
                
                <p diff="add" at="A">For example, the following <elcode>xsl:function</elcode> declaration
                declares a family of two functions, both named <code>f:compare</code>, one having arity 2 and one having
@@ -18192,7 +18181,13 @@ and <code>version="1.0"</code> otherwise.</p>
   <xsl:if test="$options?order = 'descending'" then="$arg1 gt $arg2" else="$arg2 gt $arg1"/>
 </xsl:function>]]></eg>
 
-              
+              <p>The expression defining the default value for a function parameter is evaluated in the dynamic context
+              of the function caller, so a default value such as <code>select="."</code> is permitted.</p>
+               
+               <p>Unlike other contexts where <elcode>xsl:param</elcode> elements may appear, the static context for 
+                  the select expression and contained sequence constructor of an <elcode>xsl:param</elcode> child of <elcode>xsl:function</elcode>
+               does not include variable bindings appearing it its preceding-sibling <elcode>xsl:param</elcode> elements. This means
+               that the default value of a function parameter cannot depend on the values of other parameters.</p>
                
 
                <note>
@@ -18207,26 +18202,13 @@ and <code>version="1.0"</code> otherwise.</p>
                <p diff="chg" at="variadicity">The <elcode>xsl:param</elcode> elements define the formal parameters to the
                   function. In a static function call, these are referenced either positionally or by name.
                   The rules for associating arguments in a static function call with parameter definitions
-                  in the function declaration are given in <xspecref spec="XP40" ref="id-eval-static-function-call"/>.
-                  <!--When the function is called using a
-                  function call in an XPath <termref def="dt-expression">expression</termref>, the
-                  first argument supplied is assigned to the first <elcode>xsl:param</elcode>
-                  element, the second argument supplied is assigned to the second
-                     <elcode>xsl:param</elcode> element, and so on.--></p>
-               
-               <p diff="del" at="A">Because arguments to a stylesheet function call <rfc2119>must</rfc2119> all
-                  be specified, the <elcode>xsl:param</elcode> elements within an
-                  <elcode>xsl:function</elcode> element <rfc2119>must not</rfc2119> specify
-                  a default value: this means they <rfc2119>must</rfc2119> be empty, and
-                  <rfc2119>must not</rfc2119> have a <code>select</code> attribute.</p>
-               
-              
+                  in the function declaration are given in <xspecref spec="XP40" ref="id-eval-static-function-call"/>.</p>
                <p>
                   <error spec="XT" type="static" class="SE" code="0760">
                      <p>It is a static error if an <elcode>xsl:param</elcode> child of
                         an <elcode>xsl:function</elcode> element has either a <code>select</code>
                         attribute or non-empty content<phrase diff="add" at="A">, unless it
-                        specifies <code>required="no"</code></phrase></p>
+                        specifies <code>required="no"</code>.</phrase></p>
                   </error>
                </p>
                
@@ -18255,7 +18237,9 @@ and <code>version="1.0"</code> otherwise.</p>
                of an <elcode>xsl:function</elcode> declaration with optional parameters as a syntactic 
                   short-cut for a set of <elcode>xsl:function</elcode> declarations of varying arity, each
                of which calls the function with next-higher arity, supplying the default value of the parameter
-               explicitly in the function call.</p></note>
+               explicitly in the function call.</p>
+               <p>This is not an exact equivalence, however, because the default value is evaluated with the
+               dynamic context of the caller.</p></note>
 
             </div3>
 
@@ -18297,47 +18281,78 @@ and <code>version="1.0"</code> otherwise.</p>
 
 
             </div3>
-            <div3 id="function-visibility-and-overriding">
+            <div3 id="function-visibility-and-overriding" diff="chg" at="variadicity">
                <head>Visibility and Overriding of Functions</head>
 
                <p>If the <code>visibility</code> attribute is present with the
                   value <code>abstract</code> then the <termref def="dt-sequence-constructor"/>
                   defining the function body <rfc2119>must</rfc2119> be empty.</p>
+               
+               <p>A stylesheet function may be overridden by another stylesheet function with the same name that
+                  has higher <termref def="dt-import-precedence"/>. This is only allowed, however, if the 
+                  <termref def="dt-arity-range"/> of the overriding function
+                  includes the totality of the arity range of the overridden function.</p>
+               <p><termdef id="dt-eclipsed" term="eclipsed">An <elcode>xsl:function</elcode> declaration
+                  <var>F</var> is said to be <term>eclipsed</term> if the containing package includes an <elcode>xsl:function</elcode> declaration
+                  <var>G</var> such that <var>F</var> and <var>G</var> have the same name, <var>F</var> has lower
+                  <termref def="dt-import-precedence"/> than <var>G</var>, and the <termref def="dt-arity-range"/>
+                  of <var>G</var> includes the totality of the arity range of <var>F</var>.</termdef></p>
+               
+               <p>
+                  <error spec="XT" type="static" class="SE" code="0769">
+                     <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
+                        contain an <elcode>xsl:function</elcode>
+                        declaration <var>F</var> and an <elcode>xsl:function</elcode> declaration
+                        <var>G</var> such that <var>F</var> and <var>G</var> have the same 
+                        <termref def="dt-expanded-qname"/>, <var>F</var> has lower
+                        <termref def="dt-import-precedence"/> than <var>G</var>, and the 
+                        <termref def="dt-arity-range"/>
+                        of <var>G</var> includes part but not all of the arity range of <var>F</var>,
+                     unless <var>G</var> is itself <termref def="dt-eclipsed"/> by another 
+                        <elcode>xsl:function</elcode> declaration.</p>
+                  </error>
+               </p>
+               
+               <p>
+                  <error spec="XT" type="static" class="SE" code="0770">
+                     <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
+                        contain an <elcode>xsl:function</elcode>
+                        declaration <var>F</var> and an <elcode>xsl:function</elcode> declaration
+                        <var>G</var> such that <var>F</var> and <var>G</var> have the same 
+                        <termref def="dt-expanded-qname"/> and the same
+                        <termref def="dt-import-precedence"/>, if the 
+                        <termref def="dt-arity-range">arity ranges</termref>
+                        of <var>F</var> and <var>G</var> overlap in whole or in part, 
+                        unless <var>F</var> and <var>G</var> are both <termref def="dt-eclipsed"/> by another 
+                        <elcode>xsl:function</elcode> declaration.</p>
+                       
+                  </error>
+               </p>
 
                <p>The XPath specification states that the function that is executed as the result of
-                  a function call is identified by looking in the in-scope functions of the static
-                  context for a function whose name and <termref def="dt-arity">arity</termref>
-                  matches the name and number of arguments in the function call. In XSLT 3.0, final determination of the function to be called cannot be
+                  a function call is identified by looking in the static context for a 
+                  <termref def="dt-declared-function"/> whose name and <termref def="dt-arity-range"/>
+                  match the name and number of arguments in the function call. In XSLT 3.0, final determination of the function to be called cannot be
                      made until all packages have been assembled: see <specref ref="component-references"/>.</p>
 
-               <p>An <elcode>xsl:function</elcode> declaration defines <phrase diff="chg" at="A">one or more</phrase> 
-                  <termref def="dt-stylesheet-function">stylesheet functions</termref>, <phrase diff="add" at="A">each of</phrase> which forms a
+               <p>An <elcode>xsl:function</elcode> declaration defines a
+                  <termref def="dt-stylesheet-function"/> which forms a
                      <termref def="dt-component"/> in its containing <termref def="dt-package"/>,
                   unless </p>
                <ulist>
                   <item>
-                     <p>there is another <termref def="dt-stylesheet-function">stylesheet
-                           function</termref> with the same name and <termref def="dt-arity">arity</termref>, and higher <termref def="dt-import-precedence">import
-                           precedence</termref>, or</p>
+                     <p>it is <termref def="dt-eclipsed"/>, or</p>
                   </item>
                   <item>
                      <p>the <code>override-extension-function</code> or <code>override</code>
-                        attribute has the value <code>no</code> and there is already a function with
-                        the same name and <termref def="dt-arity">arity</termref> in the in-scope
-                        functions.</p>
+                        attribute has the value <code>no</code> and there is already a 
+                        <termref def="dt-declared-function"/> 
+                        with the same name and an overlapping <termref def="dt-arity-range"/>
+                         in the static context.</p>
                   </item>
                </ulist>
                
-               <note diff="add" at="A"><p>Note that overriding of functions works independently for each <termref def="dt-arity">arity</termref>.
-               An <elcode>xsl:function</elcode> declaration <code>f:x</code> with two mandatory parameters might override the <code>f:x#2</code>
-                  function declared by another lower-precedence <elcode>xsl:function</elcode> element having three optional
-                  parameters, without overriding
-                  the <code>f:x#1</code> or <code>f:x#3</code> functions also declared by that lower-precedence declaration. 
-                  A call on <code>f:x(1)</code> with
-               a single argument then takes the default for the second argument from the overridden <elcode>xsl:function</elcode>
-               declaration (say this is 2), and makes a call on <code>f:x(1, 2)</code>, which has the effect of invoking the 
-                  overriding declaration of <code>f:x#2</code>.</p></note>
-
+               
 
                <p>The <termref def="dt-visibility">visibility</termref> of the
                   function in other packages depends on the value of the <code>visibility</code>
@@ -18365,27 +18380,26 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>The <code>override</code> attribute is a <termref def="dt-deprecated"/> synonym of <code>override-extension-function</code>,
                   retained for compatibility with XSLT 2.0. If both attributes are present then they
                      <rfc2119>must</rfc2119> have the same value.</p>
-               <p>
+               <!--<p>
                   <error spec="XT" type="static" class="SE" code="0770">
                      <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
                         contain <phrase diff="chg" at="A"><elcode>xsl:function</elcode>
-                           declarations declaring two or more functions</phrase> with the same <termref def="dt-expanded-qname">expanded QName</termref>, 
-                        the same <termref def="dt-arity">arity</termref>, and the same <termref def="dt-import-precedence">import
+                           declarations declaring two or more functions</phrase> with the same <termref def="dt-expanded-qname">expanded QName</termref>
+                        with overlapping <termref def="dt-arity-range">arity ranges</termref>, 
+                           and with the same <termref def="dt-import-precedence">import
                            precedence</termref>, unless there is another <elcode>xsl:function</elcode> declaration with the same
                            <termref def="dt-expanded-qname">expanded QName</termref> and arity, and
                         a higher import precedence.</p>
                   </error>
-               </p>
+               </p>-->
                <p>When the <elcode>xsl:function</elcode> declaration appears as a
                   child of <elcode>xsl:override</elcode>, there <rfc2119>must</rfc2119> be a
-                  stylesheet function with the same <termref def="dt-expanded-qname">expanded
-                     QName</termref> and <termref def="dt-arity">arity</termref> in the <termref def="dt-package">package</termref> referenced by the containing
+                  <termref def="dt-compatible"/> stylesheet function in the 
+                  <termref def="dt-package">package</termref> referenced by the containing
                      <elcode>xsl:use-package</elcode> element; the <termref def="dt-visibility">visibility</termref> of that function must be <code>public</code> or
-                     <code>abstract</code>, and the overriding and overridden functions
-                     <rfc2119>must</rfc2119> have the same argument types and result type.</p>
+                  <code>abstract</code> (See also <specref ref="package-overriding-components"/>.)</p>
                
-               <note diff="add" at="A"><p>For the interpretation of this rule in the presence of optional parameters, see
-               <specref ref="package-overriding-components"/>.</p></note>
+
 
             </div3>
             <div3 id="streamability-of-stylesheet-functions">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -4584,7 +4584,12 @@
                         is attempting to override <code>f:x#1</code>, but there is no such component.</p>
                      
                   </note>
-
+                  
+                  <note diff="add" at="variadicity">
+                     <p>TODO: the above rules seem tortuous. It's probably better to simplify them
+                     so the xsl:function declaration must more closely match the overridden xsl:function.</p>
+                  </note>
+                  
                   
 
 
@@ -4690,6 +4695,13 @@
                                  <code>streamability</code> attribute with the same value. [XSLT 3.0 Erratum E32, bug 30297]</p>
                            </item>
                         </olist>
+                        
+                        <p diff="add" at="variadicity">It is <rfc2119>recommended</rfc2119>, but not <rfc2119>required</rfc2119>,
+                        that the parameter names on the overriding function should be the same as on the overridden function.
+                        (This is to maintain backwards compatibility with XSLT 3.0.) If the parameter names are not the same,
+                        then the parameter names on the overriding function are effectively replaced with the names declared
+                        on the overridden function, so that any static function calls using keyword arguments to set the values
+                        of arguments must use the names defined on the overridden function.</p>
                      </item>
                      
                      <item>
@@ -15864,8 +15876,10 @@ and <code>version="1.0"</code> otherwise.</p>
                <item>
                   <p>As a child of <elcode>xsl:function</elcode> to define a parameter to a
                      stylesheet function, which may be supplied when the function is called from an
-                     XPath <termref def="dt-expression">expression</termref>. <termref def="dt-function-parameter">Function parameters</termref> are set
-                     positionally by means of the argument list in an XPath function call. </p>
+                     XPath <termref def="dt-expression">expression</termref>. 
+                     <termref def="dt-function-parameter">Function parameters</termref> are set
+                     <phrase diff="chg" at="variadicity">either positionally or by keyword</phrase>
+                     by means of the argument list in an XPath function call. </p>
                </item>
                <item>
                   <p>As a child of <elcode>xsl:iterate</elcode> to define a parameter that can vary
@@ -15924,9 +15938,9 @@ and <code>version="1.0"</code> otherwise.</p>
                   <tr>
                      <th rowspan="1" colspan="1"><elcode>xsl:function</elcode></th>
                      <td rowspan="1" colspan="1">mandatory</td>
-                     <td rowspan="1" colspan="1">disallowed</td>
                      <td rowspan="1" colspan="1">optional</td>
-                     <td rowspan="1" colspan="1"><term>yes</term></td>
+                     <td rowspan="1" colspan="1">optional</td>
+                     <td rowspan="1" colspan="1" diff="chg" at="variadicity"><term>yes</term>|no</td>
                      <td rowspan="1" colspan="1"><term>no</term></td>
                      <td rowspan="1" colspan="1"><term>no</term></td>
                   </tr>
@@ -16050,7 +16064,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      default value from the context item of the caller.
                      
               </p>
-                  <p>TODO: Reconsider this rule.</p>
+                  
                   </item>
                </ulist>
 
@@ -16069,6 +16083,10 @@ and <code>version="1.0"</code> otherwise.</p>
                      is permissible for the default value to depend on the values of other
                      parameters, or on the evaluation context, in which case the default must
                      effectively be evaluated on each invocation.</p>
+                  
+                  <p diff="add" at="variadicity">TODO: For function parameters with defaults, we probably don't want to allow the default
+                  for one parameter to depend on the value of another; but we allow it for template parameters,
+                  so perhaps we should be consistent.</p>
                </note>
 
                <p><termdef id="dt-explicit-default" term="explicit default">An <term>explicit
@@ -18086,26 +18104,27 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>
                <termdef id="dt-stylesheet-function" term="stylesheet function">An
                      <elcode>xsl:function</elcode> declaration declares the name, parameters, and
-                  implementation of a <term>stylesheet function</term> that can be called from any
+                  implementation of a family of <term>stylesheet functions</term> that can be called from any
                   XPath <termref def="dt-expression">expression</termref> within the <termref def="dt-stylesheet">stylesheet</termref>
                   (subject to visibility
                   rules).</termdef>
             </p>
             <?element xsl:function?>
-            <p>The <elcode>xsl:function</elcode> declaration defines a <termref def="dt-stylesheet-function">stylesheet function</termref> that can be called from
+            <p>The <elcode>xsl:function</elcode> declaration defines a family of 
+               <termref def="dt-stylesheet-function">stylesheet functions</termref> that can be called from
                any XPath <termref def="dt-expression">expression</termref> used in the <termref def="dt-stylesheet">stylesheet</termref> (including an XPath expression used
                within a predicate in a <termref def="dt-pattern">pattern</termref>). The
                   <code>name</code> attribute specifies the name of the function. The value of the
                   <code>name</code> attribute is an <termref def="dt-eqname">EQName</termref>, which is expanded as described in
                   <specref ref="qname"/>.</p>
             
-            <p diff="add" at="A">More strictly, the <elcode>xsl:function</elcode> declaration declares a set of 
-               <termref def="dt-stylesheet-function">stylesheet functions</termref> having the same name but (potentially)
+            <p diff="add" at="A">More specifically, the function family contains a set of 
+               <termref def="dt-stylesheet-function">stylesheet functions</termref> having the same name but 
             different <termref def="dt-arity"/>: see <specref ref="xsl-function-name"/> below.</p>
             <p>An <elcode>xsl:function</elcode> declaration can only appear as a <termref def="dt-top-level"/> element in a stylesheet module.</p>
 
             <p>The content of the <elcode>xsl:function</elcode> element consists of zero or more
-                  <elcode>xsl:param</elcode> elements that specify the formal arguments of the
+                  <elcode>xsl:param</elcode> elements that specify the formal parameters of the
                function, followed by a <termref def="dt-sequence-constructor">sequence
                   constructor</termref> that defines the value to be returned by the function.</p>
 
@@ -18113,9 +18132,10 @@ and <code>version="1.0"</code> otherwise.</p>
                <head>Function Name and Arity</head>
 
                <p>The name of the function is given by the <code>name</code>
-                  attribute; the arguments are defined by child <elcode>xsl:param</elcode> elements;
+                  attribute; the parameters are defined by child <elcode>xsl:param</elcode> elements;
                   and the return type is defined by the <code>as</code> attribute. Together these
-                  definitions constitute the <emph>function signature</emph>.</p>
+                  definitions constitute the <emph>function signature</emph> of each of the functions
+                  in the function family.</p>
                
                <p>
                   <error spec="XT" type="static" class="SE" code="0740">
@@ -18160,7 +18180,7 @@ and <code>version="1.0"</code> otherwise.</p>
                element.</p>
                
                <p diff="add" at="A">For example, the following <elcode>xsl:function</elcode> declaration
-               declares two functions, both named <code>f:compare</code>, one having arity 2 and one having
+               declares a family of two functions, both named <code>f:compare</code>, one having arity 2 and one having
                arity 3. The effect of calling <code>f:compare($a, $b)</code> is the same as the effect
                of calling <code>f:compare($a, $b, map{"order":"ascending"})</code>.</p>
                
@@ -18184,12 +18204,15 @@ and <code>version="1.0"</code> otherwise.</p>
             </div3>
             <div3 id="function-arguments">
                <head>Arguments</head>
-               <p>The <elcode>xsl:param</elcode> elements define the formal parameters to the
-                  function. These are interpreted positionally. When the function is called using a
+               <p diff="chg" at="variadicity">The <elcode>xsl:param</elcode> elements define the formal parameters to the
+                  function. In a static function call, these are referenced either positionally or by name.
+                  The rules for associating arguments in a static function call with parameter definitions
+                  in the function declaration are given in <xspecref spec="XP40" ref="id-eval-static-function-call"/>.
+                  <!--When the function is called using a
                   function call in an XPath <termref def="dt-expression">expression</termref>, the
                   first argument supplied is assigned to the first <elcode>xsl:param</elcode>
                   element, the second argument supplied is assigned to the second
-                     <elcode>xsl:param</elcode> element, and so on.</p>
+                     <elcode>xsl:param</elcode> element, and so on.--></p>
                
                <p diff="del" at="A">Because arguments to a stylesheet function call <rfc2119>must</rfc2119> all
                   be specified, the <elcode>xsl:param</elcode> elements within an


### PR DESCRIPTION
Two main separate but related features: (a) allow function declarations in XQuery and XSLT to define optional parameters, (b) allow static function calls (including partial function application) to take keyword arguments.