### PR TITLE
Issue 22: allow "for"/"let" keyword to be repeated in XPath

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -836,23 +836,25 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
 
   <g:production name="ForExpr" if="xpath40  xslt40-patterns">
     <g:ref name="SimpleForClause"/>
-    <g:string>return</g:string>
-    <g:ref name="ExprSingle"/>
+    <g:ref name="SimpleReturnClause"/>
   </g:production>
 
   <g:production name="SimpleForClause" if="xpath40 xslt40-patterns" node-type="void">
     <g:string>for</g:string>
-    <g:optional>
-      <g:string>member</g:string>
-    </g:optional>
     <g:ref name="SimpleForBinding" if="xpath40  xslt40-patterns"/>
     <g:zeroOrMore name="SimpleForClauseTail">
-      <g:string>,</g:string>
+      <g:choice>
+        <g:string>for</g:string>
+        <g:string>,</g:string>
+      </g:choice>
       <g:ref name="SimpleForBinding" if="xpath40  xslt40-patterns"/>
     </g:zeroOrMore>
   </g:production>
 
   <g:production name="SimpleForBinding" if="xpath40  xslt40-patterns"><!-- also unfolded for -->
+    <g:optional>
+      <g:string>member</g:string>
+    </g:optional>
     <g:string>$</g:string>
     <g:ref name="VarName"/>
     <g:optional if="fulltext">
@@ -861,18 +863,27 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>in</g:string>
     <g:ref name="ExprSingle"/>
   </g:production>
+  
+  <g:production name="SimpleReturnClause" if="xpath40  xslt40-patterns">
+    <g:string>return</g:string>
+    <g:ref name="ExprSingle"/>
+  </g:production>
+  
+  
 
   <g:production name="LetExpr" if="xpath40  xslt40-patterns">
     <g:ref name="SimpleLetClause"/>
-    <g:string>return</g:string>
-    <g:ref name="ExprSingle"/>
+    <g:ref name="SimpleReturnClause"/>
   </g:production>
 
   <g:production name="SimpleLetClause" if="xpath40  xslt40-patterns">
     <g:string>let</g:string>
     <g:ref name="SimpleLetBinding"/>
     <g:zeroOrMore>
-      <g:string>,</g:string>
+      <g:choice>
+        <g:string>let</g:string>
+        <g:string>,</g:string>
+      </g:choice>
       <g:ref name="SimpleLetBinding"/>
     </g:zeroOrMore>
   </g:production>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14442,6 +14442,7 @@ element because it is defined by a <termref
             <prodrecap id="ForExpr" ref="ForExpr"/>
             <prodrecap id="SimpleForClause" ref="SimpleForClause"/>
             <prodrecap id="SimpleForBinding" ref="SimpleForBinding"/>
+            <prodrecap id="SimpleReturnClause" ref="SimpleReturnClause"/>
          </scrap>
 
          <p>A <code>for</code> expression is evaluated as follows:</p>
@@ -14449,12 +14450,15 @@ element because it is defined by a <termref
          <olist>
 
             <item>
-               <p>If the <code>for</code> expression uses multiple variables, it is first expanded to a set of nested <code>for</code> expressions, each of which uses only one variable.</p>
+               <p>If the <code>for</code> expression uses multiple variables, 
+                  it is first expanded to a set of nested <code>for</code> expressions, each of which uses only one variable.
+               <phrase diff="add" at="2023-02-09">More specifically, every separating comma or <code>for</code>
+               keyword is replaced by <code>return for</code>.</phrase></p>
                <p>For example, the expression
                <code role="parse-test">for $x in X, $y in Y return $x + $y</code> is expanded to
                <code role="parse-test">for $x in X return for $y in Y return $x + $y</code>.</p>
                <p diff="add" at="A">Similarly, the expression 
-                  <code role="parse-test">for member $x in X, member $y in Y return $x + $y</code> is expanded to
+                  <code role="parse-test">for member $x in X for member $y in Y return $x + $y</code> is expanded to
                   <code role="parse-test">for member $x in X return for member $y in Y return $x + $y</code>.</p>
             </item>
             
@@ -14477,7 +14481,8 @@ element because it is defined by a <termref
                <p>When the <code>member</code> keyword is present,
                   the value of the <term>binding collection</term> must be a single array.
                   The result of the single-variable <code>for member</code> expression is obtained by evaluating the <code>return</code> expression once 
-                  for each member of that array, with the range variable bound to that member. The resulting sequences 
+                  for each member of that array, with the range variable bound to that member (recall that this can be any sequence,
+                  not necessarily a single item). The resulting sequences 
                   are concatenated (as if by the <termref def="dt-comma-operator"
                      >comma operator</termref>) in the order of the members of the binding collection from which they were derived.
                </p>
@@ -14583,6 +14588,7 @@ Instead, the expression must be written to use the variable bound in the <code>f
             <prodrecap id="LetExpr" ref="LetExpr"/>
             <prodrecap id="SimpleLetClause" ref="SimpleLetClause"/>
             <prodrecap id="SimpleLetBinding" ref="SimpleLetBinding"/>
+            <prodrecap ref="SimpleReturnClause"/>
          </scrap>
 
          <p>A let expression is evaluated as follows:</p>
@@ -14590,12 +14596,15 @@ Instead, the expression must be written to use the variable bound in the <code>f
          <ulist>
             <item>
                <p>If the let expression uses multiple variables, it is first expanded to a
-set of nested let expressions, each of which uses only one variable. For
-example, the expression <code
-                     role="parse-test"
-                     >let $x := 4, $y := 3 return $x + $y</code> is expanded to
-<code
-                     role="parse-test">let $x := 4 return let $y := 3 return $x + $y</code>.</p>
+set of nested let expressions, each of which uses only one variable. 
+<phrase diff="add" at="2023-02-09">Specifically, any separating comma or <code>let</code>
+keyword is replaced by <code>let return</code></phrase>.</p>
+               <p>For example, the expression 
+                  <code role="parse-test">let $x := 4, $y := 3 return $x + $y</code> is expanded to
+                   <code role="parse-test">let $x := 4 return let $y := 3 return $x + $y</code>.</p>
+               <p>Likewise, the expression 
+                  <code role="parse-test">let $x := 4 let $y := 3 return $x + $y</code> is expanded to
+                  <code role="parse-test">let $x := 4 return let $y := 3 return $x + $y</code>.</p>
             </item>
 
             <item>
@@ -14619,6 +14628,20 @@ another variable bound earlier in the same let expression:</p>
 let $x := doc('a.xml')/*, $y := $x//*
 return $y[@value gt $x/@min]
 ]]></eg>
+         
+         <note diff="add" at="2023-02-09">
+            <p>It is not required that the variables should have distinct names. It is permitted, 
+               for example, to write:</p>
+            <eg role="parse-test"><![CDATA[
+let $x := "[A fine romance]"
+let $x := fn:substring-after($x, "[")
+let $x := fn:substring-before($x, "]")
+return fn:upper-case($x)
+]]></eg>
+            <p>which returns the result <code>"A FINE ROMANCE"</code>. Note that this expression declares
+            three separate variables which happen to have the same name; it should not be read as declaring
+            a single variable and binding it successively to different values.</p>
+         </note>
 
       </div2>
 
@@ -17867,7 +17890,8 @@ value of a quantified expression is always <code>true</code> or <code>false</cod
             <prodrecap ref="TypeDeclaration" role="xquery"/>
          </scrap>
          <p>A <term>quantified expression</term> begins with
-a <term>quantifier</term>, which is the keyword <code>some</code> or <code>every</code>, followed by one or more in-clauses that are used to bind variables,
+a <term>quantifier</term>, which is the keyword <code>some</code> or <code>every</code>, 
+followed by one or more in-clauses that are used to bind variables,
 followed by the keyword <code>satisfies</code> and a test expression. Each in-clause associates a variable with an
 expression that returns a sequence of items, called the binding sequence for that variable. 
 The value of the quantified expression is defined by the following rules:</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14598,7 +14598,7 @@ Instead, the expression must be written to use the variable bound in the <code>f
                <p>If the let expression uses multiple variables, it is first expanded to a
 set of nested let expressions, each of which uses only one variable. 
 <phrase diff="add" at="2023-02-09">Specifically, any separating comma or <code>let</code>
-keyword is replaced by <code>let return</code></phrase>.</p>
+keyword is replaced by <code>return let</code></phrase>.</p>
                <p>For example, the expression 
                   <code role="parse-test">let $x := 4, $y := 3 return $x + $y</code> is expanded to
                    <code role="parse-test">let $x := 4 return let $y := 3 return $x + $y</code>.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14432,10 +14432,9 @@ element because it is defined by a <termref
          <head>For Expressions</head>
 
          <p>XPath provides an iteration facility called a <term>for expression</term>. 
-         <phrase diff="add" at="A">It can be used to iterate over the items of a sequence, or the
-         members of an array. In this section the term <term>collection</term> is used to mean
-         the sequence or array, and the term <term>component</term> is used to refer to the
-         items of the sequence or the members of the array.</phrase></p>
+         <phrase diff="add" at="2023-02-09">It can be used to iterate over the items of a sequence, or the
+         members of an array. In this section the term <term>binding collection</term> is used to refer to
+         this sequence or array.</phrase></p>
 
          <scrap>
             <head/>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -14575,6 +14575,14 @@ Instead, the expression must be written to use the variable bound in the <code>f
             <eg role="parse-test"
                ><![CDATA[fn:sum(for $i in order-item return $i/@price * $i/@qty)]]></eg>
          </note>
+         <note diff="add" at="2023-02-16">
+            <p>XPath 4.0 allows the format:</p>
+            <eg role="parse-test"><![CDATA[for $order in //orders
+for $line in $order/order-line
+return $line/value]]></eg>
+            <p>primarily because it is familiar to XQuery users, some of whom may regard it as more
+            readable than the XPath 3.1 alternative which uses a comma in place of the second <code>for</code>.</p>
+         </note>
       </div2>
 
       <div2 id="id-let-expressions" role="xpath">
@@ -14640,6 +14648,13 @@ return fn:upper-case($x)
             <p>which returns the result <code>"A FINE ROMANCE"</code>. Note that this expression declares
             three separate variables which happen to have the same name; it should not be read as declaring
             a single variable and binding it successively to different values.</p>
+         </note>
+         
+         <note diff="add" at="2023-02-16">
+            <p>XPath 4.0 allows the form using multiple <code>let</code> clauses, as illustrated in the previous example,
+               primarily because it is familiar to XQuery users, some of whom may regard it as more
+               readable than the XPath 3.1 alternative which uses a comma in place of the second and
+               subsequent <code>let</code> keywords.</p>
          </note>
 
       </div2>


### PR DESCRIPTION
Addresses the proposal in issue 22 to allow repetition of the "let" or "for" keyword in a ForExpr or LetExpr. (It does not, however, allow "for" and "let" to be mixed).