### PR TITLE
fn:char - editors actions from 2023-01-10

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23377,37 +23377,40 @@ declare function fn:all(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns a string containing a named character or codepoint</p>
+         <p>Returns a string containing a named character or glyph.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns a string containing a single <termref
-               def="character">character</termref> identified by <code>$name</code>.</p>
+         <p>The function returns a string, generally containing a single <termref
+               def="character">character</termref> or glyph, identified by <code>$name</code>.</p>
          <p>For example, <code>fn:char("nbsp")</code> returns a string containing the
          non-breaking space character, <code>xA0</code>.</p>
          <p>The supplied value of <code>$name</code> must be one of the following:</p>
          <olist>
-            <item><p>A decimal codepoint value in the form <code>#nnn</code>, for example
-            <code>fn:char("#10")</code> represents a newline character. Leading zeroes are optional.</p></item>
-            <item><p>A hexadecimal codepoint value in the form <code>#xnnn</code>, for example
-               <code>fn:char("#x0A")</code> represents a newline character. Leading zeroes are optional, and the
-            letters A-F may be in either upper or lower case.</p></item>
             <item><p>An HTML5 character reference name (often referred to as an entity name) as defined
                at [https://html.spec.whatwg.org/multipage/named-characters.html]. The name is
                written with no leading ampersand and no trailing semicolon.
-            For example <code>fn:char("pi")</code> represents the character <code>π</code> (x3C0).</p>
-            <p>A processor <rfc2119>may</rfc2119> recognize additional character reference names defined in
-            other versions of HTML. Character reference names are case-sensitive.</p>
-            <p>[TODO: add a proper bibliographic reference.]</p></item>
+               For example <code>fn:char("pi")</code> represents the character <code>π</code> (x3C0).</p>
+               <p>A processor <rfc2119>may</rfc2119> recognize additional character reference names defined in
+                  other versions of HTML. Character reference names are case-sensitive.</p>
+               <p>In the event that the HTML5 character reference name identifies a string
+               comprising multiple codepoints, that string is returned.</p>
+               <p>[TODO: add a proper bibliographic reference.]</p></item>
             <item><p>A backslash-escape sequence from the set <code>"\n"</code> (newline, x0A), 
                <code>"\r"</code> (carriage return, 0xD), or <code>"\t"</code> (tab, 0x09).</p></item>
+            <item><p>A decimal codepoint value in the form <code>#[0-9]+</code>, for example
+            <code>fn:char("#10")</code> represents a newline character. Leading zeroes are optional.</p></item>
+            <item><p>A hexadecimal codepoint value in the form <code>#x[0-9a-fA-F]+</code>, for example
+               <code>fn:char("#x0A")</code> represents a newline character. Leading zeroes are optional, and the
+            letters A-F may be in either upper or lower case.</p></item>
+            
          </olist>
-         <p>The character must be a valid XML character (XML 1.0 or XML 1.1, whichever is supported by
+         <p>The result must consist of valid XML characters (XML 1.0 or XML 1.1, whichever is supported by
          the processor). For example <code>fn:char("#xDEAD")</code> is invalid because it is in the surrogate range.</p>
       </fos:rules>
       <fos:errors>
          <p>The function fails with a dynamic error <errorref
                class="CH" code="0005"/> if <code>$name</code> is not a valid
-            representation of a valid character.
+            representation of a valid character or sequence of characters.
          </p>
       </fos:errors>
       <fos:notes>
@@ -23416,6 +23419,11 @@ declare function fn:all(
          may make code more readable. In addition, there may be contexts where it is necessary or prudent to
          write XPath expressions using ASCII characters only, for example where an expression is used in the query
          part of a URI.</p>
+         <p>A few HTML5 character reference names identify glyphs whose Unicode
+         representation uses multiple codepoints. For example, the name
+            <code>NotEqualTilde</code> refers to the glyph <code>≂̸</code> which is expressed
+            using the two codepoints <code>#x2242 #x0338</code>. In such cases the string length of
+         the result of the function will exceed one.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -23445,11 +23453,16 @@ declare function fn:all(
                <fos:expression>fn:char("eth")</fos:expression>
                <fos:result>&#xD0;</fos:result>
             </fos:test>
+            <fos:test>
+               <fos:expression>fn:char("NotEqualTilde")</fos:expression>
+               <fos:result>fn:codepoints-to-string((8770, 824))</fos:result>
+               <fos:postamble>This HTML5 character reference name expands to multiple codepoints.</fos:postamble>
+            </fos:test>
  
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0 in the discussion of issue #121.</fos:version>
+         <fos:version version="4.0">Accepted for 4.0 on 2023-01-10; with actions on the editor for revision. See issue #121.</fos:version>
       </fos:history>
    </fos:function>
 


### PR DESCRIPTION
Changes to the new fn:char function (issue #121) as follows:

- Action QT4CG-017-01 clarifies the definition of formats #nnn and #xnnn.
- Action QT4CG-017-02 changes the order of the rules
- In discussion it was asked whether any HTML5 entity names refer to strings comprising more than one character. On investigation it appears that they do, and the spec has been revised to allow for this.
- added history/status information