### PR TITLE
First attempt at parse-uri and build-uri functions

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1259,8 +1259,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string>$</g:string>
       <g:ref name="VarName"/>
     </g:optional>
-    <g:string>$</g:string>
-    <g:ref name="VarName"/>
     <g:string>return</g:string>
     <g:ref name="ExprSingle"/>
   </g:production>
@@ -1272,9 +1270,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="VarName"/>
       <g:string>as</g:string>
     </g:optional>
-    <g:string>$</g:string>
-    <g:ref name="VarName"/>
-    <g:string>as</g:string>
     <g:ref name="SequenceTypeUnion"/>
     <g:string>return</g:string>
     <g:ref name="ExprSingle"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23701,10 +23701,16 @@ declare function fn:some(
          is present and it’s value is not a string of length one.</p>
 
          <p>A <emph>query-segments</emph> is constructed as follows: tokenize
-         the <emph>query</emph> on the <emph>query separator</emph>,
-         apply <emph>uri decoding</emph> on each token, and convert
-         the result to an array.</p>
-         
+         the <emph>query</emph> on the <emph>query separator</emph>. For each
+         token, construct a map. If the token contains an equal sign (“=”),
+         the map contains a key named <code>key</code> with a value equal to the
+         string preceding the first equal sign and a key named <code>value</code>
+         with a value equal to the string following the first equal sign. If the
+         token does not contain an equal sign, the map contains a single key named
+         <code>value</code> with a value equal to the token. In every case,
+         <emph>uri decoding</emph> is applied to each value add to the map.
+         The resulting sequence of maps is converted into an array.</p>
+
          <p>The following map is returned:</p>
 
          <eg>{
@@ -23791,7 +23797,10 @@ map {
   "port": "080",
   "path": "/path",
   "query": "s=%22hello world%22&amp;sort=relevance",
-  "query-segments": array { "s=""hello world""", "sort=relevance" },
+  "query-segments": array {
+    map { "key": "s", "value": "&quot;&quot;hello world&quot;&quot;" },
+    map { "key": "sort", "value": "relevance" }
+  },
   "path-segments": array { "", "path" }
 }</eg></fos:result>
     </fos:test>
@@ -23929,7 +23938,9 @@ map {
   "uri": "?q=1",
   "path": "",
   "query": "q=1",
-  "query-segments": array { "q=1" }
+  "query-segments": array {
+    map { "key": "q", "value": "1" }
+  }
 }</eg></fos:result>
     </fos:test>
   </fos:example>
@@ -23944,7 +23955,9 @@ map {
   "host": "[2001:db8::7]",
   "path": "/c=GB",
   "query": "objectClass?one",
-  "query-segments": array { "objectClass?one" },
+  "query-segments": array {
+    map { "value": "objectClass?one" }
+  },
   "path-segments": array { "", "c=GB" }
 }</eg></fos:result>
     </fos:test>
@@ -24024,7 +24037,8 @@ map {
   }
 </eg></fos:result>
     </fos:test>
-  </fos:example>  <fos:example>
+  </fos:example>
+  <fos:example>
     <fos:test>
       <fos:expression><eg>fn:parse-uri("tag:jan@example.com,1999-01-31:my-uri")</eg></fos:expression>
       <fos:result><eg>
@@ -24050,6 +24064,24 @@ map {
   "path-segments": array { "file:", "C:", "Program Files", "test.jar!", "foo", "bar" }
 }
 </eg></fos:result>
+  <fos:example>
+<p>This example demonstrates that parsing the URI treats non-URI characters in
+lexical IRIs as “unreserved characters”. The rationale for this is given in the
+description of <code>fn:resolve-uri</code>.</p>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("http://www.example.org/Dürst")</eg></fos:expression>
+      <fos:result><eg>
+map {
+    "uri": "http://www.example.org/Dürst",
+    "scheme": "http",
+    "authority": "www.example.org",
+    "host": "www.example.org",
+    "path": "/Dürst",
+    "path-segments": [ "","Dürst" ]
+}
+</eg></fos:result>
+    </fos:test>
+  </fos:example>
     </fos:test>
   </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -3063,14 +3063,18 @@
       </fos:rules>
       <fos:notes>
          <p>The treatment of the <code>underflow</code> exception is defined in <specref
-               ref="op.numeric"/>. </p>
+               ref="op.numeric"/>. The following rules apply when the values are finite and non-zero, 
+            (subject to rules for overflow, underflow and approximation).</p>
          <p>If either argument is <code>NaN</code> then the result is <code>NaN</code>.</p>
-         <p>If <code>$y</code> is positive and <code>$x</code> is positive and finite, then (subject
-            to rules for overflow, underflow and approximation) the value of <code>atan2($y,
+         <p diff="chg" at="B">If <code>$x</code> is positive, then  the value of <code>atan2($y,
                $x)</code> is <code>atan($y div $x)</code>.</p>
-         <p>If <code>$y</code> is positive and <code>$x</code> is negative and finite, then (subject
-            to the same caveats) the value of <code>atan2($y, $x)</code> is <var>π</var>
-            <code>- atan($y div $x)</code>.</p>
+         <p diff="chg" at="B">If <code>$x</code> is negative, then:</p>
+         <ulist diff="chg" at="B">
+            <item><p>If <code>$y</code> is positive, then the value of <code>atan2($y, $x)</code> is 
+               <code>atan($y div $x) + </code><var>π</var>.</p></item>
+            <item><p>If <code>$y</code> is negative, then the value of <code>atan2($y, $x)</code> is 
+               <code>atan($y div $x) - </code><var>π</var>.</p></item>
+         </ulist>
          <p>Some results for special values of the arguments are shown in the examples below.</p>
 
       </fos:notes>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23606,9 +23606,10 @@ declare function fn:some(
          <p>The function parses the <code>$uri</code> provided,
          returning a map containing its constituent parts: scheme,
          authority components, path, etc.
-         <bibref ref="rfc3986"/>, which defines URIs, is concerned with
-         the syntax of absolute URIs. This function must also account
-         for relative URIs, which complicates things somewhat.</p>
+         In addition to parsing URIs as defined by <bibref ref="rfc3986"/>
+         (and <bibref ref="rfc3987"/>), this function also attempts to
+         account for strings that are not valid URIs but that often appear
+         in URI-adjacent spaces, such as file names.</p>
 
          <p>This function is described as a series of transformations
          over the input string to identify the parts of a URI that are
@@ -23741,6 +23742,17 @@ declare function fn:some(
          keys in the map be QNames with the requirement that implementation-defined
          keys be in a non-empty namespace?</p>
       </fos:rules>
+
+      <fos:notes>
+         <p>Like <code>fn:resolve-uri</code>, this function handles the additional characters
+         allowed in <bibref ref="rfc3987"/> IRIs in the same way that other unreserved
+         characters are handled.</p>
+         <p>Unlike <code>fn:resolve-uri</code>, this function is not attempting to resolve
+         one URI against another and consequently, the errors that can arise under those
+         circumstances do not apply here. The <code>fn:parse-uri</code> function will
+         accept strings that would raise errors if resolution was attempted,
+         see <code>fn:build-uri</code>.</p>
+      </fos:notes>
 
       <fos:errors>
          <p>An error is raised XXXX if the supplied path separator is not a single character.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23571,23 +23571,23 @@ declare function fn:some(
 
    <fos:function name="parse-uri" prefix="fn" diff="add">
       <fos:signatures>
-         <fos:proto name="parse-uri" return-type-ref="result-map">
+         <fos:proto name="parse-uri" return-type-ref="return-record">
             <fos:arg name="uri" type="xs:string"/>
             <fos:arg name="options" type="map(*)" default="map{}"/>
          </fos:proto>
 
-         <fos:record name="result-map">
+         <fos:record name="return-record">
            <fos:arg name="uri" type="xs:string"/>
-           <fos:arg name="scheme" type="xs:string"/>
-           <fos:arg name="authority" type="xs:string"/>
-           <fos:arg name="userinfo" type="xs:string"/>
-           <fos:arg name="host" type="xs:string"/>
-           <fos:arg name="port" type="xs:string"/>
-           <fos:arg name="path" type="xs:string"/>
-           <fos:arg name="query" type="xs:string"/>
-           <fos:arg name="fragment" type="xs:string"/>
-           <fos:arg name="path-segments" type="array(xs:string)"/>
-           <fos:arg name="query-segments"
+           <fos:arg name="scheme?" type="xs:string"/>
+           <fos:arg name="authority?" type="xs:string"/>
+           <fos:arg name="userinfo?" type="xs:string"/>
+           <fos:arg name="host?" type="xs:string"/>
+           <fos:arg name="port?" type="xs:string"/>
+           <fos:arg name="path?" type="xs:string"/>
+           <fos:arg name="query?" type="xs:string"/>
+           <fos:arg name="fragment?" type="xs:string"/>
+           <fos:arg name="path-segments?" type="array(xs:string)"/>
+           <fos:arg name="query-segments?"
                     type="array(record(key? as xs:string, value? as xs:string, *))"/>
            <fos:arg name="*"/>
          </fos:record>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23569,7 +23569,7 @@ declare function fn:some(
       </fos:history>
    </fos:function>
 
-   <fos:function name="parse-uri" prefix="fn">
+   <fos:function name="parse-uri" prefix="fn" diff="add">
       <fos:signatures>
          <fos:proto name="parse-uri" return-type="map(xs:string,xs:string)">
             <fos:arg name="uri" type="xs:string"/>
@@ -23676,7 +23676,7 @@ declare function fn:some(
          by up to two characters that are not hexadecimal digits, they are
          replaced by the single character with the
          codepoint 0xfffd. In other words “<code>A%XYC%Z</code>” becomes
-         “<code>A&#xfffd;C&#xfffd;</code>.</p>
+         “<code>A&#xfffd;C&#xfffd;</code>”.</p>
 
          <p>If the <code>$options</code> map contains a key named
          “<code>query-separator</code>”, the value of that key is the
@@ -23705,8 +23705,19 @@ declare function fn:some(
   "query-segments": <emph>query-segments</emph>
 }</eg>
 
-         <p>TODO: should the map contain keys with values that are the empty sequence or an empty array, or should they be omitted?</p>
+         <p>The map should only be populated with keys that have a non-empty value (keys
+         who’s value is the empty sequence or an empty array <rfc2119>should</rfc2119>
+         be omitted).</p>
 
+         <p>Implementations may implement additional or different rules for URIs that
+         have a scheme or pattern that they recognize. An implementation might choose
+         to parse <code>jar:</code> URIs with special rules, for example, since they extend the
+         syntax in ways not defined by <bibref ref="rfc3986"/>. Implementations may add
+         additional keys to the map. The meaning of those keys is implementation-defined.</p>
+
+         <p>TODO: In order to better support implementation extensibility, should the
+         keys in the map be QNames with the requirement that implementation-defined
+         keys be in a non-empty namespace?</p>
       </fos:rules>
       
 <fos:examples>
@@ -24009,7 +24020,7 @@ map {
       </fos:history>
    </fos:function>
 
-   <fos:function name="build-uri" prefix="fn">
+   <fos:function name="build-uri" prefix="fn" diff="add">
       <fos:signatures>
          <fos:proto name="build-uri" return-type="xs:string">
             <fos:arg name="parts" type="map(xs:string,xs:string)"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23997,9 +23997,8 @@ map {
     </fos:test>
   </fos:example>
   <fos:example>
-<p>This example uses the algorithm described above, but may not be
-useful to the user. TODO: should we allow implementations to use different parsing
-algorithms for URI schemes that they recognize?</p>
+<p>This example uses the algorithm described above, not an algorithm that is
+specifically aware of the <code>jar:</code> scheme.</p>
     <fos:test>
       <fos:expression><eg>fn:parse-uri("jar:file:/C:/Program%20Files/test.jar!/foo/bar")</eg></fos:expression>
       <fos:result><eg>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18071,36 +18071,45 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:signatures>
          <fos:proto name="build" return-type="map(*)">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="key" type="function(item()) as xs:anyAtomicType" default="fn:identity#1"/>
+            <fos:arg name="key" type="function(item()) as xs:anyAtomicType?" default="fn:identity#1"/>
             <fos:arg name="value" type="function(item()) as item()*" default="fn:identity#1"/>
-            <fos:arg name="combine" type="function(item()*, item()*) as item()*" default="op(',')"/>
+            <fos:arg name="combine" type="function(item()*, item()*) as item()*" default="fn:op(',')"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
+         <fos:property>higher-order</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns a map that contains one entry for each item in a supplied input sequence, combining duplicates.</p>
+         <p>Returns a map that typically contains one entry for each item in a supplied input sequence.</p>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function processes each item in <code>$input</code> in order. It calls the <code>$key</code> function on
-            that item to obtain a key value, and the <code>$value</code> function to obtain an associated value. 
-            If the key is not already present in the target map, it adds a new key-value pair with that key 
-            and that value. If the key is already present, it calls the <code>$combine</code> function to combine the existing value 
-            for the key with the new value, and replaces the entry with this combined value.
-         </p>
+            that item to obtain a key value, and the <code>$value</code> function to obtain an associated value.
+            If the key is non-empty, then:</p>
+         <ulist>
+            <item><p>If the key is not already present in the target map, the processor adds a new key-value pair to the map, with that key 
+               and that value. </p></item>
+            <item><p>If the key is already present, the processor calls the <code>$combine</code> function to combine the existing value 
+               for the key with the new value, and replaces the entry with this combined value.</p></item>
+         </ulist>
+            
          <p>More formally, the result of the function is the result of the following expression:</p>
          
          <eg>
             fold-left($input, map{}, ->($map, $next) {
-            let $nextKey := $key($next)
-            let $nextValue := $value($next)
-            return 
-            if (map:contains($map, $nextKey))
-            then map:put($map, $nextKey, $combine($map($nextKey), $nextValue))
-            else map:put($map, $nextKey, $nextValue)
+               let $nextKey := $key($next)
+               let $nextValue := $value($next)
+               return
+                  if (fn:exists($nextKey))
+                  then
+                     if (map:contains($map, $nextKey))
+                     then map:put($map, $nextKey, $combine($map($nextKey), $nextValue))
+                     else map:put($map, $nextKey, $nextValue)
+                  else
+                     $map
             })
          </eg>
       </fos:rules>
@@ -18117,8 +18126,8 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <ulist>
             <item><p><code>->($a, $b){$a}</code> Use the first value and discard the remainder</p></item>
             <item><p><code>->($a, $b){$b}</code> Use the last value and discard the remainder</p></item>
-            <item><p><code>concat(?, ",", ?)</code> Form the string-concatenation of the values, comma-separated</p></item>
-            <item><p><code>op('+')</code> Compute the sum of the values</p></item>
+            <item><p><code>fn:concat(?, ",", ?)</code> Form the string-concatenation of the values, comma-separated</p></item>
+            <item><p><code>fn:op('+')</code> Compute the sum of the values</p></item>
          </ulist>
       </fos:notes>
       <fos:examples>
@@ -18163,7 +18172,8 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
-               corresponding values represent the number of employees at each distinct location:</p>
+               corresponding values represent the number of employees at each distinct location. Any employees that
+               lack an <code>@location</code> attribute will be excluded from the result.</p>
             <eg>map:build(//employee, ->{@location}, ->{1}, fn:op("+"))</eg>
          </fos:example>
          <fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24013,6 +24013,31 @@ map {
     </fos:test>
   </fos:example>
   <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("tag:textalign.net,2015:ns")</eg></fos:expression>
+      <fos:result><eg>
+map {
+    "uri": "tag:textalign.net,2015:ns",
+    "scheme": "tag",
+    "path": "textalign.net,2015:ns",
+    "path-segments": [ "textalign.net,2015:ns" ]
+  }
+</eg></fos:result>
+    </fos:test>
+  </fos:example>  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("tag:jan@example.com,1999-01-31:my-uri")</eg></fos:expression>
+      <fos:result><eg>
+map {
+    "uri": "tag:jan@example.com,1999-01-31:my-uri"
+    "scheme": "tag",
+    "path": "jan@example.com,1999-01-31:my-uri",
+    "path-segments": [ "jan@example.com,1999-01-31:my-uri" ],
+}
+</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
 <p>This example uses the algorithm described above, not an algorithm that is
 specifically aware of the <code>jar:</code> scheme.</p>
     <fos:test>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23907,7 +23907,6 @@ map {
     </fos:test>
   </fos:example>
   <fos:example>
-    <p>TODO: How much effort do we want to put into parsing IPV6 host names?</p>
     <fos:test>
       <fos:expression><eg>fn:parse-uri("ldap://[2001:db8::7]/c=GB?objectClass?one")</eg></fos:expression>
       <fos:result><eg>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23741,6 +23741,11 @@ declare function fn:some(
          keys in the map be QNames with the requirement that implementation-defined
          keys be in a non-empty namespace?</p>
       </fos:rules>
+
+      <fos:errors>
+         <p>An error is raised XXXX if the supplied path separator is not a single character.</p>
+         <p>An error is raised XXXX if the supplied query separator is not a single character.</p>
+      </fos:errors>
       
 <fos:examples>
   <fos:example>
@@ -24064,6 +24069,8 @@ map {
   "path-segments": array { "file:", "C:", "Program Files", "test.jar!", "foo", "bar" }
 }
 </eg></fos:result>
+    </fos:test>
+  </fos:example>
   <fos:example>
 <p>This example demonstrates that parsing the URI treats non-URI characters in
 lexical IRIs as “unreserved characters”. The rationale for this is given in the
@@ -24082,6 +24089,36 @@ map {
 </eg></fos:result>
     </fos:test>
   </fos:example>
+  <fos:example>
+<p>This example demonstrates a non-standard query separator.</p>
+    <fos:test>
+      <fos:expression><eg>
+fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
+             map { "query-separator": ";" })</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
+  "scheme": "https",
+  "authority": "example.com:8080",
+  "host": "example.com",
+  "port": "080",
+  "path": "/path",
+  "query": "s=%22hello world%22;sort=relevance",
+  "query-segments": array {
+    map { "key": "s", "value": "&quot;&quot;hello world&quot;&quot;" },
+    map { "key": "sort", "value": "relevance" }
+  },
+  "path-segments": array { "", "path" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+<p>This example uses an invalid query separator so raises an error.</p>
+    <fos:test>
+      <fos:expression><eg>
+fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance",
+             map { "query-separator": ";;" })</eg></fos:expression>
+      <fos:error-result error-code="FOXX0000"/>
     </fos:test>
   </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24144,9 +24144,24 @@ fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance"
    <fos:function name="build-uri" prefix="fn" diff="add">
       <fos:signatures>
          <fos:proto name="build-uri" return-type="xs:string">
-            <fos:arg name="parts" type="map(xs:string,xs:string)"/>
+            <fos:arg name="parts" type-ref="parts-record"/>
             <fos:arg name="options" type="map(*)" default="map{}"/>
          </fos:proto>
+
+         <fos:record name="parts-record">
+           <fos:arg name="scheme?" type="xs:string"/>
+           <fos:arg name="authority?" type="xs:string"/>
+           <fos:arg name="userinfo?" type="xs:string"/>
+           <fos:arg name="host?" type="xs:string"/>
+           <fos:arg name="port?" type="xs:string"/>
+           <fos:arg name="path?" type="xs:string"/>
+           <fos:arg name="query?" type="xs:string"/>
+           <fos:arg name="fragment?" type="xs:string"/>
+           <fos:arg name="path-segments?" type="array(xs:string)"/>
+           <fos:arg name="query-segments?"
+                    type="array(record(key? as xs:string, value? as xs:string, *))"/>
+           <fos:arg name="*"/>
+         </fos:record>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
@@ -24159,44 +24174,50 @@ fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance"
       </fos:summary>
 
       <fos:rules>
-        <p>If the <code>segments</code> key exists in the map, then <code>$path</code> is constructed
-        with <code>string-join($parts?segments ! encode-for-uri(.), "/")</code>,
-        otherwise the value of the <code>path</code> key is used.
-        If the <code>$path</code> value is the empty sequence,
-        the empty string is used for the <code>$path</code> value.</p>
+        <p>A URI is composed from a scheme, authority, path, query, and fragment.
+        These components are derived from the contents of the <code>$parts</code>
+        map in the following way:</p>
 
-        <p>If the <code>query-keys</code> key exists in the map, the <code>$query</code> is constructed
-        with <code>string-join($parts?query-keys ! concat(encode-for-uri(.?key), "=", encode-for-uri(.?value)), "&amp;")</code>, otherwise the value of the <code>query</code> key is used.</p>
+        <p>If the <code>scheme</code> key is present in the map, the URI begins
+        with the value of that key concatenated with <code>//</code>, otherwise
+        it begins <code>//</code>.</p>
 
-        <p>If the <code>scheme</code> key is absent or is the empty sequence, then
-        <code>$scheme</code> is the scheme of the
-        static base URI, otherwise the value of the <code>scheme</code> key is
-        used. It is an error XXX if there is no static base URI.</p>
-
-        <p>If the <code>host</code> key is absent, then
-        <code>$host</code> is the host of the
-        static base URI, otherwise the value of the <code>host</code> key is used.
-        It is an error XXX if there is no static base URI.</p>
-
-        <p>The <code>$authority</code> is
+        <p>If any of <code>userinfo</code>, <code>host</code>, or <code>port</code>
+        are present in the map, the following authority is added to the URI
+        under construction:
         <eg>concat((if (exists($parts?userinfo)) then $parts?userinfo || "@" else ""),
        $host,
-       (if (exists($parts?port)) then ":" || $parts?port else ""))</eg>
-        It is an error XXX if the <code>$host</code> is the empty sequence and 
-        either <code>$parts?userinfo</code> or <code>$parts?port</code> is not
-        the empty sequence.</p>
+       (if (exists($parts?port)) then ":" || $parts?port else ""))</eg></p>
 
-        <p>If the <code>$host</code> is the empty sequence,
-        the function returns: <code>concat($scheme, ":", $path)</code>.</p>
+        <p>If none of <code>userinfo</code>, <code>host</code>, or <code>port</code>
+        is present, and <code>authority</code> is present, the value of the
+        <code>authority</code> key is added to the URI.</p>
 
-        <p>If the <code>$host</code> is not the empty sequence,
-        the function returns:
-        <eg>concat($scheme, "://", $authority, $path,
-       (if (exists($query)) then "?" || $query else ""),
-       (if (exists($parts?fragment)) then "#" || $parts?fragment else "")</eg></p>
+        <p>If the <code>path-segments</code> key exists in the map, then the
+        path is constructed
+        with <code>string-join($parts?path-segments ! encode-for-uri(.), "/")</code>,
+        otherwise the value of the <code>path</code> key is used.
+        If the <code>path</code> value is the empty sequence,
+        the empty string is used for the path. The path is added to the URI.</p>
 
-       <p>TODO: can non-hierarchical URIs have queries or fragments?</p>
+        <p>If the <code>query-segments</code> key exists in the map, then
+        a sequence of strings is constructed from each segment in turn.
+        If the segment contains both a <code>key</code> and a <code>value</code>,
+        the string is the concatenation of the value of the <code>key</code>,
+        an equal sign (“<code>=</code>”), and the value of the <code>value</code>. If it contains
+        only one of those keys, then it is the value of that key. If it contains
+        neither, it is ignored. The query is constructed by joining the resulting
+        strings into a single string, separated by ampersands (“<code>&amp;</code>”).
+        If the <code>query-segments</code> key does not exist in the map, but
+        the <code>query</code> key does, then the query is the value of the
+        <code>query</code> key. If there’s a query, it is added to the URI with
+        a preceding question mark (“<code>?</code>”).</p>
 
+        <p>If the <code>fragment</code> key exists in the map, then
+        the value of that key is added to the URI with
+        a preceding hash mark (“<code>#</code>”).</p>
+
+        <p>The resulting URI is returned.</p>
       </fos:rules>
       
       <fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23589,93 +23589,419 @@ declare function fn:some(
       <fos:rules>
          <p>The function parses the <code>$uri</code> provided,
          returning a map containing its constituent parts: scheme,
-         authority components, path, etc.</p>
+         authority components, path, etc.
+         <bibref ref="rfc3986"/>, which defines URIs, is concerned with
+         the syntax of absolute URIs. This function must also account
+         for relative URIs, which complicates things somewhat.</p>
 
-         <p>If the <code>$uri</code> provided is a relative reference,
-         it is made absolute with respect to the static base URI
-         before parsing it. It is an error XXX if the static base URI
-         is undefined.</p>
+         <p>This function is described as a series of transformations
+         over the input string to identify the parts of a URI that are
+         present. Some portions of the URI are identified by matching
+         with a regular expression. This approach is designed to make
+         the description clear and unambiguous, it is not implementation
+         advice.</p>
 
-         <p>The parts returned are the <code>scheme</code>,
-         <code>userinfo</code>, <code>host</code>, <code>port</code>,
-         <code>path</code>, <code>query</code>, and
-         <code>fragment</code> These are defined in the ABNF for URIs
-         defined in <bibref ref="rfc3986"/>.</p>
+         <p>Begin with a <emph>string</emph> that is equal to the <code>$uri</code>.
+         If the <emph>string</emph> contains any backlashes
+         (“<code>\</code>”), replace them with forward slashes
+         (“<code>/</code>”).</p>
 
-         <p>If the <code>$options</code> map contains the key
-         <code>details</code> with the effective boolean value
-         <code>true()</code>, the <code>path</code> and
-         <code>query</code> values are further parsed to provide
-         <code>segments</code> and <code>query-keys</code>.</p>
+         <p>If the <emph>string</emph> matches <code>^(.*)#([^#]*)$</code>,
+         the <emph>string</emph> is the first match group and the
+         <emph>fragment</emph> is the second match group. Otherwise,
+         the string is unchanged and the <emph>fragment</emph> is the empty
+         sequence.</p>
 
-         <p>The value of the <code>segments</code> key will be the
-         seqeuence of strings that results from tokenizing the path
-         component on the “<code>/</code>” character. Any escaped characters in each
-         segment will be replaced by their literal forms.</p>
+         <p>If the <emph>string</emph> matches <code>^(.*)\?([^\?]*)$</code>,
+         the <emph>string</emph> is the first match group and the
+         <emph>query</emph> is the second match group. Otherwise,
+         the string is unchanged and the <emph>query</emph> is the empty
+         sequence.</p>
 
-         <p>The value of the <code>query-keys</code> key will be
-         a sequence of maps. The <code>query</code> will be split into parts
-         delimited by “<code>&amp;</code>”. Each part will further be split at the
-         first “<code>=</code>”. The string preceding the equal sign, or the whole
-         string if no equal sign is present, will be stored in the map as the value
-         of the key “<code>key</code>”. The string following the equal sign, or the
-         empty string if no equal sign is present, will be stored in the map as the
-         value of the key “<code>value</code>”. Any escaped characters in the keys or
-         values will be replaced by their literal forms.</p>
+         <p>If the <emph>string</emph> matches <code>^[a-zA-Z]:</code>,
+         the <emph>scheme</emph> is <code>file</code> and the
+         <emph>string</emph> is unchanged. Otherwise, if the
+         <emph>string</emph> matches
+         <code>^([a-zA-Z][A-Za-z0-9\+\-\.]*):(.*)$</code>, the
+         <emph>scheme</emph> is the first match group and the
+         <emph>string</emph> is the second match group. If the
+         <emph>string</emph> does not match either expression, the <emph>scheme</emph>
+         is the empty sequence and the <emph>string</emph> is unchanged.</p>
+
+         <p>If the <emph>string</emph> matches <code>^//*([a-zA-Z]:.*)$</code>,
+         the <emph>authority</emph> is empty and the <emph>string</emph> is
+         the first match group. Otherwise, if the <emph>string</emph>
+         matches <code>^///*([^/]+)(/.*)?$</code> then the <emph>authority</emph>
+         is the first match group and the <emph>string</emph> is the second
+         match group. If the <emph>string</emph> does not match either
+         regular expression, the <emph>authority</emph> is the empty sequence
+         and the <emph>string</emph> is unchanged.</p>
+
+         <p>If the <emph>authority</emph> matches
+         <code>(([^@]*)@)(.*)(:([^:]*))?$</code>,
+         then the <emph>userinfo</emph> is match group 2, otherwise
+         <emph>userinfo</emph> is the empty sequence.</p>
+
+         <p>If the <emph>authority</emph> matches
+         <code>(([^@]*)@)?(.+)(:([^:]*))?$</code>,
+         then the <emph>host</emph> is match group 3, otherwise
+         <emph>host</emph> is the empty sequence.</p>
+
+         <p>If the <emph>authority</emph> matches
+         <code>(([^@]*)@)?(.*)(:([^:]*))$</code>,
+         then the <emph>port</emph> is match group 5, otherwise
+         <emph>port</emph> is the empty sequence.</p>
+
+         <p>If the <emph>string</emph> is the empty string, then
+         <emph>path</emph> is the empty sequence, otherwise the <emph>path</emph>
+         is the whole <emph>string</emph>.</p>
+
+         <p>If the <code>$options</code> map contains a key named
+         “<code>path-separator</code>”, the value of that key is the
+         <emph>path separator</emph> otherwise the separator is
+         a single slash (“<code>/</code>”). It is a dynamic error XXXX if the key
+         is present and it’s value is not a string of length one.</p>
+
+         <p>A <emph>path-segments</emph> array is constructed as follows: tokenize the
+         <emph>string</emph> on the <emph>path separator</emph>,
+         apply <emph>uri decoding</emph> on each token, and convert
+         the result to an array.</p>
+
+         <p>Applying <emph>uri decoding</emph> replaces all occurrences of
+         plus (“<code>+</code>”) with spaces and all occurrences of
+         <code>%[a-fA-F0-9][a-fA-F0-9]</code> with a single character with the
+         codepoint represented by the two digit hexadecimal number that
+         follows the “<code>%</code>”. In other words, “<code>A%42C</code>” becomes
+         “<code>ABC</code>”. If there are any occurrences of <code>%</code> followed
+         by up to two characters that are not hexadecimal digits, they are
+         replaced by the single character with the
+         codepoint 0xfffd. In other words “<code>A%XYC%Z</code>” becomes
+         “<code>A&#xfffd;C&#xfffd;</code>.</p>
+
+         <p>If the <code>$options</code> map contains a key named
+         “<code>query-separator</code>”, the value of that key is the
+         <emph>query separator</emph> otherwise the separator is
+         a single ampersand (“<code>&amp;</code>”). It is a dynamic error XXXX if the key
+         is present and it’s value is not a string of length one.</p>
+
+         <p>A <emph>query-segments</emph> is constructed as follows: tokenize
+         the <emph>query</emph> on the <emph>query separator</emph>,
+         apply <emph>uri decoding</emph> on each token, and convert
+         the result to an array.</p>
+         
+         <p>The following map is returned:</p>
+
+         <eg>{
+  "uri": $uri,
+  "scheme": <emph>scheme</emph>,
+  "authority": <emph>authority</emph>,
+  "userinfo": <emph>userinfo</emph>,
+  "host": <emph>host</emph>,
+  "port": <emph>port</emph>,
+  "path": <emph>path</emph>,
+  "query": <emph>query</emph>,
+  "fragment": <emph>fragment</emph>,
+  "path-segments": <emph>path-segments</emph>,
+  "query-segments": <emph>query-segments</emph>
+}</eg>
+
+         <p>TODO: should the map contain keys with values that are the empty sequence or an empty array, or should they be omitted?</p>
+
       </fos:rules>
       
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:parse-uri("https://qt4cg.org/specifications/index.html")</fos:expression>
-               <fos:result>map {
-    "scheme": "https",
-    "userinfo": (),
-    "host": "qt4cg.org",
-    "port": (),
-    "path": "/specifications/index.html",
-    "query": (),
-    "fragment": (),
-  }</fos:result>               
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:parse-uri("urn:example:part%3aone:two")</fos:expression>
-               <fos:result>map {
-    "scheme": "urn",
-    "host": (),
-    "path": "example:part%3aone:two"
-  }</fos:result>               
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:parse-uri("http://user@example.com:8080/a%2fb/c+d?a=b&amp;c=d&amp;c=e%26#foo", map{"details": true()})</fos:expression>
-               <fos:result>map {
-    "scheme": "http",
-    "userinfo": "user",
-    "host": "example.com",
-    "port": "8080",
-    "path": "/a%2fb/c+d",
-    "query": "a=b&amp;c=d&amp;c=e%26",
-    "fragment": "foo",
-    "segments": ("a/b", "c d"),
-    "query-keys": ({"key": "a", "value": "b"}, {"key": "c", "value": "d"}, {"key": "c", "value": "e&amp;"}), 
-  }</fos:result>               
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:parse-uri("jar:file://path/to/file.jar!/resource")</fos:expression>
-               <fos:result>map {
-    "scheme": "jar",
-    "host": (),
-    "path": "file://path/to/file.jar!/resource"
-  }</fos:result>               
-            </fos:test>
-         </fos:example>
-
+<fos:examples>
+  <fos:example>
+    <p>In the examples that follow, keys with values that are null, or an empty array,
+are elided for editorial clarity.</p>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri")</eg></fos:expression>
+      <fos:result><eg>map {
+  "uri": "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri",
+  "scheme": "http",
+  "authority": "qt4cg.org",
+  "host": "qt4cg.org",
+  "path": "/specifications/xpath-functions-40/Overview.html",
+  "fragment": "parse-uri",
+  "path-segments": array { "", "specifications", "xpath-functions-40", "Overview.html" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("http://www.ietf.org/rfc/rfc2396.txt")</eg></fos:expression>
+      <fos:result><eg>map {
+  "uri": "http://www.ietf.org/rfc/rfc2396.txt",
+  "scheme": "http",
+  "authority": "www.ietf.org",
+  "host": "www.ietf.org",
+  "path": "/rfc/rfc2396.txt",
+  "path-segments": array { "", "rfc", "rfc2396.txt" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("https://example.com/path/to/file")</eg></fos:expression>
+      <fos:result><eg>map {
+  "uri": "https://example.com/path/to/file",
+  "scheme": "https",
+  "authority": "example.com",
+  "host": "example.com",
+  "path": "/path/to/file",
+  "path-segments": array { "", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance",
+  "scheme": "https",
+  "authority": "example.com:8080",
+  "host": "example.com",
+  "port": "080",
+  "path": "/path",
+  "query": "s=%22hello world%22&amp;sort=relevance",
+  "query-segments": array { "s=""hello world""", "sort=relevance" },
+  "path-segments": array { "", "path" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("https://user@example.com/path/to/file")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "https://user@example.com/path/to/file",
+  "scheme": "https",
+  "authority": "user@example.com",
+  "userinfo": "user",
+  "host": "example.com",
+  "path": "/path/to/file",
+  "path-segments": array { "", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+  "scheme": "ftp",
+  "authority": "ftp.is.co.za",
+  "host": "ftp.is.co.za",
+  "path": "/rfc/rfc1808.txt",
+  "path-segments": array { "", "rfc", "rfc1808.txt" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("file:////uncname/path/to/file")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "file:////uncname/path/to/file",
+  "scheme": "file",
+  "authority": "uncname",
+  "host": "uncname",
+  "path": "/path/to/file",
+  "path-segments": array { "", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("file:///c:/path/to/file")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "file:///c:/path/to/file",
+  "scheme": "file",
+  "path": "c:/path/to/file",
+  "path-segments": array { "c:", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("file:/C:/Program%20Files/test.jar")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "file:/C:/Program%20Files/test.jar",
+  "scheme": "file",
+  "path": "C:/Program%20Files/test.jar",
+  "path-segments": array { "C:", "Program Files", "test.jar" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("file:\\c:\path\to\file")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "file:\\c:\path\to\file",
+  "scheme": "file",
+  "path": "c:/path/to/file",
+  "path-segments": array { "c:", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("file:\c:\path\to\file")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "file:\c:\path\to\file",
+  "scheme": "file",
+  "path": "c:/path/to/file",
+  "path-segments": array { "c:", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("c:\path\to\file")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "c:\path\to\file",
+  "scheme": "file",
+  "path": "c:/path/to/file",
+  "path-segments": array { "c:", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("/path/to/file")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "/path/to/file",
+  "path": "/path/to/file",
+  "path-segments": array { "", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("#testing")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "#testing",
+  "path": "",
+  "fragment": "testing"
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("?q=1")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "?q=1",
+  "path": "",
+  "query": "q=1",
+  "query-segments": array { "q=1" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <p>TODO: How much effort do we want to put into parsing IPV6 host names?</p>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("ldap://[2001:db8::7]/c=GB?objectClass?one")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "ldap://[2001:db8::7]/c=GB?objectClass?one",
+  "scheme": "ldap",
+  "authority": "[2001:db8::7]",
+  "host": "[2001:db8::7]",
+  "path": "/c=GB",
+  "query": "objectClass?one",
+  "query-segments": array { "objectClass?one" },
+  "path-segments": array { "", "c=GB" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("mailto:John.Doe@example.com")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "mailto:John.Doe@example.com",
+  "scheme": "mailto",
+  "path": "John.Doe@example.com",
+  "path-segments": array { "John.Doe@example.com" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("news:comp.infosystems.www.servers.unix")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "news:comp.infosystems.www.servers.unix",
+  "scheme": "news",
+  "path": "comp.infosystems.www.servers.unix",
+  "path-segments": array { "comp.infosystems.www.servers.unix" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("tel:+1-816-555-1212")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "tel:+1-816-555-1212",
+  "scheme": "tel",
+  "path": "+1-816-555-1212",
+  "path-segments": array { " 1-816-555-1212" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("telnet://192.0.2.16:80/")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "telnet://192.0.2.16:80/",
+  "scheme": "telnet",
+  "authority": "92.0.2.16:80",
+  "host": "92.0.2.16",
+  "port": "0",
+  "path": "/",
+  "path-segments": array { "", "" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+  "scheme": "urn",
+  "path": "oasis:names:specification:docbook:dtd:xml:4.1.2",
+  "path-segments": array { "oasis:names:specification:docbook:dtd:xml:4.1.2" }
+}</eg></fos:result>
+    </fos:test>
+  </fos:example>
+  <fos:example>
+<p>This example uses the algorithm described above, but may not be
+useful to the user. TODO: should we allow implementations to use different parsing
+algorithms for URI schemes that they recognize?</p>
+    <fos:test>
+      <fos:expression><eg>fn:parse-uri("jar:file:/C:/Program%20Files/test.jar!/foo/bar")</eg></fos:expression>
+      <fos:result><eg>
+map {
+  "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
+  "scheme": "jar",
+  "path": "file:/C:/Program%20Files/test.jar!/foo/bar",
+  "path-segments": array { "file:", "C:", "Program Files", "test.jar!", "foo", "bar" }
+}
+</eg></fos:result>
+    </fos:test>
+  </fos:example>
       </fos:examples>
       <fos:history>
          <fos:version version="4.0">Proposed on 17 Oct 2022 to resolve

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23571,10 +23571,26 @@ declare function fn:some(
 
    <fos:function name="parse-uri" prefix="fn" diff="add">
       <fos:signatures>
-         <fos:proto name="parse-uri" return-type="map(xs:string,xs:string)">
+         <fos:proto name="parse-uri" return-type-ref="result-map">
             <fos:arg name="uri" type="xs:string"/>
             <fos:arg name="options" type="map(*)" default="map{}"/>
          </fos:proto>
+
+         <fos:record name="result-map">
+           <fos:arg name="uri" type="xs:string"/>
+           <fos:arg name="scheme" type="xs:string"/>
+           <fos:arg name="authority" type="xs:string"/>
+           <fos:arg name="userinfo" type="xs:string"/>
+           <fos:arg name="host" type="xs:string"/>
+           <fos:arg name="port" type="xs:string"/>
+           <fos:arg name="path" type="xs:string"/>
+           <fos:arg name="query" type="xs:string"/>
+           <fos:arg name="fragment" type="xs:string"/>
+           <fos:arg name="path-segments" type="array(xs:string)"/>
+           <fos:arg name="query-segments"
+                    type="array(record(key? as xs:string, value? as xs:string, *))"/>
+           <fos:arg name="*"/>
+         </fos:record>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18067,56 +18067,120 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       </fos:examples>
    </fos:function>
 
-   <fos:function name="group-by" prefix="map">
+   <fos:function name="build" prefix="map">
       <fos:signatures>
-         <fos:proto name="group-by" return-type="map(*)">
-            <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="key" type="function(item()) as xs:anyAtomicType?" usage="inspection"/>
+         <fos:proto name="build" return-type="map(*)">
+            <fos:arg name="input" type="item()*"/>
+            <fos:arg name="key" type="function(item()) as xs:anyAtomicType" default="fn:identity#1"/>
+            <fos:arg name="value" type="function(item()) as item()*" default="fn:identity#1"/>
+            <fos:arg name="combine" type="function(item()*, item()*) as item()*" default="op(',')"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
+         <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
-         <fos:property>higher-order</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Constructs a map by taking the items in a sequence and grouping on a key that is computed for each item.</p>
+         <p>Returns a map that contains one entry for each item in a supplied input sequence, combining duplicates.</p>
       </fos:summary>
       <fos:rules>
-         <p>The result of the function <code>map:group-by($seq, $key)</code> is equivalent to the
-            result of the expression:</p>
-         <eg><![CDATA[map:merge(
-  for $item in $input,
-      $k in $key($item)
-    return map:entry($k, $item),
-  map{"duplicates":"combine"})
-            ]]></eg>
+         <p>Informally, the function processes each item in <code>$input</code> in order. It calls the <code>$key</code> function on
+            that item to obtain a key value, and the <code>$value</code> function to obtain an associated value. 
+            If the key is not already present in the target map, it adds a new key-value pair with that key 
+            and that value. If the key is already present, it calls the <code>$combine</code> function to combine the existing value 
+            for the key with the new value, and replaces the entry with this combined value.
+         </p>
+         <p>More formally, the result of the function is the result of the following expression:</p>
+         
+         <eg>
+            fold-left($input, map{}, ->($map, $next) {
+            let $nextKey := $key($next)
+            let $nextValue := $value($next)
+            return 
+            if (map:contains($map, $nextKey))
+            then map:put($map, $nextKey, $combine($map($nextKey), $nextValue))
+            else map:put($map, $nextKey, $nextValue)
+            })
+         </eg>
       </fos:rules>
+      
       <fos:notes>
-         <p>The effect of the function is to create a map that indexes the items in the supplied
-            sequence <code>$input</code>, computing a key for each one by evaluating the supplied
-            function <code>$key</code>. If the <code>$key</code> function returns an empty sequence
-            for an input item, that input item is not included in the index. If two items in the input
-            sequence have the same computed key value, then the index contains an entry in which the two
-            items both appear, retaining order.</p>
-         <p>This function may sometimes be an effective substitute for the <code>xsl:for-each-group</code>
-         instruction in XSLT.</p>
+         <p>Although defined to process the input sequence in order, this is only relevant when combining the entries
+            for duplicate keys.</p>
+         <p>The default function for both <code>$key</code> and <code>$value</code> is the identity function.
+            Although it is permitted to default both, this serves little purpose: usually at least one of these arguments
+            will be supplied.</p>
+         <p>The default action for combining entries with duplicate keys is to perform a sequence-concatenation of the corresponding values,
+            equivalent to the <code>duplicates: combine</code> option on <code>map:merge</code>. Other potentially useful
+            functions for combining duplicates include:</p>
+         <ulist>
+            <item><p><code>->($a, $b){$a}</code> Use the first value and discard the remainder</p></item>
+            <item><p><code>->($a, $b){$b}</code> Use the last value and discard the remainder</p></item>
+            <item><p><code>concat(?, ",", ?)</code> Form the string-concatenation of the values, comma-separated</p></item>
+            <item><p><code>op('+')</code> Compute the sum of the values</p></item>
+         </ulist>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:group-by(("January", "February", "March", "April", "May",
+               <fos:expression>map:build((), fn:string#1)</fos:expression>
+               <fos:result>map{}</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:build(1 to 10, ->{. mod 3})</fos:expression>
+               <fos:result>map{0: (3, 6, 9), 1: (1, 4, 7, 10), 2: (2, 5, 8)}</fos:result>
+               <fos:postamble>Returns a map with one entry for each distinct value of <code>. mod 3</code>. The
+                  function to compute the value is the identity function, and duplicates are combined by
+                  sequence concatenation.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:build(1 to 5, value := fn:format-integer(?, "w")})</fos:expression>
+               <fos:result>map{1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}</fos:result>
+               <fos:postamble>Returns a map with five entries. The function to compute the key is an identity function, the
+                  function to compute the value invokes <code>fn:format-integer</code>.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:build(("January", "February", "March", "April", "May",
                   "June", "July", "August", "September", "October", "November", "December"), fn:substring(?, 1, 1)})</fos:expression>
                <fos:result>map{"A": ("April", "August"), "D": ("December"), "F": ("February"), "J": ("January", "June", "July"), 
                   "M": ("March", "May"), "N": ("November"), "O": ("October"), "S": ("September")}</fos:result>
             </fos:test>
+            <fos:test>
+               <fos:expression>map:build(("apple", "apricot", "banana", "blueberry", "cherry"), 
+                  fn:substring(?, 1, 1), fn:string-length#1, fn:op("+"))</fos:expression>
+               <fos:result>map{"a": 12, "b": 15, "c": 6}</fos:result>
+               <fos:postamble>Constructs a map where the key is the first character of an input item, and where the corresponding value
+                  is the total string-length of the items starting with that character.</fos:postamble>
+            </fos:test>
+            
+            
          </fos:example>
          <fos:example>
-            <p>To index employees by date of birth:</p>
-            <eg>map:group-by(//employee, ->{xs:date(./date-of-birth)})</eg>
+            <p>The following expression creates a map whose keys are employee <code>@ssn</code> values, and whose
+               corresponding values are the employee nodes:</p>
+            <eg>map:build(//employee, ->{@ssn})</eg>
          </fos:example>
-
+         <fos:example>
+            <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
+               corresponding values represent the number of employees at each distinct location:</p>
+            <eg>map:build(//employee, ->{@location}, ->{1}, fn:op("+"))</eg>
+         </fos:example>
+         <fos:example>
+            <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
+               corresponding values contain the employee node for the highest-paid employee at each distinct location:</p>
+            <eg>map:build(//employee, ->{@location}, 
+               combine := ->($a, $b){fn:highest(($a, $b), ->{xs:decimal(@salary)}))</eg>
+         </fos:example>
+         <fos:example>
+            <p>The following expression creates a map allowing efficient access to every element in a document by means
+               of its <code>fn:generate-id</code> value:</p>
+            <eg>map:build(//*, fn:generate-id#1)</eg>
+         </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for version 4.0 2022-10-11</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="size" prefix="map">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23491,7 +23491,196 @@ declare function fn:some(
       </fos:history>
    </fos:function>
 
+   <fos:function name="parse-uri" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="parse-uri" return-type="map(xs:string,xs:string)">
+            <fos:arg name="uri" type="xs:string"/>
+            <fos:arg name="options" type="map(*)" default="map{}"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
 
+      <fos:summary>
+         <p>Parses the URI provided and returns a map of its parts.</p>
+      </fos:summary>
 
+      <fos:rules>
+         <p>The function parses the <code>$uri</code> provided,
+         returning a map containing its constituent parts: scheme,
+         authority components, path, etc.</p>
 
+         <p>If the <code>$uri</code> provided is a relative reference,
+         it is made absolute with respect to the static base URI
+         before parsing it. It is an error XXX if the static base URI
+         is undefined.</p>
+
+         <p>The parts returned are the <code>scheme</code>,
+         <code>userinfo</code>, <code>host</code>, <code>port</code>,
+         <code>path</code>, <code>query</code>, and
+         <code>fragment</code> These are defined in the ABNF for URIs
+         defined in <bibref ref="rfc3986"/>.</p>
+
+         <p>If the <code>$options</code> map contains the key
+         <code>details</code> with the effective boolean value
+         <code>true()</code>, the <code>path</code> and
+         <code>query</code> values are further parsed to provide
+         <code>segments</code> and <code>query-keys</code>.</p>
+
+         <p>The value of the <code>segments</code> key will be the
+         seqeuence of strings that results from tokenizing the path
+         component on the “<code>/</code>” character. Any escaped characters in each
+         segment will be replaced by their literal forms.</p>
+
+         <p>The value of the <code>query-keys</code> key will be
+         a sequence of maps. The <code>query</code> will be split into parts
+         delimited by “<code>&amp;</code>”. Each part will further be split at the
+         first “<code>=</code>”. The string preceding the equal sign, or the whole
+         string if no equal sign is present, will be stored in the map as the value
+         of the key “<code>key</code>”. The string following the equal sign, or the
+         empty string if no equal sign is present, will be stored in the map as the
+         value of the key “<code>value</code>”. Any escaped characters in the keys or
+         values will be replaced by their literal forms.</p>
+      </fos:rules>
+      
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:parse-uri("https://qt4cg.org/specifications/index.html")</fos:expression>
+               <fos:result>map {
+    "scheme": "https",
+    "userinfo": (),
+    "host": "qt4cg.org",
+    "port": (),
+    "path": "/specifications/index.html",
+    "query": (),
+    "fragment": (),
+  }</fos:result>               
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:parse-uri("urn:example:part%3aone:two")</fos:expression>
+               <fos:result>map {
+    "scheme": "urn",
+    "host": (),
+    "path": "example:part%3aone:two"
+  }</fos:result>               
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:parse-uri("http://user@example.com:8080/a%2fb/c+d?a=b&amp;c=d&amp;c=e%26#foo", map{"details": true()})</fos:expression>
+               <fos:result>map {
+    "scheme": "http",
+    "userinfo": "user",
+    "host": "example.com",
+    "port": "8080",
+    "path": "/a%2fb/c+d",
+    "query": "a=b&amp;c=d&amp;c=e%26",
+    "fragment": "foo",
+    "segments": ("a/b", "c d"),
+    "query-keys": ({"key": "a", "value": "b"}, {"key": "c", "value": "d"}, {"key": "c", "value": "e&amp;"}), 
+  }</fos:result>               
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:parse-uri("jar:file://path/to/file.jar!/resource")</fos:expression>
+               <fos:result>map {
+    "scheme": "jar",
+    "host": (),
+    "path": "file://path/to/file.jar!/resource"
+  }</fos:result>               
+            </fos:test>
+         </fos:example>
+
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed on 17 Oct 2022 to resolve
+         <a href="https://github.com/qt4cg/qtspecs/issues/72">issue #72</a>.
+         Not yet accepted.</fos:version>
+      </fos:history>
+   </fos:function>
+
+   <fos:function name="build-uri" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="build-uri" return-type="xs:string">
+            <fos:arg name="parts" type="map(xs:string,xs:string)"/>
+            <fos:arg name="options" type="map(*)" default="map{}"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-dependent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+
+      <fos:summary>
+         <p>Constructs a URI from the parts provided.</p>
+      </fos:summary>
+
+      <fos:rules>
+        <p>If the <code>segments</code> key exists in the map, then <code>$path</code> is constructed
+        with <code>string-join($parts?segments ! encode-for-uri(.), "/")</code>,
+        otherwise the value of the <code>path</code> key is used.
+        If the <code>$path</code> value is the empty sequence,
+        the empty string is used for the <code>$path</code> value.</p>
+
+        <p>If the <code>query-keys</code> key exists in the map, the <code>$query</code> is constructed
+        with <code>string-join($parts?query-keys ! concat(encode-for-uri(.?key), "=", encode-for-uri(.?value)), "&amp;")</code>, otherwise the value of the <code>query</code> key is used.</p>
+
+        <p>If the <code>scheme</code> key is absent or is the empty sequence, then
+        <code>$scheme</code> is the scheme of the
+        static base URI, otherwise the value of the <code>scheme</code> key is
+        used. It is an error XXX if there is no static base URI.</p>
+
+        <p>If the <code>host</code> key is absent, then
+        <code>$host</code> is the host of the
+        static base URI, otherwise the value of the <code>host</code> key is used.
+        It is an error XXX if there is no static base URI.</p>
+
+        <p>The <code>$authority</code> is
+        <eg>concat((if (exists($parts?userinfo)) then $parts?userinfo || "@" else ""),
+       $host,
+       (if (exists($parts?port)) then ":" || $parts?port else ""))</eg>
+        It is an error XXX if the <code>$host</code> is the empty sequence and 
+        either <code>$parts?userinfo</code> or <code>$parts?port</code> is not
+        the empty sequence.</p>
+
+        <p>If the <code>$host</code> is the empty sequence,
+        the function returns: <code>concat($scheme, ":", $path)</code>.</p>
+
+        <p>If the <code>$host</code> is not the empty sequence,
+        the function returns:
+        <eg>concat($scheme, "://", $authority, $path,
+       (if (exists($query)) then "?" || $query else ""),
+       (if (exists($parts?fragment)) then "#" || $parts?fragment else "")</eg></p>
+
+       <p>TODO: can non-hierarchical URIs have queries or fragments?</p>
+
+      </fos:rules>
+      
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:build-uri(map {
+    "scheme": "https",
+    "host": "qt4cg.org",
+    "port": (),
+    "path": "/specifications/index.html"
+  })</fos:expression>
+               <fos:result>https://qt4cg.org/specifications/index.html</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed on 17 Oct 2022 to resolve
+         <a href="https://github.com/qt4cg/qtspecs/issues/72">issue #72</a>.
+         Not yet accepted.</fos:version>
+      </fos:history>
+   </fos:function>
 </fos:functions>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3644,6 +3644,12 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
          <div2 id="func-escape-html-uri">
             <head><?function fn:escape-html-uri?></head>
          </div2>
+         <div2 id="parse-uri">
+            <head><?function fn:parse-uri?></head>
+         </div2>
+         <div2 id="build-uri">
+            <head><?function fn:build-uri?></head>
+         </div2>
       </div1>
       <div1 id="boolean-functions">
          <head>Functions and operators on Boolean values</head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3645,10 +3645,10 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
          <div2 id="func-escape-html-uri">
             <head><?function fn:escape-html-uri?></head>
          </div2>
-         <div2 id="parse-uri">
+         <div2 id="func-parse-uri">
             <head><?function fn:parse-uri?></head>
          </div2>
-         <div2 id="build-uri">
+         <div2 id="func-build-uri">
             <head><?function fn:build-uri?></head>
          </div2>
       </div1>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -202,14 +202,15 @@ for transition to Proposed Recommendation. </p>'>
                     <bibref ref="xslt-40"/> and other related XML standards.  The signatures and summaries of functions defined in this document are available at:
 <loc href="http://www.w3.org/2005/xpath-functions/">http://www.w3.org/2005/xpath-functions/</loc>.</p>
            
-<p>This document is a proposal by the editor, with no official standing, to create a new version 4.0 of the function
-   library, with additional convenience functions.</p>
+
            <p>A summary of changes since version 3.1 is provided at <specref ref="changelog"/>.</p>
 </abstract>
 
 <!--&status-section;-->
        <status>
-          <p>This is a first proposal by the editor, with no official standing whatsoever. Comments are invited.</p>
+          <p>This version of the specification is work in progress. It is produced by the QT4 Working Group, officially
+             the W3C XSLT 4.0 Extensions Community Group. Individual functions specified in the document may be at
+             different stages of review, reflected in their <term>History</term> notes. Comments are invited.</p>
        </status>
 
         <langusage>
@@ -6046,8 +6047,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-map-replace" diff="add" at="A">
                <head><?function map:replace?></head>
             </div3>  
-            <div3 id="func-map-group-by" diff="add" at="A">
-               <head><?function map:group-by?></head>
+            <div3 id="func-map-build" diff="add" at="A">
+               <head><?function map:build?></head>
             </div3>
             
  

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -92,6 +92,7 @@
 				<def>
 					<xsl:copy-of select="$fspec/fos:signatures/(@diff, @at)"/>
 					<xsl:apply-templates select="$fspec/fos:signatures/fos:proto"/>
+					<xsl:apply-templates select="$fspec/fos:signatures/fos:record"/>
 				</def>
 			</gitem>
 			<xsl:if test="$fspec/fos:properties">
@@ -196,19 +197,22 @@
 		<xsl:variable name="isOp" as="xs:boolean" select="exists(../../fos:opermap)"/>
 		<example role="signature">
 			<xsl:variable name="prefix" select="../../@prefix"/>
-			<proto name="{@name}" return-type="{@return-type}"
-				isOp="{if ($isOp) then 'yes' else 'no'}"
-				prefix="{if ($prefix) then $prefix else if ($isOp) then 'op' else 'fn'}">
-				<xsl:copy-of select="@diff, @at"/>
-				<xsl:apply-templates/>
+			<proto isOp="{if ($isOp) then 'yes' else 'no'}"
+			       prefix="{if ($prefix)
+                                        then $prefix
+                                        else if ($isOp)
+                                             then 'op'
+                                             else 'fn'}">
+			  <xsl:copy-of select="@name, @return-type, @return-type-ref, @diff, @at"/>
+			  <xsl:apply-templates/>
 			</proto>
 		</example>
 	</xsl:template>
 
 	<xsl:template match="fos:arg">
-		<arg name="{@name}" type="{@type}">
-			<xsl:copy-of select="@diff, @at, @default"/>
-		</arg>
+	  <arg>
+	    <xsl:copy-of select="@name, @type, @diff, @at, @default"/>
+	  </arg>
 	</xsl:template>
 	
 	<xsl:template match="fos:arg[@type='record']">
@@ -225,6 +229,15 @@
 			</xsl:attribute>
 			<xsl:copy-of select="@diff, @at, @default"/>
 		</arg>
+	</xsl:template>
+
+	<xsl:template match="fos:record">
+	  <example role="record">
+	    <record>
+	      <xsl:copy-of select="@name, @diff, @at"/>
+	      <xsl:apply-templates/>
+	    </record>
+	  </example>
 	</xsl:template>
 
 	<xsl:template match="fos:example">

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -258,6 +258,9 @@
 					<xsl:when test="fos:expression/@xml:space='preserve'">
 						<xsl:value-of select="translate(fos:expression, ' ', '&#xa0;')"/>
 					</xsl:when>
+                                        <xsl:when test="fos:expression/eg">
+                                          <xsl:apply-templates select="fos:expression/node()"/>
+                                        </xsl:when>
 					<xsl:otherwise>
 						<xsl:value-of select="fos:expression"/>
 					</xsl:otherwise>
@@ -283,9 +286,16 @@
 					<xsl:if test="fos:result/@allow-permutation='true'">
 						<xsl:text>some permutation of </xsl:text>
 					</xsl:if>
-					<code>
-						<xsl:value-of select="fos:result"/>
-					</code>
+                                        <xsl:choose>
+                                          <xsl:when test="fos:result/eg">
+                                            <xsl:apply-templates select="fos:result/node()"/>
+                                          </xsl:when>
+                                          <xsl:otherwise>
+					    <code>
+					      <xsl:value-of select="fos:result"/>
+					    </code>
+                                          </xsl:otherwise>
+                                        </xsl:choose>
 					<xsl:if test="fos:result/@approx='true'">
 						<xsl:text> (approximately)</xsl:text>
 					</xsl:if>

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -211,7 +211,7 @@
 
 	<xsl:template match="fos:arg">
 	  <arg>
-	    <xsl:copy-of select="@name, @type, @diff, @at, @default"/>
+	    <xsl:copy-of select="@name, @type, @type-ref, @diff, @at, @default"/>
 	  </arg>
 	</xsl:template>
 	

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -73,11 +73,15 @@ div.issueBody    { margin-left: 0.25in;
 
 code.function    { font-weight: bold;
                  }
-code.return-type { font-style: italic;
+.return-type { font-style: italic;
                  }
-code.return-varies { font-weight: bold;
+.return-varies { font-weight: bold;
                    font-style: italic;
                  }
+.proto .return-type-ref {
+  background-color: #fff6ff;
+  font-style: normal;
+}
 code.type        { font-style: italic;
                  }
 code.as          { font-style: normal;
@@ -151,6 +155,17 @@ div.proto        {
 		overflow: auto;
                  }
 
+div.record        { 
+    padding: .5em;
+		border: .5em;
+		border-left-style: solid;
+		page-break-inside: avoid;
+		margin: 1em auto;
+		border-color: #ffaaff;
+		background: #fff6ff;
+		overflow: auto;
+                 }
+
 
 div.example-chg  { border: solid thick yellow; background-color: #40e0d0; padding: 1em
                  }
@@ -186,15 +201,23 @@ table.data table.index {
  border-bottom:2px !important ;
 }
 
-table.proto tr td {
+table.proto tr td,
+table.record tr td, {
   font-family: monospace;
   padding-right: 0.5em;
 }
-table.proto tr.arg td:first-child  {
+table.proto tr.arg td:first-child,
+table.record tr.arg td:first-child  {
   padding-left: 2em;
 }
 table.proto tr.name span.name {
   font-weight: bold;
+}
+span.dagger {
+  font-family: serif;
+  font-weight: bold;
+  font-size: 150%;
+  font-style: italic;
 }
 </xsl:text>
 </xsl:param>
@@ -450,6 +473,12 @@ table.proto tr.name span.name {
     </div>
   </xsl:template>
 
+  <xsl:template match="example[@role='record']" priority="10">
+    <div>
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
 <!-- Override proto and arg to print XQuery F/O-style prototypes -->
 
 <xsl:template match="proto">
@@ -465,7 +494,6 @@ table.proto tr.name span.name {
   </xsl:variable>
 
   <div class="proto">
-    <!--<pre><xsl:sequence select="serialize(., map{'method':'xml', 'indent': true()})"/></pre>-->
     <xsl:choose>
       <xsl:when test="empty(arg)">
         <table class="proto" border="0">
@@ -536,25 +564,81 @@ table.proto tr.name span.name {
 	    <td colspan="3">
               <xsl:text>)</xsl:text>
               <code class="as">&#160;as&#160;</code>
-              <xsl:choose>
-                <xsl:when test="@returnVaries = 'yes'">
-                  <code class="return-varies">
+              <code>
+                <xsl:if test="@returnVaries = 'yes' or @return-type-ref">
+                  <xsl:attribute name="class"
+                                 select="if (@returnVaries = 'yes' and @return-type-ref)
+                                         then 'return-varies return-type-ref'
+                                         else if (@returnVaries = 'yes')
+                                              then 'return-varies'
+                                              else 'return-type-ref'"/>
+                </xsl:if>
+
+                <xsl:choose>
+                  <xsl:when test="@return-type">
                     <xsl:value-of select="@return-type"/>
                     <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
-                  </code>
-                </xsl:when>
-                <xsl:otherwise>
-                  <code class="return-type">
+                  </xsl:when>
+                  <xsl:when test="@return-type-ref">
+                    <span class="dagger">†</span>
+                    <a href="#{@return-type-ref}">
+                      <xsl:value-of select="@return-type-ref"/>
+                    </a>
+                    <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
+                  </xsl:when>
+                  <xsl:otherwise>
                     <xsl:value-of select="@return-type"/>
                     <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
-                  </code>
-                </xsl:otherwise>
-              </xsl:choose>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </code>
             </td>
           </tr>
         </table>
       </xsl:otherwise>
     </xsl:choose>
+  </div>
+</xsl:template>
+
+<xsl:template match="record">
+  <div class="record">
+    <table class="record" border="0">
+      <tr>
+        <td colspan="2">
+          <code id="{@name}" class="return-type-ref">
+            <span class="dagger">†</span>
+            <xsl:value-of select="@name"/>
+          </code>
+          <xsl:text>:</xsl:text>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <code>record(</code>
+        </td>
+      </tr>
+      <xsl:for-each select="arg">
+        <tr class="arg">
+          <td>
+            <xsl:sequence select="@name/string()"/>
+          </td>
+          <td>
+            <xsl:if test="@type">
+              <code class="as">&#160;as&#160;</code>
+              <code>
+                <xsl:value-of select="@type"/>
+              </code>
+            </xsl:if>
+            <xsl:if test="not(position() = last())">,</xsl:if>
+          </td>
+        </tr>
+      </xsl:for-each>
+      <tr>
+        <td colspan="2">
+          <code>)</code>
+        </td>
+      </tr>
+    </table>
   </div>
 </xsl:template>
 

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -541,12 +541,20 @@ span.dagger {
             <tr class="arg">
               <td>
                 <code>$<xsl:sequence select="@name/string()"/></code>
-                <xsl:if test="not(@type) and not($last)">,</xsl:if>
+                <xsl:if test="not(@type) and not(@type-ref) and not($last)">,</xsl:if>
               </td>
               <td>
                 <xsl:if test="@type">
                   <code class="as">as&#160;</code>
                   <code class="type"><xsl:sequence select="@type/string()"/></code>
+                  <xsl:if test="not (@default) and not($last)">,</xsl:if>
+                </xsl:if>
+                <xsl:if test="@type-ref">
+                  <code class="as">as&#160;</code>
+                  <span class="dagger">†</span>
+                  <a href="#{@type-ref}">
+                    <xsl:value-of select="@type-ref"/>
+                  </a>
                   <xsl:if test="not (@default) and not($last)">,</xsl:if>
                 </xsl:if>
               </td>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -737,22 +737,6 @@
          <e:parent name="try"/>
       </e:allowed-parents>
    </e:element-syntax>
-   
-   <e:element-syntax name="match">
-      <e:in-category name="instruction"/>
-      <e:attribute name="select" required="no">
-         <e:data-type name="expression"/>
-      </e:attribute>
-      <e:attribute name="pattern" required="yes">
-         <e:data-type name="pattern"/>
-      </e:attribute>
-      <e:sequence>
-         <e:element repeat="zero-or-more" name="fallback"/>
-      </e:sequence>
-      <e:allowed-parents>
-         <e:parent-category name="sequence-constructor"/>
-      </e:allowed-parents>
-   </e:element-syntax>
 
    <!-- Variables -->
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10740,31 +10740,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
 
             </div3>
-            <div3 id="testing-against-pattern" diff="add" at="A">
-               <head>Testing a Value Against a Pattern</head>
-               <p>The <elcode>xsl:match</elcode> instruction can be used to test a value against a pattern.</p>
-               <?element xsl:match?>
-               <p>The <code>select</code> attribute is a <termref def="dt-expression"/>, defaulting to <code>.</code>,
-               which selects the <termref def="dt-context-item"/>.</p>
-               <p>The <code>pattern</code> attribute is a <termref def="dt-pattern"/>.</p>
-               <p>The result of the <elcode>xsl:match</elcode> instruction is the <code>xsl:boolean</code>
-                  value <code>true</code> if every item selected
-               by the <code>select</code> expression matches the pattern, and is
-               <code>false</code> otherwise.</p>
-               <p>Any <code>xsl:fallback</code> child elements are ignored by an XSLT 4.0 processor, but
-               may be used to define fallback processing for an XSLT 3.0 or earlier processor.</p>
-               <example>
-                  <head>Declaring a function that matches against a pattern</head>
-                  <p>The following declaration declares a function that matches its argument against 
-                  a supplied pattern:</p>
-                  <eg><![CDATA[
-<xsl:function name="f:is-division" as="xs:boolean">
-  <xsl:param name="node" as="element(*)"/>
-  <xsl:match select="$node" pattern="div1 | div2 | div3 | div4"/>
-</xsl:function>]]></eg>
-                  <p>This function might then be used in an expression such as <code>child::*[f:is-division(.)]</code>.</p>
-               </example>
-            </div3>
+            
          </div2>
          <div2 id="named-item-types" diff="add" at="A">
             <head>Defining Named Item Types</head>
@@ -38359,8 +38335,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                   <elcode>xsl:for-each-group</elcode> have attributes <code>array</code> and <code>map</code>
                   which can be used in place of the <code>select</code> attribute to allow iteration over arrays or maps
                   rather than sequences.</p></item>
-               <item><p>The new instruction <elcode>xsl:match</elcode> allows items to be matched against
-               and XSLT pattern to deliver a boolean result.</p></item>
+               
                <item><p>New pattern syntax ( <code>type(T)</code>, <code>record(N, M, N)</code>) 
                   allows matching of items by item type.</p></item>
                <!--<item><p>A new attribute <code>xsl:template/@test</code> allows tunnel parameters to be taken


### PR DESCRIPTION
Close #72 

This is a first attempt to resolve issue 72 by describing `parse-uri` and `build-uri` functions.

I decided to try an approach that leverages the ABNF defined in RFC 3986. Attempting to redefine the rules just opens up the possibility that the rules we write will differ from the rules in RFC 3986 which would be wrong.

I added an options map and specified a "details" option that will further parse the path and query components. This gives the caller easy access to the percent-decoded forms of those elements without making the parse function irreversable.

Notes:

1. More examples are needed
2. I tried to use `eg` in the results so that they'd be formatted nicely, but it didn't work. Is there any markup for verbatim text in examples?
3. There's an open question about whether non-hierarchical URIs can have fragment identifiers or queries. I think not, but I need to review the RFC a little more carefully.
