### PR TITLE
Combine multiple signatures of XSLT functions to use defaults

### DIFF
--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -294,9 +294,8 @@
 
    <fos:function name="current-merge-group">
       <fos:signatures>
-         <fos:proto name="current-merge-group" return-type="item()*"/>
          <fos:proto name="current-merge-group" return-type="item()*">
-            <fos:arg name="source" type="xs:string"/>
+            <fos:arg name="source" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -329,7 +328,8 @@
 
          <ulist>
             <item>
-               <p>The single-argument form of this function returns the value of the expression
+               <p><phrase diff="add" at="2023-02-16">If <code>$source</code> is supplied
+               and is non-empty, the</phrase> function returns the value of the expression
                      <code>if (map:contains($source)) then $G($source) else error()</code>.
                   Informally, if there is an <elcode>xsl:merge-source</elcode> element whose
                      <code>name</code> attribute matches <code>$source</code>, the function returns
@@ -337,7 +337,8 @@
                   otherwise it raises a dynamic error (see below).</p>
             </item>
             <item>
-               <p>The zero-argument form of the function returns the value of the expression
+               <p><phrase diff="add" at="2023-02-16">Otherwise (when <code>$source</code> is absent or empty)</phrase>
+                  the function returns the value of the expression
                      <code>sort(map:keys($G))!$G(.)</code>, where the <code>sort()</code> function
                   sorts the names of <elcode>xsl:merge-source</elcode> elements into the document
                   order of the <elcode>xsl:merge-source</elcode> elements in the stylesheet.
@@ -399,7 +400,8 @@
             <error spec="XT" type="dynamic" class="DE" code="3490">
                <p>It is a <termref def="dt-dynamic-error">dynamic error</termref> if the
                      <code>$source</code> argument of the <function>current-merge-group</function>
-                  function does not match the <code>name</code> attribute of any
+                  function <phrase diff="add" at="2023-02-16">(when supplied)</phrase>
+                  does not match the <code>name</code> attribute of any
                      <elcode>xsl:merge-source</elcode> element for the current merge operation. The
                   error <rfc2119>may</rfc2119> be reported statically if it can be detected
                   statically.</p>
@@ -641,7 +643,6 @@
 
    <fos:function name="copy-of">
       <fos:signatures>
-         <fos:proto name="copy-of" return-type="item()"/>
          <fos:proto name="copy-of" return-type="item()*">
             <fos:arg name="input" type="item()*" default="." usage="absorption"/>
          </fos:proto>
@@ -733,7 +734,6 @@
 
    <fos:function name="snapshot">
       <fos:signatures>
-         <fos:proto name="snapshot" return-type="item()"/>
          <fos:proto name="snapshot" return-type="item()*">
             <fos:arg name="input" type="item()*" default="." usage="absorption"/>
          </fos:proto>
@@ -918,10 +918,7 @@
       <fos:signatures>
          <fos:proto name="document" return-type="node()*">
             <fos:arg name="uri-sequence" type="item()*" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="document" return-type="node()*">
-            <fos:arg name="uri-sequence" type="item()*" usage="absorption"/>
-            <fos:arg name="base-node" type="node()" usage="inspection"/>
+            <fos:arg name="base-node" type="node()?" default="()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -953,8 +950,9 @@
                      is</emph>. If it is a relative URI reference, then it is resolved as follows:</p>
                <olist>
                   <item>
-                     <p>If <code>$base-node</code> is supplied, then it is resolved against the base URI
-                  of <code>$base-node</code>.</p>
+                     <p>If <code>$base-node</code> is supplied 
+                        <phrase diff="add" at="2023-02-16">(that is, if the argument is present and non-empty)</phrase>, 
+                        then it is resolved against the base URI of <code>$base-node</code>.</p>
                   </item>
                   <item>
                      <p>Otherwise it is resolved against the static base URI from the static context of the
@@ -1061,10 +1059,7 @@
       <fos:signatures>
          <fos:proto name="unparsed-entity-uri" return-type="xs:anyURI">
             <fos:arg name="entity-name" type="xs:string" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="unparsed-entity-uri" return-type="xs:anyURI">
-            <fos:arg name="entity-name" type="xs:string" usage="absorption"/>
-            <fos:arg name="doc" type="node()" usage="inspection" default="/"/>
+            <fos:arg name="doc" type="node()" usage="inspection" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1128,10 +1123,7 @@
       <fos:signatures>
          <fos:proto name="unparsed-entity-public-id" return-type="xs:string">
             <fos:arg name="entity-name" type="xs:string" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="unparsed-entity-public-id" return-type="xs:string">
-            <fos:arg name="entity-name" type="xs:string" usage="absorption"/>
-            <fos:arg name="doc" type="node()" usage="inspection" default="/"/>
+            <fos:arg name="doc" type="node()" usage="inspection" default="."/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1191,10 +1183,6 @@
 
    <fos:function name="key">
       <fos:signatures>
-         <fos:proto name="key" return-type="node()*">
-            <fos:arg name="key-name" type="union(xs:string, xs:QName)"/>
-            <fos:arg name="key-value" type="xs:anyAtomicType*"/>
-         </fos:proto>
          <fos:proto name="key" return-type="node()*">
             <fos:arg name="key-name" type="union(xs:string, xs:QName)"/>
             <fos:arg name="key-value" type="xs:anyAtomicType*"/>
@@ -1690,139 +1678,11 @@
       </fos:notes>
    </fos:function>
 
-
-   <!--<fos:function name="deep-equal">
-      <fos:signatures>
-         <fos:proto name="deep-equal" return-type="xs:boolean">
-            <fos:arg name="parameter1" type="item()*" usage="absorption"/>
-            <fos:arg name="parameter2" type="item()*" usage="absorption"/>
-         </fos:proto>
-         <fos:proto name="deep-equal" return-type="xs:boolean">
-            <fos:arg name="parameter1" type="item()*" usage="absorption"/>
-            <fos:arg name="parameter2" type="item()*" usage="absorption"/>
-            <fos:arg name="collation" type="xs:string"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties arity="2">
-         <fos:property>deterministic</fos:property>
-         <fos:property dependency="collations implicit-timezone">context-dependent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:properties arity="3">
-         <fos:property>deterministic</fos:property>
-         <fos:property dependency="collations static-base-uri implicit-timezone">context-dependent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-
-      <fos:summary>
-         <p>This function assesses whether two sequences are deep-equal to each other. The function
-            as described here extends the definition of the XPath 3.0
-               <xfunction>deep-equal</xfunction> to explain how it should handle maps; it is
-            intended to replace the existing <xfunction>deep-equal</xfunction> function at some
-            stage in the future.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The function delivers the same result as
-               <xfunction>deep-equal</xfunction> except when (at some level of recursion) it is
-            necessary to compare two function items. In the case of
-               <xfunction>deep-equal</xfunction>, comparing two function items raises a dynamic
-            error. In the case of this function, two function items that are both maps are compared
-            as follows.</p>
-
-         <p>If two items <code>$i1</code> and <code>$i2</code> to be compared are
-            both <termref def="dt-map">maps</termref>, the result is <code>true</code> if and only
-            if all the following conditions apply:</p>
-         <olist>
-            <item>
-               <p>Both maps have the same number of entries.</p>
-            </item>
-            
-            <item>
-               <p>For every entry in the first map, there is an entry in the second map that:</p>
-               <olist>
-                  <item>
-                     <p>has the <termref def="dt-same-key">same key</termref> (note that the
-                        collation is not used when comparing keys), and </p>
-                  </item>
-                  <item>
-                     <p>has the same associated value (compared using the <code>fn:deep-equal</code>
-                        function, under the collation supplied in the original call to
-                           <code>fn:deep-equal</code>).</p>
-                  </item>
-               </olist>
-            </item>
-         </olist>
-
-      </fos:rules>
-      <fos:errors>
-         <p>An error is raised <xerrorref spec="FO30" class="TY" code="0015"/> if
-            either input sequence contains a function item that is not a
-               map.
-         </p>
-      </fos:errors>
-
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:deep-equal(map{}, map{})</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:deep-equal(map{"a":1, "b":2}, map{"b":2,
-                  "a":1.0})</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:deep-equal(map{"a":xs:double('NaN')},
-                  map{"a":xs:float('NaN')})</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:variable name="at" as="element()">
-&lt;attendees&gt;
-  &lt;name last='Parker' first='Peter'/&gt;
-  &lt;name last='Barker' first='Bob'/&gt;
-  &lt;name first='Peter' last='Parker'/&gt;
-&lt;/attendees&gt;</fos:variable>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:deep-equal($at, $at/*)</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:deep-equal($at/name[1], $at/name[2])</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:deep-equal($at/name[1], $at/name[3])</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:deep-equal($at/name[1], 'Peter Parker')</fos:expression>
-               <fos:result>false()</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-   </fos:function> 
- -->
    <fos:function name="function-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="function-available" return-type="xs:boolean">
             <fos:arg name="name" type="union(xs:QName, xs:string)"/>
-         </fos:proto>
-         <fos:proto name="function-available" return-type="xs:boolean">
-            <fos:arg name="name" type="union(xs:QName, xs:string)"/>
-            <fos:arg name="arity" type="xs:integer"/>
+            <fos:arg name="arity" type="xs:integer?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1850,11 +1710,13 @@
             namespace declarations in scope for the <termref def="dt-expression">expression</termref>. 
             If the value is an unprefixed lexical QName, then the <termref def="dt-standard-function-namespace">standard function namespace</termref> is used in
             the expanded QName.</p>
-         <p>The two-argument version of the <function>function-available</function> function returns
+         <p><phrase diff="chg" at="2023-02-16">When the <code>$arity</code> argument is present and non-empty,</phrase>
+            the <function>function-available</function> function returns
             true if and only if there is an available function whose name matches the value of the
                <code>$function-name</code> argument and whose <termref def="dt-arity-range">arity range</termref> 
             includes the value of the <code>$arity</code> argument. </p>
-         <p>The single-argument version of the <function>function-available</function> function
+         <p><phrase diff="chg" at="2023-02-16">When the <code>$arity</code> argument is omitted or empty,</phrase>
+            the <function>function-available</function> function
             returns true if and only if there is at least one available function (with some arity)
             whose name matches the value of the <code>$name</code> argument. </p>
 
@@ -2629,42 +2491,7 @@
    
    
    
-   
- <!--  
-   <fos:function name="unchanged">
-      <fos:signatures>
-         <fos:proto name="unchanged" return-type="item()*">
-            <fos:arg name="seq" type="item()*"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Returns the value of the supplied argument.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>This is an identity function: it returns the value of the supplied
-            argument, unchanged.</p>
-      </fos:rules>
-      
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:unchanged(())</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:for-each(1 to 5, fn:unchanged#1)</fos:expression>
-               <fos:result>1, 2, 3, 4, 5</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples> 
-   </fos:function>
-   -->
-   
+
 
    
  


### PR DESCRIPTION
This PR addresses issue 69, by modifying those XSLT built-in functions that currently have multiple signatures, to use a single signature with parameter defaults instead.

The changes however don't currently render correctly. The XSLT processing pipeline needs to be changed to pick up the changes that were made to the F+O stylesheets to render parameter defaults correctly. I haven't yet managed to work out where this is done.