### PR TITLE
Modify test generator to reference a real source file

### DIFF
--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -33,9 +33,7 @@
          <environment name="ka">
             <namespace prefix="math" uri="http://www.w3.org/2005/xpath-functions/math"/>
             <decimal-format name="data" decimal-separator="." grouping-separator=","/>
-            <source role=".">
-               <content><![CDATA[<doc attribute="attr_val"><e/></doc>]]></content>
-            </source>
+            <source role="." file="BuiltInKeywords/simple-doc.xml"/>
          </environment>
          <xsl:apply-templates select="//function"/>
       </test-set>      


### PR DESCRIPTION
Modify the generated test set to use a real source file. The source/content construct for inline documents works in the XSLT test suite but not in QT4.