### PR TITLE
Make './gradlew publish' work on Windows #255

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -344,7 +344,7 @@ task xslt_grammar(
               "${projectDir}/style/extract-tokens.xsl",
               "${buildDir}/xslt-40/tokens-with-dups.xml",
               ["spec": "xslt-40",
-               "grammar-file": "${buildDir}/xslt-40/temp-xslt40-grammar.xml"])
+               "grammar-file": buildDir.toURI().resolve("xslt-40/temp-xslt40-grammar.xml")])
   }
 
   doLast {
@@ -358,8 +358,8 @@ task xslt_grammar(
               "${projectDir}/specifications/xslt-40/style/convert-grammar.xsl",
               "${buildDir}/xslt-40/src/xslt-40-assembled.xml",
               ["spec": "xslt-40",
-               "grammar-file": "${buildDir}/xslt-40/temp-xslt40-grammar.xml",
-               "tokens-file": "${buildDir}/xslt-40/tokens.xml"])
+               "grammar-file": buildDir.toURI().resolve("xslt-40/temp-xslt40-grammar.xml"),
+               "tokens-file": buildDir.toURI().resolve("xslt-40/tokens.xml")])
   }
 }
 
@@ -392,16 +392,16 @@ task xslt_merge_catalog(
     transform("${xslt_grammar.outputs.getFiles().getSingleFile()}",
               "${projectDir}/specifications/xslt-40/style/merge-xslt-function-specs.xsl",
               "${buildDir}/xslt-40/src/xslt-expanded0.xml",
-              ["function-catalog": "${projectDir}/specifications/xslt-40/src/function-catalog.xml",
+              ["function-catalog": projectDir.toURI().resolve("specifications/xslt-40/src/function-catalog.xml"),
                "built-in-streamability-expanded":
-                 "${buildDir}/xslt-40/built-in-streamability-expanded.xml"])
+                 buildDir.toURI().resolve("xslt-40/built-in-streamability-expanded.xml")])
   }
 
   doLast {
     transform("${buildDir}/xslt-40/src/xslt-expanded0.xml",
               "${projectDir}/specifications/xslt-40/style/merge-element-specs.xsl",
               "${buildDir}/xslt-40/src/xslt-expanded1.xml",
-              ["catalog": "${projectDir}/specifications/xslt-40/src/element-catalog.xml"])
+              ["catalog": projectDir.toURI().resolve("specifications/xslt-40/src/element-catalog.xml")])
   }
 
   doLast {
@@ -683,7 +683,7 @@ task shared_40(
                 "${projectDir}/style/extract-tokens.xsl",
                 "${buildDir}/xquery-40/tokens-with-dups.xml",
                 ["spec": shortName,
-                 "grammar-file": "${buildDir}/xquery-40/temp-${shortName}-grammar.xml"])
+                 "grammar-file": buildDir.toURI().resolve("xquery-40/temp-${shortName}-grammar.xml")])
     }
 
     doLast {
@@ -721,8 +721,8 @@ task shared_40(
       transform("${buildDir}/xquery-40/src/${shortName}-preprocessed.xml",
                 "${projectDir}/specifications/xquery-40/style/assemble-xquery.xsl",
                 "${buildDir}/xquery-40/src/${shortName}-assembled.xml",
-                ["grammar-file": "${buildDir}/xquery-40/temp-${shortName}-grammar.xml",
-                 "tokens-file": "${buildDir}/xquery-40/tokens-${shortName}.xml",
+                ["grammar-file": buildDir.toURI().resolve("xquery-40/temp-${shortName}-grammar.xml"),
+                 "tokens-file": buildDir.toURI().resolve("xquery-40/tokens-${shortName}.xml"),
                  "spec": "${shortName}40"])
     }
 


### PR DESCRIPTION
Fix #255 

Repeat after me, "filenames are not URIs." Not on some platforms, anyway.

I still get a warning about "correctness" because of the interaction between a couple of tasks. That doesn't happen on a *nix platform so I don't know if it's related to the difference between forward and backward slashes or if it's a consequence of the build changes I made to support the new SVG (that might be) in data model. They seem harmless for the moment.
