### PR TITLE
129: Context item generalized to context value

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -346,7 +346,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:zeroOrMore>
     <g:zeroOrMore name="FunctionsAndVarsList" lookahead="2">
       <g:choice name="FunctionOrVar">
-        <g:ref name="ContextItemDecl" lookahead="2" if="xquery40"/>
+        <g:ref name="ContextValueDecl" lookahead="2" if="xquery40"/>
         <g:ref name="AnnotatedDecl" lookahead="2" if="xquery40"/>
         <g:ref name="OptionDecl" lookahead="2"/>
       </g:choice>
@@ -635,14 +635,25 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="ExprSingle"/>
   </g:production>
 
-  <g:production name="ContextItemDecl" if="xquery40">
+  <g:production name="ContextValueDecl" if="xquery40">
     <g:string>declare</g:string>
     <g:string>context</g:string>
-    <g:string>item</g:string>
-    <g:optional>
-      <g:string>as</g:string>
-      <g:ref name="ItemType"/>
-    </g:optional>
+    <g:choice>
+      <g:sequence>
+        <g:string>item</g:string>
+        <g:optional>
+          <g:string>as</g:string>
+          <g:ref name="ItemType"/>
+        </g:optional>
+      </g:sequence>
+      <g:sequence>
+        <g:string>value</g:string>
+        <g:optional>
+          <g:string>as</g:string>
+          <g:ref name="SequenceType"/>
+        </g:optional>
+      </g:sequence>
+    </g:choice>
     <g:choice>
       <g:sequence>
         <g:string>:=</g:string>
@@ -1563,20 +1574,15 @@ ErrorVal ::= "$" VarName
   
   <g:production name="FatArrowTarget" if="xpath40 xquery40">
     <g:string>=></g:string>
-    <g:choice>
-      <g:sequence>
-        <g:ref name="ArrowStaticFunction"/>
-        <g:ref name="ArgumentList"/>
-      </g:sequence>
-      <g:sequence>
-        <g:ref name="ArrowDynamicFunction"/>
-        <g:ref name="PositionalArgumentList"/>
-      </g:sequence>
-    </g:choice>
+    <g:ref name="ArrowTarget"/>
   </g:production>
   
   <g:production name="ThinArrowTarget" if="xpath40 xquery40">
     <g:string>-></g:string>
+    <g:ref name="ArrowTarget"/>
+  </g:production>
+  
+  <g:production name="ArrowTarget" if="xpath40 xquery40">
     <g:choice>
       <g:sequence>
         <g:ref name="ArrowStaticFunction"/>
@@ -1956,6 +1962,7 @@ ErrorVal ::= "$" VarName
       <g:ref name="StringLiteral" if="xpath40 xquery40"/>
       <g:ref name="VarRef" if="xpath40 xquery40"/>
       <g:ref name="ParenthesizedExpr"/>
+      <g:ref name="Predicate"/>
       <g:string process-value="yes">*</g:string>
     </g:choice>
   </g:production>
@@ -1980,6 +1987,7 @@ ErrorVal ::= "$" VarName
       <g:ref name="Literal"/>
       <g:ref name="VarRef"/>
       <g:ref name="ParenthesizedExpr"/>
+      <g:ref name="ContextValueExpr" if="xpath40 xquery40  xslt40-patterns"/>
       <g:ref name="ContextItemExpr" if="xpath40 xquery40  xslt40-patterns"/>
       <!--<g:ref name="TildeExpr" if="xpath40 xquery40"/>-->
       <g:ref name="FunctionCall" lookahead="2"/>
@@ -2025,6 +2033,10 @@ ErrorVal ::= "$" VarName
       <g:ref name="Expr"/>
     </g:optional>
     <g:string>)</g:string>
+  </g:production>
+  
+  <g:production name="ContextValueExpr">
+    <g:string process-value="yes">~</g:string>
   </g:production>
 
   <g:production name="ContextItemExpr">

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -442,7 +442,7 @@ per lexical scope.</td>
   <td>Context item static type</td>
   <td>item()</td>
   <td>overwriteable</td>
-  <td>overwriteable by <specref ref="id-context-item-declarations"/></td>
+  <td>overwriteable by <specref ref="id-context-value-declarations"/></td>
   <td>overwriteable by expresssions that set the context item</td>
   <td>None.</td></tr>
 <tr>
@@ -776,10 +776,10 @@ the value of the component for their subexpressions.</p></item>
 </tr>
 
 <tr>
-  <td>Context item</td>
+  <td>Context value</td>
   <td>none</td>
   <td>overwriteable</td>
-  <td>overwriteable by a  <specref ref="id-context-item-declarations"/> in the main module
+  <td>overwriteable by a  <specref ref="id-context-value-declarations"/> in the main module
   </td>
   <td>overwritten during evaluation of path expressions and predicates</td>
   <td>Must be the same in the dynamic context of every module in a query.
@@ -789,7 +789,7 @@ the value of the component for their subexpressions.</p></item>
   <td>Context position</td>
   <td>none</td>
   <td>overwriteable</td>
-  <td>overwriteable by a  <specref ref="id-context-item-declarations"/> in the main module
+  <td>overwriteable by a  <specref ref="id-context-value-declarations"/> in the main module
   </td>
   <td>overwritten during evaluation of path expressions and predicates</td>
   <td>If context item is defined, context position must be &gt;0 and &lt;= context size; else  context position is <xtermref spec="DM31" ref="dt-absent"/>. </td>
@@ -799,11 +799,11 @@ the value of the component for their subexpressions.</p></item>
   <td>none
   </td>
   <td>overwriteable</td>
-  <td>overwriteable by a  <specref ref="id-context-item-declarations"/> in the main module
+  <td>overwriteable by a  <specref ref="id-context-value-declarations"/> in the main module
       
   </td>
   <td>overwritten during evaluation of path expressions and predicates</td>
-  <td>If context item is defined, context size must be &gt;0; else context size is <xtermref spec="DM31" ref="dt-absent"/>.</td></tr>
+  <td>If context value is defined, context size must be &gt;0; else context size is <xtermref spec="DM31" ref="dt-absent"/>.</td></tr>
 
 
 <tr>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -9176,17 +9176,17 @@ return fn:filter($days,$m)
             node, a <termref def="dt-dynamic-error">dynamic error</termref> is
             raised <errorref class="DY" code="0050"/>.</p>
          
-         <p diff="chg" at="2023-02-20">A path expression <code>/PATH</code> that starts with "/" is an abbreviation
-            for <code>(/)!(PATH)</code>. That is, for each document node selected by the expression <code>/</code>,
-            it returns the result of evaluating <code>PATH</code> as a relative path expression. 
-            Aside from any sorting and elimination of duplicates performed while evaluating <code>PATH</code>, 
+         <p diff="chg" at="2023-02-20">A path expression <code>/PATH</code> that starts with <code>/</code> is an abbreviation
+            for <code>(/)!(./PATH)</code>. That is, for each document node selected by the expression <code>/</code>,
+            it returns the result of evaluating <code>./PATH</code> as a relative path expression. 
+            The results of each evaluation of <code>PATH</code> will be sorted into document order and deduplicated, but 
             no further sorting or deduplication occurs when combining the results of processing multiple root nodes.</p>
          
-         <p diff="chg" at="2023-02-20">A path expression <code>//PATH</code> that starts with "//" is an abbreviation
+         <p diff="chg" at="2023-02-20">A path expression <code>//PATH</code> that starts with <code>//</code> is an abbreviation
             for <code>(/)!(descendant-or-self::node()/PATH)</code>. That is, for each document node selected by 
             the expression <code>/</code>, it selects all descendants of this document, and evaluates <code>PATH</code>
-            as a relative path expression with that descendant as the context node. The result within each document
-            node are sorted into document order and deduplicated, but
+            as a relative path expression with that descendant as the context node. The resulting nodes within each document
+            will be sorted into document order and deduplicated, but
             no further sorting or deduplication occurs when combining the results of processing multiple root nodes.</p>
          
 
@@ -19178,7 +19178,8 @@ raised <errorref
                         <termref def="dt-context-size"/> is set to 1 (one).</p></item>
                   </olist>
                   <note><p>The expression <code>A => { B }</code> can be considered as an abbreviation for
-                  <code>A => (=>{B})()</code>: that is, it wraps the enclosed expression as an anonymous
+                  <code>A => (->{B})()</code>: that is, it wraps the enclosed expression as a 
+                     <termref def="dt-inline-context-function"/>
                   function binding the context value to its argument, and invokes this function with the
                   value of <code>A</code> as the supplied argument value.</p></note>
                </item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8253,8 +8253,8 @@ return $a("A")]]></eg>
                      <p>Returns employees sorted in order of increasing salary.</p>
                   </item>
                   <item>
-                     <p><code>array:sort([(1 to 3), (1 to 5), (1 to 4)], ->{count(~)})</code></p>
-                     <p>Returns [(1, 2, 3), (1, 2, 3, 4), (1, 2, 3, 4, 5)].</p>
+                     <p><code>array:sort([(1, 3, 3), (1 to 5), (3, 3, 6, 7)], ->{count(distinct-values(~))})</code></p>
+                     <p>Returns <code>[(1, 3, 3), (3, 3, 6, 7), (1, 2, 3, 4, 5)]</code>.</p>
                      <p>In this example, the value passed to the inline context function is a sequence rather than a single item.</p>
                   </item>
                </ulist>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8234,8 +8234,9 @@ return $a("A")]]></eg>
                <eg diff="add" at="A">fn:for-each-pair($A, $B, ->($a, $b) {$a + $b})</eg>
                
             <p diff="chg" at="2023-02-21">The common case where a function accepts a single argument
-               can be further abbreviated to <code>->{EXPR}</code>. This is equivalent to the 
-               expanded syntax <code>function($x as item()} as item()* {$x => {EXPR}}</code>,
+               can be abbreviated as an <termref def="dt-inline-context-function"/> using the syntax
+               <code>->{EXPR}</code>. This is equivalent to the 
+               expanded syntax <code>function($x as item()*} as item()* {$x => {EXPR}}</code>,
                where <code>x</code> is a system-allocated name that does not conflict with any user-defined variables. That is,
                it defines an anonymous arity-one function, accepting any value as its argument, and returns the
                result of evaluating the supplied expression with that value as the <termref def="dt-context-value"/>.
@@ -8253,7 +8254,7 @@ return $a("A")]]></eg>
                      <p>Returns employees sorted in order of increasing salary.</p>
                   </item>
                   <item>
-                     <p><code>array:sort([(1, 3, 3), (1 to 5), (3, 3, 6, 7)], ->{count(distinct-values(~))})</code></p>
+                     <p><code>array:sort([(1, 3, 3), (1 to 5), (3, 3, 6, 7)], ->{fn:count(fn:distinct-values(~))})</code></p>
                      <p>Returns <code>[(1, 3, 3), (3, 3, 6, 7), (1, 2, 3, 4, 5)]</code>.</p>
                      <p>In this example, the value passed to the inline context function is a sequence rather than a single item.</p>
                   </item>
@@ -8262,7 +8263,7 @@ return $a("A")]]></eg>
             
             
  
-            <p diff="add" at="A">A zero-arity function can be written as, for example, <code>->(){current-date()}</code>.</p>
+            <p diff="add" at="A">A zero-arity function can be written as, for example, <code>->(){fn:current-date()}</code>.</p>
 
 
          
@@ -8384,7 +8385,8 @@ return $a("A")]]></eg>
                      </p>
                   </item>
                   <item diff="add" at="A">
-                     <p>This example creates a function that prepends "$" to a supplied value:
+                     <p>This example creates an <termref def="dt-inline-context-function"/> 
+                        that prepends "$" to a supplied value:
                         <eg
                            role="parse-test"
                            ><![CDATA[->{"$" || .}]]></eg>
@@ -8392,7 +8394,7 @@ return $a("A")]]></eg>
                      <p>It is equivalent to the function <code>concat("$", ?)</code>.</p>
                   </item>
                   <item diff="add" at="A">
-                     <p>This example creates a function that returns the <code>name</code>
+                     <p>This example creates an <termref def="dt-inline-context-function"/>  that returns the <code>name</code>
                         attribute of a supplied element node:
                         <eg
                            role="parse-test"
@@ -19268,8 +19270,8 @@ raised <errorref
                   <code>($x -> f()) ! (.+1)</code>. Using the <code>-></code> operator in such a pipeline expression,
                      in preference to <code>!</code>, can therefore reduce the need for parentheses.</p></note>
                <note><p>The expression <code>$x -> {.+1}</code> can be considered as an abbreviation
-                  for <code>$x -> (->{.+1})()</code>: that is, it calls the anonymous function
-                  <code>->{.+1}</code> once for each item in <code>$x</code>.</p></note>
+                  for <code>$x -> (function($a){@a+1})()</code>: that is, it calls the function
+                  <code>function($a){@a+1}</code> once for each item in <code>$x</code>.</p></note>
             </item>
          </ulist>
          

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4121,7 +4121,7 @@ the schema type named <code>us:address</code>.</p>
                   
                   <ulist>
                      <item><p>Using the QName of a type in the <termref def="dt-issd"/> that is an atomic type
-                     or a <termref def="dt-pure-union-type"></termref></p></item>
+                     or a <termref def="dt-pure-union-type"/>.</p></item>
                      <item><p>Using a QName that identifies a <termref def="dt-type-alias"/> that resolves
                         to a <termref def="dt-generalized-atomic-type"/>.</p></item>
                      <item><p>Using a <nt def="ParenthesizedItemType">ParenthesizedItemType</nt> where the parentheses enclose

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -627,11 +627,15 @@ inferred by static type inference as discussed in  <specref
 
                <item>
                   <p>
-                     <termdef term="context item static type" id="dt-context-item-static-type">
-                        <term>Context item static type.</term> This component defines the <termref
+                     <termdef term="context value static type" id="dt-context-value-static-type">
+                        <term>Context <phrase diff="chg" at="2023-02-20">value</phrase> static type.</term> 
+                        This component defines the <termref
                            def="dt-static-type"
-                        >static type</termref> of the context item within the scope of a given expression.</termdef>
+                           >static type</termref> of the context <phrase diff="chg" at="2023-02-20">value</phrase> 
+                        within the scope of a given expression.</termdef>
                   </p>
+                  <p diff="add" at="2023-02-20">The type <code>xs:error</code> is used in a context 
+                     where the context value is known to be absent.</p>
                </item>
                
                <item diff="add" at="A">
@@ -1127,7 +1131,7 @@ context</termref>, and the additional components listed below.</p>
 the <termref
                      def="dt-dynamic-context"
                      >dynamic context</termref>
-(context item, context position, and context size) are called the
+(context <phrase diff="chg" at="2023-02-20">value</phrase>, context position, and context size) are called the
 <term>focus</term> of the expression. </termdef> The focus enables the
 processor to keep track of which items are being processed by the
 expression.
@@ -1137,7 +1141,7 @@ expression.
                   >If any component in the focus is defined, all components of the focus are defined.</phrase>
 
 <phrase role="xpath"
-                  >If any component in the focus is defined, both the context item and context position are known.</phrase> 
+                  >If any component in the focus is defined, both the 1197 and context position are known.</phrase> 
 <note
                   role="xpath">
                   <p>If any component in the focus is defined, context size is usually defined as well.  However, when streaming, 
@@ -1171,14 +1175,32 @@ focus</term>, while the focus for evaluating <code
 focus</term>. The inner focus is used only for the evaluation of <code
                   role="parse-test"
                >E2</code>. Evaluation of E1 continues with its original focus unchanged.</p>
+            
+            <p diff="add" at="2023-02-20">The examples above all process a sequence of items
+            one item at a time. There are other examples where multiple values (sequences) are
+            processed, one value at a time: an example occurs when applying a predicate to each
+            member of an array, since array members can be arbitrary values. To handle such
+            cases, &language; generalizes the concept of the <termref def="dt-context-item"/>
+            to a broader concept, the <termref def="dt-context-value"/>, which is not required
+            to be a single item. The expression <code>.</code> continues to refer to the 
+               <termref def="dt-context-item"/>, while the new expression <code>~</code> is
+               introduced to refer to the <termref def="dt-context-value"/>. The two concepts 
+               are not independent: the <termref def="dt-context-item"/> is the 
+               <termref def="dt-context-value"/> if the <termref def="dt-context-value"/>
+               is a single item, and is <xtermref spec="DM31" ref="dt-absent"/> otherwise.</p>
             <ulist>
 
                <item>
+                  <p  diff="add" at="2023-02-20"><termdef id="dt-context-value" term="context value"
+                     >The <term>context value</term> is the value currently being processed. The context
+                  value can be referenced using the expression <code>~</code> (tilde); some other expressions
+                  reference it implicitly.</termdef></p>
+                  <p diff="chg" at="2023-02-20">                   
+                     <termdef id="dt-context-item" term="context item">The <term>context item</term>
+                     is the same as the <termref def="dt-context-value"/> in the situation where 
+                        the context value is a single item; in any other situation, the
+                        context item is <xtermref spec="DM31" ref="dt-absent"/>.</termdef></p>
                   <p>
-                     <termdef id="dt-context-item" term="context item"
-                           >The <term>context item</term>
-is the <termref def="dt-item"
-                           >item</termref> currently being processed.</termdef>
                      <termdef id="dt-context-node" term="context node"
                            >When the context item is a
 node, it can also be referred to as the <term>context
@@ -1193,16 +1215,16 @@ sequence obtained by evaluating <code
 becomes the context item in the inner focus for an evaluation of <code
                         role="parse-test">E2</code>. </p>
                   <p role="xquery">
-                     <termdef id="dt-initial-context-item" term="initial context item"
+                     <termdef id="dt-initial-context-value" term="initial context value"
                            >
     
     
       In the dynamic context of every module in a query,
-      the context item component must have the same setting.
+      the context <phrase diff="chg" at="2023-02-20">value</phrase> component must have the same setting.
       If this shared setting is not <xtermref
                            spec="DM31" ref="dt-absent"
                            />,
-      it is referred to as the <term>initial context item</term>.
+                        it is referred to as the <term diff="chg" at="2023-02-20">initial context value</term>.
     
   </termdef>
                   </p>
@@ -1211,10 +1233,10 @@ becomes the context item in the inner focus for an evaluation of <code
 
                <item>
                   <p>
-                     <termdef id="dt-context-position" term="context position"
-                           >The <term>context
-position</term> is the position of the context item within the
-sequence of items currently being processed.</termdef> It changes whenever the context item
+                     <termdef id="dt-context-position" term="context position">The <term>context position</term> is 
+                        the position of the context <phrase diff="chg" at="2023-02-20">value</phrase> within a
+                        series of values currently being processed.</termdef> It changes whenever the context 
+                     <phrase diff="chg" at="2023-02-20">value</phrase>
 changes. When the focus is defined, the value of the context position is an integer greater than zero. The context
 position is returned by the expression <code
                         role="parse-test">fn:position()</code>. When an expression <code
@@ -1227,15 +1249,15 @@ is the position of the context item in the sequence obtained by
 evaluating <code
                         role="parse-test"
                      >E1</code>. The position of the
-first item in a sequence is always 1 (one). The context position is
+first <phrase diff="chg" at="2023-02-20">value that is processed</phrase> is always 1 (one). The context position is
 always less than or equal to the context size.</p>
                </item>
 
                <item>
                   <p>
                      <termdef id="dt-context-size" term="context size"
-                        >The <term>context
-size</term> is the number of items in the sequence of items currently
+                        >The <term>context size</term> is the number of 
+                        <phrase diff="chg" at="2023-02-20">values in the series of values</phrase> currently
 being processed.</termdef> Its value is always an
 integer greater than zero. The context size is returned by the
 expression <code
@@ -2248,11 +2270,9 @@ a type in <termref
                </item>
 
                <item>
-                  <p>The value of the <termref def="dt-context-item"
-                        >context item</termref> must match the <termref
-                        def="dt-context-item-static-type"
-                        >context item static type</termref>, using the
-matching rules in <specref
+                  <p diff="chg" at="2023-02-20">The value of the <termref def="dt-context-value"/> must match the <termref
+                        def="dt-context-value-static-type"/>, using the
+                        matching rules in <specref
                         ref="id-sequencetype-matching"/>.</p>
                </item>
 
@@ -3177,8 +3197,7 @@ defined in <xspecref
                   >dynamic context</termref> that is initialized by the external
     environment, such as a <termref
                   def="dt-variable-values">variable</termref> or
-    <termref def="dt-context-item"
-                  >context item</termref>.</p>
+    <phrase diff="chg" at="2023-02-20"><termref def="dt-context-value"/></phrase>.</p>
 
 
 
@@ -6522,7 +6541,8 @@ and <nt def="OrExpr"
          <p>
             <termdef id="dt-primary-expression" term="primary expression">
                <term>Primary expressions</term> are the basic primitives of the
-	 language. They include literals, variable references,  context item expressions, <phrase
+	 language. They include literals, variable references,  context item 
+               <phrase diff="add" at="2023-02-20">and context value</phrase> expressions, <phrase
                   role="xquery"
                >constructors, </phrase> and function calls. A primary expression may also be created by enclosing any expression in parentheses, which is sometimes helpful in controlling the precedence of operators.</termdef>
             <phrase role="xquery">Node Constructors are described in <specref ref="id-constructors"
@@ -6846,6 +6866,22 @@ At evaluation time, the value of a variable reference is the value to which the 
 		described in <specref
                   ref="construct_seq"/>.</p>
          </div3>
+         
+         <div3 id="id-context-value-expression">
+            <head>Context Value Expression</head>
+            <scrap>
+               <head/>
+               <prodrecap id="ContextValueExpr" ref="ContextValueExpr"/>
+            </scrap>
+            
+            <p>A <term>context value expression</term> evaluates to
+               the <termref def="dt-context-value"/>, which may be any value.</p>
+            <p>If the <termref def="dt-context-value"/> is <xtermref spec="DM31"
+               ref="dt-absent"/>, a context value expression raises a <termref
+                  def="dt-dynamic-error">dynamic error</termref>
+               <errorref class="DY" code="0002"/>.</p>
+            
+         </div3>
 
          <div3 id="id-context-item-expression">
             <head>Context Item Expression</head>
@@ -6865,10 +6901,15 @@ At evaluation time, the value of a variable reference is the value to which the 
               or an atomic value or function (as in the expression <code
                   role="parse-test">(1 to
               100)[. mod 5 eq 0]</code>).</p>
+            <p>If the <termref def="dt-context-value"/> is a single item, then the context item expression
+               <code>.</code> and the context value expression <code>~</code> return the same result.</p>
             <p>If the <termref def="dt-context-item">context item</termref> is <xtermref spec="DM31"
-                  ref="dt-absent"/>, a context item expression raises a <termref
+                  ref="dt-absent"/>, the context item expression raises a <termref
                   def="dt-dynamic-error">dynamic error</termref>
-               <errorref class="DY" code="0002"/>.</p>
+               <errorref class="DY" code="0002"/>.
+            <phrase diff="chg" at="2023-02-20">This can happen because the context value
+            is absent, or because the context value is an empty sequence or a sequence
+            containing more than one item.</phrase></p>
 
          </div3>
 
@@ -7698,7 +7739,8 @@ At evaluation time, the value of a variable reference is the value to which the 
                                           The <termref
                                                   def="dt-focus"
                                                   >focus</termref>
-                                          (context item, context position, and context size)
+                                          (context <phrase diff="chg" at="2023-02-20">value</phrase>, 
+                                                context position, and context size)
                                           is <xtermref
                                                   spec="DM31" ref="dt-absent"
                                                 />.
@@ -7794,6 +7836,13 @@ return shop/article/$vat(.)]]></eg>
 let $ctx := shop/article,
 $vat := function() { for $a in $ctx return $a/@vat + $a/@price }
 return $vat()
+]]></eg>
+                                    <p diff="add" at="2023-02-20">A further option in &language; is to use an 
+                                       abbreviated function syntax
+                                    which binds the context value to the single supplied argument:</p>
+                                    <eg role="parse-test" diff="add" at="2023-02-20"><![CDATA[
+let $vat := function{ @vat + @price }
+return $vat(shop/article)
 ]]></eg>
                                  </example>
 
@@ -8143,11 +8192,18 @@ return $a("A")]]></eg>
              Anonymous functions may be created, for example, by evaluating an inline function 
              expression or by partial function application.</termdef>
             </p>
+            
+            <p><termdef
+               id="dt-inline-context-function" term="inline context function">
+               An <term>inline context function</term> is a <termref def="dt-function-item"/> with no explicit
+               function signature.</termdef> For example, <code>->{. + 1}</code>. The implied function signature
+               is <code>function(item()*) as item()*</code>. 
+            </p>
 
  
 
             <note diff="add" at="A">
-               <p>A more concise notation is introduced for simple functions in &language; because it 
+               <p>Inline context functions are introduced for simple functions in &language; because they
                   can improve the readability of code
            by reducing visual clutter. For example, a sort operation previously written as <code>sort(//employee, (), 
               function($emp as element(employee)) as xs:string { $emp/@dateOfBirth })</code> can now be written
@@ -8177,15 +8233,33 @@ return $a("A")]]></eg>
                
                <eg diff="add" at="A">fn:for-each-pair($A, $B, ->($a, $b) {$a + $b})</eg>
                
-            <p diff="add" at="A">The common case where a function accepts a single argument of type
-               <code>item()</code> can be further abbreviated to <code>->{EXPR}</code>. This is equivalent to the 
-               expanded syntax <code>function($x as item()} as item()* {$x -> {EXPR}}</code>,
+            <p diff="chg" at="2023-02-21">The common case where a function accepts a single argument
+               can be further abbreviated to <code>->{EXPR}</code>. This is equivalent to the 
+               expanded syntax <code>function($x as item()} as item()* {$x => {EXPR}}</code>,
                where <code>x</code> is a system-allocated name that does not conflict with any user-defined variables. That is,
-               it defines an anonymous arity-one function, accepting any single item as its argument value, and returns the
-               result of evaluating the supplied expression with that item as the <termref def="dt-singleton-focus"/>.
-            For example, the following function call returns the sequence <code>(2, 3, 4, 5, 6)</code>.</p>
+               it defines an anonymous arity-one function, accepting any value as its argument, and returns the
+               result of evaluating the supplied expression with that value as the <termref def="dt-context-value"/>.
+               The <termref def="dt-context-position"/> and <termref def="dt-context-size"/> are both set to one (1).</p>
             
-            <eg diff="add" at="A">fn:for-each(1 to 5, ->{.+1})</eg>
+            <example diff="add" at="2023-02-21">
+               <head>Inline Context Functions</head>
+               <ulist>
+                  <item>
+                     <p><code>fn:for-each(1 to 5, ->{.+1})</code></p>
+                     <p>Returns the sequence <code>(2, 3, 4, 5, 6)</code></p>
+                  </item>
+                  <item>
+                     <p><code>fn:sort(//employee, ->{xs:decimal(@salary)})</code></p>
+                     <p>Returns employees sorted in order of increasing salary.</p>
+                  </item>
+                  <item>
+                     <p><code>array:sort([(1 to 3), (1 to 5), (1 to 4)], ->{count(~)})</code></p>
+                     <p>Returns [(1, 2, 3), (1, 2, 3, 4), (1, 2, 3, 4, 5)].</p>
+                     <p>In this example, the value passed to the inline context function is a sequence rather than a single item.</p>
+                  </item>
+               </ulist>
+            </example>
+            
             
  
             <p diff="add" at="A">A zero-arity function can be written as, for example, <code>->(){current-date()}</code>.</p>
@@ -8222,7 +8296,8 @@ return $a("A")]]></eg>
 
                <p>
           The static context for the function body is inherited from the location of the inline function expression, with the exception of the
-          static type of the context item which is initially <xtermref
+          static type of the context <phrase diff="chg" at="2023-02-20">value which (except for an
+             <termref def="dt-inline-context-function"/>)</phrase> is initially <xtermref
                      spec="DM31" ref="dt-absent"/>.
           </p>
          
@@ -8943,7 +9018,8 @@ return fn:filter($days,$m)
 
             <p>For each item in the input sequence, the predicate expression
       is evaluated using an <term>inner focus</term>, defined as
-      follows: The context item is the item currently being tested
+      follows: The context <phrase diff="chg" at="2023-02-20">value (and therefore 
+         the context item)</phrase> is the item currently being tested
       against the predicate. The context size is the number of items
       in the input sequence. The context position is the position of
       the context item within the input sequence. </p>
@@ -9084,47 +9160,33 @@ return fn:filter($days,$m)
 	 "<code>/</code>" or "<code>//</code>" is an abbreviation for
 	 one or more initial steps that are implicitly added to the
 	 beginning of the path expression, as described below.</p>
-         <p>A
-	 path expression consisting of a single step is evaluated as
-	 described in <specref
-               ref="id-steps"/>.</p>
-         <p>A "<code>/</code>"
-	 at the beginning of a path expression is an abbreviation for
-	 the initial step <code>(fn:root(self::node()) treat as document-node())/</code> (however, if the
-	 "<code>/</code>" is the entire path expression, the trailing "<code>/</code>" is omitted from the expansion.) The effect
-	 of this initial step is to begin the path at the root node of
-	 the tree that contains the context node. If the context item
-	 is not a node, a <termref
-               def="dt-type-error">type
-	 error</termref> is raised <errorref class="TY" code="0020"
-               />. At
-	 evaluation time, if the root node of the context node is
-	 not a document node, a <termref
-               def="dt-dynamic-error">dynamic error</termref> is
-	 raised <errorref class="DY"
-               code="0050"/>.</p>
-
-         <p>A "<code>//</code>" at the beginning of a path expression
-	 is an abbreviation for the initial steps
-	 <code>(fn:root(self::node()) treat as
-	 document-node())/descendant-or-self::node()/</code> (however, "<code>//</code>" by itself is not a valid path expression <errorref
-               class="ST" code="0003"
-               />.)  The
-	 effect of these initial steps is to establish an initial node
-	 sequence that contains the root of the tree in which the
-	 context node is found, plus all nodes descended from this
-	 root.
-	 This node sequence is used as the input to subsequent steps
-	 in the path expression. If the context item is not a node, a
-	 <termref
-               def="dt-type-error">type error</termref> is
-	 raised <errorref class="TY" code="0020"
-               />. At evaluation time, if the
-	 root node of the context node is not a document node, a
-	 <termref
-               def="dt-dynamic-error">dynamic error</termref> is
-	 raised <errorref class="DY"
-               code="0050"/>.</p>
+         
+         <p>A path expression consisting of a single step is evaluated as
+            described in <specref ref="id-steps"/>.</p>
+         
+         <p diff="chg" at="2023-02-20">The expression <code>/</code> (on its own)
+            is an abbreviation for <code>~!(fn:root(.) treat as document-node())</code>. That is,
+            it returns the root nodes of the trees containing the items in the 
+            <termref def="dt-context-value"/>, retaining order, without eliminating duplicates. 
+            If any of these items is not a node, a <termref def="dt-type-error">type
+            error</termref> is raised <errorref class="TY" code="0020"/>.
+            If any of the items is a node in a tree that is not rooted at a document
+            node, a <termref def="dt-dynamic-error">dynamic error</termref> is
+            raised <errorref class="DY" code="0050"/>.</p>
+         
+         <p diff="chg" at="2023-02-20">A path expression <code>/PATH</code> that starts with "/" is an abbreviation
+            for <code>(/)!(PATH)</code>. That is, for each document node selected by the expression <code>/</code>,
+            it returns the result of evaluating <code>PATH</code> as a relative path expression. 
+            Aside from any sorting and elimination of duplicates performed while evaluating <code>PATH</code>, 
+            no further sorting or deduplication occurs when combining the results of processing multiple root nodes.</p>
+         
+         <p diff="chg" at="2023-02-20">A path expression <code>//PATH</code> that starts with "//" is an abbreviation
+            for <code>(/)!(descendant-or-self::node()/PATH)</code>. That is, for each document node selected by 
+            the expression <code>/</code>, it selects all descendants of this document, and evaluates <code>PATH</code>
+            as a relative path expression with that descendant as the context node. The result within each document
+            node are sorted into document order and deduplicated, but
+            no further sorting or deduplication occurs when combining the results of processing multiple root nodes.</p>
+         
 
          <note>
             <p>The descendants of a node do not include attribute
@@ -9134,8 +9196,8 @@ return fn:filter($days,$m)
 
          <p>
          A path expression that starts with "<code>/</code>"
-         or "<code>//</code>" selects nodes starting from the root of
-         the tree containing the context item; it is often referred to
+            or "<code>//</code>" <phrase diff="del" at="2023-02-20">selects nodes starting from the root of
+         the tree containing the context item; it</phrase> is often referred to
          as an absolute path expression.
          </p>
 
@@ -15090,6 +15152,7 @@ map {
                   <head/>
                   <prodrecap id="UnaryLookup" ref="UnaryLookup"/>
                   <prodrecap id="KeySpecifier" ref="KeySpecifier"/>
+                  <prodrecap ref="Predicate"/>
                </scrap>
 
 
@@ -15097,12 +15160,20 @@ map {
                      ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
 
                <p>UnaryLookup returns a sequence of values selected from the
-  context item, which must be a map or array. If the context item is
+  context <phrase diff="add" at="2023-02-20">value</phrase>, which must be a sequence of maps or arrays. If any item is
   not a map or an array, a
   <termref
                      def="dt-type-error">type error</termref> is raised <errorref class="TY"
                      code="0004"/>.
   </p>
+               
+               <p diff="add" at="2023-02-20">If the <termref def="dt-context-value"/> <code>~</code> 
+                  is a non-singleton sequence,
+               then the result of the lookup expression <code>?X</code> is equivalent to the value of 
+                  <code>~?X</code>: that is, the result is defined in terms of the postfix lookup operator.
+               The rules for the postfix lookup operator in turn refer to the rules for evaluating
+               the unary lookup operator with respect to a context item that will always be a single map or array.
+               These rules now follow.</p>
 
 
                <p>If the context item is a map:</p>
@@ -15135,6 +15206,10 @@ for $k in fn:data(KS)
 return .($k)  
 ]]></eg>
                   </item>
+                  <item diff="add" at="2023-02-20">
+                     <p>If the <nt def="KeySpecifier">KeySpecifier</nt> is a <nt
+                        def="Predicate">Predicate</nt>, a type error is raised <errorref class="TY" code="0004"/>.</p>
+                  </item>
                   <item>
                      <p>If the <nt def="KeySpecifier"
                            >KeySpecifier</nt> is a wildcard ("<code>*</code>"), the  <nt
@@ -15145,7 +15220,7 @@ for $k in map:keys(.)
 return .($k)
 ]]></eg>
                      <note>
-                        <p>The order of keys in map:keys() is implementation-dependent, so
+                        <p>The order of keys in <code>map:keys()</code> is implementation-dependent, so
   the order of values in the result sequence is also
   implementation-dependent.</p>
                      </note>
@@ -15183,6 +15258,13 @@ return .($k)
 for $k in fn:data(KS)
 return .($k)  
 ]]></eg>
+                  </item>
+                  
+                  <item diff="add" at="2023-02-20">
+                     <p>If the <nt def="KeySpecifier">KeySpecifier</nt> is a <nt
+                        def="Predicate">Predicate</nt>, the effect is to filter the members
+                     of the supplied array, returning a new array that contains a subset of
+                     those members. For more details, see <specref ref="id-array-predicates"/>.</p>
                   </item>
 
                   <item>
@@ -15245,22 +15327,7 @@ return .($k)
                         <code>([1,2,3], [1,2,5], [1,2])[?3 = 5]</code> raises an error because <code>?3</code> on one of the
     items in the sequence fails.</p>
                   </item>
-                  <item>
-                     <p>If <code>$m</code> is bound to the weekdays map described in <specref
-                           ref="id-maps"
-                           />, then <code>$m?*</code> returns the values <code>("Sunday","Monday","Tuesday","Wednesday", "Thursday", "Friday","Saturday")</code>, in <termref
-                           def="dt-implementation-dependent"
-                        >implementation-dependent</termref> order.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[1, 2, 5, 7]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[[1, 2, 3], [4, 5, 6]]?*</code> evaluates to <code>([1, 2, 3], [4, 5, 6])</code>
-                     </p>
-                  </item>
+                  
                </ulist>
 
             </div4>
@@ -15273,13 +15340,14 @@ return .($k)
                </scrap>
 
                <p>
-      The semantics of a Postfix Lookup expression depend on the form of the KeySpecifier, as follows:
+      The semantics of a <code>PostfixLookup</code> expression depend on the form of the <code>KeySpecifier</code>, as follows:
       <ulist>
                      <item>
                         <p>If the <code>KeySpecifier</code> is an <code>NCName</code>, <code
                               diff="add" at="A"
                            >StringLiteral</code>, <code diff="add" at="A">VarRef</code>, <code>IntegerLiteral</code>, 
-                           or <code>Wildcard</code> ("<code>*</code>"), then the expression <code>E?S</code> is 
+                           <phrase diff="add" at="2023-02-20">Predicate,</phrase> or <code>Wildcard</code> ("<code>*</code>"), 
+                           then the expression <code>E?S</code> is 
                            equivalent to <code>E!?S</code>. (That is, the semantics of the postfix lookup operator 
                            are defined in terms of the unary lookup operator).</p>
                      </item>
@@ -15327,7 +15395,121 @@ return .($k)
                            class="AY" code="0001"/>
                      </p>
                   </item>
+                  <item>
+                     <p>If <code>$m</code> is bound to the weekdays map described in <specref
+                        ref="id-maps"
+                     />, then <code>$m?*</code> returns the values <code>("Sunday","Monday","Tuesday","Wednesday", "Thursday", "Friday","Saturday")</code>, in <termref
+                        def="dt-implementation-dependent"
+                        >implementation-dependent</termref> order.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[1, 2, 5, 7]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[[1, 2, 3], [4, 5, 6]]?*</code> evaluates to <code>([1, 2, 3], [4, 5, 6])</code>
+                     </p>
+                  </item>
+                  <item diff="add" at="2023-02-20">
+                     <p>
+                        <code>["a", "b", "c", ("x", "y"), ()]?[~ = ("b", "x")]</code> evaluates to 
+                        <code>["b", ("x", "y")]</code>
+                     </p>
+                  </item>
                </ulist>
+            </div4>
+            <div4 id="id-array-predicates" diff="add" at="2023-02-21">
+               <head>Array Predicates</head>
+               <p>An filtered array expression typically takes the form <code>array-expression?[filter-expression]</code>
+               where <code>array-expression</code> is an expression that evaluates to an array, and 
+               <code>filter-expression</code> is an expression that is applied to individual members of the
+               array, to decide whether they should be included in the result. The result is an array that contains
+               only those members that satisfy the predicate, retaining order.</p>
+               
+               <p>The <code>array-expression</code> may also select a sequence of arrays, in which case each one
+               is filtered independently, and the result is a corresponding sequence of filtered arrays.</p>
+               
+               <p>There is also a unary form <code>?[filter-expression]</code> which is equivalent to
+               <code>~?[filter-expression]</code>: in this case the <termref def="dt-context-value"/> (<code>~</code>)
+               must be a sequence of zero or more arrays.</p>
+               
+               <p>The semantics are similar to the semantics of a normal filter expression 
+                  (see <specref ref="id-filter-expression"/>) with some notable exceptions:</p>
+               
+               <ulist>
+                  <item><p>The input and output are arrays rather than sequences.</p></item>
+                  <item><p>In the general case, the members of an array are arbitrary sequences,
+                     rather than single items. The predicate can therefore refer to the member
+                     being tested using a <nt def="ContextValueExpr">context value expression</nt> (<code>~</code>),
+                     in place of a <nt def="ContextItemExpr">context item expresion</nt> (<code>.</code>).
+                     However, the familiar context item expression may still be used in the
+                     case where the members are single items.</p></item>
+                  <item><p>A member matches the predicate if the effective boolean value of
+                  the predicate is true. There is no special rule that applies when the value
+                  of the predicate is numeric.</p>
+                  <note><p>The reason for this is twofold. Firstly, there are other methods
+                  of selecting the member at a particular position in an array, for example
+                  <code>$array($i)</code> or <code>$array?$i</code>. Secondly, the requirement
+                  is generally to return a member of the array, rather than a singleton array
+                  containing this member.</p></note></item>
+               </ulist>
+               
+               <p>The value of the predicate can depend on <code>fn:position()</code> and <code>fn:last()</code>
+               in the usual way: for example <code>$array?[fn:position() mod 2 = 0]</code> selects all the
+               members at even-numbered positions.</p>
+               
+               <p>Since the result is an array, multiple predicates may be defined, 
+                  for example <code>$array?[fn:count(~)=1]?[~ > 5]</code>.</p>
+               
+               <p>The semantics of the construct are defined more formally as follows.</p>
+               
+               <olist>
+                  <item><p>As a postfix expression, <code>E1?[E2]</code> is equivalent to 
+                  <code>E1!(?[E2])</code>. That is, <code>E1</code> is evaluated as a sequence and
+                  the unary lookup expression <code>?[E2]</code> is evaluated taking each item in the result
+                  as the context item, retaining order. The following rules apply to the unary
+                  form of the expression.</p></item>
+                  <item><p>If the context item is not an array, a type error is reported 
+                     <errorref class="TY" code="0004"/></p></item>
+                  <item><p>The predicate expression <code>E2</code> is evaluated for each member of
+                  the array. The <termref def="dt-context-value"/> is set to that member, the 
+                     <termref def="dt-context-position"/> is set to its one-based position within the array,
+                     and the <termref def="dt-context-size"/> is set to the number of members in the array.</p></item>
+                  <item><p>The result is an array containing those members of the input array, retaining their relative
+                  position, for which the <termref def="dt-ebv">effective boolean value</termref> of the predicate
+                  expression is true.</p></item>
+               </olist>
+               
+               <example>
+                  <head>Array Predicates</head>
+                  <p>The following examples assume the declaration:</p>
+                  <eg>let $array := ["one", (2, 3, 4), [5, 6, 7], ()]</eg>
+                  <ulist>
+                     <item>
+                        <p><code>$array?[fn:count(~) = 3]</code></p>
+                        <p>Returns <code>[(2, 3, 4)]</code></p>
+                     </item>
+                     <item>
+                        <p><code>$array?[~ instance of array(*)]</code></p>
+                        <p>Returns <code>[[5, 6, 7]]</code></p>
+                     </item>
+                     <item>
+                        <p><code>$array?[fn:position() gt 2]</code></p>
+                        <p>Returns <code>[[5, 6, 7], ()]</code></p>
+                     </item>
+                     <item>
+                        <p><code>$array?[fn:position() eq fn:last()]</code></p>
+                        <p>Returns <code>[()]</code></p>
+                     </item>
+                     <item>
+                        <p><code>$array?[fn:exists(~)]?[fn:data(~) instance of xs:integer*]</code></p>
+                        <p>Returns <code>[(2, 3, 4), [5, 6, 7]]</code></p>
+                     </item>
+                  </ulist>
+               </example>
+               
+               
             </div4>
          </div3>
       <!--   <div3 id="id-composite-atomic-values" diff="add" at="A">
@@ -18958,19 +19140,21 @@ raised <errorref
             <prodrecap id="ArrowExpr" ref="ArrowExpr"/>
             <prodrecap id="FatArrowTarget" ref="FatArrowTarget"/>
             <prodrecap id="ThinArrowTarget" ref="ThinArrowTarget"/>
+            <prodrecap id="ArrowTarget" ref="ArrowTarget"/>
             <prodrecap id="ArrowStaticFunction" ref="ArrowStaticFunction"/>
             <prodrecap id="ArrowDynamicFunction" ref="ArrowDynamicFunction"/>
             <prodrecap ref="ArgumentList"/>
             <prodrecap id="PositionalArgumentList" ref="PositionalArgumentList"/>
+            <prodrecap ref="EnclosedExpr"/>
          </scrap>
 
          <p>
             <termdef term="arrow operator" id="dt-arrow-operator"
                >An <term>arrow operator</term>  applies a function to the value of an expression, using the value as the first argument to the function.</termdef>  
          </p>
-         <p diff="add" at="A">The <term>fat arrow</term> operator <code>=></code> is defined as follows:
+         <p diff="add" at="A">The <term>fat arrow</term> operator <code>=></code> is evaluated as follows:
             <ulist>
-               <item><p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
+               <item><p>Given a <nt def="UnaryExpr">UnaryExpr</nt>
                   <code>U</code>, an <nt def="ArrowStaticFunction">ArrowStaticFunction</nt>
                   <code>F</code>, and an <nt def="ArgumentList">ArgumentList</nt>
                   <code>(A, B, C...)</code>, the expression <code>U =&gt; F(A, B, C...)</code> is equivalent to the
@@ -18980,8 +19164,41 @@ raised <errorref
                   <code>F</code>, and an <nt def="PositionalArgumentList">PositionalArgumentList</nt>
                   <code>(A, B, C...)</code>, the expression <code>U =&gt; F(A, B, C...)</code> is equivalent to the
                   expression <code>F(U, A, B, C...)</code>.</p></item>
+               <item diff="add" at="2023-02-20">
+                  <p>Given a <nt def="UnaryExpr">UnaryExpr</nt>
+                     <code>U</code>, and an enclosed expression <code>{ E }</code>, the expression <code>U =&gt; { E }</code> is
+                     evaluated as follows:</p>
+                  <olist>
+                     <item><p><code>U</code> is evaluated to produce a value <code>V</code>.</p></item>
+                     <item><p><code>E</code> is evaluated with the following <termref def="dt-focus"/>: the 
+                        <termref def="dt-context-value"/> is set to <code>V</code>, the 
+                        <termref def="dt-context-position"/> is set to 1 (one), and the 
+                        <termref def="dt-context-size"/> is set to 1 (one).</p></item>
+                  </olist>
+                  <note><p>The expression <code>A => { B }</code> can be considered as an abbreviation for
+                  <code>A => (=>{B})()</code>: that is, it wraps the enclosed expression as an anonymous
+                  function binding the context value to its argument, and invokes this function with the
+                  value of <code>A</code> as the supplied argument value.</p></note>
+               </item>
             </ulist>
-            </p>
+          </p>
+         
+         <example diff="add" at="2023-02-20">
+            <p>A simple example using the fat arrow to perform a function call is:</p>
+            <eg>$x => fn:round()</eg>
+            <p>which is equivalent to:</p>
+            <eg>fn:round($x)</eg>
+            <p>The notation comes into its own when performing a sequence of calls. For example:</p>
+            <eg>$string => upper-case() => normalize-unicode() => tokenize("\s+")</eg>
+            <p>is equivalent to:</p>
+            <eg>tokenize(normalize-unicode(upper-case($string)), "\s+")</eg>
+            <p>The sequence of expressions separated by arrows can be read as a pipeline in which the output
+               of each expression forms the input to the next.</p>
+            <p>As well as function calls, the pipeline may contain enclosed expressions. For example:</p>
+            <eg>1 to 5 => { fn:min(~), fn:max(~) } => sum()</eg>
+            <p>is equivalent to:</p>
+            <eg>sum(let $in := (1 to 5) return (fn:min($in), fn:max($in)))</eg>
+         </example>
          
          <!--<ulist>
             <item>
@@ -19011,16 +19228,20 @@ raised <errorref
 
         
          
-         <p diff="add" at="A">The <term>thin arrow</term> operator <code>-></code> is defined as follows:</p>
+         <p diff="add" at="A">The <term>thin arrow</term> operator differs in that it evaluates
+            the function call or enclosed expression on the right hand side once for each
+            item in the sequence produced by the left-hand operand. The <code>-></code> 
+            operator is evaluated as follows:</p>
             
-         <ulist diff="add" at="A">
+         <ulist diff="chg" at="2023-02-21">
             <item>
                <p>If the arrow is followed by an <nt def="ArrowStaticFunction">ArrowStaticFunction</nt>:</p>
                <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
                   <code>U</code>, an <nt def="ArrowStaticFunction">ArrowStaticFunction</nt>
                <code>F</code>, and an <nt def="ArgumentList">ArgumentList</nt>
                <code>(A, B, C...)</code>, the expression <code>U -&gt; F(A, B, C...)</code> is equivalent to the
-               expression <code>(U ! F(., A, B, C...))</code>.</p>
+               expression <code>(for $u in U return F($u, A, B, C...))</code>, where <code>u</code> is some variable
+               name that is otherwise unused.</p>
                
             </item>
             <item>
@@ -19029,7 +19250,8 @@ raised <errorref
                   <code>U</code>, an <nt def="ArrowDynamicFunction">ArrowDynamicFunction</nt>
                   <code>F</code>, and an <nt def="PositionalArgumentList">PositionalArgumentList</nt>
                   <code>(A, B, C...)</code>, the expression <code>U -&gt; F(A, B, C...)</code> is equivalent to the
-                  expression <code>(U ! F(., A, B, C...))</code>.</p>
+                  expression <code>(for $u in U return F($u, A, B, C...))</code>, where <code>u</code> is some variable
+                  name that is otherwise unused.</p>
                
             </item>
             <item>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1265,50 +1265,61 @@ declare function local:f() { $b }; </eg>
 
   </div2>
 
-  <div2 id="id-context-item-declarations">
-    <head>Context Item Declaration</head>
+  <div2 id="id-context-value-declarations">
+    <head>Context Value Declaration</head>
 
     <scrap>
       <head></head>
-      <prodrecap id="ContextItemDecl" ref="ContextItemDecl"/>
+      <prodrecap id="ContextValueDecl" ref="ContextValueDecl"/>
     </scrap>
 
     <!-- ================================================================== -->
 
-    <p>A context item declaration allows a query to specify the <termref def="dt-static-type">static
-        type</termref>, value, or default value for the <termref def="dt-initial-context-item"
-        >initial context item</termref>.</p>
+    <p>A context <phrase diff="chg" at="2023-02-21">value</phrase> declaration allows a 
+      query to specify the <termref def="dt-static-type">static
+        type</termref>, value, or default value for the <phrase diff="chg" at="2023-02-21"><termref def="dt-initial-context-value"
+        >initial context value</termref></phrase>.</p>
 
-    <p>Only the main module can set the value of the <termref def="dt-initial-context-item">initial
-        context item</termref>. In a library module, a context item declaration must be external,
+    <p>Only the main module can set the value of the <phrase diff="chg" at="2023-02-21"><termref def="dt-initial-context-value"
+      >initial context value</termref></phrase>. In a library module, a context <phrase diff="chg" at="2023-02-21">value</phrase> declaration must be external,
       and specifies only the static type. Specifying a <nt def="VarValue">VarValue</nt> or <nt
-        def="VarDefaultValue">VarDefaultValue</nt> for a context item declaration in a library
+        def="VarDefaultValue">VarDefaultValue</nt> for a context <phrase diff="chg" at="2023-02-21">value</phrase> declaration in a library
       module is a static error <errorref class="ST" code="0113"/>.</p>
 
-    <p>In every module that does not contain a context item declaration, the effect is as if the
+    <p>In every module that does not contain a context <phrase diff="chg" at="2023-02-21">value</phrase> declaration, the effect is as if the
       declaration</p>
 
-    <eg>declare context item as item() external;</eg>
+    <eg diff="chg" at="2023-02-21">declare context value as item()* external;</eg>
 
     <p>appeared in that module.</p>
+    
+    <p diff="add" at="2023-02-21">Using the form <code>declare context item</code> rather than <code>declare context value</code>
+    constrains the initial context value to be a single item. In this case:</p>
+    
+    <olist diff="add" at="2023-02-21">
+      <item><p>The type, if supplied, must be an item type rather than a sequence type.</p></item>
+      <item><p>If no type is supplied, the default is <code>item()</code>; when <code>declare context value</code>
+      is used, the default type is <code>item()*</code>.</p></item>
+    </olist>
 
-    <p>During static analysis, the context item declaration has the effect of setting the context
-      item static type <code>T</code> in the static context. The context item static type is set to
-        <code>ItemType</code> if specified, or to <code>item()</code> otherwise.</p>
+    <p>During static analysis, the context <phrase diff="chg" at="2023-02-21">value</phrase> declaration has the effect of 
+      setting the context
+      <phrase diff="chg" at="2023-02-21">value</phrase> static type <code>T</code> in the static context, either
+      to the specified type, or to its default of <code>item()</code> or <code>item()*</code> as appropriate.</p>
 
-    <p>If a module contains more than one context item declaration, a static error is raised
+    <p>If a module contains more than one context <phrase diff="chg" at="2023-02-21">value</phrase> declaration, a static error is raised
         <errorref class="ST" code="0099"/>.</p>
 
     <p>The static context for an initializing expression includes all functions, variables, and
       namespaces that are declared or imported anywhere in the Prolog.</p>
 
-    <p>During query evaluation, a <termref def="dt-singleton-focus">singleton focus</termref> is
+    <p>During query evaluation, a <termref def="dt-focus">focus</termref> is
       created in the dynamic context for the evaluation of the <code>QueryBody</code> in the main
       module, and for the initializing expression of every variable declaration in every module.
       
       
-      The context item of this singleton focus is called
-      the <termref def="dt-initial-context-item">initial context item</termref>,
+      The context <phrase diff="chg" at="2023-02-21">value</phrase> of this singleton focus is called
+      the <termref def="dt-initial-context-value">initial context value</termref>,
       which is selected as follows:
       
       </p>
@@ -1316,13 +1327,13 @@ declare function local:f() { $b }; </eg>
     <ulist>
       <item>
         <p>If <code>VarValue</code> is specified, then
-          the initial context item is
+          the initial context <phrase diff="chg" at="2023-02-21">value</phrase> is
           the result of evaluating <code>VarValue</code>.</p>
         <note>
           <p>
             In such a case,
-            the initial context item does not obtain its value from the external environment.
-            If the external environment attempts to provide a value for the initial context item,
+            the initial context <phrase diff="chg" at="2023-02-21">value</phrase> does not obtain its value from the external environment.
+            If the external environment attempts to provide a value for the initial context <phrase diff="chg" at="2023-02-21">value</phrase>,
             it is outside the scope of this specification
             whether that is ignored, or results in an error.
           </p>
@@ -1332,17 +1343,19 @@ declare function local:f() { $b }; </eg>
         <p>If <code>external</code> is specified, then:</p>
         <ulist>
           <item>
-            <p>If the declaration occurs in a main module and a value is provided for the context item by the external environment, then
+            <p>If the declaration occurs in a main module and a value is provided for the context 
+              <phrase diff="chg" at="2023-02-21">value</phrase> by the external environment, then
               the initial context item is
-              that value. <note><p>If the declaration occurs in a library module, then it does not set the value of the initial context item, the value is set by the main module.</p></note></p>
+              that value. <note><p>If the declaration occurs in a library module, then it does not 
+                set the value of the initial context <phrase diff="chg" at="2023-02-21">value</phrase>, the value is set by the main module.</p></note></p>
             <p>The means by which an external value is provided by the external environment is
               implementation-defined.</p>
           </item>
 
           <item>
-            <p>If no value is provided for the context item by the external environment, and
+            <p>If no value is provided for the context <phrase diff="chg" at="2023-02-21">value</phrase> by the external environment, and
                 <code>VarDefaultValue</code> is specified, then
-                the initial context item is
+              the initial context <phrase diff="chg" at="2023-02-21">value</phrase> is
                 the result of evaluating
                 <code>VarDefaultValue</code> as described below. </p>
           </item>
@@ -1351,10 +1364,10 @@ declare function local:f() { $b }; </eg>
       </item>
     </ulist>
 
-    <p>In all cases where the context item has a value, that value must match the type
+    <p>In all cases where the context <phrase diff="chg" at="2023-02-21">value</phrase> has a value, that value must match the type
         <code>T</code> according to the rules for SequenceType matching; otherwise a type error is
-      raised <errorref class="TY" code="0004"/>. If more than one module contains a context item
-      declaration, the context item must match the type declared in each one.</p>
+      raised <errorref class="TY" code="0004"/>. If more than one module contains a context <phrase diff="chg" at="2023-02-21">value</phrase>
+      declaration, the context <phrase diff="chg" at="2023-02-21">value</phrase> must match the type declared in each one.</p>
 
     <p>If <code>VarValue</code> or <code>VarDefaultValue</code> is evaluated, the static and dynamic
       contexts for the evaluation are the current module's static and dynamic context.</p>
@@ -1365,11 +1378,11 @@ declare function local:f() { $b }; </eg>
       In invoking the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
     
 
-    <p>Here are some examples of context item declarations.</p>
+    <p>Here are some examples of context <phrase diff="chg" at="2023-02-21">value</phrase> declarations.</p>
 
     <ulist>
       <item>
-        <p>Declare the type of the context item:</p>
+        <p diff="chg" at="2023-02-21">Require the type of the context item to be a single element with a specified name:</p>
         <eg role="frag-prolog-parse-test">declare namespace env="http://www.w3.org/2003/05/soap-envelope"; 
 
 declare context item as element(env:Envelope) external;</eg>
@@ -1380,6 +1393,11 @@ declare context item as element(env:Envelope) external;</eg>
           system log is in a different location, it can be specified in the external
           environment:</p>
         <eg role="frag-prolog-parse-test">declare context item as element(sys:log) external := doc("/var/xlogs/sysevent.xml")/sys:log; </eg>
+      </item>
+      <item diff="add" at="2023-02-21">
+        <p diff="add" at="2023-02-21">Declare the initial context value to be a document collection with a specified URI:</p>
+        <eg role="frag-prolog-parse-test" diff="add" at="2023-02-21">declare context value as document-node()* external := collection("file:///my/docs"); </eg>
+        
       </item>
     </ulist>
   </div2>
@@ -1428,8 +1446,8 @@ declare context item as element(env:Envelope) external;</eg>
         def="dt-in-scope-variables">in-scope variables</termref> component also includes the
       parameters of the function being declared. 
 
-      However, its <termref def="dt-context-item-static-type">context item static type</termref> component is <xtermref spec="DM31" ref="dt-absent"/>,
-      and an implementation should raise a static error <errorref class="ST" code="0008"/> if an expression depends on the context item.
+      <phrase diff="chg" at="2023-02-20">However, its <termref def="dt-context-value-static-type">context value static type</termref> component is <xtermref spec="DM31" ref="dt-absent"/>,
+      and an implementation should raise a static error <errorref class="ST" code="0008"/> if an expression depends on the context value.</phrase>
     </p>
     
     <p diff="add" at="variadicity">The function declaration includes a list of zero or more function parameters. A parameter is


### PR DESCRIPTION
This is a first cut proposal to generalize the context item to a context value, allowing (for example) array predicates.

The proposal covers XPath and XQuery only at this stage; it doesn't address the consequences for XSLT.

Careful review requested!

Addresses issue #129 and issue #367.