### PR TITLE
Update build automation to publish tests

### DIFF
--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -5,19 +5,50 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HAVE_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN != '' }}
+      # There’s no particular reason why the TEST_REPOSITORY should be
+      # a secret. This is the only way I can think of to initialize
+      # a variable based on the repository that the action is running in,
+      # rather than the *contents* of that repository.
+      UPDATE_TESTS: ${{ secrets.TEST_REPOSITORY != '' && secrets.ACCESS_TOKEN != '' }}
+      PUBLISH_TESTS_FROM: "master"
       BRANCH_NAME: ${{ github.ref_name }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Install dependencies
         run: sudo apt-get install tidy graphviz
+
+      - name: Checkout the tests repository
+        if: ${{ env.UPDATE_TESTS == 'true' && github.ref_name == env.PUBLISH_TESTS_FROM }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ secrets.TEST_REPOSITORY }}
+          token: ${{ secrets.ACCESS_TOKEN }}
+          ref: 'master'
+
+      - name: Save the tests
+        if: ${{ env.UPDATE_TESTS == 'true' && github.ref_name == env.PUBLISH_TESTS_FROM }}
+        run: |
+          mkdir -p /tmp/test-suite/{app,array,docs,fn,map,math,misc,op,prod,ser,upd,xs}
+          rsync -ar ./app/ /tmp/test-suite/app/
+          rsync -ar ./array/ /tmp/test-suite/array/
+          rsync -ar ./docs/ /tmp/test-suite/docs/
+          rsync -ar ./fn/ /tmp/test-suite/fn/
+          rsync -ar ./map/ /tmp/test-suite/map/
+          rsync -ar ./math/ /tmp/test-suite/math/
+          rsync -ar ./misc/ /tmp/test-suite/misc/
+          rsync -ar ./op/ /tmp/test-suite/op/
+          rsync -ar ./prod/ /tmp/test-suite/prod/
+          rsync -ar ./ser/ /tmp/test-suite/ser/
+          rsync -ar ./upd/ /tmp/test-suite/upd/
+          rsync -ar ./xs/ /tmp/test-suite/xs/
+
+      - name: Checkout the specifications
+        uses: actions/checkout@v3
 
       - name: Build
         run: |
           ./gradlew
 
-      - name: Deploy to specifications
+      - name: Deploy master to specifications
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && github.ref_name == 'master' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -26,7 +57,7 @@ jobs:
           branch: gh-pages
           target-folder: /specifications
 
-      - name: Deploy to branch
+      - name: Deploy other branches to branch
         if: ${{ env.HAVE_ACCESS_TOKEN == 'true' && github.ref_name != 'master' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
@@ -34,3 +65,28 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
           branch: gh-pages
           target-folder: /branch/${{ github.ref_name }}
+
+      - name: Update the saved tests
+        if: ${{ env.UPDATE_TESTS == 'true' && github.ref_name == env.PUBLISH_TESTS_FROM }}
+        run: rsync -ar build/test-suite/ /tmp/test-suite/
+
+      - name: Checkout the tests repository again
+        if: ${{ env.UPDATE_TESTS == 'true' && github.ref_name == env.PUBLISH_TESTS_FROM }}
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ secrets.TEST_REPOSITORY }}
+          token: ${{ secrets.ACCESS_TOKEN }}
+          ref: 'master'
+
+      - name: Update the tests repository
+        run: rsync -ar /tmp/test-suite/ ./
+
+      - name: Deploy the updated tests
+        if: ${{ env.UPDATE_TESTS == 'true' && github.ref_name == env.PUBLISH_TESTS_FROM }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          repository-name: ${{ secrets.TEST_REPOSITORY }}
+          token: ${{ secrets.ACCESS_TOKEN }}
+          branch: master
+          folder: .
+          target-folder: /

--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -79,6 +79,7 @@ jobs:
           ref: 'master'
 
       - name: Update the tests repository
+        if: ${{ env.UPDATE_TESTS == 'true' && github.ref_name == env.PUBLISH_TESTS_FROM }}
         run: rsync -ar /tmp/test-suite/ ./
 
       - name: Deploy the updated tests

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ if (legacyAntBuild) {
   }
 
   task "publish-xpath-functions-40"(type: Copy,
-                                    dependsOn: ["xpath-functions-40"]) {
+                                    dependsOn: ["xpath-functions-40", 'xpath_keyword_tests']) {
     into "build/www/xpath-functions-40"
     from "specifications/xpath-functions-40/html"
   }
@@ -114,12 +114,11 @@ if (legacyAntBuild) {
 } else {
   task "publish-xquery-40"(dependsOn: ["xquery_40", "xpath_40", "shared_40"]) {
   }
-  task "publish-xpath-functions-40"(dependsOn: ["xpath_functions_40"]) {
+  task "publish-xpath-functions-40"(dependsOn: ["xpath_functions_40", 'xpath_keyword_tests']) {
   }
   task "publish-xslt-40"(dependsOn: ["xslt_40"]) {
   }
 }
-
 
 // ============================================================
 
@@ -253,6 +252,21 @@ task fo_resources(
     index.println("</body>");
     index.println("</html>");
     index.close();
+  }
+}
+
+task xpath_keyword_tests(
+  group: "Test suite",
+  description: "Create the BuiltInKeywords.xml tests"
+) {
+  inputs.file "${projectDir}/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl"
+  inputs.file "${projectDir}/specifications/xpath-functions-40/src/function-catalog.xml"
+  outputs.file "${buildDir}/test-suite/misc/BuiltInKeywords.xml"
+
+  doLast {
+    transform("${projectDir}/specifications/xpath-functions-40/src/function-catalog.xml",
+              "${projectDir}/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl",
+              "${buildDir}/test-suite/misc/BuiltInKeywords.xml")
   }
 }
 

--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -12,6 +12,20 @@
    <xsl:strip-space elements="*"/>
    
    <xsl:template match="/">
+     <xsl:comment> ************************************************** </xsl:comment>
+     <xsl:text>&#10;</xsl:text>
+     <xsl:comment> * This file is generated automatically by the    * </xsl:comment>
+     <xsl:text>&#10;</xsl:text>
+     <xsl:comment> * qtspecs build process. It is committed to the  * </xsl:comment>
+     <xsl:text>&#10;</xsl:text>
+     <xsl:comment> * test repository automatically. Any changes you * </xsl:comment>
+     <xsl:text>&#10;</xsl:text>
+     <xsl:comment> * make to this file will be lost on the next     * </xsl:comment>
+     <xsl:text>&#10;</xsl:text>
+     <xsl:comment> * build. Have a nice day. The cake is a lie.     * </xsl:comment>
+     <xsl:comment> ************************************************** </xsl:comment>
+     <xsl:text>&#10;</xsl:text>
+
       <test-set name="misc-BuiltInKeywords">
          <description>Tests for keyword argument names to built-in functions: 4.0 proposal</description>        
          <dependency type="spec" value="XP40+ XQ40+"/>


### PR DESCRIPTION
Recent changes (#184) from MK have added a new automatically generated test to the F&O build.

This PR automates the construction and publication of new test sets from the `qtspecs` repository to the `qt4stests` repository.

N.B. The repository where tests are published (`qt4cg/qt4tests` in this case) must be the value of the TEST_REPOSITORY secret. If you want to automate publication to your own fork, just set the value of that secret accordingly.