### PR TITLE
Updates to make FO valid

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -44,22 +44,22 @@
          <p>If <code>$node</code> is the empty sequence, the empty sequence is returned.</p>
          <p>Otherwise, the function returns the result of the <code>dm:node-name</code> accessor as
             defined in <bibref
-               ref="xpath-datamodel-31"/> (see <xspecref spec="DM31" ref="dm-node-name"/>).</p>
+               ref="xpath-datamodel-31"/> (see <xspecref spec="DM40" ref="dm-node-name"/>).</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -67,11 +67,11 @@
                <code>xs:QName</code>, retaining the prefix, namespace URI, and local part.</p>
          <p>For processing instructions, the name of the node is returned as an
                <code>xs:QName</code> in which the prefix and namespace URI are <xtermref
-               ref="dt-absent" spec="DM31">absent</xtermref>.</p>
+               ref="dt-absent" spec="DM40">absent</xtermref>.</p>
          <p>For a namespace node, the function returns an empty sequence if the node represents the
             default namespace; otherwise it returns an <code>xs:QName</code> in which prefix and
             namespace URI are <xtermref
-               ref="dt-absent" spec="DM31"
+               ref="dt-absent" spec="DM40"
             >absent</xtermref> and the local
             part is the namespace prefix being bound.</p>
          <p>For all other kinds of node, the function returns the empty sequence.</p>
@@ -105,22 +105,22 @@
          <p>If <code>$node</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>Otherwise the function returns the result of the <code>dm:nilled</code> accessor as
             defined in <bibref
-               ref="xpath-datamodel-31"/> (see <xspecref spec="DM31" ref="dm-nilled"/>).</p>
+               ref="xpath-datamodel-31"/> (see <xspecref spec="DM40" ref="dm-nilled"/>).</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -163,7 +163,7 @@
 
          <p>If <code>$item</code> is a node, the function returns the string value of the node, as obtained using the
                      <code>dm:string-value</code> accessor defined in <bibref
-               ref="xpath-datamodel-31"/> (see <xspecref spec="DM31" ref="dm-string-value"/>).</p>
+               ref="xpath-datamodel-31"/> (see <xspecref spec="DM40" ref="dm-string-value"/>).</p>
 
          <p>If <code>$item</code> is an atomic value, the function returns the result of the expression <code>$item cast
                      as xs:string</code> (see <specref
@@ -177,7 +177,7 @@
          <p>A dynamic error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"
                /> by
             the zero-argument version of the function if the context item is <xtermref
-               ref="dt-absent" spec="DM31">absent</xtermref>. </p>
+               ref="dt-absent" spec="DM40">absent</xtermref>. </p>
          <p>A type error is raised <errorref class="TY" code="0014" type="type"
                /> if
                <code>$item</code> is a function item (this includes maps and arrays).</p>
@@ -262,7 +262,7 @@
                   sequence. The typed value is a sequence of zero or more atomic values:
                   specifically, the result of the <code>dm:typed-value</code> accessor as defined in
                      <bibref
-                     ref="xpath-datamodel-31"/> (See <xspecref spec="DM31" ref="dm-typed-value"
+                     ref="xpath-datamodel-31"/> (See <xspecref spec="DM40" ref="dm-typed-value"
                   />).</p>
             </item>
             <item>
@@ -282,7 +282,7 @@
 
          <p>A dynamic error is raised if <code>$input</code> is omitted and the context item is
                <xtermref
-               ref="dt-absent" spec="DM31">absent</xtermref>.</p>
+               ref="dt-absent" spec="DM40">absent</xtermref>.</p>
 
 
       </fos:errors>
@@ -356,15 +356,15 @@
             is equivalent to calling <code>fn:base-uri(.)</code>.</p>
          <p>The single-argument version of the function behaves as follows:</p>
          <olist>
-            <item>If <code>$node</code> is the empty sequence, the function returns the empty
-               sequence.</item>
+            <item><p>If <code>$node</code> is the empty sequence, the function returns the empty
+               sequence.</p></item>
 
-            <item>Otherwise, the function returns the value of the <code>dm:base-uri</code> accessor
+            <item><p>Otherwise, the function returns the value of the <code>dm:base-uri</code> accessor
                applied to the node <code>$node</code>. This accessor is defined, for each kind of
                node, in the XDM specification (See <xspecref
-                  spec="DM31" ref="dm-base-uri"/>).</item>
+                  spec="DM40" ref="dm-base-uri"/>).</p></item>
          </olist>
-         <note>As explained in XDM, document, element and processing-instruction nodes have a
+         <note><p>As explained in XDM, document, element and processing-instruction nodes have a
             base-uri property which may be empty. The base-uri property for all other node kinds is
             the empty sequence. The dm:base-uri accessor returns the base-uri property of a node if
             it exists and is non-empty; otherwise it returns the result of applying the dm:base-uri
@@ -372,25 +372,25 @@
             recursive ascent up the ancestor chain encounters a parentless node whose base-uri
             property is empty, the empty sequence is returned. In the case of namespace nodes,
             however, the result is always an empty sequence &#x2014; it does not depend on the base URI of
-            the parent element.</note>
+            the parent element.</p></note>
 
 
          <p>See also <code>fn:static-base-uri</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
       </fos:errors>
    </fos:function>
    <fos:function name="document-uri" prefix="fn">
@@ -423,23 +423,23 @@
          <p>Otherwise, the function returns the value of the <code>document-uri</code> accessor
             applied to <code>$node</code>, as defined in <bibref
                ref="xpath-datamodel-31"/> (See
-               <xspecref spec="DM31"
+               <xspecref spec="DM40"
                ref="DocumentNodeAccessors"/>).</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -1711,7 +1711,7 @@
          <p>The string of characters between the parentheses, if present, is used to select between
             other possible variations of cardinal or ordinal numbering sequences. The interpretation
             of this string is <termref
-               def="implemementation-defined"
+               def="implementation-defined"
             >implementation-defined</termref>. No error occurs if the implementation does not
             define any interpretation for the defined string.</p>
 
@@ -3702,7 +3702,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       </fos:rules>
       <fos:errors>
          <p>If <code>$value</code> is not specified and the context item is <xtermref ref="dt-absent"
-               spec="DM31">absent</xtermref>, a dynamic error is raised: <xerrorref spec="XP"
+               spec="DM40">absent</xtermref>, a dynamic error is raised: <xerrorref spec="XP"
                class="DY" code="0002" type="dynamic"/>.</p>
       </fos:errors>
       <fos:notes>
@@ -3765,7 +3765,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
             (calculated using <code>fn:string</code>) of the context item (<code>.</code>). </p>
       </fos:rules>
       <fos:errors>
-         <p>If no argument is supplied and the context item is <xtermref ref="dt-absent" spec="DM31"
+         <p>If no argument is supplied and the context item is <xtermref ref="dt-absent" spec="DM40"
                >absent</xtermref> then a dynamic error is raised: <xerrorref spec="XP" class="DY"
                code="0002" type="dynamic"/>.</p>
       </fos:errors>
@@ -5400,7 +5400,7 @@ Tak, tak, tak! - da kommen sie.
                def="implementation-dependent"
                >implementation-dependent</termref> whether the two calls return the same element node
             or distinct (but deep equal) element nodes. In this respect it is <termref
-               def="nondeterministic">non-deterministic with respect to node identity</termref>.</p>
+               def="dt-nondeterministic">non-deterministic with respect to node identity</termref>.</p>
 
          <p>The base URI of the element nodes in the result is <termref
                def="implementation-dependent">implementation-dependent</termref>.</p>
@@ -5410,7 +5410,7 @@ Tak, tak, tak! - da kommen sie.
 
          <p>The result of the function will always be such that validation against this schema would succeed.
          However, it is <termref
-               def="dt-implementation-defined"
+               def="implementation-defined"
             >implementation-defined</termref> whether the result is typed or untyped,
          that is, whether the elements and attributes in the returned tree have type annotations that reflect
          the result of validating against this schema.</p>
@@ -9411,6 +9411,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <p>The function accepts a string matching the production <code>input</code> in the
             following grammar:</p>
          <table role="scrap">
+           <tbody>
             <tr>
                <td>
                   <code>input</code>
@@ -9601,6 +9602,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                   <code>( x09 | x0A | x0D | x20 )+</code>
                </td>
             </tr>
+          </tbody>
          </table>
 
          <p>The input is case-insensitive: upper-case and lower-case distinctions in the above
@@ -9628,7 +9630,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             as <code>H</code>, <code>HH</code>, <code>HMM</code>, or <code>HHMM</code> respectively, where <code>H</code>
             or <code>HH</code> is the hours part, and <code>MM</code> (if present) is the minutes part.</p>
             </item>
-            <item>If the minutes part is absent it defaults to <code>00</code>.</item>
+            <item><p>If the minutes part is absent it defaults to <code>00</code>.</p></item>
          </ulist>
 
          <p>If a <code>tzname</code> is supplied with no <code>tzoffset</code> then it is translated
@@ -9696,11 +9698,11 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <p>These formats are used widely on the Internet to represent timestamps, and were
             specified in:</p>
          <ulist>
-            <item><bibref ref="rfc822"/> (electronic mail), extended in <bibref ref="rfc1123"
-               /> to allow four-digit years;</item>
-            <item><bibref ref="rfc850"/> (Usenet Messages), obsoleted by <bibref ref="rfc1036"
-               />;</item>
-            <item>POSIX <code>asctime()</code> format</item>
+            <item><p><bibref ref="rfc822"/> (electronic mail), extended in <bibref ref="rfc1123"
+               /> to allow four-digit years;</p></item>
+            <item><p><bibref ref="rfc850"/> (Usenet Messages), obsoleted by <bibref ref="rfc1036"
+               />;</p></item>
+            <item><p>POSIX <code>asctime()</code> format</p></item>
          </ulist>
          <p><bibref ref="rfc2616"
             /> (HTTP) officially uses a subset of those three formats restricted to GMT.</p>
@@ -9794,7 +9796,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             resulting expanded-QName has no namespace part.</p>
          <p>The prefix (or absence of a prefix) in the supplied <code>$qname</code> argument is
             retained in the returned expanded-QName, as described in <xspecref
-               spec="DM31" ref="terminology"/>.</p>
+               spec="DM40" ref="terminology"/>.</p>
 
       </fos:rules>
       <fos:errors>
@@ -9911,7 +9913,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <code>$arg2</code> are equal.</p>
          <p>Otherwise, the function returns <code>false</code>.</p>
          <p>The namespace URI parts are considered equal if they are both <xtermref ref="dt-absent"
-               spec="DM31"
+               spec="DM40"
                >absent</xtermref>, or if they are both present and equal under the rules
             of the <code>fn:codepoint-equal</code> function.</p>
          <p>The local parts are also compared under the rules of the <code>fn:codepoint-equal</code>
@@ -10272,7 +10274,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <code>$arg2</code> are equal.</p>
          <p>Otherwise, the function returns <code>false</code>.</p>
          <p>The namespace URI parts are considered equal if they are both <xtermref ref="dt-absent"
-               spec="DM31"
+               spec="DM40"
                >absent</xtermref>, or if they are both present and equal under the rules
             of the <code>fn:codepoint-equal</code> function.</p>
          <p>The local parts are also compared under the rules of the <code>fn:codepoint-equal</code>
@@ -10317,18 +10319,18 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -10373,24 +10375,24 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <p>Otherwise, the function returns the local part of the expanded-QName of the node
             identified by <code>$node</code>, as determined by the <code>dm:node-name</code> accessor
             defined in <xspecref
-               spec="DM31" ref="dm-node-name"
+               spec="DM40" ref="dm-node-name"
                />). This will be an
                <code>xs:string</code> whose lexical form is an <code>xs:NCName</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
    </fos:function>
@@ -10422,31 +10424,31 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <p>If the node identified by <code>$node</code> is neither an element nor an attribute node,
             or if it is an element or attribute node whose expanded-QName (as determined by the
                <code>dm:node-name</code> accessor in the <xspecref
-               spec="DM31" ref="dm-node-name"
+               spec="DM40" ref="dm-node-name"
                />)
             is in no namespace, then the function returns the zero-length <code>xs:anyURI</code>
             value.</p>
          <p>Otherwise, the result will be the namespace URI part of the expanded-QName of the node
             identified by <code>$node</code>, as determined by the <code>dm:node-name</code> accessor
             defined in <xspecref
-               spec="DM31" ref="dm-node-name"
+               spec="DM40" ref="dm-node-name"
                />), returned as an
                <code>xs:anyURI</code> value.</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
       </fos:errors>
    </fos:function>
    <fos:function name="number" prefix="fn">
@@ -10489,7 +10491,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <p>A dynamic error is raised <xerrorref spec="XP" class="DY" code="0002" type="dynamic"
                />
             if <code>$value</code> is omitted and the context item is <xtermref
-               ref="dt-absent" spec="DM31">absent</xtermref>.</p>
+               ref="dt-absent" spec="DM40">absent</xtermref>.</p>
          <p>As a consequence of the rules given above, a type error occurs if the context item
             cannot be atomized, or if the result of atomizing the context item is a sequence
             containing more than one atomic value.</p>
@@ -10587,18 +10589,18 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
       </fos:errors>
       <fos:examples>
          <fos:example>
@@ -10734,7 +10736,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
          <ulist>
             <item>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
@@ -10837,18 +10839,18 @@ Himmlische, dein Heiligtum.</p>}]]>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
       </fos:errors>
       <fos:examples>
          <fos:example>
@@ -10936,18 +10938,18 @@ let $newi := $o/tool</eg>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -10958,11 +10960,11 @@ let $newi := $o/tool</eg>
             streamable:</p>
          <eg><![CDATA[
 <xsl:if test="exists(row)">
-  <ul>
+  <ulist>
     <xsl:for-each select="row">
-       <li><xsl:value-of select="."/></li>
+       <item><xsl:value-of select="."/></item>
     </xsl:for-each>
-  </ul>
+  </ulist>
 </xsl:if>  
 ]]></eg>
          <p>This is because it makes two downward selections to read the child <code>row</code>
@@ -12016,7 +12018,7 @@ let $newi := $o/tool</eg>
                <item><p>Otherwise -1</p></item>
             </ulist>
             </item>
-            <item>Otherwise, <code>$step</code>.</item>
+            <item><p>Otherwise, <code>$step</code>.</p></item>
          </ulist>
          <p>If <code>$STEP</code> is negative, the function returns 
             <code>$input => fn:reverse() => fn:slice(-$S, -$E, -$STEP)</code>.</p>
@@ -12406,8 +12408,8 @@ let $newi := $o/tool</eg>
                </olist>
             </item>
          </olist>
-         <p>If <code>$i1</code> and <code>$i2</code> are both <termref def="dt-array"
-               >arrays</termref>, the result is <code>true</code> if and only if all
+         <p>If <code>$i1</code> and <code>$i2</code> are both arrays,
+            the result is <code>true</code> if and only if all
             the following conditions apply:</p>
          <olist>
             <item>
@@ -12556,8 +12558,8 @@ let $newi := $o/tool</eg>
             required to have the same in-scope namespaces. They may also differ in their parent,
             their base URI, and the values returned by the <code>is-id</code> and
                <code>is-idrefs</code> accessors (see <xspecref
-               spec="DM31" ref="dm-is-id"/> and
-               <xspecref spec="DM31"
+               spec="DM40" ref="dm-is-id"/> and
+               <xspecref spec="DM40"
                ref="dm-is-idrefs"
             />). The order of children is significant,
             but the order of attributes is insignificant. </p>
@@ -12751,7 +12753,7 @@ let $newi := $o/tool</eg>
                   <td>description</td>
                   <td>xs:string</td>
                   <td>A description of the mismatch, intended for the human reader. The content is
-                     <termref def="dt-implementation-dependent">implementation-dependent</termref>.</td>
+                     <termref def="implementation-dependent">implementation-dependent</termref>.</td>
                </tr>
                <tr>
                   <td>path</td>
@@ -13147,10 +13149,10 @@ let $newi := $o/tool</eg>
             common type. After these operations, <code>$values</code> must satisfy the following condition:</p>
          <p>There must be a type <var>T</var> such that:</p>
          <olist>
-            <item>every item in <code>$values</code> is an instance of <var>T</var>.</item>
-            <item><var>T</var> is one of <code>xs:double</code>, <code>xs:float</code>,
+            <item><p>every item in <code>$values</code> is an instance of <var>T</var>.</p></item>
+            <item><p><var>T</var> is one of <code>xs:double</code>, <code>xs:float</code>,
                   <code>xs:decimal</code>, <code>xs:yearMonthDuration</code>, or
-                  <code>xs:dayTimeDuration</code>.</item>
+                  <code>xs:dayTimeDuration</code>.</p></item>
          </olist>
 
 
@@ -13740,7 +13742,7 @@ else
                         or both of the following conditions are true:</p>
                      <ulist>
                         <item>
-                           <p>The <code>is-id</code> property (See <xspecref spec="DM31"
+                           <p>The <code>is-id</code> property (See <xspecref spec="DM40"
                                  ref="dm-is-id"
                                  />.) of the element node is true, and the typed value
                               of the element node is equal to <code>V</code> under the rules of the
@@ -13750,7 +13752,7 @@ else
                         <item>
                            <p>The element has an attribute node whose <code>is-id</code> property
                               (See <xspecref
-                                 spec="DM31" ref="dm-is-id"
+                                 spec="DM40" ref="dm-is-id"
                                  />.) is true and whose typed
                               value is equal to <code>V</code> under the rules of the
                                  <code>eq</code> operator using the Unicode code point collation
@@ -13786,18 +13788,18 @@ else
                <code>$node</code>, or the context item if the second argument is absent, is a node
             in a tree whose root is not a document node.</p>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -13926,7 +13928,7 @@ else
                         <item>
                            <p>The element has an child element node whose <code>is-id</code>
                               property (See <xspecref
-                                 spec="DM31" ref="dm-is-id"
+                                 spec="DM40" ref="dm-is-id"
                                  />.) is true and
                               whose typed value is equal to <code>V</code> under the rules of the
                                  <code>eq</code> operator using the Unicode code point collation
@@ -13935,7 +13937,7 @@ else
                         <item>
                            <p>The element has an attribute node whose <code>is-id</code> property
                               (See <xspecref
-                                 spec="DM31" ref="dm-is-id"
+                                 spec="DM40" ref="dm-is-id"
                                  />.) is true and whose typed
                               value is equal to <code>V</code> under the rules of the
                                  <code>eq</code> operator using the Unicode code point collation
@@ -13969,17 +13971,17 @@ else
                /> if <code>$node</code>, or the context item if the second argument is omitted, is a node
             in a tree whose root is not a document node.</p>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>, dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -14093,7 +14095,7 @@ else
                            <code>V</code> if both of the following conditions are true:</p>
                      <ulist>
                         <item>
-                           <p>The <code>is-idrefs</code> property (see <xspecref spec="DM31"
+                           <p>The <code>is-idrefs</code> property (see <xspecref spec="DM40"
                                  ref="dm-is-idrefs"/>) of <code>$N</code> is <code>true</code>.</p>
                         </item>
                         <item>
@@ -14127,18 +14129,18 @@ else
                <code>$node</code>, or the context item if the second argument is omitted, is a node
             in a tree whose root is not a document node. </p>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -14236,7 +14238,7 @@ else
             /> provides a mapping from this string to a document node, the
             function returns that document node.</p>
          <p>The URI may include a fragment identifier.</p>
-         <p>By default, this function is <termref def="deterministic"
+         <p>By default, this function is <termref def="dt-deterministic"
             >deterministic</termref>. Two
             calls on this function return the same document node if the same URI Reference (after
             resolution to an absolute URI Reference) is supplied to both calls. Thus, the following
@@ -14409,7 +14411,7 @@ else
             against the value of the base-URI property from the static context. </p>
          <p>If <code>$uri</code> is the empty sequence, the function behaves as if it had been
             called without an argument. See above.</p>
-         <p>By default, this function is <termref def="deterministic"
+         <p>By default, this function is <termref def="dt-deterministic"
                >deterministic</termref>. This
             means that repeated calls on the function with the same argument will return the same
             result. However, for performance reasons, implementations may provide a user option to
@@ -14429,7 +14431,7 @@ else
          <p>A dynamic error is raised <errorref class="DC" code="0002"
                /> if no URI is supplied and
             the value of the default collection is <xtermref
-               ref="dt-absent" spec="DM31">absent</xtermref>.</p>
+               ref="dt-absent" spec="DM40">absent</xtermref>.</p>
          <p>A dynamic error is raised <errorref class="DC" code="0002"
             /> if a relative URI reference
             is supplied, and the base-URI property in the static context is absent.</p>
@@ -14482,7 +14484,7 @@ else
             the supplied URI in the <term>available URI collections</term> described in
                <xspecref
                spec="XP31" ref="id-xp-evaluation-context-components"/>.</p>
-         <p>By default, this function is <termref def="deterministic"
+         <p>By default, this function is <termref def="dt-deterministic"
                >deterministic</termref>. This
             means that repeated calls on the function with the same argument will return the same
             result. However, for performance reasons, implementations may provide a user option to
@@ -14503,7 +14505,7 @@ else
             is, if the function is called with no arguments, or with a single argument that
             evaluates to an empty sequence), and the value of the default resource collection is
                <xtermref
-               ref="dt-absent" spec="DM31">absent</xtermref>.</p>
+               ref="dt-absent" spec="DM40">absent</xtermref>.</p>
          <p>A dynamic error is raised <errorref class="DC" code="0002"
             /> if a relative URI reference
             is supplied, and the base-URI property in the static context is absent.</p>
@@ -14613,9 +14615,8 @@ else
             returns an empty sequence.</p>
          <p>The <code>$encoding</code> argument, if present, is the name of an encoding. The values
             for this attribute follow the same rules as for the <code>encoding</code> attribute in
-            an XML declaration. The only values which every <termref
-               def="implementation"
-               >implementation</termref> is <rfc2119>required</rfc2119> to recognize are
+            an XML declaration. The only values which every
+            implementation is <rfc2119>required</rfc2119> to recognize are
                <code>utf-8</code> and <code>utf-16</code>.</p>
          <p>The encoding of the external resource is determined as follows:</p>
          <olist>
@@ -14658,9 +14659,8 @@ else
             representation of a resource. </p>
          <p>A dynamic error is raised <errorref class="UT" code="1190"
                /> if the value of the
-               <code>$encoding</code> argument is not a valid encoding name, if the <termref
-               def="dt-processor"
-               >processor</termref> does not support the specified encoding, if
+               <code>$encoding</code> argument is not a valid encoding name, if the
+               processor does not support the specified encoding, if
             the string representation of the retrieved resource contains octets that cannot be
             decoded into Unicode <termref
                def="character"
@@ -14668,9 +14668,7 @@ else
             encoding, or if the resulting characters are not permitted XML characters.</p>
          <p>A dynamic error is raised <errorref class="UT" code="1200"
                /> if <code>$encoding</code>
-            is absent and the <termref
-               def="dt-processor"
-            >processor</termref> cannot infer the
+            is absent and the processor cannot infer the
             encoding using external information and the encoding is not UTF-8.</p>
       </fos:errors>
 
@@ -14842,7 +14840,7 @@ else
          <p>The functions <code>fn:unparsed-text</code> and
                <code>fn:unparsed-text-available</code> have the same requirement for
                <termref
-               def="deterministic"
+               def="dt-deterministic"
                >determinism</termref> as the functions
                <code>fn:doc</code> and <code>fn:doc-available</code>. This means that unless the
             user has explicitly stated a requirement for a reduced level of determinism, either of
@@ -15008,18 +15006,18 @@ else
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ul>
-            <li>
-               <p>If the context item is <xtermref ref="dt-absent" spec="DM31"
+         <ulist>
+            <item>
+               <p>If the context item is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
                   dynamic error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/></p>
-            </li>
-            <li>
+            </item>
+            <item>
                <p>If the context item is not a node, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
-            </li>
-         </ul>
+            </item>
+         </ulist>
 
       </fos:errors>
       <fos:notes>
@@ -15154,9 +15152,9 @@ else
             function call is used both as the base URI used by the XML parser to resolve relative
             entity references within the document, and as the base URI of the document node that is
             returned.</p>
-         <p>The document URI of the returned node is <termref def="absent">absent</termref>.</p>
+         <p>The document URI of the returned node is <xtermref ref="dt-absent" spec="DM40">absent</xtermref>.</p>
          <p>The function is <emph>not</emph>
-            <termref def="deterministic"
+            <termref def="dt-deterministic"
                >deterministic</termref>: that is, if the function is called
             twice with the same arguments, it is <termref
                def="implementation-dependent"
@@ -15239,9 +15237,9 @@ else
             an XML 1.0 or XML 1.1 parser is used.</p>
          <p>The <term>static base URI</term> from the static context of the <code>fn:parse-xml-fragment</code>
             function call is used as the base URI of the document node that is returned.</p>
-         <p>The document URI of the returned node is <termref def="absent">absent</termref>.</p>
+         <p>The document URI of the returned node is <xtermref ref="dt-absent" spec="DM40">absent</xtermref>.</p>
          <p>The function is <emph>not</emph>
-            <termref def="deterministic"
+            <termref def="dt-deterministic"
                >deterministic</termref>: that is, if the function is called
             twice with the same arguments, it is <termref
                def="implementation-dependent"
@@ -15786,7 +15784,7 @@ else
       <fos:errors>
          <p>A dynamic error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"
                /> if
-            the context item is <xtermref ref="dt-absent" spec="DM31"
+            the context item is <xtermref ref="dt-absent" spec="DM40"
                >absent</xtermref>.</p>
       </fos:errors>
    </fos:function>
@@ -15811,7 +15809,7 @@ else
          <p>A dynamic error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"
                /> if
             the context <phrase>size</phrase> is <xtermref ref="dt-absent"
-               spec="DM31">absent</xtermref>.</p>
+               spec="DM40">absent</xtermref>.</p>
       </fos:errors>
       <fos:notes>
          <p>Under most circumstances, the context size is absent only if the context item is absent. However, XSLT 3.0 with
@@ -17150,7 +17148,7 @@ return fn:sort($in, $SWEDISH)
             <item>
                <p>The <code>$options</code> argument can be used to control the way in which duplicate keys are handled.
                The <termref
-                     def="dt-option-parameter-conventions"
+                     def="option-parameter-conventions"
                   >option parameter conventions</termref> apply.
             </p>
             </item>
@@ -17163,7 +17161,7 @@ return fn:sort($in, $SWEDISH)
                         taken if two maps in the input sequence <code>$maps</code> contain entries with key values
                         <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
                         <termref
-                           def="same-key">same key</termref>.
+                           def="dt-same-key">same key</termref>.
                      </fos:meaning>
                      <fos:type>xs:string</fos:type>
                      <fos:default>use-first</fos:default>
@@ -17199,7 +17197,7 @@ return fn:sort($in, $SWEDISH)
                            retaining order based on the order of maps in the <code>$maps</code> argument.
                            The key value in the result map that corresponds to such a set of duplicates must
                            be the <termref
-                              def="same-key"
+                              def="dt-same-key"
                               >same key</termref> as each of the duplicates, but it is
                            otherwise unconstrained: for example if the duplicate keys are <code>xs:byte(1)</code>
                            and <code>xs:short(1)</code>, the key in the result could legitimately be <code>xs:long(1)</code>.
@@ -17225,7 +17223,7 @@ return fn:sort($in, $SWEDISH)
                         </td>
                         <td colspan="2">Determines the policy for handling duplicate keys: specifically, the action to be
                            taken if two maps in the input sequence <code>$maps</code> contain entries with key values
-                           <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the <termref def="same-key">same key</termref>.
+                           <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the <termref def="dt-same-key">same key</termref>.
                            The required type is <code>xs:string</code>. The default value is <code>use-first</code>.</td>
                      </tr>
                      <tr>
@@ -17255,8 +17253,9 @@ return fn:sort($in, $SWEDISH)
                         <td>If duplicate keys are present, the result map includes an entry for the key whose 
                            associated value is the sequence-concatenation of all the values associated with the key, 
                            retaining order based on the order of maps in the <code>$maps</code> argument.
+
                            The key value in the result map that corresponds to such a set of duplicates must
-                           be the <termref def="same-key">same key</termref> as each of the duplicates, but it is
+                           be the <termref def="dt-same-key">same key</termref> as each of the duplicates, but it is
                            otherwise unconstrained: for example if the duplicate keys are <code>xs:byte(1)</code>
                            and <code>xs:short(1)</code>, the key in the result could legitimately be <code>xs:long(1)</code>.
                         </td>
@@ -17423,7 +17422,7 @@ return fn:fold-left($MAPS, map{},
                >map</termref>
             as its <code>$map</code> argument and returns the keys that are present in the map as
             a sequence of atomic values, in <termref
-               def="dt-implementation-dependent">implementation-dependent</termref> order.</p>
+               def="implementation-dependent">implementation-dependent</termref> order.</p>
          <p>The function is <term>non-deterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
@@ -17439,7 +17438,7 @@ return fn:fold-left($MAPS, map{},
             <fos:test>
                <fos:expression>map:keys(map{1:"yes", 2:"no"})</fos:expression>
                <fos:result allow-permutation="true">(1,2)</fos:result>
-               <fos:postamble>The result is in <termref def="dt-implementation-dependent"
+               <fos:postamble>The result is in <termref def="implementation-dependent"
                      >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
          </fos:example>
@@ -17600,7 +17599,7 @@ return fn:fold-left($MAPS, map{},
             <item>
                <p>To process an item that is a map, then for each key-value entry (<var>K</var>, <var>V</var>)
                in the map (in <termref
-                     def="dt-implementation-dependent"
+                     def="implementation-dependent"
                   >implementation-dependent</termref> order)
                perform both of the following steps, in order:</p>
                <olist>
@@ -17867,7 +17866,7 @@ map:merge (
          <p>The function <code>map:for-each</code> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map, in <termref
-               def="dt-implementation-dependent"
+               def="implementation-dependent"
             >implementation-dependent</termref> order; the result is the sequence obtained by
             concatenating the results of these function calls.</p>
          <p>The function is <term>non-deterministic with respect to ordering</term>
@@ -18278,7 +18277,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             that it always generates the same collation key for two strings that are equal under the
             collation, and different collation keys for strings that are not equal. This holds only
             within a single <termref
-               ref="execution-scope"
+               def="execution-scope"
             >execution scope</termref>;
             an implementation is under no obligation to generate the same collation keys during a
             subsequent unrelated query or transformation.</p>
@@ -18454,7 +18453,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             <fos:option key="validate">
                <fos:meaning>Determines whether the generated XML tree is schema-validated.</fos:meaning>
                <fos:type>xs:boolean</fos:type>
-               <fos:default><termref def="dt-implementation-defined"
+               <fos:default><termref def="implementation-defined"
                      >Implementation-defined</termref>.</fos:default>
                <fos:values>
                   <fos:value value="true"
@@ -18464,7 +18463,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                      against the schema given at <specref
                         ref="schema-for-json"/>, or against an
                      <termref
-                        def="dt-implementation-defined"
+                        def="implementation-defined"
                         >implementation-defined</termref> schema 
                      if the <code>liberal</code> option has the value <code>true</code>.
                   </fos:value>
@@ -18564,7 +18563,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                is the element node representing the outermost construct in the JSON
             text.</p>
 
-         <p>The function is <termref ref="dt-nondeterministic"
+         <p>The function is <termref def="dt-nondeterministic"
                >non-deterministic with respect to node identity</termref>: that is, if the function is called twice with the same
             arguments, it is <termref
                def="implementation-dependent"
@@ -18875,11 +18874,11 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             <item diff="chg" at="A">
                <p>An element <code>$E</code> named <code>number</code> is processed as follows:</p>
                <olist>
-                  <item>If the <code>number-formatter</code> option is present and non-empty,
+                  <item><p>If the <code>number-formatter</code> option is present and non-empty,
                   the supplied function is called, with the string value of <code>$E</code> as its argument,
-                  and the result is output (whether or not it is valid JSON).</item>
-                  <item>Otherwise, the result of the expression <code>xs:string(xs:double(fn:string($E)))</code>
-                  is output.</item>
+                  and the result is output (whether or not it is valid JSON).</p></item>
+                  <item><p>Otherwise, the result of the expression <code>xs:string(xs:double(fn:string($E)))</code>
+                  is output.</p></item>
                </olist>
                <note><p>The default formatting results in exponential format being used for numbers whose
                   absolute value is outside the range 1e-6 to 1e+6; although this is valid according to the JSON
@@ -19597,11 +19596,11 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                         the result of atomizing the attribute value and applying the
                         <code>fn:json</code> function to the result.</p>
                   </item>
-                  <item><emph>Namespace nodes</emph></item>
-                  <p>Namespace nodes that are reached via an element node result in no output.</p>
-                  <p>Free-standing namespace nodes are output as JSON objects with properties
+                  <item><p><emph>Namespace nodes</emph></p></item>
+                  <item><p>Namespace nodes that are reached via an element node result in no output.</p></item>
+                  <item><p>Free-standing namespace nodes are output as JSON objects with properties
                   <code>#namespace</code> set to the namespace prefix (<code>""</code> for the default
-                  namespace) and <code>#uri</code> set to the namespace URI.</p>
+                  namespace) and <code>#uri</code> set to the namespace URI.</p></item>
                </ulist>            
             </item>
             <item>
@@ -21335,7 +21334,7 @@ return array:sort($in, $SWEDISH)
                <fos:type>xs:decimal</fos:type>
                <fos:default>The version given in the prolog of the library module; or
                   <termref
-                     def="dt-implementation-defined"
+                     def="implementation-defined"
                   >implementation-defined</termref> if this is absent.</fos:default>
             </fos:option>
             <fos:option key="location-hints">
@@ -21396,7 +21395,7 @@ return array:sort($in, $SWEDISH)
                      <td valign="top"><code>xs:decimal</code></td>
                      <td>The minimum level of the XQuery language that the
                         processor must support. Defaults to the version given in the prolog of the library module; or
-                        <termref def="dt-implementation-defined">implementation-defined</termref> if this is absent.</td>
+                        <termref def="implementation-defined">implementation-defined</termref> if this is absent.</td>
                   </tr>
                   <tr>
                      <td valign="top"><code>location-hints</code></td>
@@ -21458,7 +21457,7 @@ return array:sort($in, $SWEDISH)
             <xspecref
                spec="XQ31" ref="id-xq-context-components"/>.</p>
 
-         <p>It is <termref def="dt-implementation-defined"
+         <p>It is <termref def="implementation-defined"
                >implementation-defined</termref> whether constructs in the library module 
             are evaluated in the same <termref
                def="execution-scope">execution scope</termref> as the calling module.</p>
@@ -21471,7 +21470,7 @@ return array:sort($in, $SWEDISH)
 
          <p>The library module that is loaded may import schema declarations using an <code>import schema</code> declaration. It is
             <termref
-               def="dt-implementation-defined"
+               def="implementation-defined"
                >implementation-defined</termref> whether schema components in the in-scope 
             schema definitions of the calling module
             are automatically added to the in-scope schema definitions of the dynamically loaded module. The in-scope schema definitions
@@ -21608,7 +21607,7 @@ return array:sort($in, $SWEDISH)
                <p>For invocation of an XSLT 1.0 processor (see <bibref ref="xslt10"
                      />), 
                   the supplied options must include all of the following <phrase
-                     duff="chg" at="E">(if anything else is present, it is ignored)</phrase>:</p>
+                     diff="chg" at="E">(if anything else is present, it is ignored)</phrase>:</p>
                <olist>
                   <item>
                      <p>The stylesheet, provided by supplying exactly one of the following:</p>
@@ -21649,7 +21648,7 @@ return array:sort($in, $SWEDISH)
                <p>For invocation of an XSLT 2.0 processor (see <bibref ref="xslt20"
                      />), 
                   the supplied options must include all of the following <phrase
-                     duff="chg" at="E">(if anything else is present, it is ignored)</phrase>:</p>
+                     diff="chg" at="E">(if anything else is present, it is ignored)</phrase>:</p>
                <olist>
                   <item>
                      <p>The stylesheet, provided by supplying exactly one of the following:</p>
@@ -21707,7 +21706,7 @@ return array:sort($in, $SWEDISH)
                <p>For invocation of an XSLT 3.0 processor (see <bibref ref="xslt-40"
                      />), 
                   the supplied options must include all of the following <phrase
-                     duff="chg" at="E">(if anything else is present, it is ignored)</phrase>:</p>
+                     diff="chg" at="E">(if anything else is present, it is ignored)</phrase>:</p>
                <olist>
                   <item>
                      <p>The stylesheet, provided either by supplying exactly one of the following:</p>
@@ -22096,7 +22095,7 @@ return array:sort($in, $SWEDISH)
             available. If the supplied stylesheet already has a base URI (which will generally be
             the case if the stylesheet is supplied using <code>stylesheet-node</code> or
                 <code>stylesheet-location</code>) then it is <termref
-                     def="dt-implementation-defined"
+                     def="implementation-defined"
                      >implementation-defined</termref> whether this
             parameter has any effect. If the value is a relative reference, it is resolved against
             the static base URI of the <code>fn:transform</code> function call.</fos:meaning>
@@ -22196,7 +22195,7 @@ return array:sort($in, $SWEDISH)
             copy, which may lose information about the identity of the node, about its ancestors and siblings, about its base URI, about its type annotation, and about its 
             relationships to other nodes passed across the interface.</p>
 
-         <p>It is <termref def="dt-implementation-defined"
+         <p>It is <termref def="implementation-defined"
                >implementation-defined</termref> whether the XSLT transformation is executed
             within the same <termref
                def="execution-scope">execution scope</termref> as the calling code.</p>
@@ -22204,7 +22203,7 @@ return array:sort($in, $SWEDISH)
          <p>The function is <termref def="dt-nondeterministic"
                >nondeterministic</termref> in that it is 
             <termref
-               def="dt-implementation-dependent"
+               def="implementation-dependent"
                >implementation-dependent</termref> whether running the function twice against the same
          inputs produces identical results. The results of two invocations may differ in the identity of any returned nodes; they may also
          differ in other respects, for example because the value of <code>fn:current-dateTime</code> is different for the two invocations,
@@ -22242,7 +22241,7 @@ return array:sort($in, $SWEDISH)
          define error codes, but some APIs do not expose them. If multiple errors are signaled by the transformation (which is most likely
          to happen with static errors) then the error code should where possible be that of one of these errors, chosen arbitrarily; the processor
          may make details of additional errors available to the application in an <termref
-                  def="dt-implementation-defined">implementation-defined</termref>
+                  def="implementation-defined">implementation-defined</termref>
          way.</p>
          </note>
          <p>A dynamic error is raised <errorref class="XT" code="0004" type="dynamic"

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -159,9 +159,9 @@
 			<xsl:if test="$fspec/fos:history">
 				<gitem>
 					<label>History</label>
-					<def role="example">
+					<def role="example"><p>
 						<xsl:apply-templates select="$fspec/fos:history/fos:version/node()"/>
-					</def>
+					</p></def>
 				</gitem>
 			</xsl:if>
 		</glist>

--- a/specifications/xpath-functions-40/style/ns-xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/ns-xpath-functions.xsl
@@ -234,7 +234,7 @@
   
   <xsl:function name="fos:spec-date" as="xs:date">
     <xsl:param name="spec-id"/>
-    <xsl:variable name="bib-entry" select="doc('../../../etc/xsl-query-bibl.xml')//bibl[@id = substring-before($spec-id, '-ref')]"/>
+    <xsl:variable name="bib-entry" select="doc('../../../build/etc/xsl-query-bibl.xml')//bibl[@id = substring-before($spec-id, '-ref')]"/>
     <xsl:variable name="date" select="replace(normalize-space($bib-entry), '^.*This version is https://www.w3.org/TR/.*?([0-9]{8,8})/.*$', '$1', 'm')"/>
     <xsl:message select="'**DATE: ', $date"/>
     <xsl:sequence select="xs:date(concat(substring($date,1,4), '-', substring($date,5,2), '-', substring($date, 7, 2)))"/>
@@ -243,7 +243,7 @@
   <!--<xsl:template match="div1[@id='normrefs']/blist/bibl">
     <xsl:variable name="date" select="fos:spec-date(@id)"/>
     <xsl:variable name="date8" select="format-date($date, '[Y0001][M01][D01]')"/>
-    <!-\-<xsl:variable name="href" select="doc('../../../etc/xsl-query-bibl.xml')//bibl[@id = substring-before(@id, '-ref')]//a[.='latest version']/@href"/>-\->
+    <!-\-<xsl:variable name="href" select="doc('../../../build/etc/xsl-query-bibl.xml')//bibl[@id = substring-before(@id, '-ref')]//a[.='latest version']/@href"/>-\->
     <xsl:variable name="href" select="concat('https://www.w3.org/TR/', substring-before(@id, '-ref'), '/')"/>
       <dt class="label"><span><a name="{@id}" id="{@id}"></a><xsl:value-of select="@key"/></span></dt>
       <dd>


### PR DESCRIPTION
This PR doesn't (intentionally) make any substantive changes, it simply fixes the FO spec and the tools that build it so that they produce valid markup. We have accidentally been running without validation and an unpleasantly large number of errors have crept in.

I made some ad hoc changes to the DTDs (already committed to the`master branch`) where it seemed like it would be better to allow the new markup (`var` in `code`, `p` in `td`, etc.) than attempt to redraft the specification in some new way.

But that left a bunch of places where `p` or other wrappers were left out, a number of places where HTML markup instead of `xmlspec` was inserted, some broken links, etc.

Merging this into the repository while we have active PRs in flight for F&O is going to be *ugly* so I'm not proposing to merge this right away.

We should probably pause new PRs against FO until this has been sorted out.
