### PR TITLE
Improvements/fixes for the coercion rules

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7341,7 +7341,8 @@ At evaluation time, the value of a variable reference is the value to which the 
 
                   <item>
                      <p>
-                          The <termref def="dt-function-definition"/> <var>FD</var> to be used is found in the static context.
+                          The <termref def="dt-function-definition"/> <var>FD</var> to be used is found in 
+                        >the <termref def="dt-statically-known-function-definitions"/> of <var>SC</var>.
                         </p>
                      
                      <p>The <term>required arity</term> is the total number of arguments in the
@@ -7469,12 +7470,16 @@ At evaluation time, the value of a variable reference is the value to which the 
                                        </p>
                                     </item>
                                     <item>
-                                       <p>
-                                      The result is either an instance of <var>FF</var>'s return type
+                                       <p>The result is converted to the required type (the
+                                             declared return type in the function declaration, defaulting
+                                             to <code>item()*</code>) by applying the <termref def="dt-coercion-rules"/>.</p>
+                                      <p>The result of applying the coercion rules is either an instance of <var>FD</var>'s return type
                                       or a dynamic error.
-                                      This result is then the result of evaluating <var>FC</var>.
-                                    </p>
+                                      This result is then the result of evaluating <var>FC</var>.</p>
+                                      <note><p>A host language may define alternative rules for processing the result, especially
+                                      in the case of external functions implemented using a non-XDM type system.</p></note>
                                     </item>
+                                    
                                     <item>
                                        <p>
                                       Errors raised by built-in functions are defined in
@@ -8325,72 +8330,82 @@ return $a("A")]]></eg>
                      <div3 id="id-coercion-rules">
                <head>Coercion Rules</head>
 
-               <p diff="chg" at="A">
+               <p diff="chg" at="2022-11-17">
                   <termdef term="coercion rules" id="dt-coercion-rules"
-                        >The <term>coercion rules</term> are used to convert an argument value <phrase
-                        role="xquery"
-                        >or a return value </phrase> to its expected type; that is, to the declared type of the function <phrase
-                        role="xpath">parameter.</phrase>
-                     <phrase role="xquery">parameter or return.</phrase>
-                  </termdef> The expected type is expressed as a <termref def="dt-sequence-type"
-                     >sequence type</termref>. 
-		                The coercion rules are applied to a given value as follows:</p>
+                        >The <term>coercion rules</term> are rules used to convert a supplied value to a required type,
+                     for example when converting an argument of a function call to the declared type of the function parameter.
+                  </termdef> The required type is expressed as a <termref def="dt-sequence-type"
+                     >sequence type</termref>. The effect of the coercion rules may be to accept the value as supplied,
+                  to convert it to a value that matches the required type, or to reject it with a type error.</p>
+                        
+               <p diff="chg" at="2022-11-17">This section defines how the coercion rules operate; the situations in which the rules apply
+                  are defined elsewhere, by reference to this section.</p>
+                        
+                        <note diff="add" at="A">
+                           <p>In previous versions of this specification, the coercion rules were referred to as the
+                              <emph>function conversion</emph> rules. The terminology has changed because the rules are not exclusively
+                              associated with functions or function calling.</p>
+                        </note>
+		            
+                        <p diff="chg" at="2022-11-17">The coercion rules are applied to a supplied value <var>V</var> 
+		               and a required <termref def="dt-sequence-type"/> <var>T</var> as follows:</p>
 
-               <note role="xpath">
-                  <p>In XSLT, the coercion rules are also used to convert the value of a variable to its declared type.</p>
-               </note>
-
-               <note diff="add" at="A">
-                  <p>In previous versions of this specification, the coercion rules were referred to as the
-               <emph>function conversion</emph> rules. The terminology has changed because the rules are not exclusively
-               associated with functions or function calling.</p>
-               </note>
+               
                <ulist>
 
                   <item role="xpath">
-                     <p>In a static function call, if  <termref def="dt-xpath-compat-mode">XPath
-                          1.0 compatibility mode</termref> is <code>true</code> and an
-                          argument of a static function is not of
-                          the expected type, then the following conversions are applied
-                          sequentially to the argument value V:</p>
+                     <p>If  <termref def="dt-xpath-compat-mode">XPath
+                          1.0 compatibility mode</termref> is <code>true</code> and <var>V</var>
+                          is not of the required type <var>T</var>, then the following conversions are applied
+                          sequentially to <var>V</var>:</p>
 
                      <olist>
 
                         <item>
-                           <p>If the expected type calls for a single item or optional single item (examples: <code>xs:string</code>, <code>xs:string?</code>, <code>xs:untypedAtomic</code>, <code>xs:untypedAtomic?</code>, <code>node()</code>, <code>node()?</code>, <code>item()</code>, <code>item()?</code>), then the value V is effectively replaced by V[1].</p>
+                           <p>If <var>T</var> requires a single item or optional single item 
+                              (examples: <code>xs:string</code>, <code>xs:string?</code>, 
+                              <code>xs:untypedAtomic</code>, <code>xs:untypedAtomic?</code>, 
+                              <code>node()</code>, <code>node()?</code>, <code>item()</code>, 
+                              <code>item()?</code>), then <var>V</var> is effectively replaced by <code>V[1]</code>.</p>
                         </item>
 
                         <item>
-                           <p>If the expected type is <code>xs:string</code> or <code>xs:string?</code>,
-                      		then the  value <code>V</code> is effectively replaced by
+                           <p>If <var>T</var> is <code>xs:string</code> or <code>xs:string?</code>,
+                      		then <var>V</var> is effectively replaced by
                       		<code>fn:string(V)</code>.</p>
+                           <note diff="add" at="2022-11-17"><p>This rule does not apply where <var>T</var> is derived from <code>xs:string</code>
+                           or <code>xs:string?</code>, because derived types did not arise in XPath 1.0.</p></note>
                         </item>
 
                         <item>
-                           <p>If
-		the expected type is <code>xs:double</code> or <code>xs:double?</code>, then the value <code>V</code> is effectively replaced by
-		<code>fn:number(V)</code>.</p>
+                           <p>If <var>T</var> is <code>xs:double</code> or <code>xs:double?</code>, then 
+                              <code>V</code> is effectively replaced by <code>fn:number(V)</code>.</p>
+                           <note diff="add" at="2022-11-17"><p>This rule does not apply where <var>T</var> is derived from <code>xs:double</code>
+                              or <code>xs:double?</code>, because derived types did not arise in XPath 1.0.</p></note>
                         </item>
                      </olist>
 
                      <note>
                         <p>
-                           <termref def="dt-xpath-compat-mode"
+                           The special rules for <termref def="dt-xpath-compat-mode"
                               >XPath 1.0 compatibility
-    mode</termref> has no effect on dynamic function calls,
-    converting the result of an inline function to its required type,
-    partial function application, or implicit function calls that
-    occur when evaluating functions such as fn:for-each and fn:filter.</p>
+    mode</termref> are used for converting the arguments of a static function call, and
+                           in certain XSLT constructs. They are not invoked in other contexts such as dynamic function calls,
+    for converting the result of an inline function to its required type,
+    for partial function application, or for implicit function calls such as
+    occur when evaluating functions such as <code>fn:for-each</code> and <code>fn:filter</code>.</p>
                      </note>
 
                   </item>
 
                   <item>
-                     <p>If the expected type is <phrase diff="add" at="A">a <code>SequenceType</code>
+                     <p>If <var>T</var> is <phrase diff="add" at="A">a <code>SequenceType</code>
                      whose <code>ItemType</code> is a <termref def="dt-generalized-atomic-type"/> 
-                     other than a union type or enumeration type,</phrase> (possibly with an occurrence indicator 
+                     other than an enumeration type,</phrase> (possibly with an occurrence indicator 
                         <code>*</code>, <code>+</code>, or <code>?</code>), then the following conversions are applied,
                         <phrase diff="add" at="A">in order</phrase>:</p>
+                     
+                     <p>TODO: coercion for enumeration types needs further work.</p>
 
                      <olist>
 
@@ -8419,6 +8434,10 @@ return $a("A")]]></eg>
                       		<termref def="dt-type-promotion">promoted</termref> to the expected atomic type
 		                      using numeric promotion as described in <specref ref="promotion"/>, the promotion is
 		                      done.</p>
+                           <note diff="add" at="2022-11-17"><p>Numeric promotion is performed only when the required type is <code>xs:double</code>
+                           or <code>xs:float</code> (perhaps with an occurrence indicator). It is not performed
+                              when the required type is derived from <code>xs:double</code>
+                              or <code>xs:float</code>.</p></note>
                         </item>
 
                         <item>
@@ -8426,45 +8445,55 @@ return $a("A")]]></eg>
                               in the atomic sequence that can be <termref def="dt-type-promotion">promoted</termref> to the 
 		                         expected atomic type using URI promotion as described in <specref
                                  ref="promotion"/>, the promotion is done.</p>
+                           <note diff="add" at="2022-11-17"><p>Promotion of <code>xs:anyURI</code> values is performed 
+                              only when the required type is <code>xs:string</code> (perhaps with an occurrence indicator). It is not performed
+                              when the required type is derived from <code>xs:string</code>.</p></note>
                         </item>
                         
                         <item diff="add" at="A">
-                           <p>If the expected type is a sequence type whose item type is an atomic type <var>D</var>,
-                              where <var>D</var> is derived from the primitive type <var>P</var>, then any item <var>V</var>in the 
+                           <p>If <var>T</var> is a sequence type whose item type is an atomic type <var>D</var>,
+                              where <var>D</var> is derived from some primitive type <var>P</var>, then any atomic value <var>A</var> in the 
                               atomic sequence is <term>relabeled</term> as an instance of <var>D</var> if it satisfies
                               all the following conditions: 
                            </p>
                            <olist>
-                              <item><p><var>V</var> is an instance of <var>P</var>.</p></item>
-                              <item><p><var>V</var> is not an instance of <var>D</var>.</p></item>
-                              <item><p><var>V</var> is within the value space of <var>D</var>.</p></item>
+                              <item><p><var>A</var> is an instance of <var>P</var>.</p></item>
+                              <item><p><var>A</var> is not an instance of <var>D</var>.</p></item>
+                              <item><p>The <xtermref spec="DM40" ref="dt-datum"/> of <var>A</var> is 
+                                 within the value space of <var>D</var>.</p></item>
                            </olist>
-                           <p>Relabeling an atomic value changes the type annotation but not the value. For example, the
+                           <p>Relabeling an atomic value changes the <termref def="dt-type-annotation"/> but not the 
+                              <xtermref spec="DM40" ref="dt-datum"/>. For example, the
                            <code>xs:integer</code> value 3 can be relabeled as an instance of <code>xs:unsignedByte</code>, because
-                              the value is within the value space of <code>xs:unsignedByte</code>.</p>
-                           <p>Relabeling is not the same as casting. For example, the <code>xs:decimal</code> value 10.1
+                              the datum is within the value space of <code>xs:unsignedByte</code>.</p>
+                           <note><p>Relabeling is not the same as casting. For example, the <code>xs:decimal</code> value 10.1
                            can be cast to <code>xs:integer</code>, but it cannot be relabeled as <code>xs:integer</code>,
-                           because it is not within the value space of <code>xs:integer</code>.</p>
+                           because its datum not within the value space of <code>xs:integer</code>.</p></note>
+                           
                            <note><p>The effect of this rule is that if, for example, a function parameter is declared
                            with an expected type of <code>xs:positiveInteger</code>, then a call that supplies the literal
-                           value 3 will succeed, whereas a call that supplies -3 will fail.</p>
+                           value 3 will succeed, whereas a call that supplies -3 will fail.</p></note>
                               
-                           <p>This differs from previous versions of this specification, where both these calls would fail.</p>
-                           <p>In principle this change allows the arguments of existing functions to be defined with a 
+                           <note><p>This differs from previous versions of this specification, where both these calls would fail.</p>
+                           <p>This change allows the arguments of existing functions to be defined with a 
                            more precise type. For example, the <code>$position</code> argument of <code>array:get</code>
-                           could be defined as <code>xs:positiveInteger</code> rather than <code>xs:integer</code>. In practice,
-                           however, it is not always possible to do this, because it would change the error codes thrown
-                           when an invalid value is supplied.</p>
-                           <p>TODO: define the interaction of numeric promotion and relabeling. For example, required type
-                           = <code>xs:unsignedByte</code>, supplied value = <code>xs:decimal</code> 255.3.</p></note>
+                           can be defined as <code>xs:positiveInteger</code> rather than <code>xs:integer</code>. To enable
+                           this to be done without breaking backwards compatibility in respect of error behavior, 
+                           built-in functions in many cases define custom error codes to be raised where 
+                           relabeling of argument values fails.</p></note>
+                            
+                            <note><p>Numeric promotion and <code>xs:anyURI</code> promotion occur only when <var>T</var>
+                            is a primitive type (<code>xs:double</code>, <code>xs:float</code>, or <code>xs:string</code>).
+                            Relabeling occurs only when <var>T</var> is a derived type. Promotion and relabeling are therefore
+                            never combined.</p></note>
                         </item>
                      </olist>
                   </item>
 
                   <item diff="add" at="A">
-                     <p>If the expected type is a <nt def="RecordTest"
+                     <p>If <var>T</var> is a <nt def="RecordTest"
                            >RecordTest</nt> (possibly with an occurrence indicator <code>*</code>,
-                        <code>+</code>, or <code>?</code>), then the supplied value must be a map or sequence of maps, and the values of any
+                        <code>+</code>, or <code>?</code>), then <var>V</var> must be a map or sequence of maps, and the values of any
                      entries in these maps whose keys correspond to field declarations in the <code>RecordTest</code> are converted
                      to the required type defined by that field declaration, by applying these rules recursively 
                      (but with XPath 1.0 compatibility mode treated as false).</p>
@@ -8488,14 +8517,14 @@ return $a("A")]]></eg>
                   <item>
                      <p> If, after the
 		above conversions, the resulting value does not match
-		the expected type according to the rules for <termref
+		the expected type <var>T</var> according to the rules for <termref
                            def="dt-sequencetype-matching"
                            >SequenceType
 		Matching</termref>, a <termref def="dt-type-error"
                            >type error</termref> is
 		raised <errorref class="TY" code="0004"
-                           />.
-		<phrase role="xquery"
+                           />.</p>
+		<p diff="del" at="2022-11-17"><phrase role="xquery"
                               >If the function call takes place in a <termref def="dt-module"
                               >module</termref> other
 		than the <termref def="dt-module"
@@ -15506,15 +15535,19 @@ let $z := g($x, $y)]]></eg>
                      <termdef term="type declaration" id="dt-type-declaration"
                            >A variable binding may be accompanied by a <term>type declaration</term>, which consists of the keyword <code>as</code> followed by the static type of the variable, declared using the syntax in  <specref
                            ref="id-sequencetype-syntax"
-                        />.</termdef> At run time, if the value bound to the variable does not match the declared type according to the rules for <termref
-                        def="dt-sequencetype-matching">SequenceType
-matching</termref>, a <termref
-                        def="dt-type-error">type error</termref> is raised <errorref class="TY"
+                        />.</termdef> <phrase diff="add" at="2022-11-17">The type declaration defines a required type for the
+                        value. At run-time, the supplied value for the variable is converted to the required type
+                        by applying the <termref def="dt-coercion-rules"/>. If conversion is not possible, </phrase>                    
+                        a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
                         code="0004"
                         />. For example, the following <code>let</code> clause raises a <termref
                         def="dt-type-error"
                         >type error</termref> because the variable <code>$salary</code> has a type declaration that is not satisfied by the value that is bound to it:</p>
                   <eg><![CDATA[let $salary as xs:decimal :=  "cat"]]></eg>
+                  <p  diff="add" at="2022-11-17">The following <code>let</code> clause, however, succeeds, because the <termref def="dt-coercion-rules"/>
+                  allow an <code>xs:decimal</code> to be supplied where an <code>xs:double</code> is required:</p>
+                  <eg><![CDATA[let $temperature as xs:double := 32.5]]></eg>
+                  <p>In applying the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
                </item>
                <item diff="add" at="A">
                   <p>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1186,6 +1186,11 @@ return $i/xx:bing]]>
         initializing expression includes all functions, variables, and namespaces that are declared
         or imported anywhere in the Prolog, other than the variable being declared.</termdef>
     </p>
+    
+    <p diff="add" at="2022-11-17">If a required type is defined, then the value obtained by 
+      evaluating the initializing expression is converted to the required type by applying
+    the <termref def="dt-coercion-rules"/>. A type error occurs if this is not possible.
+      In invoking the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
 
 
     <p>In a module's dynamic context, a variable value (or the context item) may <termref
@@ -1353,6 +1358,12 @@ declare function local:f() { $b }; </eg>
 
     <p>If <code>VarValue</code> or <code>VarDefaultValue</code> is evaluated, the static and dynamic
       contexts for the evaluation are the current module's static and dynamic context.</p>
+    
+    <p diff="add" at="2022-11-17">If a required type is defined, then the value obtained by 
+      evaluating <code>VarValue</code> or <code>VarDefaultValue</code> is converted to the required type by applying
+      the <termref def="dt-coercion-rules"/>. A type error occurs if this is not possible.
+      In invoking the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
+    
 
     <p>Here are some examples of context item declarations.</p>
 


### PR DESCRIPTION
This PR is concerned with the coercion rules (formerly known as function conversion rules).

It fixes issue #242, a minor omission where we failed to say that coercion rules are used to convert the result of a static function call to the required return type.

It implements the proposal in issue #189, to apply the coercion rules to variable declarations/bindings as well as to function arguments and results. This brings XQuery into line with XSLT, and thus paves the way to allowing type declarations on "let" clauses in XPath.

It does some further editorial tidying up of the rules, such as improvng the definition of the term "coercion rules", adding clarifying notes, etc.

In approving this PR, I am requesting approval of the change (which was already in the draft, but has not been discussed) to introduce "down-casting" or "relabelling". This allows a function to declare a parameter with required type `xs:positiveInteger`, and for a caller to supply the value 42 without explicitly casting it to `xs:positiveInteger`.