### PR TITLE
NW for MK: Drop xsl:match instruction (185)

### DIFF
--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -737,22 +737,6 @@
          <e:parent name="try"/>
       </e:allowed-parents>
    </e:element-syntax>
-   
-   <e:element-syntax name="match">
-      <e:in-category name="instruction"/>
-      <e:attribute name="select" required="no">
-         <e:data-type name="expression"/>
-      </e:attribute>
-      <e:attribute name="pattern" required="yes">
-         <e:data-type name="pattern"/>
-      </e:attribute>
-      <e:sequence>
-         <e:element repeat="zero-or-more" name="fallback"/>
-      </e:sequence>
-      <e:allowed-parents>
-         <e:parent-category name="sequence-constructor"/>
-      </e:allowed-parents>
-   </e:element-syntax>
 
    <!-- Variables -->
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10740,31 +10740,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
 
             </div3>
-            <div3 id="testing-against-pattern" diff="add" at="A">
-               <head>Testing a Value Against a Pattern</head>
-               <p>The <elcode>xsl:match</elcode> instruction can be used to test a value against a pattern.</p>
-               <?element xsl:match?>
-               <p>The <code>select</code> attribute is a <termref def="dt-expression"/>, defaulting to <code>.</code>,
-               which selects the <termref def="dt-context-item"/>.</p>
-               <p>The <code>pattern</code> attribute is a <termref def="dt-pattern"/>.</p>
-               <p>The result of the <elcode>xsl:match</elcode> instruction is the <code>xsl:boolean</code>
-                  value <code>true</code> if every item selected
-               by the <code>select</code> expression matches the pattern, and is
-               <code>false</code> otherwise.</p>
-               <p>Any <code>xsl:fallback</code> child elements are ignored by an XSLT 4.0 processor, but
-               may be used to define fallback processing for an XSLT 3.0 or earlier processor.</p>
-               <example>
-                  <head>Declaring a function that matches against a pattern</head>
-                  <p>The following declaration declares a function that matches its argument against 
-                  a supplied pattern:</p>
-                  <eg><![CDATA[
-<xsl:function name="f:is-division" as="xs:boolean">
-  <xsl:param name="node" as="element(*)"/>
-  <xsl:match select="$node" pattern="div1 | div2 | div3 | div4"/>
-</xsl:function>]]></eg>
-                  <p>This function might then be used in an expression such as <code>child::*[f:is-division(.)]</code>.</p>
-               </example>
-            </div3>
+            
          </div2>
          <div2 id="named-item-types" diff="add" at="A">
             <head>Defining Named Item Types</head>
@@ -38359,8 +38335,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                   <elcode>xsl:for-each-group</elcode> have attributes <code>array</code> and <code>map</code>
                   which can be used in place of the <code>select</code> attribute to allow iteration over arrays or maps
                   rather than sequences.</p></item>
-               <item><p>The new instruction <elcode>xsl:match</elcode> allows items to be matched against
-               and XSLT pattern to deliver a boolean result.</p></item>
+               
                <item><p>New pattern syntax ( <code>type(T)</code>, <code>record(N, M, N)</code>) 
                   allows matching of items by item type.</p></item>
                <!--<item><p>A new attribute <code>xsl:template/@test</code> allows tunnel parameters to be taken


### PR DESCRIPTION
This PR is intended to be technically equivalent to #185.

I've reworked a series of MK commits so that they are independent; I fear we would wind up with merge conflicts otherwise and cleaning up the merge conflicts, without accidentally making some other change, seemed riskier than just teasing them apart and making them independent before we accept and merge them. 

Close #119 