### PR TITLE
Add grammar for "if (test) then {expr}" with no else

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1319,10 +1319,15 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>(</g:string>
     <g:ref name="Expr"/>
     <g:string>)</g:string>
-    <g:string>then</g:string>
-    <g:ref name="ExprSingle"/>
-    <g:string>else</g:string>
-    <g:ref name="ExprSingle"/>
+    <g:choice>
+      <g:sequence>
+        <g:string>then</g:string>
+        <g:ref name="ExprSingle"/>
+        <g:string>else</g:string>
+        <g:ref name="ExprSingle"/>
+      </g:sequence>
+      <g:ref name="EnclosedExpr"/>
+    </g:choice>
   </g:production>
 
   <!-- [ start TryCatchExpr -->

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1320,14 +1320,44 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="Expr"/>
     <g:string>)</g:string>
     <g:choice>
-      <g:sequence>
-        <g:string>then</g:string>
-        <g:ref name="ExprSingle"/>
-        <g:string>else</g:string>
-        <g:ref name="ExprSingle"/>
-      </g:sequence>
-      <g:ref name="EnclosedExpr"/>
+      <g:ref name="UnbracedActions"/>
+      <g:ref name="BracedActions"/>
     </g:choice>
+  </g:production>
+  
+  <g:production name="UnbracedActions">
+    <g:string>then</g:string>
+    <g:ref name="ExprSingle"/>
+    <g:string>else</g:string>
+    <g:ref name="ExprSingle"/>
+  </g:production>
+  
+  <g:production name="BracedActions">
+    <g:ref name="ThenAction"/>
+    <g:zeroOrMore>
+      <g:ref name="ElseIfAction"/>
+    </g:zeroOrMore>
+    <g:optional>
+      <g:ref name="ElseAction"/>
+    </g:optional>
+  </g:production>
+  
+  <g:production name="ThenAction">
+    <g:ref name="EnclosedExpr"/>
+  </g:production>
+  
+  <g:production name="ElseIfAction">
+    <g:string>else</g:string>
+    <g:string>if</g:string>
+    <g:string>(</g:string>
+    <g:ref name="Expr"/>
+    <g:string>)</g:string>
+    <g:ref name="EnclosedExpr"/>
+  </g:production>
+  
+  <g:production name="ElseAction">
+    <g:string>else</g:string>
+    <g:ref name="EnclosedExpr"/>
   </g:production>
 
   <!-- [ start TryCatchExpr -->

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -17402,44 +17402,79 @@ Also, within a <termref def="dt-path-expression"
       <div2 id="id-conditionals">
          <head>Conditional Expressions</head>
          <p diff="chg" at="2022-12-07">&language; allows conditional expressions to be written in several different ways.</p>
-         <scrap diff="chg" at="2022-12-07">
+         <scrap diff="chg" at="2023-01-10">
             <head/>
             <prodrecap id="IfExpr" ref="IfExpr"/>
+            <prodrecap id="UnbracedActions" ref="UnbracedActions"/>
+            <prodrecap id="BracedActions" ref="BracedActions"/>
+            <prodrecap id="ThenAction" ref="ThenAction"/>
+            <prodrecap id="ElseIfAction" ref="ElseIfAction"/>
+            <prodrecap id="ElseAction" ref="ElseAction"/>
             <prodrecap ref="EnclosedExpr"/>
             <prodrecap id="TernaryConditionalExpr" ref="TernaryConditionalExpr"/>
          </scrap>
          
-         <p diff="chg" at="2022-12-07">There are three formats with essentially the same semantics.</p>
-         <ulist diff="chg" at="2022-12-07">
-         <item><p >The first format uses three keywords: <code>if</code>, <code>then</code> and <code>else</code>:</p>
-            <eg >if (test-expression) then then-expression else else-expression</eg></item>
-            <item><p>The second format uses the keyword <code>if</code> followed by an expression in curly braces:</p>
-            <eg>if (test-expression) { then-expression }</eg>
-         <p>With this format, the <code>else-expression</code> is omitted, and is implicitly <code>()</code> (the empty sequence).</p>
-            <note><p>The grammar for <nt def="EnclosedExpr">EnclosedExpr</nt> allows the <code>then-expression</code> to be omitted,
-               defaulting to <code>()</code>: this is allowed, but not useful.</p></note>
-       
-         </item>
-            <item><p>The ternary operator syntax uses the operators <code>??</code> and <code>!!</code>:</p>
-               <eg>test-expression ?? then-expression !! else-expression</eg>
-         
-               <note><p>The ternary operator syntax is borrowed from Perl6.</p></note></item>
+         <p diff="chg" at="2023-01-10">There are three formats with essentially the same semantics.</p>
+         <ulist diff="chg" at="2023-01-10">
+            <item><p>The unbraced expression <code>if (C) then T else E</code> is equivalent to
+            the braced expression <code>if (C) {T} else {E}</code>.</p></item>
+            <item><p>The ternary expression <code>C ?? T !! E</code> is equivalent to the
+               braced expression <code>if (C) {T} else {E}</code>.</p>
+               <note><p>The ternary operator syntax is borrowed from Perl6.</p></note>
+            </item>
+            <item><p>The value <var>V</var> of a conditional expression using the
+               braced format is obtained by applying the following rules in order, finishing
+               as soon as <var>V</var> has a value:</p>
+              <olist>
+                 <item><p>Let <var>C</var> be the <termref
+                       def="dt-ebv"
+                       >effective boolean value</termref> of the test expression, as defined in <specref
+                          ref="id-ebv"/>.</p>
+                 </item>
+                    <item><p>If <var>C</var> is true, <var>V</var> is the
+                       value of the <nt def="EnclosedExpr">EnclosedExpr</nt> in the <nt def="ThenAction">ThenAction</nt>.</p>
+                    </item>
+                 <item><p>The <nt def="ElseIfAction">ElseIfActions</nt> (if any) are processed in order as follows:</p>
+                    <olist>
+                       <item><p>Let <var>C'</var> be the <termref
+                          def="dt-ebv"
+                          >effective boolean value</termref> of the test expression, as defined in <specref
+                             ref="id-ebv"/>.</p></item>
+                       <item><p>If <var>C'</var> is true, <var>V</var> is the
+                          value of the <nt def="EnclosedExpr">EnclosedExpr</nt> in the <nt def="ElseIfAction">ElseIfAction</nt>
+                           
+                       </p>
+                       </item>
+                    </olist>
+                 </item>
+                 <item>
+                    <p>If there is an <nt def="ElseAction">ElseAction</nt>, then <var>V</var>
+                       is the value of its <nt def="EnclosedExpr">EnclosedExpr</nt>.</p>
+                 </item>
+                 <item>
+                    <p><var>V</var> is the empty sequence.</p>
+                 </item>
+              </olist>
             
+            </item>
+  
+     
          </ulist>
          
-         <p>Whichever format is used, the first step in processing a conditional expression is to find
+         <p diff="del" at="2023-01-10">Whichever format is used, the first step in processing a conditional expression is to find
 the <termref
                def="dt-ebv"
                >effective boolean value</termref> of the test expression, as defined in <specref
                ref="id-ebv"/>.</p>
 
-         <p>The value of a conditional expression is defined as follows: If the
+         <p diff="del" at="2023-01-10">The value of a conditional expression is defined as follows: If the
 effective boolean value of the test expression is <code>true</code>, the value of the then-expression is returned. If the
 effective boolean value of the test expression is <code>false</code>,
 the value of the else-expression is returned.</p>
          <p>Conditional expressions have a special rule for propagating <termref
                def="dt-dynamic-error"
-               >dynamic errors</termref>: <phrase diff="chg" at="B">the <code>then</code> and <code>else</code> expressions are
+               >dynamic errors</termref>: <phrase diff="chg" at="2023-01-10">expressions whose value is not needed for
+                  computing the result are
             <termref def="dt-guarded"/>, as described in <specref ref="id-guarded-expressions"/>, to prevent
                   spurious dynamic errors.</phrase></p>
          <p>Here are some examples of conditional expressions:</p>
@@ -17467,8 +17502,17 @@ named <code>discounted</code>, independently of its value:</p>
   else $part/retail]]></eg>
             </item>
             
+            <item diff="add" at="2023-01-10">
+               <p>The above expression can equivalently be written:</p>
+               <eg role="parse-test"><![CDATA[if ($part/@discounted) {
+    $part/wholesale
+  } else {
+    $part/retail
+  }]]></eg>
+            </item>
+            
             <item diff="add" at="2022-10-01">
-               <p>The above example can instead be written:</p>
+               <p>The above example can also be written:</p>
                <eg role="parse-test">$part/(@discounted ?? wholesale !! retail)</eg>
                <p>(Note: the equivalence holds only if <code>$part</code> is a single item.)</p>
             </item>
@@ -17479,10 +17523,14 @@ named <code>discounted</code>, independently of its value:</p>
                
             </item>
          </ulist>
-         <note diff="add" at="2022-12-07">
-            <p>When a <code>then</code> clause is present, the <code>else</code> clause is mandatory. When curly braces
-            are used, the <code>else</code> clause is disallowed. This is done to avoid the "dangling else ambiguity"
-            found in many other languages.</p>
+         <note diff="add" at="2023-01-10">
+            <p>The "dangling else ambiguity" found in many other languages cannot arise:</p>
+            <ulist>
+               <item><p>In the unbraced format, both the <code>then</code> and <code>else</code> clauses
+                  are mandatory.</p></item>
+               <item><p>In the braced format, an <code>else</code> clause is always unambiguously
+               associated with the immediately containing <nt def="IfExpr">IfExpr</nt>.</p></item>
+            </ulist>
          </note>
       </div2>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -17401,26 +17401,33 @@ Also, within a <termref def="dt-path-expression"
 
       <div2 id="id-conditionals">
          <head>Conditional Expressions</head>
-         <p>&language; provides a conditional expression based on the keywords <code>if</code>, <code>then</code>, and <code>else</code>.</p>
-         <p diff="add" at="A">In addition, it provides a more concise syntax as a ternary expression using the operators <code>??</code>
-         and <code>!!</code></p>
-         <scrap>
+         <p diff="chg" at="2022-12-07">&language; allows conditional expressions to be written in several different ways.</p>
+         <scrap diff="chg" at="2022-12-07">
             <head/>
             <prodrecap id="IfExpr" ref="IfExpr"/>
+            <prodrecap ref="EnclosedExpr"/>
             <prodrecap id="TernaryConditionalExpr" ref="TernaryConditionalExpr"/>
          </scrap>
          
-         <p diff="add" at="A">Both constructs have the same semantics. There are three expressions, called the <term>test expression</term>,
-            the <term>then-expression</term>, and the the <term>else-expression</term>.
-         </p>
-         <p diff="add" at="A">With the keyword syntax, the format is:</p>
-         <eg diff="add" at="A">if (test-expression) then then-expression else else-expression</eg>
-         <p diff="add" at="A">With the ternary operator syntax, the format is:</p>
-         <eg diff="add" at="A">test-expression ?? then-expression !! else-expression</eg>
+         <p diff="chg" at="2022-12-07">There are three formats with essentially the same semantics.</p>
+         <ulist diff="chg" at="2022-12-07">
+         <item><p >The first format uses three keywords: <code>if</code>, <code>then</code> and <code>else</code>:</p>
+            <eg >if (test-expression) then then-expression else else-expression</eg></item>
+            <item><p>The second format uses the keyword <code>if</code> followed by an expression in curly braces:</p>
+            <eg>if (test-expression) { then-expression }</eg>
+         <p>With this format, the <code>else-expression</code> is omitted, and is implicitly <code>()</code> (the empty sequence).</p>
+            <note><p>The grammar for <nt def="EnclosedExpr">EnclosedExpr</nt> allows the <code>then-expression</code> to be omitted,
+               defaulting to <code>()</code>: this is allowed, but not useful.</p></note>
+       
+         </item>
+            <item><p>The ternary operator syntax uses the operators <code>??</code> and <code>!!</code>:</p>
+               <eg>test-expression ?? then-expression !! else-expression</eg>
          
-         <note><p>The ternary operator syntax is borrowed from Perl6.</p></note>
+               <note><p>The ternary operator syntax is borrowed from Perl6.</p></note></item>
+            
+         </ulist>
          
-         <p>The first step in processing a conditional expression is to find
+         <p>Whichever format is used, the first step in processing a conditional expression is to find
 the <termref
                def="dt-ebv"
                >effective boolean value</termref> of the test expression, as defined in <specref
@@ -17460,12 +17467,23 @@ named <code>discounted</code>, independently of its value:</p>
   else $part/retail]]></eg>
             </item>
             
-            <item diff="add" at="A">
+            <item diff="add" at="2022-10-01">
                <p>The above example can instead be written:</p>
                <eg role="parse-test">$part/(@discounted ?? wholesale !! retail)</eg>
                <p>(Note: the equivalence holds only if <code>$part</code> is a single item.)</p>
             </item>
+            <item diff="add" at="2022-12-07">
+               <p>The following example returns the attribute node <code>@discount</code> provided the value of <code>@price</code>
+                  is greater than 100; otherwise it returns the empty sequence:</p>
+               <eg role="parse-test">if (@price gt 100) {@discount}</eg>
+               
+            </item>
          </ulist>
+         <note diff="add" at="2022-12-07">
+            <p>When a <code>then</code> clause is present, the <code>else</code> clause is mandatory. When curly braces
+            are used, the <code>else</code> clause is disallowed. This is done to avoid the "dangling else ambiguity"
+            found in many other languages.</p>
+         </note>
       </div2>
 
       <div2 id="id-otherwise" diff="add" at="A">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -17505,10 +17505,10 @@ named <code>discounted</code>, independently of its value:</p>
             <item diff="add" at="2023-01-10">
                <p>The above expression can equivalently be written:</p>
                <eg role="parse-test"><![CDATA[if ($part/@discounted) {
-    $part/wholesale
-  } else {
-    $part/retail
-  }]]></eg>
+  $part/wholesale
+} else {
+  $part/retail
+}]]></eg>
             </item>
             
             <item diff="add" at="2022-10-01">
@@ -17521,6 +17521,18 @@ named <code>discounted</code>, independently of its value:</p>
                   is greater than 100; otherwise it returns the empty sequence:</p>
                <eg role="parse-test">if (@price gt 100) {@discount}</eg>
                
+            </item>
+            <item diff="add" at="2023-01-10">
+               <p>The following example tests a number of conditions:</p>
+               <eg role="parse-test"><![CDATA[if (@code = 1) {
+  "food"
+} else if (@code = 2) {
+  "fashion"
+} else if (@code = 3) {
+  "household"
+} else {
+  "general"
+}]]></eg>
             </item>
          </ulist>
          <note diff="add" at="2023-01-10">

--- a/specifications/xquery-40/src/query-examples.xml
+++ b/specifications/xquery-40/src/query-examples.xml
@@ -304,18 +304,18 @@ declare function local:swizzle($n as node()) as node() {
 				<code>product</code>, <code>size</code>, and <code>color</code> that occur together
 			in an <code>order</code>. The following query returns this list, enclosing each distinct
 			combination in a new element named <code>option</code>:</p>
-		<eg role="parse-test">for $p in fn:distinct-values(/orders/order/product), 
+		<eg role="parse-test" diff="chg" at="2022-12-07">for $p in fn:distinct-values(/orders/order/product), 
     $s in fn:distinct-values(/orders/order/size), 
     $c in fn:distinct-values(/orders/order/color)
 order by $p, $s, $c 
 return 
    if (fn:exists(/orders/order[product eq $p 
-         and size eq $s and color eq $c])) then 
+         and size eq $s and color eq $c])) { 
       &lt;option&gt; 
          &lt;product&gt;{$p}&lt;/product&gt;
          &lt;size&gt;{$s}&lt;/size&gt; 
          &lt;color&gt;{$c}&lt;/color&gt; 
       &lt;/option&gt; 
-   else ()</eg>
+   }</eg>
 	</div2>
 </inform-div1>


### PR DESCRIPTION
As discussed in issue #234. In reviewing this PR, I suggest we consider it together with the existing proposals for ternary conditionals (x ?? y !! z) and the "otherwise" operator.