### PR TITLE
Issue270 xslt mode visibility

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2743,7 +2743,7 @@ ErrorVal ::= "$" VarName
     <g:string>)</g:string>
   </g:production>
   
-  <g:production name="FieldDeclaration" if="xpath40 xquery40">
+  <g:production name="FieldDeclaration" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="FieldName"/>
     <g:optional>
       <g:string>?</g:string>
@@ -2757,21 +2757,21 @@ ErrorVal ::= "$" VarName
     </g:optional>
   </g:production>
   
-  <g:production name="FieldName" if="xpath40 xquery40">
+  <g:production name="FieldName" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="NCName"/>
       <g:ref name="StringLiteral"/>
     </g:choice>
   </g:production>
   
-  <g:production name="SelfReference" if="xpath40 xquery40">
+  <g:production name="SelfReference" if="xpath40 xquery40 xslt40-patterns">
     <g:string>..</g:string>
     <g:optional>
       <g:ref name="OccurrenceIndicator"/>
     </g:optional>
   </g:production>
   
-  <g:production name="ExtensibleFlag" if="xpath40 xquery40">
+  <g:production name="ExtensibleFlag" if="xpath40 xquery40 xslt40-patterns">
     <g:string>,</g:string>
     <g:string>*</g:string>
   </g:production>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2218,7 +2218,7 @@ ErrorVal ::= "$" VarName
 
   </g:production>
 
-  <g:production name="LocalNamespaceDecls">
+  <!--<g:production name="LocalNamespaceDecls">
     <g:zeroOrMore>
       <g:ref name="LocalNamespaceDecl"/>
     </g:zeroOrMore>
@@ -2230,7 +2230,7 @@ ErrorVal ::= "$" VarName
     <g:ref name="Lbrace"/>
     <g:ref name="URILiteral"/>
     <g:ref name="Rbrace"/>
-  </g:production>
+  </g:production>-->
 
   <g:production name="EnclosedContentExpr" if="xquery40">
     <g:ref name="EnclosedExpr"/>
@@ -4326,7 +4326,7 @@ ErrorVal ::= "$" VarName
     generate the parser.
   -->
 
-  <g:token name="PITarget" delimiter-type="hide" inline="false" if=" xquery40" value-type="string" is-xml="yes" xhref="http://www.w3.org/TR/REC-xml#NT-PITarget" xgc-id="xml-version">
+  <g:token name="PITarget" delimiter-type="hide" inline="false" if="xquery40" value-type="string" is-xml="yes" xhref="http://www.w3.org/TR/REC-xml#NT-PITarget" xgc-id="xml-version">
     <g:ref name="NCNameTok"/>
   </g:token>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -3568,8 +3568,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <p>
             <code>fn:round($start) &lt;= $p</code>
          </p>
-         <p>In the above computations, the rules for <code>op:numeric-less-than</code> and
-               <code>op:numeric-greater-than</code> apply.</p>
+         <p>In the above computations, the rules for <code>op:numeric-less-than</code> <phrase diff="del" at="2022-11-27">and
+               op:numeric-greater-than</phrase> apply.</p>
       </fos:rules>
       <fos:notes>
          <p>The first character of a string is located at position 1, not position 0.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11782,7 +11782,6 @@ let $newi := $o/tool</eg>
          <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
-         <fos:property>special-streaming-rules</fos:property>
       </fos:properties>
       <fos:summary>
          <p>Produces multiple copies of a sequence.</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -9871,6 +9871,10 @@ ISBN 0 521 77752 6.</bibl>
             <error class="RX" code="0004" label="Invalid replacement string." type="dynamic">
                <p>Raised by <code>fn:replace</code> to report errors in the replacement string.</p>
             </error>
+            <error class="RX" code="0005" label="Incompatible arguments for fn:replace()." type="dynamic">
+               <p>Raised by <code>fn:replace</code> if both the <code>$replacement</code> 
+                  and <code>$action</code> arguments are supplied.</p>
+            </error>
 			   <error class="TY" code="0012" label="Argument to fn:data() contains a node that does not have a typed value."
                    type="dynamic">
                <p>Raised by <code>fn:data</code>, or by implicit atomization, if applied to a node with no typed value,

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8118,8 +8118,8 @@ return $a("A")]]></eg>
                <prodrecap id="InlineFunctionExpr" ref="InlineFunctionExpr"/>
                <prodrecap ref="Annotation" role="xquery"/>
                <prodrecap ref="FunctionSignature" id="FunctionSignature"/>
-               <prodrecap ref="ParamList" role="xpath"/>
-               <prodrecap ref="Param" role="xpath"/>
+               <prodrecap id="ParamList" ref="ParamList"/>
+               <prodrecap id="Param" ref="Param"/>
                <prodrecap ref="TypeDeclaration" role="xpath"/>
                <prodrecap ref="FunctionBody" role="xpath"/>
             </scrap>
@@ -8978,7 +8978,7 @@ return fn:filter($days,$m)
                <head/>
                <prodrecap ref="PostfixExpr"/>
                <prodrecap id="ArgumentList" ref="ArgumentList"/>              
-               <prodrecap ref="PositionalArguments"/>  
+               <prodrecap id="PositionalArguments" ref="PositionalArguments"/>  
                <prodrecap ref="Argument"/>
                <prodrecap ref="ArgumentPlaceholder"/>
                <prodrecap id="KeywordArguments" ref="KeywordArguments"/>
@@ -13685,7 +13685,7 @@ return comment {fn:concat($homebase, ", we have a problem.")}]]></eg>
                <scrap>
                   <head/>
                   <prodrecap id="CompNamespaceConstructor" ref="CompNamespaceConstructor"/>
-                  <prodrecap ref="Prefix"/>
+                  <prodrecap id="Prefix" ref="Prefix"/>
                   <prodrecap id="EnclosedPrefixExpr" ref="EnclosedPrefixExpr"/>
                   <prodrecap id="EnclosedURIExpr" ref="EnclosedURIExpr"/>
                   <prodrecap ref="EnclosedExpr"/>
@@ -15430,9 +15430,9 @@ return .($k)
             <prodrecap id="FLWORExpr" ref="FLWORExpr11"/>
             <prodrecap id="InitialClause" ref="InitialClause"/>
             <prodrecap id="IntermediateClause" ref="IntermediateClause"/>
-            <prodrecap id="ForClause" ref="ForClause"/>
+            <prodrecap ref="ForClause"/>
             <prodrecap ref="ForBinding"/>
-            <prodrecap id="LetClause" ref="LetClause"/>
+            <prodrecap ref="LetClause"/>
             <prodrecap ref="LetBinding"/>
             <prodrecap id="TypeDeclaration" ref="TypeDeclaration"/>
             <prodrecap id="AllowingEmpty" ref="AllowingEmpty"/>
@@ -15446,13 +15446,13 @@ return .($k)
             <prodrecap id="CurrentItem" ref="CurrentItem"/>
             <prodrecap id="PreviousItem" ref="PreviousItem"/>
             <prodrecap id="NextItem" ref="NextItem"/>
-            <prodrecap id="CountClause" ref="CountClause"/>
-            <prodrecap id="WhereClause" ref="WhereClause"/>
+            <prodrecap ref="CountClause"/>
+            <prodrecap ref="WhereClause"/>
             <prodrecap id="GroupByClause" ref="GroupByClause"/>
             <prodrecap id="GroupingSpecList" ref="GroupingSpecList"/>
             <prodrecap id="GroupingSpec" ref="GroupingSpec"/>
             <prodrecap id="GroupingVariable" ref="GroupingVariable"/>
-            <prodrecap id="OrderByClause" ref="OrderByClause"/>
+            <prodrecap ref="OrderByClause"/>
             <prodrecap ref="OrderSpecList" id="OrderSpecList"/>
             <prodrecap ref="OrderSpec" id="OrderSpec"/>
             <prodrecap ref="OrderModifier" id="OrderModifier"/>
@@ -15550,8 +15550,10 @@ matching</termref>, a <termref
             <head>For Clause</head>
             <scrap>
                <head/>
-               <prodrecap ref="ForClause"/>
-               <prodrecap ref="ForBinding"/>
+               <prodrecap id="ForClause" ref="ForClause"/>
+               <prodrecap id="ForMemberClause" ref="ForMemberClause"/>
+               <prodrecap id="ForBinding" ref="ForBinding"/>
+               <prodrecap id="ForMemberBinding" ref="ForMemberBinding"/>
                <prodrecap ref="TypeDeclaration"/>
                <prodrecap ref="AllowingEmpty"/>
                <prodrecap ref="PositionalVar"/>
@@ -15853,8 +15855,8 @@ for member $y in $expr2]]></eg>
             <head>Let Clause</head>
             <scrap>
                <head/>
-               <prodrecap ref="LetClause"/>
-               <prodrecap ref="LetBinding"/>
+               <prodrecap id="LetClause" ref="LetClause"/>
+               <prodrecap id="LetBinding" ref="LetBinding"/>
                <prodrecap ref="TypeDeclaration"/>
             </scrap>
             <p>The purpose of a <code>let</code> clause is to bind values to one or more variables. Each variable is bound to the result of evaluating an expression.</p>
@@ -16420,7 +16422,7 @@ group by $symbol]]></eg>
             <head>Where Clause</head>
             <scrap>
                <head/>
-               <prodrecap ref="WhereClause"/>
+               <prodrecap id="WhereClause" ref="WhereClause"/>
             </scrap>
             <p>A <code>where</code> clause serves as a filter for the tuples in its input tuple stream. The expression in the <code>where</code> clause, called the <term>where-expression</term>, is evaluated once for
 each of these tuples. If the <termref
@@ -16467,7 +16469,7 @@ return $x</phrase>
             <head>Count Clause</head>
             <scrap>
                <head/>
-               <prodrecap ref="CountClause"/>
+               <prodrecap id="CountClause" ref="CountClause"/>
             </scrap>
 
             <p>The purpose of a <code>count</code> clause is to enhance the tuple
@@ -16936,7 +16938,7 @@ return
             <head>Order By Clause</head>
             <scrap>
                <head/>
-               <prodrecap ref="OrderByClause"/>
+               <prodrecap id="OrderByClause" ref="OrderByClause"/>
                <prodrecap ref="OrderSpecList"/>
                <prodrecap ref="OrderSpec"/>
                <prodrecap ref="OrderModifier"/>
@@ -18154,6 +18156,8 @@ be used to process an expression in a way that depends on its <termref
                <head/>
                <prodrecap id="CastExpr" ref="CastExpr"/>
                <prodrecap id="SingleType" ref="SingleType"/>
+               <prodrecap id="SimpleTypeName" ref="SimpleTypeName"/>
+               <prodrecap ref="TypeName"/>
                <prodrecap ref="LocalUnionType"/>
             </scrap>
             <p>Sometimes
@@ -18287,6 +18291,9 @@ The result of a cast expression is one of the following:
 
                <prodrecap id="CastableExpr" ref="CastableExpr"/>
                <prodrecap ref="SingleType"/>
+               <prodrecap ref="LocalUnionType"/>
+               <prodrecap ref="SimpleTypeName"/>
+               <prodrecap ref="TypeName"/>
                <prodrecap ref="LocalUnionType"/>
             </scrap>
             <p>&language;

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1265,7 +1265,7 @@ declare function local:f() { $b }; </eg>
 
     <scrap>
       <head></head>
-      <prodrecap ref="ContextItemDecl"/>
+      <prodrecap id="ContextItemDecl" ref="ContextItemDecl"/>
     </scrap>
 
     <!-- ================================================================== -->

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -982,7 +982,7 @@
             <item>
                <p> If <code>$uri-sequence</code> (after atomizing any nodes) contains an 
                   item other than an atomic value of type <code>xs:string</code>, <code>xs:anyURI</code>, or
-                     <code>xs:untypedAtomic</code> then a type error is raised <xerrorref spec="XP30" class="TY" code="0004"/>. </p>
+                     <code>xs:untypedAtomic</code> then a type error is raised <xerrorref spec="XP40" class="TY" code="0004"/>. </p>
             </item>
          </ulist>
 
@@ -1100,11 +1100,11 @@
             <ulist>
                <item>
                <p>If the context item is absent, <termref def="dt-dynamic-error"/> 
-                  <xerrorref spec="XP30" class="DY" code="0002"/>.</p>
+                  <xerrorref spec="XP40" class="DY" code="0002"/>.</p>
             </item>
                <item>
                <p>If the context item is not a node, <termref def="dt-type-error"/> 
-                  <xerrorref spec="XP30" class="TY" code="0004"/>.</p>
+                  <xerrorref spec="XP40" class="TY" code="0004"/>.</p>
             </item>
             </ulist>
             
@@ -1169,11 +1169,11 @@
             <ulist>
                <item>
                <p>If the context item is absent, <termref def="dt-dynamic-error"/> 
-                  <xerrorref spec="XP30" class="DY" code="0002"/>.</p>
+                  <xerrorref spec="XP40" class="DY" code="0002"/>.</p>
             </item>
                <item>
                <p>If the context item is not a node, <termref def="dt-type-error"/> 
-                  <xerrorref spec="XP30" class="TY" code="0004"/>.</p>
+                  <xerrorref spec="XP40" class="TY" code="0004"/>.</p>
             </item>
             </ulist>
             
@@ -1217,7 +1217,7 @@
       <fos:rules>
          <p>The <function>key</function> function does for keys what the <xfunction>element-with-id</xfunction> function does for IDs.</p>
          <p>The <code>$key-name</code> argument specifies the name of the <termref def="dt-key">key</termref>. 
-            The value of the argument <rfc2119>must</rfc2119> be <phrase diff="add" at="A">either an <code>xs:QName</code>, or </phrase>
+            The value of the argument <rfc2119>must</rfc2119> be <phrase diff="add" at="2022-01-01">either an <code>xs:QName</code>, or </phrase>
             a string containing an <termref def="dt-eqname"/>. If it is
             a <termref def="dt-lexical-qname">lexical QName</termref>, then it is expanded as
             described in <specref ref="qname"/> (no prefix means no namespace).</p>
@@ -1490,7 +1490,7 @@
 
          
          <p>The value of the <code>$name</code> argument 
-            <rfc2119>must</rfc2119> be <phrase diff="add" at="A">either an <code>xs:QName</code>, or </phrase>
+            <rfc2119>must</rfc2119> be <phrase diff="add" at="2022-01-01">either an <code>xs:QName</code>, or </phrase>
             a string containing an <termref def="dt-eqname">EQName</termref>. If it is a 
             <termref def="dt-lexical-qname">lexical QName</termref>
             with a prefix, then it is expanded into an <termref def="dt-expanded-qname">expanded
@@ -1679,7 +1679,7 @@
       <fos:notes>
          <p>The function returns a list of QNames, containing no duplicates.</p>
          <p>The QNames in this list are suitable for passing to the
-            <function>system-property</function> function.<phrase diff="del" at="A"> However, they must first be converted to
+            <function>system-property</function> function.<phrase diff="del" at="2022-01-01"> However, they must first be converted to
             the form expected by the <function>system-property</function> function, which is either
             a lexical QName or to an EQName in the form <code>Q{uri}local</code>. Because the prefix 
             of the returned QName is unpredictable, the <code>Q{uri}local</code> is likely
@@ -1837,12 +1837,13 @@
       <fos:rules>
 
          <p>A function is said to be available within an XPath expression if it is present in the
-               <xtermref spec="XP30" ref="dt-known-func-signatures">statically known function
-               signatures</xtermref> for that expression (see <specref ref="static-context"/>).
-            Functions in the static context are uniquely identified by the name of the function (a
-            QName) in combination with its <termref def="dt-arity">arity</termref>.</p>
+               <xtermref spec="XP40" ref="dt-statically-known-function-definitions">statically known function
+               definitions</xtermref> for that expression (see <specref ref="static-context"/>).
+            <phrase diff="chg" at="2022-11-27">Function definitions</phrase> in the static context are uniquely identified 
+            by the name of the function (a QName) in combination with its
+            <termref diff="chg" at="2022-11-27" def="dt-arity-range">arity range</termref>.</p>
          <p>The value of <code>$name</code> <rfc2119>must</rfc2119> be 
-            <phrase diff="add" at="A">either an <code>xs:QName</code>, or </phrase>a
+            <phrase diff="add" at="2022-01-01">either an <code>xs:QName</code>, or </phrase>a
             string containing an <termref def="dt-eqname">EQName</termref>. A lexical QName is
             expanded into an <termref def="dt-expanded-qname">expanded QName</termref> using the
             namespace declarations in scope for the <termref def="dt-expression">expression</termref>. 
@@ -1850,7 +1851,8 @@
             the expanded QName.</p>
          <p>The two-argument version of the <function>function-available</function> function returns
             true if and only if there is an available function whose name matches the value of the
-               <code>$function-name</code> argument and whose <termref def="dt-arity">arity</termref> matches the value of the <code>$arity</code> argument. </p>
+               <code>$function-name</code> argument and whose <termref def="dt-arity-range">arity range</termref> 
+            includes the value of the <code>$arity</code> argument. </p>
          <p>The single-argument version of the <function>function-available</function> function
             returns true if and only if there is at least one available function (with some arity)
             whose name matches the value of the <code>$name</code> argument. </p>
@@ -1888,7 +1890,7 @@
                <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the 
                   <code>$name</code> argument
                      <error.extra>passed to the <function>function-available</function>
-                     function</error.extra> <phrase diff="chg" at="A">evaluates to a string that is not</phrase> a valid
+                     function</error.extra> <phrase diff="chg" at="2022-01-01">evaluates to a string that is not</phrase> a valid
                   <termref def="dt-eqname">EQName</termref>, or if the value is a
                   <termref def="dt-lexical-qname">lexical QName</termref> with a prefix for which no
                   namespace declaration is present in the static context. If the processor is able
@@ -1997,7 +1999,7 @@
 
 
          <p>The value of the <code>$name</code> argument
-               <rfc2119>must</rfc2119> be <phrase diff="add" at="A">either an <code>xs:QName</code>,
+               <rfc2119>must</rfc2119> be <phrase diff="add" at="2022-01-01">either an <code>xs:QName</code>,
                or</phrase> a string containing an <termref def="dt-eqname">EQName</termref>. 
             If it is a <termref def="dt-lexical-qname">lexical QName</termref>
             with a prefix, then it is expanded into an <termref def="dt-expanded-qname">expanded
@@ -2015,11 +2017,11 @@
             URI, the <function>element-available</function> function will return false. </p>
 
          <p>If the <termref def="dt-expanded-qname">expanded QName</termref> is not in the <termref def="dt-xslt-namespace">XSLT namespace</termref>, the function returns true if and
-            only if the processor has an <phrase diff="add" at="A">external</phrase> implementation 
+            only if the processor has an <phrase diff="add" at="2022-01-01">external</phrase> implementation 
             available of an <termref def="dt-extension-instruction">extension instruction</termref> with the given
             expanded QName. This applies whether or not the namespace has been designated as an
                <termref def="dt-extension-namespace">extension namespace</termref>.</p>
-         <p diff="add" at="A">The term <term>external implementation</term> excludes the use of a 
+         <p diff="add" at="2022-01-01">The term <term>external implementation</term> excludes the use of a 
             <termref def="dt-named-template"/> as the instruction's implementation. The function does not return
          true simply because the name matches the name of a <termref def="dt-named-template"/>.</p>
          <p>If the processor does not have an implementation of a particular extension instruction
@@ -2034,7 +2036,7 @@
             <error spec="XT" type="dynamic" class="DE" code="1440">
                <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the argument
                      <error.extra>passed to the <function>element-available</function>
-                     function</error.extra> <phrase diff="chg" at="A">evaluates to a string that is 
+                     function</error.extra> <phrase diff="chg" at="2022-01-01">evaluates to a string that is 
                         not</phrase> a valid <termref def="dt-eqname">EQName</termref>, or if the value 
                   is a <termref def="dt-lexical-qname">lexical QName</termref> with a prefix for which no
                   namespace declaration is present in the static context. If the processor is able
@@ -2110,12 +2112,13 @@
       <fos:rules>
 
          <p>A schema type (that is, a simple type or a complex type) is said to be available within
-            an XPath expression if it is a type definition that is present in the <xtermref spec="XP30" ref="dt-is-types">in-scope schema types</xtermref> for that expression
+            an XPath expression if it is a type definition that is present in the 
+            <xtermref spec="XP40" ref="dt-is-types">in-scope schema types</xtermref> for that expression
             (see <specref ref="static-context"/>). This includes built-in types, types imported
             using <elcode>xsl:import-schema</elcode>, and extension types defined by the
             implementation.</p>
          <p>The value of the <code>$name</code> argument <rfc2119>must</rfc2119> be 
-            <phrase diff="add" at="A">either an <code>xs:QName</code>, or</phrase> a string
+            <phrase diff="add" at="2022-01-01">either an <code>xs:QName</code>, or</phrase> a string
             containing an <termref def="dt-eqname">EQName</termref>. The EQName is expanded into 
             an <termref def="dt-expanded-qname">expanded QName</termref> using the namespace declarations in
             scope for the <termref def="dt-expression">expression</termref>. If the value is an
@@ -2130,7 +2133,7 @@
             <error spec="XT" type="dynamic" class="DE" code="1428">
                <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the argument
                      <error.extra>passed to the <function>type-available</function>
-                     function</error.extra> <phrase diff="chg" at="A">evaluates to a string that is 
+                     function</error.extra> <phrase diff="chg" at="2022-01-01">evaluates to a string that is 
                         not</phrase> a valid <termref def="dt-eqname">EQName</termref>, or if the 
                   value is a <termref def="dt-lexical-qname">lexical QName</termref> with a prefix for which no
                   namespace declaration is present in the static context. If the processor is able
@@ -2230,7 +2233,7 @@
       <fos:rules>
          <p>The <code>$name</code> argument specifies the name of the <termref def="dt-accumulator"/>. 
             The value of the argument <rfc2119>must</rfc2119> be 
-            <phrase diff="add" at="A">either an <code>xs:QName</code>, or</phrase>
+            <phrase diff="add" at="2022-01-01">either an <code>xs:QName</code>, or</phrase>
             a string containing an <termref def="dt-eqname"/>. If it is a 
             <termref def="dt-lexical-qname">lexical QName</termref>, then it is expanded as described in
                <specref ref="qname"/> (no prefix means no namespace).</p>
@@ -2250,7 +2253,7 @@
                <p>It is a <termref def="dt-dynamic-error"/> if the value of the first
                      argument to the <function>accumulator-before</function> or
                         <function>accumulator-after</function> function is 
-                  <phrase diff="add" at="A">a string that is</phrase> not a valid
+                  <phrase diff="add" at="2022-01-01">a string that is</phrase> not a valid
                      <termref def="dt-eqname"/>, or if there is no namespace declaration in scope
                   for the prefix of the QName, or if the name obtained by expanding the QName is not
                   the same as the expanded name of any <elcode>xsl:accumulator</elcode> declaration
@@ -2359,7 +2362,7 @@
 
          <p>The <code>$name</code> argument specifies the name of the <termref def="dt-accumulator"/>. 
             The value of the argument <rfc2119>must</rfc2119> be 
-            <phrase diff="add" at="A">either an <code>xs:QName</code>, or</phrase>
+            <phrase diff="add" at="2022-01-01">either an <code>xs:QName</code>, or</phrase>
             a string containing an <termref def="dt-eqname">EQName</termref>. If it is a
                <termref def="dt-lexical-qname">lexical QName</termref>, then it is expanded as
             described in <specref ref="qname"/> (no prefix means no namespace).</p>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12890,10 +12890,10 @@ and <code>version="1.0"</code> otherwise.</p>
                                  <code>name</code> attribute is absent, then the
                                  <code>visibility</code> attribute if present
                                  <rfc2119>must</rfc2119> have the value
-                              <code>private</code>. A
-                                 named mode is not
+                              <code>private</code>.<phrase diff="del" at="2022-11-25"> A named mode is not
                               eligible to be used as the <termref def="dt-initial-mode"/> if its
-                              visibility is <code>private</code>.</td>
+                              visibility is <code>private</code>.</phrase>
+                           <ednote><edtext>See issue 270.</edtext></ednote></td>
 
                      </tr>
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -14568,9 +14568,9 @@ and <code>version="1.0"</code> otherwise.</p>
                <rfc2119>must</rfc2119> have no children. That is, the <code>then</code> attribute and the
                contained sequence constructor are mutually exclusive.</p>
             <p>The result of the <elcode>xsl:if</elcode> instruction depends on the <xtermref
-               spec="XP30" ref="dt-ebv">effective boolean value</xtermref> of the expression in
+               spec="XP40" ref="dt-ebv">effective boolean value</xtermref> of the expression in
                the <code>test</code> attribute. The rules for determining the effective boolean
-               value of an expression are given in <bibref ref="xpath-30"/>: they are the same as
+               value of an expression are given in <bibref ref="xpath-40"/>: they are the same as
                the rules used for XPath conditional expressions.</p>
             <p diff="add" at="2022-01-01">If the effective boolean value of the <termref def="dt-expression"
                >expression</termref> is true, then:</p>
@@ -14667,7 +14667,7 @@ and <code>version="1.0"</code> otherwise.</p>
                elements is satisfied. If none of the <elcode>xsl:when</elcode> elements is
                satisfied, then the <elcode>xsl:otherwise</elcode> element is considered, as
                described below.</p>
-            <p>An <elcode>xsl:when</elcode> element is satisfied if the <xtermref spec="XP30"
+            <p>An <elcode>xsl:when</elcode> element is satisfied if the <xtermref spec="XP40"
                ref="dt-ebv">effective boolean value</xtermref> of the <termref
                   def="dt-expression">expression</termref> in its <code>test</code> attribute is
                <code>true</code>. The rules for determining the effective boolean value of an
@@ -18269,7 +18269,8 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <note>
                   <p>Functions are not polymorphic. Although the XPath function call mechanism
-                     allows two functions to have the same name and different <termref def="dt-arity">arity</termref>, 
+                     allows two functions to have the same name and 
+                     <phrase diff="chg" at="2022-11-26">non-overlapping <termref def="dt-arity-range">arity ranges</termref></phrase>, 
                      it does not allow them to be distinguished
                      by the types of their arguments.</p>
                </note>
@@ -18436,7 +18437,9 @@ and <code>version="1.0"</code> otherwise.</p>
                   attribute and other factors, as described in <specref ref="packages"/>.</p>
 
                <p>The optional <code>override-extension-function</code> attribute defines what
-                  happens if this function has the same name and <termref def="dt-arity">arity</termref> as a function provided by the implementer or made available in
+                  happens if this function has the same name and an 
+                  <phrase diff="chg" at="2022-11-27"><termref def="dt-arity-range">arity range</termref> that conflicts 
+                  with a function</phrase> provided by the implementer or made available in
                   the static context using an implementation-defined mechanism. If the <code>override-extension-function</code> attribute
                   has the value <code>yes</code>, then this function is used in preference; if it
                   has the value <code>no</code>, then the other function is used in preference. The
@@ -18451,8 +18454,9 @@ and <code>version="1.0"</code> otherwise.</p>
                      to be used in preference to the stylesheet implementation, which is useful when
                      the extension function is more efficient.</p>
                   <p>The <code>override-extension-function</code> attribute does <emph>not</emph>
-                     affect the rules for deciding which of several <termref def="dt-stylesheet-function">stylesheet functions</termref> with the same
-                     name and <termref def="dt-arity">arity</termref> takes precedence.</p>
+                     affect the rules for deciding which of several 
+                     <termref def="dt-stylesheet-function">stylesheet functions</termref> with the same
+                     name and <termref def="dt-arity-range">arity range</termref> takes precedence.</p>
                </note>
                <p>The <code>override</code> attribute is a <termref def="dt-deprecated"/> synonym of <code>override-extension-function</code>,
                   retained for compatibility with XSLT 2.0. If both attributes are present then they
@@ -18506,16 +18510,16 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <p>If a <termref def="dt-stylesheet-function">stylesheet
                      function</termref> with a particular <termref def="dt-expanded-qname">expanded
-                     QName</termref> and <termref def="dt-arity">arity</termref> exists in the
+                     QName</termref> and <termref def="dt-arity-range">arity range</termref> exists in the
                   stylesheet, then a call to the <xfunction>function-lookup</xfunction> function
-                  supplying that name and arity will return the function as a value. This applies
+                  <phrase diff="chg" at="2022-11-27">will return the function as a value if it supplies that name and an arity within that range</phrase>. This applies
                   only if the static context for the call on <xfunction>function-lookup</xfunction>
                   includes the stylesheet function, which implies that the function is visible in
                   the containing package.</p>
 
                <p>The <function>function-available</function> function, when
                   called with a particular <termref def="dt-expanded-qname">expanded QName</termref>
-                  and <termref def="dt-arity">arity</termref>, returns true if and only if a call on
+                  and arity, returns true if and only if a call on
                      <xfunction>function-lookup</xfunction> with the same arguments, in the same
                   static context, would return a function item.</p>
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -5315,7 +5315,7 @@
                <div4 id="dynamic-component-references">
                   <head>Dynamic References to Components</head>
 
-                  <p>There are several functions in which a dynamically-evaluated QName is used to
+                  <p>There are several functions in which a dynamically evaluated QName is used to
                      identify a component: these include <function>key</function>,
                         <function>accumulator-before</function>,
                         <function>accumulator-after</function>,
@@ -5632,7 +5632,7 @@
                <p>The element is a <termref def="dt-declaration"/> that
                   can appear at most once in any stylesheet module; and if more than one
                      <elcode>xsl:global-context-item</elcode> declaration appears within a <termref def="dt-package"/>, then the declarations must be consistent. Specifically, all
-                  the attributes <rfc2119>must</rfc2119> have semantically-equivalent values.</p>
+                  the attributes <rfc2119>must</rfc2119> have semantically equivalent values.</p>
 
                <note>
                   <p>This means that omitting an attribute is equivalent to specifying its default
@@ -9201,8 +9201,11 @@ and <code>version="1.0"</code> otherwise.</p>
                         <specref ref="unprefixed-type-names"/>..</p>
                   </item>
                   <item>
-                     <p diff="chg" at="2022-01-01">The algorithm used as the <xtermref ref="dt-function-name-resolver" 
-                        spec="XP40">function resolver</xtermref> is described in <specref ref="resolving-function-names"/>.</p>
+                     <p diff="chg" at="2022-11-25">The <xtermref ref="dt-default-function-namespace" 
+                        spec="XP40">default function namespace</xtermref> is
+                        <code>http://www.w3.org/2005/xpath-functions</code> (and cannot be changed).
+                        The XSLT 4.0 specification refines the XPath 4.0 rules for resolving
+                        function names as described in <specref ref="resolving-function-names"/>.</p>
                   </item>
                   <item>
                      <p>The <xtermref spec="XP40" ref="dt-issd">in-scope schema
@@ -9225,8 +9228,8 @@ and <code>version="1.0"</code> otherwise.</p>
                            see <specref ref="determining-static-type"/>.</p>
                   </item>
                   <item>
-                     <p>The <xtermref spec="XP40" ref="dt-known-func-signatures">statically known
-                           function signatures</xtermref> are:</p>
+                     <p>The <xtermref spec="XP40" ref="dt-statically-known-function-definitions">statically known
+                           function definitions</xtermref> are:</p>
 
                      <ulist>
                         <item>
@@ -9350,9 +9353,10 @@ and <code>version="1.0"</code> otherwise.</p>
             </div3>
             <div3 id="resolving-function-names" diff="add" at="2022-01-01">
                <head>Resolving Function Names</head>
-               <p>This section defines how function names appearing in XPath expressions and patterns
-               are resolved: specifically, it defines the <xtermref ref="dt-function-name-resolver" spec="XP40"/> that
-                  forms part of the <xtermref ref="dt-static-context" spec="XP40"/>.</p>
+               <p diff="chg" at="2022-11-25">This section defines how function names appearing in XPath expressions and patterns
+               are resolved. It refines the rules given in the XPath 4.0 specification, which rely
+                  simply on looking up a function name and arity in the <xtermref ref="dt-static-context" spec="XP40"/>.
+               The refinements are necessary to handle function overriding.</p>
                <p>The rules depend on whether or not the stylesheet module contains an
                <elcode>xsl:function-library</elcode> declaration: the following two sections describe
                these two cases.</p>
@@ -9725,7 +9729,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            elements</termref>.</p>
                      </item>
                      <item>
-                        <p>The <xtermref spec="XP40" ref="dt-named-functions">named functions</xtermref>
+                        <p diff="chg" at="2022-11-25">The <xtermref spec="XP40" ref="dt-dynamically-known-function-definitions">dynamically known function definitions</xtermref>
                         (representing the functions accessible using <function>function-available</function> or <xfunction>function-lookup</xfunction>)
                            include all the functions available in the static context, and may also include an additional 
                            <termref def="dt-implementation-defined"/> set of functions that are available dynamically but not statically.
@@ -10083,7 +10087,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </item>
                <item>
                   <p><termdef id="dt-type-pattern" term="type pattern">A <term>type pattern</term> can be written as
-                     <code>type(T)</code> (where <var>T</var> is an <xnt spec="XP40" ref="nt-ItemType">ItemType</xnt>
+                     <code>type(T)</code> (where <var>T</var> is an <xnt spec="XP40" ref="prod-xpath40-ItemType">ItemType</xnt>
                      followed by zero or more predicates in square
                      brackets, and it matches any item of type <var>T</var> which each of the predicates evaluates
                      to <code>true</code>.</termdef></p>
@@ -10420,6 +10424,9 @@ and <code>version="1.0"</code> otherwise.</p>
                      <prodrecap ref="MapTest" id="MapTest"/>
                      <prodrecap ref="ArrayTest" id="ArrayTest"/>
                      <prodrecap ref="RecordTest" id="RecordTest"/>
+                     <prodrecap ref="FieldDeclaration" id="FieldDeclaration"/>
+                     <prodrecap ref="FieldName" id="FieldName"/>
+                     <prodrecap ref="ExtensibleFlag" id="ExtensibleFlag"/>
                      <prodrecap ref="EnumerationType" id="EnumerationType"/>
                      <prodrecap ref="NamedItemType" id="NamedItemType"/>
                      <prodrecap ref="PredicateList"/>
@@ -15289,7 +15296,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <p>When <code>rollback-output="no"</code> is specified, it is still possible to
                   ensure recovery of errors happens predictably by evaluating the
-                  potentially-failing code in <termref def="dt-temporary-output-state"/>: typically,
+                  potentially failing code in <termref def="dt-temporary-output-state"/>: typically,
                   within an <elcode>xsl:variable</elcode>. In effect the variable acts as an
                   explicit buffer for temporary results, which is only copied to the final output if
                   evaluation succeeds.</p>
@@ -16920,7 +16927,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <tr>
                      <td rowspan="1" colspan="1">Variable values</td>
                      <td rowspan="1" colspan="1">A value for every variable present in the in-scope variables. For <termref def="dt-static-parameter">static parameters</termref> where an external
-                        value is supplied: the externally-supplied value of the parameter. In all
+                        value is supplied: the externally supplied value of the parameter. In all
                         other cases: the value of the variable as defined in <specref ref="variable-values"/>.</td>
                   </tr>
                   <tr>
@@ -18985,7 +18992,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <p>The XSLT-specific aspects of the dynamic context described in <specref ref="additional-dynamic-context"/> are all <termref def="dt-absent"/>.</p>
                   </item>
                   <item>
-                     <p>The <xtermref spec="XP40" ref="dt-named-functions">named functions</xtermref>
+                     <p diff="chg" at="2022-11-25">The <xtermref spec="XP40" ref="dt-dynamically-known-function-definitions">dynamically known function definitions</xtermref>
                         (representing the functions accessible using <function>function-available</function> or <xfunction>function-lookup</xfunction>)
                         include all the functions available in the static context, and may also include an additional 
                         <termref def="dt-implementation-defined"/> set of functions that are available dynamically but not statically.
@@ -31354,7 +31361,7 @@ the same group, and the-->
                      described in <specref ref="streamability-fn-root"/>.</p>
                   <note>
                      <p>Taken together, these rewrites have the effect that a path expression such
-                        as <code>//a</code> is streamable only if the statically-determined context
+                        as <code>//a</code> is streamable only if the statically determined context
                         item type is <code>document-node()</code>, which will be the case for
                         example immediately within <elcode>xsl:source-document</elcode>, or in a template
                         rule with <code>match="/"</code>.</p>
@@ -31576,7 +31583,7 @@ the same group, and the-->
                         <p>If the <termref def="dt-context-posture"/> is <termref def="dt-roaming"/>, then the sweep is <termref def="dt-free-ranging"/> and the posture is <termref def="dt-roaming"/>;</p>
                      </item>
                      <item>
-                        <p>If the statically-inferred <termref def="dt-context-item-type"/> is such
+                        <p>If the statically inferred <termref def="dt-context-item-type"/> is such
                            that the axis will always be empty (for example, applying the child axis
                            to a text node or the parent axis to a document node), or if the <code>NodeTest</code> is one that can never
                               select nodes on the chosen axis (for example, selecting attribute
@@ -33040,7 +33047,7 @@ the same group, and the-->
                                              <p>Therefore rules 1 and 2 do not apply.</p>
                                           </item>
                                           <item>
-                                             <p>The statically-inferred context item type is derived
+                                             <p>The statically inferred context item type is derived
                                                 from the match pattern (<code>match="para"</code>).
                                                 This gives a type of <var>U{element()}</var>. The
                                                 child axis for element nodes is not necessarily
@@ -36581,7 +36588,7 @@ return ($m?price - $m?discount)</eg>
                <div4 id="validation-xsl-type">
                   <head>Validation using the <code>[xsl:]type</code> Attribute</head>
                   <p>The <code>[xsl:]type</code> attribute takes as its value an 
-                     <phrase diff="chg" at="2022-01-01"><xnt spec="XP40" ref="dt-EQName"/></phrase>.
+                     <phrase diff="chg" at="2022-01-01"><xnt spec="XP40" ref="prod-xpath40-EQName"/></phrase>.
                      If it is a lexical QName with no prefix, it is
                      expanded using the <phrase diff="chg" at="2022-01-01">default namespace for types</phrase>.
                      This <rfc2119>must</rfc2119> be the name of a type definition included in the

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -495,7 +495,7 @@
                            items, and returns a sequence of
                         atomic values, in which the nodes are replaced by their typed values as
                         defined in <bibref ref="xpath-datamodel-30"/>. 
-                        <phrase diff="del" at="A">If the XPath 3.1 feature is implemented,
+                        <phrase diff="del" at="2022-01-01">If the XPath 3.1 feature is implemented,
                         then</phrase> Arrays (see <specref ref="arrays"/>) are atomized by atomizing their
                         members, recursively.</termdef> For some items (for example, elements with element-only
                      content, function items, and maps, atomization
@@ -632,14 +632,14 @@
                         <label><code>item-type</code></label>
                         <def>
                            <p>An <xnt spec="XP40" ref="prod-xpath40-ItemType">ItemType</xnt> as defined in the XPath
-                              <phrase diff="chg" at="A">4.0</phrase> specification.</p>
+                              <phrase diff="chg" at="2022-01-01">4.0</phrase> specification.</p>
                         </def>
                      </gitem>
                      <gitem>
                         <label><code>sequence-type</code></label>
                         <def>
                            <p>A <xnt spec="XP40" ref="prod-xpath40-SequenceType">SequenceType</xnt>
-                              as defined in the XPath <phrase diff="chg" at="A">4.0</phrase> specification.</p>
+                              as defined in the XPath <phrase diff="chg" at="2022-01-01">4.0</phrase> specification.</p>
                         </def>
                      </gitem>
                      <gitem>
@@ -686,22 +686,22 @@
                      <gitem>
                         <label><code>integer</code></label>
                         <def>
-                           <p>An integer, that is a string <phrase diff="chg" at="B">that is castable to</phrase> the schema type
+                           <p>An integer, that is a string <phrase diff="chg" at="2022-11-01">that is castable to</phrase> the schema type
                                  <code>xs:integer</code></p>
                         </def>
                      </gitem>
                      <gitem>
                         <label><code>decimal</code></label>
                         <def>
-                           <p>A decimal value, that is a string <phrase diff="chg" at="B">that is castable to</phrase> the schema
+                           <p>A decimal value, that is a string <phrase diff="chg" at="2022-11-01">that is castable to</phrase> the schema
                               type <code>xs:decimal</code></p>
                         </def>
                      </gitem>
                      <gitem>
-                        <label><code>ncname;</code> <phrase diff="add" at="A"><code>ncnames</code></phrase></label>
+                        <label><code>ncname;</code> <phrase diff="add" at="2022-01-01"><code>ncnames</code></phrase></label>
                         <def>
-                           <p>An unprefixed name: a string <phrase diff="chg" at="B">that is castable to</phrase> the schema type
-                                 <code>xs:NCName</code>; <phrase diff="add" at="A">a whitespace-separated list of such strings</phrase></p>
+                           <p>An unprefixed name: a string <phrase diff="chg" at="2022-11-01">that is castable to</phrase> the schema type
+                                 <code>xs:NCName</code>; <phrase diff="add" at="2022-01-01">a whitespace-separated list of such strings</phrase></p>
                         </def>
                      </gitem>
                      <gitem>
@@ -990,10 +990,10 @@
                                  context item</term> for the transformation. This item acts
                            as the <termref def="dt-context-item"/> when evaluating
                             the <code>select</code> expression or <termref def="dt-sequence-constructor"/> of a
-                                 <termref def="dt-global-variable"/> <phrase diff="chg" at="A">whose declaration is</phrase>
+                                 <termref def="dt-global-variable"/> <phrase diff="chg" at="2022-01-01">whose declaration is</phrase>
                            within the <termref def="dt-top-level-package"/>, as described in <specref ref="focus"/>. The global context item may also be available in a <termref def="dt-named-template"/>
                         when the stylesheet is invoked as described in <specref ref="invoking-initial-template"/></termdef>.
-                        <phrase diff="add" at="A">[XSLT 3.0 Erratum E7, bug 30179].</phrase></p>
+                        <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E7, bug 30179].</phrase></p>
 
                      <note>
                         <p>In previous releases of this specification, a single node was typically
@@ -1371,7 +1371,7 @@
                   </error>
                </p>
                
-               <note diff="add" at="A">
+               <note diff="add" at="2022-01-01">
                   <p>When the top-level package is rooted at an <elcode>xsl:stylesheet</elcode> or 
                      <elcode>xsl:transform</elcode> element, named templates having no explicit 
                      <code>visibility</code> attribute are automatically exposed as public components. 
@@ -1519,9 +1519,9 @@
     by applying the rules for the process of <xtermref spec="SER30" ref="sequence-normalization"/> as defined in 
        <bibref ref="xslt-xquery-serialization-30"/>. This process takes as input the serialization parameters defined in the
     unnamed <termref def="dt-output-definition"/> of the <termref def="dt-top-level-package"/>; though the only parameter
-    that is actually used by this process is <code>item-separator</code>. <phrase diff="del" at="A">In particular, sequence normalization is carried
+    that is actually used by this process is <code>item-separator</code>. <phrase diff="del" at="2022-01-01">In particular, sequence normalization is carried
        out regardless of any <code>method</code> attribute in the unnamed <termref def="dt-output-definition"/>.</phrase>
-    <phrase diff="add" at="A">[XSLT 3.0 Erratum E14, bug 30208].</phrase></p>
+    <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E14, bug 30208].</phrase></p>
     
     <p>The sequence normalization process either returns a document node, or raises
     a serialization error. The content of the document node is not necessarily well-formed (the document node may have any number
@@ -2071,7 +2071,7 @@
             constrains the type and number of items in a sequence. The term is used both to denote the
             concept, and to refer to the syntactic form in which sequence types are expressed in the
             XPath grammar: specifically <xnt spec="XP40" ref="prod-xpath40-SequenceType">SequenceType</xnt> in
-                <bibref ref="xpath-30"/>.</termdef><phrase diff="del" at="A">, or <xnt spec="XP40" ref="prod-xpath40-SequenceType">SequenceType</xnt> in
+                <bibref ref="xpath-30"/>.</termdef><phrase diff="del" at="2022-01-01">, or <xnt spec="XP40" ref="prod-xpath40-SequenceType">SequenceType</xnt> in
                 <bibref ref="xpath-31"/>, depending on whether or not the XPath 3.1 feature
             is implemented.</phrase></p>
             <p>
@@ -2925,9 +2925,9 @@
                <termdef id="dt-standard-attributes" term="standard attributes">There are a number of
                      <term>standard attributes</term> that may appear on any <termref def="dt-xslt-element">XSLT element</termref>: specifically
                      <code>default-collation</code>, 
-                     <code diff="add" at="A">default-element-namespace</code>, 
+                     <code diff="add" at="2022-01-01">default-element-namespace</code>, 
                      <code>default-mode</code>,
-                     <code diff="add" at="A">default-type-namespace</code>, 
+                     <code diff="add" at="2022-01-01">default-type-namespace</code>, 
                      <code>default-validation</code>,
                      <code>exclude-result-prefixes</code>, <code>expand-text</code>, <code>extension-element-prefixes</code>,
                      <code>use-when</code>, <code>version</code>, and
@@ -2936,9 +2936,9 @@
             <p>These attributes may also appear on a <termref def="dt-literal-result-element">literal result element</termref>, but in this case, to distinguish them from
                user-defined attributes, the names of the attributes are in the <termref def="dt-xslt-namespace">XSLT namespace</termref>. They are thus typically written
                as <code>xsl:default-collation</code>,
-               <code diff="add" at="A">xsl:default-element-namespace</code>,
+               <code diff="add" at="2022-01-01">xsl:default-element-namespace</code>,
                <code>xsl:default-mode</code>, 
-               <code diff="add" at="A">xsl:default-type-namespace</code>,
+               <code diff="add" at="2022-01-01">xsl:default-type-namespace</code>,
                <code>xsl:default-validation</code>,
                   <code>xsl:exclude-result-prefixes</code>, <code>xsl:expand-text</code>, 
                <code>xsl:extension-element-prefixes</code>, <code>xsl:use-when</code>,
@@ -2956,8 +2956,8 @@
                the XSLT namespace have the same effect; the XSLT namespace is used for the attribute
                if and only if its parent element is <emph>not</emph> in the XSLT namespace.</p>
             <p>In the case of <code>[xsl:]default-collation</code>, 
-               <code diff="add" at="A">[xsl:]default-element-namespace</code>,
-               <code diff="add" at="A">[xsl:]default-type-namespace</code>, 
+               <code diff="add" at="2022-01-01">[xsl:]default-element-namespace</code>,
+               <code diff="add" at="2022-01-01">[xsl:]default-type-namespace</code>, 
                <code>[xsl:]expand-text</code>, 
                <code>[xsl:]version</code>, and <code>[xsl:]xpath-default-namespace</code>, the value
                can be overridden by a different value for the same attribute appearing on a
@@ -2997,7 +2997,7 @@
                      </p>
                   </def>
                </gitem>
-               <gitem diff="add" at="A">
+               <gitem diff="add" at="2022-01-01">
                   <label>
                      <code>[xsl:]default-element-namespace</code>
                   </label>
@@ -3016,7 +3016,7 @@
                      </p>
                   </def>
                </gitem>
-               <gitem diff="add" at="A">
+               <gitem diff="add" at="2022-01-01">
                   <label>
                      <code>[xsl:]default-type-namespace</code>
                   </label>
@@ -4037,7 +4037,7 @@
 
                   <p>The value may be a <code>NamedFunctionRef</code> only in the case of stylesheet
                      functions, and distinguishes functions with the same name and different
-                     arity. <phrase diff="add" at="A">A <xnt spec="XP40" ref="prod-xpath40-NameTest">NameTest</xnt>
+                     arity. <phrase diff="add" at="2022-01-01">A <xnt spec="XP40" ref="prod-xpath40-NameTest">NameTest</xnt>
                      on its own (that is, with no arity) cannot be used to identify a function. [XSLT 3.0 Erratum E36, bug 30323].</phrase></p>
 
                   <p>The visibility of a 
@@ -4677,7 +4677,7 @@
                            </item>
                            
                            <item>
-                              <p diff="chg" at="A">If the overridden function has a <code>streamability</code> attribute with a value
+                              <p diff="chg" at="2022-01-01">If the overridden function has a <code>streamability</code> attribute with a value
                               other than <code>unspecified</code>, then the overriding function has a
                                  <code>streamability</code> attribute with the same value. [XSLT 3.0 Erratum E32, bug 30297]</p>
                            </item>
@@ -4734,9 +4734,9 @@
                         <olist>
                            <item>
                               <p>Their declared types are <termref def="dt-identical-types">identical</termref>.
-                              <phrase diff="add" at="A">For this purpose, the declared type is the first
+                              <phrase diff="add" at="2022-01-01">For this purpose, the declared type is the first
                               of the following that applies:</phrase></p>
-                              <ulist diff="add" at="A">
+                              <ulist diff="add" at="2022-01-01">
                                  <item><p>If there is an <code>as</code> attribute, then the type defined by that attribute.</p></item>
                                  <item><p>If there is a <code>select</code> attribute, then <code>item()*</code>.</p></item>
                                  <item><p>If there is a non-empty sequence constructor, then <code>document-node()</code>.</p></item>
@@ -5221,7 +5221,7 @@
                      </error>
                   </p>
 
-                  <note diff="chg" at="A">
+                  <note diff="chg" at="2022-01-01">
                      <p>Abstract components in a used package by default become hidden in the using package, 
                         which means that a reference to the component in the top-level package will fail 
                         to resolve (resulting in a different static error). This particular error occurs 
@@ -5726,11 +5726,11 @@
 
 
                <p>A <termref def="dt-type-error"/> is signaled if 
-                  <phrase diff="chg" at="A">the <termref def="dt-top-level-package"/> contains</phrase>
+                  <phrase diff="chg" at="2022-01-01">the <termref def="dt-top-level-package"/> contains</phrase>
                   an <elcode>xsl:global-context-item</elcode>
                   declaration specifying a required type that does not match the supplied <termref def="dt-global-context-item"/>. The error code is the same as for
                      <elcode>xsl:param</elcode>: <errorref spec="XT" class="TE" code="0590"/>.
-                  <phrase diff="add" at="A">[XSLT 3.0 Erratum E7, bug 30179].</phrase></p>
+                  <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E7, bug 30179].</phrase></p>
 
 
 
@@ -5744,7 +5744,7 @@
                      document.</p>
                </note>
                
-               <p diff="add" at="A">
+               <p diff="add" at="2022-01-01">
                   <error spec="XT" type="dynamic" class="DE" code="3086">
                      <p>It is a <termref def="dt-dynamic-error">dynamic error</termref> if an
                         <elcode>xsl:global-context-item</elcode> declaration specifies
@@ -6348,7 +6348,7 @@ there is no need to make it needlessly implausible.</p>-->
 
             <!--For this version of XSLT, the value <rfc2119>should</rfc2119> normally
 be <code>
-                  <phrase diff="chg" at="A">3.0</phrase>
+                  <phrase diff="chg" at="2022-01-01">3.0</phrase>
                </code>.  A value of <code>1.0</code> indicates that the stylesheet module
 was written with the intention that it <rfc2119>should</rfc2119> be processed using an XSLT 1.0 processor,
                <phrase diff="add" at="D">while a value of <code>2.0</code> indicates that the module
@@ -6359,33 +6359,33 @@ outermost element of the <termref def="dt-principal-stylesheet-module">principal
 stylesheet module</termref> (that is, <code>version="1.0"</code> in the case of a 
 <termref def="dt-standard-stylesheet-module">standard stylesheet module</termref>, or
 <code>xsl:version="1.0"</code> in the case of a <termref def="dt-simplified-stylesheet-module">simplified
-stylesheet module</termref>) is submitted to an XSLT <phrase diff="chg" at="A">3.0</phrase> processor, the processor <rfc2119>should</rfc2119> output
+stylesheet module</termref>) is submitted to an XSLT <phrase diff="chg" at="2022-01-01">3.0</phrase> processor, the processor <rfc2119>should</rfc2119> output
 a warning advising the user of possible incompatibilities, unless the user has requested otherwise. 
 The processor <rfc2119>must</rfc2119> then process the stylesheet
 using the rules for <termref def="dt-backwards-compatible-behavior"/>.
 These rules require that if the processor does not support 
 <termref def="dt-backwards-compatible-behavior"/>, it <rfc2119>must</rfc2119>
 signal an error and <rfc2119>must not</rfc2119> execute the transformation.</p>
-            <p>When the value of the <code>version</code> attribute is greater than <phrase diff="chg" at="A">3.0</phrase>, 
+            <p>When the value of the <code>version</code> attribute is greater than <phrase diff="chg" at="2022-01-01">3.0</phrase>, 
 <termref def="dt-forwards-compatible-behavior">forwards compatible behavior</termref> 
 is enabled (see <specref ref="forwards"/>).</p>
             <note>
                <p>XSLT 1.0 allowed the <code>[xsl:]version</code> attribute to take any numeric value,
 and specified that if the value was not equal to 1.0, the <termref def="dt-stylesheet">stylesheet</termref> would be executed in
-forwards compatible mode. XSLT 2.0 <phrase diff="chg" at="A">and 3.0</phrase>continue to allow the attribute to take any unsigned decimal value.
-A software product that includes both an XSLT <phrase diff="chg" at="A">3.0</phrase> processor and
-<phrase diff="chg" at="A">a processor supporting a different XSLT version</phrase> (or that can execute as either) may use the <code>[xsl:]version</code> attribute to 
+forwards compatible mode. XSLT 2.0 <phrase diff="chg" at="2022-01-01">and 3.0</phrase>continue to allow the attribute to take any unsigned decimal value.
+A software product that includes both an XSLT <phrase diff="chg" at="2022-01-01">3.0</phrase> processor and
+<phrase diff="chg" at="2022-01-01">a processor supporting a different XSLT version</phrase> (or that can execute as either) may use the <code>[xsl:]version</code> attribute to 
 decide which processor to invoke; such behavior is outside the scope of this specification. 
-When the stylesheet is executed with an XSLT <phrase diff="chg" at="A">3.0</phrase> processor, the value
+When the stylesheet is executed with an XSLT <phrase diff="chg" at="2022-01-01">3.0</phrase> processor, the value
 <code>1.0</code> is taken to indicate that the stylesheet module
 was written with XSLT 1.0
 in mind: if this value appears on the outermost element of the principal stylesheet module then
-an XSLT <phrase diff="chg" at="A">3.0</phrase> processor will either reject the stylesheet or execute it in backwards compatible
+an XSLT <phrase diff="chg" at="2022-01-01">3.0</phrase> processor will either reject the stylesheet or execute it in backwards compatible
 mode, as described above. 
-Setting <code>version="<phrase diff="chg" at="A">3.0</phrase>"</code> indicates that the <termref def="dt-stylesheet">stylesheet</termref> is to be
+Setting <code>version="<phrase diff="chg" at="2022-01-01">3.0</phrase>"</code> indicates that the <termref def="dt-stylesheet">stylesheet</termref> is to be
 executed with neither backwards nor forwards compatible behavior enabled. Any other value less than
 <code>2.0</code> enables backwards compatible behavior, while any value greater than <code>
-                     <phrase diff="chg" at="A">3.0</phrase>
+                     <phrase diff="chg" at="2022-01-01">3.0</phrase>
                   </code>
 enables forwards compatible behavior.</p>
                
@@ -7898,7 +7898,7 @@ and <code>version="1.0"</code> otherwise.</p>
          </div2>
          <div2 id="xdm-versions">
             <head>XDM versions</head>
-            <p diff="chg" at="A">XSLT 4.0 <rfc2119>requires</rfc2119> a processor to support XDM 3.1 as defined in
+            <p diff="chg" at="2022-01-01">XSLT 4.0 <rfc2119>requires</rfc2119> a processor to support XDM 3.1 as defined in
                   <bibref ref="xpath-datamodel-31"/>.</p>
             <!--<p>A processor <rfc2119>may</rfc2119> also provide a user option to support XDM 3.1 as
                defined in <bibref ref="xpath-datamodel-31"/>, in which case it must do so as defined
@@ -8150,7 +8150,7 @@ and <code>version="1.0"</code> otherwise.</p>
                requested by specifying <code>input-type-annotations="strip"</code> on the <elcode>xsl:package</elcode> element. This
                attribute has three permitted values: <code>strip</code>, <code>preserve</code>, and
                   <code>unspecified</code>. The default value is <code>unspecified</code>. 
-            <phrase diff="add" at="A">Specifying <code>unspecified</code> has the same effect
+            <phrase diff="add" at="2022-01-01">Specifying <code>unspecified</code> has the same effect
             as omitting the attribute [XSLT 3.0 Erratum E43, bug 30383].</phrase></p>
 
             <p>The <code>input-type-annotations</code> attribute may also
@@ -8170,7 +8170,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </error>
             </p>
             
-            <p diff="add" at="A">Type annotations are stripped from relevant source documents if 
+            <p diff="add" at="2022-01-01">Type annotations are stripped from relevant source documents if 
                at least one <termref def="dt-stylesheet-module"/> in the <termref def="dt-stylesheet"/>
                specifies <code>input-type-annotations="strip"</code> on the <elcode>xsl:package</elcode>, 
                <elcode>xsl:stylesheet</elcode>, or <elcode>xsl:transform</elcode> element [XSLT 3.0 Erratum E43, bug 30383].</p>
@@ -8433,7 +8433,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <div3 id="streaming-other-types">
                <head>Other Data Structures</head>
                
-               <p diff="chg" at="A">Maps and arrays were defined in XPath 3.1.</p>
+               <p diff="chg" at="2022-01-01">Maps and arrays were defined in XPath 3.1.</p>
                <p>Streaming facilities in this specification are, for the most part, relevant 
                   only to streamed processing of XML trees, and not to other structures such as 
                   sequences, maps and arrays, which will typically be held in memory unless 
@@ -8576,7 +8576,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   </item>
                </ulist>
                
-               <p diff="add" at="B">The rules for the use of these constructs generally permit
+               <p diff="add" at="2022-11-01">The rules for the use of these constructs generally permit
                leading and trailing whitespace, which is ignored.</p>
 
                <note>
@@ -8719,7 +8719,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
                </olist>
             </div3>
-            <div3 id="unprefixed-qnames" diff="chg" at="A">
+            <div3 id="unprefixed-qnames" diff="chg" at="2022-01-01">
                <head>Unprefixed Lexical QNames in Expressions and Patterns</head>
                
                
@@ -8916,7 +8916,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <item>
                      <p> The namespace
                            <code>http://www.w3.org/2005/xpath-functions/array</code> is reserved for
-                        use as described in <bibref ref="xpath-functions-31"/>.<phrase diff="del" at="A"> The namespace is
+                        use as described in <bibref ref="xpath-functions-31"/>.<phrase diff="del" at="2022-01-01"> The namespace is
                         reserved whether or not the processor actually supports XPath 3.1.</phrase></p>
                   </item>
                   <item>
@@ -9034,9 +9034,9 @@ and <code>version="1.0"</code> otherwise.</p>
                   string that matches the production <xnt spec="XP40" ref="prod-xpath40-Expr">Expr</xnt> 
                   defined in <bibref ref="xpath-30"/><phrase diff="del">, with the extensions defined in <specref ref="map"/></phrase>.</termdef>
             </p>
-            <p diff="del" at="A">If the processor implements the XPath 3.1 feature, then the definition of the production
+            <p diff="del" at="2022-01-01">If the processor implements the XPath 3.1 feature, then the definition of the production
                   <code>Expr</code> from XPath 3.1 is used.</p>
-            <p diff="del" at="A">If the processor is configured to use a version of XPath
+            <p diff="del" at="2022-01-01">If the processor is configured to use a version of XPath
                later than XPath 3.1, then the syntax of an XPath expression is <termref def="dt-implementation-defined"/>.</p>
             <p>An XPath expression may occur as the value of certain attributes on XSLT-defined
                elements, and also within curly brackets in <termref def="dt-attribute-value-template">attribute value templates</termref>
@@ -9067,14 +9067,14 @@ and <code>version="1.0"</code> otherwise.</p>
                   <code>item()*</code>. </p>
             
 
-            <p diff="chg" at="A">
+            <p diff="chg" at="2022-01-01">
                <termdef id="dt-coercion-rules" term="coercion rules"> When
                   used in this specification without further qualification, the term <term>coercion rules</term> 
                   means the coercion rules defined in <bibref ref="xpath-40"/>, applied with XPath 1.0 
                   compatibility mode set to false.</termdef>
             </p>
             
-            <note diff="add" at="A">
+            <note diff="add" at="2022-01-01">
                <p>In earlier versions of this specification, these were referred to as the
                <term>function conversion rules.</term></p>
             </note>
@@ -9106,11 +9106,11 @@ and <code>version="1.0"</code> otherwise.</p>
                   convert an integer to a date is a type error, because such a conversion is never
                   possible. Type errors can be reported statically if they can be detected
                   statically, whether or not the construct in question is ever evaluated. Attempting
-                  to convert the <phrase diff="chg" at="A"><code>xs:untypedAtomic</code></phrase> value 
+                  to convert the <phrase diff="chg" at="2022-01-01"><code>xs:untypedAtomic</code></phrase> value 
                   <code>2003-02-29</code> to a date is a dynamic error rather
                   than a type error, because the problem is with this particular value, not with its
                   type. Dynamic errors are reported only if the instructions or expressions that
-                  cause them are actually evaluated. <phrase diff="add" at="A">[XSLT 3.0 Erratum E21, bug 30236]</phrase></p>
+                  cause them are actually evaluated. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E21, bug 30236]</phrase></p>
             </note>
 
             <p>The XPath specification states that the host language must
@@ -9141,7 +9141,7 @@ and <code>version="1.0"</code> otherwise.</p>
                This section describes the way in which these components are initialized when an
                XPath expression is contained within an XSLT stylesheet.</p>
             
-            <p diff="add" at="A">
+            <p diff="add" at="2022-01-01">
                This section does not apply to <termref def="dt-static-expression">static expressions</termref> 
                (whose context is defined in <specref ref="static-expression"/>), nor to XPath expressions 
                evaluated using <elcode>xsl:evaluate</elcode> (whose context is defined in 
@@ -9191,17 +9191,17 @@ and <code>version="1.0"</code> otherwise.</p>
                         for the containing element.</p>
                   </item>
                   <item>
-                     <p diff="chg" at="A">The <xtermref spec="XP40" ref="dt-def-element-ns">default element
+                     <p diff="chg" at="2022-01-01">The <xtermref spec="XP40" ref="dt-def-element-ns">default element
                            namespace</xtermref> is determined as described in
                         <specref ref="unprefixed-element-names"/>.</p>
                   </item>
                   <item>
-                     <p diff="chg" at="A">The <xtermref spec="XP40" ref="dt-def-type-ns">default type
+                     <p diff="chg" at="2022-01-01">The <xtermref spec="XP40" ref="dt-def-type-ns">default type
                         namespace</xtermref> is determined as described in
                         <specref ref="unprefixed-type-names"/>..</p>
                   </item>
                   <item>
-                     <p diff="chg" at="A">The algorithm used as the <xtermref ref="dt-function-name-resolver" 
+                     <p diff="chg" at="2022-01-01">The algorithm used as the <xtermref ref="dt-function-name-resolver" 
                         spec="XP40">function resolver</xtermref> is described in <specref ref="resolving-function-names"/>.</p>
                   </item>
                   <item>
@@ -9339,7 +9339,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <p>The set of <xtermref spec="XP40" ref="dt-static-decimal-formats">statically
                            known decimal formats</xtermref> is the set of decimal formats defined by
                            <elcode>xsl:decimal-format</elcode> declarations in the stylesheet. </p>
-                     <note diff="del" at="A">
+                     <note diff="del" at="2022-01-01">
                         <p>XSLT 3.0 provides support for the <code>exponent-separator</code>
                            property which is added to the static context in XPath 3.1; when XSLT 3.0
                            is used with XPath 3.0, this property is ignored.</p>
@@ -9348,7 +9348,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </ulist>
 
             </div3>
-            <div3 id="resolving-function-names" diff="add" at="A">
+            <div3 id="resolving-function-names" diff="add" at="2022-01-01">
                <head>Resolving Function Names</head>
                <p>This section defines how function names appearing in XPath expressions and patterns
                are resolved: specifically, it defines the <xtermref ref="dt-function-name-resolver" spec="XP40"/> that
@@ -9670,12 +9670,12 @@ and <code>version="1.0"</code> otherwise.</p>
                      initial context item, context position, and context size for the XPath <termref def="dt-expression">expression</termref> are the same as the <termref def="dt-context-item">context item</termref>, <termref def="dt-context-position">context position</termref>, and <termref def="dt-context-size">context size</termref> for the evaluation of the
                      containing instruction or literal result element.</p>
                   <p>The context item for evaluating global
-                        variables <phrase diff="add" at="A">declared</phrase>
+                        variables <phrase diff="add" at="2022-01-01">declared</phrase>
                      in the <termref def="dt-top-level-package"/> is set to the <termref def="dt-global-context-item"/>
                         supplied when the transformation is invoked (see <specref ref="initiating"/>).
-                     <phrase diff="add" at="A">For global variables declared in a </phrase> <termref def="dt-library-package">library
-                           package</termref>, the context item <phrase diff="del" at="A">for evaluating global variables</phrase> is
-                     <termref def="dt-absent"/>. <phrase diff="add" at="A">[XSLT 3.0 Erratum E7, bug 30179].</phrase></p>
+                     <phrase diff="add" at="2022-01-01">For global variables declared in a </phrase> <termref def="dt-library-package">library
+                           package</termref>, the context item <phrase diff="del" at="2022-01-01">for evaluating global variables</phrase> is
+                     <termref def="dt-absent"/>. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E7, bug 30179].</phrase></p>
                   <p>For an XPath expression contained in a <termref def="dt-value-template"/>, the initial context item, context position, and
                      context size for the XPath <termref def="dt-expression">expression</termref>
                      are the same as the <termref def="dt-context-item">context item</termref>,
@@ -9777,7 +9777,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <item>
                         <p>All other aspects of the dynamic context (for example,
                            the current date and time, the implicit timezone, the default language, calendar, and place,
-                           the available documents, text resources, and collections, and the default collection<phrase diff="del" at="A"> — details
+                           the available documents, text resources, and collections, and the default collection<phrase diff="del" at="2022-01-01"> — details
                            vary slightly between XPath 3.0 and XPath 3.1</phrase>) are <termref def="dt-implementation-defined"/>,
                         and do not change in the course of a single transformation, except to the extent that they
                         <rfc2119>may</rfc2119> be different from one <termref def="dt-package"/> to another.</p>
@@ -10068,11 +10068,11 @@ and <code>version="1.0"</code> otherwise.</p>
                      item that does not satisfy the conditions
                   does not match the pattern.</termdef></p>
 
-            <p diff="chg" at="A">There are three kinds of pattern: <termref def="dt-predicate-pattern">predicate patterns</termref>, 
+            <p diff="chg" at="2022-01-01">There are three kinds of pattern: <termref def="dt-predicate-pattern">predicate patterns</termref>, 
                <termref def="dt-type-pattern">type patterns</termref>,
                and <termref def="dt-node-pattern">node patterns</termref>:</p>
 
-            <ulist diff="chg" at="A">
+            <ulist diff="chg" at="2022-01-01">
                <item>
                   <p><termdef id="dt-predicate-pattern" term="predicate pattern">A <term>predicate pattern</term> is written as
                            <code>.</code> (dot) followed by zero or more predicates in square
@@ -10157,7 +10157,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            </item>
                         </olist>
                      </item>
-                     <item diff="add" at="A">
+                     <item diff="add" at="2022-01-01">
                         <p><emph>Type Patterns</emph></p>
                         <olist>
                            <item>
@@ -10347,7 +10347,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   where relevant, for example the rules for whitespace handling and
                   extra-grammatical constraints.</p>
                
-               <scrap headstyle="show" id="Patterns-scrap" diff="add" at="A">
+               <scrap headstyle="show" id="Patterns-scrap" diff="add" at="2022-01-01">
                   <head></head>
                   
                   <prodrecap ref="Pattern40" id="Pattern40"/>
@@ -10356,9 +10356,9 @@ and <code>version="1.0"</code> otherwise.</p>
                   <prodrecap ref="NodePattern" id="NodePattern"/>
                </scrap>
                
-               <p diff="add" at="A">Patterns fall into three groups:</p>
+               <p diff="add" at="2022-01-01">Patterns fall into three groups:</p>
                
-               <ulist diff="add" at="A">
+               <ulist diff="add" at="2022-01-01">
                   <item><p>A <code>PredicatePattern</code> matches items according to conditions that the item must
                   satisfy: for example <code>.[. castable as xs:integer]</code> matches any value (it might
                   be an atomic value, a node, or an array) that is castable as an integer.</p></item>
@@ -10372,7 +10372,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   whose parent node is an element named <code>billing-address</code>.</p></item>
                </ulist>
                
-               <p diff="add" at="A">The following sections define the rules for each of these groups.</p>
+               <p diff="add" at="2022-01-01">The following sections define the rules for each of these groups.</p>
                
                <div4 id="predicate-patterns">
                   <head>Predicate Patterns</head>
@@ -10400,7 +10400,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         way in the interests of consistency with XPath.</p>
                   </note>
                   
-                  <p diff="add" at="A">For example, the pattern <code>.[contains(., "XSLT")]</code>
+                  <p diff="add" at="2022-01-01">For example, the pattern <code>.[contains(., "XSLT")]</code>
                   matches any item whose typed value contains <code>"XSLT"</code> as a substring. 
                   It matches values such as the string "XSLT Transformations", the <code>xs:anyURI</code> value
                      <code>http://www.w3.org/TR/XSLT</code>, the attribute node 
@@ -10408,7 +10408,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   
                </div4>
                
-               <div4 id="type-patterns" diff="add" at="A">
+               <div4 id="type-patterns" diff="add" at="2022-01-01">
                   <head>Type Patterns</head>
                   
                   <scrap headstyle="show" id="TypePatterns-scrap">
@@ -10505,7 +10505,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   the corresponding XPath 3.0 construct without the suffix. Constructs labeled with
                   the suffix “XP40” are defined in <bibref ref="xpath-40"/>.</p>
 
-               <p diff="del" at="A">Where the XSLT 3.0 processor implements the XPath 3.1 feature, the definitions that apply to constructs labeled
+               <p diff="del" at="2022-01-01">Where the XSLT 3.0 processor implements the XPath 3.1 feature, the definitions that apply to constructs labeled
                   with the suffix “XP30” are those in [XPath 3.1]</p>
 
 
@@ -10658,7 +10658,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      select nodes using the attribute or namespace axes. It does not match document
                      nodes because for backwards compatibility reasons the <code>child-or-top</code>
                      axis does not match a document node.</p>
-                  <note diff="add" at="A">
+                  <note diff="add" at="2022-01-01">
                      <p>The pattern <code>type(node())</code> matches all nodes.</p>
                   </note>
                   <p>The <termref def="dt-node-pattern"/>
@@ -10742,7 +10742,7 @@ and <code>version="1.0"</code> otherwise.</p>
             </div3>
             
          </div2>
-         <div2 id="named-item-types" diff="add" at="A">
+         <div2 id="named-item-types" diff="add" at="2022-01-01">
             <head>Defining Named Item Types</head>
             
             <?element xsl:item-type?>
@@ -10840,7 +10840,7 @@ and <code>version="1.0"</code> otherwise.</p>
             
             
             
-            <p diff="del" at="A"> The <code>exponent-separator</code> attribute is provided
+            <p diff="del" at="2022-01-01"> The <code>exponent-separator</code> attribute is provided
                for use with XPath 3.1. It has no effect when used with XPath 3.0. </p>
             
             
@@ -11456,7 +11456,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      is replaced by its members, recursively. This is equivalent to applying
                      the <xfunction spec="FO40">array:flatten</xfunction> function defined in 
                      <bibref ref="xpath-functions-31"/>.</p>
-                     <note diff="del" at="A"><p>This situation only arises if the XPath 3.1 feature is implemented.
+                     <note diff="del" at="2022-01-01"><p>This situation only arises if the XPath 3.1 feature is implemented.
                      Note that if the array contains nodes, this operation leaves the nodes in the sequence: they
                      are not <termref def="dt-atomization">atomized</termref>.</p></note>
                   </item>
@@ -12236,7 +12236,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <head>Applying Templates to Atomic Values</head>
                <p>This example reads a non-XML text file and processes it line-by-line, applying
                   different template rules based on the content of each line:</p>
-               <eg xml:space="preserve" role="xslt-declarations" diff="chg" at="A">&lt;xsl:template name="main"&gt;
+               <eg xml:space="preserve" role="xslt-declarations" diff="chg" at="2022-01-01">&lt;xsl:template name="main"&gt;
   &lt;xsl:apply-templates select="unparsed-text-lines('input.txt')"/&gt;
 &lt;/xsl:template&gt;
 
@@ -12324,7 +12324,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   present a denial of service security risk.</p>
             </note>
          </div2>
-         <div2 id="apply-templates-separator" diff="add" at="A">
+         <div2 id="apply-templates-separator" diff="add" at="2022-01-01">
             <head>The <code>separator</code> attribute</head>
             
             <p>If the <code>separator</code> attribute of <elcode>xsl:apply-templates</elcode>
@@ -12358,7 +12358,7 @@ and <code>version="1.0"</code> otherwise.</p>
                sequence is used for constructing the value of a node, then zero-length text nodes will be discarded: see
                <specref ref="constructing-simple-content"/> and <specref ref="constructing-complex-content"/>.)</p>
          </div2>
-         <!--<div2 id="template-test" diff="add" at="A">
+         <!--<div2 id="template-test" diff="add" at="2022-01-01">
             <head>The <code>test</code> Attribute</head>
             <p>If a template rule has a <code>test</code> attribute, then its value is an <termref def="dt-expression"/>,
                and the template rule is a candidate for evaluation only if the <code>test</code> condition is true.
@@ -12662,11 +12662,11 @@ and <code>version="1.0"</code> otherwise.</p>
                </item>
                <item>
                   <p>If the pattern is a <nt def="PathExprP">PathExprP</nt> taking the form of an
-                        <xnt spec="Names" ref="NT-NCName">NCName</xnt><code>:*</code><phrase diff="add" at="A">, 
+                        <xnt spec="Names" ref="NT-NCName">NCName</xnt><code>:*</code><phrase diff="add" at="2022-01-01">, 
                            <xnt spec="XP40" ref="prod-xpath40-BracedURILiteral"/>*,</phrase> or
                         <code>*:</code><xnt spec="Names" ref="NT-NCName">NCName</xnt>, optionally
                      preceded by a <nt def="ForwardAxisP">ForwardAxisP</nt>, then the priority is
-                     −0.25. <phrase diff="add" at="A">[XSLT 3.0 Erratum E37, bug 30375].</phrase></p>
+                     −0.25. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E37, bug 30375].</phrase></p>
                </item>
                <item>
                   <p>If the pattern is a <nt def="PathExprP">PathExprP</nt> taking the form of any
@@ -12676,7 +12676,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </item>
                <item>
                   <p>In all other cases, the priority is +0.5. 
-                     <phrase diff="add" at="A">TODO: define default priorities for type patterns,
+                     <phrase diff="add" at="2022-01-01">TODO: define default priorities for type patterns,
                      as suggested in https://www.saxonica.com/papers/xmlprague-2020mhk.pdf section 6.5.1</phrase></p>
                </item>
             </olist>
@@ -12790,7 +12790,7 @@ and <code>version="1.0"</code> otherwise.</p>
                               <elcode>xsl:mode</elcode> declaration provides properties of the
                               <termref def="dt-unnamed-mode">unnamed mode</termref></td>
                      </tr>
-                     <tr diff="add" at="A">
+                     <tr diff="add" at="2022-01-01">
                         <td valign="top" rowspan="1" colspan="1">as</td>
                         <td valign="top" rowspan="1" colspan="1">A <code>SequenceType</code></td>
                         <td valign="top" rowspan="1" colspan="1">Declares the type of value returned by all
@@ -12982,11 +12982,11 @@ and <code>version="1.0"</code> otherwise.</p>
                   </item>
                   <item>
                      <p>The token <code>#all</code>, to indicate that the template rule is
-                        applicable to all modes <phrase diff="chg" at="A">other than <termref def="dt-enclosing-mode">enclosing modes</termref></phrase>
+                        applicable to all modes <phrase diff="chg" at="2022-01-01">other than <termref def="dt-enclosing-mode">enclosing modes</termref></phrase>
                         (specifically, to the unnamed mode and to every mode that is named explicitly or implicitly in an
                            <elcode>xsl:apply-templates</elcode> instruction  anywhere in
                         the stylesheet).</p>
-                     <p diff="chg" at="A">More specifically, when a template rule specifies <code>mode="#all"</code> this makes the
+                     <p diff="chg" at="2022-01-01">More specifically, when a template rule specifies <code>mode="#all"</code> this makes the
                         template rule <termref def="dt-applicable"/> to:</p>
                         <ulist>
                            <item><p>The unnamed mode.</p></item>
@@ -12998,7 +12998,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         </ulist>
                         <p>The value <code>mode="#all"</code>
                         cannot be used on a template rule declared within an
-                        <elcode>xsl:override</elcode> <phrase diff="add" at="A">or <elcode>xsl:mode</elcode></phrase> element.</p>
+                        <elcode>xsl:override</elcode> <phrase diff="add" at="2022-01-01">or <elcode>xsl:mode</elcode></phrase> element.</p>
                   </item>
                </ulist>
 
@@ -13215,7 +13215,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
             </div3>
             
-            <div3 id="mode-result-type" diff="add" at="A">
+            <div3 id="mode-result-type" diff="add" at="2022-01-01">
                <head>Declaring the result type of a mode</head>
                <p>Traditionally, template rules have most commonly been used to construct XDM nodes, and the <elcode>xsl:apply-templates</elcode>
                instruction has been used to add nodes to a result tree. However, it is also possible to use template rules to produce
@@ -13251,7 +13251,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </ulist>
             </div3>
             
-            <div3 id="enclosing-modes" diff="add" at="A">
+            <div3 id="enclosing-modes" diff="add" at="2022-01-01">
                <head>Enclosing Modes</head>
                <p><termdef id="dt-enclosing-mode" term="enclosing mode">A mode declared by
                   an <elcode>xsl:mode</elcode> declaration that has one or more contained <elcode>xsl:template</elcode>
@@ -13271,7 +13271,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      it must not have a <code>default-mode</code> attribute with any other value.</p>
                   <note><p>This means that <elcode>xsl:apply-templates</elcode> instructions within the template
                   rules of the enclosing mode default to using the enclosing mode.</p></note></item>
-                  <item><p>No <elcode>xsl:template</elcode> that is in the same <phrase diff="chg" at="B"><termref def="dt-package"/></phrase>
+                  <item><p>No <elcode>xsl:template</elcode> that is in the same <phrase diff="chg" at="2022-11-01"><termref def="dt-package"/></phrase>
                      as the containing mode, but not declared within the containing mode, may be <termref def="dt-applicable"/>
                   to the containing mode.</p>
                    
@@ -13382,7 +13382,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <p>Specifying <code>streamable="yes"</code> on an
                      <elcode>xsl:mode</elcode> declaration declares an intent that every template
-                  rule <phrase diff="chg" at="A">to which that mode is <termref def="dt-applicable"/></phrase> 
+                  rule <phrase diff="chg" at="2022-01-01">to which that mode is <termref def="dt-applicable"/></phrase> 
                   (explicitly or implicitly, including by specifying
                      <code>#all</code>), should be streamable,
                      either because it is <termref def="dt-guaranteed-streamable"/>, or because it
@@ -13693,10 +13693,10 @@ and <code>version="1.0"</code> otherwise.</p>
                      <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if
                            <elcode>xsl:apply-templates</elcode>, <elcode>xsl:apply-imports</elcode>
                         or <elcode>xsl:next-match</elcode> is used to process 
-                        <phrase diff="chg" at="A">an item</phrase> using a mode
+                        <phrase diff="chg" at="2022-01-01">an item</phrase> using a mode
                         whose declaration specifies <code>on-no-match="fail"</code> when there is no
                            <termref def="dt-template-rule"/> in the <termref def="dt-stylesheet"/>
-                        whose match pattern matches that <phrase diff="chg" at="A">item</phrase>. </p>
+                        whose match pattern matches that <phrase diff="chg" at="2022-01-01">item</phrase>. </p>
                   </error>
                </p>
             </div3>
@@ -13911,7 +13911,7 @@ and <code>version="1.0"</code> otherwise.</p>
          <head>Repetition</head>
          <p>XSLT offers two constructs for processing each <phrase diff="chg">entry in a collection</phrase>:
                <elcode>xsl:for-each</elcode> and <elcode>xsl:iterate</elcode>.</p>
-         <p diff="add" at="A">Both instructions can be used to process the items in a sequence, the
+         <p diff="add" at="2022-01-01">Both instructions can be used to process the items in a sequence, the
          elements in an array, or the entries in a map. Arrays and maps are processed by reducing them
          to a sequence of items, so in what follows, the terms <term>item</term> and <term>sequence</term> 
          are used generically.</p>
@@ -13930,15 +13930,15 @@ and <code>version="1.0"</code> otherwise.</p>
          <div2 id="for-each">
             <head>The <code>xsl:for-each</code> instruction</head>
             <?element xsl:for-each?>
-            <p diff="del" at="B">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
+            <p diff="del" at="2022-11-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
             are mutually exclusive: exactly one of these three attributes must be present.</p>
-            <p diff="del" at="B">Specifying <code>array="EXPR"</code> is equivalent to specifying
+            <p diff="del" at="2022-11-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
             <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
             elements of an input array to a sequence of items, each item being a map having a single entry, whose
             key is the string <code>value</code> and whose corresponding value is the relevant element of the
             array. Within the contained sequence constructor, the current array element can be refered to
             as <code>?value</code>.</p>
-            <p diff="del" at="B">Specifying <code>map="EXPR"</code> is equivalent to specifying
+            <p diff="del" at="2022-11-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
                <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
@@ -14024,7 +14024,7 @@ and <code>version="1.0"</code> otherwise.</p>
   &lt;/html&gt;
 &lt;/xsl:template&gt;</eg>
             </example>
-            <example diff="chg" at="B">
+            <example diff="chg" at="2022-11-01">
                <head>Using <elcode>xsl:for-each</elcode> to process an array</head>
                <p>Consider a JSON document of the form:</p>
                <eg>[
@@ -14048,7 +14048,7 @@ and <code>version="1.0"</code> otherwise.</p>
                used to deliver the contents of the array as a sequence of <emph>parcels</emph>, and the contents
                of each parcel can be extracted (as a sequence) using the <function>unparcel</function> function.</p>
             </example>
-            <example diff="add" at="B">
+            <example diff="add" at="2022-11-01">
                <head>Using <elcode>xsl:for-each</elcode> to process a map</head>
                <p>Consider a JSON document of the form:</p>
                <eg>{
@@ -14069,7 +14069,7 @@ and <code>version="1.0"</code> otherwise.</p>
                a map with two entries, <code>"key"</code> and <code>"value"</code>, which can be accessed using
                the lookup expressions <code>?key</code> and <code>?value</code>.</p>
             </example>
-            <div3 id="for-each-separator" diff="add" at="A">
+            <div3 id="for-each-separator" diff="add" at="2022-01-01">
                <head>The <code>separator</code> attribute</head>
             
             <p>If the <code>separator</code> attribute is present, then its <termref def="dt-effective-value"/>
@@ -14100,22 +14100,22 @@ and <code>version="1.0"</code> otherwise.</p>
             in order; unlike <code>xsl:for-each</code>, the result of processing one item can affect the way that
             subsequent items are processed.</p>
             
-            <p diff="add" at="A">As with <code>xsl:for-each</code>, the instruction is extended in XSLT 4.0 to allow maps and arrays
+            <p diff="add" at="2022-01-01">As with <code>xsl:for-each</code>, the instruction is extended in XSLT 4.0 to allow maps and arrays
             to be processed.</p>
             
             <?element xsl:iterate?>
             <?element xsl:next-iteration?>
             <?element xsl:break?>
             <?element xsl:on-completion?>
-            <p diff="del" at="A">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
+            <p diff="del" at="2022-01-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
                are mutually exclusive: exactly one of these three attributes must be present.</p>
-            <p diff="del" at="A">Specifying <code>array="EXPR"</code> is equivalent to specifying
+            <p diff="del" at="2022-01-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
                <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
                elements of an input array to a sequence of items, each item being a map having a single entry, whose
                key is the string <code>value</code> and whose corresponding value is the relevant element of the
                array. Within the contained sequence constructor, the current array element can be refered to
                as <code>?value</code>.</p>
-            <p diff="del" at="A">Specifying <code>map="EXPR"</code> is equivalent to specifying
+            <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
                <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
@@ -14492,7 +14492,7 @@ and <code>version="1.0"</code> otherwise.</p>
  &lt;/xsl:template&gt;</eg>
 
             </example>
-            <example diff="add" at="A">
+            <example diff="add" at="2022-01-01">
                <head>Processing an array using <code>xsl:iterate</code></head>
                <p>Consider the following JSON document representing transactions in a bank account:</p>
                <eg>[
@@ -14518,16 +14518,16 @@ and <code>version="1.0"</code> otherwise.</p>
       <div1 id="conditionals">
          <head>Conditional Processing</head>
          <p>There are several instructions in XSLT that support conditional processing:
-               <elcode>xsl:if</elcode>, <elcode>xsl:choose</elcode><phrase diff="add" at="A">, and <elcode>xsl:switch</elcode></phrase>. 
+               <elcode>xsl:if</elcode>, <elcode>xsl:choose</elcode><phrase diff="add" at="2022-01-01">, and <elcode>xsl:switch</elcode></phrase>. 
             The <elcode>xsl:if</elcode>
-            instruction provides simple <phrase diff="chg" at="B">if-then-else</phrase> conditionality; the <elcode>xsl:choose</elcode>
+            instruction provides simple <phrase diff="chg" at="2022-11-01">if-then-else</phrase> conditionality; the <elcode>xsl:choose</elcode>
             instruction supports selection of one choice when there are several possibilities,
-            <phrase diff="add" at="A">and <elcode>xsl:switch</elcode> allows a branch to be selected based on the value of a given
+            <phrase diff="add" at="2022-01-01">and <elcode>xsl:switch</elcode> allows a branch to be selected based on the value of a given
          expression.</phrase></p>
          <p>XSLT 3.0 also supports <elcode>xsl:try</elcode> and
                <elcode>xsl:catch</elcode> which define conditional processing to handle <termref def="dt-dynamic-error">dynamic errors</termref>.</p>
          
-         <note diff="add" at="B"><p>XSLT offers a number of ways of expressing conditional logic.</p>
+         <note diff="add" at="2022-11-01"><p>XSLT offers a number of ways of expressing conditional logic.</p>
          <p>XSLT 1.0 offered the <elcode>xsl:if</elcode> instruction for cases where output was to be produced only if a condition was true,
          with <elcode>xsl:choose</elcode> available for multi-way branches where different output was to be produced under different
          input conditions. In addition, of course, XSLT 1.0 also offered the option of rule-based processing using templates and match patterns.</p>
@@ -14557,7 +14557,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>The <elcode>xsl:if</elcode> element has a mandatory <code>test</code> attribute,
                whose value is an <termref def="dt-expression">expression</termref>. The content is
                a <termref def="dt-sequence-constructor"/>.</p>
-            <p diff="add" at="A">If the <elcode>xsl:if</elcode> element has a <code>then</code> attribute, then it
+            <p diff="add" at="2022-01-01">If the <elcode>xsl:if</elcode> element has a <code>then</code> attribute, then it
                <rfc2119>must</rfc2119> have no children. That is, the <code>then</code> attribute and the
                contained sequence constructor are mutually exclusive.</p>
             <p>The result of the <elcode>xsl:if</elcode> instruction depends on the <xtermref
@@ -14565,9 +14565,9 @@ and <code>version="1.0"</code> otherwise.</p>
                the <code>test</code> attribute. The rules for determining the effective boolean
                value of an expression are given in <bibref ref="xpath-30"/>: they are the same as
                the rules used for XPath conditional expressions.</p>
-            <p diff="add" at="A">If the effective boolean value of the <termref def="dt-expression"
+            <p diff="add" at="2022-01-01">If the effective boolean value of the <termref def="dt-expression"
                >expression</termref> is true, then:</p>
-            <ulist diff="add" at="A">
+            <ulist diff="add" at="2022-01-01">
                <item><p>If there is a <code>then</code> attribute, the expression in the <code>then</code>
                   attribute is evaluated, and the resulting value is returned as the result of the 
                   <elcode>xsl:if</elcode> instruction.</p></item>
@@ -14578,9 +14578,9 @@ and <code>version="1.0"</code> otherwise.</p>
                   <elcode>xsl:if</elcode> instruction is an empty sequence.</p></item>
             </ulist>
             
-            <p diff="add" at="A">If the effective boolean value of the <code>test</code> <termref def="dt-expression"
+            <p diff="add" at="2022-01-01">If the effective boolean value of the <code>test</code> <termref def="dt-expression"
                >expression</termref> is false, then:</p>
-            <ulist diff="add" at="A">
+            <ulist diff="add" at="2022-01-01">
                <item><p>If there is an <code>else</code> attribute, the expression in the <code>else</code>
                   attribute is evaluated, and the resulting value is returned as the result of the 
                   <elcode>xsl:if</elcode> instruction.</p></item>
@@ -14589,11 +14589,11 @@ and <code>version="1.0"</code> otherwise.</p>
             </ulist>
             
 
-            <p diff="add" at="A">If the <code>test</code> expression has no effective boolean value (for example,
+            <p diff="add" at="2022-01-01">If the <code>test</code> expression has no effective boolean value (for example,
             if it is a sequence of several integers, or a map), then a <termref def="dt-dynamic-error"/> occurs. 
             (See <xerrorref spec="FO" class="RG" code="0006"/>.)</p>
 
-            <note diff="add" at="B">
+            <note diff="add" at="2022-11-01">
                <p>The semantics of the <elcode>xsl:if</elcode> instruction are essentially equivalent to the semantics
                of the conditional expression in XPath: the construct <code>&lt;xsl:if test="C" then="X" else="Y"/></code>
                   can equivalently be written <code>&lt;xsl:sequence select="if (C) then X else Y"/></code>. The same
@@ -14614,21 +14614,21 @@ and <code>version="1.0"</code> otherwise.</p>
   <xsl:apply-templates/>
   <xsl:if test="not(position()=last())">, </xsl:if>
 </xsl:template>]]></eg>
-               <p diff="add" at="B">This adds a comma after every item except the last. This can also be
+               <p diff="add" at="2022-11-01">This adds a comma after every item except the last. This can also be
                   expressed as:</p>
-               <eg diff="add" at="B" xml:space="preserve" role="xslt-declaration"><![CDATA[<xsl:template match="namelist/name">
+               <eg diff="add" at="2022-11-01" xml:space="preserve" role="xslt-declaration"><![CDATA[<xsl:template match="namelist/name">
   <xsl:if test="not(position()=1)">, </xsl:if>
   <xsl:apply-templates/> 
 </xsl:template>]]></eg>
-               <p diff="add" at="B">which inserts a comma before every item except the first. (This formulation might
+               <p diff="add" at="2022-11-01">which inserts a comma before every item except the first. (This formulation might
                   be more efficient, since determining whether an item is the last may involve look-ahead.)</p>
             </example>
             <example>
                <head>Using <elcode>xsl:if</elcode> as the body of a function</head>
 
-               <p diff="add" at="B">The following example shows the use of <elcode>xsl:if</elcode> to
+               <p diff="add" at="2022-11-01">The following example shows the use of <elcode>xsl:if</elcode> to
                   deliver the result of a recursive function:</p>
-               <eg xml:space="preserve" role="xslt-declaration" diff="chg" at="A"><![CDATA[<xsl:function name="f:product" as="xs:double">
+               <eg xml:space="preserve" role="xslt-declaration" diff="chg" at="2022-01-01"><![CDATA[<xsl:function name="f:product" as="xs:double">
    <xsl:param name="in" as="xs:double*"/>
    <xsl:if test="empty($in)" then="1e0" else="head($in) * f:product(tail($in))"/>
 </xsl:function>]]></eg>
@@ -14644,9 +14644,9 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>The <elcode>xsl:choose</elcode> element selects one among a number of possible
                alternatives. It consists of a sequence of one or more <elcode>xsl:when</elcode>
                elements followed by an optional <elcode>xsl:otherwise</elcode> element. Each
-               <elcode>xsl:when</elcode> element has <phrase diff="chg" at="A">an</phrase> attribute, <code>test</code>, which
+               <elcode>xsl:when</elcode> element has <phrase diff="chg" at="2022-01-01">an</phrase> attribute, <code>test</code>, which
                specifies an <termref def="dt-expression">expression</termref> used as a condition.</p>
-            <p diff="add" at="A">The effective value of an <elcode>xsl:when</elcode> or <elcode>xsl:otherwise</elcode>
+            <p diff="add" at="2022-01-01">The effective value of an <elcode>xsl:when</elcode> or <elcode>xsl:otherwise</elcode>
                branch may be supplied using either a <code>select</code> attribute or a contained
                <termref def="dt-sequence-constructor"/>. These are
                mutually exclusive: if the <code>select</code> attribute is present then the
@@ -14666,8 +14666,8 @@ and <code>version="1.0"</code> otherwise.</p>
                <code>true</code>. The rules for determining the effective boolean value of an
                expression are given in <bibref ref="xpath-30"/>: they are the same as the rules used
                for XPath conditional expressions.</p>
-            <p>The <phrase diff="del" at="A">content of the</phrase> first, and only the first, <elcode>xsl:when</elcode> element that
-               is satisfied is evaluated, and the resulting sequence <phrase diff="add" at="A">(that is,
+            <p>The <phrase diff="del" at="2022-01-01">content of the</phrase> first, and only the first, <elcode>xsl:when</elcode> element that
+               is satisfied is evaluated, and the resulting sequence <phrase diff="add" at="2022-01-01">(that is,
                   the result of evaluating its <code>select</code> attribute or contained <termref def="dt-sequence-constructor"/> 
                   as appropriate)</phrase> is returned as the result of
                the <elcode>xsl:choose</elcode> instruction. If no <elcode>xsl:when</elcode> element
@@ -14676,7 +14676,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <elcode>xsl:choose</elcode> instruction. If no <elcode>xsl:when</elcode> element
                is satisfied, and no <elcode>xsl:otherwise</elcode> element is present, the result of
                the <elcode>xsl:choose</elcode> instruction is an empty sequence.</p>
-            <p><phrase diff="chg" at="A">The <code>select</code> expressions and sequence constructors of  
+            <p><phrase diff="chg" at="2022-01-01">The <code>select</code> expressions and sequence constructors of  
                <elcode>xsl:when</elcode> and
                <elcode>xsl:otherwise</elcode> instructions after the selected one are not evaluated.</phrase> 
                The <code>test</code>
@@ -14712,7 +14712,7 @@ and <code>version="1.0"</code> otherwise.</p>
   </fo:list-item>
 </xsl:template>]]></eg>
             </example>
-            <example diff="add" at="A">
+            <example diff="add" at="2022-01-01">
                <head>Using the <code>select</code> attribute of <elcode>xsl:when</elcode> and <elcode>xsl:otherwise</elcode></head>
                <p>The following example is equivalent to the one above:</p>
                <eg xml:space="preserve" role="xslt-declaration xmlns:fo='fo'"><![CDATA[<xsl:template match="orderedlist/listitem">
@@ -14739,7 +14739,7 @@ and <code>version="1.0"</code> otherwise.</p>
             
          </div2>
          
-         <div2 diff="add" at="A" id="xsl-switch">
+         <div2 diff="add" at="2022-01-01" id="xsl-switch">
             <head>Conditional Processing with <elcode>xsl:switch</elcode>
             </head>
             <?element xsl:switch?>
@@ -14790,7 +14790,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>An <elcode>xsl:when</elcode> element is satisfied if the result of this comparison is
                      <code>true</code>.</p></item>
                <item><p>The first, and only the first, <elcode>xsl:when</elcode> element that
-                  is satisfied is evaluated, and the resulting sequence <phrase diff="add" at="A">(that is,
+                  is satisfied is evaluated, and the resulting sequence <phrase diff="add" at="2022-01-01">(that is,
                      the result of evaluating its <code>select</code> attribute or contained <termref def="dt-sequence-constructor"/> 
                      as appropriate)</phrase> is returned as the result of
                   the <elcode>xsl:switch</elcode> instruction. If no <elcode>xsl:when</elcode> element
@@ -15579,7 +15579,7 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <p><termdef id="dt-vacuous" term="vacuous">An item is <term>vacuous</term> if
                it is one of the following: a zero-length text node; a document node with no children; an atomic value which, 
-               on casting to <code>xs:string</code>, produces a zero-length string; or <phrase diff="del" at="A">(when XPath 3.1 is supported)</phrase> an array 
+               on casting to <code>xs:string</code>, produces a zero-length string; or <phrase diff="del" at="2022-01-01">(when XPath 3.1 is supported)</phrase> an array 
                   which on flattening using the <xfunction spec="FO40">array:flatten</xfunction> function produces either an empty sequence 
                   or a sequence consisting entirely of <termref def="dt-vacuous"/> items.</termdef></p>
                                 
@@ -16066,7 +16066,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <p>The <termref def="dt-supplied-value">supplied value</termref> of the parameter is
                   converted to the <termref def="dt-required-type"/> using the <termref def="dt-coercion-rules"/>.</p>
-               <p diff="chg" at="A">
+               <p diff="chg" at="2022-01-01">
                   <error spec="XT" type="type" class="TE" code="0590">
                      <p>It is a <termref def="dt-type-error">type error</termref> if the conversion
                         of the <termref def="dt-supplied-value">supplied value</termref> of a
@@ -16081,32 +16081,32 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <p>The optional <code>required</code> attribute of
                      <elcode>xsl:param</elcode> may be used to indicate whether a <termref def="dt-stylesheet-parameter"/>, 
-                  <termref def="dt-template-parameter"/><phrase diff="add" at="A">, or <termref def="dt-function-parameter"/></phrase> is
-                  mandatory or optional. The only value <phrase diff="del" at="A">permitted for a <termref def="dt-function-parameter"/>
+                  <termref def="dt-template-parameter"/><phrase diff="add" at="2022-01-01">, or <termref def="dt-function-parameter"/></phrase> is
+                  mandatory or optional. The only value <phrase diff="del" at="2022-01-01">permitted for a <termref def="dt-function-parameter"/>
                   is <code>yes</code> (these are always mandatory), and the only value</phrase> permitted for
                   a parameter to <elcode>xsl:iterate</elcode> is <code>no</code> (these are always
                   initialized to a default value).</p>
                
-               <p diff="add" at="A">The default value for a <termref def="dt-function-parameter"/> is <code>required="yes"</code>; in all
+               <p diff="add" at="2022-01-01">The default value for a <termref def="dt-function-parameter"/> is <code>required="yes"</code>; in all
                other cases it is <code>required="no"</code>.</p>
 
                <p><termdef id="dt-explicitly-mandatory" term="explicitly mandatory">A parameter is
                         <term>explicitly mandatory</term> if it is a 
                   <termref def="dt-function-parameter">function parameter</termref> 
-                  <phrase diff="add" at="A">with no <code>required</code> attribute</phrase>, or if the
+                  <phrase diff="add" at="2022-01-01">with no <code>required</code> attribute</phrase>, or if the
                         <code>required</code> attribute is present and has the value
                         <code>yes</code>.</termdef> If a parameter is explicitly mandatory, then the
                      <elcode>xsl:param</elcode> element <rfc2119>must</rfc2119> be empty and
                      <rfc2119>must not</rfc2119> have a <code>select</code> attribute.</p>
 
-               <p diff="add" at="A">The static context for evaluating the default value depends on where the
+               <p diff="add" at="2022-01-01">The static context for evaluating the default value depends on where the
                relevant expression appears in the stylesheet, in the usual way. Note however that
                for <elcode>xsl:param</elcode> elements defining <termref def="dt-function-parameter">function parameters</termref>,
                   the static context does not include variables bound in preceding-sibling <elcode>xsl:param</elcode> elements.</p>
                
-               <p diff="add" at="A">The dynamic context is different for different kinds of parameter:</p>
+               <p diff="add" at="2022-01-01">The dynamic context is different for different kinds of parameter:</p>
                
-               <ulist diff="add" at="A">
+               <ulist diff="add" at="2022-01-01">
                   <item><p>For <termref def="dt-stylesheet-parameter">stylesheet parameters</termref>, the 
                   context is the same as the context for evaluating global variables.</p></item>
                   <item><p>For <termref def="dt-template-parameter">template parameters</termref>, the 
@@ -16523,9 +16523,9 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>
                <termdef id="dt-global-variable" term="global variable">A <termref def="dt-top-level"/> <termref def="dt-variable-binding-element">variable-binding element</termref> declares a
                      <term>global variable</term> that is visible everywhere 
-                  <phrase diff="del" at="A">(except within its own declaration, and where it is 
+                  <phrase diff="del" at="2022-01-01">(except within its own declaration, and where it is 
                   <termref def="dt-shadows">shadowed</termref> by another binding)</phrase>
-                  <phrase diff="add" at="A">except (a) within the <elcode>xsl:variable</elcode> or <elcode>xsl:param</elcode> 
+                  <phrase diff="add" at="2022-01-01">except (a) within the <elcode>xsl:variable</elcode> or <elcode>xsl:param</elcode> 
                      element itself, (b) within any other global variable declaration that binds a variable with the same name, 
                      and (c) within any region where it is <termref def="dt-shadows">shadowed</termref> 
                      by another variable binding.</phrase>.</termdef>
@@ -16719,7 +16719,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </item>
             </olist>
             
-            <note diff="add" at="A">
+            <note diff="add" at="2022-01-01">
                <p>It is not an error to have two global variables or parameters with the same name, 
                   one static and one non-static, provided that they have different import precedence. 
                   If the static variable has higher precedence, then it will be used as the selected 
@@ -16785,17 +16785,17 @@ and <code>version="1.0"</code> otherwise.</p>
                      <td rowspan="1" colspan="1">determined by the in-scope namespaces for the containing element in the
                         stylesheet</td>
                   </tr>
-                  <tr diff="chg" at="A">
+                  <tr diff="chg" at="2022-01-01">
                      <td rowspan="1" colspan="1">Default element namespace</td>
                      <td rowspan="1" colspan="1">determined by the <code>xpath-default-namespace</code> attribute if present
                         (see <specref ref="unprefixed-qnames"/>); otherwise the null namespace</td>
                   </tr>
-                  <tr diff="chg" at="A">
+                  <tr diff="chg" at="2022-01-01">
                      <td rowspan="1" colspan="1">Default type namespace</td>
                      <td rowspan="1" colspan="1">determined by the <code>xpath-default-namespace</code> attribute if present
                         (see <specref ref="unprefixed-qnames"/>); otherwise the null namespace</td>
                   </tr>
-                  <tr diff="chg" at="A">
+                  <tr diff="chg" at="2022-01-01">
                      <td rowspan="1" colspan="1">Function name resolver</td>
                      <td rowspan="1" colspan="1">Prefixed function names are resolved using the in-scope namespaces of
                         the containing element; unprefixed function names are taken as being in the <termref def="dt-standard-function-namespace"/>.
@@ -16838,7 +16838,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <td rowspan="1" colspan="1">Statically known function
                         signatures</td>
                      <td rowspan="1" colspan="1">The functions defined in <bibref ref="xpath-functions-40"/> in the <code>fn</code>
-                        <code>math</code>, <phrase diff="add" at="A"><code>map</code>, and <code>array</code></phrase>  namespaces, together with:
+                        <code>math</code>, <phrase diff="add" at="2022-01-01"><code>map</code>, and <code>array</code></phrase>  namespaces, together with:
                         <olist>
                            <item><p>the functions
                               <function>element-available</function>,
@@ -16850,7 +16850,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            <item><p>functions that appear in both this specification and in <bibref ref="xpath-functions-31"/>
                            (for example, the functions in the <code>map</code> namespaces, and a few others such as <code>collation-key</code>
                            and <code>json-to-xml</code>);</p></item>
-                           <item diff="del" at="A"><p>if XPath 3.1 is supported, functions defined in <bibref ref="xpath-functions-31"/>
+                           <item diff="del" at="2022-01-01"><p>if XPath 3.1 is supported, functions defined in <bibref ref="xpath-functions-31"/>
                               in the <code>fn</code>, <code>math</code>, <code>map</code>, and <code>array</code> namespaces;</p></item>
                            <item><p>constructor functions for built-in types;</p></item>
                            <item><p>the set of extension functions that are present in the static context of
@@ -17063,7 +17063,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         <elcode>xsl:catch</elcode> instruction that is a sibling of the variable
                      binding element.</p>
                </item>
-               <item diff="add" at="A">
+               <item diff="add" at="2022-01-01">
                   <p>Within an <elcode>xsl:function</elcode> declaration, a <termref def="dt-function-parameter"/>
                      is not visible within sibling <elcode>xsl:param</elcode> elements.</p>
                </item>
@@ -17073,10 +17073,10 @@ and <code>version="1.0"</code> otherwise.</p>
                   <elcode>xsl:param</elcode> element itself.</p>
             <p>If a binding is visible for an element then it is visible for every
                attribute of that element and for every text node child of that element.</p>
-            <p diff="add" at="A">An <elcode>xsl:param</elcode> element specifying <code>tunnel="yes"</code>
+            <p diff="add" at="2022-01-01">An <elcode>xsl:param</elcode> element specifying <code>tunnel="yes"</code>
             is also visible in the <code>test</code> attribute of the containing <elcode>xsl:template</elcode>
             element.</p>
-            <p diff="del" at="A">
+            <p diff="del" at="2022-01-01">
                A binding <term>shadows</term> another
                   binding if the binding occurs at a point where the other binding is visible, and
                   the bindings have the same name. It is not an error if a binding
@@ -17084,7 +17084,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <termref def="dt-shadows">shadows</termref> a global binding. In this case, the
                global binding will not be visible in the region of the 
                <termref def="dt-stylesheet">stylesheet</termref> where it is shadowed by the other binding.</p>
-            <p diff="add" at="A"><termdef id="dt-shadows" term="shadows">Within a region of the 
+            <p diff="add" at="2022-01-01"><termdef id="dt-shadows" term="shadows">Within a region of the 
                stylesheet where a binding <var>B</var>1 is visible, <var>B1</var> shadows another 
                binding <var>B2</var> having the same name as <var>B1</var> if <var>B1</var> occurs at 
                a point where <var>B2</var> is visible.</termdef> [XSLT 3.0 Erratum E5, bug 30171].</p>
@@ -17428,7 +17428,7 @@ and <code>version="1.0"</code> otherwise.</p>
               
             </div3>
             
-            <div3 id="invoking-templates-with-extension-instructions" diff="add" at="A">
+            <div3 id="invoking-templates-with-extension-instructions" diff="add" at="2022-01-01">
                <head>Invoking Named Templates using Extension Instructions</head>
                <p>As an alternative to the use of <elcode>xsl:call-template</elcode>, it is
                possible to invoke a named template using an instruction. For example, given
@@ -17694,7 +17694,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      a single <elcode>xsl:apply-templates</elcode> or <elcode>xsl:call-template</elcode> instruction
                      that neglects to pass the information on will lead to failures that are difficult to diagnose.</p>
                      
-                     <p diff="add" at="A">This style of processing is even more useful when handling JSON input,
+                     <p diff="add" at="2022-01-01">This style of processing is even more useful when handling JSON input,
                      because with maps and arrays, there is no ancestor axis to examine properties of nodes further
                      up the tree; with a recursive descent of the tree, all context information needs to be passed down
                      explicitly. One way of handling this is for each level of processing in the tree to bind a tunnel
@@ -17736,7 +17736,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   set, then the parameter created using <elcode>xsl:with-param</elcode> overrides
                   the parameter in the base set; otherwise, the parameter created using
                      <elcode>xsl:with-param</elcode> is added to the base set.</p>
-               <p diff="chg" at="A">When a template specifies <code>&lt;xsl:param tunnel="yes"></code>,
+               <p diff="chg" at="2022-01-01">When a template specifies <code>&lt;xsl:param tunnel="yes"></code>,
                   this declares the intention to make use of a <termref def="dt-tunnel-parameter">tunnel
                      parameter</termref>; it does not remove the parameter from the base set
                   of tunnel parameters that is passed on to any templates called by this
@@ -18238,7 +18238,7 @@ and <code>version="1.0"</code> otherwise.</p>
                that may appear in a call to this function.</p> 
  
                
-               <p diff="add" at="A">For example, the following <elcode>xsl:function</elcode> declaration
+               <p diff="add" at="2022-01-01">For example, the following <elcode>xsl:function</elcode> declaration
                declares a function, named <code>f:compare</code>, with an arity range of (2 to 3). 
                   The effect of calling <code>f:compare($a, $b)</code> is the same as the effect
                of calling <code>f:compare($a, $b, map{"order":"ascending"})</code>.</p>
@@ -18277,12 +18277,12 @@ and <code>version="1.0"</code> otherwise.</p>
                   <error spec="XT" type="static" class="SE" code="0760">
                      <p>It is a static error if an <elcode>xsl:param</elcode> child of
                         an <elcode>xsl:function</elcode> element has either a <code>select</code>
-                        attribute or non-empty content<phrase diff="add" at="A">, unless it
+                        attribute or non-empty content<phrase diff="add" at="2022-01-01">, unless it
                         specifies <code>required="no"</code>.</phrase></p>
                   </error>
                </p>
                
-               <p diff="add" at="A">
+               <p diff="add" at="2022-01-01">
                   <error spec="XT" type="static" class="SE" code="0761">
                      <p>It is a static error if an <elcode>xsl:param</elcode> child of
                         an <elcode>xsl:function</elcode> element specifies
@@ -18302,7 +18302,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>If the <code>as</code> attribute is omitted, no conversion takes place and any
                   value is accepted.</p>
                
-               <note diff="add" at="A"><p>When considering function overriding, dynamic function calls,
+               <note diff="add" at="2022-01-01"><p>When considering function overriding, dynamic function calls,
                and details such as the <code>function-lookup</code> function, it is useful to think
                of an <elcode>xsl:function</elcode> declaration with optional parameters as a syntactic 
                   short-cut for a set of <elcode>xsl:function</elcode> declarations of varying arity, each
@@ -18316,10 +18316,10 @@ and <code>version="1.0"</code> otherwise.</p>
             <div3 id="function-result">
                <head>Function Result</head>
 
-               <p>The result of the function<phrase diff="add" at="A">, if all arguments are supplied,</phrase> 
+               <p>The result of the function<phrase diff="add" at="2022-01-01">, if all arguments are supplied,</phrase> 
                   is the result of evaluating the contained <termref def="dt-sequence-constructor"/>.</p>
                
-               <p diff="add" at="A">If a reduced-arity form of the function is invoked by omitting optional arguments, then
+               <p diff="add" at="2022-01-01">If a reduced-arity form of the function is invoked by omitting optional arguments, then
                the result of the function is obtained by evaluating the sequence constructor after binding the
                omitted arguments to their default values, which are obtained by evaluating the <code>select</code>
                attribute or sequence constructor of the relevant <elcode>xsl:param</elcode> element, as
@@ -18453,7 +18453,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <!--<p>
                   <error spec="XT" type="static" class="SE" code="0770">
                      <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
-                        contain <phrase diff="chg" at="A"><elcode>xsl:function</elcode>
+                        contain <phrase diff="chg" at="2022-01-01"><elcode>xsl:function</elcode>
                            declarations declaring two or more functions</phrase> with the same <termref def="dt-expanded-qname">expanded QName</termref>
                         with overlapping <termref def="dt-arity-range">arity ranges</termref>, 
                            and with the same <termref def="dt-import-precedence">import
@@ -18667,7 +18667,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <div3 id="function-examples">
                <head>Examples of Stylesheet Functions</head>
 
-               <example diff="chg" at="A">
+               <example diff="chg" at="2022-01-01">
                   <head>A Stylesheet Function</head>
                   <p>The following example creates a recursive <termref def="dt-stylesheet-function">stylesheet function</termref> named <code>str:reverse</code> that reverses
                      the words in a supplied sentence, and then invokes this function from within a
@@ -18829,7 +18829,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <item>
                      <p>XPath 1.0 compatibility mode is <code>false</code>.</p>
                   </item>
-                  <item diff="chg" at="A">
+                  <item diff="chg" at="2022-01-01">
                      <p>Statically known namespaces and default namespaces for 
                         elements and for types:</p>
                      <ulist>
@@ -18840,7 +18840,7 @@ and <code>version="1.0"</code> otherwise.</p>
                               in-scope namespaces of the resulting node are used as the statically
                               known namespaces for the target expression. The binding for the
                               default namespace in the in-scope namespaces is used as the default
-                              namespace for <phrase diff="add" at="A">both</phrase>
+                              namespace for <phrase diff="add" at="2022-01-01">both</phrase>
                               elements and types in the target expression.</p>
                            <p>
                               <error spec="XT" type="type" class="TE" code="3170">
@@ -18905,7 +18905,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <p>Function signatures:</p>
                      <ulist>
                         <item><p>All functions defined in <bibref ref="xpath-functions-40"/> in the
-                           <code>fn</code> and <code>math</code>, <phrase diff="add" at="A"><code>map</code>, and <code>array</code></phrase> namespaces;</p></item>
+                           <code>fn</code> and <code>math</code>, <phrase diff="add" at="2022-01-01"><code>map</code>, and <code>array</code></phrase> namespaces;</p></item>
                         
                         <item><p>Constructor functions for named simple types included in the in-scope schema definitions;</p></item>
                         <item><p>All user-defined functions present in the containing package provided their visibility is
@@ -19571,7 +19571,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   using <code>#default</code> instead of a prefix. If no default namespace is in
                   force, specifying <code>#default</code> denotes the null namespace URI. This
                   allows elements that are in no namespace in the stylesheet to acquire a namespace
-                  in the result document, or vice versa. <phrase diff="add" at="A">
+                  in the result document, or vice versa. <phrase diff="add" at="2022-01-01">
                      Defining an alias for the null namespace URI does not affect no-namespace attributes; 
                      these remain in no namespace. However, where <code>result-prefix="#default"</code> is specified and 
                      no default namespace is in force, attributes whose namespace matches the literal namespace 
@@ -20769,7 +20769,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   applied to the tree that remains after the relevant namespaces have been removed.
                   This will cause validation to fail if there is namespace-sensitive content that
                   depends on the presence of the removed namespaces.</p>
-               <p diff="del" at="A">The base URI of a node is copied, except in the case of an element node having an
+               <p diff="del" at="2022-01-01">The base URI of a node is copied, except in the case of an element node having an
                      <code>xml:base</code> attribute, in which case the base URI of the new node is
                   taken as the value of the <code>xml:base</code> attribute, resolved if it is
                   relative against the base URI of the <elcode>xsl:copy-of</elcode> instruction. If
@@ -20777,10 +20777,10 @@ and <code>version="1.0"</code> otherwise.</p>
                   node, the final copy of the node inherits its base URI from its parent node,
                   unless this is overridden using an <code>xml:base</code> attribute.</p>
                
-               <p diff="add" at="A">
+               <p diff="add" at="2022-01-01">
                   For any node <var>N</var> that is explicitly selected by the evaluation of the 
                   <code>select</code> expression, the base URI of the new copy is as follows:</p>
-               <ulist diff="add" at="A">
+               <ulist diff="add" at="2022-01-01">
                   <item><p>If <var>N</var> is an element node having an <code>xml:base</code> attribute, 
                      the base URI of the new node is taken as the value of the <code>xml:base</code> attribute, 
                      resolved if it is relative against the static base URI of the <code>xsl:copy-of</code> instruction.
@@ -20788,24 +20788,24 @@ and <code>version="1.0"</code> otherwise.</p>
                   <item><p>Otherwise, the base URI of the new copy is the same as the base URI of <var>N</var>.
                   </p></item>
                </ulist>   
-               <p diff="add" at="A">For any element or processing-instruction node that has <var>N</var> as an ancestor, 
+               <p diff="add" at="2022-01-01">For any element or processing-instruction node that has <var>N</var> as an ancestor, 
                      the base URI of the new copy is set to be the same as that of its new parent, 
                      with the following exception: if a copied element has an <code>xml:base</code> 
                      attribute, then its base URI is set to the value of that attribute, 
                      resolved if it is relative against the base URI of the new parent node.
                   </p>
-               <note diff="add" at="A"><p>If two elements in a subtree have different base URIs for some reason 
+               <note diff="add" at="2022-01-01"><p>If two elements in a subtree have different base URIs for some reason 
                      unconnected with <code>xml:base</code> attributes (for example, if they originated in different 
                      external entities), then these differences are lost when the subtree is copied.
                   </p></note>
                   
-               <note diff="add" at="A">
+               <note diff="add" at="2022-01-01">
                      <p>As a consequence of rules specified elsewhere (see <specref ref="constructing-complex-content"/>), 
                         if a node created using the <code>xsl:copy-of</code> instruction is subsequently attached 
                         as a child to a new element or document node, the final copy of the node inherits 
                         its base URI from its new parent node, unless this is overridden using an <code>xml:base</code> attribute.
                      </p></note>
-               <p diff="add" at="A">[XSLT 3.0 Erratum E16, bug 30222]</p>
+               <p diff="add" at="2022-01-01">[XSLT 3.0 Erratum E16, bug 30222]</p>
                <p>The effect of the <code>copy-accumulators</code> attribute is described in
                   <specref ref="applicability-of-accumulators"/>.</p>
             </div3>
@@ -21978,7 +21978,7 @@ for $i in 1 to count($V) return
                      interpreted as described in section 6.6 of <bibref ref="UNICODE-TR10"/>.</p>
                </note>
                
-               <p diff="add" at="A">
+               <p diff="add" at="2022-01-01">
                   The <code>collation</code>, <code>case-order</code>, and <code>lang</code> attributes are 
                   ignored when no string comparisons are performed during the sorting process; this 
                   includes the cases where (a) the sequences to be sorted are empty, (b) the sort 
@@ -22082,7 +22082,7 @@ for $i in 1 to count($V) return
                order in which the groups are to be processed. For the effect of
                   <elcode>xsl:for-each-group</elcode>, see <specref ref="grouping"/>. </p>
          </div2>
-         <div2 id="uca-collations" diff="del" at="A">
+         <div2 id="uca-collations" diff="del" at="2022-01-01">
             <head>The Unicode Collation Algorithm</head>
 
 
@@ -22291,7 +22291,7 @@ for $i in 1 to count($V) return
                instruction may be used anywhere within a <termref def="dt-sequence-constructor">sequence
                constructor</termref>.</p>
             
-            <p diff="add" at="A">As with <code>xsl:for-each</code>, the instruction is extended in XSLT 4.0 to allow maps and arrays
+            <p diff="add" at="2022-01-01">As with <code>xsl:for-each</code>, the instruction is extended in XSLT 4.0 to allow maps and arrays
                to be processed.</p>
             
  
@@ -22299,15 +22299,15 @@ for $i in 1 to count($V) return
             <?element xsl:for-each-group?>
             
             
-            <p diff="del" at="A">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
+            <p diff="del" at="2022-01-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
                are mutually exclusive: exactly one of these three attributes must be present.</p>
-            <p diff="del" at="A">Specifying <code>array="EXPR"</code> is equivalent to specifying
+            <p diff="del" at="2022-01-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
                <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
                elements of an input array to a sequence of items, each item being a map having a single entry, whose
                key is the string <code>value</code> and whose corresponding value is the relevant element of the
                array. Within the contained sequence constructor, the current array element can be refered to
                as <code>?value</code>.</p>
-            <p diff="del" at="A">Specifying <code>map="EXPR"</code> is equivalent to specifying
+            <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
                <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
@@ -22315,7 +22315,7 @@ for $i in 1 to count($V) return
                can be refered to as <code>?key</code> and <code>?value</code> respectively.</p>
             
             
-            <p>The <code>select</code> attribute <phrase diff="add" at="A">(whether written explicitly, or constructed
+            <p>The <code>select</code> attribute <phrase diff="add" at="2022-01-01">(whether written explicitly, or constructed
                as described above)</phrase> contains an
                <termref def="dt-expression">expression</termref> which is evaluated to produce a
                sequence, called the <termref def="dt-population"/>.</p>
@@ -22334,7 +22334,7 @@ for $i in 1 to count($V) return
                <termdef id="dt-population" term="population">The sequence of items to be grouped,
                   which is referred to as the <term>population</term>, is determined by evaluating
                   the XPath <termref def="dt-expression">expression</termref> contained in the
-                  <code>select</code> attribute, <phrase diff="add" at="A">or constructed from the expressions in the 
+                  <code>select</code> attribute, <phrase diff="add" at="2022-01-01">or constructed from the expressions in the 
                   <code>array</code> or <code>map</code> attributes</phrase>.</termdef>
             </p>
             <p>
@@ -22345,13 +22345,13 @@ for $i in 1 to count($V) return
                zero.</p>
             <p>The assignment of items to groups depends on the <code>group-by</code>,
                   <code>group-adjacent</code>, <code>group-starting-with</code>, 
-                  <code>group-ending-with</code>, <phrase diff="add" at="A">and <code>break-when</code></phrase> attributes. </p>
+                  <code>group-ending-with</code>, <phrase diff="add" at="2022-01-01">and <code>break-when</code></phrase> attributes. </p>
             <p>
                <error spec="XT" type="static" class="SE" code="1080">
-                  <p>These <phrase diff="add" at="A">five</phrase> attributes <error.extra>the <code>group-by</code>,
+                  <p>These <phrase diff="add" at="2022-01-01">five</phrase> attributes <error.extra>the <code>group-by</code>,
                            <code>group-adjacent</code>, <code>group-starting-with</code>, 
                      <code>group-ending-with</code>, 
-                     <phrase diff="add" at="A">and <code>break-when</code></phrase> attributes of
+                     <phrase diff="add" at="2022-01-01">and <code>break-when</code></phrase> attributes of
                            <elcode>xsl:for-each-group</elcode>
                      </error.extra> are mutually exclusive: it is a <termref def="dt-static-error">static error</termref> 
                      if none of these attributes is present or if
@@ -22403,7 +22403,7 @@ for $i in 1 to count($V) return
                            <code>composite="yes"</code> is specified.</p>
                </error>
             </p>
-            <p diff="chg" at="A">
+            <p diff="chg" at="2022-01-01">
                <termref def="dt-grouping-key">Grouping keys</termref> are compared using
                the rules of the <function>distinct-values</function> function, using the relevant collation.
                The relevant collation is the collation specified as the 
@@ -22453,7 +22453,7 @@ the same group, and the-->
                   <p>The number of groups will be the same as the number of distinct grouping key
                      values present in the <termref def="dt-population">population</termref>. </p>
                   <!--Text inserted by erratum E25 change 2"-->
-                  <p diff="del" at="A">If the population contains values of different numeric types that differ from
+                  <p diff="del" at="2022-01-01">If the population contains values of different numeric types that differ from
                      each other by small amounts, then the <code>eq</code> operator is not
                      transitive, because of rounding effects occurring during type promotion. The
                      effect of this is described in <specref ref="non-transitivity"/>.</p>
@@ -22482,7 +22482,7 @@ the same group, and the-->
                      member. Otherwise, the item is appended to the same group as its preceding
                         item within the population.</p>
                </item>
-               <item diff="add" at="A">
+               <item diff="add" at="2022-01-01">
                   <p>If the <code>break-when</code> attribute is present, then its value
                      <rfc2119>must</rfc2119> be an expression.
                      This expression is evaluated once for every item in the <termref def="dt-population"/>
@@ -22595,7 +22595,7 @@ the same group, and the-->
                the streamability of an <elcode>xsl:for-each-group</elcode> instruction to be
                assessed statically, as described in <specref ref="streamability-xsl-for-each-group"/>.</p>
 
-            <note diff="add" at="A">
+            <note diff="add" at="2022-01-01">
                <p>If the <code>array</code> attribute of <elcode>xsl:for-each-group</elcode> is used, the value
                of the <termref def="dt-current-group"/> will be a sequence of maps, each having a single entry
                with the key <code>value</code>. It is therefore possible to process the array elements making
@@ -22659,7 +22659,7 @@ the same group, and the-->
                the group whose <termref def="dt-sort-key-value">sort key value</termref> is being
                determined, and the <termref def="dt-current-grouping-key"/> is the grouping key for
                that group. If the <elcode>xsl:for-each-group</elcode> instruction uses the
-               <code>group-starting-with</code>, <code>group-ending-with</code><phrase diff="add" at="A">,
+               <code>group-starting-with</code>, <code>group-ending-with</code><phrase diff="add" at="2022-01-01">,
                   or <code>break-when</code></phrase>
                attributes, then the <termref def="dt-current-grouping-key"/> is <termref def="dt-absent"/>.</p>
             <example>
@@ -22970,7 +22970,7 @@ the same group, and the-->
     &lt;/xsl:for-each-group&gt;
 &lt;/xsl:template&gt;</eg>
             </example>
-            <example diff="add" at="A">
+            <example diff="add" at="2022-01-01">
                <head>Grouping entries in a Map</head>
                <p>Consider a map with composite keys that might appear in a JSON document as:</p>
                <eg>{
@@ -23013,7 +23013,7 @@ the same group, and the-->
             </example>
          </div2>
          <!--Text inserted by erratum E25 change 3"-->
-         <div2 id="non-transitivity" diff="del" at="A">
+         <div2 id="non-transitivity" diff="del" at="2022-01-01">
             <head>Non-Transitivity</head>
             <p>If the population contains values of different numeric types that differ from each
                other by small amounts, then the <code>eq</code> operator is not transitive, because
@@ -23321,12 +23321,12 @@ the same group, and the-->
             <p><error spec="XT" class="SE" type="static" code="3195">
                   <p>If the <code>for-each-item</code> attribute is present then the
                         <code>for-each-source</code>, <code>use-accumulators</code>, and <code>streamable</code> attributes
-                     must all be absent. If <phrase diff="chg" at="A">either or both of the
+                     must all be absent. If <phrase diff="chg" at="2022-01-01">either or both of the
                         <code>use-accumulators</code> or <code>streamable</code> attributes is present </phrase>
                      then the <code>for-each-source</code> attribute must be present. If the
                         <code>for-each-source</code> attribute is present then the
                      <code>for-each-item</code> attribute must be absent. 
-                     <phrase diff="add" at="A">[XSLT 3.0 Erratum E40, bugs 30265 and 30378].</phrase></p>
+                     <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E40, bugs 30265 and 30378].</phrase></p>
                </error></p>
 
             <p>The <code>use-accumulators</code> attribute defines the
@@ -23409,11 +23409,11 @@ the same group, and the-->
                   <code>type</code> are used to control schema validation of documents read by
                virtue of their appearance in the result of the <code>for-each-source</code>
                expression. These attributes are mutually exclusive <errorref spec="XT" class="SE" code="1505"/>. 
-               <phrase diff="del" at="A">The rules are the same as for an <elcode>xsl:source-document</elcode>
+               <phrase diff="del" at="2022-01-01">The rules are the same as for an <elcode>xsl:source-document</elcode>
                instruction specifying <code>streamable="yes"</code>. </phrase>
                If the <code>for-each-source</code> attribute is absent, then the
                   <code>validation</code> and <code>type</code> attributes <rfc2119>must</rfc2119>
-               both be absent. <phrase diff="add" at="A">The process of validation follows
+               both be absent. <phrase diff="add" at="2022-01-01">The process of validation follows
                the rules defined in <specref ref="validation"/> [XSLT 3.0 Erratum E44, bug 30384].</phrase></p>
 
             
@@ -23422,7 +23422,7 @@ the same group, and the-->
                the value <code>no</code>, then each merge input sequence <rfc2119>must</rfc2119> already
                be in the correct order for merging (a dynamic error occurs if it is not). If the
                attribute is present with the value <code>yes</code>, then each input sequence will
-               first be sorted to ensure that it is in the correct order. <phrase diff="add" at="A">
+               first be sorted to ensure that it is in the correct order. <phrase diff="add" at="2022-01-01">
                   The sorting is carried out as if by evaluating an <elcode>xsl:perform-sort</elcode> 
                   instruction with <elcode>xsl:sort</elcode> children corresponding one-to-one with 
                   the <elcode>xsl:merge-key</elcode> children of the <elcode>xsl:merge-source</elcode> 
@@ -23686,12 +23686,12 @@ the same group, and the-->
                   <elcode>xsl:merge-source</elcode> element. Each <elcode>xsl:merge-key</elcode>
                element defines one merge key component. The syntax and semantics of an
                   <elcode>xsl:merge-key</elcode> element are closely based on the rules for the
-                  <elcode>xsl:sort</elcode> element (<phrase diff="chg" at="A">with minor exceptions
+                  <elcode>xsl:sort</elcode> element (<phrase diff="chg" at="2022-01-01">with minor exceptions
                   noted below; the only difference in syntax is</phrase> the absence of the
-                  <code>stable</code> attribute); the <phrase diff="add" at="A">main</phrase> difference is that
+                  <code>stable</code> attribute); the <phrase diff="add" at="2022-01-01">main</phrase> difference is that
                   <elcode>xsl:merge-key</elcode> elements do not cause a sort to take place, they
                merely declare the existing sort order of the input sequence. 
-               <phrase diff="add" at="A">[See XSLT 3.0 Erratum E42, bugs 30130 and 30382].</phrase></p>
+               <phrase diff="add" at="2022-01-01">[See XSLT 3.0 Erratum E42, bugs 30130 and 30382].</phrase></p>
 
             <?element xsl:merge-key?>
 
@@ -23706,13 +23706,13 @@ the same group, and the-->
                </error>
             </p>
             
-            <p diff="chg" at="A">The value of <var>N</var>th item in the merge key of an item
+            <p diff="chg" at="2022-01-01">The value of <var>N</var>th item in the merge key of an item
                <var>J</var> in a <termref def="dt-merge-input-sequence">merge input
                   sequence</termref>
                <var>S</var> is computed as follows, where <var>K</var> is the <var>N</var>th
                <elcode>xsl:merge-key</elcode> element of the relevant <elcode>xsl:merge-source</elcode>:</p>
             
-            <olist diff="chg" at="A">
+            <olist diff="chg" at="2022-01-01">
                <item><p>If <var>K</var> has a <code>select</code> attribute, then the result 
                   of evaluating and atomizing that <code>select</code> expression;</p></item>
                <item><p>If <var>K</var> contains a non-empty sequence constructor, then the 
@@ -23720,7 +23720,7 @@ the same group, and the-->
                <item><p>Otherwise, the result of atomizing the context item.</p></item>
             </olist>
             
-            <p diff="chg" at="A">In each case the evaluation uses a <termref def="dt-singleton-focus"/> 
+            <p diff="chg" at="2022-01-01">In each case the evaluation uses a <termref def="dt-singleton-focus"/> 
                based on <var>J</var>, or, if <code>streamable="yes"</code> is specified on the
                <elcode>xsl:merge-source</elcode> element, a <termref def="dt-singleton-focus"/> based on 
                a snapshot of <var>J</var> (see <specref ref="streamable-merging"/>). 
@@ -23753,7 +23753,7 @@ the same group, and the-->
                      same number of <elcode>xsl:merge-key</elcode> child elements; let this number
                      be <var>N</var>.</p>
                </item>
-               <item diff="chg" at="A">
+               <item diff="chg" at="2022-01-01">
                   <p>For each integer <var>J</var> in 1..<var>N</var>, consider the set <var>S</var> of
                         <elcode>xsl:merge-key</elcode> elements that are in position <var>J</var>
                      among the <elcode>xsl:merge-key</elcode> children of their parent
@@ -23928,7 +23928,7 @@ the same group, and the-->
                   <code>case-order</code>, and <code>data-type</code> attributes of the merge key
                definitions.</p>
 
-            <p><phrase diff="chg" at="A">Comparison of merge key values follows the rules for 
+            <p><phrase diff="chg" at="2022-01-01">Comparison of merge key values follows the rules for 
                <elcode>xsl:sort</elcode> given in <specref ref="comparing-sort-keys"/>. 
                This means that except for special cases such as empty sequences and NaN</phrase>, 
                two sets of merge key values are distinct if any corresponding items in
@@ -23940,7 +23940,7 @@ the same group, and the-->
                partitioning of items into sets having distinct key values is handled in the same way
                as for <elcode>xsl:for-each-group</elcode> (see <specref ref="non-transitivity"/>),
                and is to some extent <termref def="dt-implementation-dependent">implementation-dependent</termref>. 
-            <phrase diff="add" at="A">[XSLT 3.0 Erratum E39, bug 30377].</phrase>
+            <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E39, bug 30377].</phrase>
             </p>
 
             
@@ -25112,8 +25112,8 @@ the same group, and the-->
                            <code>@value</code>. The left-hand operand <code>transactions/transaction</code> has
                               <termref def="dt-striding"/>
                               <termref def="dt-posture"/>. The right-hand operand <code>@value</code>, given
-                           that <phrase diff="chg" at="A">the context posture is striding</phrase>, is <termref def="dt-motionless"/>. The <code>RelativePathExpr</code> argument to <code>max</code> is
-                           therefore consuming. <phrase diff="add" at="A">[XSLT 3.0 Erratum E9, bug 30130].</phrase></p>
+                           that <phrase diff="chg" at="2022-01-01">the context posture is striding</phrase>, is <termref def="dt-motionless"/>. The <code>RelativePathExpr</code> argument to <code>max</code> is
+                           therefore consuming. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E9, bug 30130].</phrase></p>
                      </item>
                      <item>
                         <p>The entire body of the <elcode>xsl:source-document</elcode> instruction is
@@ -25783,11 +25783,11 @@ the same group, and the-->
                <head>Dynamic Errors in Accumulators</head>
                <p>If a dynamic error occurs when evaluating the <code>initial-value</code> expression
                of <elcode>xsl:accumulator</elcode>, or the <code>select</code> expression of <elcode>xsl:accumulator-rule</elcode>,
-                  <phrase diff="add" at="A">or the sequence constructor contained in <elcode>xsl:accumulator-rule</elcode>, </phrase>
+                  <phrase diff="add" at="2022-01-01">or the sequence constructor contained in <elcode>xsl:accumulator-rule</elcode>, </phrase>
                then the error is signaled as an error from any subsequent call on <function>accumulator-before</function>
                   or <function>accumulator-after</function> that references the accumulator. If no such call on <function>accumulator-before</function>
                   or <function>accumulator-after</function> happens, then the error goes unreported.
-               <phrase diff="add" at="A">[XSLT 3.0 Erratum E38, bug 30376].</phrase></p>
+               <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E38, bug 30376].</phrase></p>
                
                <note><p>In the above rule, the phrase <term>subsequent call</term> is to be understood in terms of functional dependency; that is, a call to
                   <function>accumulator-before</function> or <function>accumulator-after</function> signals an error if the accumulator value at the node in question is
@@ -25819,7 +25819,7 @@ the same group, and the-->
                   <error spec="XT" type="static" class="SE" code="3350">
                      <p>It is a <termref def="dt-static-error">static error</termref> for a 
                         <termref def="dt-package">package</termref> to contain two or more 
-                        <phrase diff="del" at="A">non-hidden</phrase><!-- Erratum E47, bug 30394 -->
+                        <phrase diff="del" at="2022-01-01">non-hidden</phrase><!-- Erratum E47, bug 30394 -->
                         accumulators with the same <termref def="dt-expanded-qname">expanded
                            QName</termref> and the same <termref def="dt-import-precedence">import
                            precedence</termref>, unless there is another accumulator with the same
@@ -25971,7 +25971,7 @@ the same group, and the-->
          select="$value + count(tokenize(.))"/&gt;
   &lt;/xsl:accumulator&gt;
   </eg>
-                  <p diff="del" at="A"><emph>Note: the call on <code>tokenize#1</code> relies on XPath 3.1</emph></p>
+                  <p diff="del" at="2022-01-01"><emph>Note: the call on <code>tokenize#1</code> relies on XPath 3.1</emph></p>
                   <p>The final value can be output at the end of the document:</p>
                   <eg role="xslt-declaration" xml:space="preserve">
    &lt;xsl:template match="/"&gt;
@@ -26569,7 +26569,7 @@ the same group, and the-->
                      </item>
                      <item>
                         <p><code>FunctionTest</code>, <code>MapTest</code>, 
-                           and <phrase diff="del" at="A">(if the XPath 3.1 feature
+                           and <phrase diff="del" at="2022-01-01">(if the XPath 3.1 feature
                            is implemented) </phrase><code>ArrayTest</code> 
                            map to <var>U{function(*)}</var></p>
                      </item>
@@ -28764,10 +28764,10 @@ the same group, and the-->
                            elements (usage <termref def="dt-inspection"/>).</p>
                      </item>
                      <item>
-                        <p>The sequence constructors <phrase diff="add" at="B">and <code>select</code> expressions</phrase>
+                        <p>The sequence constructors <phrase diff="add" at="2022-11-01">and <code>select</code> expressions</phrase>
                            contained within <elcode>xsl:when</elcode> and
                               <elcode>xsl:otherwise</elcode> child elements (usage <termref def="dt-transmission"/>). 
-                           These <phrase diff="del" at="B">sequence constructor</phrase> operands form a
+                           These <phrase diff="del" at="2022-11-01">sequence constructor</phrase> operands form a
                               <termref def="dt-choice-operand-group"/>.</p>
                      </item>
                   </olist>
@@ -28776,7 +28776,7 @@ the same group, and the-->
                      <p>The effect is to allow either of the following:</p>
                      <olist>
                         <item>
-                           <p>Any or all of the sequence constructors <phrase diff="add" at="B">and <code>select</code> expressions</phrase>
+                           <p>Any or all of the sequence constructors <phrase diff="add" at="2022-11-01">and <code>select</code> expressions</phrase>
                               in <elcode>xsl:when</elcode> and
                                  <elcode>xsl:otherwise</elcode> branches may be <termref def="dt-consuming"/>,  in
                               which case the <code>test</code> expressions must all be <termref def="dt-motionless"/>.</p>
@@ -28784,7 +28784,7 @@ the same group, and the-->
                         <item>
                            <p>Any one of the <code>test</code> expressions may be <termref def="dt-consuming"/>, 
                               in which case all the other <code>test</code> expressions, and all the 
-                              sequence constructors <phrase diff="add" at="B">and <code>select</code> expressions</phrase>, 
+                              sequence constructors <phrase diff="add" at="2022-11-01">and <code>select</code> expressions</phrase>, 
                               must be <termref def="dt-motionless"/>.</p>
                         </item>
                      </olist>
@@ -29234,13 +29234,13 @@ the same group, and the-->
                      <item>
                         <p>The <code>test</code> expression (usage <termref def="dt-inspection"/>)</p>
                      </item>
-                     <item diff="add" at="B">
+                     <item diff="add" at="2022-11-01">
                         <p>The <code>then</code> and <code>else</code> expressions and the 
                            contained <termref def="dt-sequence-constructor"/> (usage <termref def="dt-transmission"/>).
                         These operands form a <termref def="dt-choice-operand-group"/></p>
                      </item>
                   </olist>
-                  <note diff="add" at="B">
+                  <note diff="add" at="2022-11-01">
                      <p>The effect is to allow either of the following:</p>
                      <olist>
                         <item><p>The <code>test</code> expression may be <termref def="dt-motionless"/>, in which case any or all
@@ -29834,7 +29834,7 @@ the same group, and the-->
 
                </div4>
                
-               <div4 id="streamability-xsl-switch" diff="add" at="B">
+               <div4 id="streamability-xsl-switch" diff="add" at="2022-11-01">
                   <head>Streamability of <elcode>xsl:switch</elcode></head>
                   
                   <p>The <termref def="dt-posture"/> and <termref def="dt-sweep"/> of
@@ -30649,10 +30649,10 @@ the same group, and the-->
                            and <termref def="dt-sweep"/> obtained by assessing the function call
                            using the <termref def="dt-general-streamability-rules"/>, where the
                            operands are the arguments to the function call, with an <termref def="dt-operand-usage"/> 
-                           for the first argument of <phrase diff="chg" at="A"><termref def="dt-transmission"/></phrase>, 
+                           for the first argument of <phrase diff="chg" at="2022-01-01"><termref def="dt-transmission"/></phrase>, 
                            and an <termref def="dt-operand-usage"/> for
                            arguments after the first being the <termref def="dt-type-determined-usage"/> based on the declared type of the
-                           corresponding <termref def="dt-function-parameter"/>. <phrase diff="add" at="A">[XSLT 3.0 Erratum E31, bug 30289]</phrase></p>
+                           corresponding <termref def="dt-function-parameter"/>. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E31, bug 30289]</phrase></p>
                      </item>
                      <item>
                         <p>If <var>P0</var> is <termref def="dt-roaming"/> or <var>S0</var> is
@@ -30670,7 +30670,7 @@ the same group, and the-->
                         <p>If <var>P0</var> is <termref def="dt-grounded"/>, then the function call
                            is <termref def="dt-grounded"/> and <termref def="dt-motionless"/>.</p>
                      </item>
-                     <item diff="add" at="A">
+                     <item diff="add" at="2022-01-01">
                         <p>If the declared return type of the function does not permit nodes, then the function call
                            is <termref def="dt-grounded"/> and <termref def="dt-motionless"/>. [XSLT 3.0 Erratum E31, bug 30289].</p>
                      </item>
@@ -31886,7 +31886,7 @@ the same group, and the-->
                      
                      <p>This means it is desirable to declare the type of any variable holding a map or array. 
                      If streamable nodes are used to lookup a value in a map or array, then it may be advisable to use
-                     the <code>map:get</code> or <code>array:get</code> functions explicitly; or<phrase diff="del" at="A">, if XPath 3.1 is available,</phrase>
+                     the <code>map:get</code> or <code>array:get</code> functions explicitly; or<phrase diff="del" at="2022-01-01">, if XPath 3.1 is available,</phrase>
                      the lookup operator (<code>?</code>).</p>
                      
                   </note>
@@ -32056,7 +32056,7 @@ the same group, and the-->
                <div4 id="streamability-of-lookup-expressions">
                   <head>Streamability of Lookup Expressions</head>
                   
-                  <p diff="del" at="A">Lookup expressions for maps are defined in XPath 3.1, and are available
+                  <p diff="del" at="2022-01-01">Lookup expressions for maps are defined in XPath 3.1, and are available
                   in XSLT 3.0 whether or not XPath 3.1 is supported. Lookup expressions for arrays are defined in the
                   XPath 3.1 specification (see <xspecref spec="XP40" ref="id-lookup"/>), and are available only in XSLT 3.0
                   processors that provide the XPath 3.1 Feature (see ....).</p>
@@ -34103,8 +34103,8 @@ the same group, and the-->
       <div1 id="map">
          <head>Maps</head>
          
-         <p diff="chg" at="A">Maps are defined in the XDM Data Model.</p>
-         <div2 id="map-type" diff="del" at="A">
+         <p diff="chg" at="2022-01-01">Maps are defined in the XDM Data Model.</p>
+         <div2 id="map-type" diff="del" at="2022-01-01">
             <head>The Type of a Map</head>
 
 
@@ -34271,12 +34271,12 @@ the same group, and the-->
             <p>The contained sequence constructor <rfc2119>must</rfc2119> evaluate to a sequence of
                maps: call this <code>$maps</code>.</p>
 
-            <p><phrase diff="chg" at="A">In the absense of duplicate keys,</phrase> the result of the instruction  
+            <p><phrase diff="chg" at="2022-01-01">In the absense of duplicate keys,</phrase> the result of the instruction  
                is then given by the XPath 3.1 expression:</p>
             <eg role="non-xml" xml:space="preserve">map:merge($maps)</eg>
 
             <note>
-               <p>Informally: <phrase diff="chg" at="A">in the absence of duplicate keys</phrase> the resulting map contains
+               <p>Informally: <phrase diff="chg" at="2022-01-01">in the absence of duplicate keys</phrase> the resulting map contains
                   the union of the map entries from the supplied sequence of maps.</p>
             </note>
             
@@ -34376,7 +34376,7 @@ the same group, and the-->
 </eg>
             </example>
             
-            <div3 id="duplicate-keys" diff="add" at="A">
+            <div3 id="duplicate-keys" diff="add" at="2022-01-01">
                <head>Handling of duplicate keys</head>
                
                <p>This section describes what happens when two or more maps returned by the sequence constructor
@@ -34487,7 +34487,7 @@ the same group, and the-->
             </div3>
          </div2>
 
-         <div2 id="map-constructors" diff="del" at="A">
+         <div2 id="map-constructors" diff="del" at="2022-01-01">
             <head>Map Constructors</head>
             <p>A Map Constructor is a new kind of expression added to the syntax of XPath.</p>
             <note>
@@ -34800,7 +34800,7 @@ return ($m?price - $m?discount)</eg>
          </div2>
       </div1>
       
-      <div1 id="arrays" diff="add" at="A">
+      <div1 id="arrays" diff="add" at="2022-01-01">
          <head>Arrays</head>
          
          <p>Arrays are defined in the XDM Data Model.</p>
@@ -35003,7 +35003,7 @@ return ($m?price - $m?discount)</eg>
                arrays.</p>
          </note>
 
-         <div2 id="json-to-xml-mapping" diff="del" at="A">
+         <div2 id="json-to-xml-mapping" diff="del" at="2022-01-01">
             <head>XML Representation of JSON</head>
 
 
@@ -35218,7 +35218,7 @@ return ($m?price - $m?discount)</eg>
                schema would succeed.</p>
          </div2>
          
-         <div2 id="options"  diff="del" at="A">
+         <div2 id="options"  diff="del" at="2022-01-01">
             <head>Option Parameter Conventions</head>
             <p><emph>This section describes conventions which in principle can be adopted by the specification
             of any function. At the time of writing, the function which invoke these conventions are 
@@ -35870,12 +35870,12 @@ return ($m?price - $m?discount)</eg>
                value of the <code>build-tree</code> attribute. If the effective value of
                the <code>build-tree</code> attribute is <code>yes</code>, then 
                   a <termref def="dt-final-result-tree"/> is created
-               by invoking the process of <xtermref spec="SER30" ref="sequence-normalization"/>. <phrase diff="del" at="A">The default for the
+               by invoking the process of <xtermref spec="SER30" ref="sequence-normalization"/>. <phrase diff="del" at="2022-01-01">The default for the
                   <code>build-tree</code> attribute depends on the serialization method. For the
                   <code>xml</code>, <code>html</code>, <code>xhtml</code>, and <code>text</code>
                methods the default value is <code>yes</code>. For
                   the <code>json</code> and <code>adaptive</code> methods the default value is <code>no</code>.</phrase>
-               <phrase diff="add" at="A">Conversely, if the result <emph>is</emph> serialized, then 
+               <phrase diff="add" at="2022-01-01">Conversely, if the result <emph>is</emph> serialized, then 
                   the decision whether or not to construct a tree depends on the choice of 
                   serialization method, and the <code>build-tree</code> attribute is then ignored. 
                   For example, with <code>method="xml"</code> a tree is always constructed, whereas 
@@ -36006,7 +36006,7 @@ return ($m?price - $m?discount)</eg>
                   methods (xml, html, xhtml, text) then the expanded name must have a non-absent
                   namespace.</p>
             </note>
-            <p diff="del" at="A">Unless the processor implements the XPath 3.1 feature, the 
+            <p diff="del" at="2022-01-01">Unless the processor implements the XPath 3.1 feature, the 
                <code>method</code> values <code>json</code> and
                   <code>adaptive</code>
                <rfc2119>must</rfc2119> be rejected as invalid, and the attributes
@@ -36278,19 +36278,19 @@ return ($m?price - $m?discount)</eg>
                   <elcode>xsl:document</elcode>, and <elcode>xsl:result-document</elcode>
                instructions, and of the <code>xsl:validation</code> attribute of all
                <termref def="dt-literal-result-element">literal result elements</termref>,
-               appearing <phrase diff="chg" at="A">appearing as descendants of the element 
+               appearing <phrase diff="chg" at="2022-01-01">appearing as descendants of the element 
                   on which the attribute appears, unless there is an inner element that defines 
-                  a different default</phrase>. <phrase diff="del" at="A">It also determines
+                  a different default</phrase>. <phrase diff="del" at="2022-01-01">It also determines
                the validation applied to the implicit <termref def="dt-final-result-tree">final
                   result tree</termref> created in the absence of an
-                  <elcode>xsl:result-document</elcode> instruction.</phrase> This default <phrase diff="del" at="A">applies within the
+                  <elcode>xsl:result-document</elcode> instruction.</phrase> This default <phrase diff="del" at="2022-01-01">applies within the
                containing <termref def="dt-stylesheet-module">stylesheet module</termref> or
                   <termref def="dt-package"/>: it</phrase> does not extend to included or imported stylesheet
                modules or used packages. If the attribute is omitted, the default is
                   <code>strip</code>. The permitted values are <code>preserve</code> and
                   <code>strip</code>.</p>
             
-            <p diff="add" at="A">
+            <p diff="add" at="2022-01-01">
                The <code>default-validation</code> attribute on the outermost element of the principal
                stylesheet module of the <termref def="dt-top-level-package"/> also determines the validation 
                applied to the implicit final result tree created in the absence of an 
@@ -36581,9 +36581,9 @@ return ($m?price - $m?discount)</eg>
                <div4 id="validation-xsl-type">
                   <head>Validation using the <code>[xsl:]type</code> Attribute</head>
                   <p>The <code>[xsl:]type</code> attribute takes as its value an 
-                     <phrase diff="chg" at="A"><xnt spec="XP40" ref="dt-EQName"/></phrase>.
+                     <phrase diff="chg" at="2022-01-01"><xnt spec="XP40" ref="dt-EQName"/></phrase>.
                      If it is a lexical QName with no prefix, it is
-                     expanded using the <phrase diff="chg" at="A">default namespace for types</phrase>.
+                     expanded using the <phrase diff="chg" at="2022-01-01">default namespace for types</phrase>.
                      This <rfc2119>must</rfc2119> be the name of a type definition included in the
                         <termref def="dt-in-scope-schema-component">in-scope schema
                         components</termref> for the stylesheet. </p>
@@ -36643,7 +36643,7 @@ return ($m?price - $m?discount)</eg>
                            is not defined in an in-scope namespace declaration, or if the QName is
                            not the name of a type definition included in the <termref def="dt-in-scope-schema-component">in-scope schema
                               components</termref> for the <termref def="dt-package">package</termref>.
-                        <phrase diff="add" at="A">[XSLT 3.0 Erratum E20, bug 30234]</phrase></p>
+                        <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E20, bug 30234]</phrase></p>
                      </error>
                   </p>
                   <p>
@@ -36989,7 +36989,7 @@ return ($m?price - $m?discount)</eg>
                   attribute. </p>
             </error>
          </p>
-         <p diff="del" at="A">The <code>build-tree</code> attribute controls whether the
+         <p diff="del" at="2022-01-01">The <code>build-tree</code> attribute controls whether the
             raw <termref def="dt-principal-result"/> or <termref def="dt-secondary-result"/> is
             converted to a <termref def="dt-final-result-tree"/>. The default depends on the value
             of the <code>method</code> attribute: the default is <code>yes</code> if the
@@ -36997,7 +36997,7 @@ return ($m?price - $m?discount)</eg>
                <code>xhtml</code>, or <code>text</code>, or if it is omitted; the default is <code>no</code> if the <code>method</code> attribute
                specifies <code>json</code> or <code>adaptive</code>. A <termref def="dt-final-result-tree"/> may be constructed whether or not it is subsequently
             serialized.</p>
-         <p diff="add" at="A">
+         <p diff="add" at="2022-01-01">
             If the result is not serialized, then the decision whether to return the raw result 
             or to construct a tree depends on the effective value of the <code>build-tree</code> attribute. 
             If the effective value of the <code>build-tree</code> attribute is <code>yes</code>, then a 
@@ -37012,7 +37012,7 @@ return ($m?price - $m?discount)</eg>
                methods or for serialization methods introduced in future versions of this
                specification.</p>
          </note>
-         <p diff="del" at="A">Unless the processor implements the XPath 3.1 feature, the 
+         <p diff="del" at="2022-01-01">Unless the processor implements the XPath 3.1 feature, the 
             <code>method</code> values <code>json</code> and
                <code>adaptive</code>
             <rfc2119>must</rfc2119> be rejected as invalid, and the attributes
@@ -37189,9 +37189,9 @@ return ($m?price - $m?discount)</eg>
                   the serialization parameter to the literal 7-character string <code>"#absent"</code>. </p>
                <note>
                   <p>The <code>item-separator</code> attribute has no
-                     effect if the sequence being serialized contains only one item<phrase diff="del" at="A">, which will
+                     effect if the sequence being serialized contains only one item<phrase diff="del" at="2022-01-01">, which will
                      always be the case if the effective value of <code>build-tree</code> is
-                        <code>yes</code></phrase>. <phrase diff="add" at="A">[XSLT 3.0 Erratum E14, bug 30208].</phrase></p>
+                        <code>yes</code></phrase>. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E14, bug 30208].</phrase></p>
                </note>
             </item>
             <item>
@@ -37200,7 +37200,7 @@ return ($m?price - $m?discount)</eg>
                   value is <code>text/xml</code> in the case of the <code>xml</code> output method,
                      <code>text/html</code> in the case of the <code>html</code> and
                      <code>xhtml</code> output methods, and <code>text/plain</code> in the case of
-                  the <code>text</code> output method. <phrase diff="add" at="A">The default for 
+                  the <code>text</code> output method. <phrase diff="add" at="2022-01-01">The default for 
                      the <code>json</code> output method is <code>application/json</code>; the default 
                      for the adaptive output method is <termref def="dt-implementation-defined"/>.
                   [XSLT 3.0 Erratum E26, bug 30245].</phrase></p>
@@ -37556,7 +37556,7 @@ return ($m?price - $m?discount)</eg>
                <p>The higher-order functions feature, defined in
                <specref ref="hof-feature"/>.</p>
             </item>
-            <item diff="del" at="A">
+            <item diff="del" at="2022-01-01">
                <p>The XPath 3.1 feature, defined in ... .</p>
             </item>
             
@@ -37613,7 +37613,7 @@ return ($m?price - $m?discount)</eg>
             processor <rfc2119>must</rfc2119> provide a mode of operation which conforms to the 3.0
             versions of those specifications as extended by <specref ref="map"/> and <specref ref="json"/>.</p>
 
-         <p diff="del" at="A">A processor <rfc2119>may</rfc2119> also provide a mode of
+         <p diff="del" at="2022-01-01">A processor <rfc2119>may</rfc2119> also provide a mode of
             operation which conforms to the 3.1 versions of those specifications; in this case it
             must do so as described in XPath 3.1 feature.</p>
 
@@ -37643,7 +37643,7 @@ return ($m?price - $m?discount)</eg>
             or nodes with non-trivial type annotations.</p></item>
             <item><p>A processor that does not provide the <termref def="dt-hof-feature"/> constrains the data model so that
             it does not contain function items other than maps or arrays.</p></item>
-            <item diff="del" at="A"><p>A processor that does not provide the XPath 3.1 feature constrains the data model so that
+            <item diff="del" at="2022-01-01"><p>A processor that does not provide the XPath 3.1 feature constrains the data model so that
                it does not contain arrays.</p></item>
          </ulist>
          
@@ -37820,7 +37820,7 @@ return ($m?price - $m?discount)</eg>
                <rfc2119>may</rfc2119> offer alternative serialization capabilities, and these
                <rfc2119>may</rfc2119> make use of the serialization parameters defined on
                <elcode>xsl:output</elcode> and/or <elcode>xsl:result-document</elcode>.
-                  <phrase diff="add" at="A">Such a processor <rfc2119>may</rfc2119> implement 
+                  <phrase diff="add" at="2022-01-01">Such a processor <rfc2119>may</rfc2119> implement 
                      selected parts of the serialization capabilities defined in this specification. 
                      For example, it may implement selected output methods, or selected serialization 
                      properties. It may implement sequence normalization using the <code>item-separator</code> 
@@ -37829,7 +37829,7 @@ return ($m?price - $m?discount)</eg>
             
             <p>If the processor claims conformance with 
                the serialization feature then it <rfc2119>must</rfc2119> fully implement the 
-               <xfunction>serialize</xfunction> function defined in <phrase diff="chg" at="A"><bibref ref="xpath-functions-40"/></phrase>,
+               <xfunction>serialize</xfunction> function defined in <phrase diff="chg" at="2022-01-01"><bibref ref="xpath-functions-40"/></phrase>,
                and <rfc2119>must not</rfc2119>
                raise error <xerrorref spec="FO40" code="0010" class="DC"/> as the result of such a call.</p>
             
@@ -38411,7 +38411,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
       <inform-div1 id="schema-for-xslt">
          <head>Schemas for XSLT 4.0 Stylesheets</head>
          
-         <p diff="add" at="A">TODO: the two schemas need to be updated for XSLT 4.0</p>
+         <p diff="add" at="2022-01-01">TODO: the two schemas need to be updated for XSLT 4.0</p>
          
          <p>For convenience, schemas are provided for validation of XSLT 3.0 stylesheets
          using the XSD 1.1 and Relax NG schema languages. These are non-normative. Neither will detect
@@ -38510,7 +38510,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
 
       </inform-div1>
 
-      <inform-div1 id="changes-since-3.0" diff="add" at="A">
+      <inform-div1 id="changes-since-3.0" diff="add" at="2022-01-01">
          <head>Changes since XSLT 3.0</head>
          <div2 id="xslt-changes-since-3.0">
             <head>Changes in successive Drafts</head>
@@ -38607,7 +38607,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
          </div2>
       </inform-div1>
    
-      <inform-div1 id="todo-list" diff="add" at="A">
+      <inform-div1 id="todo-list" diff="add" at="2022-01-01">
          <head>Changes Pending</head>
          <p>Further work is needed in the following areas:</p>
             <olist>
@@ -38620,7 +38620,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
             </olist>
       </inform-div1>
 
-      <inform-div1 id="incompatibilities" diff="add" at="A">
+      <inform-div1 id="incompatibilities" diff="add" at="2022-01-01">
          <head>Incompatibilities with XSLT 3.0</head>
          <p>This section lists all known incompatibilities with XSLT 3.0, that is, situations
                where a stylesheet that is error-free

--- a/style/extract.xsl
+++ b/style/extract.xsl
@@ -91,7 +91,7 @@
 </xsl:template>
 
 <xsl:template match="termdef">
-  <xsl:copy>
+  <xsl:copy copy-namespaces="no">
     <xsl:copy-of select="@*"/>
   </xsl:copy>
 </xsl:template>


### PR DESCRIPTION
This PR fixes issue #270 concerning the visibility of XSLT modes.

It also deals with a lot of editorial issues, some highlighted in issue #275.

It changes the manual change markup in the XSLT spec to use `at-"date"` format rather than `at="draft-number"` (dates are more useful for the incremental development process we are following). And it fixes some cross-spec-reference issues, and some violations of hyphenation diktats.

Also bundled with this bug fix are other editorial changes to fix cross-spec linking errors; for details see the individual commit messages.