### PR TITLE
Editorial: update change logs and status

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12441,7 +12441,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for addition in 4.0</fos:version>
+         <fos:version version="4.0">Accepted 2022-11-01</fos:version>
       </fos:history>
    </fos:function>
    
@@ -12529,7 +12529,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for addition in 4.0</fos:version>
+         <fos:version version="4.0">Accepted 2022-11-01</fos:version>
       </fos:history>
    </fos:function>
    
@@ -12625,7 +12625,7 @@ else if (fn:empty($input))
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for addition in 4.0</fos:version>
+         <fos:version version="4.0">Accepted 2022-11-01</fos:version>
       </fos:history>
    </fos:function>
 
@@ -18704,7 +18704,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for version 4.0 2022-10-11</fos:version>
+         <fos:version version="4.0">Accepted for version 4.0 2022-10-18</fos:version>
       </fos:history>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -10391,36 +10391,79 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
 	      <?imp-def-features?>
 	     
       </inform-div1>
-	  <inform-div1 id="changelog" diff="chg" at="A">
+	  <inform-div1 id="changelog" diff="chg" at="2022-11-16">
           <head>Changes since version 3.1</head>
         <div2 id="new-functions">
            <head>New Functions</head>
-           <p>A number of new functions are added:</p>
-           <olist>             
-              <item><p><code>fn:index-where</code></p></item>
-              <item><p><code>fn:slice</code></p></item>
-              <item><p><code>fn:items-before</code></p></item>
-              <item><p><code>fn:items-until</code></p></item>
-              <item><p><code>fn:items-from</code></p></item>
-              <item><p><code>fn:items-after</code></p></item>
-              <item><p><code>fn:is-NaN</code></p></item>
+           <p>A number of new functions have been defined:</p>
+           <ulist> 
+              <item><p><code>fn:all</code></p></item>
+              <item><p><code>fn:all-different</code></p></item>
+              <item><p><code>fn:all-equal</code></p></item>
+              <item><p><code>fn:build-uri</code></p></item>
+              <item><p><code>fn:characters</code></p></item>
+              <item><p><code>fn:contains-sequence</code></p></item>
+              <item><p><code>fn:ends-with-sequence</code></p></item>
+              <item><p><code>fn:expanded-QName</code></p></item>
+              <item><p><code>fn:highest</code></p></item>
+              <item><p><code>fn:identity</code></p></item>
               <item><p><code>fn:in-scope-namespaces</code></p></item>
-              <!--<item><p><code>fn:replace-with</code></p></item>-->
-              <item><p><code>fn:stack-trace</code></p></item>             
-           </olist>
-           <p>TODO: complete the list</p>
+              <item><p><code>fn:index-where</code></p></item>
+              <item><p><code>fn:intersperse</code></p></item>
+              <item><p><code>fn:is-NaN</code></p></item>
+              <item><p><code>fn:items-after</code></p></item>
+              <item><p><code>fn:items-before</code></p></item>
+              <item><p><code>fn:items-ending-where</code></p></item>
+              <item><p><code>fn:items-starting-where</code></p></item>
+              <item><p><code>fn:iterate-while</code></p></item>
+              <item><p><code>fn:lowest</code></p></item>
+              <item><p><code>fn:op</code></p></item>
+              <item><p><code>fn:parse-QName</code></p></item>
+              <item><p><code>fn:parse-uri</code></p></item>
+              <item><p><code>fn:replicate</code></p></item>
+              <item><p><code>fn:some</code></p></item>
+              <item><p><code>fn:starts-with-sequence</code></p></item>
+               
+           </ulist>
+
+           <p>A number of functions are included in the draft specification but have not yet been reviewed or accepted:</p>
+           
+           <ulist>
+              <item><p><code>fn:differences</code></p></item>
+              <item><p><code>fn:json</code></p></item>
+              <item><p><code>fn:slice</code></p></item>
+              <item><p><code>fn:stack-trace</code></p></item>
+              <item><p><code>map:filter</code></p></item>
+              <item><p><code>map:replace</code></p></item>
+              <item><p><code>map:substitute</code></p></item>
+              <item><p><code>array:partition</code></p></item>
+              <item><p><code>array:replace</code></p></item>
+              <item><p><code>array:slice</code></p></item>
+              
+           </ulist>
+           
 	     </div2>
 	     <div2 id="changes-to-existing-functions">
 	        <head>Changes to Existing Functions</head>
 	        <olist>
+	           
+	           <item><p>The keywords used for parameter names have been changed. Previously these names were
+	              of no significance, but in 4.0 they can be used with <code>keyword := value</code>
+	              argument syntax in function calls.</p></item>
+	        </olist>
+	        <p>The following changes are present in this draft, but have not been agreed by the community group:</p>
+	        <olist>
 	           <item><p>The third argument of <code>fn:format-number</code> can now be supplied
-	           as an <code>xs:QName</code> instead of as a string that can be converted to a QName.
-	           Using a <code>xs:QName</code>, especially in the (rare) cases when the value is
-	           supplied dynamically, avoids the need to maintain the static namespace context
-	           at execution time.</p></item>
+	              as an <code>xs:QName</code> instead of as a string that can be converted to a QName.
+	              Using a <code>xs:QName</code>, especially in the (rare) cases when the value is
+	              supplied dynamically, avoids the need to maintain the static namespace context
+	              at execution time.</p></item>
+	           
 	           <item><p>The function <code>fn:xml-to-json</code> accepts an additional option:
-	           <code>number-formatter</code> allows the user to control the formatting of numeric 
+	              <code>number-formatter</code> allows the user to control the formatting of numeric 
 	              values, for example by preventing the use of exponential notation for large integers.</p></item>
+	           
+	           
 	        </olist>
 	     </div2>
 	     <div2 id="editorial-changes">
@@ -10441,8 +10484,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
 	           functions, and <code>op:S2A</code> which does the inverse. This has enabled many of the
 	           functions to be specified more concisely, and with less duplication between similar functions
 	           for sequences and arrays.</p></item>
-	           <item><p></p></item>
-	           <item><p></p></item>
+
 	        </olist>
 	     </div2>
 	     <div2 id="changes-to-operators">

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1275,6 +1275,12 @@ See
 <inform-div1 id="id-incompatibilities">
 
 <head>Backwards Compatibility</head>
+  
+  <div2 id="id-incompatibilities-31" diff="add" at="2022-11-16">
+    <head>Incompatibilities relative to &language-tech; 3.1</head>
+    
+    <p>None.</p>
+  </div2>
 
 <div2 id="id-incompatibilities-30">
 <head>Incompatibilities relative to &language-tech; 3.0</head>
@@ -1327,7 +1333,7 @@ See
 
 </inform-div1>
 
-<inform-div1 id="id-revision-log">
+<inform-div1 id="id-revision-log" diff="chg" at="2022-11-16">
 <head>Change Log</head>
 
 <p role="xquery">This appendix lists the changes that have been made to this
@@ -1337,10 +1343,28 @@ specification since the publication of the XQuery 3.1 Recommendation.</p>
 specification since the publication of XPath 3.1 Recommendation.</p>
 
 <div2 id="id-changes-since-3.1">
-  <head>Changes since &language;</head>
+  <head>Changes since version 3.1</head>
   <div3 id="id-substantive-changes-since-3.1">
     <head>Substantive Changes</head>
   
+  <p>The following changes have been agreed by the working group:</p>
+    <olist>
+      <item><p>Function definitions in the static context may now have optional parameters,
+      provided this does not cause ambiguity across multiple function definitions with the same name.
+      Optional parameters are given a default value, which can be any expression, including one that
+      depends on the context of the caller (so an argument can default to the context item).</p></item>
+      <item><p>In a static function call, arguments can be specified either positionally or using keywords,
+      or a combination of both.</p></item>
+      <item><p>The rules for "errors and optimization" have been tightened up to disallow
+        many cases of optimizations that alter error behavior. In particular
+        there are restrictions on reordering the operands of <code>and</code> and <code>or</code>,
+        and of predicates in filter expressions, in a way that might allow the processor to raise dynamic
+        errors that the author intended to prevent.
+      </p></item>
+
+    </olist>
+    
+    <p>The following changes are present in this draft, but are awaiting review and agreement:</p>
   <olist>
     <item><p>The static context now allows the default namespace for elements and
     the default namespace for types to be different. XSLT 4.0 takes advantage of this,
@@ -1380,23 +1404,23 @@ specification since the publication of XPath 3.1 Recommendation.</p>
     have changed to be transitive. A decimal value is no longer converted to double, instead the double is converted
     to a decimal without loss of precision. This may affect compatibility in edge cases involving comparison of
     values that are numerically very close.</p></item>
+    <item><p>A <code>for member</code> clause is added to FLWOR expressions to allow iteration over
+    an array.</p></item>
     <item><p>Mathematical operator symbols are available as alternatives to alphabetic operator names, for example
     <code>div</code> can be written as <code>÷</code>, while <code>intersect</code> can be written as <code></code>.</p></item>
-    <item><p></p></item>
-    <item><p></p></item>
+ 
   </olist>
   </div3>
   <div3 id="id-editorial-changes-since-3.1">
     <head>Editorial Changes</head>
     
     <olist>
-      <item><p>The presentation of the rules for the <code>itemtype-subtype</code> relation has been clarified.</p></item>
+      <item><p>The presentation of the rules for the subtype relationship between sequence types and item types has been substantially
+        rewritten to improve clarity; no change to the semantics is intended.</p></item>
       <item><p>The operator mapping table has been simplified by removing entries for the operators <code>ne</code>,
       <code>le</code>, <code>gt</code>, and <code>ge</code>; these are now defined by reference to the
       rules for the operators <code>eq</code> and <code>lt</code>.</p></item>
-      <item><p></p></item>
-      <item><p></p></item>
-      <item><p></p></item>
+
     </olist>
   </div3>
 </div2>

--- a/specifications/xquery-40/src/xpath-backwards-compat.xml
+++ b/specifications/xquery-40/src/xpath-backwards-compat.xml
@@ -2,8 +2,9 @@
 <div2 role="xpath" id="id-backwards-compatibility">
     <head>Incompatibilities relative to XPath 1.0</head>
     
-    <p>This appendix provides a summary of the areas of incompatibility between <phrase diff="chg" at="bug28782">XPath 3.1</phrase> and
-            <bibref ref="xpath"/>. In each of these cases, an  <phrase diff="chg" at="bug28782">XPath 3.1</phrase> processor is compatible with an XPath 2.0 processor <phrase diff="chg" at="bug28782">or an XPath 3.0 processor</phrase>.</p>
+    <p>This appendix provides a summary of the areas of incompatibility between XPath 4.0 and
+            <bibref ref="xpath"/>. In each of these cases, an XPath 4.0 processor is compatible
+        with an XPath 2.0, 3.0, or 3.1 processor.</p>
 
     <p>Three separate cases are considered:</p>
 
@@ -33,7 +34,7 @@
         <head>Incompatibilities when Compatibility Mode is true</head>
 
         <p>The list below contains all known areas, within the scope of this specification, where an
-            <phrase diff="chg" at="bug28782">XPath 3.1</phrase> processor running with compatibility mode set to true will produce different
+            XPath 4.0 processor running with compatibility mode set to true will produce different
             results from an XPath 1.0 processor evaluating the same expression, assuming that the
             expression was valid in XPath 1.0, and that the nodes in the source document have no
             type annotations other than <code>xs:untyped</code> and
@@ -42,7 +43,7 @@
         <p>Incompatibilities in the behavior of individual functions are not listed here, but are
             included in an appendix of <bibref ref="xpath-functions-40"/>.</p>
 
-        <p>Since both XPath 1.0 and <phrase diff="chg" at="bug28782">XPath 3.1</phrase> leave some aspects of the specification
+        <p>Since both XPath 1.0 and <phrase diff="chg" at="bug28782">XPath 4.0</phrase> leave some aspects of the specification
             implementation-defined, there may be incompatibilities in the behavior of a particular
             implementation that are outside the scope of this specification. Equally, some aspects
             of the behavior of XPath are defined by the host language.</p>
@@ -51,10 +52,10 @@
         <olist>
             <item>
                 <p>Consecutive comparison operators such as <code>A &lt; B &lt; C</code> were
-                    supported in XPath 1.0, but are not permitted by the <phrase diff="chg" at="bug28782">XPath 3.1</phrase> grammar. In most
+                    supported in XPath 1.0, but are not permitted by the <phrase diff="chg" at="bug28782">XPath 4.0</phrase> grammar. In most
                     cases such comparisons in XPath 1.0 did not have the intuitive meaning, so it is
                     unlikely that they have been widely used in practice. If such a construct is
-                    found, an <phrase diff="chg" at="bug28782">XPath 3.1</phrase> processor will report a syntax error, and the construct can
+                    found, an <phrase diff="chg" at="bug28782">XPath 4.0</phrase> processor will report a syntax error, and the construct can
                     be rewritten as <code role="parse-test">(A &lt; B) &lt; C</code></p>
             </item>
 
@@ -62,7 +63,7 @@
                 <p>When converting strings to numbers (either explicitly when using the
                         <code>number</code> function, or implicitly say on a function call), certain
                     strings that converted to the special value <code>NaN</code> under XPath 1.0
-                    will convert to values other than <code>NaN</code> under <phrase diff="chg" at="bug28782">XPath 3.1</phrase>. These
+                    will convert to values other than <code>NaN</code> under <phrase diff="chg" at="bug28782">XPath 4.0</phrase>. These
                     include any number written with a leading <code>+</code> sign, any number in
                     exponential floating point notation (for example <code>1.0e+9</code>), and the
                     strings <code>INF</code> and <code>-INF</code>.</p>
@@ -70,14 +71,14 @@
                 <p>Furthermore, the strings <code>Infinity</code> and <code>-Infinity</code>, which
                     were accepted by XPath 1.0 as representations of the floating-point values
                     positive and negative infinity, are no longer recognized. They are converted to
-                        <code>NaN</code> when running under <phrase diff="chg" at="bug28782">XPath 3.1</phrase> with compatibility mode set to
+                        <code>NaN</code> when running under <phrase diff="chg" at="bug28782">XPath 4.0</phrase> with compatibility mode set to
                     true, and cause a dynamic error when compatibility mode is set to false.</p>
             </item>
 
             <item>
-                <p><phrase diff="chg" at="bug28782">XPath 3.1</phrase> does not allow a token starting with a letter to follow immediately
+                <p><phrase diff="chg" at="bug28782">XPath 4.0</phrase> does not allow a token starting with a letter to follow immediately
                     after a numeric literal, without intervening whitespace. For example,
-                        <code>10div 3</code> was permitted in XPath 1.0, but in <phrase diff="chg" at="bug28782">XPath 3.1</phrase> must be
+                        <code>10div 3</code> was permitted in XPath 1.0, but in <phrase diff="chg" at="bug28782">XPath 4.0</phrase> must be
                     written as <code>10 div 3</code>.</p>
             </item>
 
@@ -93,7 +94,7 @@
             <item>
                 <p>In XPath 1.0, the expression <code>-x|y</code> parsed as <code>-(x|y)</code>, and
                     returned the negation of the numeric value of the first node in the union of
-                        <code>x</code> and <code>y</code>. In <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, this expression parses as
+                        <code>x</code> and <code>y</code>. In <phrase diff="chg" at="bug28782">XPath 4.0</phrase>, this expression parses as
                         <code>(-x)|y</code>. When XPath 1.0 Compatibility Mode is true, this will
                     always cause a type error.</p>
             </item>
@@ -113,13 +114,13 @@
                     XPath 1.0, if neither operand of a comparison operation using the &lt;, &lt;=,
                     &gt; or &gt;= operator was a node set, both operands were converted to numbers.
                     The result of the expression <code>true() &gt; number('0.5')</code> is therefore
-                    true in XPath 1.0, but is false in <phrase diff="chg" at="bug28782">XPath 3.1</phrase> even when compatibility mode is set
+                    true in XPath 1.0, but is false in <phrase diff="chg" at="bug28782">XPath 4.0</phrase> even when compatibility mode is set
                     to true.</p>
             </item>
 
 
             <item>
-                <p>In <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, a type error is raised if the PITarget specified in a SequenceType
+                <p>In <phrase diff="chg" at="bug28782">XPath 4.0</phrase>, a type error is raised if the PITarget specified in a SequenceType
                     of form <code>processing-instruction(PITarget)</code> is not a valid NCName. In
                     XPath 1.0, this condition was not treated as an error.</p>
             </item>
@@ -133,7 +134,7 @@
         <head>Incompatibilities when Compatibility Mode is false</head>
 
         <p>Even when the setting of the XPath 1.0 compatibility mode is false, many XPath
-            expressions will still produce the same results under <phrase diff="chg" at="bug28782">XPath 3.1</phrase> as under XPath 1.0. The
+            expressions will still produce the same results under XPath 4.0 as under XPath 1.0. The
             exceptions are described in this section.</p>
 
         <p>In all cases it is assumed that the expression in question was valid under XPath 1.0,
@@ -150,7 +151,7 @@
             <item>
                 <p>When a node-set containing more than one node is supplied as an argument to a
                     function or operator that expects a single node or value, the XPath 1.0 rule was
-                    that all nodes after the first were discarded. Under <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, a type error
+                    that all nodes after the first were discarded. Under XPath 4.0, a type error
                     occurs if there is more than one node. The XPath 1.0 behavior can always be
                     restored by using the predicate <code>[1]</code> to explicitly select the first
                     node in the node-set.</p>
@@ -159,7 +160,7 @@
             <item>
                 <p>In XPath 1.0, the <code>&lt;</code> and <code>&gt;</code> operators, when applied
                     to two strings, attempted to convert both the strings to numbers and then made a
-                    numeric comparison between the results. In <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, these operators perform a
+                    numeric comparison between the results. In XPath 4.0, these operators perform a
                     string comparison using the default collating sequence. (If either value is
                     numeric, however, the results are compatible with XPath 1.0)</p>
             </item>
@@ -177,7 +178,7 @@
                     argument is of type <code>xs:untypedAtomic</code> (which will commonly be the
                     case when a node in a schemaless document is supplied as the argument). For
                     example, the function call <code role="parse-test">substring-before(10 div 3,
-                        ".")</code> raises a type error under <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, because the arguments to
+                        ".")</code> raises a type error under XPath 4.0, because the arguments to
                     the <code>substring-before</code> function must be strings rather than numbers.
                     The XPath 1.0 behavior can be restored by performing an explicit conversion to
                     the required type using a constructor function or cast.</p>
@@ -188,13 +189,13 @@
                     expression such as <code role="parse-test">$node-set = true()</code> was
                     evaluated by converting the node-set to a boolean and then performing a boolean
                     comparison: so this expression would return <code>true</code> if
-                        <code>$node-set</code> was non-empty. In <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, this expression is
+                        <code>$node-set</code> was non-empty. In XPath 4.0, this expression is
                     handled in the same way as other comparisons between a sequence and a singleton:
                     it is <code>true</code> if <code>$node-set</code> contains at least one node
                     whose value, after atomization and conversion to a boolean using the casting
                     rules, is <code>true</code>.</p>
 
-                <p>This means that if <code>$node-set</code> is empty, the result under <phrase diff="chg" at="bug28782">XPath 3.1</phrase>
+                <p>This means that if <code>$node-set</code> is empty, the result under XPath 4.0
                     will be <code>false</code> regardless of the value of the boolean operand, and
                     regardless of which operator is used. If <code>$node-set</code> is non-empty,
                     then in most cases the comparison with a boolean is likely to fail, giving a
@@ -204,7 +205,7 @@
 
             <item>
                 <p>Comparisons of a number to a boolean, a number to a string, or a string to a
-                    boolean are not allowed in <phrase diff="chg" at="bug28782">XPath 3.1</phrase>: they result in a type error. In XPath 1.0
+                    boolean are not allowed in XPath 4.0: they result in a type error. In XPath 1.0
                     such comparisons were allowed, and were handled by converting one of the
                     operands to the type of the other. So for example in XPath 1.0 <code
                         role="parse-test">4 = true()</code> was true; <code role="parse-test">4 =
@@ -235,27 +236,27 @@
             </item>
 
             <item>
-                <p>Many operations in <phrase diff="chg" at="bug28782">XPath 3.1</phrase> produce an empty sequence as their result when one
+                <p>Many operations in XPath 4.0 produce an empty sequence as their result when one
                     of the arguments or operands is an empty sequence. Where the operation expects a
                     string, an empty sequence is usually considered equivalent to a zero-length
                     string, which is compatible with the XPath 1.0 behavior. Where the operation
                     expects a number, however, the result is not the same. For example, if
                         <code>@width</code> returns an empty sequence, then in XPath 1.0 the result
                     of <code role="parse-test">@width+1</code> was <code>NaN</code>, while with
-                    <phrase diff="chg" at="bug28782">XPath 3.1</phrase> it is <code>()</code>. This has the effect that a filter expression
+                    XPath 4.0 it is <code>()</code>. This has the effect that a filter expression
                     such as <code role="parse-test">item[@width+1 != 2]</code> will select items
                     having no <code>width</code> attribute under XPath 1.0, and will not select them
-                    under <phrase diff="chg" at="bug28782">XPath 3.1</phrase>.</p>
+                    under XPath 4.0.</p>
             </item>
 
             <item>
                 <p>The typed value of a comment node, processing instruction node, or namespace node
-                    under <phrase diff="chg" at="bug28782">XPath 3.1</phrase> is of type <code>xs:string</code>, not
+                    under XPath 4.0 is of type <code>xs:string</code>, not
                         <code>xs:untypedAtomic</code>. This means that no implicit conversions are
                     applied if the value is used in a context where a number is expected. If a
                     processing-instruction node is used as an operand of an arithmetic operator, for
                     example, XPath 1.0 would attempt to convert the string value of the node to a
-                    number (and deliver <code>NaN</code> if unsuccessful), while <phrase diff="chg" at="bug28782">XPath 3.1</phrase> will
+                    number (and deliver <code>NaN</code> if unsuccessful), while XPath 4.0 will
                     report a type error.</p>
             </item>
 
@@ -263,7 +264,7 @@
                 <p>In XPath 1.0, it was defined that with an expression of the form <code>A and
                         B</code>, B would not be evaluated if A was false. Similarly in the case of
                         <code>A or B</code>, B would not be evaluated if A was true. This is no
-                    longer guaranteed with <phrase diff="chg" at="bug28782">XPath 3.1</phrase>: the implementation is free to evaluate the two
+                    longer guaranteed with XPath 4.0: the implementation is free to evaluate the two
                     operands in either order or in parallel. This change has been made to give more
                     scope for optimization in situations where XPath expressions are evaluated
                     against large data collections supported by indexes. Implementations may choose
@@ -274,10 +275,10 @@
             <item>
                 <p>In XPath 1.0, the expression <code>-x|y</code> parsed as <code>-(x|y)</code>, and
                     returned the negation of the numeric value of the first node in the union of
-                        <code>x</code> and <code>y</code>. In <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, this expression parses as
+                        <code>x</code> and <code>y</code>. In XPath 4.0, this expression parses as
                         <code>(-x)|y</code>. When XPath 1.0 Compatibility Mode is false, this will
                     cause a type error, except in the situation where <code>x</code> evaluates to an
-                    empty sequence. In that situation, <phrase diff="chg" at="bug28782">XPath 3.1</phrase> will return the value of
+                    empty sequence. In that situation, XPath 4.0 will return the value of
                         <code>y</code>, whereas XPath 1.0 returned the negation of the numeric value
                     of <code>y</code>.</p>
             </item>
@@ -299,7 +300,7 @@
 
         <p>Suppose that the context node is an element node derived from the following markup:
                 <code>&lt;background color="red green blue"/&gt;</code>. In XPath 1.0, the predicate
-                <code>[@color="blue"]</code> would return <code>false</code>. In <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, if the
+                <code>[@color="blue"]</code> would return <code>false</code>. In XPath 4.0, if the
                 <code>color</code> attribute is defined in a schema to be of type
                 <code>xs:NMTOKENS</code>, the same predicate will return <code>true</code>.</p>
 
@@ -307,7 +308,7 @@
             applied to the element <code>&lt;person birth="1901-06-06"
                 death="1991-05-09"/&gt;</code>. With XPath 1.0, this expression would return false,
             because both attributes are converted to numbers, which returns <code>NaN</code> in each
-            case. With <phrase diff="chg" at="bug28782">XPath 3.1</phrase>, in the presence of a schema that annotates these attributes as
+            case. With XPath 4.0, in the presence of a schema that annotates these attributes as
             dates, the expression returns <code>true</code>.</p>
 
         <p>Once schema validation is applied, elements and attributes cannot be used as operands and
@@ -321,7 +322,7 @@
                 >substring-after(@temperature, "-")</code> might be rewritten as <code
                 role="parse-test">abs(@temperature)</code>.</p>
 
-        <p>In the case of an <phrase diff="chg" at="bug28782">XPath 3.1</phrase> implementation that provides the static typing feature, many
+        <p>In the case of an XPath 4.0 implementation that provides the static typing feature, many
             further type errors will be reported in respect of expressions that worked under XPath
             1.0. For example, an expression such as <code role="parse-test">round(../@price)</code>
             might lead to a static type error because the processor cannot infer statically that


### PR DESCRIPTION
This PR is purely editorial: it updates change logs and status information to reflect the current state of play. In particular, the change logs in appendices now attempt to distinguish changes approved by the WG from changes that were in the baseline draft prepared by the editor, but which have not yet been reviewed or approved.