### PR TITLE
Update fn:parse-html to apply review feedback.

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -15816,8 +15816,16 @@ else
                <tr>
                   <td>*</td>
                   <td>*</td>
-                  <td>An <termref def="implementation-defined"/> parsing algorithm, tree construction,
-                     and validation consistent with the specified HTML version.</td>
+                  <td>
+                     <p>An <termref def="implementation-defined"/> parsing algorithm, tree construction,
+                     and validation consistent with the specified HTML version.</p>
+                     <example>
+                        <p>This allows an implementation to provide their own method, html-version
+                           combinations. For example, an implementation could use the values
+                           "whatwg" and "2023-01-28" for an implementation of the WHATWG HTML Living
+                           Standard at a given date.</p>
+                     </example>
+                  </td>
                </tr>
             </tbody>
          </table>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -15866,7 +15866,7 @@ else
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
+         <fos:version version="4.0">New in 4.0. Accepted 2023-01-10.</fos:version>
       </fos:history>
    </fos:function>
    <fos:function name="position" prefix="fn">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -15753,6 +15753,16 @@ else
             in a way consistent with <bibref ref="html5"/> section 13.2.3.1, <emph>Parsing with a
             known character encoding</emph>. The specific character encoding is
             <termref def="implementation-dependent"/>.</p>
+         <note>
+            <p>The HTML specification uses this for when the encoding of the input byte stream is
+               known for certain, such as when the byte stream has already been decoded.</p>
+            <p>This means that an implementation should set the encoding to the encoding of the
+               underlying string representation. For example, a Java program could specify the
+               encoding as UTF-16. If the implementation supports passing native string values
+               then that can be used instead of using a byte stream and encoding.</p>
+            <p>Be aware that the WHATWG Encoding specification defines the ISO 8859-1 (latin1)
+               and ASCII encodings as aliases of the windows-1252 encoding.</p>
+         </note>
          <p>If the type of <code>$html</code> is a sequence of octets (<code>xs:hexBinary</code> or
             <code>xs:base64Binary</code>), the encoding is determined in a way consistent with
             <bibref ref="html5"/> section 13.2.3.2, <emph>Determining the character encoding</emph>.

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -15863,6 +15863,7 @@ else
             <p>The expression <code>parse-html($html, method:=&quot;tagsoup&quot;, nons:=true())</code>
                could use the <emph>tagsoup</emph> application to parse <code>$html</code> if supported
                by the implementation, passing the <code>--nons</code> argument to the application.</p>
+            <p>[TODO: The examples depend on keyword arguments.]</p>
          </fos:example>
       </fos:examples>
       <fos:history>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6975,6 +6975,15 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>The result of the <xspecref spec="DM40" ref="dm-unparsed-entity-public-id"/>
                   <code>dm:unparsed-entity-public-id($node)</code> for an HTML DOM <code>Node</code>
                   is an empty sequence.</p>
+
+               <note>
+                  <p>The <bibref ref="html5"/> specification does not include unparsed entity references.
+                     Section 13.2.5.73, <emph>Named character reference state</emph> reports an
+                     <code>unknown-named-character-reference</code> error for these and places the
+                     literal text of the entity reference in the content stream.</p>
+                  <p>The XDM should treat these unknown named character references as starting with
+                     <code>&amp;amp;</code> so that the text is valid XML.</p>
+               </note>
             </div3>
             <div3 id="html-unparsed-entity-system-id-accessor">
                <head>unparsed-entity-system-id Accessor</head>
@@ -6983,6 +6992,15 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>The result of the <xspecref spec="DM40" ref="dm-unparsed-entity-system-id"/>
                   <code>dm:unparsed-entity-system-id($node)</code> for an HTML DOM <code>Node</code>
                   is an empty sequence.</p>
+
+               <note>
+                  <p>The <bibref ref="html5"/> specification does not include unparsed entity references.
+                     Section 13.2.5.73, <emph>Named character reference state</emph> reports an
+                     <code>unknown-named-character-reference</code> error for these and places the
+                     literal text of the entity reference in the content stream.</p>
+                  <p>The XDM should treat these unknown named character references as starting with
+                     <code>&amp;amp;</code> so that the text is valid XML.</p>
+               </note>
             </div3>
          </div2>
       </div1>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6062,11 +6062,20 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
          </div2>
          <div2 id="html">
-            <head>Conversion from HTML</head>
+            <head>XDM Mapping from HTML DOM Nodes</head>
 
 
             <p>The HTML5 format is specified in <bibref ref="html5"/>. This section describes facilities
-               allowing HTML5 documents to be converted to XDM nodes.</p>
+               allowing HTML5 documents as defined by <bibref ref="dom-ls"/> HTML DOM nodes to be mapped
+               to XDM accessors/nodes.</p>
+
+            <p>An implementation must match the semantics of the mapping described in this section, but
+               the specific way it achieves that is <termref def="implementation-dependent">implementation-dependent</termref>.</p>
+
+            <note>
+               <p>An implementation may use the HTML DOM directly, using XDM accessor bindings for the
+                  HTML DOM nodes.</p>
+            </note>
 
             <p>The <bibref ref="dom-ls"/> specification defines HTML DOM nodes that are mapped to XDM
                nodes as follows:</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6191,6 +6191,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
                      <code>Attr</code> nodes are both set to the qualified name.</p>
                </note>
+
+               <note>
+                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                     <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
+                     ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
+               </note>
             </div3>
             <div3 id="html-base-uri-accessor">
                <head>base-uri Accessor</head>
@@ -6473,6 +6479,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
                         <code>Attr</code> nodes are both set to the qualified name.</p>
                   </note>
+
+                  <note>
+                     <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                        <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
+                        ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
+                  </note>
                </div4>
             </div3>
             <div3 id="html-nilled-accessor">
@@ -6537,6 +6549,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <p>When the resulting document is an HTML DOM <code>HTMLDocument</code>, the
                      <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
                      <code>Attr</code> nodes are both set to the qualified name.</p>
+               </note>
+
+               <note>
+                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                     <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
+                     ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                </note>
             </div3>
             <div3 id="html-node-name-accessor">
@@ -6672,9 +6690,24 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                </note>
 
                <note>
+                  <p>The <code>Element.localName</code> property must be ASCII lowercase. The
+                     <bibref ref="html5"/> section 13.2.5.8, <emph>Tag name state</emph> specifies that
+                     ASCII upper alpha characters are appended to the attribute's name in lowercase.
+                     This is used when processing the <emph>Tag open state</emph> and
+                     <emph>End tag open state</emph> HTML parser states for open and close tags
+                     respectively.</p>
+               </note>
+
+               <note>
                   <p>When the resulting document is an HTML DOM <code>HTMLDocument</code>, the
                      <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
                      <code>Attr</code> nodes are both set to the qualified name.</p>
+               </note>
+
+               <note>
+                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                     <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
+                     ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                </note>
             </div3>
             <div3 id="html-parent-accessor">
@@ -6866,6 +6899,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
                      <code>Attr</code> nodes are both set to the qualified name.</p>
                </note>
+
+               <note>
+                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                     <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
+                     ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
+               </note>
             </div3>
             <div3 id="html-typed-value-accessor">
                <head>typed-value Accessor</head>
@@ -6921,6 +6960,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <p>When the resulting document is an HTML DOM <code>HTMLDocument</code>, the
                      <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
                      <code>Attr</code> nodes are both set to the qualified name.</p>
+               </note>
+
+               <note>
+                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                     <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
+                     ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                </note>
             </div3>
             <div3 id="html-unparsed-entity-public-id-accessor">


### PR DESCRIPTION
This PR applies the following review comments:
- [x] QT4CG-016-03: RD to add a note clarifying “known character encoding”
- [x] QT4CG-016-04: RD to add a note clarifying the “*”/”*” html/version combination
- [x] QT4CG-016-05: RD to add a “todo” noting the dependency on keyword arguments
- [x] QT4CG-016-06: RD to reword the introduction to mapping to clarify who’s doing the mapping
- [ ] QT4CG-016-08: RD to clarify how namespace comparisons are performed.
- [x] QT4CG-016-09: RD to add a note stating that the local name should always be lowercase
- [x] QT4CG-016-10: RD to consider how to clarify parsed entity parsing.
