### PR TITLE
Drop ternary conditionals, as agreed on 2023-01-17

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -814,7 +814,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="ExitExpr" if="scripting" lookahead="2"/>
       <g:ref name="WhileExpr" if="scripting" lookahead="2"/>
       <g:ref name="OrExpr" not-if="xpath40 xquery40"/>
-      <g:ref name="TernaryConditionalExpr" if="xpath40 xquery40"/>
     </g:choice>
   </g:production>
   
@@ -834,19 +833,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="URILiteral" if="xquery40"/>
     <g:ref name="StringLiteral" if="xpath40"/>
   </g:production>
-  
-  
-  <g:production name="TernaryConditionalExpr" if="xpath40 xquery40">
-    <g:ref name="OrExpr"/>
-    <g:optional>
-      <g:string>??</g:string>
-      <g:ref name="TernaryConditionalExpr"/>
-      <g:string>!!</g:string>
-      <g:ref name="TernaryConditionalExpr"/>
-    </g:optional>
-  </g:production>
-
-  
 
   <g:production name="ForExpr" if="xpath40  xslt40-patterns">
     <g:ref name="SimpleForClause"/>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1397,7 +1397,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
     map keys are strings other than NCNames.</p></item>
     <item><p>An <code>otherwise</code> operator is introduced: <code>A otherwise B</code> returns the
     value of <code>A</code>, unless it is an empty sequence, in which case it returns the value of <code>B</code>.</p></item>
-    <item><p>A ternary conditional expression (<code>A ?? B !! C</code>) is introduced.</p></item>
+    <item diff="del" at="2023-01-17"><p>A ternary conditional expression (<code>A ?? B !! C</code>) is introduced.</p></item>
     <item><p>The arrow operator <code>=></code> is now complemented by a "thin arrow" operator <code>-></code>
     which applies a function to each item in the input sequence independently.</p></item>
     <item><p>The rules for value comparisons when comparing values of different types (for example, decimal and double)

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -17463,14 +17463,13 @@ Also, within a <termref def="dt-path-expression"
             <prodrecap id="ElseIfAction" ref="ElseIfAction"/>
             <prodrecap id="ElseAction" ref="ElseAction"/>
             <prodrecap ref="EnclosedExpr"/>
-            <prodrecap id="TernaryConditionalExpr" ref="TernaryConditionalExpr"/>
          </scrap>
          
-         <p diff="chg" at="2023-01-10">There are three formats with essentially the same semantics.</p>
+         <p diff="chg" at="2023-01-17">There are two formats with essentially the same semantics.</p>
          <ulist diff="chg" at="2023-01-10">
             <item><p>The unbraced expression <code>if (C) then T else E</code> is equivalent to
             the braced expression <code>if (C) {T} else {E}</code>.</p></item>
-            <item><p>The ternary expression <code>C ?? T !! E</code> is equivalent to the
+            <item diff="del" at="2023-01-17"><p>The ternary expression <code>C ?? T !! E</code> is equivalent to the
                braced expression <code>if (C) {T} else {E}</code>.</p>
                <note><p>The ternary operator syntax is borrowed from Perl6.</p></note>
             </item>
@@ -17563,7 +17562,7 @@ named <code>discounted</code>, independently of its value:</p>
 }]]></eg>
             </item>
             
-            <item diff="add" at="2022-10-01">
+            <item diff="del" at="2023-01-17">
                <p>The above example can also be written:</p>
                <eg role="parse-test">$part/(@discounted ?? wholesale !! retail)</eg>
                <p>(Note: the equivalence holds only if <code>$part</code> is a single item.)</p>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -38686,9 +38686,9 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                </item>
                
                <item>
-                  <p>XPath 4.0 introduces abbreviated syntax for conditional expressions
-                  (<code>condition ?? action1 !! action2</code>) and for inline functions
-                  (<code>-> $x, $y {$x + $y}</code>).</p>
+                  <p>XPath 4.0 introduces abbreviated syntax for <phrase diff="del" at="2023-01-17">conditional expressions
+                  (<code>condition ?? action1 !! action2</code>) and for</phrase> inline functions
+                  (for example <code>-> ($x, $y) {$x + $y}</code>).</p>
                </item>
 
  


### PR DESCRIPTION
We agreed today to drop ternary conditional expressions from the proposal; this PR implements that change.