### PR TITLE
Rewrite XSLT §10.3.4 (function overriding) for clarity

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -18351,54 +18351,116 @@ and <code>version="1.0"</code> otherwise.</p>
 
 
             </div3>
-            <div3 id="function-visibility-and-overriding" diff="chg" at="variadicity">
+            <div3 id="function-visibility-and-overriding" diff="chg" at="2022-11-29">
                <head>Visibility and Overriding of Functions</head>
+               
+               <p>It is possible to have multiple function declarations sharing the same function name and arity:</p>
+               <ulist>
+                  <item><p>Multiple <elcode>xsl:function</elcode> declarations 
+                     are allowed within a single <termref def="dt-package"/> if they have different
+                     <termref def="dt-import-precedence"/>.</p></item>
+                  <item><p>A function declared using <elcode>xsl:function</elcode>
+                  may have the same name and arity as an <termref def="dt-extension-function"/>.</p></item>
+                  <item><p>A function declared within one package may be overridden
+                  (using <elcode>xsl:override</elcode>) in another package.</p></item>
+               </ulist>
+               
+               <p>The rules governing these three scenarios are given in the sections that follow.</p>
+               
+               <div4 id="function-overriding-within-package">
+                  <head>Overriding Functions within a Package</head>
+                  
+                  <p>Two stylesheet functions with the same name may appear in a package if their
+                  <termref def="dt-arity-range">arity ranges</termref> do not overlap. Neither overrides the other;
+                  the function that is selected is determined by the arity of the function call or function reference.</p>
+                  
+                  <p>In addition, a stylesheet function may be overridden by another stylesheet function with the same name that
+                     has higher <termref def="dt-import-precedence"/>. Such overriding is only allowed, however, if the 
+                     <termref def="dt-arity-range"/> of the overriding function
+                     includes the totality of the arity range of the overridden function.</p>
+                  
+                  <p><termdef id="dt-eclipsed" term="eclipsed">An <elcode>xsl:function</elcode> declaration
+                     <var>F</var> is said to be <term>eclipsed</term> if the containing package includes 
+                     an <elcode>xsl:function</elcode> declaration
+                     <var>G</var> such that <var>F</var> and <var>G</var> have the same name, <var>F</var> has lower
+                     <termref def="dt-import-precedence"/> than <var>G</var>, and the <termref def="dt-arity-range"/>
+                     of <var>G</var> includes the totality of the arity range of <var>F</var>.</termdef></p>
+                  
+                  <p>
+                     <error spec="XT" type="static" class="SE" code="0769">
+                        <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
+                           contain an <elcode>xsl:function</elcode>
+                           declaration <var>F</var> and an <elcode>xsl:function</elcode> declaration
+                           <var>G</var> such that <var>F</var> and <var>G</var> have the same 
+                           <termref def="dt-expanded-qname"/>, <var>F</var> has lower
+                           <termref def="dt-import-precedence"/> than <var>G</var>, and the 
+                           <termref def="dt-arity-range"/>
+                           of <var>G</var> includes part but not all of the arity range of <var>F</var>,
+                           unless <var>G</var> is itself <termref def="dt-eclipsed"/> by another 
+                           <elcode>xsl:function</elcode> declaration.</p>
+                     </error>
+                  </p>
+                  
+                  <p>
+                     <error spec="XT" type="static" class="SE" code="0770">
+                        <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
+                           contain an <elcode>xsl:function</elcode>
+                           declaration <var>F</var> and an <elcode>xsl:function</elcode> declaration
+                           <var>G</var> such that <var>F</var> and <var>G</var> have the same 
+                           <termref def="dt-expanded-qname"/> and the same
+                           <termref def="dt-import-precedence"/>, if the 
+                           <termref def="dt-arity-range">arity ranges</termref>
+                           of <var>F</var> and <var>G</var> overlap in whole or in part, 
+                           unless <var>F</var> and <var>G</var> are both <termref def="dt-eclipsed"/> by another 
+                           <elcode>xsl:function</elcode> declaration.</p>
+                        
+                     </error>
+                  </p>
+                  
+               </div4>
+               
+               <div4 id="overriding-extension-functions">
+                  <head>Overriding Extension Functions</head>
+                  
+                  <p>The optional <code>override-extension-function</code> attribute defines what
+                     happens if an <elcode>xsl:function</elcode> declaration has the same name and 
+                     overlapping <termref def="dt-arity-range"/> 
+                     as a function provided by the implementer or made available in
+                     the static context using an implementation-defined mechanism. If the <code>override-extension-function</code> attribute
+                     has the value <code>yes</code>, then this function is used in preference; if it
+                     has the value <code>no</code>, then the other function is used in preference. The
+                     default value is <code>yes</code>.</p>
+                  <note>
+                     <p>Specifying <code>override-extension-function="yes"</code> ensures
+                        interoperable behavior: the same code will execute with all processors.
+                        Specifying <code>override-extension-function="no"</code> is useful when
+                        writing a fallback implementation of a function that is available with some
+                        processors but not others: it allows the vendor’s implementation of the
+                        function (or a user’s implementation written as an extension function)
+                        to be used in preference to the stylesheet implementation, which is useful when
+                        the extension function is more efficient.</p>
+                     <p>The <code>override-extension-function</code> attribute does <emph>not</emph>
+                        affect the rules for deciding which of several <termref def="dt-stylesheet-function">stylesheet functions</termref> with the same
+                        name and <termref def="dt-arity">arity</termref> takes precedence.</p>
+                  </note>
+                  <p>The <code>override</code> attribute is a <termref def="dt-deprecated"/> synonym of <code>override-extension-function</code>,
+                     retained for compatibility with XSLT 2.0. If both attributes are present then they
+                     <rfc2119>must</rfc2119> have the same value.</p>
+                  
+               </div4>
+               
+               <div4 id="overriding-functions-in-used-packages">
+                  <head>Overriding Functions in a Used Package</head>   
+               
+               <p>When a package is referenced in <elcode>xsl:use-package</elcode>, functions
+               declared in the used package become available in the using package, conditional
+               on their declared <termref def="dt-visibility">visibility</termref>, as described 
+                  in <specref ref="packages"/>.</p>
 
-               <p>If the <code>visibility</code> attribute is present with the
+               <p>If the <code>visibility</code> attribute of <elcode>xsl:function</elcode> is present with the
                   value <code>abstract</code> then the <termref def="dt-sequence-constructor"/>
                   defining the function body <rfc2119>must</rfc2119> be empty.</p>
                
-               <p>A stylesheet function may be overridden by another stylesheet function with the same name that
-                  has higher <termref def="dt-import-precedence"/>. This is only allowed, however, if the 
-                  <termref def="dt-arity-range"/> of the overriding function
-                  includes the totality of the arity range of the overridden function.</p>
-               <p><termdef id="dt-eclipsed" term="eclipsed">An <elcode>xsl:function</elcode> declaration
-                  <var>F</var> is said to be <term>eclipsed</term> if the containing package includes an <elcode>xsl:function</elcode> declaration
-                  <var>G</var> such that <var>F</var> and <var>G</var> have the same name, <var>F</var> has lower
-                  <termref def="dt-import-precedence"/> than <var>G</var>, and the <termref def="dt-arity-range"/>
-                  of <var>G</var> includes the totality of the arity range of <var>F</var>.</termdef></p>
-               
-               <p>
-                  <error spec="XT" type="static" class="SE" code="0769">
-                     <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
-                        contain an <elcode>xsl:function</elcode>
-                        declaration <var>F</var> and an <elcode>xsl:function</elcode> declaration
-                        <var>G</var> such that <var>F</var> and <var>G</var> have the same 
-                        <termref def="dt-expanded-qname"/>, <var>F</var> has lower
-                        <termref def="dt-import-precedence"/> than <var>G</var>, and the 
-                        <termref def="dt-arity-range"/>
-                        of <var>G</var> includes part but not all of the arity range of <var>F</var>,
-                     unless <var>G</var> is itself <termref def="dt-eclipsed"/> by another 
-                        <elcode>xsl:function</elcode> declaration.</p>
-                  </error>
-               </p>
-               
-               <p>
-                  <error spec="XT" type="static" class="SE" code="0770">
-                     <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
-                        contain an <elcode>xsl:function</elcode>
-                        declaration <var>F</var> and an <elcode>xsl:function</elcode> declaration
-                        <var>G</var> such that <var>F</var> and <var>G</var> have the same 
-                        <termref def="dt-expanded-qname"/> and the same
-                        <termref def="dt-import-precedence"/>, if the 
-                        <termref def="dt-arity-range">arity ranges</termref>
-                        of <var>F</var> and <var>G</var> overlap in whole or in part, 
-                        unless <var>F</var> and <var>G</var> are both <termref def="dt-eclipsed"/> by another 
-                        <elcode>xsl:function</elcode> declaration.</p>
-                       
-                  </error>
-               </p>
-
                <p>The XPath specification states that the function that is executed as the result of
                   a function call is identified by looking in the static context for a 
                   <termref def="dt-function-definition"/> whose name and <termref def="dt-arity-range"/>
@@ -18424,32 +18486,9 @@ and <code>version="1.0"</code> otherwise.</p>
                
                
 
-               <p>The <termref def="dt-visibility">visibility</termref> of the
-                  function in other packages depends on the value of the <code>visibility</code>
-                  attribute and other factors, as described in <specref ref="packages"/>.</p>
+               
 
-               <p>The optional <code>override-extension-function</code> attribute defines what
-                  happens if this function has the same name and <termref def="dt-arity">arity</termref> as a function provided by the implementer or made available in
-                  the static context using an implementation-defined mechanism. If the <code>override-extension-function</code> attribute
-                  has the value <code>yes</code>, then this function is used in preference; if it
-                  has the value <code>no</code>, then the other function is used in preference. The
-                  default value is <code>yes</code>.</p>
-               <note>
-                  <p>Specifying <code>override-extension-function="yes"</code> ensures
-                     interoperable behavior: the same code will execute with all processors.
-                     Specifying <code>override-extension-function="no"</code> is useful when
-                     writing a fallback implementation of a function that is available with some
-                     processors but not others: it allows the vendor’s implementation of the
-                     function (or a user’s implementation written as an extension function)
-                     to be used in preference to the stylesheet implementation, which is useful when
-                     the extension function is more efficient.</p>
-                  <p>The <code>override-extension-function</code> attribute does <emph>not</emph>
-                     affect the rules for deciding which of several <termref def="dt-stylesheet-function">stylesheet functions</termref> with the same
-                     name and <termref def="dt-arity">arity</termref> takes precedence.</p>
-               </note>
-               <p>The <code>override</code> attribute is a <termref def="dt-deprecated"/> synonym of <code>override-extension-function</code>,
-                  retained for compatibility with XSLT 2.0. If both attributes are present then they
-                     <rfc2119>must</rfc2119> have the same value.</p>
+               
                <!--<p>
                   <error spec="XT" type="static" class="SE" code="0770">
                      <p>It is a <termref def="dt-static-error">static error</termref> for a <termref def="dt-package">package</termref> to
@@ -18466,10 +18505,11 @@ and <code>version="1.0"</code> otherwise.</p>
                   child of <elcode>xsl:override</elcode>, there <rfc2119>must</rfc2119> be a
                   <termref def="dt-compatible"/> stylesheet function in the 
                   <termref def="dt-package">package</termref> referenced by the containing
-                     <elcode>xsl:use-package</elcode> element; the <termref def="dt-visibility">visibility</termref> of that function must be <code>public</code> or
+                     <elcode>xsl:use-package</elcode> element; the <termref def="dt-visibility">visibility</termref> 
+                  of that function must be <code>public</code> or
                   <code>abstract</code> (See also <specref ref="package-overriding-components"/>.)</p>
                
-
+               </div4>
 
             </div3>
             <div3 id="streamability-of-stylesheet-functions">


### PR DESCRIPTION
Essentially editorial - clarifies the existing rules, as described in issue #277