### PR TITLE
Issue 314 array composition and decomposition

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -15051,7 +15051,7 @@ else
       </fos:examples>
    </fos:function>
    
-   <fos:function name="parcel"  prefix="fn">
+   <!--<fos:function name="parcel"  prefix="fn">
       <fos:signatures>
          <fos:proto name="parcel" return-type="item()">
             <fos:arg name="input" type="item()*"/>
@@ -15108,7 +15108,7 @@ else
             </fos:test>
          </fos:example>
       </fos:examples>
-   </fos:function>
+   </fos:function>-->
    
    <fos:function name="parse-xml" prefix="fn">
       <fos:signatures>
@@ -16411,6 +16411,8 @@ declare function fn:for-each($input, $action) {
          <p>The function call <code>fn:for-each($SEQ, $F)</code> is equivalent to the expression
                <code>for $i in $SEQ return $F($i)</code>, assuming that ordering mode is
                <code>ordered</code>.</p>
+         <p diff="add" at="2023-02-20">See also <code>array:build</code>, which provides similar functionality for the
+         case where the input is a sequence rather than an array.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -16433,6 +16435,10 @@ declare function fn:for-each($input, $action) {
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
    <fos:function name="filter" prefix="fn">
       <fos:signatures>
@@ -18535,6 +18541,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
 
@@ -20030,7 +20040,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function returns the number of members in the array.</p>
-         <p diff="chg" at="A">More formally, the function returns the value of <code>count(op:A2S($array))</code>.</p>
+         <p diff="chg" at="A">More formally, the function returns the value of <code>fn:count(array:members($array))</code>.</p>
       </fos:rules>
       <fos:notes>
          <p>Note that because an array is an item, the <code>fn:count</code> function when applied to an array always returns 1 (one).</p>
@@ -20175,7 +20185,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function returns the member at a specified position in the array.</p>
-         <p diff="chg" at="A">More formally, the function returns the value of <code role="example">op:A2S($array)[$position]()</code>.</p>
+         <p diff="chg" at="A">More formally, the function returns the value of <code role="example">array:members($array)[$position]?value</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
@@ -20242,6 +20252,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Unchanged in 4.0.</fos:version>
+      </fos:history>
    </fos:function>
    
    <fos:function name="replace" prefix="array">
@@ -20292,6 +20306,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
    
 
@@ -20315,7 +20333,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             members in positions 1 to <code>array:size($array)</code> are the same as the members in the corresponding position
             of <code>$array</code>, and the member in position <code>array:size($array) + 1</code> is <code>$add</code>.</p>
          <p diff="chg" at="A">More formally, the result is the value of the expression
-            <code>(op:A2S($array), function(){$add}) => op:S2A()</code>.</p>
+            <code>array:of((array:members($array), map{'value':$add}))</code>.</p>
 
       </fos:rules>
       <fos:examples>
@@ -20334,6 +20352,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="join" prefix="array">
@@ -20353,7 +20375,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:rules>
          <p>Informally, the function concatenates the members of several arrays into a single array.</p>
          <p diff="chg" at="A">More formally, the function returns the result of 
-            <code>($arrays ! op:A2S(.)) => op:S2A()</code>.</p>
+            <code>array:of($arrays ! array:members(.))</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -20379,6 +20401,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="subarray" prefix="array">
@@ -20406,7 +20432,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <p diff="add" at="2022-12-19">Setting the third argument to the empty sequence has the same effect as omitting the argument.</p>
          <p>Except in error cases, the result of the three-argument version of the function is the 
             value of the expression
-            <code role="example">op:A2S($array) => fn:subsequence($start, $length) => op:S2A()</code>.</p>
+            <code role="example">array:of(array:members($array) => fn:subsequence($start, $length))</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="AY" code="0001"
@@ -20462,6 +20488,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
    
    <fos:function name="index-where" prefix="array">
@@ -20536,7 +20566,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <p>Returns an array containing selected members of a supplied input array based on their position.</p>
       </fos:summary>
       <fos:rules>
-         <p>Returns the value of <code role="example">op:A2S($input) => fn:slice($start, $end, $step) => op:S2A()</code></p>
+         <p>Returns the value of <code role="example">array:of(array:members($input) => fn:slice($start, $end, $step))</code></p>
       </fos:rules>
       <fos:notes>
          <p>The function is formally defined by converting the array to a sequence, applying 
@@ -20632,6 +20662,9 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0; not yet reviewed?.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="remove" prefix="array">
@@ -20656,7 +20689,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             except the members whose position (counting from 1) is present in the sequence <code>$positions</code>.
          The order of the remaining members is preserved.</p>
          <p diff="chg" at="A">More formally, the result of the function, except in error cases, is given by the expression
-            <code role="example">op:A2S($array)[not(position() = $positions)] => op:S2A()</code>.
+            <code role="example">array:of(array:members($array) => fn:remove($positions))</code>.
          </p>
       </fos:rules>
       <fos:errors>
@@ -20689,6 +20722,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="insert-before" prefix="array">
@@ -20713,7 +20750,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             then all members from <code>$array</code> whose position is greater than or equal to <code>$position</code>. 
             Positions are counted from 1.</p>
          <p>More formally, except in error cases, the result is the value of the expression
-            <code role="example">op:A2S($array) => fn:insert-before($position, function(){$member}) => op:S2A()</code>.</p>
+            <code role="example">array:of(array:members($array) => fn:insert-before($position, map{'value':$member}))</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
@@ -20740,6 +20777,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
 
@@ -20781,6 +20822,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Unchanged in 4.0.</fos:version>
+      </fos:history>
    </fos:function>
    
    <fos:function name="foot" prefix="array">
@@ -20821,7 +20866,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0, see issue 97</fos:version>
+         <fos:version version="4.0">Proposed and accepted for 4.0, see issue 97</fos:version>
       </fos:history>
    </fos:function>
 
@@ -20862,6 +20907,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Unchanged in 4.0.</fos:version>
+      </fos:history>
    </fos:function>
    
    <fos:function name="trunk" prefix="array">
@@ -20902,7 +20951,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0, see issue 97</fos:version>
+         <fos:version version="4.0">Proposed and accepted for 4.0, see issue 97</fos:version>
       </fos:history>
    </fos:function>
 
@@ -20922,7 +20971,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       </fos:summary>
       <fos:rules>
          <p diff="chg" at="A">The function returns the result of the expression:
-            <code role="example">op:A2S($array) => fn:reverse() => op:S2A()</code></p>
+            <code role="example">array:of(array:members($array) => fn:reverse())</code></p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -20944,6 +20993,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="for-each" prefix="array">
@@ -20968,7 +21021,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <p>Informally, the function returns an array whose members are obtained by applying 
          the supplied <code>$function</code> to each member of the input array in turn.</p>
          <p>More formally, the function returns the result of the expression
-            <code>(for $member in op:A2S($array) return function(){$action($member())) => op:S2A()</code>.</p>
+            <code>array:of(array:members($array) ! map{'value':$action(?value)}</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -21019,7 +21072,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <p>Informally, the function returns an array containing those members of the input
          array that satisfy the supplied predicate.</p>
          <p>More formally, the function returns the result of the expression
-            <code role="example">op:A2S($array) => fn:filter(function($m){$predicate($m())}) => op:S2A()</code>.</p>
+            <code role="example">array:of(array:members($array) => fn:filter(function($m){$predicate($m?value)})</code>.</p>
 
       </fos:rules>
       <fos:errors>
@@ -21043,6 +21096,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="fold-left" prefix="array">
@@ -21066,7 +21123,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       </fos:summary>
       <fos:rules>
          <p>The result of the function is the value of the expression 
-            <code role="example">op:A2S($array) => fn:fold-left($zero, function($a, $b){$action($a, $b()})</code></p>
+            <code role="example">array:members($array) => fn:fold-left($zero, function($a, $b){$action($a, $b?value})</code></p>
 <!--         <eg>
 if (array:size($array) eq 0)
 then $zero
@@ -21099,6 +21156,10 @@ else array:fold-left(array:tail($array),
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="fold-right" prefix="array">
@@ -21122,16 +21183,8 @@ else array:fold-left(array:tail($array),
       </fos:summary>
       <fos:rules>
          <p>The result of the function is the value of the expression 
-            <code role="example">op:A2S($array) => fn:fold-right($zero, function($a, $b){$action($a, $b()})</code></p>
-        <!-- 
-         <p>The effect of the function is equivalent to the following recursive definition:</p>
-         <eg>
-if (array:size($array) eq 0)
-then $zero
-else $action( array:head($array), 
-                array:fold-right(array:tail($array), $zero, $action) 
-              )
-         </eg>-->
+            <code role="example">array:members($array) => fn:fold-right($zero, function($a, $b){$action($a, $b?value})</code></p>
+ 
       </fos:rules>
       <fos:notes>
          <p>If the supplied array is empty, the function returns <code>$zero</code>.</p>
@@ -21157,6 +21210,10 @@ else $action( array:head($array),
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="for-each-pair" prefix="array">
@@ -21179,19 +21236,13 @@ else $action( array:head($array),
             the two supplied arrays.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the result of the expression
-         <code>fn:for-each-pair(op:A2S($array1), op:A2S($array2), function($m, $n) {function(){$action($m(), $n()}}) => op:S2A()</code>.</p>
-         <!--<p>Returns the result of the recursive expression:</p>
-         <eg>
-            <code>
-if (array:size($array1) eq 0 or array:size($array2) eq 0)
-then [ ]
-else array:concat(
-        $action(array:head($array1), array:head($array2)), 
-        array:for-each-pair(array:tail($array1), array:tail($array2), $action)
-     )
-         </code>
-         </eg>-->
+         <p>The function returns the result of the expression:</p>
+         <eg><code>array:of(
+    fn:for-each-pair(array:members($array1), 
+                     array:members($array2), 
+                     function($m, $n) {map{'value': $action($m?value, $n?value)}}))</code>
+         </eg>
+         
       </fos:rules>
       <fos:notes>
          <p>If the arrays have different size, excess members in the longer array are ignored.</p>
@@ -21208,11 +21259,15 @@ else array:concat(
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
-   <fos:function name="from-sequence" prefix="array">
+   <fos:function name="build" prefix="array">
       <fos:signatures>
-         <fos:proto name="from-sequence" return-type="array(*)">
+         <fos:proto name="build" return-type="array(*)">
             <fos:arg name="input" type="item()*" usage="inspection"/>
             <fos:arg name="action" type="function(item()) as item()*" usage="inspection" default="fn:identity#1"/>
          </fos:proto>
@@ -21229,50 +21284,55 @@ else array:concat(
       <fos:rules>
          <p>If the function is called with one argument, the effect is the same as calling the two-argument
          function with <code>fn:identity#1</code> as the second argument.</p>
-         <p>Informally, <code>array:from-sequence#2</code> applies the supplied function to each item 
+         <p>Informally, <code>array:build#2</code> applies the supplied function to each item 
             in the input sequence, and the resulting sequence becomes one member of the returned array.</p>
-         <p>More formally, <code>array:from-sequence#2</code> returns the result of the expression:</p>
-         <eg>fn:for-each($input, function($x)(function(){$action($x)})) => op:S2A()</eg>
+         <p>More formally, <code>array:build#2</code> returns the result of the expression:</p>
+         <eg>array:of($input ! map{'value':$action(.)})</eg>
       </fos:rules>
       <fos:notes>
-         <p>The single-argument function <code>array:from-sequence($input)</code> is equivalent to the XPath
+         <p>The single-argument function <code>array:build($input)</code> is equivalent to the XPath
          expression <code>array{$input}</code>, but it is useful to have this available as a function.</p>
          <p>The two-argument form facilitates the construction of arrays whose members are arbitrary
          sequences.</p>
+         <p>See also <code>array:for-each</code>, which provides similar functionality for the
+            case where the input is an array rather than a sequence.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:from-sequence(1 to 5)</fos:expression>
+               <fos:expression>array:build(1 to 5)</fos:expression>
                <fos:result>[1, 2, 3, 4, 5]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:from-sequence(1 to 5, ->{2*.})</fos:expression>
+               <fos:expression>array:build(1 to 5, ->{2*.})</fos:expression>
                <fos:result>[2, 4, 6, 8, 10]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:from-sequence(1 to 5, ->{1 to .})</fos:expression>
+               <fos:expression>array:build(1 to 5, ->{1 to .})</fos:expression>
                <fos:result>[1, (1,2), (1,2,3), (1,2,3,4), (1,2,3,4,5)]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:from-sequence(("red", "green", "blue"), fn:characters#1)</fos:expression>
+               <fos:expression>array:build(("red", "green", "blue"), fn:characters#1)</fos:expression>
                <fos:result>[("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e)]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:from-sequence(1 to 5, ->{array{1 to .}})</fos:expression>
+               <fos:expression>array:build(1 to 5, ->{array{1 to .}})</fos:expression>
                <fos:result>[[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5]]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:from-sequence(1 to 20, ->{array{1 to .}})</fos:expression>
+               <fos:expression>array:build(1 to 20, ->{array{1 to .}})</fos:expression>
                <fos:result>[[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5]]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0, initially under the name <code>array:from-sequence</code>.</fos:version>
+      </fos:history>
    </fos:function>
    
    <fos:function name="members" prefix="array">
       <fos:signatures>
-         <fos:proto name="members" return-type="item()*">
+         <fos:proto name="members" return-type="record(value as item()*)*">
             <fos:arg name="input" type="array(*)" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -21282,23 +21342,21 @@ else array:concat(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Delivers the contents of an array as a sequence of parcels.</p>
+         <p>Delivers the contents of an array as a sequence of <term>value records</term>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The members of the array are delivered as a sequence of <term>parcels</term>. 
-            A parcel is an item that encapsulates an arbitrary sequence; the content of the parcel
-         may be obtained using the <code>fn:unparcel</code> function.</p>
-         <p>The result of the function is equivalent to calling 
-            <code>array:for-each($input, fn:parcel#1)</code>.</p>
+         <p>The members of the array are delivered as a sequence of <term>value records</term>. 
+            A value record is an item that encapsulates an arbitrary sequence <code>$S</code>: specifically
+            it is a map comprising a single entry whose key is the <code>xs:string</code> value
+            <code>"value"</code> and whose corresponding value is <code>$S</code>. The content encapsulated
+         by a value record <code>$V</code> can be obtained using the expression <code>$V?value</code>.</p>
+         
          
       </fos:rules>
       <fos:notes>
-         <p>Implementations may define a more precise type for the result, depending on how they
-            choose to implement parcels. Using a more precise type will give better type checking
-            of expressions that use parcels.</p>
-         
-         
+         <p>This function is the inverse of <code>array:of</code>.</p>   
       </fos:notes>
+ 
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -21306,11 +21364,11 @@ else array:concat(
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:members([1 to 5])!fn:unparcel(.)</fos:expression>
+               <fos:expression>array:members([1 to 5])?value</fos:expression>
                <fos:result>(1, 2, 3, 4, 5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:members([(1,1) (2,4), (3,9), (4,16), (5,25)])!fn:sum(fn:unparcel(.)))</fos:expression>
+               <fos:expression>array:members([(1,1) (2,4), (3,9), (4,16), (5,25)])!fn:sum(?value))</fos:expression>
                <fos:result>(2, 6, 12, 20, 30)</fos:result>
             </fos:test>
             <fos:test>
@@ -21319,12 +21377,15 @@ else array:concat(
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0, see issues 23, 113, 314.</fos:version>
+      </fos:history>
    </fos:function>
    
    <fos:function name="of" prefix="array">
       <fos:signatures>
          <fos:proto name="of" return-type="array(*)">
-            <fos:arg name="input" type="item()*" usage="inspection"/>
+            <fos:arg name="input" type="record(value as item()*)*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -21333,21 +21394,19 @@ else array:concat(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Constructs an array from the contents of a sequence of parcels.</p>
+         <p>Constructs an array from the contents of a sequence of <term>value records</term>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The input items must be <term>parcels</term>. A parcel is an item that encapsulates an arbitrary sequence,
-            and it may be obtained as the result
-         of the <code>fn:parcel</code> function, or by deconstructing an array using the <code>array:members</code>
-         function,</p>
-         <p>The result of the function is equivalent to calling 
-            <code>fn:from-sequence($input, fn:unparcel#1)</code>.</p>
+         <p>The input items must be <term>value records</term>.  A value record is an item that encapsulates 
+            an arbitrary sequence <code>$S</code>: specifically
+            it is a map comprising a single entry whose key is the <code>xs:string</code> value
+            <code>"value"</code> and whose corresponding value is <code>$S</code>. The content encapsulated
+            by a value record <code>$V</code> can be obtained using the expression <code>$V?value</code>.</p>
+  
 
       </fos:rules>
       <fos:notes>
-         <p>Implementations may define a more precise type for the argument, depending on how they
-         choose to implement parcels. Using a more precise type will give better type checking
-         of expressions that use parcels.</p>
+         <p>This function is the inverse of <code>array:members</code>.</p>
 
          
       </fos:notes>
@@ -21358,19 +21417,22 @@ else array:concat(
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of(parcel(1 to 5))</fos:expression>
+               <fos:expression>array:of(map{'value',(1 to 5)})</fos:expression>
                <fos:result>[(1, 2, 3, 4, 5)]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of((1 to 5)!parcel(.))</fos:expression>
+               <fos:expression>array:of((1 to 5)!map{'value':.})</fos:expression>
                <fos:result>[1, 2, 3, 4, 5]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of((1 to 5)!parcel(., .*.))</fos:expression>
+               <fos:expression>array:of((1 to 5)!map{'value':(., .*.)})</fos:expression>
                <fos:result>[(1,1) (2,4), (3,9), (4,16), (5,25)]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0, see issues 23, 113, 314.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="sort" prefix="array">
@@ -21416,56 +21478,9 @@ else array:concat(
                ref="choosing-a-collation"/>.</p>
          
          <p diff="chg" at="A">The result of <code>array:sort#3</code> is the value of the expression
-            <code role="example">op:A2S($array) => fn:sort($collation, function($x){$key($x())}) => op:S2A()</code></p>
+            <code role="example">array:of(array:members($array) => fn:sort($collation, function($x){$key($x?value)}))</code></p>
 
-         <!--<p>The result of the function is obtained as follows:</p>
-         <ulist>
-            <item>
-               <p>For each member of the array <code>$array</code>, the function supplied as <code>$key</code> 
-               is evaluated with that member as its argument. 
-               The resulting values are the sort keys of the members of the array.
-            </p>
-            </item>
-            <item>
-               <p>The result array contains the same members as the input array <code>$array</code>, but generally in a different order.</p>
-            </item>
-            <item>
-               <p>Let <var>$C</var> be the selected collation, or the default collation where applicable.</p>
-            </item>
-            <item>
-               <p>The order of items in the result is such that, given two items <code>$A</code> and <code>$B</code>:</p>
-               <ulist>
-                  <item>
-                     <p>If <code>(fn:deep-equal($key($A), $key($B), $C)</code>, then the relative order of <code>$A</code> and <code>$B</code> 
-                     in the output is the same as their relative order in the input (that is, the sort is stable)
-                  </p>
-                  </item>
-                  <item>
-                     <p>Otherwise, if <code>(deep-less-than($key($A), $key($B), $C)</code>, then <code>$A</code> precedes <code>$B</code> in the output. 
-                     The function <code>deep-less-than</code> is defined as the boolean result of the expression:
-                  </p>
-                     <eg>
-                        <code>if (fn:empty($A)) 
-     then fn:exists($B)
-else if (fn:deep-equal($A[1], $B[1], $C)) 
-     then deep-less-than(fn:tail($A), fn:tail($B), $C)
-else if ($A[1] ne $A[1] (:that is, $A[1] is NaN:)) 
-     then fn:true()
-else if (is-string($A[1]) and is-string($B[1]) 
-     then fn:compare($A[1], $B[1], $C) lt 0
-else $A[1] lt $B[1]</code>
-                     </eg>
-                     <p>where the function <code>is-string($X)</code> returns true if and only if <code>$X</code> is an instance of 
-                        <code>xs:string</code>, <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>.</p>
-
-
-                     <p>This ordering of sequences is referred to by mathematicians as "lexicographic ordering".
-                     </p>
-                  </item>
-               </ulist>
-            </item>
-         </ulist>
--->
+        
       </fos:rules>
       <fos:errors>
          <p>If the set of computed sort keys contains values that are not comparable using the <code>le</code> operator then the sort 
@@ -21501,6 +21516,10 @@ return array:sort($in, $SWEDISH)
             <eg>array:sort($employees, (), function($emp) {$emp?name?last, $emp?name?first})</eg>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="flatten" prefix="array">
@@ -21557,6 +21576,10 @@ return array:sort($in, $SWEDISH)
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="3.1">First introduced in 3.1.</fos:version>
+         <fos:version version="4.0">Retained unchanged.</fos:version>
+      </fos:history>
    </fos:function>
 
    <fos:function name="partition" prefix="array">
@@ -21627,188 +21650,12 @@ return array:sort($in, $SWEDISH)
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0. Not yet reviewed?</fos:version>
+      </fos:history>
    </fos:function>
 
-   <!--<fos:function name="spread" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="spread" return-type="array(item())*">
-            <fos:arg name="input" type="item(*)"/>
-            <fos:arg name="limit" type="xs:numeric"/>
-         </fos:proto>
-         <fos:proto name="spread" return-type="array(item())*">
-            <fos:arg name="input" type="item(*)"/>
-            <fos:arg name="limit" type="xs:numeric"/>
-            <fos:arg name="weight" type="function(item()) as union(xs:numeric, xs:boolean)"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Converts a supplied sequence into a sequence of arrays, based on a user-supplied function
-         that determines the maximum "weight" of each of these arrays.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The supplied <code>$weight</code> function returns a quantity that is used to assess how many
-         items from the input sequence to include in each array in the result. The returned value must
-         either be a numeric value (which must not be negative, infinite, or NaN), or a boolean (in which
-         case true is interpreted as one, false as zero).</p>
-         <p>Calling the two-argument version of the function is equivalent to
-         calling the three-argument function with <code>fn:exists#1</code> as the third
-         argument: that is, by default each item in the input sequence has a weight of 1.</p>
-
-         <p>The value of <code>$limit</code> function must not be negative, zero, infinite, or NaN.</p>
-         <p>The function attempts to split the supplied input sequence <code>$input</code> into a sequence of 
-            arrays, each one having a total "weight" that is less than or equal to <code>$limit</code>;
-            however, if one individual member has a "weight" greater than <code>$limit</code>, then
-            it will be returned as a partition with a single member. The 
-            concatenation of the returned partions is identical to the original input sequence.
-         </p>
-      </fos:rules>
-      <fos:notes>
-         <p>In the absence of a weighting function, the input sequence is partitioned
-            into fixed size arrays of size <code>$limit</code>, except that the final array may be shorter than the limit.
-            This option is useful, for example, when arranging data into rows or columns in a table, or when
-            splitting a sequence of lines of text into fixed-size pages.
-         </p>
-         <p>With a weighting function, the size of sub-arrays is not fixed, but is determined
-         by some threshold being reached. For example, <code>fn:spread($words, 80, fn:string-length#1)</code>
-         splits a sequence of words so that (where possible) the totol length of the words in each
-         partition does not exceed 80.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:spread((1, 2, 3, 4, 5, 6), 2)</fos:expression>
-               <fos:result>([1, 2], [3, 4], [5, 6])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:spread((1, 2, 3, 4, 5, 6), 3)</fos:expression>
-               <fos:result>([1, 2, 3], [4, 5, 6])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:spread((1, 2, 3, 4, 5), 2)</fos:expression>
-               <fos:result>([1, 2], [3, 4], [5])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:spread((1), 2)</fos:expression>
-               <fos:result>([1])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:spread((), 2)</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:spread((1, 2, 3, 4), 1)</fos:expression>
-               <fos:result>([1], [2], [3], [4])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:spread((1, 2, 3, 4), 0.5)</fos:expression>
-               <fos:result>([1], [2], [3], [4])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:spread((1, 2, 3, 4, 5), 4, ->{.})</fos:expression>
-               <fos:result>([1, 2], [3], [4], [5])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:spread(tokenize("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam ornare mi vitae tellus interdum efficitur.", 40, ->{string-length()+1})</fos:expression>
-               <fos:result>(["Lorem", "ipsum", "dolor", "sit", "amet"], [], etc  TBA</fos:result>
-               <fos:postamble>Splits a sequence of words into lines of a given length, here 40. If a single word exceeds the
-               line length, it appears on a line of its own.</fos:postamble>
-            </fos:test>
-
-         </fos:example>
-      </fos:examples>
-   </fos:function>-->
-
-   <!--<fos:function name="break" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="break" return-type="array(item())*">
-            <fos:arg name="input" type="item(*)"/>
-            <fos:arg name="when" type="function(item(), item()) as xs:boolean"/>
-         </fos:proto>
-         <fos:proto name="break" return-type="array(item())*">
-            <fos:arg name="input" type="item(*)"/>
-            <fos:arg name="when" type="function(item(), item()) as xs:boolean"/>
-            <fos:arg name="action" type="function(item()*) as item()"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Groups the items a supplied sequence into a sequence of groups, with a break occurring
-            at any point where the user-supplied condition is true;
-            and applies a supplied function to each of the resulting groups.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>If the third argument is omitted, the default is <code>array:from-sequence#1</code>,
-         which returns each group as an array of items.</p>
-         <p>The supplied <code>$when</code> function is called once for each pair of adjacent items
-            in the input sequence: for example if the input sequence is <code>(1, 2, 3, 4)</code>,
-            then there will be three calls: <code>$when(1, 2)</code>, <code>$when(2, 3)</code>,
-            and <code>$when(3, 4)</code>. If the function returns true, the input sequence
-         is broken at that point (that is, the two items end up in different output arrays). Conversely,
-         if the function returns false, the two items end up in the same output array.</p>
-         <p>The concatenation of the returned arrays is identical to the original input sequence.
-         </p>
-      </fos:rules>
-      <fos:notes>
-         <p>The function enables three forms of grouping algorithm, equivalent to the options
-         <code>group-adjacent</code>, <code>group-starting-with</code>, and <code>group-ending-with</code>
-         in XSLT:</p>
-         <ulist>
-            <item>
-               <p>To achieve the same effect as <code>group-adjacent</code>, the <code>$when</code> function
-            should test whether the two arguments differ in their grouping key.</p>
-            </item>
-            <item>
-               <p>To achieve the same effect as <code>group-starting-with</code>, the <code>$when</code>
-               should test some condition applied to the second argument.</p>
-            </item>
-            <item>
-               <p>To achieve the same effect as <code>group-ending-with</code>, the <code>$when</code>
-               should test some condition applied to the first argument.</p>
-            </item>
-         </ulist>
-         <p>The function also enables a sequence to be partitioned in ways that are awkward to achieve
-         with <code>xsl:for-each-group</code>, for example splitting the sequence when adjacent items
-         differ by more than one, or splitting it between every two elements except when both are named
-         <code>bullet</code>, or splitting it if one item ends with "." and the next item starts with
-         a capital letter.</p>
-         <p>In XQuery, the function offers an alternative to the <code>window</code> clause in FLWOR
-         expressions.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>fn:break(("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
-                  ->($x, $y){fn:substring($x,1,1) ne fn:substring($y,1,1)})</fos:expression>
-               <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:break((1, 2, 5, 6, 7, 10, 11), ->$x, $y{$y ne $x+1})</fos:expression>
-               <fos:result>([1, 2], [5, 6, 7], [10, 11])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:break((1, 2, 5, 6, 7, 10, 11), ->$x, $y{$y ne $x+1}, fn:string-join(?, '-')}</fos:expression>
-               <fos:result>("1-2", "5-6-7", "10-11")</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>fn:break(tokenize("I came. I saw. I conquered."), ends-with#1(?, '.'), fn:string-join(?, ' '))</fos:expression>
-               <fos:result>("I came.", "I saw.", "I conquered.")</fos:result>
-               <fos:postamble>This example exploits the fact that it is possible to supply an arity-1 function
-               where an arity-2 function is expected; the second argument is dropped.</fos:postamble>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-   </fos:function>
--->
-
+ 
    <fos:function name="load-xquery-module" prefix="fn">
       <fos:signatures>
          <fos:proto name="load-xquery-module" return-type="map(*)">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21378,7 +21378,7 @@ else array:fold-left(array:tail($array),
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0, see issues 23, 113, 314.</fos:version>
+         <fos:version version="4.0">Proposed for 4.0, see issues 29, 113, 314.</fos:version>
       </fos:history>
    </fos:function>
    
@@ -21431,7 +21431,7 @@ else array:fold-left(array:tail($array),
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0, see issues 23, 113, 314.</fos:version>
+         <fos:version version="4.0">Proposed for 4.0, see issues 29, 113, 314.</fos:version>
       </fos:history>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7107,31 +7107,32 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          </div2>
       </div1>
 
-      <div1 id="maps-and-arrays">
-         <head>Maps and Arrays</head>
+      <div1 id="maps">
+         <head>Maps</head>
          
-         <p>Maps and arrays are introduced as new datatypes in XDM 3.1. This section describes functions that
-         operate on maps and arrays. It also describes functions that operate on JSON data structures, which make
-         extensive use of maps and arrays.</p>
+         <p>Maps were introduced as a new datatype in XDM 3.1. This section describes functions that
+         operate on maps.</p>
+         
+         <p>A map is an additional kind of item.</p>
+         
+         <p><termdef id="dt-map" term="map">A map consists of a set of entries. Each entry comprises a key 
+            which is an arbitrary atomic value, and an arbitrary sequence called the associated value.</termdef></p>
+         
+         <p><termdef id="dt-same-key" term="same key">Within a map, no two entries have the <term>same key</term>. 
+            Two atomic values <code>K1</code> and <code>K2</code> are the <term>same key</term>
+            for this purpose if the <phrase diff="chg" at="2023-01-25">function call <code>fn:atomic-equal($K1, $K2)</code></phrase>
+            returns true.</termdef></p>
+         
+         <p>It is not necessary that all the keys in a map should be
+            of the same type (for example, they can include a mixture of integers and strings).</p>
+         
+         
          
          <div2 id="map-functions">
             <head>Functions that Operate on Maps</head>
             
             <p>The functions defined in this section use a conventional namespace prefix <code>map</code>, which
                is assumed to be bound to the namespace URI <code>http://www.w3.org/2005/xpath-functions/map</code>.</p>
-            
-            <p>A map is an additional kind of item.</p>
-            
-            <p><termdef id="dt-map" term="map">A map consists of a set of entries. Each entry comprises a key 
-               which is an arbitrary atomic value, and an arbitrary sequence called the associated value.</termdef></p>
-            
-            <p><termdef id="dt-same-key" term="same key">Within a map, no two entries have the <term>same key</term>. 
-               Two atomic values <code>K1</code> and <code>K2</code> are the <term>same key</term>
-               for this purpose if the <phrase diff="chg" at="2023-01-25">function call <code>fn:atomic-equal($K1, $K2)</code></phrase>
-               returns true.</termdef></p>
-            
-            <p>It is not necessary that all the keys in a map should be
-               of the same type (for example, they can include a mixture of integers and strings).</p>
             
             
             
@@ -7228,16 +7229,29 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <p>There is no function or operator to atomize a map or convert it to a string (other than <code>fn:serialize</code>,
                which can be used to serialize some maps as JSON texts).</p>
             
-            
-            
-            
          </div2>
+      </div1>
+      <div1 id="arrays">
+         <head>Arrays</head>
+         
+         <p>Arrays were introduced as a new datatype in XDM 3.1. This section describes functions that
+            operate on arrays.</p>
+         
+         <p>An array is an additional kind of item. An array of size <var>N</var> is a mapping from the integers
+            (1 to <var>N</var>) to a set of values, called the members of the array, each of which is an arbitrary
+            sequence. Because an array is an item, and therefore a sequence, arrays can be nested.</p>
+         
+         <p>An array acts as a function from integer positions to associated values, so the
+            function call <code>$array($index)</code> can be used to retrieve the array member at a given position.
+            The function corresponding to the array has the signature 
+            <code>function($index as xs:integer) as item()*</code>. 
+            The fact that an array is a function item allows it to be passed as an argument to higher-order functions 
+            that expect a function item as one of their arguments.</p>
+         
+         
          <div2 id="array-functions">
             <head>Functions that Operate on Arrays</head>
             
-            <p>An array is an additional kind of item. An array of size <var>N</var> is a mapping from the integers
-            (1 to <var>N</var>) to a set of values, called the members of the array, each of which is an arbitrary
-            sequence. Because an array is an item, and therefore a sequence, arrays can be nested.</p>
             
             <p>The functions defined in this section use a conventional namespace prefix <code>array</code>, which
                is assumed to be bound to the namespace URI <code>http://www.w3.org/2005/xpath-functions/array</code>.</p>   
@@ -7248,51 +7262,31 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                on <code>array:reverse</code> with the same argument will return arrays that are indistinguishable from
                each other; there is no way of asking whether these are "the same array". Like sequences, arrays have no identity. </p>
             
-            <p>An array acts as a function from integer positions to associated values, so the
-               function call <code>$array($index)</code> can be used to retrieve the array member at a given position.
-               The function corresponding to the array has the signature 
-               <code>function($index as xs:integer) as item()*</code>. 
-               The fact that an array is a function item allows it to be passed as an argument to higher-order functions 
-               that expect a function item as one of their arguments.</p>
             
-            <p>In the function definitions that follow, all the array functions are defined in terms of five primitives:</p>
             
-            <ulist>
-               <item><p><code>[]</code> represents the zero-length array (an array with no members).</p></item>
-               <item><p><code>$array($index)</code> returns the member at position <code>$index</code>.</p></item>
-               <item><p><code>op:A2S($array)</code> converts the array to a sequence in which each member of the array
-               is replaced by a zero-arity function that returns the corresponding value. For example,
-               <code>[(1,2), (3,4)]</code> becomes <code>(function(){1,2}, function(){3,4})</code>.</p></item>
-               <item><p><code role="example">op:S2A($seq)</code> is the inverse of <code role="example">op:A2S</code>: it takes as input a sequence
-                  of zero-arity functions, and returns the array whose members are the results of evaluating
-                  these functions. For example, <code>(function(){1,2}, function(){3,4})</code>
-                  becomes <code>[(1,2), (3,4)]</code>.</p></item>
-               <!--<item><p><code>array:size($array)</code> returns the number of members in the array.</p></item>
-               <item><p><code>op:array-singleton($seq)</code> returns an array of size one whose single member
-                  is the supplied sequence <code>$seq</code>. This operation is not directly available
-                  as a user-visible function, because the effect can easily be achieved using the syntax <code>[ $seq ]</code>.</p></item>
-               <item><p><code>op:array-concat($array1, $array2)</code> returns an array whose members are first the members of 
-               <code>$array1</code> and then the members of <code>$array2</code>. This operation is not directly available
-               as a user-visible function, because the effect can easily be achieved using <code>array:join</code>.</p></item>
-            -->   </ulist>
+            <p diff="chg" at="2023-02-20">All functionality on arrays is defined in terms of two primitives:</p>
             
-            <p>There are two operations on arrays for which the XPath language provides custom syntax:</p>
-            
-            <ulist>
-               <item><p><code>array { $sequence }</code> constructs an array whose members are the items in <code>$sequence</code>.
-                  Every member of this array will be a singleton item.
-               This can be defined as <code>fn:fold-left($sequence, [], function($x, $y){ op:array-concat($x, op:array-singleton($y))</code></p></item>
-               <item><p><code>[ E1, E2, E3, ..., En]</code> constructs an array in which <code>E1</code> is the first member,
-               <code>E2</code> is the second member, and so on. If <var>N=0</var>, the value is the empty array <code>[]</code>;
-               if <var>N=1</var>, the value is <code>op:array-concat([], array { E1 })</code>, and if <var>N &gt; 1</var>,
-               the value is <code>op:array-concat(op:array-singleton(E1), [ E2, ... En ])</code>.</p></item>
+            <ulist diff="chg" at="2023-02-20">
+               <item><p>The function <code>array:members</code> decomposes an array to a sequence of 
+                  <term>value records</term>.</p></item>
+               <item><p>The function <code>array:of</code> composes an array from a sequence of 
+               <term>value records</term>.</p></item>
             </ulist>
+            
+            <p diff="chg" at="2023-02-20">A <term>value record</term> here is an item that encapsulates an arbitrary value; the representation
+            chosen for a value record is <code>record(value as item()*)</code>, that is, a map containing a single
+            entry whose key is the string <code>"value"</code> and whose value is the encapsulated sequence.</p>
  
+            
+     
             
             <?local-function-index?>
             
-            <div3 id="func-array-size">
-               <head><?function array:size?></head>
+            <div3 id="func-array-append">
+               <head><?function array:append?></head>
+            </div3>
+            <div3 id="func-array-build" diff="chg" at="2023-02-20">
+               <head><?function array:build?></head>
             </div3>
             <div3 id="func-array-empty" diff="add" at="2022-12-06">
                <head><?function array:empty?></head>
@@ -7300,53 +7294,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-array-exists" diff="add" at="2022-12-06">
                <head><?function array:exists?></head>
             </div3>
-            <div3 id="func-array-get">
-               <head><?function array:get?></head>
-            </div3>
-            <div3 id="func-array-put">
-               <head><?function array:put?></head>
-            </div3>
-            <div3 id="func-array-replace" diff="add" at="A">
-               <head><?function array:replace?></head>
-            </div3>
-            <div3 id="func-array-append">
-               <head><?function array:append?></head>
-            </div3>
-            <div3 id="func-array-slice" diff="add" at="A">
-               <head><?function array:slice?></head>
-            </div3> 
-            <div3 id="func-array-subarray">
-               <head><?function array:subarray?></head>
-            </div3> 
-            <div3 id="func-array-remove">
-               <head><?function array:remove?></head>
-            </div3>
-            <div3 id="func-array-insert-before">
-               <head><?function array:insert-before?></head>
-            </div3>
-            <div3 id="func-array-head">
-               <head><?function array:head?></head>
-            </div3>
-            <div3 id="func-array-foot" diff="add" at="2022-11-16">
-               <head><?function array:foot?></head>
-            </div3>
-            <div3 id="func-array-tail">
-               <head><?function array:tail?></head>
-            </div3>
-            <div3 id="func-array-trunk" diff="add" at="2022-11-16">
-               <head><?function array:trunk?></head>
-            </div3>
-            <div3 id="func-array-reverse">
-               <head><?function array:reverse?></head>
-            </div3>
-            <div3 id="func-array-join">
-               <head><?function array:join?></head>
-            </div3>
-            <div3 id="func-array-for-each">
-               <head><?function array:for-each?></head>
-            </div3>
             <div3 id="func-array-filter">
                <head><?function array:filter?></head>
+            </div3>
+            <div3 id="func-array-flatten">
+               <head><?function array:flatten?></head>
             </div3>
             <div3 id="func-array-fold-left">
                <head><?function array:fold-left?></head>
@@ -7354,27 +7306,110 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-array-fold-right">
                <head><?function array:fold-right?></head>
             </div3>
+            <div3 id="func-array-foot" diff="add" at="2022-11-16">
+               <head><?function array:foot?></head>
+            </div3>
             <div3 id="func-array-for-each-pair">
                <head><?function array:for-each-pair?></head>
             </div3>
-            <div3 id="func-array-sort">
-               <head><?function array:sort?></head>
+            
+            <div3 id="func-array-for-each">
+               <head><?function array:for-each?></head>
             </div3>
-            <div3 id="func-array-flatten">
-               <head><?function array:flatten?></head>
+            <div3 id="func-array-get">
+               <head><?function array:get?></head>
             </div3>
-            <div3 id="func-array-from-sequence">
-               <head><?function array:from-sequence?></head>
+            <div3 id="func-array-head">
+               <head><?function array:head?></head>
             </div3>
-            <div3 id="func-array-partition" diff="add" at="A">
-               <head><?function array:partition?></head>
+            <div3 id="func-array-of" diff="add" at="2023-02-20">
+               <head><?function array:of?></head>
             </div3>
             <div3 id="func-array-index-where" diff="add" at="2022-11-17">
                <head><?function array:index-where?></head>
             </div3>
+            <div3 id="func-array-insert-before">
+               <head><?function array:insert-before?></head>
+            </div3>
+            <div3 id="func-array-join">
+               <head><?function array:join?></head>
+            </div3>
+            <div3 id="func-array-members" diff="add" at="2023-02-20">
+               <head><?function array:members?></head>
+            </div3>
+            <div3 id="func-array-partition" diff="add" at="A">
+               <head><?function array:partition?></head>
+            </div3>
+            <div3 id="func-array-put">
+               <head><?function array:put?></head>
+            </div3>
+            <div3 id="func-array-remove">
+               <head><?function array:remove?></head>
+            </div3>
+            <div3 id="func-array-replace" diff="add" at="A">
+               <head><?function array:replace?></head>
+            </div3>
+            <div3 id="func-array-reverse">
+               <head><?function array:reverse?></head>
+            </div3>
+            <div3 id="func-array-size">
+               <head><?function array:size?></head>
+            </div3>
+            <div3 id="func-array-slice" diff="add" at="A">
+               <head><?function array:slice?></head>
+            </div3>
+            <div3 id="func-array-sort">
+               <head><?function array:sort?></head>
+            </div3>
+            <div3 id="func-array-subarray">
+               <head><?function array:subarray?></head>
+            </div3> 
             
             
-         </div2>   
+            
+            
+            <div3 id="func-array-tail">
+               <head><?function array:tail?></head>
+            </div3>
+            <div3 id="func-array-trunk" diff="add" at="2022-11-16">
+               <head><?function array:trunk?></head>
+            </div3>
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+            
+         </div2> 
+         <div2 id="additional-array-operations" diff="add" at="2023-02-20">
+            <head>Additional Operations on Arrays</head>
+            <p><emph>This section is non-normative.</emph></p>
+            <p>The XPath language provides explicit syntax for certain operations on arrays. These constructs can
+            all be specified in terms of the primitives <code>array:of</code> and <code>array:members</code>:</p>
+            
+             <ulist>
+               <item><p><code>array{$sequence}</code> constructs an array whose members are the items in <code>$sequence</code>.
+                  Every member of this array will be a singleton item.
+                  This can be defined as <code>array:of($sequence ! map{'value': .})</code>.</p></item>
+               <item><p><code>[E1, E2, E3, ..., En]</code> constructs an array in which <code>E1</code> is the first member,
+                  <code>E2</code> is the second member, and so on. The result is equivalent to the expression
+                  <code>array:of((map{'value':E1}, map{'value':E2}, map{'value':E3}, ... map{'value':En})). </code></p></item>
+               <item><p>The lookup expression <code>$array?*</code> is equivalent to 
+                  <code>array:members($array)!?value</code>.</p></item>
+                <item><p>The lookup expression <code>$array?$N</code>, where <code>$N</code> is an integer within the bounds
+                   of the array, is equivalent to 
+                   <code>array:members($array)[$N]?value</code>.</p></item>
+                <item><p>Similarly, applying the array as a function, <code>$array($N)</code>, is also equivalent to 
+                   <code>array:members($array)[$N]?value</code></p></item>
+            </ulist>
+            
+            
+         </div2>
 
          
       </div1>
@@ -11369,8 +11404,8 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
 	           the specification now gives a single function signature indicating default values
 	           for arguments that may be omitted, rather than multiple signatures.</p></item>
 	           <item><p>The formal specifications of array functions have been rewritten to use two new
-	              primitives: <code role="example">op:A2S</code> which converts an array to a sequence of zero-arity
-	              functions, and <code role="example">op:S2A</code> which does the inverse. This has enabled many of the
+	              primitives: <code role="example">array:members</code> which converts an array to a sequence of value records, 
+	              and <code role="example">array:of</code> which does the inverse. This has enabled many of the
 	           functions to be specified more concisely, and with less duplication between similar functions
 	           for sequences and arrays.</p></item>
 


### PR DESCRIPTION
This PR addresses parts of issue 29, issue 113, and issue 314 relating to the composition and decomposition of arrays.

It introduces two functions `array:of` for array composition, and `array:members` for decomposition, and defines all other array functions in terms of these two primitives (replacing the internal functions `op:A2S` and `op:S2A`). The items in the decomposed form of an array are called "value records", singleton maps of the form `map{'value': $value}`

The function `array:from-sequence` is renamed `array:build` to reflect its symmetry with `map:build`.

Question for the group: should we have a new function for constructing a "value record", or is the syntax `map{'value': $value}` adequate for the purpose?