### PR TITLE
Issue 221: op:same-key becomes fn:atomic-equal

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17128,11 +17128,11 @@ return fn:sort($in, $SWEDISH)
          <fos:version version="4.0">New in 4.0. Accepted 2022-10-11.</fos:version>
       </fos:history>
    </fos:function>
-   <fos:function name="same-key" prefix="op">
+   <fos:function name="atomic-equal" prefix="fn" diff="chg" at="2023-01-25">
       <fos:signatures>
-         <fos:proto name="same-key" return-type="xs:boolean">
-            <fos:arg name="k1" type="xs:anyAtomicType"/>
-            <fos:arg name="k2" type="xs:anyAtomicType"/>
+         <fos:proto name="atomic-equal" return-type="xs:boolean">
+            <fos:arg name="value1" type="xs:anyAtomicType"/>
+            <fos:arg name="value2" type="xs:anyAtomicType"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17141,15 +17141,21 @@ return fn:sort($in, $SWEDISH)
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Determines whether two atomic values can coexist as separate keys within a map.</p>
+         <p>Determines whether two atomic values are equal, under the rules used for comparing keys in a map.</p>
       </fos:summary>
       <fos:rules>
-         <p>The internal function <code>op:same-key</code> (which is not available at the user level) is used to assess whether two atomic
-            values are considered to be duplicates when used as keys in a map. A map cannot
-         contain two separate entries whose keys are <term>the same</term> as defined by this function. 
-         The function is also used when matching keys in functions such as <code>map:get</code>
-         and <code>map:remove</code>.</p>
-
+         <p>The function <code>fn:atomic-equal</code> is used to compare two atomic values for equality. This function
+         has the following properties (which do not all apply to the <code>eq</code> operator):</p>
+         <ulist>
+            <item><p>Any two atomic values can be compared, regardless of their type.</p></item>
+            <item><p>No dynamic error is ever raised (the result is either true or false).</p></item>
+            <item><p>The result of the comparison never depends on the static or dynamic context.</p></item>
+            <item><p>Every value (including <code>NaN</code>) is equal to itself.</p></item>
+            <item><p>The comparison is symmetric: if <var>A</var> equals <var>B</var>, then <var>B</var> equals <var>A</var>.</p></item>
+            <item><p>The comparison is transitive: if <var>A</var> equals <var>B</var> and <var>B</var> equals <var>C</var>,
+               then <var>A</var> equals <var>C</var>.</p></item>
+         </ulist>
+         
          <p>The function returns true if and only if one of the following conditions is true:</p>
 
          <olist>
@@ -17157,14 +17163,14 @@ return fn:sort($in, $SWEDISH)
                <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p><code>$k1</code> is an instance of <code>xs:string</code>, <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code></p>
+                     <p><code>$value1</code> is an instance of <code>xs:string</code>, <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code></p>
                   </item>
                   <item>
-                     <p><code>$k2</code> is an instance of <code>xs:string</code>, <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code></p>
+                     <p><code>$value2</code> is an instance of <code>xs:string</code>, <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code></p>
                   </item>
                   <item>
                      <p>
-                        <code>fn:codepoint-equal($k1, $k2)</code>
+                        <code>fn:codepoint-equal($value1, $value2)</code>
                      </p>
                   </item>
                </olist>
@@ -17176,34 +17182,34 @@ return fn:sort($in, $SWEDISH)
                <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p><code>$k1</code> is an instance of <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code></p>
+                     <p><code>$value1</code> is an instance of <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code></p>
                   </item>
                   <item>
-                     <p><code>$k2</code> is an instance of <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code></p>
+                     <p><code>$value2</code> is an instance of <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code></p>
                   </item>
                   <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
                         <item>
-                           <p>Both <code>$k1</code> and <code>$k2</code> are <code>NaN</code></p>
+                           <p>Both <code>$value1</code> and <code>$value2</code> are <code>NaN</code></p>
                            <note>
                               <p><code>xs:double('NaN')</code> is the same key as <code>xs:float('NaN')</code></p>
                            </note>
                         </item>
                         <item>
-                           <p>Both <code>$k1</code> and <code>$k2</code> are positive infinity</p>
+                           <p>Both <code>$value1</code> and <code>$value2</code> are positive infinity</p>
                            <note>
                               <p><code>xs:double('INF')</code> is the same key as <code>xs:float('INF')</code></p>
                            </note>
                         </item>
                         <item>
-                           <p>Both <code>$k1</code> and <code>$k2</code> are negative infinity</p>
+                           <p>Both <code>$value1</code> and <code>$value2</code> are negative infinity</p>
                            <note>
                               <p><code>xs:double('-INF')</code> is the same key as <code>xs:float('-INF')</code></p>
                            </note>
                         </item>
                         <item>
-                           <p><code>$k1</code> and <code>$k2</code> when converted to decimal numbers with no rounding or loss of precision
+                           <p><code>$value1</code> and <code>$value2</code> when converted to decimal numbers with no rounding or loss of precision
                            are mathematically equal.</p>
                            <note>
                               <p>Every instance of <code>xs:double</code>, <code>xs:float</code>, and <code>xs:decimal</code> can be represented
@@ -17212,7 +17218,7 @@ return fn:sort($in, $SWEDISH)
                               comparison is transitive.</p>
                            </note>
                            <note>
-                              <p>Positive and negative zero are the same key.</p>
+                              <p>Positive and negative zero compare equal.</p>
                            </note>
                         </item>
                      </olist>
@@ -17220,31 +17226,32 @@ return fn:sort($in, $SWEDISH)
                </olist>
 
             </item>
+
             <item>
                <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p><code>$k1</code> is an instance of <code>xs:date</code>, <code>xs:time</code>, <code>xs:dateTime</code>,
+                     <p><code>$value1</code> is an instance of <code>xs:date</code>, <code>xs:time</code>, <code>xs:dateTime</code>,
                      <code>xs:gYear</code>, <code>xs:gYearMonth</code>, <code>xs:gMonth</code>, <code>xs:gMonthDay</code>, or <code>xs:gDay</code></p>
                   </item>
                   <item>
-                     <p><code>$k2</code> is an instance of <code>xs:date</code>, <code>xs:time</code>, <code>xs:dateTime</code>,
+                     <p><code>$value2</code> is an instance of <code>xs:date</code>, <code>xs:time</code>, <code>xs:dateTime</code>,
                      <code>xs:gYear</code>, <code>xs:gYearMonth</code>, <code>xs:gMonth</code>, <code>xs:gMonthDay</code>, or <code>xs:gDay</code></p>
                   </item>
                   <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
                         <item>
-                           <p>Both <code>$k1</code> and <code>$k2</code> have a timezone</p>
+                           <p>Both <code>$value1</code> and <code>$value2</code> have a timezone</p>
                         </item>
                         <item>
-                           <p>Neither <code>$k1</code> nor <code>$k2</code> has a timezone</p>
+                           <p>Neither <code>$value1</code> nor <code>$value2</code> has a timezone</p>
                         </item>
                      </olist>
                   </item>
                   <item>
                      <p>
-                        <code>fn:deep-equal($k1, $k2)</code>
+                        <code>fn:deep-equal($value1, $value2)</code>
                      </p>
                      <note>
                         <p>The use of <code>deep-equal</code> rather than <code>eq</code> ensures that comparing values of different
@@ -17253,25 +17260,23 @@ return fn:sort($in, $SWEDISH)
                   </item>
 
                </olist>
-               <note>
-                  <p>Unlike the <code>eq</code> operator, this comparison has no dependency on the implicit timezone, which means that
-                  the question of whether or not a map contains duplicate keys is not dependent on this aspect of the dynamic context.</p>
-               </note>
+               
             </item>
+            
             <item>
                <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p><code>$k1</code> is an instance of <code>xs:boolean</code>, <code>xs:hexBinary</code>, <code>xs:base64Binary</code>,
+                     <p><code>$value1</code> is an instance of <code>xs:boolean</code>, <code>xs:hexBinary</code>, <code>xs:base64Binary</code>,
                      <code>xs:duration</code>, <code>xs:QName</code>, or <code>xs:NOTATION</code></p>
                   </item>
                   <item>
-                     <p><code>$k2</code> is an instance of <code>xs:boolean</code>, <code>xs:hexBinary</code>, <code>xs:base64Binary</code>,
+                     <p><code>$value2</code> is an instance of <code>xs:boolean</code>, <code>xs:hexBinary</code>, <code>xs:base64Binary</code>,
                      <code>xs:duration</code>, <code>xs:QName</code>, or <code>xs:NOTATION</code></p>
                   </item>
                   <item>
                      <p>
-                        <code>fn:deep-equal($k1, $k2)</code>
+                        <code>fn:deep-equal($value1, $value2)</code>
                      </p>
                      <note>
                         <p>The use of <code>deep-equal</code> rather than <code>eq</code> ensures that comparing values of different
@@ -17285,6 +17290,17 @@ return fn:sort($in, $SWEDISH)
       </fos:rules>
 
       <fos:notes>
+         <p>The internal function <code role="example">op:same-key</code> was introduced in an earlier version of this specification
+            for comparing keys within a map.
+            In this version of the specification, the functionality is unchanged, but the function is exposed so that it
+            is available directly to applications.</p>
+         
+         <p>The function is used to assess whether two atomic
+            values are considered to be duplicates when used as keys in a map. A map cannot
+            contain two separate entries whose keys are <term>the same</term> as defined by this function. 
+            The function is also used when matching keys in functions such as <code>map:get</code>
+            and <code>map:remove</code>.</p>
+         
          <p>The rules for comparing keys in a map are chosen to ensure that the comparison is:</p>
          <ulist>
             <item>
@@ -17298,12 +17314,55 @@ return fn:sort($in, $SWEDISH)
                then <var>A</var> is the same key as <var>C</var>.</p>
             </item>
          </ulist>
+         <p>Two atomic values may be distinguishable even though they are equal under this comparison. For example: they may have
+         different type annotations; dates and times may have different timezones; <code>xs:QName</code> values may have different
+         prefixes.</p>
          <p>As always, any algorithm that delivers the right result is acceptable. For example, when testing whether an <code>xs:double</code>
          value <var>D</var> is the same key as an <code>xs:decimal</code> value that has <var>N</var> significant digits, it is not
          necessary to know all the digits in the decimal expansion of <var>D</var> to establish the result: computing the first <var>N+1</var> 
             significant digits (or indeed, simply knowing that there are more than <var>N</var> significant digits) is sufficient.</p>
       </fos:notes>
-
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>fn:atomic-equal(3, 3)</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>fn:atomic-equal(3, 3e0)</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>fn:atomic-equal(xs:double('NaN'), xs:float('NaN'))</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>fn:atomic-equal("a", "a")</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>fn:atomic-equal("a", "A")</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>fn:atomic-equal("a", xs:untypedAtomic("a"))</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>fn:atomic-equal("https://www.w3.org/", xs:anyURI("https://www.w3.org/"))</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>fn:atomic-equal(12, "12")</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0; the function is identical to the internal <code>op:same-key</code>
+         function in 3.1</fos:version>
+      </fos:history>
+      
    </fos:function>
 
    <fos:function name="merge" prefix="map">
@@ -18016,11 +18075,11 @@ map:merge(for $b in //book return map:entry($b/isbn, $b))]]></eg>
             that key value is simply ignored</phrase>.</p>
          <p>The effect of the function call <code>map:remove($MAP, $KEY)</code> can be described more formally as the result of the expression below:</p>
 
-         <eg><![CDATA[
+         <eg diff="chg" at="2023-01-25"><![CDATA[
 map:merge (
     map:for-each (
        $MAP, -> $k, $v { 
-               if (some $key in $KEY satisfies (op:same-key($k, $key)) 
+               if (some $key in $KEY satisfies (fn:atomic-equal($k, $key)) 
                then () 
                else map:entry($k, $v)
              } ) ) ]]></eg>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -652,7 +652,7 @@ for transition to Proposed Recommendation. </p>'>
                given as <code>map(*)</code>.</p></item>
                <item><p>Although option names are described above as strings, the actual key may be
                   any value that compares equal to the required string (using the <code>eq</code> operator
-                  with Unicode codepoint collation; or equivalently, the <code>op:same-key</code> relation). 
+                  with Unicode codepoint collation; or equivalently, the <code diff="chg" at="2023-01-25">fn:atomic-equal</code> relation). 
                   For example, instances of <code>xs:untypedAtomic</code>
                   or <code>xs:anyURI</code> are equally acceptable.</p>
                   <note><p>This means that the implementation of the function can check for the
@@ -1704,8 +1704,8 @@ This differs from <bibref ref="xmlschema-2"/> which defines
                            <p>This change removes the problems caused for <code>fn:distinct-values</code> and
                            <code>xsl:for-each-group</code> as a result of non-transitivity, and it aligns the semantics
                               of the <code>eq</code> operator (used also in <code>fn:distinct-values</code>, <code>fn:index-of</code>,
-                           and <code>fn:deep-equal</code>) with the semantics of the <code>op:same-key</code> comparison
-                           used for maps.</p>
+                              and <code>fn:deep-equal</code>) with the semantics of the 
+                              <code diff="chg" at="2023-01-25">fn:atomic-equal</code> comparison used for maps.</p>
                         </note>
                      </item>
                   </olist>
@@ -7097,7 +7097,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
             <p><termdef id="dt-same-key" term="same key">Within a map, no two entries have the <term>same key</term>. 
                Two atomic values <code>K1</code> and <code>K2</code> are the <term>same key</term>
-                  for this purpose if the (internal) function call <code>op:same-key($K1, $K2)</code>
+               for this purpose if the <phrase diff="chg" at="2023-01-25">function call <code>fn:atomic-equal($K1, $K2)</code></phrase>
                returns true.</termdef></p>
             
             <p>It is not necessary that all the keys in a map should be
@@ -7131,8 +7131,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
             <?local-function-index?>
             
-            <div3 id="func-same-key">
-               <head><?function op:same-key?></head>
+            <div3 id="func-atomic-equal">
+               <head><?function fn:atomic-equal?></head>
             </div3>
             <div3 id="func-map-merge">
                <head><?function map:merge?></head>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14619,8 +14619,8 @@ processing with JSON processing.</p>
     <code>K2</code> have the <term>same key value</term> if
     
     
-      <code>op:same-key(K1, K2)</code> returns <code>true</code>, as specified in <xspecref
-                        spec="FO31" ref="func-same-key"/>
+      <code>fn:atomic-equal(K1, K2)</code> returns <code>true</code>, as specified in <xspecref
+         spec="FO40" ref="func-atomic-equal"  diff="chg" at="2023-01-25"/>
                   </termdef>
 
     If two or more entries have the <termref def="dt-same-key"

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -34473,7 +34473,7 @@ the same group, and the-->
                <p>This section describes what happens when two or more maps returned by the sequence constructor
                within an <elcode>xsl:map</elcode> instruction contain duplicate keys: that is, when one of these
                maps contains an entry with key <var>K</var>, and another contains an entry with key <var>L</var>,
-               and <code>op:same-key(K, L)</code> is true.</p>
+                  and <code diff="chg" at="2023-01-25">fn:atomic-equal(K, L)</code> is true.</p>
                
                <p><error spec="XT" class="DE" code="3365" type="dynamic">
                   <p>In the absence of the <code>on-duplicates</code> attribute, 
@@ -38722,7 +38722,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
             <item>
                <p>The rules for comparing values in <elcode>xsl:for-each-group</elcode> now reference
                the rules for <function>distinct-values</function>, which have themselves changed
-               to reference <function>op:same-key</function>. This change eliminates the intransitivity
+               <phrase diff="chg" at="2023-01-25">to be compatible with <function>fn:atomic-equal</function></phrase>. This change eliminates the intransitivity
                in the previous specification, which meant that in edge cases involving rounding of numeric values
                of different types, two items in different groups could compare equal. Any change in behavior
                is confined to this edge case.</p>


### PR DESCRIPTION
The proposal renames op:same-key as fn:atomic-equal, thus making it directly available to applications.