### PR TITLE
New functions fn:foot, fn:truncate, array:foot, array:truncate

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11716,6 +11716,7 @@ let $newi := $o/tool</eg>
          </fos:example>
       </fos:examples>
    </fos:function>
+   
    <fos:function name="tail" prefix="fn">
       <fos:signatures>
          <fos:proto name="tail" return-type="item()*">
@@ -11769,6 +11770,64 @@ let $newi := $o/tool</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+   </fos:function>
+   
+   <fos:function name="truncate" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="truncate" return-type="item()*">
+            <fos:arg name="input" type="item()*" usage="transmission"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns all but the last item in a sequence. </p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function returns the value of the expression <code>fn:remove($input, count($input))</code></p>
+      </fos:rules>
+      <fos:notes>
+         <p>If <code>$input</code> is the empty sequence, or a sequence containing a single item, then
+            the empty sequence is returned. </p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:truncate(1 to 5)</fos:expression>
+               <fos:result>(1, 2, 3, 4)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:truncate(("a", "b", "c"))</fos:expression>
+               <fos:result>("a", "b")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:truncate("a")</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:truncate(())</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:truncate([1,2,3])</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="replicate" prefix="fn">
@@ -11929,45 +11988,7 @@ let $newi := $o/tool</eg>
          <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
       </fos:history>
    </fos:function>
-   
-   <fos:function name="truncate" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="truncate" return-type="item()?">
-            <fos:arg name="input" type="item()*" usage="transmission"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Returns all but the last item in a sequence. </p>
-      </fos:summary>
-      <fos:rules>
-         <p>The function returns the value of the expression <code>$input[position() ne last()]</code></p>
-      </fos:rules>
-      <fos:notes>
-         <p>If <code>$input</code> is the empty sequence, or if it contains only one item,
-            then the empty sequence is returned. </p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:truncate(1 to 5)</fos:expression>
-               <fos:result>(1, 2, 3, 4)</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:truncate(())</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:truncate(5)</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-   </fos:function>
+ 
 
    <fos:function name="reverse" prefix="fn">
       <fos:signatures>
@@ -20853,6 +20874,48 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </fos:example>
       </fos:examples>
    </fos:function>
+   
+   <fos:function name="foot" prefix="array">
+      <fos:signatures>
+         <fos:proto name="foot" return-type="item()*">
+            <fos:arg name="array" type="array(*)" usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns the last member of an array, that is <code>$array(array:size($array))</code>.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function returns last member of <code>$array</code>, that is the value of <code>array:get($array, array:size($array))</code>.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error occurs <errorref class="AY" code="0001"
+         /> if <code>$array</code> is empty.</p>
+      </fos:errors>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>array:foot([5, 6, 7, 8])</fos:expression>
+               <fos:result>8</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>array:foot([["a", "b"], ["c", "d"]])</fos:expression>
+               <fos:result>["c", "d"]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>array:fot([("a", "b"), ("c", "d")])</fos:expression>
+               <fos:result>"c", "d"</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0, see issue 97</fos:version>
+      </fos:history>
+   </fos:function>
 
    <fos:function name="tail" prefix="array">
       <fos:signatures>
@@ -20891,6 +20954,48 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+   </fos:function>
+   
+   <fos:function name="truncate" prefix="array">
+      <fos:signatures>
+         <fos:proto name="truncate" return-type="array(*)">
+            <fos:arg name="array" type="array(*)" usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns an array containing all members except the last from a supplied array.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function returns an array containing all members of the supplied array except the last,
+            that is <code>array:remove($array, array:size($array))</code>.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error occurs <errorref class="AY" code="0001"
+         /> if <code>$array</code> is empty.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>If the supplied array contains exactly one member, the result will be an empty array.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>array:truncate([5, 6, 7, 8])</fos:expression>
+               <fos:result>[5, 6, 7]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>array:truncate([5])</fos:expression>
+               <fos:result>[ ]</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0, see issue 97</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="reverse" prefix="array">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5610,6 +5610,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-exists">
                <head><?function fn:exists?></head>
             </div3>
+            <div3 id="func-foot" diff="add" at="2022-11-16">
+               <head><?function fn:foot?></head>
+            </div3>
             <div3 id="func-head">
                <head><?function fn:head?></head>
             </div3>
@@ -5642,6 +5645,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
             <div3 id="func-tail">
                <head><?function fn:tail?></head>
+            </div3>
+            <div3 id="func-truncate" diff="add" at="2022-11-16">
+               <head><?function fn:truncate?></head>
             </div3>
             <div3 id="func-unordered">
                <head><?function fn:unordered?></head>
@@ -6183,8 +6189,14 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-array-head">
                <head><?function array:head?></head>
             </div3>
+            <div3 id="func-array-foot" diff="add" at="2022-11-16">
+               <head><?function array:foot?></head>
+            </div3>
             <div3 id="func-array-tail">
                <head><?function array:tail?></head>
+            </div3>
+            <div3 id="func-array-truncate" diff="add" at="2022-11-16">
+               <head><?function array:truncate?></head>
             </div3>
             <div3 id="func-array-reverse">
                <head><?function array:reverse?></head>


### PR DESCRIPTION
New functions fn:foot, fn:truncate, array:foot, array:truncate, as proposed in issue #97. Note that not everyone was happy with the name "truncate".