### PR TITLE
Issue 98 - add options parameter to fn:deep-equal

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12467,6 +12467,12 @@ else if (fn:empty($input))
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
                </fos:option>
+               <fos:option key="nilled-property">
+                  <fos:meaning>Determines whether the <code>nilled</code> property of elements and attributes is significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
                <fos:option key="normalization-form">
                   <fos:meaning>If present, indicates that text and attributes are converted to the specified
                      Unicode normalization form prior to comparison. The value is as for the corresponding
@@ -12474,13 +12480,7 @@ else if (fn:empty($input))
                   </fos:meaning>
                   <fos:type>xs:string?</fos:type>
                   <fos:default>()</fos:default>
-               </fos:option>
-               <fos:option key="nilled-property">
-                  <fos:meaning>Determines whether the <code>nilled</code> property of elements and attributes is significant.
-                  </fos:meaning>
-                  <fos:type>xs:boolean</fos:type>
-                  <fos:default>false</fos:default>
-               </fos:option>
+               </fos:option>              
                <fos:option key="normalize-space">
                   <fos:meaning>The value <code>false</code> indicates that text and attributes are compared <emph>as-is</emph>;
                      the value <code>true</code> indicates that they are compared after normalization using <code>fn:normalize-space</code>.

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12365,7 +12365,7 @@ else if (fn:empty($input))
          <fos:proto name="deep-equal" return-type="xs:boolean">
             <fos:arg name="input1" type="item()*" usage="absorption"/>
             <fos:arg name="input2" type="item()*" usage="absorption"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
             <fos:arg name="options" type="map(*)" default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -12394,7 +12394,8 @@ else if (fn:empty($input))
       <fos:rules>
          <p>The <code>$collation</code> argument identifies a collation which is used at all levels
             of recursion when strings are compared (but not when names are compared), according to
-            the rules in <specref ref="choosing-a-collation"/>.</p>
+            the rules in <specref ref="choosing-a-collation"/>. If the argument is not supplied,
+            or if it is empty, then the default collation from the static context of the caller is used.</p>
          <p>The <code>$options</code> argument, if present, defines additional parameters controlling
             how the comparison is done. The <termref def="option-parameter-conventions"
                >option parameter conventions</termref> apply.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12407,8 +12407,7 @@ else if (fn:empty($input))
             deciding whether two items are deep-equal appear below.</p>
          
 
-            <p>The entries that may appear in the <code>$options</code> map are as follows. As a general convention
-               for boolean options, the value true indicates that the comparison is more strict. The detailed rules
+            <p>The entries that may appear in the <code>$options</code> map are as follows. The detailed rules
                for the interpretation of each option appear later.</p>
             
             <fos:options>
@@ -12435,8 +12434,10 @@ else if (fn:empty($input))
                   <fos:default>false</fos:default>
                </fos:option>
                <fos:option key="false-on-error">
-                  <fos:meaning>If true, then in the event of a dynamic error the function will return false rather than
-                     throwing the error.
+                  <fos:meaning>If true, then in the event of a dynamic error occurring in the course of
+                     the comparison, the function will return false rather than throwing the error. (This option does
+                     not affect the handling of errors in the supplied values of the <code>$collation</code>
+                     and <code>$options</code> arguments.)
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
@@ -12481,21 +12482,27 @@ else if (fn:empty($input))
                   <fos:default>false</fos:default>
                </fos:option>
                <fos:option key="normalize-space">
-                  <fos:meaning>The value false indicates that text and attributes are compared <emph>as-is</emph>;
-                     the value true indicates that they are compared after normalization using <code>fn:normalize-space</code>.
+                  <fos:meaning>The value <code>false</code> indicates that text and attributes are compared <emph>as-is</emph>;
+                     the value <code>true</code> indicates that they are compared after normalization using <code>fn:normalize-space</code>.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>true</fos:default>
+               </fos:option>
+               <fos:option key="preserve-space">
+                  <fos:meaning>Determines whether text nodes consisting entirely of whitespace are significant.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>true</fos:default>
                </fos:option>
                <fos:option key="processing-instructions">
-                  <fos:meaning>Determines whether processing-instructions are significant.
+                  <fos:meaning>Determines whether processing instructions are significant.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
                </fos:option>
                <fos:option key="text-boundaries">
                   <fos:meaning>Determines whether boundaries between text nodes are significant, even when two text
-                     nodes are separated by a comment or processing instruction that is ignored. (This property
+                     nodes are separated by an ignored comment or processing instruction. (This property
                      is provided, with the default <code>true</code>, for compatibility with previous versions.)
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
@@ -12534,23 +12541,10 @@ else if (fn:empty($input))
                   <fos:type>xs:QName*</fos:type>
                   <fos:default>()</fos:default>
                </fos:option>
-               <fos:option key="whitespace-retained">
-                  <fos:meaning>The value true indicates that text and attributes are compared <emph>as-is</emph>;
-                     the value false indicates that they are compared after normalization using <code>fn:normalize-space</code>.
-                  </fos:meaning>
-                  <fos:type>xs:boolean</fos:type>
-                  <fos:default>true</fos:default>
-               </fos:option>
-               <fos:option key="whitespace-text-nodes">
-                  <fos:meaning>Determines whether text nodes consisting entirely of whitespace are significant.
-                  </fos:meaning>
-                  <fos:type>xs:boolean</fos:type>
-                  <fos:default>true</fos:default>
-               </fos:option>
             </fos:options>
          
-         <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
-         follow.</p>
+         <note><p>As a general rule for boolean options (but not invariably), the value true indicates 
+            that the comparison is more strict. </p></note>
 
          <p>In the following rules, where a recursive call on <code>fn:deep-equal</code> is made, this is assumed
          to use the same values of <code>$collation</code> and <code>$options</code> as the original call.</p>
@@ -12580,8 +12574,9 @@ else if (fn:empty($input))
     return fn:compare($n1($n2($s1)), $n1($n2($s2)), $collation) eq 0    
 }]]></eg>
          
-         <p>The two items are deep-equal
-         if one or more of the following conditions is true:</p>
+         <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
+            are as follows. The two items are deep-equal
+            if one or more of the following conditions is true:</p>
          <olist>
             <item>
                <p>All of the following conditions are true:</p>
@@ -12591,15 +12586,17 @@ else if (fn:empty($input))
                   <item>
                      <p><code>$i2</code> is an atomic value.</p></item>
                   <item>
+                     <p>Either the <code>type-annotations</code> option is false, or both atomic values have
+                     the same type annotation.</p>
+                  </item>
+                  <item>
                      <p>If both the following conditions are true:</p>
                      <ulist>
-                        <item><p><code>$i1</code> is an instance of <code>xs:string</code>, <code>xs:untypedAtomic</code>,
-                           or <code>xs:anyURI</code>.</p></item>
-                        <item><p><code>$i2</code> is an instance of <code>xs:string</code>, <code>xs:untypedAtomic</code>,
-                           or <code>xs:anyURI</code>.</p></item>
+                        <item><p><code>$i1</code> is an instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p></item>
+                        <item><p><code>$i2</code> is an instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p></item>
                      </ulist>
                      <p>then the function <code>equal-strings($i1, $i2, $collation, $options)</code> returns true.</p>
-                     <p>Otherwise (the items are of some other type), either:</p>
+                     <p>Otherwise (at least one of the items is of some other type), either:</p>
                      <ulist>
                         <item><p><code>$i1</code> and <code>$i2</code> are comparable,
                            and <code>($i1 eq $i2)</code> is <code>true</code>; or</p></item>
@@ -12684,13 +12681,15 @@ else if (fn:empty($input))
                   <item><p><code>$i1</code> is a node.</p></item>
                   <item><p><code>$i2</code> is a node.</p></item>
                   <item><p>Both nodes have the same node kind.</p></item>
+                  <item><p>Either the <code>base-uri</code> option is false, or both nodes have the same value
+                     for their base URI property, or both nodes have an absent base URI.</p></item>
                   <item><p>Let <code>significant-children($parent)</code> be the sequence of nodes applying the following
                   steps to the children of <code>$parent</code>, in turn:</p>
                      <olist>
                         <item><p>Comment nodes are discarded if the option <code>comments</code> is false.</p></item>
                         <item><p>Processing instruction nodes are discarded if the option <code>processing-instructions</code> is false.</p></item>
                         <item><p>Adjacent text nodes are merged if the option <code>text-boundaries</code> is false.</p></item>
-                        <item><p>Whitespace-only text nodes are discarded if the option <code>whitespace-text-nodes</code> is false,
+                        <item><p>Whitespace-only text nodes are discarded if the option <code>preserve-space</code> is false,
                            or if <code>$parent</code> is an element node whose type annotation is a complex type with an element-only
                            or empty content model.</p></item>
                  
@@ -12879,11 +12878,37 @@ else if (fn:empty($input))
                         <item>
                            <p>Both nodes are text nodes, and the <code>equal-strings</code> function 
                               returns true when applied to their string values.</p>
+                           <note>
+                              <p>The handling of whitespace is controlled by a number of options:</p>
+                              <ulist>
+                                 <item><p>Firstly, text nodes consisting entirely of whitespace are considered
+                                 significant by default, unless the parent element has been schema-validated and
+                                 has an element-only content model. This can be overridden by setting the
+                                 <code>preserve-space</code> option to <code>false</code>. The process is not influenced
+                                 by any <code>xml:space</code> attributes that might be present.</p></item>
+                                 <item><p>The decision whether a text node is whitespace is made after
+                                 stripping comments and processing instructions. However, the text nodes
+                                 either side of a comment or processing instruction are merged only if the
+                                 <code>text-boundaries</code> option is true (it is false by default).
+                                 </p></item>
+                                 <item><p>If the <code>preserve-space</code> option and the
+                                 <code>normalize-space</code> option are both true, then a whitespace-only
+                                 text node will be reduced to zero length; this means that all whitespace-only
+                                 text nodes will compare equal regardless of their actual content, but the
+                                 presence of the node is still considered significant.</p></item>
+                                 <item><p>The <code>normalize-space</code> option affects the comparison
+                                 of text nodes, attribute nodes, comments and processing instructions (if not
+                                 stripped): it applies to all such nodes when their string values are
+                                 compared, and to nodes whose typed value is a string when comparing typed
+                                 values. It also affects strings within maps and arrays. It has no effect where
+                                 more specific rules apply, for example when comparing node names, namespace URIs,
+                                 or map keys.</p></item>
+                              </ulist>
+                           </note>
                         </item>
                   </olist>
                   </item>
-                  <item><p>Either the <code>base-uri</code> option is false, or both nodes have the same value
-                     for their base URI property, or both nodes have an absent base URI.</p></item>
+                  
                </olist>
             </item>
          </olist>
@@ -12894,9 +12919,16 @@ else if (fn:empty($input))
                /> if either input
             sequence contains a function item <phrase>that is not a map or
                array</phrase>. </p>
-         <p>However, no error is raised if the <code>false-on-error</code> option has the
+         <p>However, the above error is not raised if the <code>false-on-error</code> option has the
          value true; in this case, the function returns false rather than raising an error.</p>
-
+         <p>A type error is raised <errorref spec="XP" class="TY" code="0004" tupe="type"
+         /> if the value of 
+            <code>$options</code> includes an entry whose key is defined 
+            in this specification, and whose value is not of the permitted type for that key.</p>
+         <p>A dynamic error is raised <errorref spec="FO" class="JS" code="0005"
+         /> if the value of 
+            <code>$options</code> includes an entry whose key is defined 
+            in this specification, and whose value is not a permitted value for that key.</p>
       </fos:errors>
       <fos:notes>
          <p>By default, two nodes are not required to have the same type annotation, and they are not

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12416,14 +12416,24 @@ else if (fn:empty($input))
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
                </fos:option>
+               <fos:option key="debug">
+                  <fos:meaning>Requests diagnostics in the case where the function returns false.
+                     When this option is set and the two inputs are found to be not equal, the implementation
+                     <rfc2119>should</rfc2119> output messages (in an implementation-dependent format and to
+                     an implementation-dependent destination) indicating the nature of the differences that
+                     were found.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
                <fos:option key="id-property">
                   <fos:meaning>Determines whether the <code>id</code> property of elements and attributes is significant.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
                </fos:option>
-               <fos:option key="idref-property">
-                  <fos:meaning>Determines whether the <code>idref</code> property of elements and attributes is significant.
+               <fos:option key="idrefs-property">
+                  <fos:meaning>Determines whether the <code>idrefs</code> property of elements and attributes is significant.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
@@ -12516,46 +12526,71 @@ else if (fn:empty($input))
                   <fos:default>true</fos:default>
                </fos:option>
             </fos:options>
+         
+         <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
+         follow.</p>
 
          <p>In the following rules, where a recursive call on <code>fn:deep-equal</code> is made, this is assumed
          to use the same values of <code>$collation</code> and <code>$options</code> as the original call.</p>
          
-         <p>Call the two items <code>$i1</code> and <code>$i2</code> respectively. The two items are deep-equal
+         <p>The rules reference a function <code>equal-strings</code> which compares two strings as follows:</p>
+         
+         <olist>
+            <item><p>If the <code>normalization-form</code> option is present, each string is normalized
+            by calling the <code>fn:normalize-unicode</code> function, supplying the specified normalization
+            form.</p></item>
+            <item><p>If the <code>retain-whitespace</code> option is false, each string is processed
+               by calling the <code>fn:normalize-space</code> function.</p></item>
+            <item><p>The two strings are compared for equality under the requested <code>$collation</code>.</p></item>
+         </olist>
+         
+         <p>The two items are deep-equal
          if one or more of the following conditions is true:</p>
          <olist>
             <item>
                <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p><code>$i1</code> is an atomic value</p></item>
+                     <p><code>$i1</code> is an atomic value.</p></item>
                   <item>
-                     <p><code>$i2</code> is an atomic value</p></item>
+                     <p><code>$i2</code> is an atomic value.</p></item>
                   <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
+                        <item>
+                           <p>All of the following conditions are true:</p>
+                           <olist>
+                              <item><p><code>$i1</code> is an instanceof of <code>xs:string</code>, <code>xs:untypedAtomic</code>,
+                              or <code>xs:anyURI</code>.</p></item>
+                              <item><p><code>$i2</code> is an instanceof of <code>xs:string</code>, <code>xs:untypedAtomic</code>,
+                                 or <code>xs:anyURI</code>.</p></item>
+                              <item><p>The relation <code>equal-strings</code> holds between <code>$i1</code> and <code>$i2</code>.</p></item>
+                           </olist>
+                        </item>           
                         <item><p><code>($i1 eq $i2)</code> is <code>true</code> (and the comparison 
-                           does not fail with a dynamic or type error)</p></item>
+                           does not fail with a dynamic or type error)</p>
+                           <note><p>This rule is only needed for comparing non-string values.</p></note></item>
                         <item><p>Both <code>$i1</code> and <code>$i2</code> are <code>NaN</code></p></item>
                      </olist>
                   </item>
                   <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
-                        <item><p>Option <code>namespace-prefixes</code> is false</p></item>
+                        <item><p>Option <code>namespace-prefixes</code> is false.</p></item>
                         <item><p>Neither <code>$i1</code> nor <code>$i2</code> is of type
-                        <code>xs:QName</code> or <code>xs:NOTATION</code></p></item>
-                        <item><p><code>$i1</code> and <code>$i2</code> are qualified names with the same namespace prefix</p></item>
+                        <code>xs:QName</code> or <code>xs:NOTATION</code>.</p></item>
+                        <item><p><code>$i1</code> and <code>$i2</code> are qualified names with the same namespace prefix.</p></item>
                      </olist>
                   </item>
                   <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
-                        <item><p>Option <code>timezones</code> is false</p></item>
+                        <item><p>Option <code>timezones</code> is false.</p></item>
                         <item><p>Neither <code>$i1</code> nor <code>$i2</code> is of type
                            <code>xs:date</code>, <code>xs:time</code>, <code>xs:dateTime</code>, 
                            <code>xs:gYear</code>, <code>xs:gYearMonth</code>, <code>xs:gMonth</code>, 
-                           <code>xs:gMonthDay</code>, or <code>xs:gDay</code></p></item>
-                        <item><p>Neither <code>$i1</code> nor <code>$i2</code> has a timezone component</p></item>
+                           <code>xs:gMonthDay</code>, or <code>xs:gDay</code>.</p></item>
+                        <item><p>Neither <code>$i1</code> nor <code>$i2</code> has a timezone component.</p></item>
                         <item><p>Both <code>$i1</code> and <code>$i2</code> have a timezone component and the
                         timezone components are equal.</p></item>
                      </olist>
@@ -12566,10 +12601,10 @@ else if (fn:empty($input))
                <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p><code>$i1</code> is a map</p>
+                     <p><code>$i1</code> is a map.</p>
                   </item>
                   <item>
-                     <p><code>$i2</code> is a map</p>
+                     <p><code>$i2</code> is a map.</p>
                   </item>
                   <item>
                      <p>Both maps have the same number of entries.</p>
@@ -12593,8 +12628,8 @@ else if (fn:empty($input))
             <item>
                <p>All the following conditions are true:</p>
                <olist>
-                  <item><p><code>$i1</code> is an array</p></item>
-                  <item><p><code>$i2</code> is an array</p></item>
+                  <item><p><code>$i1</code> is an array.</p></item>
+                  <item><p><code>$i2</code> is an array.</p></item>
                   <item>
                      <p>Both arrays have the same number of members (<code>array:size($i1) eq
                            array:size($i2)</code>).</p>
@@ -12602,16 +12637,16 @@ else if (fn:empty($input))
                   <item>
                      <p>Members in the same position of both arrays are deep-equal to each other: that is,
                            <code>every $p in 1 to array:size($i1) satisfies deep-equal($i1($p), $i2($p),
-                           $collation, $options)</code></p>
+                           $collation, $options).</code></p>
                   </item>
                </olist>
             </item>
             <item>
                <p>All the following conditions are true:</p>
                <olist>
-                  <item><p><code>$i1</code> is a node</p></item>
-                  <item><p><code>$i2</code> is a node</p></item>
-                  <item><p>Both nodes have the same node kind</p></item>
+                  <item><p><code>$i1</code> is a node.</p></item>
+                  <item><p><code>$i2</code> is a node.</p></item>
+                  <item><p>Both nodes have the same node kind.</p></item>
                   <item><p>Let <code>significant-children($parent)</code> be the sequence of nodes formed by
                   filtering the children of <code>$parent</code> as follows:</p>
                      <olist>
@@ -12636,8 +12671,8 @@ else if (fn:empty($input))
                      <p>One of the following conditions is true.</p>
                      <olist>
                         <item>
-                           <p>Both nodes are document nodes, and the sequence <code>significant-children($i1)</code> is deep-equal to the sequence
-                              <code>significant-children($i2)</code>.</p>
+                           <p>Both nodes are document nodes, and the sequence <code>significant-children($i1)</code> 
+                              is deep-equal to the sequence <code>significant-children($i2)</code>.</p>
                         </item>
                         <item>
                            <p>Both nodes are element nodes, and all the following conditions are true:</p>
@@ -12652,15 +12687,19 @@ else if (fn:empty($input))
                               </item>
                               <item>
                                  <p>Either the option <code>in-scope-namespaces</code> is false, or both element
-                                    names have the same in-scope namespace bindings.</p>
+                                    nodes have the same in-scope namespace bindings.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>type-annotations</code> is false, or both
+                                    element nodes have the same type annotation.</p>
                               </item>
                               <item>
                                  <p>Either the option <code>id-property</code> is false, or both element
-                                    names have the same value for their <code>id</code> property.</p>
+                                    nodes have the same value for their <code>is-id</code> property.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>idref-property</code> is false, or both element
-                                    nodes have the same value for their <code>idref</code> property.</p>
+                                 <p>Either the option <code>idrefs-property</code> is false, or both element
+                                    nodes have the same value for their <code>is-idrefs</code> property.</p>
                               </item>
                               <item>
                                  <p>Either the option <code>nilled-property</code> is false, or both element
@@ -12671,14 +12710,14 @@ else if (fn:empty($input))
                                  <olist>
                                     <item><p>The option <code>type-variety</code> is false.</p></item>
                                     <item><p>Both nodes are annotated as having simple content.
-                                       For this purpose "simple content"
+                                       For this purpose <term>simple content</term>
                                        means either a simple type or a complex type with simple content.</p></item>
                                     <item><p>Both nodes are annotated as having complex content. For this purpose 
-                                       "complex content" means a complex type whose variety is mixed, element-only, or
+                                       <term>complex content</term> means a complex type whose variety is mixed, element-only, or
                                        empty.</p></item>
                                  </olist>
                                  <note>
-                                    <p>It is a consequence of this rule that validating a document <var>D</var>
+                                    <p>It is a consequence of this rule that, by default, validating a document <var>D</var>
                                        against a schema will usually (but not necessarily) result in a document
                                        that is not deep-equal to <var>D</var>. The exception is when the schema
                                        allows all elements to have mixed content.</p>
@@ -12703,8 +12742,8 @@ else if (fn:empty($input))
                                     <item>
                                        <p>Both element nodes are annotated as having simple content (as defined
                                           above), the <code>typed-values</code> option is false, 
-                                          and the string value of <code>$i1</code> is deep-equal
-                                          to the string value of <code>$i2</code>.</p>
+                                          and the equal-strings relation holds between the string value of <code>$i1</code> 
+                                          and the string value of <code>$i2</code>.</p>
                                     </item>
                                     <item>
                                        <p>Both element nodes have a type annotation that is a complex type, 
@@ -12721,20 +12760,34 @@ else if (fn:empty($input))
                            <olist>
       
                               <item>
-                                 <p>The two nodes have the same name, that is <code>(node-name($i1) eq
+                                 <p>The two attribute nodes have the same name, that is <code>(node-name($i1) eq
                                        node-name($i2))</code>.</p>
                               </item>
                               <item>
-                                 <p>The typed value of <code>$i1</code> is deep-equal to the typed value of
+                                 <p>Either the option <code>namespace-prefixes</code> is false, or both
+                                 attribute names have the same prefix.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>type-annotations</code> is false, or both
+                                 attribute nodes have the same type annotation.</p>
+                              </item>
+                              <item>
+                                 <p>The option <code>typed-value</code> is true and 
+                                    the typed value of <code>$i1</code> is deep-equal to the typed value of
                                        <code>$i2</code>.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>id-property</code> is false, or both attribute nodes
-                                    have the same value for their <code>id</code> property.</p>
+                                 <p>The option <code>typed-value</code> is false and 
+                                    the equal-strings relation holds between the string value of <code>$i1</code> 
+                                    and the string value of <code>$i2</code>.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>idref-property</code> is false, or both attribute nodes
-                                    have the same value for their <code>idref</code> property.</p>
+                                 <p>Either the option <code>id-property</code> is false, or both attribute nodes
+                                    have the same value for their <code>is-id</code> property.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>idrefs-property</code> is false, or both attribute nodes
+                                    have the same value for their <code>is-idrefs</code> property.</p>
                               </item>
                            </olist>
                         </item>
@@ -12747,8 +12800,8 @@ else if (fn:empty($input))
                                           node-name($i2))</code>.</p>
                                  </item>
                                  <item>
-                                    <p>The string value of <code>$i1</code> is equal to the string value of
-                                          <code>$i2</code>.</p>
+                                    <p>The equal-strings relation holds between the string value of <code>$i1</code> 
+                                       and the string value of <code>$i2</code>.</p>
                                  </item>
                               </olist>
                         </item>
@@ -12768,19 +12821,12 @@ else if (fn:empty($input))
                            passed explicitly to the <code>fn:deep-equal</code> function.</p></note>
                         </item>
                         <item>
-                           <p>Both nodes are comment nodes, and their string-values are equal (under the selected collation) .</p>
+                           <p>Both nodes are comment nodes, and the equal-strings relation holds
+                              between their string values.</p>
                         </item>
                         <item>
-                           <p>Both nodes are text nodes, and their string-values are equal (under the selected collation) 
-                              after adjusting as follows:</p>
-                           <olist>
-                              <item><p>If the <code>normalization-form</code> option is present, the string value
-                              of both text nodes is converted to the required normalization form by applying
-                              the <code>fn:normalize-unicode</code> function.</p></item>
-                              <item><p>If the <code>whitespace-retained</code> option is false, the string value
-                                 of both text nodes is processed by applying
-                                 the <code>fn:normalize-space</code> function.</p></item>
-                           </olist>
+                           <p>Both nodes are text nodes, and the equal-strings relation holds
+                              between their string values.</p>
                         </item>
                   </olist>
                   </item>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12394,15 +12394,17 @@ else if (fn:empty($input))
       <fos:rules>
          <p>The <code>$collation</code> argument identifies a collation which is used at all levels
             of recursion when strings are compared (but not when names are compared), according to
-            the rules in <specref
-               ref="choosing-a-collation"/>.</p>
+            the rules in <specref ref="choosing-a-collation"/>.</p>
+         <p>The <code>$options</code> argument, if present, defines additional parameters controlling
+            how the comparison is done. The <termref def="option-parameter-conventions"
+               >option parameter conventions</termref> apply.</p>
          <p>If the two sequences are both empty, the function returns <code>true</code>.</p>
          <p>If the two sequences are of different lengths, the function returns
             <code>false</code>.</p>
          <p>If the two sequences are of the same length, the function returns <code>true</code> if
             and only if every item in the sequence <code>$input1</code> is deep-equal to the
             item at the same position in the sequence <code>$input2</code>. The rules for
-            deciding whether two items are deep-equal follow.</p>
+            deciding whether two items are deep-equal appear below.</p>
          
 
             <p>The entries that may appear in the <code>$options</code> map are as follows. As a general convention
@@ -12422,6 +12424,13 @@ else if (fn:empty($input))
                      <rfc2119>should</rfc2119> output messages (in an implementation-dependent format and to
                      an implementation-dependent destination) indicating the nature of the differences that
                      were found.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="false-on-error">
+                  <fos:meaning>If true, then in the event of a dynamic error the function will return false rather than
+                     throwing the error.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
@@ -12465,6 +12474,13 @@ else if (fn:empty($input))
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
                </fos:option>
+               <fos:option key="normalize-space">
+                  <fos:meaning>The value false indicates that text and attributes are compared <emph>as-is</emph>;
+                     the value true indicates that they are compared after normalization using <code>fn:normalize-space</code>.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>true</fos:default>
+               </fos:option>
                <fos:option key="processing-instructions">
                   <fos:meaning>Determines whether processing-instructions are significant.
                   </fos:meaning>
@@ -12493,10 +12509,10 @@ else if (fn:empty($input))
                </fos:option>
                <fos:option key="type-variety">
                   <fos:meaning>Determines whether the variety of the type annotation of an element 
-                     (as a simple or complex type) is significant.
+                     (whether it has complex content or simple content) is significant.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
-                  <fos:default>false</fos:default>
+                  <fos:default>true</fos:default>
                </fos:option>
                <fos:option key="typed-values">
                   <fos:meaning>Determines whether nodes are compared using their typed values rather than
@@ -12536,13 +12552,27 @@ else if (fn:empty($input))
          <p>The rules reference a function <code>equal-strings</code> which compares two strings as follows:</p>
          
          <olist>
-            <item><p>If the <code>normalization-form</code> option is present, each string is normalized
-            by calling the <code>fn:normalize-unicode</code> function, supplying the specified normalization
-            form.</p></item>
-            <item><p>If the <code>retain-whitespace</code> option is false, each string is processed
+            <item><p>If the <code>normalize-space</code> option is true, each string is processed
                by calling the <code>fn:normalize-space</code> function.</p></item>
-            <item><p>The two strings are compared for equality under the requested <code>$collation</code>.</p></item>
+            <item><p>If the <code>normalization-form</code> option is present, each string is then normalized
+            by calling the <code>fn:normalize-unicode</code> function, supplying the specified normalization
+            form.</p></item>           
+            <item><p>The two strings are then compared for equality under the requested <code>$collation</code>.</p></item>
          </olist>
+         
+         <p>More formally, the <code>equal-strings</code> function can be expressed as follows:</p>
+         
+         <eg><![CDATA[function ($s1 as xs:string, $s2 as xs:string, 
+                   $collation as xs:string, $options as map(*)) as xs:boolean {
+    let $n1 := if (exists($options?normalization-form))
+               then fn:normalize-unicode(?, $options?normalization-form) 
+               else fn:identity#1,
+        $n2 := if ($options?normalize-space)
+               then fn:normalize-space#1 
+               else fn:identity#1               
+    }
+    return fn:compare($n1($n2($s1)), $n1($n2($s2)), $collation) eq 0    
+}]]></eg>
          
          <p>The two items are deep-equal
          if one or more of the following conditions is true:</p>
@@ -12555,24 +12585,25 @@ else if (fn:empty($input))
                   <item>
                      <p><code>$i2</code> is an atomic value.</p></item>
                   <item>
-                     <p>One of the following conditions is true:</p>
-                     <olist>
-                        <item>
-                           <p>All of the following conditions are true:</p>
-                           <olist>
-                              <item><p><code>$i1</code> is an instanceof of <code>xs:string</code>, <code>xs:untypedAtomic</code>,
-                              or <code>xs:anyURI</code>.</p></item>
-                              <item><p><code>$i2</code> is an instanceof of <code>xs:string</code>, <code>xs:untypedAtomic</code>,
-                                 or <code>xs:anyURI</code>.</p></item>
-                              <item><p>The relation <code>equal-strings</code> holds between <code>$i1</code> and <code>$i2</code>.</p></item>
-                           </olist>
-                        </item>           
-                        <item><p><code>($i1 eq $i2)</code> is <code>true</code> (and the comparison 
-                           does not fail with a dynamic or type error)</p>
-                           <note><p>This rule is only needed for comparing non-string values.</p></note></item>
-                        <item><p>Both <code>$i1</code> and <code>$i2</code> are <code>NaN</code></p></item>
-                     </olist>
+                     <p>If both the following conditions are true:</p>
+                     <ulist>
+                        <item><p><code>$i1</code> is an instance of <code>xs:string</code>, <code>xs:untypedAtomic</code>,
+                           or <code>xs:anyURI</code>.</p></item>
+                        <item><p><code>$i2</code> is an instance of <code>xs:string</code>, <code>xs:untypedAtomic</code>,
+                           or <code>xs:anyURI</code>.</p></item>
+                     </ulist>
+                     <p>then the function <code>equal-strings($i1, $i2, $collation, $options)</code> returns true.</p>
+                     <p>Otherwise (the items are of some other type), either:</p>
+                     <ulist>
+                        <item><p><code>$i1</code> and <code>$i2</code> are comparable,
+                           and <code>($i1 eq $i2)</code> is <code>true</code>; or</p></item>
+                        <item><p>both <code>$i1</code> and <code>$i2</code> are <code>NaN</code>.</p></item> 
+                     </ulist>
+                     <note><p>If <code>$i1</code> and <code>$i2</code> are not comparable, that is,
+                        if the expression <code>($i1 eq $i2)</code> would raise an error, then the function
+                     returns false; it does not report an error.</p></note>
                   </item>
+                  
                   <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
@@ -12619,7 +12650,7 @@ else if (fn:empty($input))
                         </item>
                         <item>
                            <p>has the same associated value (compared using the <code>fn:deep-equal</code>
-                              function).</p>
+                              function, recursively).</p>
                         </item>
                      </olist>
                   </item>
@@ -12647,8 +12678,8 @@ else if (fn:empty($input))
                   <item><p><code>$i1</code> is a node.</p></item>
                   <item><p><code>$i2</code> is a node.</p></item>
                   <item><p>Both nodes have the same node kind.</p></item>
-                  <item><p>Let <code>significant-children($parent)</code> be the sequence of nodes formed by
-                  filtering the children of <code>$parent</code> as follows:</p>
+                  <item><p>Let <code>significant-children($parent)</code> be the sequence of nodes applying the following
+                  steps to the children of <code>$parent</code>, in turn:</p>
                      <olist>
                         <item><p>Comment nodes are discarded if the option <code>comments</code> is false.</p></item>
                         <item><p>Processing instruction nodes are discarded if the option <code>processing-instructions</code> is false.</p></item>
@@ -12656,14 +12687,7 @@ else if (fn:empty($input))
                         <item><p>Whitespace-only text nodes are discarded if the option <code>whitespace-text-nodes</code> is false,
                            or if <code>$parent</code> is an element node whose type annotation is a complex type with an element-only
                            or empty content model.</p></item>
-                        <item><p>If <code>$parent</code> is an element node and its name is included in the value
-                           of option <code>unordered-elements</code>, then all text nodes are discarded, and element nodes are
-                           sorted first by namespace and then by local-name, retaining the original order when multiple elements
-                           have the same name.</p>
-                           <note><p>It is inadvisable to use this option for mixed-content elements, or for elements
-                           that allow multiple children with the same name. The rules permit this, but the results
-                           might not be intuitive.</p></note>
-                        </item>
+                 
                      </olist>
                   
                   </item>
@@ -12738,17 +12762,37 @@ else if (fn:empty($input))
                                           above), the <code>typed-values</code> option is true, 
                                           and the typed value of <code>$i1</code> is deep-equal
                                           to the typed value of <code>$i2</code>.</p>
+                                       <note><p>The typed value of an element node is used only when the element
+                                       has simple content, which means that no error can occur as a result
+                                       of atomizing a node with no typed value.</p></note>
                                     </item>
                                     <item>
                                        <p>Both element nodes are annotated as having simple content (as defined
                                           above), the <code>typed-values</code> option is false, 
-                                          and the equal-strings relation holds between the string value of <code>$i1</code> 
+                                          and the <code>equal-strings</code> function returns true when
+                                          applied to the string value of <code>$i1</code> 
                                           and the string value of <code>$i2</code>.</p>
                                     </item>
                                     <item>
-                                       <p>Both element nodes have a type annotation that is a complex type, 
+                                       <p>Both element nodes have a type annotation that is a complex type with
+                                          element-only, mixed, or empty content,
+                                          the (common) element name is not present in the <code>unordered-elements</code> option,
                                           and the sequence <code>significant-children($i1)</code> is
                                           deep-equal to the sequence <code>significant-children($i2)</code>.</p>
+                                    </item>
+                                    <item>
+                                       <p>Both element nodes have a type annotation that is a complex type with
+                                          element-only, mixed, or empty content,
+                                          the (common) element name is present in the <code>unordered-elements</code> option,
+                                          and the sequence <code>significant-children($i1)</code> is
+                                          deep-equal to some permutation of the sequence <code>significant-children($i2)</code>.</p>
+                                       <note>
+                                          <p>Elements annotated as <code>xs:untyped</code> fall into this category.</p>
+                                          <p>Including an element name in the <code>unordered-elements</code> list is unlikely
+                                          to be useful except when the relevant elements have element-only content, but
+                                          this is not a requirement: the rules apply equally to elements with mixed content,
+                                          or even (trivially) to elements with empty content.</p>
+                                       </note>
                                     </item>
                                  </olist>
                               </item>
@@ -12772,16 +12816,6 @@ else if (fn:empty($input))
                                  attribute nodes have the same type annotation.</p>
                               </item>
                               <item>
-                                 <p>The option <code>typed-value</code> is true and 
-                                    the typed value of <code>$i1</code> is deep-equal to the typed value of
-                                       <code>$i2</code>.</p>
-                              </item>
-                              <item>
-                                 <p>The option <code>typed-value</code> is false and 
-                                    the equal-strings relation holds between the string value of <code>$i1</code> 
-                                    and the string value of <code>$i2</code>.</p>
-                              </item>
-                              <item>
                                  <p>Either the option <code>id-property</code> is false, or both attribute nodes
                                     have the same value for their <code>is-id</code> property.</p>
                               </item>
@@ -12789,6 +12823,17 @@ else if (fn:empty($input))
                                  <p>Either the option <code>idrefs-property</code> is false, or both attribute nodes
                                     have the same value for their <code>is-idrefs</code> property.</p>
                               </item>
+                              <item>
+                                 <p>Either the option <code>typed-value</code> is false, or 
+                                    the typed value of <code>$i1</code> is deep-equal to the typed value of
+                                       <code>$i2</code>.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>typed-value</code> is true, or 
+                                    the <code>equal-strings</code> function returns true when applied to the string value of <code>$i1</code> 
+                                    and the string value of <code>$i2</code>.</p>
+                              </item>
+                              
                            </olist>
                         </item>
 
@@ -12800,7 +12845,8 @@ else if (fn:empty($input))
                                           node-name($i2))</code>.</p>
                                  </item>
                                  <item>
-                                    <p>The equal-strings relation holds between the string value of <code>$i1</code> 
+                                    <p>The <code>equal-strings</code> function returns true when applied to 
+                                       the string value of <code>$i1</code> 
                                        and the string value of <code>$i2</code>.</p>
                                  </item>
                               </olist>
@@ -12821,12 +12867,12 @@ else if (fn:empty($input))
                            passed explicitly to the <code>fn:deep-equal</code> function.</p></note>
                         </item>
                         <item>
-                           <p>Both nodes are comment nodes, and the equal-strings relation holds
-                              between their string values.</p>
+                           <p>Both nodes are comment nodes, and the <code>equal-strings</code> function 
+                              returns true when applied to their string values.</p>
                         </item>
                         <item>
-                           <p>Both nodes are text nodes, and the equal-strings relation holds
-                              between their string values.</p>
+                           <p>Both nodes are text nodes, and the <code>equal-strings</code> function 
+                              returns true when applied to their string values.</p>
                         </item>
                   </olist>
                   </item>
@@ -12840,6 +12886,9 @@ else if (fn:empty($input))
                /> if either input
             sequence contains a function item <phrase>that is not a map or
                array</phrase>. </p>
+         <p>However, no error is raised if the <code>false-on-error</code> option has the
+         value true; in this case, the function returns false rather than raising an error.</p>
+
       </fos:errors>
       <fos:notes>
          <p>By default, two nodes are not required to have the same type annotation, and they are not
@@ -12858,9 +12907,11 @@ else if (fn:empty($input))
             or processing instruction, if it causes a text node to be split into two text nodes, may
             affect the result.</p>
          <p>Comparing items of different kind (for example, comparing an atomic
-            value to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns false, it does not return an error. So
+            value to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns false, 
+            it does not return an error. So
             the result of <code>fn:deep-equal(1, current-dateTime())</code> is <code>false</code>.</p>
-         <p>Comparing a function (other than a map or array) to any other value raises a type error.</p>
+         <p>Comparing a function (other than a map or array) to any other value raises a type error,
+         unless the error is suppressed using the <code>false-on-error</code> option.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="at" id="v-deep-equal-at" as="element()"
@@ -12909,9 +12960,82 @@ else if (fn:empty($input))
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[fn:deep-equal(
+    parse-xml("<a xmlns='AA'/>"),
+    parse-xml("<p:a xmlns:p='AA'/>"))]]></eg></fos:expression>
+               <fos:result>true()</fos:result>
+               <fos:postamble>By default, namespace prefixes are ignored</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[fn:deep-equal(
+    parse-xml("<a xmlns='AA'/>"),
+    parse-xml("<p:a xmlns:p='AA'/>"),
+    options := map{'prefixes':true()})]]></eg></fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>False because the namespace prefixes differ</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[fn:deep-equal(
+    parse-xml("<a xmlns='AA'/>"),
+    parse-xml("<p:a xmlns:p='AA'/>"),
+    options := map{'in-scope-namespaces':true()})]]></eg></fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>False because the in-scope namespace bindings differ</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[fn:deep-equal(
+    parse-xml("<a><b/><c/></a>"),
+    parse-xml("<a><c/><b/></a>"))]]></eg></fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>By default, order of elements is significant</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[fn:deep-equal(
+    parse-xml("<a><b/><c/></a>"),
+    parse-xml("<a><c/><b/></a>"),
+    options := map{'unordered-elements': fn:QName('a')})]]></eg></fos:expression>
+               <fos:result>true()</fos:result>
+               <fos:postamble>The <code>unordered-elements</code> option means that the ordering of the children
+               of <code>a</code> is ignored.</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[fn:deep-equal(
+    parse-xml("<para style="bold"><span>x</span></para>"),
+    parse-xml("<para style=" bold"> <span>x</span></para>"))]]></eg></fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>By default, both the leading whitespace in the <code>style</code> attribute
+                  and the whitespace text node preceding the <code>span</code> element are significant.</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[fn:deep-equal(
+    parse-xml("<para style="bold"><span>x</span></para>"),
+    parse-xml("<para style=" bold"> <span>x</span></para>"),
+    options := map{'normalize-space': true(), 'whitespace-text-nodes': false())]]></eg></fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>The <code>normalize-space</code> option ensures that the leading whitespace
+                  in the attribute value is ignored; the <code>whitespace-text-nodes</code> option
+                  causes the whitespace preceding the <code>span</code> element to be ignored.</fos:postamble>
+            </fos:test>
+         </fos:example>
       </fos:examples>
+      
       <fos:history>
-         <fos:version version="4.0">Options parameter added; not yet reviewed.</fos:version>
+         <fos:version version="4.0">Options parameter added. Approved in principle on 2023-01-31, subject
+            to further review.</fos:version>
       </fos:history>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12360,12 +12360,13 @@ else if (fn:empty($input))
             empty sequence or a sequence containing more than one item.</p>
       </fos:errors>
    </fos:function>
-   <fos:function name="deep-equal" prefix="fn">
+   <fos:function name="deep-equal" prefix="fn" diff="chg" at="2023-01-25">
       <fos:signatures>
          <fos:proto name="deep-equal" return-type="xs:boolean">
             <fos:arg name="input1" type="item()*" usage="absorption"/>
             <fos:arg name="input2" type="item()*" usage="absorption"/>
             <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="options" type="map(*)" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -12374,6 +12375,11 @@ else if (fn:empty($input))
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:properties arity="3">
+         <fos:property>deterministic</fos:property>
+         <fos:property dependency="collations static-base-uri implicit-timezone">context-dependent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:properties arity="4">
          <fos:property>deterministic</fos:property>
          <fos:property dependency="collations static-base-uri implicit-timezone">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
@@ -12397,170 +12403,388 @@ else if (fn:empty($input))
             and only if every item in the sequence <code>$input1</code> is deep-equal to the
             item at the same position in the sequence <code>$input2</code>. The rules for
             deciding whether two items are deep-equal follow.</p>
+         
 
-         <p>Call the two items <code>$i1</code> and <code>$i2</code> respectively.</p>
-         <p>If <code>$i1</code> and <code>$i2</code> are both atomic values, they are deep-equal if
-            and only if <code>($i1 eq $i2)</code> is <code>true</code>, or if both values are
-               <code>NaN</code>. If the <code>eq</code> operator is not defined for <code>$i1</code>
-            and <code>$i2</code>, the function returns <code>false</code>.</p>
-         <p>If <code>$i1</code> and <code>$i2</code> are both <termref def="dt-map"
-               >maps</termref>, the result is <code>true</code> if and only if all the
-            following conditions apply:</p>
+            <p>The entries that may appear in the <code>$options</code> map are as follows. As a general convention
+               for boolean options, the value true indicates that the comparison is more strict. The detailed rules
+               for the interpretation of each option appear later.</p>
+            
+            <fos:options>
+               <fos:option key="comments">
+                  <fos:meaning>Determines whether comments are significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="id-property">
+                  <fos:meaning>Determines whether the <code>id</code> property of elements and attributes is significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="idref-property">
+                  <fos:meaning>Determines whether the <code>idref</code> property of elements and attributes is significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="in-scope-namespaces">
+                  <fos:meaning>Determines whether the in-scope namespaces of elements are significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="namespace-prefixes">
+                  <fos:meaning>Determines whether namespace prefixes in <code>xs:QName</code> values (particularly
+                     the names of elements and attributes) are significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="normalization-form">
+                  <fos:meaning>If present, indicates that text and attributes are converted to the specified
+                     Unicode normalization form prior to comparison. The value is as for the corresponding
+                     argument of <code>fn:normalize-unicode</code>.
+                  </fos:meaning>
+                  <fos:type>xs:string?</fos:type>
+                  <fos:default>()</fos:default>
+               </fos:option>
+               <fos:option key="nilled-property">
+                  <fos:meaning>Determines whether the <code>nilled</code> property of elements and attributes is significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="processing-instructions">
+                  <fos:meaning>Determines whether processing-instructions are significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="text-boundaries">
+                  <fos:meaning>Determines whether boundaries between text nodes are significant, even when two text
+                     nodes are separated by a comment or processing instruction that is ignored. (This property
+                     is provided, with the default <code>true</code>, for compatibility with previous versions.)
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>true</fos:default>
+               </fos:option>
+               <fos:option key="timezones">
+                  <fos:meaning>Determines whether timezones in date/time values are significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="type-annotations">
+                  <fos:meaning>Determines whether type annotations are significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="type-variety">
+                  <fos:meaning>Determines whether the variety of the type annotation of an element 
+                     (as a simple or complex type) is significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
+               <fos:option key="typed-values">
+                  <fos:meaning>Determines whether nodes are compared using their typed values rather than
+                     their string values.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>true</fos:default>
+               </fos:option>
+               <fos:option key="unordered-elements">
+                  <fos:meaning>A list of QNames of elements considered to be unordered: that is, their child
+                     elements may appear in any order.
+                  </fos:meaning>
+                  <fos:type>xs:QName*</fos:type>
+                  <fos:default>()</fos:default>
+               </fos:option>
+               <fos:option key="whitespace-retained">
+                  <fos:meaning>The value true indicates that text and attributes are compared <emph>as-is</emph>;
+                     the value false indicates that they are compared after normalization using <code>fn:normalize-space</code>.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>true</fos:default>
+               </fos:option>
+               <fos:option key="whitespace-text-nodes">
+                  <fos:meaning>Determines whether text nodes consisting entirely of whitespace are significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>true</fos:default>
+               </fos:option>
+            </fos:options>
+
+         <p>In the following rules, where a recursive call on <code>fn:deep-equal</code> is made, this is assumed
+         to use the same values of <code>$collation</code> and <code>$options</code> as the original call.</p>
+         
+         <p>Call the two items <code>$i1</code> and <code>$i2</code> respectively. The two items are deep-equal
+         if one or more of the following conditions is true:</p>
          <olist>
             <item>
-               <p>Both maps have the same number of entries.</p>
-            </item>
-            <item>
-               <p>For every entry in the first map, there is an entry in the second map that:</p>
+               <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p>has the <termref def="dt-same-key"
-                        >same key</termref> (note that the
-                        collation is not used when comparing keys), and </p>
+                     <p><code>$i1</code> is an atomic value</p></item>
+                  <item>
+                     <p><code>$i2</code> is an atomic value</p></item>
+                  <item>
+                     <p>One of the following conditions is true:</p>
+                     <olist>
+                        <item><p><code>($i1 eq $i2)</code> is <code>true</code> (and the comparison 
+                           does not fail with a dynamic or type error)</p></item>
+                        <item><p>Both <code>$i1</code> and <code>$i2</code> are <code>NaN</code></p></item>
+                     </olist>
                   </item>
                   <item>
-                     <p>has the same associated value (compared using the <code>fn:deep-equal</code>
-                        function, under the collation supplied in the original call to
-                           <code>fn:deep-equal</code>).</p>
+                     <p>One of the following conditions is true:</p>
+                     <olist>
+                        <item><p>Option <code>namespace-prefixes</code> is false</p></item>
+                        <item><p>Neither <code>$i1</code> nor <code>$i2</code> is of type
+                        <code>xs:QName</code> or <code>xs:NOTATION</code></p></item>
+                        <item><p><code>$i1</code> and <code>$i2</code> are qualified names with the same namespace prefix</p></item>
+                     </olist>
+                  </item>
+                  <item>
+                     <p>One of the following conditions is true:</p>
+                     <olist>
+                        <item><p>Option <code>timezones</code> is false</p></item>
+                        <item><p>Neither <code>$i1</code> nor <code>$i2</code> is of type
+                           <code>xs:date</code>, <code>xs:time</code>, <code>xs:dateTime</code>, 
+                           <code>xs:gYear</code>, <code>xs:gYearMonth</code>, <code>xs:gMonth</code>, 
+                           <code>xs:gMonthDay</code>, or <code>xs:gDay</code></p></item>
+                        <item><p>Neither <code>$i1</code> nor <code>$i2</code> has a timezone component</p></item>
+                        <item><p>Both <code>$i1</code> and <code>$i2</code> have a timezone component and the
+                        timezone components are equal.</p></item>
+                     </olist>
                   </item>
                </olist>
             </item>
-         </olist>
-         <p>If <code>$i1</code> and <code>$i2</code> are both arrays,
-            the result is <code>true</code> if and only if all
-            the following conditions apply:</p>
-         <olist>
             <item>
-               <p>Both arrays have the same number of members (<code>array:size($i1) eq
-                     array:size($i2)</code>).</p>
-            </item>
-            <item>
-               <p>Members in the same position of both arrays are deep-equal to each other, under
-                  the collation supplied in the original call to <code>fn:deep-equal</code>: that is,
-                     <code>every $p in 1 to array:size($i1) satisfies deep-equal($i1($p), $i2($p),
-                     $collation)</code></p>
-            </item>
-         </olist>
-         <p>If <code>$i1</code> and <code>$i2</code> are both nodes, they are compared as described
-            below:</p>
-         <olist>
-            <item>
-               <p>If the two nodes are of different kinds, the result is <code>false</code>.</p>
-            </item>
-            <item>
-               <p>If the two nodes are both document nodes then they are deep-equal if and only if
-                  the sequence <code>$i1/(*|text())</code> is deep-equal to the sequence
-                     <code>$i2/(*|text())</code>.</p>
-               <note diff="add" at="A"><p>This rule was designed to ensure that comments and
-               processing instructions are ignored in the comparison. Unfortunately, however,
-               it fails to merge text nodes that are separated by a comment or processing
-               instruction. This oversight has been corrected in the new <code>fn:differences</code>
-               function.</p></note>
-            </item>
-            <item>
-               <p> If the two nodes are both element nodes then they are deep-equal if and only if
-                  all of the following conditions are satisfied:</p>
+               <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p>The two nodes have the same name, that is <code>(node-name($i1) eq
-                           node-name($i2))</code>.</p>
+                     <p><code>$i1</code> is a map</p>
                   </item>
                   <item>
-                     <!-- bug 17252 -->
-                     <p>Either both nodes are annotated as having simple content or both nodes
-                        are annotated as having complex content. For this purpose "simple content"
-                        means either a simple type or a complex type with simple content; "complex
-                        content" means a complex type whose variety is mixed, element-only, or
-                        empty.</p>
-                     <note>
-                        <p>It is a consequence of this rule that validating a document <var>D</var>
-                           against a schema will usually (but not necessarily) result in a document
-                           that is not deep-equal to <var>D</var>. The exception is when the schema
-                           allows all elements to have mixed content.</p>
-                     </note>
+                     <p><code>$i2</code> is a map</p>
                   </item>
                   <item>
-                     <p>The two nodes have the same number of attributes, and for every attribute
-                           <code>$a1</code> in <code>$i1/@*</code> there exists an attribute
-                           <code>$a2</code> in <code>$i2/@*</code> such that <code>$a1</code> and
-                           <code>$a2</code> are deep-equal.</p>
+                     <p>Both maps have the same number of entries.</p>
                   </item>
                   <item>
-                     <p> One of the following conditions holds:</p>
-                     <ulist>
+                     <p>For every entry in the first map, there is an entry in the second map that:</p>
+                     <olist>
                         <item>
-                           <p>Both element nodes are annotated as having simple content (as defined
-                              in 3(b) above), and the typed value of <code>$i1</code> is deep-equal
-                              to the typed value of <code>$i2</code>.</p>
+                           <p>has the <termref def="dt-same-key"
+                              >same key</termref> (note that the
+                              collation is not used when comparing keys), and </p>
                         </item>
                         <item>
-                           <p>Both element nodes have a type annotation that is a complex type with
-                              variety element-only, and the sequence <code>$i1/*</code> is
-                              deep-equal to the sequence <code>$i2/*</code>.</p>
+                           <p>has the same associated value (compared using the <code>fn:deep-equal</code>
+                              function).</p>
+                        </item>
+                     </olist>
+                  </item>
+               </olist>
+             </item>
+            <item>
+               <p>All the following conditions are true:</p>
+               <olist>
+                  <item><p><code>$i1</code> is an array</p></item>
+                  <item><p><code>$i2</code> is an array</p></item>
+                  <item>
+                     <p>Both arrays have the same number of members (<code>array:size($i1) eq
+                           array:size($i2)</code>).</p>
+                  </item>
+                  <item>
+                     <p>Members in the same position of both arrays are deep-equal to each other: that is,
+                           <code>every $p in 1 to array:size($i1) satisfies deep-equal($i1($p), $i2($p),
+                           $collation, $options)</code></p>
+                  </item>
+               </olist>
+            </item>
+            <item>
+               <p>All the following conditions are true:</p>
+               <olist>
+                  <item><p><code>$i1</code> is a node</p></item>
+                  <item><p><code>$i2</code> is a node</p></item>
+                  <item><p>Both nodes have the same node kind</p></item>
+                  <item><p>Let <code>significant-children($parent)</code> be the sequence of nodes formed by
+                  filtering the children of <code>$parent</code> as follows:</p>
+                     <olist>
+                        <item><p>Comment nodes are discarded if the option <code>comments</code> is false.</p></item>
+                        <item><p>Processing instruction nodes are discarded if the option <code>processing-instructions</code> is false.</p></item>
+                        <item><p>Adjacent text nodes are merged if the option <code>text-boundaries</code> is false.</p></item>
+                        <item><p>Whitespace-only text nodes are discarded if the option <code>whitespace-text-nodes</code> is false,
+                           or if <code>$parent</code> is an element node whose type annotation is a complex type with an element-only
+                           or empty content model.</p></item>
+                        <item><p>If <code>$parent</code> is an element node and its name is included in the value
+                           of option <code>unordered-elements</code>, then all text nodes are discarded, and element nodes are
+                           sorted first by namespace and then by local-name, retaining the original order when multiple elements
+                           have the same name.</p>
+                           <note><p>It is inadvisable to use this option for mixed-content elements, or for elements
+                           that allow multiple children with the same name. The rules permit this, but the results
+                           might not be intuitive.</p></note>
+                        </item>
+                     </olist>
+                  
+                  </item>
+                  <item>
+                     <p>One of the following conditions is true.</p>
+                     <olist>
+                        <item>
+                           <p>Both nodes are document nodes, and the sequence <code>significant-children($i1)</code> is deep-equal to the sequence
+                              <code>significant-children($i2)</code>.</p>
                         </item>
                         <item>
-                           <p>Both element nodes have a type annotation that is a complex type with
-                              variety mixed, and the sequence <code>$i1/(*|text())</code> is
-                              deep-equal to the sequence <code>$i2/(*|text())</code>.</p>
-                           <note diff="add" at="A"><p>This rule was designed to ensure that comments and
-                              processing instructions are ignored in the comparison. Unfortunately, however,
-                              it fails to merge text nodes that are separated by a comment or processing
-                              instruction. This oversight has been corrected in the new <code>fn:differences</code>
-                              function.</p></note>
+                           <p>Both nodes are element nodes, and all the following conditions are true:</p>
+                           <olist>
+                              <item>
+                                 <p>The two nodes have the same name, that is <code>(node-name($i1) eq
+                                    node-name($i2))</code>.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>namespace-prefixes</code> is false, or both element
+                                    names have the same prefix.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>in-scope-namespaces</code> is false, or both element
+                                    names have the same in-scope namespace bindings.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>id-property</code> is false, or both element
+                                    names have the same value for their <code>id</code> property.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>idref-property</code> is false, or both element
+                                    nodes have the same value for their <code>idref</code> property.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>nilled-property</code> is false, or both element
+                                    nodes have the same value for their <code>nilled</code> property.</p>
+                              </item>
+                              <item>
+                                 <p>One of the following conditions is true:</p>
+                                 <olist>
+                                    <item><p>The option <code>type-variety</code> is false.</p></item>
+                                    <item><p>Both nodes are annotated as having simple content.
+                                       For this purpose "simple content"
+                                       means either a simple type or a complex type with simple content.</p></item>
+                                    <item><p>Both nodes are annotated as having complex content. For this purpose 
+                                       "complex content" means a complex type whose variety is mixed, element-only, or
+                                       empty.</p></item>
+                                 </olist>
+                                 <note>
+                                    <p>It is a consequence of this rule that validating a document <var>D</var>
+                                       against a schema will usually (but not necessarily) result in a document
+                                       that is not deep-equal to <var>D</var>. The exception is when the schema
+                                       allows all elements to have mixed content.</p>
+                                 </note>
+                                 
+                              </item>
+                              <item>
+                                 <p>The two nodes have the same number of attributes, and for every attribute
+                                    <code>$a1</code> in <code>$i1/@*</code> there exists an attribute
+                                    <code>$a2</code> in <code>$i2/@*</code> such that <code>$a1</code> and
+                                    <code>$a2</code> are deep-equal.</p>
+                              </item>
+                              <item>
+                                 <p> One of the following conditions holds:</p>
+                                 <olist>
+                                    <item>
+                                       <p>Both element nodes are annotated as having simple content (as defined
+                                          above), the <code>typed-values</code> option is true, 
+                                          and the typed value of <code>$i1</code> is deep-equal
+                                          to the typed value of <code>$i2</code>.</p>
+                                    </item>
+                                    <item>
+                                       <p>Both element nodes are annotated as having simple content (as defined
+                                          above), the <code>typed-values</code> option is false, 
+                                          and the string value of <code>$i1</code> is deep-equal
+                                          to the string value of <code>$i2</code>.</p>
+                                    </item>
+                                    <item>
+                                       <p>Both element nodes have a type annotation that is a complex type, 
+                                          and the sequence <code>significant-children($i1)</code> is
+                                          deep-equal to the sequence <code>significant-children($i2)</code>.</p>
+                                    </item>
+                                 </olist>
+                              </item>
+                           </olist>
+                        </item>
+  
+                        <item>
+                           <p>Both nodes are attribute nodes, and all the following conditions are true:</p>
+                           <olist>
+      
+                              <item>
+                                 <p>The two nodes have the same name, that is <code>(node-name($i1) eq
+                                       node-name($i2))</code>.</p>
+                              </item>
+                              <item>
+                                 <p>The typed value of <code>$i1</code> is deep-equal to the typed value of
+                                       <code>$i2</code>.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>id-property</code> is false, or both attribute nodes
+                                    have the same value for their <code>id</code> property.</p>
+                              </item>
+                              <item>
+                                 <p>Either the option <code>idref-property</code> is false, or both attribute nodes
+                                    have the same value for their <code>idref</code> property.</p>
+                              </item>
+                           </olist>
+                        </item>
+
+                        <item>
+                           <p>Both nodes are processing instruction nodes, and all the following conditions are true:</p>
+                              <olist>
+                                 <item>
+                                    <p>The two nodes have the same name, that is <code>(node-name($i1) eq
+                                          node-name($i2))</code>.</p>
+                                 </item>
+                                 <item>
+                                    <p>The string value of <code>$i1</code> is equal to the string value of
+                                          <code>$i2</code>.</p>
+                                 </item>
+                              </olist>
                         </item>
                         <item>
-                           <p>Both element nodes have a type annotation that is a complex type with
-                              variety empty.</p>
+                           <p>Both nodes are namespace nodes, and all the following conditions are true:</p>
+                           <olist>
+                              <item>
+                                 <p>The two nodes either have the same name or are both nameless, that is
+                                    <code>fn:deep-equal(node-name($i1), node-name($i2))</code>.</p>
+                              </item>
+                              <item>
+                                 <p>The string value of <code>$i1</code> is equal to the string value of
+                                    <code>$i2</code> when compared using the Unicode codepoint collation.</p>
+                              </item>
+                           </olist>
+                           <note><p>Namespace nodes are not considered directly unless they appear in the top-level sequences
+                           passed explicitly to the <code>fn:deep-equal</code> function.</p></note>
                         </item>
-                     </ulist>
+                        <item>
+                           <p>Both nodes are comment nodes, and their string-values are equal (under the selected collation) .</p>
+                        </item>
+                        <item>
+                           <p>Both nodes are text nodes, and their string-values are equal (under the selected collation) 
+                              after adjusting as follows:</p>
+                           <olist>
+                              <item><p>If the <code>normalization-form</code> option is present, the string value
+                              of both text nodes is converted to the required normalization form by applying
+                              the <code>fn:normalize-unicode</code> function.</p></item>
+                              <item><p>If the <code>whitespace-retained</code> option is false, the string value
+                                 of both text nodes is processed by applying
+                                 the <code>fn:normalize-space</code> function.</p></item>
+                           </olist>
+                        </item>
+                  </olist>
                   </item>
                </olist>
-            </item>
-            <item>
-               <p>If the two nodes are both attribute nodes then they are deep-equal if and only if
-                  both the following conditions are satisfied:</p>
-               <olist>
-                  <item>
-                     <p>The two nodes have the same name, that is <code>(node-name($i1) eq
-                           node-name($i2))</code>.</p>
-                  </item>
-                  <item>
-                     <p>The typed value of <code>$i1</code> is deep-equal to the typed value of
-                           <code>$i2</code>.</p>
-                  </item>
-               </olist>
-            </item>
-            <item>
-               <p>If the two nodes are both processing instruction nodes, then they are deep-equal
-                  if and only if both the following conditions are satisfied:</p>
-               <olist>
-                  <item>
-                     <p>The two nodes have the same name, that is <code>(node-name($i1) eq
-                           node-name($i2))</code>.</p>
-                  </item>
-                  <item>
-                     <p>The string value of <code>$i1</code> is equal to the string value of
-                           <code>$i2</code>.</p>
-                  </item>
-               </olist>
-            </item>
-            <item>
-               <p> If the two nodes are both namespace nodes, then they are deep-equal if and only
-                  if both the following conditions are satisfied:</p>
-               <olist>
-                  <item>
-                     <p>The two nodes either have the same name or are both nameless, that is
-                           <code>fn:deep-equal(node-name($i1), node-name($i2))</code>.</p>
-                  </item>
-                  <item>
-                     <p>The string value of <code>$i1</code> is equal to the string value of
-                           <code>$i2</code> when compared using the Unicode codepoint collation.</p>
-                  </item>
-               </olist>
-            </item>
-            <item>
-               <p>If the two nodes are both text nodes or comment nodes, then they are deep-equal if
-                  and only if their string-values are equal.</p>
             </item>
          </olist>
          <p>In all other cases the result is false.</p>
@@ -12572,7 +12796,7 @@ else if (fn:empty($input))
                array</phrase>. </p>
       </fos:errors>
       <fos:notes>
-         <p>The two nodes are not required to have the same type annotation, and they are not
+         <p>By default, two nodes are not required to have the same type annotation, and they are not
             required to have the same in-scope namespaces. They may also differ in their parent,
             their base URI, and the values returned by the <code>is-id</code> and
                <code>is-idrefs</code> accessors (see <xspecref
@@ -12581,7 +12805,7 @@ else if (fn:empty($input))
                ref="dm-is-idrefs"
             />). The order of children is significant,
             but the order of attributes is insignificant. </p>
-         <p>The contents of comments and processing instructions are significant only if these nodes
+         <p>By default, the contents of comments and processing instructions are significant only if these nodes
             appear directly as items in the two sequences being compared. The content of a comment
             or processing instruction that appears as a descendant of an item in one of the
             sequences being compared does not affect the result. However, the presence of a comment
@@ -12640,6 +12864,9 @@ else if (fn:empty($input))
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Options parameter added; not yet reviewed.</fos:version>
+      </fos:history>
    </fos:function>
    
    <fos:function name="differences" prefix="fn">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12412,6 +12412,12 @@ else if (fn:empty($input))
                for the interpretation of each option appear later.</p>
             
             <fos:options>
+               <fos:option key="base-uri">
+                  <fos:meaning>Determines whether the <code>base-uri</code> of a node is significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
                <fos:option key="comments">
                   <fos:meaning>Determines whether comments are significant.
                   </fos:meaning>
@@ -12876,6 +12882,8 @@ else if (fn:empty($input))
                         </item>
                   </olist>
                   </item>
+                  <item><p>Either the <code>base-uri</code> option is false, or both nodes have the same value
+                     for their base URI property, or both nodes have an absent base URI.</p></item>
                </olist>
             </item>
          </olist>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12921,8 +12921,8 @@ else if (fn:empty($input))
                array</phrase>. </p>
          <p>However, the above error is not raised if the <code>false-on-error</code> option has the
          value true; in this case, the function returns false rather than raising an error.</p>
-         <p>A type error is raised <errorref spec="XP" class="TY" code="0004" tupe="type"
-         /> if the value of 
+         <p>A type error is raised <xerrorref spec="XP" class="TY"
+            code="0004" type="type"/> if the value of 
             <code>$options</code> includes an entry whose key is defined 
             in this specification, and whose value is not of the permitted type for that key.</p>
          <p>A dynamic error is raised <errorref spec="FO" class="JS" code="0005"


### PR DESCRIPTION
This proposal adds an options parameter to fn:deep-equal, giving much more detailed control over how the comparison is performed (while remaining backwards compatible by default).

This proposal is a first draft and I would request careful review, it's not one to pass through "on the nod".