### PR TITLE
Subtyping

### DIFF
--- a/schema/xsl-query.dtd
+++ b/schema/xsl-query.dtd
@@ -47,6 +47,7 @@
 <!ENTITY % xtermref.element "IGNORE">
 <!ENTITY % xtermref.attlist "IGNORE">
 <!ENTITY % author.element "IGNORE">
+<!ENTITY % code.element "IGNORE">
 
 <!-- add the "at" attribute to indicate when a change was last made to an element -->
 <!ENTITY % diff.att
@@ -144,6 +145,9 @@
 
 <!-- tweak author -->
 <!ELEMENT author (name, affiliation?, (email|loc)?)>
+
+<!-- Allow a 'code' element to contain a 'var' element for italicised code -->
+<!ELEMENT code (%tech.pcd.mix;|var)*>
 
 <!ATTLIST issue
         id              ID		#REQUIRED

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16853,6 +16853,65 @@ return fn:sort($in, $SWEDISH)
          </fos:example>
       </fos:examples>
    </fos:function>
+   
+   <fos:function name="op" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="op" return-type="function(item()*, item()*) as item()*">
+            <fos:arg name="operator" type="xs:string"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+         <fos:property>higher-order</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns a function whose effect is to apply a supplied binary operator to two arguments.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The supplied operator must be one of the following:</p>
+         <p><code><![CDATA[",", "and", "or", 
+            "+", "-", "*", "div", "idiv", "mod",
+            "=", "<", "<=", ">", ">=", "!=",
+            "eq", "lt", "le", "gt", "ge", "ne",
+            "<<", ">>", "is", "||", "|",
+            "union", "except", "intersect", "to",
+            "otherwise"]]></code></p>
+         <p>The result of calling <code>fn:op("⊙")</code>, where <code>⊙</code> is one of the above operators, is
+         the function represented by the XPath expression:</p>
+         <p><code>function($x, $y) { $x ⊙ $y }</code></p>
+         <p>For example, <code>op("+")</code> returns <code>function($x, $y) { $x + $y }</code>.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error is raised if the supplied argument is not one of the supported operators ([TODO: error code]).
+         </p>
+      </fos:errors>
+      <fos:notes>
+         <p>The function is useful in contexts where an arity-2 callback function needs to be supplied, and
+            a standard operator meets the requirement.</p>
+         <p>For example, the XSLT <code>xsl:map</code> instruction
+            has an <code>on-duplicates</code> attribute that expects such a function. Specifying
+         <code>on-duplicates="op(',')"</code> is equivalent to specifying 
+         <code>on-duplicates="function($x, $y) { $x, $y }</code></p>
+         <p>The function is also useful in cases where the choice of operator to apply is
+         made dynamically.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:for-each-pair(21 to 25, 1 to 5, fn:op("+"))</fos:expression>
+               <fos:result>22, 24, 26, 28, 30</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:for-each-pair(21 to 25, 1 to 5, fn:op("-"))</fos:expression>
+               <fos:result>20, 20, 20, 20, 20</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
 
    <fos:function name="same-key" prefix="op">
       <fos:signatures>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11669,6 +11669,9 @@ let $newi := $o/tool</eg>
          multiple references to the same node. So, for example, <code>fn:count(fn:replicate(/, 6)|())</code>
          returns 1, because the <code>fn:replicate</code> call creates duplicates, and the
             union operation eliminates them.</p>
+         <p>[TODO: the use of type <code>xs:nonNegativeInteger</code> for the second argument
+         assumes we will accept the proposal to allow downcasting in the coercion rules for
+         function arguments. MHK 2022-10-04.]</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -11703,7 +11706,7 @@ let $newi := $o/tool</eg>
          </fos:example>        
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
+         <fos:version version="4.0">New in 4.0. Accepted 2022-10-04.</fos:version>
       </fos:history>
    </fos:function>
    

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -411,7 +411,7 @@
 
       <error spec="XP" code="0051" class="ST" type="static">
          <p>It is a <termref def="dt-static-error">static error</termref> if an <termref
-               def="dt-expanded-qname">expanded QName</termref> used as an <nt def="ItemType"/>
+               def="dt-expanded-qname">expanded QName</termref> used as an <nt def="ItemType">ItemType</nt>
                in a <nt def="SequenceType">SequenceType</nt> is not defined
             in the <termref def="dt-static-context"/> either as a <termref def="dt-type-alias"/>
             or as a <termref

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1882,19 +1882,29 @@ data (step DQ4), and on the <termref
                      def="dt-dynamic-context"
                   >dynamic context</termref> (step DQ5)&mdash;for example, by binding values to variables.</p>
 
-               <p>
-                  <termdef term="dynamic type" id="dt-dynamic-type"
-                        >A <term>dynamic type</term> is associated with each value as it is computed. The dynamic type of a value may be more specific than the <termref
-                        def="dt-static-type"
-                        >static type</termref> of the expression that computed it (for example, the  static type of an expression might be <code>xs:integer*</code>, denoting a sequence of zero or more integers, but at evaluation time its value may have the dynamic type <code>xs:integer</code>, denoting exactly one integer.)</termdef>
+               <p diff="chg" at="B">
+                  <termdef term="dynamic type" id="dt-dynamic-type">
+                  Every value matches one or more <termref def="dt-sequence-type">sequence types</termref>. 
+                     A value is said to have a <term>dynamic type</term> <var>T</var> if it matches (or <term>is an instance of</term>) 
+                     the sequence type <var>T</var>.</termdef></p>
+               <p diff="chg" at="B">In many cases (but not all), one of the dynamic types that a value matches will 
+                     be a subtype of all the others, in which case it makes sense to speak of "the dynamic type" of the value as 
+                     meaning this single most specific type. In other cases (examples are empty maps and empty arrays) none of the 
+                     dynamic types is more specific than all the others.</p>
+               <note diff="chg" at="B"><p>For atomic values in particular, there is always one dynamic type that is specifically
+               associated with the value, so we can refer to the <termref def="dt-dynamic-type"/> of an atomic value without ambiguity; this will
+               be a <termref def="dt-subtype"/> of all the other types that it matches.</p></note>
+               
+               <p diff="chg" at="B">A value may conform with a dynamic type that is more specific than the <termref def="dt-static-type"/> 
+                  of the expression that computed it (for example, the static type of an expression might be <code>xs:integer*</code>, 
+                  denoting a sequence of zero or more integers, but at evaluation time its value may be an instance of <code>xs:integer</code>, 
+                  denoting exactly one integer).
                </p>
-               <p> If an operand of an expression is found
-to have a <termref def="dt-dynamic-type"
-                     >dynamic type</termref> that is not appropriate for that operand, a
-<termref
-                     def="dt-type-error">type error</termref> is
-raised <errorref class="TY"
-                     code="0004"/>.</p>
+               
+               <p diff="chg" at="B">If an operand of an expression does not have a <termref def="dt-dynamic-type"
+                     >dynamic type</termref> that is a <termref def="dt-subtype"/> of the <termref def="dt-static-type"/>
+                  required for that operand, a <termref def="dt-type-error">type error</termref> is
+                  raised <errorref class="TY" code="0004"/>.</p>
                <p>Even though static typing can catch many <termref def="dt-type-error"
                      >type errors</termref> before an expression is executed, it is possible for an expression to raise an error during evaluation that was not detected by static  analysis. For example, an expression may contain a cast of a string into an integer, which is statically valid. However, if the actual value of the string at run time cannot be cast into an integer, a <termref
                      def="dt-dynamic-error"
@@ -3189,10 +3199,20 @@ defined in <xspecref
          <p>
             <termdef id="dt-sequence-type" term="sequence type"
                   >A <term>sequence type</term> is a type that can be expressed using the <nt
-                  def="SequenceType"
-                  >SequenceType</nt>
-syntax. Sequence types are used whenever it is necessary to refer to a type in an &language; expression. The term <term>sequence type</term> suggests that this syntax is used to describe the type of an &language; value, which is always a sequence.</termdef>
+                  def="SequenceType">SequenceType</nt>
+                  syntax. Sequence types are used whenever it is necessary to refer to a type in an &language; expression. 
+                  The term <term>sequence type</term> suggests that this syntax is used to describe the type of an &language; value, 
+               which is always a sequence.</termdef>
          </p>
+      <p diff="add" at="B">
+         <termdef id="dt-item-type" term="item type"
+            >An <term>item type</term> is a type that can be expressed using the <nt
+               def="ItemType">ItemType</nt> syntax, which forms part of the <nt def="SequenceType">SequenceType</nt>
+            syntax. Item types match individual <termref def="dt-item">items</termref>.</termdef>
+         With the exception of the generic types <code>item()</code>, which matches all items, and <code>xs:error</code>,
+         which matches no items, item types match either <termref def="dt-atomic-value">atomic values</termref>,
+         <termref def="dt-node">nodes</termref>, or <xtermref spec="DM31" ref="dt-function-item">functions</xtermref>.
+      </p>
          <p>
             <termdef id="dt-schema-type" term="schema type"
                   >A <term>schema type</term> is a type that is (or could be) defined using the facilities of <bibref
@@ -3734,15 +3754,12 @@ the schema type named <code>us:address</code>.</p>
 
          <div2 id="id-sequencetype-matching">
             <head>Sequence Type Matching</head>
-            <p>
+            <p diff="chg" at="B">
                <termdef id="dt-sequencetype-matching" term="SequenceType matching">
-                  <term>SequenceType matching</term> compares the <termref def="dt-dynamic-type"
-                     >dynamic type</termref> of a value
-		  with an expected <termref
+                  <term>SequenceType matching</term> compares a value with an expected <termref
                      def="dt-sequence-type"
-                  >sequence type</termref>. </termdef> For example, an <code>instance of</code> expression returns <code>true</code> if the <termref
-                  def="dt-dynamic-type"
-                  >dynamic type</termref> of a given value matches a given <termref
+                  >sequence type</termref>. </termdef> For example, an <code>instance of</code> expression 
+               returns <code>true</code> if a given value matches a given <termref
                   def="dt-sequence-type"
                >sequence type</termref>, or <code>false</code> if it does not.</p>
 
@@ -3753,10 +3770,10 @@ the schema type named <code>us:address</code>.</p>
                   >An &language; implementation must be able to determine relationships among the types in ISSDs used in different modules of the same query.</phrase>
             </p>
 
-            <p>
+            <p diff="chg" at="B">
                <termdef term="subtype substitution" id="dt-subtype-substitution"
-                     >The use of a value whose <termref def="dt-dynamic-type"
-                     >dynamic type</termref> is derived from an
+                     >The use of a value that has a <termref def="dt-dynamic-type"/>
+                      that is a <termref def="dt-subtype"/> of the
 		  expected type is known as <term>subtype substitution</term>.</termdef>
 		  Subtype substitution does not change the actual type of a value. For
 		  example, if an <code>xs:integer</code> value is used where an
@@ -3982,7 +3999,7 @@ the schema type named <code>us:address</code>.</p>
                <div3 id="id-atomic-and-union-types">
                   <head>Atomic and Union Types</head>
                   
-                  <p>A <termref def="dt-generalized-atomic-type"/> may be expressed as an <nt def="ItemType"/> in 
+                  <p>A <termref def="dt-generalized-atomic-type"/> may be expressed as an <nt def="ItemType">ItemType</nt> in 
                   any of the following ways:</p>
                   
                   <ulist>
@@ -3990,10 +4007,10 @@ the schema type named <code>us:address</code>.</p>
                      or a <termref def="dt-pure-union-type"></termref></p></item>
                      <item><p>Using a QName that identifies a <termref def="dt-type-alias"/> that resolves
                         to a <termref def="dt-generalized-atomic-type"/>.</p></item>
-                     <item><p>Using a <nt def="ParenthesizedItemType"/> where the parentheses enclose
+                     <item><p>Using a <nt def="ParenthesizedItemType">ParenthesizedItemType</nt> where the parentheses enclose
                         a <termref def="dt-generalized-atomic-type"/>.</p></item>
-                     <item><p>Using a <nt def="LocalUnionType"/> as described below.</p></item>
-                     <item><p>Using an <nt def="EnumerationType"/> as described below.</p></item>
+                     <item><p>Using a <nt def="LocalUnionType">LocalUnionType</nt> as described below.</p></item>
+                     <item><p>Using an <nt def="EnumerationType">EnumerationType</nt> as described below.</p></item>
                   </ulist>
                
                
@@ -4700,7 +4717,13 @@ name.</p>
          </div3>
          <div3 id="id-function-map-array-tests">
             <head>Function, Map, and Array Tests</head>
-            <ulist>
+            
+            <p>The following sections describe the syntax for <termref def="dt-item-type">item types</termref>
+            for function, including arrays and maps.</p>
+            
+            <p>The <termref def="dt-subtype"/> relation among these types is described in the various subsections
+            of <specref ref="id-itemtype-subtype"/>.</p>
+            <!--<ulist>
                <item>
                   <p>The <code>ItemType</code>
                      <code>map(K, V)</code> matches an item <var>M</var> if (a) <var>M</var> is a 
@@ -4736,7 +4759,7 @@ name.</p>
                      <code>array(*)</code> matches any array regardless of its contents.</p>
                </item>
                
-            </ulist>
+            </ulist>-->
             <div4 id="id-function-test">
                <head>Function Test</head>
 
@@ -4885,6 +4908,8 @@ name.</p>
   is an instance of <code>X</code> and the type of every value is an
   instance of <code>Y</code>.</p>
                
+               
+               
                <p diff="add" at="A">Although the grammar for <code>TypedMapTest</code>
                allows the key to be described using the full <code>ItemType</code> syntax, the item type used must be
                a <termref def="dt-generalized-atomic-type"/>. [TODO: error code].</p>
@@ -4989,6 +5014,9 @@ name.</p>
                         >function coercion</termref>n ensures that <code>$M</code> can be used successfully 
   anywhere that the required type is <code>function(xs:integer) as xs:string</code>.</p>
                </note>
+               
+               <p>Rules defining whether one map type is a <termref def="dt-subtype"/> of another
+               are given in <specref ref="id-item-subtype-maps"/>.</p>
 
             </div4>
             
@@ -5152,7 +5180,8 @@ declare function flatten($tree as tree) as item()* {
 		                <code>match="record(longitude, latitude)"</code></p>
                </note>
 
-
+               <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
+                  are given in <specref ref="id-item-subtype-records"/>.</p>
 
             </div4>
 
@@ -5248,6 +5277,9 @@ declare function flatten($tree as tree) as item()* {
   operator. In such cases, a type error will only occur if an actual
   call on the array (treated as a function) returns a value that is
   not an instance of the required return type.</p>
+               
+               <p>Rules defining whether one array type is a <termref def="dt-subtype"/> of another
+                  are given in <specref ref="id-item-subtype-arrays"/>.</p>
 
             </div4>
          </div3>
@@ -5333,23 +5365,68 @@ declare function flatten($tree as tree) as item()* {
          <div2 id="id-sequencetype-subtype">
             <head>Subtype Relationships</head>
 
-            <p>
-  Given two <termref def="dt-sequence-type"
-                  >sequence types</termref>, it is possible to determine if one is a subtype of the other.
-  <termdef
-                  term="subtype" id="dt-subtype">A <termref def="dt-sequence-type"
+            <p diff="chg" at="B"><termdef term="subtype" id="dt-subtype">Given two 
+               <termref def="dt-sequence-type">sequence types</termref>
+               or <termref def="dt-item-type">item types</termref>, it is possible to determine if one 
+               is a <term>subtype</term> of the other. A type <code>A</code> is a subtype of <code>B</code>
+               if it can be established that every value matched by <code>A</code> is also
+               matched by <code>B</code>.</termdef></p>
+            
+            <note diff="add" at="B"><p>Under this definition, <code>subtype(A, A)</code> is always true:
+               every type is a subtype of itself.</p></note>
+            
+            <p diff="chg" at="B">The rules for deciding whether one <termref def="dt-sequence-type"/> is a subtype
+               of another are given in <specref ref="id-seqtype-subtype"/>. They rule for deciding whether
+               one <termref def="dt-item-type"/> is a subtype of another are given in <specref ref="id-itemtype-subtype"/>.</p>
+  
+ <!-- A <termref def="dt-sequence-type"
                      >sequence type</termref>
                   <code>A</code> is a <term>subtype</term> of a sequence type <code>B</code>
-  if the judgement <code>subtype(A, B)</code> is true.</termdef>
+  if the judgement <code>subtype(A, B)</code> is true.
   
-  When the judgement <code>subtype(A, B)</code> is true, it is always the case that for any value <code>V</code>, <code>(V instance of A)</code> implies <code>(V instance of B)</code>.</p>
+  When the judgement <code>subtype(A, B)</code> is true, it is always the case that for any 
+               value <code>V</code>, <code>(V instance of A)</code> implies <code>(V instance of B)</code>.</p>
+  -->          
+            
+            
+            <note diff="add" at="B"><p>The subtype relationship is not acyclic. There are cases where <code>subtype(A, B)</code> and
+               <code>subtype(B, A)</code> are both true. This implies that <code>A</code> and <code>B</code>
+               have the same value space, but they can still be different types. For example this applies when <code>A</code>
+               is a union type with member types <code>xs:string</code> and <code>xs:integer</code>, while 
+               <code>B</code> is a union type with member types <code>xs:string</code> and <code>xs:integer</code>.
+               These are different types (<code>"23" cast as A</code> produces an integer, while <code>"23" cast as B</code>
+               produces a string) but they have the same value space.
+            </p></note>
 
 
             <div3 id="id-seqtype-subtype">
-               <head>The judgement <code>subtype(A, B)</code>
-               </head>
+               <head>Subtypes of Sequence Types</head>
 
-               <p>The judgement <code>subtype(A, B)</code> determines if the <termref
+               <p>We use the notation <code>A ⊑ B</code>, or <code>subtype(A, B)</code> to indicate that
+                  a <termref def="dt-sequence-type"/> <code>A</code> is a <termref def="dt-subtype"/> of a sequence type <code>B</code>.
+               This section defines the rules for deciding whether any two sequence types have this relationship.</p>
+               
+               <p>To define the rules, we divide sequence types into six categories:</p>
+               
+               <ulist>
+                  <item><p>The category <code>empty</code> includes the sequence types <code>empty-sequence()</code>,
+                   <code>xs:error*</code> and <code>xs:error?</code>. All these sequence types
+                  match the empty sequence as their only instance.</p></item>
+                  <item><p>The category <code>void</code> includes the sequence types <code>xs:error</code> and <code>xs:error+</code>,
+                  which have no instances (not even the empty sequence).</p></item>
+                  <item><p>The categories <code>X?</code>, <code>X*</code>, <code>X</code> and <code>X+</code> includes all sequence types 
+                     having an item type <code>X</code> other than <code>xs:error</code>, together with an occurrence indicator of 
+                     <code>?</code> (zero or more), <code>*</code> (one or more), absent (exactly one), or <code>+</code> (one or more)
+                     respectively. We use the notation <var>X/i</var> to indicate the item type of such a sequence type.</p></item>
+               </ulist>
+               
+               <p>The judgement <code>A ⊑ B</code> is then determined by the categories of the two sequence types, as defined
+               in the table below. In many cases the relationship depends on the relationship between the item types of <code>A</code>
+                  and <code>B</code>, as determined in <specref ref="id-itemtype-subtype"/>.</p>
+               
+               <!--<p>The judgement <code>A ⊑ B</code> (read as <term>sequence type A is a subtype of sequence type B</term>), 
+                  applied to two <termref
+                     def="dt-sequence-type">sequence types</termref>, determines if the <termref
                      def="dt-sequence-type">sequence type</termref>
                   <code>A</code>
     is a <termref def="dt-subtype"
@@ -5364,7 +5441,7 @@ declare function flatten($tree as tree) as item()* {
     The result of the <code>subtype(A, B)</code> judgement can be determined from the table below, which makes use of the auxiliary judgement <code>subtype-itemtype(Ai, Bi)</code> defined
     in <specref
                      ref="id-itemtype-subtype"/>.
-    </p>
+    </p>-->
 
                <table role="medium">
                   <tbody>
@@ -5372,34 +5449,36 @@ declare function flatten($tree as tree) as item()* {
                         <th rowspan="2" colspan="2"/>
                         <th colspan="6">
                            <termref def="dt-sequence-type">Sequence type</termref>
-                           <code>B</code>
+                           <var>B</var>
                         </th>
                      </tr>
                      <tr>
                         <th>
-                           <code>empty-sequence()</code>
+                           <code>empty</code>
                         </th>
                         <th>
-                           <code>Bi?</code>
+                           <code><var>B/i</var>?</code>
                         </th>
                         <th>
-                           <code>Bi*</code>
+                           <code><var>B/i</var>*</code>
                         </th>
                         <th>
-                           <code>Bi</code>
+                           <code><var>B/i</var></code>
                         </th>
                         <th>
-                           <code>Bi+</code>
+                           <code><var>B/i</var>+</code>
                         </th>
-                        <th>xs:error</th>
+                        <th>
+                           <code>void</code>
+                        </th>
                      </tr>
                      <tr>
                         <th rowspan="6">
                            <termref def="dt-sequence-type">Sequence type</termref>
-                           <code>A</code>
+                           <var>A</var>
                         </th>
                         <th>
-                           <code>empty-sequence()</code>
+                           <code>empty</code>
                         </th>
                         <td>true</td>
                         <td>true</td>
@@ -5410,14 +5489,14 @@ declare function flatten($tree as tree) as item()* {
                      </tr>
                      <tr>
                         <th>
-                           <code>Ai?</code>
+                           <code><var>A/i</var>?</code>
                         </th>
                         <td>false</td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>false</td>
                         <td>false</td>
@@ -5425,12 +5504,12 @@ declare function flatten($tree as tree) as item()* {
                      </tr>
                      <tr>
                         <th>
-                           <code>Ai*</code>
+                           <code><var>A/i</var>*</code>
                         </th>
                         <td>false</td>
                         <td>false</td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>false</td>
                         <td>false</td>
@@ -5438,41 +5517,41 @@ declare function flatten($tree as tree) as item()* {
                      </tr>
                      <tr>
                         <th>
-                           <code>Ai</code>
+                           <code><var>A/i</var></code>
                         </th>
                         <td>false</td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>false</td>
                      </tr>
                      <tr>
                         <th>
-                           <code>Ai+</code>
+                           <code><var>A/i</var>+</code>
                         </th>
                         <td>false</td>
                         <td>false</td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>false</td>
                         <td>
-                           <code>subtype-itemtype(Ai, Bi)</code>
+                           <code><var>A/i</var> ⊆ <var>B/i</var></code>
                         </td>
                         <td>false</td>
                      </tr>
                      <tr>
                         <th>
-                           <code>xs:error</code>
+                           <code>void</code>
                         </th>
                         <td>true</td>
                         <td>true</td>
@@ -5485,145 +5564,215 @@ declare function flatten($tree as tree) as item()* {
                </table>
 
 
-               <p>
-                  <code>xs:error+</code> is treated the same way as <code>xs:error</code> in the above table. <code>xs:error?</code> and <code>xs:error*</code> are treated the same way as <code>empty-sequence()</code>.</p>
+            <!--   <p>
+                  <code>xs:error+</code> is treated the same way as <code>xs:error</code> in the above table. 
+                  <code>xs:error?</code> and <code>xs:error*</code> are treated the same way as <code>empty-sequence()</code>.</p>-->
 
             </div3>
 
             <div3 id="id-itemtype-subtype">
-               <head>The judgement <code>subtype-itemtype(A, B)</code>
-               </head>
+               <head>Subtypes of Item Types</head>
+               
+               <p>We use the notation <code>A ⊆ B</code>, or <code>itemtype-subtype(A, B)</code> to indicate that
+                  a <termref def="dt-item-type"/> <code>A</code> is a <termref def="dt-subtype"/> of an item type <code>B</code>.
+                  This section defines the rules for deciding whether any two item types have this relationship.</p>
+               
 
-               <p>The judgement <code>subtype-itemtype(A, B)</code> determines whether the <nt
-                     def="ItemType">ItemType</nt>
-                  <code>A</code>
-    is a <termref def="dt-subtype"
-                     >subtype</termref> of the ItemType <code>B</code>.</p>
+               <!--<p>The judgement <code>A ⊆ B</code>, read as <term>A is a subtype of B</term>, determines whether the <nt
+                     def="ItemType">ItemType</nt> <code>A</code> is a <termref def="dt-subtype"
+                     >subtype</termref> of the ItemType <code>B</code>.</p>-->
                
                <p diff="add" at="A">Before applying these rules, any ItemType written
                as <code>item-type(N)</code> is replaced with the definition of the named item type
                   <code>N</code>, recursively. The rules are written in terms of the lexical
-               form of the two ItemTypes, but it is assumed that trivial variations are first 
+                  form of the two <termref def="dt-item-type">item types</termref>, but it is 
+                  assumed that trivial variations are first 
                eliminated: comments and unnecessary whitespace are removed, lexical QNames are
                replaced by URI-qualified names applying appropriate defaults in the case of unprefixed
                names, equivalent forms such as <code>element()</code> and <code>element(*)</code>
                are normalized.</p>
                
-               <p><code>A</code> is a subtype of <code>B</code>
-    if and only if at least one of the following conditions applies:</p>
+               <p>The relationship <code>A ⊆ B</code> is true
+               if and only if at least one of the conditions listed in the following subsections applies:</p>
 
-               <olist>
-                  <item>
-                     <p>
-                        <emph>General rules:</emph>
-                     </p>
+               <div4 id="id-item-subtype-general">
+                  <head>General Rules</head>
+                  <p>Given <termref def="dt-item-type">item types</termref> <var>A</var> and <var>B</var>, 
+                     <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+ 
+ 
                      <olist>
                         <item diff="chg" at="A">
-                           <p><code>A</code> is <code>xs:error</code>.</p>
+                           <p><var>A</var> is <code>xs:error</code>.</p>
                         </item>
                         <item>
-                           <p><code>B</code> is <code>item()</code>.</p>
+                           <p><var>B</var> is <code>item()</code>.</p>
                         </item>
                         <item diff="chg" at="A">
-                           <p><code>A</code> and <code>B</code> are the same <code>ItemType</code>.</p> 
+                           <p><var>A</var> and <var>B</var> are the same <termref def="dt-item-type"/>.</p> 
                         </item>
                         <item diff="chg" at="A">
-                           <p>There is an <nt def="ItemType">ItemType</nt>
-                              <code>C</code> such that <code>subtype-itemtype(A, C)</code>
-                        and <code>subtype-itemtype(C, B)</code>. (This is referred to below as the <term>transitivity rule</term>).</p>
+                           <p>There is an <termref def="dt-item-type"/>
+                              <var>X</var> such that <code><var>A</var> ⊆ <var>X</var></code>
+                              and <code><var>X</var> ⊆ <var>B</var></code>. (This is referred to below as the <term>transitivity rule</term>).</p>
                         </item>
                      </olist>
-                  </item>
-                  <item>
-                     <p>
-                        <emph>Conditions for atomic and union types:</emph>
-                     </p>
+               </div4>
+               <div4 id="id-item-subtype-atomic">
+                  <head>Atomic and Union Types</head>
+                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+  
                      <olist>
                         <item>
-                           <p><code>A</code> and <code>B</code> are <termref def="dt-generalized-atomic-type">generalized atomic types</termref>, 
-                              and <code>derives-from(A, B)</code> returns <code>true</code>.</p>
+                           <p><var>A</var> and <var>B</var> are <termref def="dt-generalized-atomic-type">generalized atomic types</termref>, 
+                              and <code>derives-from(<var>A</var>, <var>B</var>)</code> returns <code>true</code>.</p>
+                           <p>The <code>derives-from</code> relationship is defined in <specref ref="id-sequencetype-matching"/>.</p>
+                           <note diff="add" at="B"><p>For example:</p>
+                              <ulist>
+                                 <item><p><code>xs:integer ⊆ xs:decimal</code> because <code>xs:integer</code> is derived
+                                 by restriction from <code>xs:decimal</code>.</p></item>
+                                 <item><p><code>xs:decimal ⊆ xs:numeric</code> because <code>xs:numeric</code> is a pure union
+                                    type that includes <code>xs:decimal</code> as a member type.</p></item>
+                              </ulist>
+                           </note>
                         </item>
                         <item>
-                           <p><code>A</code> is the name of a pure union type, 
-                              and every type <code>T</code> in the transitive membership of <code>A</code>
-                              satisfies <code>subtype-itemType(T, B)</code>.</p>
+                           <p><var>A</var> is a <termref def="dt-pure-union-type"/>, 
+                              and every type <var>T</var> in the transitive membership of <var>A</var>
+                              satisfies <code><var>T</var> ⊆ <var>B</var></code>.</p>
+                           <note diff="add" at="B"><p>For example:</p>
+                              <olist>
+                                 <item><p><code>union(xs:short, xs:long) ⊆ xs:integer</code>
+                                    because <code>xs:short ⊆ xs:integer</code> and <code>xs:long ⊆ xs:integer</code>.</p></item>
+                                 <item><p><code>union(P, Q) ⊆ union(P, Q, R)</code>
+                                 because <code>P ⊆ union(P, Q, R)</code> and <code>Q ⊆ union(P, Q, R)</code>.</p></item>
+                              </olist>                             
+                           </note>
+                           <note><p>This rule applies both when <code>A</code> is a schema-defined union type
+                              and when it is a <nt def="LocalUnionType">LocalUnionType</nt>.
+                           </p></note>
                         </item>
                         <item diff="add" at="A">
-                           <p><code>A</code> is a <code>LocalUnionType</code> in the form <code>union(T1, T2, ...)</code>
-                              and every type <code>T</code> in (T1, T2, ...) satisfies <code>subtype-itemType(T, B)</code>.</p>
-                        </item>
-                        <item diff="add" at="A">
-                           <p><code>A</code> is an <termref def="dt-EnumerationType"/>, and <code>B</code> matches
-                              every string literal in the enumeration of <code>A</code>.</p>
+                           <p><var>A</var> is an <termref def="dt-EnumerationType"/>, and <var>B</var> matches
+                              every string literal in the enumeration of <var>A</var>.</p>
                            <note>
-                              <p>This means, for example, that the type <code>enum("red", "green", "blue")</code>
-                              is a subtype of <code>enum("red", "green", "blue", "yellow")</code>, as
-                              well as being a subtype of <code>xs:string</code>.</p>
+                              <p>For example:</p>
+                              <olist>
+                                 <item><p><code>enum("red", "green", "blue") ⊆ xs:string</code></p></item>
+                                 <item><p><code>enum("red", "green", "blue") ⊆ enum("red", "green", "blue", "yellow")</code></p></item>
+                              </olist>
                            </note>
                         </item>
                      </olist>
-                  </item>
-                  <item>
-                     <p>
-                        <emph>Conditions for node types:</emph>
-                     </p>
+               </div4>
+               <div4 id="id-item-subtype-nodes">
+                  <head>Node Types: General Rules</head>
+                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  
                      <olist>
                         <item>
-                           <p><code>A</code> is a <nt def="KindTest">KindTest</nt> and <code>B</code> is <code>node()</code>.</p>
+                           <p><var>A</var> is a <nt def="KindTest">KindTest</nt> and <var>B</var> is <code>node()</code>.</p>
+                           <note><p>For example <code>comment() ⊆ node()</code>.</p></note>
                         </item>
                         <item>
-                           <p><code>A</code> is <code>processing-instruction(N)</code> for any name <code>N</code>,
-                              and <code>B</code> is <code>processing-instruction()</code>.</p>
+                           <p><var>A</var> is <code>processing-instruction(<var>N</var>)</code> for any name <var>N</var>,
+                              and <var>B</var> is <code>processing-instruction()</code>.</p>
                         </item>
                         <item>
-                           <p><code>A</code> is <code>document-node(E)</code> for any <nt def="ElementTest">ElementTest</nt> <code>E</code>,
-                              and <code>B</code> is <code>document-node()</code>.</p>
-                        </item>
-                        <item>
-                           <p>All the following are true:</p>
-                           <olist>
-                              <item><p><code>A</code> is <code>document-node(Ae)</code></p></item>
-                              <item><p><code>B</code> is <code>document-node(Be)</code></p></item>
-                              <item><p><code>subtype-itemtype(Ae, Be)</code></p></item>
-                           </olist>
-                        </item>
-                        <item>
-                           <p><code>A</code> is an <nt def="ElementTest">ElementTest</nt> and
-                              <code>B</code> is <code>element()</code> (or <code>element(*)</code>).</p>
+                           <p><var>A</var> is <code>document-node(<var>E</var>)</code> for any <nt def="ElementTest">ElementTest</nt> <var>E</var>,
+                              and <var>B</var> is <code>document-node()</code>.</p>
                         </item>
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is either <code>element(An)</code> or <code>element(An, T)</code>  
-                                 or <code>element(An, T?)</code> for some type T</p></item>
-                              <item><p><code>B</code> is either <code>element(Bn)</code> or <code>element(Bn, xs:anyType?)</code></p></item>
-                              <item><p>the <termref def="dt-expanded-qname">expanded QName</termref> of <code>An</code> 
-                                 equals the <termref def="dt-expanded-qname">expanded QName</termref> of <code>Bn</code>.</p></item>
+                              <item><p><var>A</var> is <code>document-node(<var>A/e</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>document-node(<var>B/e</var>)</code></p></item>
+                              <item><p><code><var>A/e</var> ⊆ <var>B/e</var></code></p></item>
                            </olist>
+                           <note><p>For example, <code>document-node(element(title)) ⊆ document-node(element(*))</code>.</p></note>
+                        </item>
+                     </olist>
+               </div4>
+               <div4 id="id-item-subtype-elements">
+                  <head>Node Types: Element Tests</head>
+                  
+                  <p><termdef id="dt-wildcard-matches" term="wildcard-matches">In these rules, if <var>M</var> and <var>N</var> 
+                     are <nt def="NameTest">NameTests</nt>, 
+                     then <var>M</var> <term>wildcard-matches</term> <var>N</var> is true if any of the following apply:</termdef></p>
+                  
+                  <olist>
+                     <item><p><var>M</var> and <var>N</var> are the same <code>NameTest</code>.</p></item>
+                     <item><p><var>M</var> is an <code>EQName</code> and <var>N</var> is a 
+                        <nt def="Wildcard">Wildcard</nt> that matches <var>M</var>.</p></item>
+                     <item><p><var>N</var> is the <nt def="Wildcard">Wildcard</nt> <code>*</code>.</p></item>
+                  </olist>
+                  
+                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply.</p>
+                  
+                  <olist>
+                        <item>
+                           <p>All the following are true:</p>
+                           <olist>
+                              <item><p><var>A</var> is either <code>element(<var>A/n</var>)</code> or <code>element(<var>A/n</var>, <var>T</var>)</code>  
+                                 or <code>element(<var>A/n</var>, <var>T</var>?)</code> for some type <var>T</var></p></item>
+                              <item><p><var>B</var> is either <code>element(<var>B/n</var>)</code> or <code>element(<var>B/n</var>, xs:anyType?)</code></p></item>
+                              <item><p><var>A/n</var> <termref def="dt-wildcard-matches"/> <var>B/n</var></p></item>
+                              
+                           </olist>
+                           <note>
+                              <p>For example:</p>
+                              <olist>
+                                 <item><p><code>element(title) ⊆ element(*)</code></p></item>
+                                 <item><p><code>element(title, xs:string) ⊆ element(*)</code></p></item>
+                                 <item><p><code>element(title, xs:string?) ⊆ element(*)</code></p></item>
+                                 <item><p><code>element(title) ⊆ element(title, xs:anyType?)</code></p></item>
+                                 <item><p><code>element(title, xs:integer) ⊆ element(title, xs:anyType?)</code></p></item>
+                                 <item><p><code>element(title, xs:string?) ⊆ element(title, xs:anyType?)</code></p></item>
+                                 <item><p><code>element(my:title) ⊆ element(*:title)</code></p></item>
+                                 <item><p><code>element(my:title) ⊆ element(my:*)</code></p></item>
+                              </olist>
+                           </note>
                         </item>
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>element(An, At)</code></p></item>
-                              <item><p><code>B</code> is <code>element(Bn, Bt)</code></p></item>
-                              <item><p>the <termref def="dt-expanded-qname">expanded QName</termref> of <code>An</code> equals the <termref
-                                    def="dt-expanded-qname">expanded QName</termref> of <code>Bn</code></p></item>
-                              <item><p><code>derives-from(At, Bt)</code>.</p></item>
+                              <item><p><var>A</var> is <code>element(<var>A/n</var>, <var>A/t</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>element(<var>B/n</var>, <var>B/t</var>)</code></p></item>
+                              <item><p><var>A/n</var> <termref def="dt-wildcard-matches"/> <var>B/n</var></p></item>
+                              <item><p><code>derives-from(<var>A/t</var>, <var>B/t</var>)</code>.</p></item>
                            </olist>
-                           <p>TODO: An and Bn as wildcards</p>
+                           <note>
+                              <p>For example:</p>
+                              <olist>
+                                 <item><p><code>element(size, xs:integer) ⊆ element(size, xs:decimal)</code></p></item>
+                                 <item><p><code>element(size, xs:integer) ⊆ element(*, xs:decimal)</code></p></item>
+                                 <item><p><code>element(*, xs:integer) ⊆ element(*, xs:decimal)</code></p></item>
+                                 <item><p><code>element(my:*, xs:integer) ⊆ element(*, xs:decimal)</code></p></item>
+                               
+                              </olist>
+                           </note>
                         </item>
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is either <code>element(An, At)</code> or <code>element(An, At?)</code></p></item>
-                              <item><p><code>B</code> is <code>element(Bn, Bt?)</code></p></item>
-                              <item><p>the <termref def="dt-expanded-qname">expanded QName</termref> of <code>An</code> equals the <termref
-                                 def="dt-expanded-qname">expanded QName</termref> of <code>Bn</code></p></item>
-                              <item><p><code>derives-from(At, Bt)</code>.</p></item>
+                              <item><p><var>A</var> is either <code>element(<var>A/n</var>, <var>A/t</var>)</code> or 
+                                 <code>element(<var>A/n</var>, <var>A/t</var>?)</code></p></item>
+                              <item><p><var>B</var> is <code>element(<var>B/n</var>, <var>B/t</var>?)</code></p></item>
+                              <item><p><var>A/n</var> <termref def="dt-wildcard-matches"/> <var>B/n</var></p></item>                             
+                              <item><p><code>derives-from(<var>A/t</var>, <var>B/t</var>)</code>.</p></item>
                            </olist>
-                           <p>TODO: An and Bn as wildcards</p>
+                           <note>
+                              <p>For example:</p>
+                              <olist>
+                                 <item><p><code>element(size, xs:integer) ⊆ element(size, xs:decimal?)</code></p></item>
+                                 <item><p><code>element(size, xs:integer?) ⊆ element(*, xs:decimal?)</code></p></item>
+                                 <item><p><code>element(*, xs:integer) ⊆ element(*, xs:decimal?)</code></p></item>
+                                 <item><p><code>element(my:*, xs:integer?) ⊆ element(*, xs:decimal?)</code></p></item>
+                                 
+                              </olist>
+                           </note>
                         </item>
-                        <item>
+                        <!--<item>
                            <p>All the following are true:</p>
                            <olist>
                               <item><p><code>Ai</code> is either <code>element(*, At)</code> or <code>element(N, At)</code> for any name N</p></item>
@@ -5631,12 +5780,9 @@ declare function flatten($tree as tree) as item()* {
                               <item><p><code>derives-from(At, Bt)</code>.</p></item>
                            </olist>
                            
-                        </item>
+                        </item>     -->               
                         
-                        
-                        
-                        
-                        <item>
+                        <!--<item>
                            <p>All the following are true:</p>
                            <olist>
                               <item><p><code>A</code> is either <code>element(*, At)</code>, <code>element(*, At?)</code>, 
@@ -5644,39 +5790,55 @@ declare function flatten($tree as tree) as item()* {
                               <item><p><code>B</code> is <code>element(*, Bt?)</code></p></item>
                               <item><p><code>derives-from(At, Bt)</code>.</p></item>
                            </olist>
-                        </item>
+                        </item>-->
 
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>schema-element(An)</code></p></item>
-                              <item><p><code>B</code> is <code>schema-element(Bn)</code></p></item>
-                              <item><p>every element declaration that is an actual member of the substitution group of <code>An</code> 
-                                 is also an actual member of the substitution group of <code>Bn</code></p></item>
+                              <item><p><var>A</var> is <code>schema-element(<var>A/n</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>schema-element(<var>B/n</var>)</code></p></item>
+                              <item><p>Every element declaration that is an actual member of the substitution group of <var>A/n</var> 
+                                 is also an actual member of the substitution group of <var>B/n</var>.</p></item>
                            </olist>
                            <note>
-                                <p>The fact that <code>P</code> is a member of the substitution group of <code>Q</code> 
-                                   does not mean that every element declaration in the substitution group of <code>P</code> 
-                                   is also in the substitution group of <code>Q</code>. For example, <code>Q</code> might 
-                                   block substitution of elements whose type is derived by extension, while <code>P</code> does not.</p>
+                                <p>The fact that <var>P</var> is a member of the substitution group of <var>Q</var> 
+                                   does not mean that every element declaration in the substitution group of <var>P</var> 
+                                   is also in the substitution group of <var>Q</var>. For example, <var>Q</var> might 
+                                   block substitution of elements whose type is derived by extension, while <var>P</var> does not.</p>
                            </note>
                         </item>
-
+                  </olist>
+               </div4>
+               <div4 id="id-item-subtype-attributes">
+                  <head>Node Types: Attribute Tests</head>
+                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                    <olist>
                         <item>
-                           <p><code>A</code> is an <nt
+                           <p><var>A</var> is an <nt
                                  def="AttributeTest">AttributeTest</nt> and
-                              <code>B</code> is either <code>attribute()</code> or <code>attribute(*)</code>
+                              <var>B</var> is either <code>attribute()</code> or <code>attribute(*)</code>
                            </p>
                         </item>
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is either <code>attribute(An)</code> or <code>attribute(An, T)</code> 
-                                 for any type T.</p></item>
-                              <item><p><code>B</code> is either <code>attribute(Bn)</code> or <code>attribute(Bn, xs:anyType)</code></p></item>
-                              <item><p>the <termref def="dt-expanded-qname">expanded QName</termref> of <code>An</code> equals the <termref
-                                 def="dt-expanded-qname">expanded QName</termref> of <code>Bn</code></p></item>
+                              <item><p><var>A</var> is either <code>attribute(<var>A/n</var>)</code> or <code>attribute(<var>A/n</var>, <var>T</var>)</code> 
+                                 for any type <var>T</var>.</p></item>
+                              <item><p><var>B</var> is either <code>attribute(Bn)</code> or 
+                                 <code>attribute(<var>B/n</var>, xs:anyAtomicType)</code></p></item>
+                              <item><p><var>A/n</var> <termref def="dt-wildcard-matches"/> <var>B/n</var></p></item>
+                              
                            </olist>
+                           <note>
+                              <p>For example:</p>
+                              <olist>
+                                 <item><p><code>attribute(code) ⊆ attribute(*)</code></p></item>
+                                 <item><p><code>attribute(code, xs:untypedAtomic) ⊆ attribute(*)</code></p></item>
+                                 <item><p><code>attribute(code, xs:string) ⊆ attribute(code, xs:anyAtomicType)</code></p></item>                                
+                                 <item><p><code>attribute(my:code) ⊆ attribute(*:code)</code></p></item>
+                                 <item><p><code>attribute(my:code) ⊆ attribute(my:*)</code></p></item>
+                              </olist>
+                           </note>
                            
                            </item>
                         
@@ -5686,16 +5848,27 @@ declare function flatten($tree as tree) as item()* {
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>attribute(An, At)</code></p></item>
-                              <item><p><code>B</code> is <code>attribute(Bn, Bt)</code></p></item>
-                              <item><p>the <termref def="dt-expanded-qname">expanded QName</termref> of 
-                                 <code>An</code> equals the <termref
-                                 def="dt-expanded-qname">expanded QName</termref> of <code>Bn</code></p></item>
-                              <item><p><code>derives-from(At, Bt)</code>.</p></item>
+                              <item><p><var>A</var> is <code>attribute(<var>A/n</var>, <var>A/t</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>attribute(<var>B/n</var>, <var>B/t</var>)</code></p></item>
+                              <item><p><var>A/n</var> <termref def="dt-wildcard-matches"/> <var>B/n</var></p></item>
+                              
+                              <item><p><code>derives-from(<var>A/t</var>, <var>B/t</var>)</code>.</p></item>
                            </olist>
                            
+                           <note>
+                              <p>For example:</p>
+                              <olist>
+                                 <item><p><code>attribute(*, xs:ID) ⊆ attribute(*, xs:string)</code></p></item>
+                                 <item><p><code>attribute(my:*, xs:ID) ⊆ attribute(*, xs:string)</code></p></item>
+                                 <item><p><code>attribute(code, xs:ID) ⊆ attribute(code, xs:string)</code></p></item>
+                                 <item><p><code>attribute(code, xs:ID) ⊆ attribute(*, xs:string)</code></p></item>
+                                 <item><p><code>attribute(code, xs:ID) ⊆ attribute(*:code, xs:ID)</code></p></item>
+                                 <item><p><code>attribute(my:code, xs:ID) ⊆ attribute(my:*, xs:string)</code></p></item>
+                              </olist>
+                           </note>
+                           
                         </item>
-                        <item>
+                        <!--<item>
                            <p>All the following are true:</p>
                            <olist>
                               <item><p><code>A</code> is either <code>attribute(*, At)</code>, or <code>attribute(N, At)</code> for any name N</p></item>
@@ -5703,265 +5876,303 @@ declare function flatten($tree as tree) as item()* {
                               <item><p><code>derives-from(At, Bt)</code>.</p></item>
                            </olist>
                         </item>
-
+-->
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>schema-attribute(An)</code></p></item>
-                              <item><p><code>B</code> is <code>schema-attribute(Bn)</code></p></item>
+                              <item><p><var>A</var> is <code>schema-attribute(<var>A/n</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>schema-attribute(<var>B/n</var>)</code></p></item>
                               <item><p>the <termref
                                  def="dt-expanded-qname"
-                                 >expanded QName</termref> of <code>An</code> equals the <termref
+                                 >expanded QName</termref> of <var>A/n</var> equals the <termref
                                  def="dt-expanded-qname"
-                                 >expanded QName</termref> of <code>Bn</code></p></item>
-                              <item><p><code>derives-from(At, Bt)</code>.</p></item>
+                                 >expanded QName</termref> of <var>B/n</var></p></item>
+       
                            </olist>
                         </item>
                      </olist>
-                  </item>
-                  <item>
-                     <p>
-                        <emph>Conditions for functions, maps and arrays:</emph>
-                     </p>
+               </div4>
+               <div4 id="id-item-subtype-functions">
+                  <head>Functions</head>
+                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  
+
                      <olist>
                         <item><p>All the following are true:</p>
                         <olist>
-                           <item><p><code>A</code> is a <nt def="FunctionTest">FunctionTest</nt>
+                           <item><p><var>A</var> is a <nt def="FunctionTest">FunctionTest</nt>
                               <phrase role="xquery"> with annotations <code>[AnnotationsA]</code></phrase></p></item>
-                           <item><p><code>Bi</code> is <code>
+                           <item><p><var>B</var> is <code>
                                  <phrase role="xquery">[AnnotationsB]</phrase> function(*)</code></p></item>
                            <item role="xquery"><p><code>subtype-assertions(AnnotationsA, AnnotationsB)</code>, 
                               where <code>[AnnotationsB]</code> and <code>[AnnotationsA]</code> 
                               are optional lists of one or more annotations.</p></item>
-                        </olist></item>
+                        </olist>
+                           <note>
+                              <p>For example, <code>function(xs:integer) as xs:string ⊆ function(*)</code>:</p>
+                           </note>
+                        </item>
                         
 
                         <item>
                            <p>All the following are true:</p>
                               <olist>
-                                 <item><p><code>A</code> is <code>
+                                 <item><p><var>A</var> is <code>
                                     <phrase role="xquery"
-                                       >AnnotationsA </phrase>function(Aa_1, Aa_2, ... Aa_M) as Ar</code></p></item>
-                                 <item><p><code>B</code> is <code>
+                                       >AnnotationsA </phrase>function(<var>a/1</var>, <var>a/2</var>, ... <var>a/M</var>) as <var>R/A</var></code></p></item>
+                                 <item><p><var>B</var> is <code>
                                     <phrase role="xquery"
-                                       >AnnotationsB </phrase>function(Ba_1, Ba_2, ... Ba_N) as Br</code></p></item>
+                                       >AnnotationsB </phrase>function(<var>b/1</var>, <var>b/2</var>, ... <var>b/N</var>) as <var>R/B</var></code></p></item>
                                  <item role="xquery"><p><code>[AnnotationsB]</code> and <code>[AnnotationsA]</code> are optional lists of one or more annotations;</p></item>
-                                 <item><p><code>N</code> (arity of B) equals <code>M</code> (arity of A)
+                                 <item><p><var>N</var> (the arity of <var>B</var>) equals <var>M</var> (the arity of <var>A</var>)
                                     </p></item>
-                                 <item><p><code>subtype(Ar, Br)</code></p></item>
-                                 <item><p>for all values of <code>I</code> between 1 and <code>N</code>, <code>subtype(Ba_I, Aa_I)</code>
+                                 <item><p><code><var>R/A</var> ⊑ <var>R/B</var></code></p></item>
+                                 <item><p>For all values of <var>p</var> between 1 and <var>N</var>, <code><var>b/p</var> ⊑ <var>a/p</var></code>
                                     <phrase role="xquery">, and <code>subtype-assertions(AnnotationsA, AnnotationsB)</code>
                                     </phrase></p></item>
                               </olist>
-                           
-              
                            <note>
-                              <p>Function return types are covariant because this rule invokes subtype(Ar, Br) for  return types. 
-                                 Function arguments are contravariant because this rule invokes subtype(Ba_I, Aa_I) for arguments.</p>
+                              <p>For example:</p>
+                              <olist>
+                                 <item><p><code>function(xs:integer) as xs:string ⊆ function(xs:long) as xs:string</code></p></item>
+                                 <item><p><code>function(xs:integer) as xs:ID ⊆ function(xs:integer) as xs:string</code></p></item>
+                                 <item><p><code>function(xs:integer) as xs:ID ⊆ function(xs:long) as xs:string</code></p></item>
+                               
+                              </olist>
+ 
+                              <p>Function return types are covariant because this rule invokes <code><var>R/A</var> ⊑ <var>R/B</var></code> for return types. 
+                                 Function parameter types are contravariant because this rule invokes <code><var>b/p</var> ⊑ <var>a/p</var></code> for parameter types.</p>
                            </note>
                         </item>
-
+                     </olist>
+               </div4>
+               <div4 id="id-item-subtype-maps">
+                  <head>Maps</head>
+                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  
+                     <olist>
                         <item>
-                           <p>All the following are true:</p>
+                           <p>Both of the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>map(K, V)</code>,
-                                 for any <code>K</code> and <code>V</code></p></item>
-                              <item><p><code>B</code> is <code>map(*)</code></p></item>
+                              <item><p><var>A</var> is <code>map(<var>K</var>, <var>V</var>)</code>,
+                                 for any <var>K</var> and <var>V</var></p></item>
+                              <item><p><var>B</var> is <code>map(*)</code></p></item>
                            </olist>
+                           <note><p>For example, <code>map(xs:integer, item()*) ⊆ map(*)</code></p></note>
                         </item>
                         
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>map(Ka, Va)</code></p></item>
-                              <item><p><code>B</code> is <code>map(Kb, Vb)</code></p></item>
-                              <item><p><code>subtype-itemtype(Ka, Kb)</code></p></item>
-                              <item><p><code>subtype(Va, Vb)</code></p></item>
+                              <item><p><var>A</var> is <code>map(<var>K/a</var>, <var>V/a</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>map(<var>K/b</var>, <var>V/b</var>)</code></p></item>
+                              <item><p><code><var>K/a</var> ⊆ <var>K/b</var></code></p></item>
+                              <item><p><code><var>V/a</var> ⊑ <var>V/b</var></code></p></item>
                            </olist>
-                           
+                           <note><p>For example, <code>map(xs:long, item()) ⊆ map(xs:integer, item()+)</code></p></note>
                         </item>
                         
                         <item>
-                           <p>All the following are true:</p>
+                           <p>Both the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>map(*)</code>
+                              <item><p><var>A</var> is <code>map(*)</code>
                                  (or, because of the transitivity rules, any other map type)</p></item>
-                              <item><p><code>B</code> is <code>function(*)</code></p></item>
+                              <item><p><var>B</var> is <code>function(*)</code></p></item>
                            </olist>
+                           <note><p>For example, <code>map(xs:long, xs:string?) ⊆ function(*)</code></p></note>
                         </item>
                         
                         <item>
-                           <p>All the following are true:</p>
+                           <p>Both the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>map(*)</code>
+                              <item><p><var>A</var> is <code>map(*)</code>
                                  (or, because of the transitivity rules, any other map type)</p></item>
-                              <item><p><code>B</code> is 
+                              <item><p><var>B</var> is 
                                  <code>function(xs:anyAtomicType) as item()*</code></p></item>
                            </olist>
+                           <note><p>For example, <code>map(xs:long, xs:string?) ⊆ function(xs:anyAtomicType) as item()*</code></p></note>
                         </item>
                         
                         <item>
-                           <p>All the following are true:</p>
+                           <p>Both the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>map(K, V)</code></p></item>
-                              <item><p><code>B</code> is <code>function(xs:anyAtomicType) as V?</code></p></item>
+                              <item><p><var>A</var> is <code>map(<var>K</var>, <var>V</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>function(xs:anyAtomicType) as <var>W</var></code>,
+                              where <var>W</var> has the same item type as <var>V</var>, but also allows
+                              an empty sequence.</p></item>
                            </olist>
+                           <note>
+                              <p>For example:</p>
+                              <olist>
+                                 <item><p><code>map(xs:int, node()) ⊆ function(xs:anyAtomicType) as node()?</code></p></item>
+                                 <item><p><code>map(xs:int, node()+) ⊆ function(xs:anyAtomicType) as node()*</code></p></item>
+                              </olist>
+                              <p>The function accepts type <code>xs:anyAtomicType</code> rather than <code>xs:int</code>,
+                              because <code>$M("xyz")</code> is a valid call on a map (treated as a function) even
+                              when all the keys in the map are integers.</p>
+                              <p>The return type of the function is extended from <code>node()</code> or <code>node()+</code> to allow an empty sequence
+                                 because <code>$M("xyz")</code> can return an empty sequence even if none of the entries
+                              in the map contains an empty sequence.</p>
+                           </note>
                         </item>
-                        
-                        
+                     </olist>
+               </div4>
+               <div4 id="id-item-subtype-arrays">
+                  <head>Arrays</head>
+                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  
+                     <olist>   
                         
                         <item>
-                           <p>All the following are true:</p>
+                           <p>Both the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>array(X)</code></p></item>
-                              <item><p><code>B</code> is <code>array(*)</code></p></item>
+                              <item><p><var>A</var> is <code>array(<var>X</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>array(*)</code></p></item>
                            </olist>
+                           <note><p>For example, <code>array(xs:integer) ⊆ array(*)</code></p></note>
                         </item>
                         
                         <item>
                            <p>All the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>array(X)</code></p></item>
-                              <item><p><code>B</code> is <code>array(Y)</code></p></item>
-                              <item><p><code>subtype(X, Y)</code></p></item>
+                              <item><p><var>A</var> is <code>array(<var>X</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>array(<var>Y</var>)</code></p></item>
+                              <item><p><code><var>X</var> ⊑ <var>Y</var></code></p></item>
                            </olist>
+                           <note><p>For example, <code>array(xs:integer) ⊆ array(xs:decimal+)</code></p></note>
                         </item>
                         
                         <item>
-                           <p>All the following are true:</p>
+                           <p>Both the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>array(*)</code>
+                              <item><p><var>A</var> is <code>array(*)</code>
                                  (or, because of the transitivity rules, any other array type)</p></item>
-                              <item><p><code>B</code> is <code>function(*)</code></p></item>
+                              <item><p><var>B</var> is <code>function(*)</code></p></item>
                            </olist>
+                           <note><p>For example, <code>array(xs:integer) ⊆ function(*)</code></p></note>
                         </item>
                         
                         <item>
-                           <p>All the following are true:</p>
+                           <p>Both the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>array(*)</code>
+                              <item><p><var>A</var> is <code>array(*)</code>
                                  (or, because of the transitivity rules, any other array type)</p></item>
-                              <item><p><code>Bi</code> is <code>function(xs:integer) as item()*</code></p></item>
+                              <item><p><var>B</var> is <code>function(xs:integer) as item()*</code></p></item>
                            </olist>
+                           <note><p>For example, <code>array(*) ⊆ function(xs:integer) as item()*</code></p></note>
                         </item>
                       
                         <item>
-                           <p>All the following are true:</p>
+                           <p>Both the following are true:</p>
                            <olist>
-                              <item><p><code>A</code> is <code>array(X)</code></p></item>
-                              <item><p><code>B</code> is <code>function(xs:integer) as X</code></p></item>
+                              <item><p><var>A</var> is <code>array(<var>X</var>)</code></p></item>
+                              <item><p><var>B</var> is <code>function(xs:integer) as <var>X</var></code></p></item>
                            </olist>
-                        </item>
-                        
-
-                        <item diff="add" at="A">
-                           <p>All of the following are true:</p>
-                           <olist>
-                              <item><p><code>A</code> is a record test</p></item>
-                              <item><p><code>B</code> is <code>map(*)</code></p></item>
-                           </olist>
-                        </item>
-                        
-                        <item diff="add" at="A">
-                           <p>All of the following are true:</p>
-                           <olist>
-                              <item><p><code>A</code> is a record test</p></item>
-                              <item><p><code>A</code> is not extensible</p></item>
-                              <item><p><code>B</code> is <code>map(K, V)</code></p></item>
-                              <item><p><code>K</code> is either <code>xs:string</code> or <code>xs:anyAtomicType</code></p></item>
-                              <item><p>For every field <code>F</code> in <code>A</code>,
-                                 where <code>T</code> is the declared type of <code>F</code> (or its default, <code>item()*</code>,
-                                 <code>subtype(T, V)</code> is true.</p></item>
-                           </olist>
-                        </item>
-                        
-                        <item diff="add" at="A">
-                           <p>All of the following are true:</p>
-                           <olist>
-                              <item><p><code>A</code> is a record test</p></item>
-                              <item><p><code>B</code> is a record test</p></item>
-                              <item><p><code>A</code> is extensible</p></item>
-                              <item><p><code>B</code> is extensible</p></item>
-                              <item><p>For every field <code>F</code> that is declared in <code>B</code>,
-                                 where the declared type of <code>F</code> is <code>U</code>,
-                                 one of the following is true:</p>
-                                 <olist>
-                                    <item>
-                                       <p>All of the following are true:</p>
-                                       <olist>
-                                          <item><p><code>F</code> is also declared in <code>A</code>,
-                                          with required type T</p></item>
-                                          <item><p>If the field <code>F</code> in <code>B</code>
-                                             is mandatory, then the field <code>F</code> in <code>A</code>is also 
-                                             mandatory</p></item>
-                                          <item><p><code>subtype(T, U)</code></p></item>
-                                       </olist>
-                                    </item>
-                                    <item><p>TODO: other possibilities?</p></item>
-                                 </olist>
-                              </item>
-                           </olist>
-                        </item>
-                        
-                        <item diff="add" at="A">
-                           <p>All of the following are true:</p>
-                           <olist>
-                              <item><p><code>A</code> is a record test</p></item>
-                              <item><p><code>B</code> is a record test</p></item>
-                              <item><p><code>A</code> is not extensible</p></item>
-                              <item><p><code>B</code> is extensible</p></item>
-                              <item><p>For every field <code>F</code> that is declared in <code>B</code>,
-                                 where the declared type of <code>F</code> is <code>U</code>,
-                                 one of the following is true:</p>
-                                 <olist>
-                                    <item>
-                                       <p>All of the following are true:</p>
-                                       <olist>
-                                          <item><p><code>F</code> is also declared in <code>A</code>,
-                                             with required type T</p></item>
-                                          <item><p>If the field <code>F</code> in <code>B</code>
-                                             is mandatory, then the field <code>F</code> in <code>A</code>is also 
-                                             mandatory</p></item>
-                                          <item><p><code>subtype(T, U)</code></p></item>
-                                       </olist>
-                                    </item>
-                                    <item><p>TODO: other possibilities?</p></item>
-                                 </olist>
-                              </item>
-                           </olist>
-                        </item>
-                        
-                        <item diff="add" at="A">
-                           <p>All of the following are true:</p>
-                           <olist>
-                              <item><p><code>A</code> is a record test</p></item>
-                              <item><p><code>B</code> is a record test</p></item>
-                              <item><p><code>A</code> is not extensible</p></item>
-                              <item><p><code>B</code> is not extensible</p></item>
-                              <item><p>For every field <code>F</code> that is declared in <code>B</code>,
-                                 where the declared type of <code>F</code> is <code>U</code>,
-                                 one of the following is true:</p>
-                                 <olist>
-                                    <item>
-                                       <p>All of the following are true:</p>
-                                       <olist>
-                                          <item><p><code>F</code> is also declared in <code>A</code>,
-                                             with required type T</p></item>
-                                          <item><p>If the field <code>F</code> in <code>B</code>
-                                             is mandatory, then the field <code>F</code> in <code>A</code>is also 
-                                             mandatory</p></item>
-                                          <item><p><code>subtype(T, U)</code></p></item>
-                                       </olist>
-                                    </item>
-                                    <item><p>TODO: other possibilities?</p></item>
-                                 </olist>
-                              </item>
-                           </olist>
+                           <note><p>For example, <code>array(xs:string) ⊆ function(xs:integer) as xs:string</code></p></note>
                         </item>
                      </olist>
-                  </item>
+               </div4>
+               <div4 id="id-item-subtype-records">
+                  <head>Record Tests</head>
+                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  <olist>
+                     <item diff="add" at="A">
+                        <p>All of the following are true:</p>
+                        <olist>
+                           <item><p><var>A</var> is a record test</p></item>
+                           <item><p><var>B</var> is <code>map(*)</code></p></item>
+                        </olist>
+                        <note><p>For example, <code>record(longitude, latitude)</code> ⊆ <code>map(*)</code>.</p></note>
+                     </item>
+                     
+                     <item diff="add" at="A">
+                        <p>All of the following are true:</p>
+                        <olist>
+                           <item><p><var>A</var> is a non-extensible record test</p></item>
+                           <item><p><var>B</var> is <code>map(<var>K</var>, <var>V</var>)</code></p></item>
+                           <item><p><var>K</var> is either <code>xs:string</code> or <code>xs:anyAtomicType</code></p></item>
+                           <item><p>For every field <var>F</var> in <var>A</var>,
+                              where <var>T</var> is the declared type of <var>F</var> (or its default, <code>item()*</code>),
+                              <code><var>T</var> ⊑ <var>V</var></code>.</p></item>
+                        </olist>
+                        <note><p>For example:</p>
+                           <olist>
+                              <item><p><code>record(x, y)</code> ⊆ <code>map(xs:string, item()*)</code></p></item>
+                              <item><p><code>record(x as xs:double, y as xs:double)</code> ⊆ <code>map(xs:string, xs:double)</code></p></item>
+                           </olist>
+                         </note>
+                     </item>
+                     
+                     <item diff="add" at="A">
+                        <p>All of the following are true:</p>
+                        <olist>
+                           <item><p><var>A</var> is a non-extensible record test.</p></item>
+                           <item><p><var>B</var> is a non-extensible record test.</p></item>
+                           <item><p>Every field in <var>A</var> is also declared in <var>B</var>.</p></item>
+                           <item><p>Every mandatory field in <var>B</var> is also declared in <var>A</var>.</p></item>
+                           <item><p>For every field that is declared in both <var>A</var> and <var>B</var>,
+                              where the declared type in <var>A</var> is <var>T</var> 
+                              and the declared type in <var>B</var> is <var>U</var>, <code><var>T</var> ⊑ <var>U</var></code>.</p>                               
+                           </item>
+                        </olist>
+                        <note><p>For example:</p>
+                           <olist>
+                              <item><p><code>record(x, y as xs:integer) ⊆ record(x, y as xs:decimal)</code></p></item>
+                              <item><p><code>record(x, y) ⊆ record(x, y, z?)</code></p></item>
+                           </olist>
+                        </note>
+                     </item>
+                        
+                        <item diff="add" at="A">
+                           <p>All of the following are true:</p>
+                           <olist>
+                              <item><p><var>A</var> is an extensible record test</p></item>
+                              <item><p><var>B</var> is an extensible record test</p></item>
+                              <item><p>Every mandatory field in <var>B</var> is also declared in <var>A</var>.</p></item>
+                              <item><p>For every field that is declared in both <var>A</var> and <var>B</var>,
+                                 where the declared type in <var>A</var> is <var>T</var> 
+                                 and the declared type in <var>B</var> is <var>U</var>, <code><var>T</var> ⊑ <var>U</var></code>.</p></item> 
+                              <item><p>For every field that is declared in <var>B</var>
+                                 but not in <var>A</var>, the declared type in <var>B</var> is <code>item()*</code>.</p>
+                              </item>  
+                           </olist>
+                           <note><p>For example:</p>
+                              <olist>
+                                 <item><p><code>record(x, y, z, *) ⊆ record(x, y, *)</code></p></item>
+                                 <item><p><code>record(x?, y?, z?, *) ⊆ record(x, y, *)</code></p></item>
+                                 <item><p><code>record(x as xs:integer, y as xs:integer, *) ⊆ record(x as xs:decimal, y as xs:integer*, *)</code></p></item>
+                                 <item><p><code>record(x as xs:integer, *) ⊆ record(x as xs:decimal, y as item(), *)</code></p></item>                               
+                              </olist>
+                           </note>
+                           
+                        </item>
+                     
+                     <item diff="add" at="A">
+                        <p>All of the following are true:</p>
+                        <olist>
+                           <item><p><var>A</var> is a non-extensible record test.</p></item>
+                           <item><p><var>B</var> is an extensible record test.</p></item>
+                           <item><p>Every mandatory field in <var>B</var> is also declared in <var>A</var>.</p></item>
+                           <item><p>Every field that is declared in <var>B</var> with a type other than <code>item()*</code>
+                              is also declared in <var>A</var>.</p></item>
+                           <item><p>For every field that is declared in both <var>A</var> and <var>B</var>,
+                              where the declared type in <var>A</var> is <var>T</var> 
+                              and the declared type in <var>B</var> is <var>U</var>, <code><var>T</var> ⊑ <var>U</var></code>.</p>                               
+                           </item>
+                        </olist>
+                        <note><p>For example:</p>
+                           <olist>
+                              <item><p><code>record(x, y as xs:integer) ⊆ record(x, y as xs:decimal, *)</code></p></item>
+                              <item><p><code>record(y as xs:integer) ⊆ record(x?, y as xs:decimal, *)</code></p></item>
+                           </olist>
+                        </note>
+                     </item>
+                        
+                        
+                  </olist>
+               </div4>
+   
 
-               </olist>
 
             </div3>
 
@@ -7355,26 +7566,18 @@ At evaluation time, the value of a variable reference is the value to which the 
                                         </p>
 
                                              <p>
-                                          When
-                                          this is done,
-                                          the converted argument value retains
-                                          its most specific
-                                          <termref
-                                                  def="dt-dynamic-type"
-                                                  >dynamic type</termref>,
-                                          even though this type
-                                          may be derived from the type of the formal parameter.
+                                          <phrase diff="chg" at="B">When this is done,
+                                          the converted argument values retain
+                                          their <termref def="dt-dynamic-type">dynamic types</termref>,
+                                          even where these are <termref def="dt-subtype">subtypes</termref> 
+                                          of the declared parameter types.</phrase>
                                           For example, a function with
                                           a parameter <code>$p</code> of type <code>xs:decimal</code>
                                           can be invoked with an argument of type <code>xs:integer</code>,
                                           which is derived from <code>xs:decimal</code>.
                                           During the processing of this function
-                                          call,
-                                          the <termref
-                                                  def="dt-dynamic-type"
-                                                  >dynamic type</termref>
-                                          of <code>$p</code> inside the body of the function
-                                          is considered to be <code>xs:integer</code>.
+                                          call, the value of <code>$p</code> inside the body of the function 
+                                          retains its <termref def="dt-dynamic-type"/> of <code>xs:integer</code>.
                                         </p>
                                           </item>
 
@@ -7408,8 +7611,8 @@ At evaluation time, the value of a variable reference is the value to which the 
                                        <p>
                                       As with argument values,
                                       the value returned by a function
-                                      retains its most specific type,
-                                      which may be derived from the declared return type of <var>F</var>.
+                                      retains its <termref def="dt-dynamic-type"/>,
+                                      which may be a <termref def="dt-subtype"/> of the declared return type of <var>F</var>.
                                       For example, a function that has
                                       a declared return type of <code>xs:decimal</code>
                                       may in fact return a value of dynamic type <code>xs:integer</code>.

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -2231,6 +2231,24 @@
       <xsl:apply-templates/>
     </var>
   </xsl:template>
+  
+  <xsl:template match="var[matches(., '[A-Z][0-9]')]">
+    <var>
+      <xsl:value-of select="substring(., 1, 1)"/>
+      <sub><xsl:value-of select="substring(., 2, 1)"/></sub>
+    </var>
+  </xsl:template>
+  
+  <xsl:template match="var[contains(., '/')]">
+    <var>
+      <xsl:value-of select="substring-before(., '/')"/>
+      <sub><xsl:value-of select="substring-after(., '/')"/></sub>
+    </var>
+  </xsl:template>
+  
+  <xsl:template match="var[matches(., '[A-Z]''')]">
+    <var><xsl:value-of select="translate(., '''', '&#x2032;')"/></var>
+  </xsl:template>  
 
   <!-- vc: validity check reference in a formal production -->
   <xsl:template match="vc">


### PR DESCRIPTION
Editorial. Improve the presentation of XPath section §3.7 on subtype relationships, including supplying some rules that were previously marked TODO. To enable this, migrate some DTD and stylesheet extensions for `var` elements previously used for the xslt spec only. Add some clarifications concerning dynamic type, see issue #191