### PR TITLE
Mike's content changes from PR 292

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <fos:functions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.w3.org/xpath-functions/spec/namespace fos.xsd"
    xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace">
@@ -17,9 +16,33 @@
       <fos:variable id="v-item2" name="item2" select="$po/line-item[2]"/>
       <fos:variable id="v-item3" name="item3" select="$po/line-item[3]"/>
    </fos:global-variables>
+
+   <fos:type id="uri-structure-record">
+      <fos:record extensible="true">
+         <fos:field name="uri" type="xs:string" required="false"/>
+         <fos:field name="scheme" type="xs:string" required="false"/>
+         <fos:field name="authority" type="xs:string" required="false"/>
+         <fos:field name="userinfo" type="xs:string" required="false"/>
+         <fos:field name="host" type="xs:string" required="false"/>
+         <fos:field name="port" type="xs:string" required="false"/>
+         <fos:field name="path" type="xs:string" required="false"/>
+         <fos:field name="query" type="xs:string" required="false"/>
+         <fos:field name="fragment" type="xs:string" required="false"/>
+         <fos:field name="path-segments" type="array(xs:string)" required="false"/>
+         <fos:field name="query-segments" type="array(record(key? as xs:string, value? as xs:string, *))" required="false"/>
+      </fos:record>
+   </fos:type>
+   
+   <fos:type id="random-number-generator-record">
+      <fos:record extensible="true">
+         <fos:field name="number" type="xs:double" required="true"/>
+         <fos:field name="next" type="function() as #random-number-generator-record" required="true"/>
+         <fos:field name="permute" type="function(item()*) as item()*" required="true"/>
+      </fos:record>
+   </fos:type>
+   
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
-         <fos:proto at="F" name="node-name" return-type="xs:QName?"/>
          <fos:proto name="node-name" return-type="xs:QName?">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -38,9 +61,9 @@
          <p>Returns the name of a node, as an <code>xs:QName</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context item (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p>If <code>$node</code> is the empty sequence, the empty sequence is returned.</p>
          <p>Otherwise, the function returns the result of the <code>dm:node-name</code> accessor as
             defined in <bibref
@@ -79,7 +102,6 @@
    </fos:function>
    <fos:function name="nilled" prefix="fn">
       <fos:signatures>
-         <fos:proto name="nilled" return-type="xs:boolean?"/>
          <fos:proto name="nilled" return-type="xs:boolean?">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -99,9 +121,9 @@
          <p>Returns true for an element that is <term>nilled</term>.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). <phrase diff="del" at="2022-11-29">The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p>If <code>$node</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>Otherwise the function returns the result of the <code>dm:nilled</code> accessor as
             defined in <bibref
@@ -136,7 +158,6 @@
    </fos:function>
    <fos:function name="string" prefix="fn">
       <fos:signatures>
-         <fos:proto name="string" return-type="xs:string"/>
          <fos:proto name="string" return-type="xs:string">
             <fos:arg name="item" type="item()?" default="." usage="absorption"/>
          </fos:proto>
@@ -228,7 +249,6 @@
    </fos:function>
    <fos:function name="data" prefix="fn">
       <fos:signatures>
-         <fos:proto name="data" return-type="xs:anyAtomicType*"/>
          <fos:proto name="data" return-type="xs:anyAtomicType*">
             <fos:arg name="input" type="item()*" default="." usage="absorption"/>
          </fos:proto>
@@ -248,9 +268,9 @@
             nodes by their typed values.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context item (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p> The result of <code>fn:data</code> is the sequence of atomic values produced by
             applying the following rules to each item in <code>$input</code>:</p>
          <ulist>
@@ -332,7 +352,6 @@
    </fos:function>
    <fos:function name="base-uri" prefix="fn">
       <fos:signatures>
-         <fos:proto name="base-uri" return-type="xs:anyURI?"/>
          <fos:proto name="base-uri" return-type="xs:anyURI?">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -395,7 +414,6 @@
    </fos:function>
    <fos:function name="document-uri" prefix="fn">
       <fos:signatures>
-         <fos:proto name="document-uri" return-type="xs:anyURI?"/>
          <fos:proto name="document-uri" return-type="xs:anyURI?">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -414,9 +432,9 @@
          <p>Returns the URI of a resource where a document can be found, if available.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). <phrase diff="del" at="2022-11-29">The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p>If <code>$node</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>If <code>$node</code> is not a document node, the function returns the empty
             sequence.</p>
@@ -464,17 +482,9 @@
    </fos:function>
    <fos:function name="error" prefix="fn">
       <fos:signatures>
-         <fos:proto name="error" return-type="none"/>
          <fos:proto name="error" return-type="none">
-            <fos:arg name="code" type="xs:QName?"/>
-         </fos:proto>
-         <fos:proto name="error" return-type="none">
-            <fos:arg name="code" type="xs:QName?"/>
-            <fos:arg name="description" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="error" return-type="none">
-            <fos:arg name="code" type="xs:QName?"/>
-            <fos:arg name="description" type="xs:string"/>
+            <fos:arg name="code" type="xs:QName?" default="()"/>
+            <fos:arg name="description" type="xs:string?" default="()"/>
             <fos:arg name="error-object" type="item()*" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
@@ -498,7 +508,7 @@
             external processing environment is <termref
                def="implementation-dependent">implementation-dependent</termref>.</p>
 
-         <p>There are three pieces of information that may be associated with an error:</p>
+         <p>There are three pieces of information that may be associated with an error.</p>
          <ulist>
             <item>
                <p>The <code>$code</code> is an error code that distinguishes this error from others.
@@ -513,15 +523,16 @@
                   namespace URI <code>NS</code> and local part <code>LP</code> will be returned in
                   the form <code>NS#LP</code>. The namespace URI part of the error code should
                   therefore not include a fragment identifier.</p>
-               <p>If no value is supplied for the <code>$code</code> argument (that is,
-                  if the function is called with no arguments or if the first argument is an empty sequence),
+               <p>If no value is supplied for the <code>$code</code> argument, <phrase diff="add" at="2022-12-19">or if the value supplied
+                  is an empty sequence,</phrase>
                   the effective value of the error code is <code>fn:QName('http://www.w3.org/2005/xqt-errors', 'err:FOER0000')</code>.</p>
             </item>
             <item>
                <p>The <code>$description</code> is a natural-language description of the error
                   condition.</p>
                <p>If no value is supplied for the <code>$description</code>
-                  argument (that is, if the function is called with less than two arguments), then the
+                  argument, <phrase diff="add" at="2022-12-19">or if the value supplied
+                     is an empty sequence,</phrase> then the
                   effective value of the description is <termref
                      def="implementation-dependent">implementation-dependent</termref>.</p>
             </item>
@@ -530,7 +541,8 @@
                   information about the error, and may be used in any way the application
                   chooses.</p>
                <p>If no value is supplied for the <code>$error-object</code>
-                  argument (that is, if the function is called with less than three arguments), then the
+                  argument <phrase diff="add" at="2022-12-19">or if the value supplied
+                     is an empty sequence,</phrase>, then the
                   effective value of the error object is <termref
                      def="implementation-dependent">implementation-dependent</termref>.</p>
             </item>
@@ -580,11 +592,8 @@
    <fos:function name="trace" prefix="fn">
       <fos:signatures>
          <fos:proto name="trace" return-type="item()*">
-            <fos:arg name="value" type="item()*"/>
-         </fos:proto>
-         <fos:proto name="trace" return-type="item()*">
             <fos:arg name="value" type="item()*" usage="transmission"/>
-            <fos:arg name="label" type="xs:string"/>
+            <fos:arg name="label" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -598,7 +607,7 @@
       <fos:rules>
          <p>The function returns <code>$value</code>, unchanged.</p>
          <p>In addition, the values of <code>$value</code>, converted to an <code>xs:string</code>,
-            and <code>$label</code> (if supplied)
+            and <code>$label</code> (if supplied <phrase diff="add" at="2022-12-19">and non-empty</phrase>)
             <rfc2119>may</rfc2119> be directed to a trace data set. The destination of the trace
             output is <termref
                def="implementation-defined"
@@ -1184,10 +1193,7 @@
       <fos:signatures>
          <fos:proto name="round" return-type="xs:numeric?">
             <fos:arg name="value" type="xs:numeric?"/>
-         </fos:proto>
-         <fos:proto name="round" return-type="xs:numeric?">
-            <fos:arg name="value" type="xs:numeric?"/>
-            <fos:arg name="precision" type="xs:integer"/>
+            <fos:arg name="precision" type="xs:integer" default="0"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1289,10 +1295,7 @@
       <fos:signatures>
          <fos:proto name="round-half-to-even" return-type="xs:numeric?">
             <fos:arg name="value" type="xs:numeric?"/>
-         </fos:proto>
-         <fos:proto name="round-half-to-even" return-type="xs:numeric?">
-            <fos:arg name="value" type="xs:numeric?"/>
-            <fos:arg name="precision" type="xs:integer"/>
+            <fos:arg name="precision" type="xs:integer" default="0"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1393,11 +1396,7 @@
          <fos:proto name="format-integer" return-type="xs:string">
             <fos:arg name="value" type="xs:integer?"/>
             <fos:arg name="picture" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="format-integer" return-type="xs:string">
-            <fos:arg name="value" type="xs:integer?"/>
-            <fos:arg name="picture" type="xs:string"/>
-            <fos:arg name="lang" type="xs:string?"/>
+            <fos:arg name="lang" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -1873,11 +1872,7 @@
          <fos:proto name="format-number" return-type="xs:string">
             <fos:arg name="value" type="xs:numeric?"/>
             <fos:arg name="picture" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="format-number" return-type="xs:string">
-            <fos:arg name="value" type="xs:numeric?"/>
-            <fos:arg name="picture" type="xs:string"/>
-            <fos:arg name="decimal-format-name" type="union(xs:string, xs:QName)?"/>
+            <fos:arg name="decimal-format-name" type="union(xs:string, xs:QName)?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -2070,7 +2065,7 @@
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the value of <var>e</var><sup><var>x</var></sup> where <var>x</var> is the argument value.</p>
+         <p>Returns the value of <var>e</var><sup>x</sup> where <var>x</var> is the argument value.</p>
       </fos:summary>
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
@@ -2136,7 +2131,7 @@
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the value of <code>10</code><sup><var>x</var></sup>, where <var>x</var> is the supplied argument value.</p>
+         <p>Returns the value of <code>10</code><sup>x</sup>, where <var>x</var> is the supplied argument value.</p>
       </fos:summary>
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
@@ -3211,11 +3206,7 @@
          <fos:proto name="compare" return-type="xs:integer?">
             <fos:arg name="value1" type="xs:string?"/>
             <fos:arg name="value2" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="compare" return-type="xs:integer?">
-            <fos:arg name="value1" type="xs:string?"/>
-            <fos:arg name="value2" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -3436,10 +3427,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:signatures>
          <fos:proto name="string-join" return-type="xs:string">
             <fos:arg name="values" type="xs:anyAtomicType*"/>
-         </fos:proto>
-         <fos:proto name="string-join" return-type="xs:string">
-            <fos:arg name="values" type="xs:anyAtomicType*"/>
-            <fos:arg name="separator" type="xs:string"/>
+            <fos:arg name="separator" type="xs:string" default='""'/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -3526,11 +3514,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="substring" return-type="xs:string">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="start" type="xs:double"/>
-         </fos:proto>
-         <fos:proto name="substring" return-type="xs:string">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="start" type="xs:double"/>
-            <fos:arg name="length" type="xs:double"/>
+            <fos:arg name="length" type="xs:double?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -3550,7 +3534,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <p>Otherwise, the function returns a string comprising those <termref def="character"
             >characters</termref> of <code>$value</code> whose index position (counting
             from one) is greater than or equal to <code>$start</code> (rounded to an
-            integer), and (if <code>$length</code> is specified) less than the sum of
+            integer), and (if <code>$length</code> is specified 
+            <phrase diff="add" at="2022-12-19">and non-empty</phrase>) less than the sum of
                <code>$start</code> and <code>$length</code> (both rounded to integers).</p>
          <p>The characters returned do not extend beyond <code>$value</code>. If
                <code>$start</code> is zero or negative, only those characters in positions greater
@@ -3674,9 +3659,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
    </fos:function>
    <fos:function name="string-length" prefix="fn">
       <fos:signatures>
-         <fos:proto name="string-length" return-type="xs:integer"/>
          <fos:proto name="string-length" return-type="xs:integer">
-            <fos:arg name="value" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?" default="fn:string(.)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -3733,9 +3717,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
    </fos:function>
    <fos:function name="normalize-space" prefix="fn">
       <fos:signatures>
-         <fos:proto name="normalize-space" return-type="xs:string"/>
          <fos:proto name="normalize-space" return-type="xs:string">
-            <fos:arg name="value" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?" default="fn:string(.)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -3797,10 +3780,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:signatures>
          <fos:proto name="normalize-unicode" return-type="xs:string">
             <fos:arg name="value" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="normalize-unicode" return-type="xs:string">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="form" type="xs:string"/>
+            <fos:arg name="form" type="xs:string" default='"NFC"'/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -4301,11 +4281,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="contains" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="contains" return-type="xs:boolean">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4410,11 +4386,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="starts-with" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="starts-with" return-type="xs:boolean">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4523,11 +4495,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="ends-with" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="ends-with" return-type="xs:boolean">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4637,11 +4605,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="substring-before" return-type="xs:string">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="substring-before" return-type="xs:string">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4743,11 +4707,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="substring-after" return-type="xs:string">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="substring-after" return-type="xs:string">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4850,11 +4810,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="matches" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="pattern" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="matches" return-type="xs:boolean">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="pattern" type="xs:string"/>
-            <fos:arg name="flags" type="xs:string"/>
+            <fos:arg name="flags" type="xs:string" default='""'/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -5182,15 +5138,8 @@ Tak, tak, tak! - da kommen sie.
       <fos:signatures>
          <fos:proto name="tokenize" return-type="xs:string*">
             <fos:arg name="value" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="tokenize" return-type="xs:string*">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="pattern" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="tokenize" return-type="xs:string*">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="pattern" type="xs:string"/>
-            <fos:arg name="flags" type="xs:string"/>
+            <fos:arg name="pattern" type="xs:string" default='" "'/>
+            <fos:arg name="flags" type="xs:string" default='""'/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -5325,11 +5274,7 @@ Tak, tak, tak! - da kommen sie.
          <fos:proto name="analyze-string" return-type="element(fn:analyze-string-result)">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="pattern" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="analyze-string" return-type="element(fn:analyze-string-result)">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="pattern" type="xs:string"/>
-            <fos:arg name="flags" type="xs:string"/>
+            <fos:arg name="flags" type="xs:string" default='""'/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -5509,11 +5454,7 @@ Tak, tak, tak! - da kommen sie.
          <fos:proto name="contains-token" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string*"/>
             <fos:arg name="token" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="contains-token" return-type="xs:boolean">
-            <fos:arg name="value" type="xs:string*"/>
-            <fos:arg name="token" type="xs:string"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -5584,20 +5525,12 @@ Tak, tak, tak! - da kommen sie.
       <fos:signatures>
          <fos:proto name="resolve-uri" return-type="xs:anyURI?">
             <fos:arg name="relative" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="resolve-uri" return-type="xs:anyURI?">
-            <fos:arg name="relative" type="xs:string?"/>
-            <fos:arg name="base" type="xs:string"/>
+            <fos:arg name="base" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
-      <fos:properties arity="1">
+      <fos:properties>
          <fos:property>deterministic</fos:property>
          <fos:property dependency="static-base-uri">context-dependent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:properties arity="2">
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -5628,7 +5561,8 @@ Tak, tak, tak! - da kommen sie.
                unchanged.</p>
             </item>
             <item>
-               <p>If the <code>$base</code> argument is not supplied, then:</p>
+               <p>If the <code>$base</code> argument is not supplied, 
+                  <phrase diff="add" at="2022-12-19">or is supplied as an empty sequence</phrase> then:</p>
                <olist>
                   <item>
                      <p>If the static base URI in the static context is not absent, it is used as the effective
@@ -5649,15 +5583,6 @@ Tak, tak, tak! - da kommen sie.
                RFC3986 treats unreserved characters. No percent-encoding takes place.</p>
             </item>
          </olist>
-
-
-
-
-
-
-
-
-
       </fos:rules>
       <fos:errors>
          <p>The first form of this function resolves <code>$relative</code> against the value of the
@@ -5918,376 +5843,6 @@ Tak, tak, tak! - da kommen sie.
          <fos:example>
             <p><code>fn:not(1 to 10)</code> raises a type error <errorref class="RG" code="0006"
                />.</p>
-         </fos:example>
-      </fos:examples>
-   </fos:function>
-   <fos:function name="parts" diff="add" at="A"  prefix="fn">
-      <fos:signatures>
-         <fos:proto name="parts" return-type="map(xs:string, item()*)"></fos:proto>
-      </fos:signatures>
-      <fos:summary><p>Returns the components of an atomic value, as a map.</p></fos:summary>
-      <fos:rules>
-
-            <p>Some <termref def="dt-atomic-value">atomic values</termref> (despite the name) can be divided into
-            parts: for example, an <code>xs:date</code> comprises year, month, day, and timezone.
-               The <code>fn:parts</code> function returns these components, as a map. This allows
-               the lookup operator to be used to access the components of the value. For example
-            <code>fn:parts(fn:current-date())?year</code> returns the current year, while <code>document-uri($doc)?scheme</code>
-            returns the scheme part of a URI.</p>
-            
-            <p>Previous versions of this specification provided functions such as <code>fn:year-from-date</code>
-            to access these components. These functions remain available, but the <code>fn:parts</code> function
-               provides a generic alternative, which also
-            allows the lookup operator to be used to obtain the components of other data types including
-               <code>xs:anyURI</code>, <code>xs:gYear</code>, <code>xs:gYearMonth</code>, <code>xs:gMonth</code>, 
-               <code>xs:gMonthDay</code>, <code>xs:gDay</code>, <code>xs:hexBinary</code>, and 
-               <code>xs:base64Binary</code>.</p>
-            
-            
-            
-            <p>The atomic types that have components are defined by the table below. 
-            Regardless of the type of value, <code>fn:parts($a)</code> returns a map that includes
-            an entry whose key is <code>value</code> and whose associated value is <code>$a</code>.
-               Additional entries in the returned map depend on the type
-               of value: the table lists the components that are available, their types, and their values.</p>
-            
-            <table role="medium" width="100%">
-               <thead>
-                  <tr>
-                     <th>Type</th>
-                     <th>Component</th>
-                     <th>Component Type</th>
-                     <th>Value</th>
-                  </tr>
-               </thead>
-               <tbody>
-                  <tr>
-                     <td><code>xs:dateTime</code></td>
-                     <td><code>date</code></td>
-                     <td><code>xs:date</code></td>
-                     <td><code>xs:date(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>time</code></td>
-                     <td><code>xs:time</code></td>
-                     <td><code>xs:time(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>year</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:year-from-dateTime(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>month</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:month-from-dateTime(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>day</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:day-from-dateTime(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>hours</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:hours-from-dateTime(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>minutes</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:minutes-from-dateTime(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>seconds</code></td>
-                     <td><code>xs:decimal</code></td>
-                     <td><code>fn:seconds-from-dateTime(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>timezone</code></td>
-                     <td><code>xs:dayTimeDuration?</code></td>
-                     <td><code>fn:timezone-from-dateTime(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:date</code></td>
-                     <td><code>year</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:year-from-date(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>month</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:month-from-date(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>day</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:day-from-date(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>timezone</code></td>
-                     <td><code>xs:dayTimeDuration?</code></td>
-                     <td><code>fn:timezone-from-date(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:time</code></td>
-                     <td><code>hours</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:hours-from-time(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>minutes</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:minutes-from-time(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>seconds</code></td>
-                     <td><code>xs:decimal</code></td>
-                     <td><code>fn:seconds-from-time(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>timezone</code></td>
-                     <td><code>xs:dayTimeDuration?</code></td>
-                     <td><code>fn:timezone-from-time(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:gYear</code></td>
-                     <td><code>year</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>timezone</code></td>
-                     <td><code>xs:dayTimeDuration?</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:gYearMonth</code></td>
-                     <td><code>year</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>month</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>timezone</code></td>
-                     <td><code>xs:dayTimeDuration?</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:gMonth</code></td>
-                     <td><code>month</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>timezone</code></td>
-                     <td><code>xs:dayTimeDuration?</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:gMonthDay</code></td>
-                     <td><code>month</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>day</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>timezone</code></td>
-                     <td><code>xs:dayTimeDuration?</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:gDay</code></td>
-                     <td><code>day</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td>See below</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>timezone</code></td>
-                     <td><code>xs:dayTimeDuration?</code></td>
-                     <td>See below</td>
-                  </tr>
-                  
-                  <tr>
-                     <td><code>xs:duration</code></td>
-                     <td><code>years</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:years-from-duration(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>months</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:months-from-duration(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>days</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:days-from-duration(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>hours</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:hours-from-duration(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>minutes</code></td>
-                     <td><code>xs:integer</code></td>
-                     <td><code>fn:minutes-from-duration(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>seconds</code></td>
-                     <td><code>xs:decimal</code></td>
-                     <td><code>fn:seconds-from-duration(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:hexBinary</code></td>
-                     <td><code>octets</code></td>
-                     <td><code>xs:unsignedByte*</code></td>
-                     <td>A sequence of integers in the range 0 to 255 representing the octets in the binary value</td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:base64Binary</code></td>
-                     <td><code>octets</code></td>
-                     <td><code>xs:unsignedByte*</code></td>
-                     <td>A sequence of integers in the range 0 to 255 representing the octets in the binary value</td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:QName</code></td>
-                     <td><code>prefix</code></td>
-                     <td><code>xs:NCName?</code></td>
-                     <td><code>fn:prefix-from-QName(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>local-name</code></td>
-                     <td><code>xs:NCName</code></td>
-                     <td><code>fn:local-name-from-QName(.)</code></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>namespace-uri</code></td>
-                     <td><code>xs:anyURI</code></td>
-                     <td><code>fn:namespace-uri-from-QName</code></td>
-                  </tr>
-                  <tr>
-                     <td><code>xs:anyURI</code></td>
-                     <td><code>scheme</code></td>
-                     <td><code>xs:string?</code></td>
-                     <td>The scheme part of the URI (as defined in RFC2396), if present</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>authority</code></td>
-                     <td><code>xs:string?</code></td>
-                     <td>The authority part of the URI (as defined in RFC2396), if present</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>path</code></td>
-                     <td><code>xs:string?</code></td>
-                     <td>The path component of the URI (as defined in RFC2396), if present</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>query</code></td>
-                     <td><code>xs:string</code></td>
-                     <td>The query component of the URI (as defined in RFC2396), if present</td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>query-parameters</code></td>
-                     <td><code>map(xs:string, xs:string*)</code></td>
-                     <td>The query component of the URI (as defined in RFC2396), if present and parseable.
-                     The query is parsed as follows:
-                     <olist>
-                        <item><p>The query is split into parts using "&amp;" or ";" as a separator.</p></item>
-                        <item><p>If a query part contains an "=" character, the resulting map contains
-                        an entry whose key is the string that precedes the first "=" character, and whose value is
-                        the string that follows the first "=" character.</p></item>
-                        <item><p>If a query part contains no "=" character, the resulting map contains
-                        an entry whose key is equal to the complete query part and whose value is the
-                        <code>xs:boolean</code> value <code>true()</code>.</p></item>
-                        <item><p>If two query parts have the same key, the resulting map contains a single
-                           entry with this key, in which the corresponding values are
-                        combined into a sequence, retaining order.</p></item>
-                     </olist></td>
-                  </tr>
-                  <tr>
-                     <td><code></code></td>
-                     <td><code>fragment</code></td>
-                     <td><code>xs:string?</code></td>
-                     <td>The fragment component of the URI reference (as defined in RFC2396), if present</td>
-                  </tr>
-               </tbody>
-            </table>
-            
-            <p>The components for types <code>xs:gYear</code>, <code>xs:gYearMonth</code>, <code>xs:gMonth</code>, 
-               <code>xs:gMonthDay</code>, and <code>xs:gDay</code> are defined as follows. Given a value 
-               <code>G</code> of one of these types, it can be expanded to an instance of <code>xs:date</code>
-               (call it <code>D</code>) by supplying arbitrary values for the absent components in the 7-property model as defined
-               in XSD 1.1 Part 2. The value of component <var>C</var> in <var>G</var> is then the same as the
-            value of the same component in <code>D</code>.</p>
-            
-            <p>When extracting the components of an <code>xs:anyURI</code> value, percent-encoded characters
-            are expanded: for example the fragment part of the <code>xs:anyURI</code> value 
-               <code>book#part%201</code> is returned as <code>"part 1"</code>.</p>
-
-      </fos:rules>
-      <fos:notes>
-         <p>TODO: define the function in such a way that it's possible to report an incorrect component
-         name (for example <code>parts(current-date())?hours</code> as a static error.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:parts(xs:date('2001-05-04'))?month</fos:expression>
-               <fos:result>5</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:parts(xs:gYearMonth('2001-05'))?month</fos:expression>
-               <fos:result>5</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:parts(xs:time('15:00:00'))?timezone</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:parts(xs:date('2001-05-04'))?value</fos:expression>
-               <fos:result>xs:date('2001-05-04')</fos:result>
-            </fos:test>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -8363,10 +7918,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:signatures>
          <fos:proto name="adjust-dateTime-to-timezone" return-type="xs:dateTime?">
             <fos:arg name="value" type="xs:dateTime?"/>
-         </fos:proto>
-         <fos:proto name="adjust-dateTime-to-timezone" return-type="xs:dateTime?">
-            <fos:arg name="value" type="xs:dateTime?"/>
-            <fos:arg name="timezone" type="xs:dayTimeDuration?"/>
+            <fos:arg name="timezone" type="xs:dayTimeDuration?" default="fn:implicit-timezone()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -8475,10 +8027,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:signatures>
          <fos:proto name="adjust-date-to-timezone" return-type="xs:date?">
             <fos:arg name="value" type="xs:date?"/>
-         </fos:proto>
-         <fos:proto name="adjust-date-to-timezone" return-type="xs:date?">
-            <fos:arg name="value" type="xs:date?"/>
-            <fos:arg name="timezone" type="xs:dayTimeDuration?"/>
+            <fos:arg name="timezone" type="xs:dayTimeDuration?" default="fn:implicit-timezone()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -8592,10 +8141,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:signatures>
          <fos:proto name="adjust-time-to-timezone" return-type="xs:time?">
             <fos:arg name="value" type="xs:time?"/>
-         </fos:proto>
-         <fos:proto name="adjust-time-to-timezone" return-type="xs:time?">
-            <fos:arg name="value" type="xs:time?"/>
-            <fos:arg name="timezone" type="xs:dayTimeDuration?"/>
+            <fos:arg name="timezone" type="xs:dayTimeDuration?" default="fn:implicit-timezone()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -9302,13 +8848,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:proto name="format-dateTime" return-type="xs:string?">
             <fos:arg name="value" type="xs:dateTime?"/>
             <fos:arg name="picture" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="format-dateTime" return-type="xs:string?">
-            <fos:arg name="value" type="xs:dateTime?"/>
-            <fos:arg name="picture" type="xs:string"/>
-            <fos:arg name="language" type="xs:string?"/>
-            <fos:arg name="calendar" type="xs:string?"/>
-            <fos:arg name="place" type="xs:string?"/>
+            <fos:arg name="language" type="xs:string?" default="()"/>
+            <fos:arg name="calendar" type="xs:string?" default="()"/>
+            <fos:arg name="place" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -9333,13 +8875,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:proto name="format-date" return-type="xs:string?">
             <fos:arg name="value" type="xs:date?"/>
             <fos:arg name="picture" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="format-date" return-type="xs:string?">
-            <fos:arg name="value" type="xs:date?"/>
-            <fos:arg name="picture" type="xs:string"/>
-            <fos:arg name="language" type="xs:string?"/>
-            <fos:arg name="calendar" type="xs:string?"/>
-            <fos:arg name="place" type="xs:string?"/>
+            <fos:arg name="language" type="xs:string?" default="()"/>
+            <fos:arg name="calendar" type="xs:string?" default="()"/>
+            <fos:arg name="place" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -9364,13 +8902,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:proto name="format-time" return-type="xs:string?">
             <fos:arg name="value" type="xs:time?"/>
             <fos:arg name="picture" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="format-time" return-type="xs:string?">
-            <fos:arg name="value" type="xs:time?"/>
-            <fos:arg name="picture" type="xs:string"/>
-            <fos:arg name="language" type="xs:string?"/>
-            <fos:arg name="calendar" type="xs:string?"/>
-            <fos:arg name="place" type="xs:string?"/>
+            <fos:arg name="language" type="xs:string?" default="()"/>
+            <fos:arg name="calendar" type="xs:string?" default="()"/>
+            <fos:arg name="place" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -9635,7 +9169,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
 
          <p>If a <code>tzname</code> is supplied with no <code>tzoffset</code> then it is translated
             to a timezone offset as follows:</p>
-         <table class="data">
+         <table role="data">
             <thead>
                <tr>
                   <th>tzname</th>
@@ -10408,7 +9942,6 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    </fos:function>
    <fos:function name="name" prefix="fn">
       <fos:signatures>
-         <fos:proto name="name" return-type="xs:string"/>
          <fos:proto name="name" return-type="xs:string">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -10428,9 +9961,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             string, or has the lexical form of an <code>xs:QName</code>. </p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context item (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p>If the argument is supplied and is the empty sequence, the function returns the
             zero-length string.</p>
          <p>If the node identified by <code>$node</code> has no name (that is, if it is a document
@@ -10465,7 +9998,6 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    </fos:function>
    <fos:function name="local-name" prefix="fn">
       <fos:signatures>
-         <fos:proto name="local-name" return-type="xs:string"/>
          <fos:proto name="local-name" return-type="xs:string">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -10486,9 +10018,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <code>xs:NCName</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context item (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p>If the argument is supplied and is the empty sequence, the function returns the
             zero-length string.</p>
          <p>If the node identified by <code>$node</code> has no name (that is, if it is a document
@@ -10520,7 +10052,6 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    </fos:function>
    <fos:function name="namespace-uri" prefix="fn">
       <fos:signatures>
-         <fos:proto name="namespace-uri" return-type="xs:anyURI"/>
          <fos:proto name="namespace-uri" return-type="xs:anyURI">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -10540,9 +10071,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <code>xs:anyURI</code> value.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context node (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context node (<code>.</code>). <phrase diff="del" at="2022-11-29">The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p>If the node identified by <code>$node</code> is neither an element nor an attribute node,
             or if it is an element or attribute node whose expanded-QName (as determined by the
                <code>dm:node-name</code> accessor in the <xspecref
@@ -10575,7 +10106,6 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    </fos:function>
    <fos:function name="number" prefix="fn">
       <fos:signatures>
-         <fos:proto name="number" return-type="xs:double"/>
          <fos:proto name="number" return-type="xs:double">
             <fos:arg name="value" type="xs:anyAtomicType?" default="."/>
          </fos:proto>
@@ -10652,9 +10182,6 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    </fos:function>
    <fos:function name="lang" prefix="fn">
       <fos:signatures>
-         <fos:proto name="lang" return-type="xs:boolean">
-            <fos:arg name="language" type="xs:string?"/>
-         </fos:proto>
          <fos:proto name="lang" return-type="xs:boolean">
             <fos:arg name="language" type="xs:string?"/>
             <fos:arg name="node" type="node()" default="." usage="inspection"/>
@@ -10761,17 +10288,16 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    </fos:function>
    <fos:function name="path" prefix="fn">
       <fos:signatures>
-         <fos:proto name="path" return-type="xs:string?"/>
          <fos:proto name="path" return-type="xs:string?">
             <fos:arg name="node" type="node()?" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
-      <fos:properties arity="1">
+      <fos:properties arity="0">
          <fos:property>deterministic</fos:property>
          <fos:property>context-dependent</fos:property>
          <fos:property>focus-dependent</fos:property>
       </fos:properties>
-      <fos:properties arity="2">
+      <fos:properties arity="1">
          <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
@@ -10930,7 +10456,6 @@ Himmlische, dein Heiligtum.</p>}]]>
    </fos:function>
    <fos:function name="root" prefix="fn">
       <fos:signatures>
-         <fos:proto name="root" return-type="node()"/>
          <fos:proto name="root" return-type="node()?">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -10953,8 +10478,8 @@ Himmlische, dein Heiligtum.</p>}]]>
       </fos:summary>
       <fos:rules>
          <p>If the function is called without an argument, the context item (<code>.</code>) is used
-            as the default argument. The behavior of the function if the argument is omitted is
-            exactly the same as if the context item had been passed as the argument.</p>
+            as the default argument.<phrase diff="del" at="2022-11-29"> The behavior of the function if the argument is omitted is
+            exactly the same as if the context item had been passed as the argument.</phrase></p>
 
          <p>The function returns the value of the expression
                <code>($arg/ancestor-or-self::node())[1]</code>.</p>
@@ -11031,7 +10556,6 @@ let $newi := $o/tool</eg>
    </fos:function>
    <fos:function name="has-children" prefix="fn">
       <fos:signatures>
-         <fos:proto name="has-children" return-type="xs:boolean"/>
          <fos:proto name="has-children" return-type="xs:boolean">
             <fos:arg name="node" type="node()?" default="." usage="inspection"/>
          </fos:proto>
@@ -11050,9 +10574,9 @@ let $newi := $o/tool</eg>
          <p>Returns true if the supplied node has one or more child nodes (of any kind).</p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context item (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p>Provided that the supplied argument <code>$node</code> matches the expected type
                <code>node()?</code>, the result of the function call
                <code>fn:has-children($node)</code> is defined to be the same as the result of the
@@ -11182,11 +10706,7 @@ let $newi := $o/tool</eg>
          <fos:proto name="index-of" return-type="xs:integer*">
             <fos:arg name="input" type="xs:anyAtomicType*"/>
             <fos:arg name="search" type="xs:anyAtomicType"/>
-         </fos:proto>
-         <fos:proto name="index-of" return-type="xs:integer*">
-            <fos:arg name="input" type="xs:anyAtomicType*"/>
-            <fos:arg name="search" type="xs:anyAtomicType"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -11392,10 +10912,7 @@ let $newi := $o/tool</eg>
       <fos:signatures>
          <fos:proto name="distinct-values" return-type="xs:anyAtomicType*">
             <fos:arg name="values" type="xs:anyAtomicType*"/>
-         </fos:proto>
-         <fos:proto name="distinct-values" return-type="xs:anyAtomicType*">
-            <fos:arg name="values" type="xs:anyAtomicType*"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -12052,11 +11569,7 @@ let $newi := $o/tool</eg>
          <fos:proto name="subsequence" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="start" type="xs:double"/>
-         </fos:proto>
-         <fos:proto name="subsequence" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="transmission"/>
-            <fos:arg name="start" type="xs:double"/>
-            <fos:arg name="length" type="xs:double"/>
+            <fos:arg name="length" type="xs:double?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -12070,9 +11583,10 @@ let $newi := $o/tool</eg>
             continuing for the number of items indicated by <code>$length</code>. </p>
       </fos:summary>
       <fos:rules>
-         <p>In the two-argument case, returns:</p>
+         <p>In the two-argument case <phrase diff="add" at="2022-12-19">(or where the 
+            third argument is an empty sequence),</phrase> the function returns:</p>
          <eg xml:space="preserve">$input[fn:round($start) le position()]</eg>
-         <p>In the three-argument case, returns:</p>
+         <p>In the three-argument case, the function returns:</p>
          <eg xml:space="preserve">$input[fn:round($start) le position() 
          and position() lt fn:round($start) + fn:round($length)]</eg>
 
@@ -12834,11 +12348,7 @@ else if (fn:empty($input))
          <fos:proto name="deep-equal" return-type="xs:boolean">
             <fos:arg name="input1" type="item()*" usage="absorption"/>
             <fos:arg name="input2" type="item()*" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="deep-equal" return-type="xs:boolean">
-            <fos:arg name="input1" type="item()*" usage="absorption"/>
-            <fos:arg name="input2" type="item()*" usage="absorption"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -13120,17 +12630,8 @@ else if (fn:empty($input))
          <fos:proto name="differences" return-type="map(*)*">
             <fos:arg name="input1" type="item()" usage="absorption"/>
             <fos:arg name="input2" type="item()" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="differences" return-type="map(*)*">
-            <fos:arg name="input1" type="item()" usage="absorption"/>
-            <fos:arg name="input2" type="item()" usage="absorption"/>
-            <fos:arg name="options" type="map(*)" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="differences" return-type="map(*)*">
-            <fos:arg name="input1" type="item()" usage="absorption"/>
-            <fos:arg name="input2" type="item()" usage="absorption"/>
-            <fos:arg name="options" type="map(*)" usage="absorption"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="options" type="map(*)" usage="absorption" default="map{}"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -13216,7 +12717,7 @@ else if (fn:empty($input))
  
          <p>The result of the function is a sequence of maps, each map holding information about one
          <term>difference</term> (that is, a failure to satisfy a rule). The map contains the following entries:</p>
-         <table class="no-code-break data">
+         <table role="no-code-break data">
             <thead>
                <tr>
                   <td>key</td>
@@ -13249,9 +12750,9 @@ else if (fn:empty($input))
                <tr>
                   <td>path</td>
                   <td>xs:string</td>
-                  <td><p>Path to the items from the root. This captures how the failing values were reached
+                  <td>Path to the items from the root. This captures how the failing values were reached
                   from the original input to the function, as a sequence of selection steps. The steps recorded
-                  are as follows:</p>
+                  are as follows:
                   <ulist>
                      <item><p>When selecting an item within a sequence, the 1-based position of the item within
                      the sequence.</p></item>
@@ -13297,7 +12798,7 @@ else if (fn:empty($input))
          
          <p>The rules for comparing sequences (at any level of recursion) are as follows:</p>
          
-         <table class="data">
+         <table role="data">
             <thead>
                <tr>
                   <th>Name</th>
@@ -13307,18 +12808,18 @@ else if (fn:empty($input))
             </thead>
             <tbody>
                <tr>
-                  <td><p>COUNT</p></td>
-                  <td><p><code>item()*</code></p></td>
-                  <td><p><code>count($A) eq count($B)</code></p></td>
+                  <td>COUNT</td>
+                  <td><code>item()*</code></td>
+                  <td><code>count($A) eq count($B)</code></td>
                </tr>
                <tr>
-                  <td><p>ITEMS</p></td>
-                  <td><p><code>item()*</code></p></td>
-                  <td><p>For each pair of items in corresponding positions in the two sequences,
+                  <td>ITEMS</td>
+                  <td><code>item()*</code></td>
+                  <td>For each pair of items in corresponding positions in the two sequences,
                      apply the rules for comparing items recursively, appending <code>[N]</code>
                      to the current path where <code>N</code> is the 1-based position of the item
                      in the sequence.
-                  </p></td>
+                  </td>
                </tr>
             </tbody>
          </table>
@@ -13329,7 +12830,7 @@ else if (fn:empty($input))
                whose key matches the rule name, and whose value is <code>false()</code>. Conversely,
             a rule that is not checked by default can be activated by means of an entry whose value is 
                <code>true()</code></p>
-         <table class="data">
+         <table role="data">
                <thead>
                   <tr>
                      <th>Name</th>
@@ -13339,116 +12840,116 @@ else if (fn:empty($input))
                </thead>
                <tbody>
                   <tr>
-                     <td><p>KIND</p></td>
-                     <td><p><code>item()</code></p></td>
-                     <td><p>Either both items are atomic, or both items are nodes, or both items are functions.</p></td>
+                     <td>KIND</td>
+                     <td><code>item()</code></td>
+                     <td>Either both items are atomic, or both items are nodes, or both items are functions.</td>
                   </tr>
                   <tr>
-                     <td><p>VALUE</p></td>
-                     <td><p><code>xs:anyAtomicType</code></p></td>
-                     <td><p><code>$A eq $B</code> (using the appropriate collation).</p></td>
+                     <td>VALUE</td>
+                     <td><code>xs:anyAtomicType</code></td>
+                     <td><code>$A eq $B</code> (using the appropriate collation).</td>
                   </tr>
                   <tr>
-                     <td><p>ATOMIC-TYPE†</p></td>
-                     <td><p><code>xs:anyAtomicType</code></p></td>
-                     <td><p><code>$A</code> and <code>$B</code> have the same type annotation.</p></td>
+                     <td>ATOMIC-TYPE†</td>
+                     <td><code>xs:anyAtomicType</code></td>
+                     <td><code>$A</code> and <code>$B</code> have the same type annotation.</td>
                   </tr>
                   <tr>
-                     <td><p>NODE-KIND</p></td>
-                     <td><p><code>node()</code></p></td>
-                     <td><p><code>$A</code> and <code>$B</code> are nodes of the same kind (for example, both elements, or both attributes)</p></td>
+                     <td>NODE-KIND</td>
+                     <td><code>node()</code></td>
+                     <td><code>$A</code> and <code>$B</code> are nodes of the same kind (for example, both elements, or both attributes)</td>
                   </tr>
                   <tr>
-                     <td><p>NODE-NAME</p></td>
-                     <td><p><code>node()</code></p></td>
-                     <td><p><code>fn:deep-equal(fn:node-name($A), fn:node-name($B))</code></p></td>
+                     <td>NODE-NAME</td>
+                     <td><code>node()</code></td>
+                     <td><code>fn:deep-equal(fn:node-name($A), fn:node-name($B))</code></td>
                   </tr>
                   <tr>
-                     <td><p>PREFIX†</p></td>
-                     <td><p><code>element(*)</code> or <code>attribute(*)</code></p></td>
-                     <td><p><code>fn:codepoint-equal(fn:prefix-from-QName(fn:node-name($A)), fn:prefix-from-QName(fn:node-name($B)))</code></p></td>
+                     <td>PREFIX†</td>
+                     <td><code>element(*)</code> or <code>attribute(*)</code></td>
+                     <td><code>fn:codepoint-equal(fn:prefix-from-QName(fn:node-name($A)), fn:prefix-from-QName(fn:node-name($B)))</code></td>
                   </tr>
                   <tr>
-                     <td><p>NODE-TYPE-ANNOTATION†</p></td>
-                     <td><p><code>element(*)</code> or <code>attribute(*)</code></p></td>
-                     <td><p><code>$A</code> and <code>$B</code> have the same type annotation</p></td>
+                     <td>NODE-TYPE-ANNOTATION†</td>
+                     <td><code>element(*)</code> or <code>attribute(*)</code></td>
+                     <td><code>$A</code> and <code>$B</code> have the same type annotation</td>
                   </tr>
                   <tr>
-                     <td><p>BASE-URI†</p></td>
-                     <td><p><code>document-node()</code> or <code>element(*)</code></p></td>
-                     <td><p><code>fn:codepoint-equal(fn:base-uri($A), fn:base-uri($B)))</code></p></td>
+                     <td>BASE-URI†</td>
+                     <td><code>document-node()</code> or <code>element(*)</code></td>
+                     <td><code>fn:codepoint-equal(fn:base-uri($A), fn:base-uri($B)))</code></td>
                   </tr>
                   <tr>
-                     <td><p>CONTENT</p></td>
-                     <td><p><code>element(*)</code> or <code>document-node()</code></p></td>
-                     <td><p>Apply the rules for comparing sequences recursively to the sequence of child nodes,
-                        appending <code>"/node()"</code> to the path.</p></td>
+                     <td>CONTENT</td>
+                     <td><code>element(*)</code> or <code>document-node()</code></td>
+                     <td>Apply the rules for comparing sequences recursively to the sequence of child nodes,
+                        appending <code>"/node()"</code> to the path.</td>
                   </tr>
                   <tr>
-                     <td><p>ATTRIBUTES</p></td>
-                     <td><p>element(*)</p></td>
-                     <td><p>Construct maps representing the attributes of the two elements by applying
+                     <td>ATTRIBUTES</td>
+                     <td>element(*)</td>
+                     <td>Construct maps representing the attributes of the two elements by applying
                         the function <code>map:group-by($A/@*, fn:node-name#1)</code> to each of them, and compare these
                      two maps by recursively invoking the rules for comparing items, appending <code>"/@"</code>
-                     to the path.</p></td>
+                     to the path.</td>
                   </tr>
                   <tr>
-                     <td><p>NAMESPACES†</p></td>
-                     <td><p>element(*)</p></td>
-                     <td><p>Construct maps representing the namespaces of the two elements by applying
+                     <td>NAMESPACES†</td>
+                     <td>element(*)</td>
+                     <td>Construct maps representing the namespaces of the two elements by applying
                         the function <code>fn:in-scope-namespaces()</code> to each of them, and compare these
                         two maps by recursively invoking the rules for comparing items, appending <code>"/namespace::"</code>
-                        to the path.</p></td>
+                        to the path.</td>
                   </tr>
                   <tr>
-                     <td><p>STRING-VALUE</p></td>
-                     <td><p><code>node()</code></p></td>
-                     <td><p><code>string($A) eq string($B)</code> (using the appropriate collation)</p></td>
+                     <td>STRING-VALUE</td>
+                     <td><code>node()</code></td>
+                     <td><code>string($A) eq string($B)</code> (using the appropriate collation)</td>
                   </tr>
                   <tr>
-                     <td><p>TYPED-VALUE†</p></td>
-                     <td><p><code>node()</code></p></td>
-                     <td><p>Compare the typed values of the two nodes by recursively invoking the 
-                        rules for comparing sequences, appending <code>/data()</code> to the path.</p>
+                     <td>TYPED-VALUE†</td>
+                     <td><code>node()</code></td>
+                     <td>Compare the typed values of the two nodes by recursively invoking the 
+                        rules for comparing sequences, appending <code>/data()</code> to the path.
                         <note><p>The typed value of a node is, in general, a sequence.</p></note></td>
                   </tr>
                                    
                   <tr>
-                     <td><p>FUNCTION-KIND</p></td>
-                     <td><p>function(*)</p></td>
-                     <td><p><code>$A instance of map(*) eq $B instance of map(*) and $A instance of array(*) eq $B instance of array(*)</code></p></td>
+                     <td>FUNCTION-KIND</td>
+                     <td>function(*)</td>
+                     <td><code>$A instance of map(*) eq $B instance of map(*) and $A instance of array(*) eq $B instance of array(*)</code></td>
                   </tr>
                   <tr>
-                     <td><p>ARRAY-SIZE</p></td>
-                     <td><p><code>array(*)</code></p></td>
-                     <td><p><code>array:size($A) eq array:size($B)</code></p></td>
+                     <td>ARRAY-SIZE</td>
+                     <td><code>array(*)</code></td>
+                     <td><code>array:size($A) eq array:size($B)</code></td>
                   </tr>
                   <tr>
-                     <td><p>ARRAY-CONTENT</p></td>
-                     <td><p>array(*)</p></td>
-                     <td><p>for every <code>$i</code> in <code>(1 to min((array:size($A), array:size($B)))</code>, compare
+                     <td>ARRAY-CONTENT</td>
+                     <td>array(*)</td>
+                     <td>for every <code>$i</code> in <code>(1 to min((array:size($A), array:size($B)))</code>, compare
                       <code>$A?$i</code> and <code>$B?$i</code>, by recursively applying the rules for
                         comparing sequences, appending <code>?N</code> to the path where <code>N</code>
-                        is the value of <code>$i</code>.</p></td>
+                        is the value of <code>$i</code>.</td>
                   </tr>
                   <tr>
-                     <td><p>3</p></td>
-                     <td><p>MAP-SIZE</p></td>
-                     <td><p><code>map(*)</code></p></td>
-                     <td><p><code>map:size($A) eq map:size($B)</code></p></td>
+                     <td>3</td>
+                     <td>MAP-SIZE</td>
+                     <td><code>map(*)</code></td>
+                     <td><code>map:size($A) eq map:size($B)</code></td>
                   </tr>
                   <tr>
-                     <td><p>MAP-KEYS</p></td>
-                     <td><p><code>map(*)</code></p></td>
-                     <td><p><code>map:size(map:remove($A, map:keys($B)))=0 and map:size(map:remove($B, map:keys($A)))=0</code></p>
+                     <td>MAP-KEYS</td>
+                     <td><code>map(*)</code></td>
+                     <td><code>map:size(map:remove($A, map:keys($B)))=0 and map:size(map:remove($B, map:keys($A)))=0</code>
                      <note><p>That is, the two maps have the same set of key values</p></note></td>
                   </tr>
                   <tr>
-                     <td><p>5</p></td>
-                     <td><p>MAP-ENTRIES</p></td>
-                     <td><p><code>map(*)</code></p></td>
-                     <td><p>For every key <code>$k</code> in <code>map:keys($A)</code>, compare <code>$A?$k</code> and <code>$B?$k</code>
-                        by recursively applying the rules for comparing sequences, appending to the path as follows:</p>
+                     <td>5</td>
+                     <td>MAP-ENTRIES</td>
+                     <td><code>map(*)</code></td>
+                     <td>For every key <code>$k</code> in <code>map:keys($A)</code>, compare <code>$A?$k</code> and <code>$B?$k</code>
+                        by recursively applying the rules for comparing sequences, appending to the path as follows:
                         <ulist>
                            <item><p>If the current path ends with <code>"/@"</code> (that is, if we are comparing
                            attribute values), append the local name of the attribute node if it is in no namespace,
@@ -13469,23 +12970,23 @@ else if (fn:empty($input))
                         to the two sequences, using the same options, and retaining <code>$k</code> in the path.</td>
                   </tr>
                   <tr>
-                     <td><p>2</p></td>
-                     <td><p>FUNCTION-NAME</p></td>
-                     <td><p><code>function(*)</code></p></td>
-                     <td><p><code>fn:deep-equal(fn:function-name($A), fn:function-name($B))</code></p></td>
+                     <td>2</td>
+                     <td>FUNCTION-NAME</td>
+                     <td><code>function(*)</code></td>
+                     <td><code>fn:deep-equal(fn:function-name($A), fn:function-name($B))</code></td>
                   </tr>
                   <tr>
-                     <td><p>2</p></td>
-                     <td><p>FUNCTION-ARITY</p></td>
-                     <td><p><code>function(*)</code></p></td>
-                     <td><p><code>fn:function-arity($A) eq fn:function-arity($B)</code></p></td>
+                     <td>2</td>
+                     <td>FUNCTION-ARITY</td>
+                     <td><code>function(*)</code></td>
+                     <td><code>fn:function-arity($A) eq fn:function-arity($B)</code></td>
                   </tr>
                   <tr>
-                     <td><p>2</p></td>
-                     <td><p>FUNCTION-SIGNATURE†</p></td>
-                     <td><p><code>function(*)</code></p></td>
-                     <td><p>The signatures of the two functions are identical (that is, the types of the arguments
-                        and the type of the result, but ignoring the names of arguments).</p></td>
+                     <td>2</td>
+                     <td>FUNCTION-SIGNATURE†</td>
+                     <td><code>function(*)</code></td>
+                     <td>The signatures of the two functions are identical (that is, the types of the arguments
+                        and the type of the result, but ignoring the names of arguments).</td>
                   </tr>
                </tbody>
             </table>
@@ -13493,7 +12994,7 @@ else if (fn:empty($input))
          The following normalizations are defined. Each is performed only if there is an entry in <code>$options</code>
          whose key matches the name of the normalization rule, and whose corresponding value is <code>true()</code>.</p>
          
-         <table class="no-code-break data">
+         <table role="no-code-break data">
             <thead>
                <tr>
                   <th>Normalization Rule</th>
@@ -13502,29 +13003,29 @@ else if (fn:empty($input))
             </thead>
             <tbody>
                <tr>
-                  <td><p>ignore-comments</p></td>
-                  <td><p>Comment nodes are removed within a tree (but not if they appear as top-level items).
-                  Following removal of a comment node, adjacent text nodes are merged.</p></td>
+                  <td>ignore-comments</td>
+                  <td>Comment nodes are removed within a tree (but not if they appear as top-level items).
+                  Following removal of a comment node, adjacent text nodes are merged.</td>
                </tr>
                <tr>
-                  <td><p>ignore-processing-instructions</p></td>
-                  <td><p>Processing instruction nodes are removed within a tree (but not if they appear as top-level items).
-                     Following removal of a processing instruction node, adjacent text nodes are merged.</p></td>
+                  <td>ignore-processing-instructions</td>
+                  <td>Processing instruction nodes are removed within a tree (but not if they appear as top-level items).
+                     Following removal of a processing instruction node, adjacent text nodes are merged.</td>
                </tr>
                <tr>
-                  <td><p>ignore-whitespace-nodes</p></td>
-                  <td><p>Whitespace text nodes are removed within a tree (but not if they appear as top-level items).</p></td>
+                  <td>ignore-whitespace-nodes</td>
+                  <td>Whitespace text nodes are removed within a tree (but not if they appear as top-level items).</td>
                </tr>
                <tr>
-                  <td><p>normalize-space</p></td>
-                  <td><p>Any string values that are compared using a collation are first processed
-                     using the <code>fn:normalize-space()</code> function.</p></td>
+                  <td>normalize-space</td>
+                  <td>Any string values that are compared using a collation are first processed
+                     using the <code>fn:normalize-space()</code> function.</td>
                </tr>
                <tr>
-                  <td><p>normalize-unicode</p></td>
-                  <td><p>Any string values that are compared using a collation are first processed
+                  <td>normalize-unicode</td>
+                  <td>Any string values that are compared using a collation are first processed
                      using the <code>fn:normalize-unicode()</code> function. This is applied after 
-                     <code>normalize-space</code>.</p></td>
+                     <code>normalize-space</code>.</td>
                </tr>
             </tbody>
          </table>
@@ -13702,10 +13203,7 @@ else if (fn:empty($input))
       <fos:signatures>
          <fos:proto name="max" return-type="xs:anyAtomicType?">
             <fos:arg name="values" type="xs:anyAtomicType*"/>
-         </fos:proto>
-         <fos:proto name="max" return-type="xs:anyAtomicType?">
-            <fos:arg name="values" type="xs:anyAtomicType*"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -13854,10 +13352,7 @@ else if (fn:empty($input))
       <fos:signatures>
          <fos:proto name="min" return-type="xs:anyAtomicType?">
             <fos:arg name="values" type="xs:anyAtomicType*"/>
-         </fos:proto>
-         <fos:proto name="min" return-type="xs:anyAtomicType?">
-            <fos:arg name="values" type="xs:anyAtomicType*"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -14010,12 +13505,9 @@ else if (fn:empty($input))
    </fos:function>
    <fos:function name="sum" prefix="fn">
       <fos:signatures>
-         <fos:proto name="sum" return-type="xs:anyAtomicType">
-            <fos:arg name="values" type="xs:anyAtomicType*"/>
-         </fos:proto>
          <fos:proto name="sum" return-type="xs:anyAtomicType?">
             <fos:arg name="values" type="xs:anyAtomicType*"/>
-            <fos:arg name="zero" type="xs:anyAtomicType?"/>
+            <fos:arg name="zero" type="xs:anyAtomicType?" default="0"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -14191,9 +13683,6 @@ else
       <fos:signatures>
          <fos:proto name="id" return-type="element()*">
             <fos:arg name="values" type="xs:string*"/>
-         </fos:proto>
-         <fos:proto name="id" return-type="element()*">
-            <fos:arg name="values" type="xs:string*"/>
             <fos:arg name="node" type="node()" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>
@@ -14364,9 +13853,6 @@ else
    </fos:function>
    <fos:function name="element-with-id" prefix="fn">
       <fos:signatures>
-         <fos:proto name="element-with-id" return-type="element()*">
-            <fos:arg name="values" type="xs:string*"/>
-         </fos:proto>
          <fos:proto name="element-with-id" return-type="element()*">
             <fos:arg name="values" type="xs:string*"/>
             <fos:arg name="node" type="node()" default="." usage="navigation"/>
@@ -14542,9 +14028,6 @@ else
    </fos:function>
    <fos:function name="idref" prefix="fn">
       <fos:signatures>
-         <fos:proto name="idref" return-type="node()*">
-            <fos:arg name="values" type="xs:string*"/>
-         </fos:proto>
          <fos:proto name="idref" return-type="node()*">
             <fos:arg name="values" type="xs:string*"/>
             <fos:arg name="node" type="node()" default="." usage="navigation"/>
@@ -14871,9 +14354,8 @@ else
    </fos:function>
    <fos:function name="collection" prefix="fn">
       <fos:signatures>
-         <fos:proto name="collection" return-type="item()*"/>
          <fos:proto name="collection" return-type="item()*">
-            <fos:arg name="uri" type="xs:string?"/>
+            <fos:arg name="uri" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -14949,9 +14431,8 @@ else
    </fos:function>
    <fos:function name="uri-collection" prefix="fn">
       <fos:signatures>
-         <fos:proto name="uri-collection" return-type="xs:anyURI*"/>
          <fos:proto name="uri-collection" return-type="xs:anyURI*">
-            <fos:arg name="uri" type="xs:string?"/>
+            <fos:arg name="uri" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15076,10 +14557,7 @@ else
       <fos:signatures>
          <fos:proto name="unparsed-text" return-type="xs:string?">
             <fos:arg name="href" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="unparsed-text" return-type="xs:string?">
-            <fos:arg name="href" type="xs:string?"/>
-            <fos:arg name="encoding" type="xs:string"/>
+            <fos:arg name="encoding" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15104,7 +14582,8 @@ else
                resources</xtermref> component of the dynamic context.</p>
          <p>If the value of the <code>$href</code> argument is an empty sequence, the function
             returns an empty sequence.</p>
-         <p>The <code>$encoding</code> argument, if present, is the name of an encoding. The values
+         <p>The <code>$encoding</code> argument, if present 
+            <phrase diff="add" at="2022-12-19"> and non-empty</phrase>, is the name of an encoding. The values
             for this attribute follow the same rules as for the <code>encoding</code> attribute in
             an XML declaration. The only values which every
             implementation is <rfc2119>required</rfc2119> to recognize are
@@ -15257,10 +14736,7 @@ else
       <fos:signatures>
          <fos:proto name="unparsed-text-lines" return-type="xs:string*">
             <fos:arg name="href" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="unparsed-text-lines" return-type="xs:string*">
-            <fos:arg name="href" type="xs:string?"/>
-            <fos:arg name="encoding" type="xs:string"/>
+            <fos:arg name="encoding" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15303,10 +14779,7 @@ else
       <fos:signatures>
          <fos:proto name="unparsed-text-available" return-type="xs:boolean">
             <fos:arg name="href" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="unparsed-text-available" return-type="xs:boolean">
-            <fos:arg name="href" type="xs:string?"/>
-            <fos:arg name="encoding" type="xs:string"/>
+            <fos:arg name="encoding" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15459,7 +14932,6 @@ else
    </fos:function>
    <fos:function name="generate-id" prefix="fn">
       <fos:signatures>
-         <fos:proto name="generate-id" return-type="xs:string"/>
          <fos:proto name="generate-id" return-type="xs:string">
             <fos:arg name="node" type="node()?" usage="inspection" default="."/>
          </fos:proto>
@@ -15478,9 +14950,9 @@ else
          <p>This function returns a string that uniquely identifies a given node. </p>
       </fos:summary>
       <fos:rules>
-         <p>If the argument is omitted, it defaults to the context item (<code>.</code>). The
+         <p>If the argument is omitted, it defaults to the context item (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
             behavior of the function if the argument is omitted is exactly the same as if the
-            context item had been passed as the argument.</p>
+            context item had been passed as the argument.</phrase></p>
          <p>If the argument is the empty sequence, the result is the zero-length string.</p>
          <p>In other cases, the function returns a string that uniquely identifies a given node.
             <phrase>More formally, it is guaranteed that within a single
@@ -15790,10 +15262,7 @@ else
       <fos:signatures>
          <fos:proto name="serialize" return-type="xs:string">
             <fos:arg name="input" type="item()*" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="serialize" return-type="xs:string">
-            <fos:arg name="input" type="item()*" usage="absorption"/>
-            <fos:arg name="options" type="item()?" usage="absorption"/>
+            <fos:arg name="options" type="item()?" usage="absorption" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15891,7 +15360,7 @@ else
             </item>
             <item><p>If no entry is present in the map for a particular serialization parameter name, then that parameter takes a default value as defined in the
             following table:</p>-->
-         <table class="no-code-break data">
+         <table role="no-code-break data">
             <thead>
                <tr>
                   <th>Parameter</th>
@@ -17121,6 +16590,15 @@ declare function fn:iterate-while(
   )
 };]]></eg>
       </fos:rules>
+      <fos:notes>
+         <p>While-loops are very common in procedural programming languages, and this function
+            provides a way to write functionally clean and interruptible iterations without
+            side-effects. An initial value is tested and replaced by new values until it matches
+            a given condition. Depending on the use case, the value can be a simple atomic item
+            or an arbitrarily complex data structure.</p>
+         <p>Note that, just as when writing recursive functions, it is easy to construct infinite
+            loops.</p>
+      </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -17176,15 +16654,7 @@ return $map?numbers
             ]]></eg>
          </fos:example>
       </fos:examples>
-      <fos:notes>
-         <p>While-loops are very common in procedural programming languages, and this function
-            provides a way to write functionally clean and interruptible iterations without
-            side-effects. An initial value is tested and replaced by new values until it matches
-            a given condition. Depending on the use case, the value can be a simple atomic item
-            or an arbitrarily complex data structure.</p>
-         <p>Note that, just as when writing recursive functions, it is easy to construct infinite
-            loops.</p>
-      </fos:notes>
+
    </fos:function>
    <fos:function name="for-each-pair" prefix="fn">
       <fos:signatures>
@@ -17267,15 +16737,8 @@ declare function fn:for-each-pair($input1, $input2, $action)
       <fos:signatures>
          <fos:proto name="sort" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-         </fos:proto>
-         <fos:proto name="sort" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="sort" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption"/>
-            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection"/>
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -17332,25 +16795,23 @@ declare function fn:for-each-pair($input1, $input2, $action)
                <olist>
                   <item><p>Let <code>$REL</code> be the result of evaluating <code>op:lexicographic-compare($key($A), $key($B), $C)</code>
                      where <code>op:lexicographic-compare($a, $b, $C)</code> is defined as follows:</p>
-                     <eg><code>
-if (empty($a) and empty($b)) then 0 
+                     <eg
+>if (empty($a) and empty($b)) then 0 
 else if (empty($a)) then -1
 else if (empty($b)) then +1
 else let $rel = op:simple-compare(head($a), head($b), $C)
      return if ($rel eq 0)
             then op:lexicographic-compare(tail($a), tail($b), $C)
-            else $rel
-                        </code></eg>
+            else $rel</eg>
                   </item>
                   <item><p>Here <code>op:simple-compare($k1, $k2)</code> is defined as follows:</p>
-                     <eg><code>
-if ($k1 instance of union(xs:string, xs:anyURI, xs:untypedAtomic)
+                     <eg
+>if ($k1 instance of union(xs:string, xs:anyURI, xs:untypedAtomic)
         and $k2 instance of union(xs:string, xs:anyURI, xs:untypedAtomic))
     then fn:compare($k1, $k2, $C)
     else if ($k1 eq $k2 or (fn:is-NaN($k1) and fn:is-NaN($k2))) then 0
     else if (fn:is-NaN($k1) or $k2 lt $k2) then -1
-    else +1          
-                     </code></eg>
+    else +1</eg>
                      <note><p>This raises an error if two keys are not comparable, for example
                      if one is a string and the other is a number, or if both belong to a non-ordered
                      type such as <code>xs:QName</code>.</p></note>
@@ -17704,10 +17165,7 @@ return fn:sort($in, $SWEDISH)
       <fos:signatures>
          <fos:proto name="merge" return-type="map(*)">
             <fos:arg name="maps" type="map(*)*" usage="inspection"/>
-         </fos:proto>
-         <fos:proto name="merge" return-type="map(*)">
-            <fos:arg name="maps" type="map(*)*" usage="inspection"/>
-            <fos:arg name="options" type="map(*)" usage="inspection"/>
+            <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -18841,10 +18299,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:signatures>
          <fos:proto name="collation-key" return-type="xs:base64Binary">
             <fos:arg name="value" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="collation-key" return-type="xs:base64Binary">
-            <fos:arg name="value" type="xs:string"/>
-            <fos:arg name="collation" type="xs:string"/>
+            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -18967,10 +18422,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:signatures>
          <fos:proto name="json-to-xml" return-type="document-node()?">
             <fos:arg name="json" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="json-to-xml" return-type="document-node()?">
-            <fos:arg name="json" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)" usage="inspection"/>
+            <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -19314,10 +18766,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:signatures>
          <fos:proto name="xml-to-json" return-type="xs:string?">
             <fos:arg name="node" type="node()?" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="xml-to-json" return-type="xs:string?">
-            <fos:arg name="node" type="node()?" usage="absorption"/>
-            <fos:arg name="options" type="map(*)" usage="inspection"/>
+            <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -19640,10 +19089,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:signatures>
          <fos:proto name="parse-json" return-type="item()?">
             <fos:arg name="json" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="parse-json" return-type="item()?">
-            <fos:arg name="json" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)" usage="inspection"/>
+            <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -19955,10 +19401,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:signatures>
          <fos:proto name="json-doc" return-type="item()?">
             <fos:arg name="href" type="xs:string?"/>
-         </fos:proto>
-         <fos:proto name="json-doc" return-type="item()?">
-            <fos:arg name="href" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)" usage="inspection"/>
+            <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -20019,11 +19462,8 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
    <fos:function name="json" prefix="fn">
       <fos:signatures>
          <fos:proto name="json" return-type="xs:string">
-            <fos:arg name="input" type="item()*"/>
-         </fos:proto>
-         <fos:proto name="json" return-type="xs:string">
             <fos:arg name="input" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)" usage="inspection"/>
+            <fos:arg name="options" type="map(*)" usage="inspection"  default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -20443,7 +19883,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:notes>
          <p>The function name is chosen by analogy with <code>fn:exists</code>. Note that the function tests whether
          any array members exist, not whether the array itself exists. A function such as:</p>
-         <eg><code>function($a as array(*)?) as xs:boolean { return array:exists($a) }</code></eg>
+         <eg>function($a as array(*)?) as xs:boolean { return array:exists($a) }</eg>
             <p>will raise a type error (rather than returning false) if the argument <code>$a</code> is
             an empty sequence, because <code>array:exists</code> does not allow the argument to be
             an empty sequence.</p>
@@ -20702,11 +20142,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <fos:proto name="subarray" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
             <fos:arg name="start" type="xs:integer"/>
-         </fos:proto>
-         <fos:proto name="subarray" return-type="array(*)">
-            <fos:arg name="array" type="array(*)" usage="inspection"/>
-            <fos:arg name="start" type="xs:integer"/>
-            <fos:arg name="length" type="xs:integer"/>
+            <fos:arg name="length" type="xs:integer?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -20723,6 +20159,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             the two-argument version of the function returns the same result as the three-argument
             version when called with <code>$length</code> equal to the value of <code>array:size($array) -
                $start + 1</code>.</p>
+         <p diff="add" at="2022-12-19">Setting the third argument to the empty sequence has the same effect as omitting the argument.</p>
          <p>Except in error cases, the result of the three-argument version of the function is the 
             value of the expression
             <code role="example">op:A2S($array) => fn:subsequence($start, $length) => op:S2A()</code>.</p>
@@ -21533,10 +20970,7 @@ else array:concat(
       <fos:signatures>
          <fos:proto name="from-sequence" return-type="array(*)">
             <fos:arg name="input" type="item()*" usage="inspection"/>
-         </fos:proto>
-         <fos:proto name="from-sequence" return-type="array(*)">
-            <fos:arg name="input" type="item()*" usage="inspection"/>
-            <fos:arg name="action" type="function(item()) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="function(item()) as item()*" usage="inspection" default="fn:identity#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -21554,9 +20988,7 @@ else array:concat(
          <p>Informally, <code>array:from-sequence#2</code> applies the supplied function to each item 
             in the input sequence, and the resulting sequence becomes one member of the returned array.</p>
          <p>More formally, <code>array:from-sequence#2</code> returns the result of the expression:</p>
-         <eg>
-            <code>fn:for-each($input, function($x)(function(){$action($x)})) => op:S2A()</code>
-         </eg>
+         <eg>fn:for-each($input, function($x)(function(){$action($x)})) => op:S2A()</eg>
       </fos:rules>
       <fos:notes>
          <p>The single-argument function <code>array:from-sequence($input)</code> is equivalent to the XPath
@@ -21701,15 +21133,8 @@ else array:concat(
       <fos:signatures>
          <fos:proto name="sort" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
-         </fos:proto>
-         <fos:proto name="sort" return-type="array(*)">
-            <fos:arg name="array" type="array(*)" usage="inspection"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="sort" return-type="array(*)">
-            <fos:arg name="array" type="array(*)" usage="inspection"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption"/>
-            <fos:arg name="key" type="function(item()*) as xs:anyAtomicType*" usage="inspection"/>
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="key" type="function(item()*) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -21860,14 +21285,12 @@ return array:sort($in, $SWEDISH)
          </ulist>
          <p>The process is then repeated so long as the sequence contains an array among its items.</p>
          <p>The function is equivalent to the following XQuery implementation (assuming static typing is not in force):</p>
-         <eg>
-            <code>declare function flatten ($S as item()*) {
+         <eg>declare function flatten ($S as item()*) {
     for $s in $S return (
       typeswitch($s)
         case $a as array(*) return flatten($a?*)
         default return $s
-)}</code>
-         </eg>
+)}</eg>
 
       </fos:rules>
       <fos:notes>
@@ -22146,10 +21569,7 @@ return array:sort($in, $SWEDISH)
       <fos:signatures>
          <fos:proto name="load-xquery-module" return-type="map(*)">
             <fos:arg name="module-uri" type="xs:string"/>
-         </fos:proto>
-         <fos:proto name="load-xquery-module" return-type="map(*)">
-            <fos:arg name="module-uri" type="xs:string"/>
-            <fos:arg name="options" type="map(*)" usage="inspection"/>
+            <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23132,13 +22552,9 @@ return $result?output//body
 
    <fos:function name="random-number-generator" prefix="fn">
       <fos:signatures>
-
-         <fos:proto name="random-number-generator" return-type="item-type(rng)"/>
-
-         <fos:proto name="random-number-generator" return-type="item-type(rng)">
-            <fos:arg name="seed" type="xs:anyAtomicType?"/>
+         <fos:proto name="random-number-generator" return-type-ref="random-number-generator-record">
+            <fos:arg name="seed" type="xs:anyAtomicType?" default="()"/>
          </fos:proto>
-
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
@@ -23150,19 +22566,18 @@ return $result?output//body
          <p>Returns a random number generator, which can be used to generate sequences of random numbers.</p>
       </fos:summary>
       <fos:rules>
-         <p diff="chg" at="A"
+         <p diff="chg" at="2022-12-19"
                >The function returns a random number generator. A random number generator is represented as a value of type 
-            <code>rng</code>, defined as follows:</p>
+            <code>random-number-generator-record</code>, defined as follows:</p>
+         
+         <?type random-number-generator-record?>
 
-         <eg diff="chg" at="A"
-            >record(
-       number   as xs:double,
-       next     as (function() as record(number, next, permute, *)),
-       permute  as (function(item()*) as item()*),
-       *
-   )</eg>
-
-
+         <note diff="add" at="2022-12-19"><p>This type is self-referential in a way that the 
+            current syntax for record type declarations does not allow. The
+         use of the type <code>#random-number-generator-record</code> as the return type of the <code>next</code>
+         function is purely for expository purposes; an approximation allowed by the grammar would be
+            <code>next as (function() as record(number, next, permute, *))</code>.</p></note>
+         
          <p>That is, the result of the function is a map containing three entries. 
             The keys of each entry are strings:</p>
          <olist>
@@ -23426,15 +22841,8 @@ declare function fn:all(
       <fos:signatures>
          <fos:proto name="highest" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-         </fos:proto>
-         <fos:proto name="highest" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="highest" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption"/>
-            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection"/>
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23459,13 +22867,13 @@ declare function fn:all(
          <p>The third argument defaults to the function <code>data#1</code>.</p>
          
          <p>Let <code>$modified-key</code> be the function:</p>
-         <eg><code>
+         <eg>
 function($item){
    $key($item) => fn:data() ! (
       if (. instance of xs:untypedAtomic)
       then xs:double(.)
       else .)
-}</code></eg>
+}</eg>
          
          <p>That is, the supplied function for computing key values is wrapped in a function that
          converts any <code>xs:untypedAtomic</code> values in its result to <code>xs:double</code>. This makes
@@ -23932,15 +23340,8 @@ function($item){
       <fos:signatures>
          <fos:proto name="lowest" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-         </fos:proto>
-         <fos:proto name="lowest" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="lowest" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption"/>
-            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection"/>
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23965,13 +23366,13 @@ function($item){
          <p>The third argument defaults to the function <code>data#1</code>.</p>
          
          <p>Let <code>$modified-key</code> be the function:</p>
-         <eg><code>
+         <eg>
             function($item){
             $key($item) => fn:data() ! (
             if (. instance of xs:untypedAtomic)
             then xs:double(.)
             else .)
-            }</code></eg>
+            }</eg>
          
          <p>That is, the supplied function for computing key values is wrapped in a function that
             converts any <code>xs:untypedAtomic</code> values in its result to <code>xs:double</code>. This makes
@@ -24274,10 +23675,7 @@ declare function fn:some(
       <fos:signatures>
          <fos:proto name="all-equal" return-type="xs:boolean">
             <fos:arg name="values" type="xs:anyAtomicType*" usage="navigation"/>
-         </fos:proto>
-         <fos:proto name="all-equal" return-type="xs:boolean">
-            <fos:arg name="values" type="xs:anyAtomicType*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string" usage="absorption"/>
+            <fos:arg name="collation" type="xs:string" usage="absorption" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24357,10 +23755,7 @@ declare function fn:some(
       <fos:signatures>
          <fos:proto name="all-different" return-type="xs:boolean">
             <fos:arg name="values" type="xs:anyAtomicType**" usage="navigation"/>
-         </fos:proto>
-         <fos:proto name="all-different" return-type="xs:boolean">
-            <fos:arg name="values" type="xs:anyAtomicType**" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string" usage="absorption"/>
+            <fos:arg name="collation" type="xs:string" usage="absorption" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24593,6 +23988,11 @@ declare function fn:some(
          keys in the map be QNames with the requirement that implementation-defined
          keys be in a non-empty namespace?</p>
       </fos:rules>
+      
+      <fos:errors>
+         <p>An error is raised XXXX if the supplied path separator is not a single character.</p>
+         <p>An error is raised XXXX if the supplied query separator is not a single character.</p>
+      </fos:errors>
 
       <fos:notes>
          <p>Like <code>fn:resolve-uri</code>, this function handles the additional characters
@@ -24605,10 +24005,7 @@ declare function fn:some(
          see <code>fn:build-uri</code>.</p>
       </fos:notes>
 
-      <fos:errors>
-         <p>An error is raised XXXX if the supplied path separator is not a single character.</p>
-         <p>An error is raised XXXX if the supplied query separator is not a single character.</p>
-      </fos:errors>
+      
       
 <fos:examples>
   <fos:example>
@@ -24779,8 +24176,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("/path/to/file")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "/path/to/file",
   "path": "/path/to/file",
   "path-segments": array { "", "path", "to", "file" }
@@ -24790,8 +24187,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("#testing")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "#testing",
   "path": "",
   "fragment": "testing"
@@ -24801,8 +24198,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("?q=1")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "?q=1",
   "path": "",
   "query": "q=1",
@@ -24815,8 +24212,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("ldap://[2001:db8::7]/c=GB?objectClass?one")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "ldap://[2001:db8::7]/c=GB?objectClass?one",
   "scheme": "ldap",
   "authority": "[2001:db8::7]",
@@ -24833,8 +24230,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("mailto:John.Doe@example.com")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "mailto:John.Doe@example.com",
   "scheme": "mailto",
   "path": "John.Doe@example.com",
@@ -24845,8 +24242,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("news:comp.infosystems.www.servers.unix")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "news:comp.infosystems.www.servers.unix",
   "scheme": "news",
   "path": "comp.infosystems.www.servers.unix",
@@ -24857,8 +24254,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("tel:+1-816-555-1212")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "tel:+1-816-555-1212",
   "scheme": "tel",
   "path": "+1-816-555-1212",
@@ -24869,8 +24266,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("telnet://192.0.2.16:80/")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "telnet://192.0.2.16:80/",
   "scheme": "telnet",
   "authority": "92.0.2.16:80",
@@ -24884,8 +24281,8 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
   "scheme": "urn",
   "path": "oasis:names:specification:docbook:dtd:xml:4.1.2",
@@ -24896,27 +24293,27 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("tag:textalign.net,2015:ns")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
     "uri": "tag:textalign.net,2015:ns",
     "scheme": "tag",
     "path": "textalign.net,2015:ns",
     "path-segments": [ "textalign.net,2015:ns" ]
-  }
-</eg></fos:result>
+  }</eg>
+</fos:result>
     </fos:test>
   </fos:example>
   <fos:example>
     <fos:test>
       <fos:expression>fn:parse-uri("tag:jan@example.com,1999-01-31:my-uri")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
     "uri": "tag:jan@example.com,1999-01-31:my-uri"
     "scheme": "tag",
     "path": "jan@example.com,1999-01-31:my-uri",
     "path-segments": [ "jan@example.com,1999-01-31:my-uri" ],
-}
-</eg></fos:result>
+}</eg>
+</fos:result>
     </fos:test>
   </fos:example>
   <fos:example>
@@ -24924,14 +24321,14 @@ map {
 specifically aware of the <code>jar:</code> scheme.</p>
     <fos:test>
       <fos:expression>fn:parse-uri("jar:file:/C:/Program%20Files/test.jar!/foo/bar")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
   "scheme": "jar",
   "path": "file:/C:/Program%20Files/test.jar!/foo/bar",
   "path-segments": array { "file:", "C:", "Program Files", "test.jar!", "foo", "bar" }
-}
-</eg></fos:result>
+}</eg>
+</fos:result>
     </fos:test>
   </fos:example>
   <fos:example>
@@ -24940,16 +24337,16 @@ lexical IRIs as “unreserved characters”. The rationale for this is given in 
 description of <code>fn:resolve-uri</code>.</p>
     <fos:test>
       <fos:expression>fn:parse-uri("http://www.example.org/Dürst")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
     "uri": "http://www.example.org/Dürst",
     "scheme": "http",
     "authority": "www.example.org",
     "host": "www.example.org",
     "path": "/Dürst",
     "path-segments": [ "","Dürst" ]
-}
-</eg></fos:result>
+}</eg>
+</fos:result>
     </fos:test>
   </fos:example>
   <fos:example>
@@ -24958,8 +24355,8 @@ map {
       <fos:expression>
 fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
              map { "query-separator": ";" })</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result>
+<eg>map {
   "uri": "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
   "scheme": "https",
   "authority": "example.com:8080",
@@ -25059,12 +24456,12 @@ map {
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:build-uri(map {
+               <fos:expression><eg>fn:build-uri(map {
     "scheme": "https",
     "host": "qt4cg.org",
     "port": (),
     "path": "/specifications/index.html"
-  })</fos:expression>
+  })</eg></fos:expression>
                <fos:result>https://qt4cg.org/specifications/index.html</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -269,6 +269,37 @@ for transition to Proposed Recommendation. </p>'>
                 superscripts have the following meanings: 'XQ' <bibref ref="xquery-40"/>, 'XT' <bibref ref="xslt-40"/>,
             'XP' <bibref ref="xpath-40"/>, and 'DM' <bibref ref="xpath-datamodel-31"/>.</p>
          
+         <div2 id="operators" diff="add" at="2022-12-20">
+            <head>Operators</head>
+            <p>Despite the title of this document, it does not attempt to define the semantics of all the operators available
+               in the <bibref ref="xpath-40"/> language; indeed, in the interests of avoiding duplication, the majority of
+               operators (including all higher-order operators such as <code>x/y</code>, <code>x!y</code>, and <code>x[y]</code>,
+               as well simple operators such as <code>x,y</code>, <code>x and y</code>, <code>x or y</code>,            
+            <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x is y</code>, <code>x||y</code>, <code>x|y</code>,
+            <code>x union x</code>, <code>x except y</code>, <code>x intersect y</code>, <code>x to y</code>
+            and <code>x otherwise y</code>) are now defined entirely within <bibref ref="xpath-40"/>.</p>
+            
+            <p>The remaining operators that are described in this publication are those where the semantics of the operator
+            depend on the types of the arguments. For these operators, the language specification describes rules for selecting
+            an internal function defined in this specification to underpin the operator. For example, when the operator <code>x+y</code>
+            is applied to two operands of type <code>xs:double</code>, the function <code>op:numeric-add</code> is selected.</p>
+            
+            <p>XPath defines a range of comparison operators <code>x=y</code>, <code>x!=y</code>, <code>x&lt;y</code>, 
+               <code>x>y</code>, <code>x&lt;=y</code>, <code>x>=y</code>, <code>x eq y</code>, <code>x ne y</code>, <code>x lt y</code>, 
+               <code>x gt y</code>, <code>x le y</code>, <code>x ge y</code>, which apply to a variety of operand types including
+            for example numeric values, strings, dates and times, and durations. For each relevant data type, two functions
+            are defined in this specification, for example <code>op:date-equal</code> and <code>op:date-less-than</code>.
+            These define the semantics of the <code>eq</code> and <code>lt</code> operators applied to operands of that data type. The operators
+               <code>x ne y</code>, <code>x gt y</code>, <code>x le y</code>, and <code>x ge y</code> are defined by reference to
+               these two; and the <term>general comparison</term> operators <code>=</code>, <code>!=</code>, <code>&lt;</code>, 
+               <code>></code>, <code>&lt;=</code>, and <code>>=</code> are defined by reference to 
+               <code>eq</code>, <code>ne</code>, <code>lt</code>, 
+               <code>gt</code>, <code>le</code>, and <code>ge</code> respectively.</p>
+            
+            <note><p>Previous versions of this specification also defined a third comparison function of the form
+            <code role="example">op:date-greater-than</code>. This has been dropped, as it is always the inverse of the <code>-less-than</code>
+            form.</p></note>
+         </div2>
          
          <div2 id="conformance">
             <head>Conformance</head>
@@ -424,7 +455,12 @@ for transition to Proposed Recommendation. </p>'>
                         <arg name="arg1" type="xs:numeric"/>
                         <arg name="arg2" type="xs:numeric"/>
                      </proto>
-                  </example>  
+                  </example>
+                  
+                  <p diff="add" at="2022-12-20">Sometimes there is a need to use an operator as a function.
+                  To meet this requirement, the function <code>fn:op</code> takes any simple binary operator as its argument,
+                  and returns a corresponding function. So for example <code>fn:for-each-pair($seq1, $seq2, op("+"))</code>
+                  performs a pairwise addition of the values in two input sequences.</p>
                   
                </item>
             </ulist>
@@ -475,9 +511,16 @@ for transition to Proposed Recommendation. </p>'>
                intercapitalized spelling and is used in the function name as such. An example is <code>fn:timezone-from-dateTime</code>.</p>
             <p>The first section in the proforma is a short summary of what the function does. This is intended
             to be informative rather than normative.</p>
-            <p>Each function is then defined by specifying its signature, which defines the
+            <p>Each function is then defined by specifying its signature(s), which define the
                types of the parameters and of the result value.</p>
-            <p>Each function's signature is presented in a form like this:</p>
+            <p diff="add" at="2022-11-29">Where functions take a variable number of arguments, two conventions are used:</p>
+            <ulist diff="add" at="2022-11-29">
+               <item><p>Wherever possible, a single function signature is used giving default values
+               for those parameters that can be omitted.</p></item>
+               <item><p>If this is not possible, because the effect of omitting a parameter cannot
+               be specified by giving a default value, multiple signatures are given for the function.</p></item>
+            </ulist>
+            <p>Each function signature is presented in a form like this:</p>
             <example role="signature">
                <proto role="example" name="function-name" return-type="return-type">
                   <arg name="parameter-name" type="parameter-type"/>
@@ -488,13 +531,21 @@ for transition to Proposed Recommendation. </p>'>
                     function whose signature is being specified. If the function takes no
                     parameters, then the name is followed by an empty parameter list:
                     "<code>()</code>"; otherwise, the name is followed by a parenthesized list of
-                    parameter declarations, in which each declaration specifies the static type of the
-                    parameter, in italics, and a descriptive, but non-normative, name. If there are
-                    two or more parameter declarations, they are separated by a comma. The <emph>
-                        <code>return-type</code></emph>, also in italics, specifies the static type of the value returned by the
+                    parameter declarations. Each parameter declaration includes:</p>
+            <ulist diff="add" at="2022-11-29">
+               <item><p>The name of the parameter (which in 4.0 is significant because it can be used
+               as a keyword in a function call)</p></item>
+               <item><p>The static type of the parameter (in italics)</p></item>
+               <item><p>If the parameter is optional, then an expression giving the default value 
+                  (preceded by the symbol <code>:=</code>).</p></item>
+            </ulist>
+            <p>If there are two or more parameter declarations, they are separated by a comma.</p> 
+            <p>The <emph> <code>return-type</code></emph>, also in italics, specifies the static type of the value returned by the
                     function. The dynamic type of the value returned by the function is the same as its static
                     type or derived from the static type. All parameter types and return types are
                     specified using the SequenceType notation defined in <xspecref spec="XP31" ref="id-sequencetype-syntax"/>.</p>
+            
+           
             <p>One function, <code>fn:concat</code>, has a variable number of arguments (two or more).
             More strictly, there is an infinite set of functions having the name <code>fn:concat</code>, with arity
             ranging from 2 to infinity. For this special case, a single function signature is given, with an ellipsis
@@ -3321,23 +3372,10 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 
            <p>The structured representation of a URI is described by the
            <code>uri-structure-record</code>:</p>
+            
+            <?type uri-structure-record?>
 
-           <example role="record">
-             <record id="uri-structure-record">
-               <arg name="uri?" type="xs:string"/>
-               <arg name="scheme?" type="xs:string"/>
-               <arg name="authority?" type="xs:string"/>
-               <arg name="userinfo?" type="xs:string"/>
-               <arg name="host?" type="xs:string"/>
-               <arg name="port?" type="xs:string"/>
-               <arg name="path?" type="xs:string"/>
-               <arg name="query?" type="xs:string"/>
-               <arg name="fragment?" type="xs:string"/>
-               <arg name="path-segments?" type="array(xs:string)"/>
-               <arg name="query-segments?" type="array(record(key? as xs:string, value? as xs:string, *))"/>
-               <arg name="*"/>
-             </record>
-           </example> 
+
 
            <p>The parts of this structure are:</p>
 
@@ -10077,29 +10115,21 @@ declare function eg:value-except (
             <p>The index is 1-based, not 0-based.</p>
             <p>The result sequence is in ascending numeric order.</p>
             <p>XSLT implementation</p>
-            <eg xml:space="preserve"><![CDATA[
+            <eg xml:space="preserve" diff="chg" at="2022-11-30"><![CDATA[
 <xsl:function name="eg:index-of-node" as="xs:integer*">
   <xsl:param name="seq" as="node()*"/>
   <xsl:param name="search" as="node()"/>
-  <xsl:sequence select="filter(
-      1 to count($seq),
-      function($i as xs:integer) as xs:boolean {$seq[$i] is $search}  
-    )
-  "/>
+  <xsl:sequence select="fn:index-where($seq, fn:op('is')(?, $search))"/>
 </xsl:function>]]></eg>
             <p>XQuery implementation</p>
             <eg xml:space="preserve"><![CDATA[
 declare function eg:index-of-node($seq as node()*, $search as node()) as xs:integer* 
 {
-    fn:filter(
-      1 to fn:count($seq),
-      function($i as xs:integer) as xs:boolean {$seq[$i] is $search}   
-    )
-
+    fn:index-where($seq, fn:op('is')(?, $search))
 }]]></eg>
-            <p>An alternative implementation, which might be faster in systems where indexing into a sequence
+            <p diff="del" at="2022-11-29">An alternative implementation, which might be faster in systems where indexing into a sequence
             is slow, is:</p>
-            <eg xml:space="preserve"><![CDATA[
+            <eg xml:space="preserve" diff="del" at="2022-11-29"><![CDATA[
 declare function eg:index-of-node($seq as node()*, $search as node()) as xs:integer* 
 {
   fn:for-each-pair(
@@ -10127,21 +10157,21 @@ declare function eg:index-of-node($seq as node()*, $search as node()) as xs:inte
             <p>Returns a <code>xs:string</code> consisting of a given number of copies of an
                     <code>xs:string</code> argument concatenated together.</p>
             <p>XSLT implementation</p>
-            <eg xml:space="preserve"><![CDATA[
+            <eg xml:space="preserve" diff="chg" at="2022-11-29"><![CDATA[
 <xsl:function name="eg:string-pad" as="xs:string">
   <xsl:param name="padString" as="xs:string?"/>
   <xsl:param name="padCount" as="xs:integer"/>
   <xsl:sequence select="
-     fn:string-join(1 to $padCount ! $padString)"/>
+     fn:string-join(fn:replicate($padString, $padCount))"/>
  </xsl:function>
                 ]]></eg>
             <p>XQuery implementation</p>
-            <eg xml:space="preserve"><![CDATA[
+            <eg xml:space="preserve" diff="chg" at="2022-11-29"><![CDATA[
 declare function eg:string-pad (
   $padString as xs:string?,
   $padCount as xs:integer) as xs:string 
 {
-   fn:string-join(1 to $padCount ! $padString)
+   fn:string-join(fn:replicate($padString, $padCount))
 }
                 ]]></eg>
             <p>This returns the zero-length string if <code>$padString</code> is the empty
@@ -10279,6 +10309,11 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
 	              <code>number-formatter</code> allows the user to control the formatting of numeric 
 	              values, for example by preventing the use of exponential notation for large integers.</p></item>
 	           
+	           <item><p>In the functions <code>fn:substring</code>, <code>fn:subsequence</code>,
+	              <code>fn:unparsed-text</code>, <code>fn:unparsed-text-available</code>, <code>fn:unparsed-text-lines</code>,
+	           and <code>array:subarray</code>, <code>fn:resolve-uri</code>, <code>fn:error</code>, and <code>fn:trace</code>,
+	              arguments that can be omitted can now also be set to an empty sequence;
+	           the effect of supplying an empty sequence is equivalent to the effect of not supplying the argument.</p></item>
 	           
 	        </olist>
 	     </div2>
@@ -10295,6 +10330,9 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
 	           for arguments are now more consistent across the function library.</p></item>
 	           <item><p>Where appropriate, the phrase "the value of <code>$x</code>" has been replaced
 	           by the simpler "<code>$x</code>". No change in meaning is intended.</p></item>
+	           <item><p>For functions tht take a variable number of arguments, wherever possible
+	           the specification now gives a single function signature indicating default values
+	           for arguments that may be omitted, rather than multiple signatures.</p></item>
 	           <item><p>The formal specifications of array functions have been rewritten to use two new
 	              primitives: <code role="example">op:A2S</code> which converts an array to a sequence of zero-arity
 	              functions, and <code role="example">op:S2A</code> which does the inverse. This has enabled many of the
@@ -10332,6 +10370,11 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               comparisons non-transitive, leading to problems when grouping (for example using <code>fn:distinct-values</code>,
               and potentially (depending on the sort algorithm) with sorting. The problem has been fixed by requiring
               comparisons to be performed based on the exact mathematical value without any loss of precision.</p>
+           </item>
+           <item diff="add" at="2022-12-18">
+              <p>In version 4.0, omitting the <code>$error-object</code> of <code>fn:error</code> has the same
+                 effect as setting it to an empty sequence. In 3.1, the effects could be different (the effect of omitting
+                 the argument was implementation-defined).</p>
            </item>
         </olist>
  


### PR DESCRIPTION
I teased apart some of the omnibus PR #292. I've commited the schema and stylesheet changes. This PR covers the remaining prose changes.

Mike writes:

> I regret that this has turned into a bit of an omnibus PR. The main changes are:
>
> * Fix validity issues with the function catalog and its schema (Issue 291)
> * Convert all functions to use a single signature with optional parameters (Issue 70)
> * Extend the function catalog to handle record definitions (Issue 257)
> * Fix the (trivial) bug with properties of fn:path (Issue 288)
> * Add introductory text concerning the handling of operators (Issue 35)

Fix #291 
Fix #70
Fix #257 
Fix #288 
Fix #35 
