### PR TITLE
Issue 370: forwards and backwards compatibility for 4.0

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -525,12 +525,13 @@
                <item>
                   <p>
                      <termdef id="dt-xpath-compat-mode" term="XPath 1.0 compatibility mode">The term
-                           <term>XPath 1.0 compatibility mode</term> is defined in <xspecref spec="XP40" ref="static_context"/>. This is a setting in the static
+                           <term>XPath 1.0 compatibility mode</term> is defined in 
+                        <xspecref spec="XP40" ref="static_context"/>. This is a setting in the static
                         context of an XPath expression; it has two values, <code>true</code> and
                            <code>false</code>. When the value is set to true, the semantics of
                         function calls and certain other operations are adjusted to give a greater
                         degree of backwards compatibility between XPath
-                           3.0 and XPath 1.0.</termdef>
+                        <phrase diff="chg" at="2023-02-24">4.0</phrase> and XPath 1.0.</termdef>
                   </p>
 
 
@@ -1865,7 +1866,8 @@
                stylesheet. Other information may be supplied externally or implicitly: an example is
                the current date and time.</p>
             <p>The context information used in processing an XSLT stylesheet includes as a subset
-               all the context information required when evaluating XPath expressions. The XPath 3.0 specification defines a static and dynamic
+               all the context information required when evaluating XPath expressions. 
+               The XPath 4.0 specification defines a static and dynamic
                context that the host language (in this case, XSLT) may initialize, which affects the
                results of XPath expressions used in that context. XSLT augments the context with
                additional information: this additional information is used firstly by XSLT
@@ -2682,8 +2684,8 @@
   &lt;/xsl:otherwise&gt;
 &lt;/xsl:choose&gt;</eg>
                <p>Then the XSLT processor must not report an error, because the relevant XPath
-                  construct appears in a context where it will never be executed by an XSLT 2.0
-                     or 3.0 processor. (An XSLT 1.0 processor
+                  construct appears in a context where it will never be executed by an XSLT 
+                  <phrase diff="chg" at="2023-02-24">4.0</phrase>. (An XSLT 1.0 processor
                   will execute this code successfully, returning positive infinity, because it uses
                   double arithmetic rather than decimal arithmetic.)</p>
             </example>
@@ -3112,11 +3114,12 @@
             <p>The <code>version</code> attribute indicates the
                version of the XSLT language specification to which the package manifest conforms.
                   The value <rfc2119>should</rfc2119> normally be
-                     <code>3.0</code>. If the value is numerically less than <code>3.0</code>, the
+                     <phrase diff="chg" at="2023-02-24"><code>4.0</code></phrase>. 
+               If the value is numerically less than <phrase diff="chg" at="2023-02-24"><code>4.0</code></phrase>, the
                   content of the <elcode>xsl:package</elcode> element is processed using the rules
                   for <termref def="dt-backwards-compatible-behavior">backwards compatible
                      behavior</termref> (see <specref ref="backwards"/>). If the value is
-                  numerically greater than <code>3.0</code>, it is processed using the rules for
+               numerically greater than <phrase diff="chg" at="2023-02-24"><code>4.0</code></phrase>, it is processed using the rules for
                      <termref def="dt-forwards-compatible-behavior"/> (see <specref ref="forwards"/>).</p>
 
 
@@ -3169,7 +3172,8 @@
                         <elcode>xsl:include</elcode> declaration as a reference to the effective
                         top-level stylesheet module; this approach is particularly suitable when
                         writing code that is required to run under earlier releases of XSLT as well as
-                        under XSLT 3.0. Another approach is to include the substance of the top-level
+                        under XSLT 3.0 <phrase diff="add" at="2023-02-24">and 4.0</phrase>. 
+                        Another approach is to include the substance of the top-level
                         stylesheet module inline within the package manifest.</p></item>
                   </olist>
                </item>
@@ -3303,7 +3307,7 @@
  
 
                <p>Here <xnt ref="prod-xpath40-IntegerLiteral" spec="XP40">IntegerLiteral</xnt> and <code>NCName</code> are as defined in
-                     the XPath 3.0 grammar productions of the same name (including rules on
+                  the XPath <phrase diff="chg" at="2023-02-24">4.0</phrase> grammar productions of the same name (including rules on
                      limits). Leading and trailing whitespace is ignored; no other
                   whitespace is allowed.</p>
                <p>Examples of valid version numbers are <code>2.0.5</code> or
@@ -6341,10 +6345,11 @@ there is no need to make it needlessly implausible.</p>-->
             <p>The <code>version</code> attribute is intended to indicate the
                version of the XSLT specification against which the stylesheet is written. In a
                stylesheet written to use XSLT 4.0, the value <rfc2119>should</rfc2119> normally be
-               set to <code>4.0</code>. If the value is numerically less than <code>4.0</code>, the
+               set to <code>4.0</code>. If the value is numerically less than 4.0, the
                stylesheet is processed using the rules for <termref def="dt-backwards-compatible-behavior">backwards compatible behavior</termref>
                (see <specref ref="backwards"/>). If the value is numerically greater than
-                  <code>3.0</code>, the stylesheet is processed using the rules for <termref def="dt-forwards-compatible-behavior"/> (see <specref ref="forwards"/>).</p>
+               <phrase diff="chg" at="2023-02-24">4.0</phrase>, the stylesheet is processed using the rules for 
+               <termref def="dt-forwards-compatible-behavior"/> (see <specref ref="forwards"/>).</p>
 
             <!--For this version of XSLT, the value <rfc2119>should</rfc2119> normally
 be <code>
@@ -6740,9 +6745,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      that is used as the outermost element of a simplified stylesheet module
                         <rfc2119>must</rfc2119> have an <code>xsl:version</code> attribute.</p>
                </error> This indicates the version of XSLT that the stylesheet requires. For this
-               version of XSLT, the value will normally be <code>
-                  3.0
-               </code>; the value <rfc2119>must</rfc2119> be a valid instance of the type
+               version of XSLT, the value will normally be <phrase diff="chg" at="2023-02-24">4.0</phrase>; the 
+               value <rfc2119>must</rfc2119> be a valid instance of the type
                   <code>xs:decimal</code> as defined in <bibref ref="xmlschema-2"/>.</p>
             
             <p>The allowed content of a literal result element when used as a simplified stylesheet
@@ -6762,9 +6766,10 @@ and <code>version="1.0"</code> otherwise.</p>
                   ancestor element that has such an attribute, excluding the <code>version</code>
                   attribute on an <elcode>xsl:output</elcode> element.</termdef></p>
             <p>
-               <termdef id="dt-backwards-compatible-behavior" term="backwards compatible behavior">An element is processed with <term>backwards compatible behavior</term> if its
+               <termdef id="dt-backwards-compatible-behavior" term="backwards compatible behavior">An element is 
+                  processed with <term>backwards compatible behavior</term> if its
                      <termref def="dt-effective-version">effective version</termref> is less than
-                     <code>3.0</code>.</termdef>
+                  <phrase diff="chg" at="2023-02-24">4.0</phrase>.</termdef>
             </p>
             <p>Specifically:</p>
             <ulist>
@@ -6779,12 +6784,19 @@ and <code>version="1.0"</code> otherwise.</p>
                         <specref ref="backwards-2.0"/>.</p>
                </item>
                <item>
+                  <p>If the <termref def="dt-effective-version">effective version</termref> is equal
+                     to 2.0, then the element is processed with XSLT 2.0 behavior as described in
+                     <specref ref="backwards-3.0"/>.</p>
+               </item>
+               <item>
                   <p>If the <termref def="dt-effective-version">effective version</termref> is any
-                     other value less than 3.0, the <rfc2119>recommended</rfc2119> action is to
+                     other value less than <phrase diff="chg" at="2023-02-24">4.0</phrase>, 
+                     the <rfc2119>recommended</rfc2119> action is to
                      report a static error; however, processors <rfc2119>may</rfc2119> recognize
                      such values and process the element in an <termref def="dt-implementation-defined"/> way.</p>
-                  <imp-def-feature id="idf-err-unknownversion">If the <termref def="dt-effective-version">effective version</termref> of any element in the
-                     stylesheet is not 1.0 or 2.0 but is less than 3.0, the
+                  <imp-def-feature id="idf-err-unknownversion">If the 
+                     <termref def="dt-effective-version">effective version</termref> of any element in the
+                     stylesheet is not 1.0 or 2.0 but is less than <phrase diff="chg" at="2023-02-24">4.0</phrase>, the
                         <rfc2119>recommended</rfc2119> action is to report a static error; however,
                      processors <rfc2119>may</rfc2119> recognize such values and process the element
                      in an <termref def="dt-implementation-defined"/> way.</imp-def-feature>
@@ -6812,12 +6824,12 @@ and <code>version="1.0"</code> otherwise.</p>
                <error spec="XT" type="dynamic" class="DE" code="0160">
                   <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if an element has
                      an <termref def="dt-effective-version">effective version</termref> of
-                        <var>V</var> (with <var>V</var> &lt; 3.0) when the implementation does not
+                     <var>V</var> (with <var>V</var> &lt; <phrase diff="chg" at="2023-02-24">4.0</phrase>) when the implementation does not
                      support backwards compatible behavior for XSLT version <var>V</var>.</p>
                </error>
             </p>
             <imp-def-feature id="idf-feature-backwardscompatibility">It is implementation-defined
-               whether an XSLT 3.0 processor supports backwards
+               whether an XSLT 4.0 processor supports backwards
                compatible behavior for any XSLT version earlier than XSLT 4.0.</imp-def-feature>
 
             <note>
@@ -6833,7 +6845,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   expressions use backwards compatible behavior. Because the same data model is used
                   in both cases, expressions are fully composable. The result of evaluating
                   instructions or expressions with backwards compatible behavior is fully defined in
-                  the XSLT 4.0 and XPath 3.0 specifications, it is not defined by reference to earlier versions of the XSLT and XPath
+                  the XSLT 4.0 and XPath 4.0 specifications, it is not defined by reference to earlier versions of the XSLT and XPath
                      specifications. </p>
 
                <p>To write a stylesheet that makes use of features that
@@ -6843,15 +6855,16 @@ and <code>version="1.0"</code> otherwise.</p>
                      XSLT version <var>N</var>, and the rules for
                   forwards compatible behavior in XSLT version
                         <var>M</var>. If the <elcode>xsl:stylesheet</elcode> element
-                  specifies <code>version="2.0"</code>
-                  or <code>version="3.0"</code>, then an XSLT 1.0
-                  processor will ignore XSLT 2.0 and XSLT 3.0
+                  specifies <phrase>a <code>version</code> attribute with a value greater than 1.0</phrase>, then an XSLT 1.0
+                  processor will ignore <phrase diff="del" at="2023-02-24">XSLT 2.0 and XSLT 3.0</phrase>
                   <termref def="dt-declaration">declarations</termref> that were not defined in XSLT
-                  1.0, for example <elcode>xsl:function</elcode> and
-                     <elcode>xsl:import-schema</elcode>. If any new XSLT
-                     3.0 instructions are used (for example <elcode>xsl:evaluate</elcode>
-                  or <elcode>xsl:source-document</elcode>), or if new XPath
-                     3.0 features are used (for example, new functions, or let expressions), then the stylesheet must provide
+                  1.0, for example <elcode>xsl:function</elcode>,
+                     <elcode>xsl:import-schema</elcode><phrase diff="add" at="2023-02-24">, 
+                        and <elcode>xsl:mode</elcode></phrase>. If any new XSLT
+                  <phrase diff="chg" at="2023-02-24">4.0 instructions are used (for example <elcode>xsl:switch</elcode>
+                     or <elcode>xsl:array</elcode>)</phrase>, or if new XPath
+                  <phrase diff="chg" at="2023-02-24">4.0 features are used (for example, keyword arguments in function calls)</phrase>, 
+                     then the stylesheet must provide
                   fallback behavior that relies only on facilities available in the earliest XSLT version supported. The fallback
                   behavior can be invoked by using the <elcode>xsl:fallback</elcode> instruction, or
                   by testing the results of the <function>function-available</function> or
@@ -6907,19 +6920,43 @@ and <code>version="1.0"</code> otherwise.</p>
                <p><termdef id="dt-xslt-20-behavior" term="XSLT 2.0 behavior">An element is processed
                      with <term>XSLT 2.0 behavior</term> if its <termref def="dt-effective-version">effective version</termref> is equal to 2.0.</termdef></p>
                <p>In this specification, no differences are defined for XSLT 2.0 behavior. An XSLT
-                  3.0 processor will therefore produce the same results whether the <termref def="dt-effective-version">effective version</termref> of an element is set to
-                  2.0 or 3.0.</p>
+                  <phrase diff="chg" at="2023-02-24">4.0</phrase> processor will therefore 
+                  produce the same results whether the <termref def="dt-effective-version">effective version</termref> of an element is set to
+                  2.0 or <phrase diff="chg" at="2023-02-24">4.0</phrase>.</p>
                <note>
                   <p>An XSLT 2.0 processor, by contrast, will in some cases produce different
                      results in the two cases. For example, if the stylesheet contains an
-                        <elcode>xsl:iterate</elcode> instruction with an
-                        <elcode>xsl:fallback</elcode> child, an XSLT 3.0 processor will process the
-                        <elcode>xsl:iterate</elcode> instruction regardless whether the effective
-                     version is 2.0 or 3.0, while an XSLT 2.0 processor will report a static error
+                        <elcode>xsl:switch</elcode> instruction with an
+                     <elcode>xsl:fallback</elcode> child, an XSLT <phrase diff="chg" at="2023-02-24">4.0</phrase> processor will process the
+                        <elcode>xsl:switch</elcode> instruction regardless whether the effective
+                     version is 2.0, 3.0, <phrase diff="chg" at="2023-02-24">or 4.0</phrase>, while an 
+                     XSLT 2.0 processor will report a static error
                      if the effective version is 2.0, and will take the fallback action if the
-                     effective version is 3.0.</p>
+                     effective version is 3.0 or 4.0.</p>
                </note>
 
+            </div3>
+            <div3 id="backwards-3.0" diff="add" at="2023-02-24">
+               <head>XSLT 3.0 Compatibility Mode</head>
+               <p><termdef id="dt-xslt-30-behavior" term="XSLT 3.0 behavior">An element is processed
+                  with <term>XSLT 3.0 behavior</term> if its <termref def="dt-effective-version">effective version</termref> 
+                  is equal to 3.0.</termdef></p>
+               <p>In this specification, no differences are defined for XSLT 3.0 behavior. An XSLT
+                  <phrase diff="chg" at="2023-02-24">4.0</phrase> processor will therefore 
+                  produce the same results whether the <termref def="dt-effective-version">effective version</termref> of an element is set to
+                  3.0 or <phrase diff="chg" at="2023-02-24">4.0</phrase>.</p>
+               <note>
+                  <p>An XSLT 3.0 processor, by contrast, will in some cases produce different
+                     results in the two cases. For example, if the stylesheet contains an
+                     <elcode>xsl:switch</elcode> instruction with an
+                     <elcode>xsl:fallback</elcode> child, an XSLT <phrase diff="chg" at="2023-02-24">4.0</phrase> processor will process the
+                     <elcode>xsl:switch</elcode> instruction regardless whether the effective
+                     version is 2.0, 3.0, <phrase diff="chg" at="2023-02-24">or 4.0</phrase>, while an 
+                     XSLT 2.0 processor will report a static error
+                     if the effective version is 2.0, and will take the fallback action if the
+                     effective version is 3.0 or 4.0.</p>
+               </note>
+               
             </div3>
          </div2>
          <div2 id="forwards">
@@ -6930,15 +6967,16 @@ and <code>version="1.0"</code> otherwise.</p>
                ability to execute the stylesheet with an XSLT 4.0
                processor using appropriate fallback behavior.</p>
             <p>It is always possible to write conditional code to run under different XSLT versions
-               by using the <code>use-when</code> feature described in <specref ref="conditional-inclusion"/>. The rules for forwards compatible behavior
+               by using the <code>use-when</code> feature described in <specref ref="conditional-inclusion"/>. 
+               The rules for forwards compatible behavior
                supplement this mechanism in two ways:</p>
             <ulist>
                <item>
-                  <p>certain constructs in the stylesheet that mean nothing to an XSLT 4.0 processor are ignored, rather than being treated as
-                     errors.</p>
+                  <p>Certain constructs in the stylesheet that mean nothing to an XSLT 4.0 processor are ignored, 
+                     rather than being treated as errors.</p>
                </item>
                <item>
-                  <p>explicit fallback behavior can be defined for instructions defined in a future
+                  <p>Explicit fallback behavior can be defined for instructions defined in a future
                      XSLT release, using the <elcode>xsl:fallback</elcode> instruction.</p>
                </item>
             </ulist>
@@ -6947,7 +6985,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <termdef id="dt-forwards-compatible-behavior" term="forwards compatible behavior">An
                   element is processed with <term>forwards compatible behavior</term> if its
                      <termref def="dt-effective-version">effective version</termref> is greater than
-                     <code>3.0</code>.</termdef>
+                     <phrase diff="chg" at="2023-02-24">4.0</phrase>.</termdef>
             </p>
             
             <p>These rules do not apply to the <code>version</code> attribute of the
@@ -6957,7 +6995,8 @@ and <code>version="1.0"</code> otherwise.</p>
             <ulist>
                <item>
                   <p>If the element is in the XSLT namespace and appears as a child of the
-                        <elcode>xsl:stylesheet</elcode> element, and XSLT 4.0 does not allow the element to appear as a child of the
+                        <elcode>xsl:stylesheet</elcode> element, and XSLT 4.0 does not allow the element 
+                        to appear as a child of the
                         <elcode>xsl:stylesheet</elcode> element, then the element and its content
                         <rfc2119>must</rfc2119> be ignored.</p>
                </item>
@@ -6966,9 +7005,10 @@ and <code>version="1.0"</code> otherwise.</p>
                         <rfc2119>must</rfc2119> be ignored.</p>
                </item>
                <item>
-                  <p>If the element is in the XSLT namespace and appears as a child of an element whose content model requires a
+                  <p>If the element is in the XSLT namespace and appears as a child of an element 
+                     whose content model requires a
                      <termref def="dt-sequence-constructor">sequence constructor</termref>, and XSLT
-                        3.0 does not allow such elements to
+                     <phrase diff="chg" at="2023-02-24">4.0</phrase> does not allow such elements to
                      appear as part of a sequence constructor, then:</p>
                   <olist>
                      <item>
@@ -7015,7 +7055,8 @@ and <code>version="1.0"</code> otherwise.</p>
 &lt;/xsl:stylesheet&gt;</eg>
             </example>
             <note>
-               <p>If a stylesheet depends crucially on a <termref def="dt-declaration">declaration</termref> introduced by a version of XSLT after 3.0, then the stylesheet can use an
+               <p>If a stylesheet depends crucially on a <termref def="dt-declaration">declaration</termref> 
+                  introduced by a version of XSLT after <phrase diff="chg" at="2023-02-24">4.0</phrase>, then the stylesheet can use an
                      <elcode>xsl:message</elcode> element with <code>terminate="yes"</code> (see
                      <specref ref="message"/>) to ensure that implementations that conform to an
                   earlier version of XSLT will not silently ignore the <termref def="dt-declaration">declaration</termref>.</p>


### PR DESCRIPTION
This is essentially editorial; it updates the rules for forwards and backwards compatible processing to acknowledge the fact that the current version is now 4.0.