### PR TITLE
Exclude spec XSL from PRs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,6 +31,7 @@ jobs:
           rsync -ar ./specifications/ /tmp/pr-sources/specifications/
           rsync -ar ./use-cases/ /tmp/pr-sources/use-cases/
           find /tmp/pr-sources -type f -name "build*.xml" -exec rm {} \;
+          find /tmp/pr-sources -type f -name "*.xsl" -exec rm {} \;
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Letting the specification-specific XSL through means you can get a mismatch with the common XSL. So don't do that.