### PR TITLE
256: Context for default parameter values

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -44,7 +44,7 @@
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="node-name" return-type="xs:QName?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -103,7 +103,7 @@
    <fos:function name="nilled" prefix="fn">
       <fos:signatures>
          <fos:proto name="nilled" return-type="xs:boolean?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -159,7 +159,7 @@
    <fos:function name="string" prefix="fn">
       <fos:signatures>
          <fos:proto name="string" return-type="xs:string">
-            <fos:arg name="item" type="item()?" default="." usage="absorption"/>
+            <fos:arg name="item" type="item()?" default="$context?item()" usage="absorption"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -250,7 +250,7 @@
    <fos:function name="data" prefix="fn">
       <fos:signatures>
          <fos:proto name="data" return-type="xs:anyAtomicType*">
-            <fos:arg name="input" type="item()*" default="." usage="absorption"/>
+            <fos:arg name="input" type="item()*" default="$context?item()" usage="absorption"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -353,7 +353,7 @@
    <fos:function name="base-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="base-uri" return-type="xs:anyURI?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -415,7 +415,7 @@
    <fos:function name="document-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="document-uri" return-type="xs:anyURI?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -485,7 +485,7 @@
          <fos:proto name="error" return-type="none">
             <fos:arg name="code" type="xs:QName?" default="()"/>
             <fos:arg name="description" type="xs:string?" default="()"/>
-            <fos:arg name="error-object" type="item()*" default="." usage="navigation"/>
+            <fos:arg name="error-object" type="item()*" default="$context?item()" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -3206,7 +3206,7 @@
          <fos:proto name="compare" return-type="xs:integer?">
             <fos:arg name="value1" type="xs:string?"/>
             <fos:arg name="value2" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -3660,7 +3660,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
    <fos:function name="string-length" prefix="fn">
       <fos:signatures>
          <fos:proto name="string-length" return-type="xs:integer">
-            <fos:arg name="value" type="xs:string?" default="fn:string(.)"/>
+            <fos:arg name="value" type="xs:string?" default="fn:string($context?item())"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -3718,7 +3718,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
    <fos:function name="normalize-space" prefix="fn">
       <fos:signatures>
          <fos:proto name="normalize-space" return-type="xs:string">
-            <fos:arg name="value" type="xs:string?" default="fn:string(.)"/>
+            <fos:arg name="value" type="xs:string?" default="fn:string($context?item())"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -4281,7 +4281,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="contains" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4386,7 +4386,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="starts-with" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4495,7 +4495,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="ends-with" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4605,7 +4605,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="substring-before" return-type="xs:string">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -4707,7 +4707,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:proto name="substring-after" return-type="xs:string">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="substring" type="xs:string?"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -5455,7 +5455,7 @@ Tak, tak, tak! - da kommen sie.
          <fos:proto name="contains-token" return-type="xs:boolean">
             <fos:arg name="value" type="xs:string*"/>
             <fos:arg name="token" type="xs:string"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -9944,7 +9944,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    <fos:function name="name" prefix="fn">
       <fos:signatures>
          <fos:proto name="name" return-type="xs:string">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -10000,7 +10000,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    <fos:function name="local-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="local-name" return-type="xs:string">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -10054,7 +10054,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    <fos:function name="namespace-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="namespace-uri" return-type="xs:anyURI">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -10108,7 +10108,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    <fos:function name="number" prefix="fn">
       <fos:signatures>
          <fos:proto name="number" return-type="xs:double">
-            <fos:arg name="value" type="xs:anyAtomicType?" default="."/>
+            <fos:arg name="value" type="xs:anyAtomicType?" default="$context?item()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -10185,7 +10185,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:signatures>
          <fos:proto name="lang" return-type="xs:boolean">
             <fos:arg name="language" type="xs:string?"/>
-            <fos:arg name="node" type="node()" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -10290,7 +10290,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    <fos:function name="path" prefix="fn">
       <fos:signatures>
          <fos:proto name="path" return-type="xs:string?">
-            <fos:arg name="node" type="node()?" default="." usage="navigation"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -10458,7 +10458,7 @@ Himmlische, dein Heiligtum.</p>}]]>
    <fos:function name="root" prefix="fn">
       <fos:signatures>
          <fos:proto name="root" return-type="node()?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -10558,7 +10558,7 @@ let $newi := $o/tool</eg>
    <fos:function name="has-children" prefix="fn">
       <fos:signatures>
          <fos:proto name="has-children" return-type="xs:boolean">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+            <fos:arg name="node" type="node()?" default="$context?item()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -10707,7 +10707,7 @@ let $newi := $o/tool</eg>
          <fos:proto name="index-of" return-type="xs:integer*">
             <fos:arg name="input" type="xs:anyAtomicType*"/>
             <fos:arg name="search" type="xs:anyAtomicType"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -10913,7 +10913,7 @@ let $newi := $o/tool</eg>
       <fos:signatures>
          <fos:proto name="distinct-values" return-type="xs:anyAtomicType*">
             <fos:arg name="values" type="xs:anyAtomicType*"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -12365,7 +12365,7 @@ else if (fn:empty($input))
          <fos:proto name="deep-equal" return-type="xs:boolean">
             <fos:arg name="input1" type="item()*" usage="absorption"/>
             <fos:arg name="input2" type="item()*" usage="absorption"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -12648,7 +12648,7 @@ else if (fn:empty($input))
             <fos:arg name="input1" type="item()" usage="absorption"/>
             <fos:arg name="input2" type="item()" usage="absorption"/>
             <fos:arg name="options" type="map(*)" usage="absorption" default="map{}"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -13220,7 +13220,7 @@ else if (fn:empty($input))
       <fos:signatures>
          <fos:proto name="max" return-type="xs:anyAtomicType?">
             <fos:arg name="values" type="xs:anyAtomicType*"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -13369,7 +13369,7 @@ else if (fn:empty($input))
       <fos:signatures>
          <fos:proto name="min" return-type="xs:anyAtomicType?">
             <fos:arg name="values" type="xs:anyAtomicType*"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -13704,7 +13704,7 @@ else
       <fos:signatures>
          <fos:proto name="id" return-type="element()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="node()" default="$context?item()" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -13876,7 +13876,7 @@ else
       <fos:signatures>
          <fos:proto name="element-with-id" return-type="element()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="node()" default="$context?item()" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -14051,7 +14051,7 @@ else
       <fos:signatures>
          <fos:proto name="idref" return-type="node()*">
             <fos:arg name="values" type="xs:string*"/>
-            <fos:arg name="node" type="node()" default="." usage="navigation"/>
+            <fos:arg name="node" type="node()" default="$context?item()" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -14954,7 +14954,7 @@ else
    <fos:function name="generate-id" prefix="fn">
       <fos:signatures>
          <fos:proto name="generate-id" return-type="xs:string">
-            <fos:arg name="node" type="node()?" usage="inspection" default="."/>
+            <fos:arg name="node" type="node()?" usage="inspection" default="$context?item()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -16922,7 +16922,7 @@ declare function fn:for-each-pair($input1, $input2, $action)
       <fos:signatures>
          <fos:proto name="sort" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="$context?default-collation()"/>
             <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
          </fos:proto>
       </fos:signatures>
@@ -18543,7 +18543,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:signatures>
          <fos:proto name="collation-key" return-type="xs:base64Binary">
             <fos:arg name="value" type="xs:string"/>
-            <fos:arg name="collation" type="xs:string" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -21377,7 +21377,7 @@ else array:concat(
       <fos:signatures>
          <fos:proto name="sort" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="$context?default-collation()"/>
             <fos:arg name="key" type="function(item()*) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
          </fos:proto>
       </fos:signatures>
@@ -23186,7 +23186,7 @@ declare function fn:all(
       <fos:signatures>
          <fos:proto name="highest" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="$context?default-collation()"/>
             <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
          </fos:proto>
       </fos:signatures>
@@ -23685,7 +23685,7 @@ function($item){
       <fos:signatures>
          <fos:proto name="lowest" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="$context?default-collation()"/>
             <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
          </fos:proto>
       </fos:signatures>
@@ -24020,7 +24020,7 @@ declare function fn:some(
       <fos:signatures>
          <fos:proto name="all-equal" return-type="xs:boolean">
             <fos:arg name="values" type="xs:anyAtomicType*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" usage="absorption" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24100,7 +24100,7 @@ declare function fn:some(
       <fos:signatures>
          <fos:proto name="all-different" return-type="xs:boolean">
             <fos:arg name="values" type="xs:anyAtomicType*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="collation" type="xs:string" usage="absorption" default="$context?default-collation()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1497,42 +1497,76 @@ declare context item as element(env:Envelope) external;</eg>
         with the same name. The type of a function parameter can be any type that can be expressed as
         a <termref def="dt-sequence-type">sequence type</termref>.</p>
       
-      <p diff="add" at="2023-02-27">When a default value is supplied for a function parameter (using the syntax <code>:= ExprSingle</code>),
+      <p diff="add" at="2023-03-10">When a default value is supplied for a function parameter (using the syntax <code>:= ExprSingle</code>),
       the static and dynamic context for evaluating the <code>ExprSingle</code> are the same as the static
       and dynamic context for evaluating the <termref def="dt-initializing-expression"/> of a 
-        <termref def="dt-variable-declaration"/>, with one addition, a zero-arity function named <code>fn:caller-context</code>,
-      defined as follows:</p>
+        <termref def="dt-variable-declaration"/>, with one addition, a variable named <code>context</code>,
+        which holds information about the static and dynamic context of the function call (or function reference)
+        that causes the default value to be evaluated.</p>
       
-      <ulist>
-        <item><p>The name of the function has local part <code>caller-context</code> and namespace
-        <code>http://www.w3.org/2005/xpath-functions</code>.</p></item>
-        <item><p>The type of the function is:</p>
-        <eg>function() as record(
-   context-item? as (function() as item()), 
-   position? as (function() as xs:integer), 
-   last? as (function() as xs:integer),
-   default-collation? as (function() as xs:anyURI),
-   *)</eg></item>
-        <item><p>The function provides access to information about the static and dynamic context of the function
-        call or function reference that caused the function to be invoked. Specifically:</p>
-        <ulist>
-          <item><p><code>$fn:caller-context()?context-item()</code> provides the context item of the caller.</p></item>
-          <item><p><code>$fn:caller-context()?position()</code> provides the context position of the caller.</p></item>
-          <item><p><code>$fn:caller-context()?last()</code> provides the context size of the caller.</p></item>
-          <item><p><code>$fn:caller-context()?default-collation()</code> provides the default collation of the caller.</p></item>
-        </ulist>
-          <p>Note that if any of these values is absent, an attempt to retrieve the value will return an empty sequence.</p>
+      <ednote diff="add" at="2023-03-10"><edtext>I decided to use a magic variable rather than a magic function because (a) there are fewer
+      edge cases that need to be defined in the specification, for example what happens if it's a function and
+      you use function-lookup() to find it, and (b) because it's easy for an implementation to determine
+      statically that a particular default value expression actually uses this feature, which makes it easier
+      to pre-evaluate default value expressions that don't.</edtext></ednote>
+      
+      <p diff="add" at="2023-03-10">More specifically:</p>
+      
+      <ulist diff="add" at="2023-03-10">
+        <item><p>The <termref def="dt-in-scope-variables"/> component of the static context is augmented
+        with a variable whose name is <code>context</code> (in no namespace) and whose type is:</p>
+        <eg>record(
+    item as (function() as item()),
+    default-collation? as (function() as xs:anyURI),
+    *)
+        </eg>
+        <ednote><edtext>I decided, after we reviewed this, to make the fields functions rather than simple values
+        because it is easier to reproduce the behavior of core functions where a dynamic error is raised
+        if the context item in the caller is absent.</edtext></ednote>
+        </item>
+        <item><p>The <termref def="dt-variable-values"/> component of the dynamic context is augmented
+        with a value for this variable. The value is map, whose entries are as follows:</p>
+        <table class="data">
+          <thead>
+            <tr>
+              <th>key</th>
+              <th>value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><p>item</p></td>
+              <td><p>A zero-arity function that returns the <termref def="dt-context-item"/> 
+                from the dynamic context of the caller; if this is absent,
+              the function raises a dynamic error <errorref class="DY" code="0002"/>.</p>
+              <note><p>Using a context item expression (<code>.</code>) in the default
+              value expression is interpreted as a reference to the initial context item
+              of the query, which is not the same thing, and is probably a mistake.</p></note></td>
+            </tr>
+            <tr>
+              <td><p>default&#x2011;collation</p></td>
+              <td><p>A zero-arity function that returns the <termref def="dt-def-collation"/>
+              from the static context of the caller.</p></td>
+            </tr>
+          </tbody>
+        </table>
+        
         </item>
 
       </ulist>
       
-      <p>So, for example, a parameter whose default value is the context item of the caller can be declared as
-      <code>$input as item() := $fn:caller-context()?context-item()</code>.</p>
+      <p diff="add" at="2023-03-10">So, for example, a parameter whose default value is the context item of the caller can be declared as
+      <code>$input as item() := $context?item()</code>.</p>
       
-     <!-- <note diff="add" at="2023-02-27"><p>The initializing expression thus has a fixed value, which does not depend in any way on
-      the static or dynamic context of the caller. It is not possible to replicated the convention used
-      for built-in functions, whereby the default value of a parameter may be taken from the context
-      item or default collation of the caller.</p></note>-->
+      <note diff="add" at="2023-03-10"><p>This capability allows user-defined functions to mimic the behavior of 
+        those core functions that take default argument values from the caller's static or dynamic context. It is not designed to 
+     enable all core functions to be implemented in XQuery. For example (a) it does not provide access
+     to all parts of the caller's context, such as the caller's in-scope namespaces or static base URI, 
+     and (b) it allows access to context information only in an expression used to compute default values 
+     of parameters, not in the body of the function implementation.</p></note>
+      
+      <ednote diff="add" at="2023-03-10"><edtext>The mechanism is extensible, we could easily add more entries to the map. However,
+      providing these two is sufficient for all functions in the core library that have context-dependent default arguments.</edtext></ednote>
       
  
     </div3>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1048,27 +1048,33 @@ return $i/xx:bing]]>
 
 
 
-    <p>A <term>variable declaration</term> adds the <termref def="dt-static-type">static
+    <p><termdef id="dt-variable-declaration" term="variable declaration">A 
+      <term>variable declaration</term> adds the <phrase diff="add" at="2023-02-27">name and</phrase> 
+      <termref def="dt-static-type">static
         type</termref> of a variable to the <termref def="dt-in-scope-variables">in-scope
         variables</termref>, and may also add a value for the variable to the <termref
-        def="dt-variable-values">variable values</termref>. </p>
+          def="dt-variable-values">variable values</termref>. </termdef></p>
 
     <note>
-      <p>A <term>variable declaration</term> always refers to a declaration of a variable in a
-        Prolog. The binding of a variable to a value in a query expression, such as a FLWOR
+      <p><phrase diff="chg" at="2023-02-27">The term</phrase> <term>variable declaration</term> 
+        always refers to a declaration of a variable in a
+        <code>Prolog</code>. The binding of a variable to a value in a query expression, such as a FLWOR
         expression, is known as a <term>variable binding</term>, and does not make the variable
         visible to an importing module.</p>
     </note>
 
-    <p>During static analysis, a variable declaration causes a pair <code>(expanded QName N, type
-        T)</code> to be added to the <termref def="dt-in-scope-variables">in-scope
-        variables</termref>. The expanded QName N is the <code>VarName</code>. If N is equal (as
-      defined by the eq operator) to the expanded QName of another variable in in-scope variables, a
+    <p>During static analysis, a variable declaration causes a pair <code>(expanded QName <var>N</var>, type
+        <var>T</var>)</code> to be added to the <termref def="dt-in-scope-variables">in-scope
+        variables</termref>. The expanded QName <var>N</var> is the <code>VarName</code>. If <var>N</var> is equal (as
+      defined by the <code>eq</code> operator) to the expanded QName of another variable in the in-scope variables, a
         <termref def="dt-static-error">static error</termref> is raised <errorref class="ST"
-        code="0049"/>.
+        code="0049"/>.</p>
+      
+      <div3 id="id-variable-type">
+        <head>Variable Type</head>
+
         
-      The type T of the declared variable is as follows:
-    </p>
+      <p>The type <var>T</var> of the declared variable is as follows:</p>
     <ulist>
       <item>
           <p>If <code>TypeDeclaration</code> is present, then the <code>SequenceType</code> in the
@@ -1089,9 +1095,25 @@ return $i/xx:bing]]>
         <p> Otherwise, <code>item()*</code>.</p>
       </item>
     </ulist>
+    
+    </div3>
+    <div3 id="id-variable-names">
+      <head>Variable Names</head>
 
-    <p>All variable names declared in a library module must (when expanded) be in the target
-      namespace of the library module <errorref class="ST" code="0048"/>. A variable declaration may
+
+      <p>All variable names declared in a library module must (when expanded) be in the target
+        namespace of the library module <errorref class="ST" code="0048"/>.</p>
+      
+      <p>Variable names that have no namespace prefix are in no namespace. Variable declarations that
+        have no namespace prefix may appear only in a main module.</p>
+      
+    </div3>
+    <div3 id="id-variable-annotations">
+      <head>Variable Annotations</head>
+      
+      
+      
+      <p>A variable declaration may
       use annotations to specify that the variable is <code>%private</code> or <code>%public</code>
       (which is the default). <termdef id="dt-private-variable" term="private
   variable">A
@@ -1110,10 +1132,21 @@ return $i/xx:bing]]>
           <code>%private</code> and a <code>%public</code> annotation, more than one
           <code>%private</code> annotation, or more than one <code>%public</code>
         annotation.</termdef></p>
+      
+      <p>
+        An implementation can provide annotations it needs. For instance,
+        an implementation that supports volatile external variables
+        might allow them to be declared using an annotation:</p>
+      
+      <eg role="frag-prolog-parse-test">declare %eg:volatile variable $time as xs:time external;</eg>
+      
+      
 
+    </div3>
+    <div3 id="id-variable-declaration-examples">
+      <head>Examples of Variable Declarations</head>
 
-    <p>Variable names that have no namespace prefix are in no namespace. Variable declarations that
-      have no namespace prefix may appear only in a main module.</p>
+ 
 
 
     <p>Here are some examples of variable declarations:</p>
@@ -1169,14 +1202,10 @@ return $i/xx:bing]]>
       </item>
     </ulist>
 
-    <p>
-      An implementation can provide annotations it needs. For instance,
-      an implementation that supports volatile external variables
-      might allow them to be declared using an annotation:</p>
+    </div3>
+    <div3 id="id-variable-initialization">
+      <head>Variable Initialization</head>
 
-    <eg role="frag-prolog-parse-test">declare %eg:volatile variable $time as xs:time external;</eg>
-
-    
    
 
     <p>
@@ -1189,7 +1218,8 @@ return $i/xx:bing]]>
     
     <p diff="add" at="2022-11-17">If a required type is defined, then the value obtained by 
       evaluating the initializing expression is converted to the required type by applying
-    the <termref def="dt-coercion-rules"/>. A type error occurs if this is not possible.
+      the <termref def="dt-coercion-rules"/>. A type error occurs if this is not possible <errorref
+        class="TY" code="0004"/>.
       In invoking the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
 
 
@@ -1214,7 +1244,7 @@ declare function local:f() { $b }; </eg>
       not contain cycles, as it makes the population of the dynamic context impossible. If it is
       discovered, during static analysis or during dynamic evaluation, that such a cycle exists,
       error <errorref class="DY" code="0054"/> must be raised.</p>
-
+    
 
     <!-- ================================================= -->
 
@@ -1236,7 +1266,9 @@ declare function local:f() { $b }; </eg>
           <item>
             <p> if a value is provided for the variable by the external environment, then V is that
               value. The means by which typed values of external variables are provided by the
-              external environment is implementation-defined.</p>
+              external environment is implementation-defined. <phrase diff="add" at="2023-02-27">It
+              is also implementation-defined whether the coercion rules are applied in this
+              case.</phrase></p>
           </item>
 
           <item>
@@ -1257,9 +1289,7 @@ declare function local:f() { $b }; </eg>
       </item>
     </ulist>
 
-    <p>In all cases the value V must match the type T according to the rules for SequenceType
-      matching; otherwise a <termref def="dt-type-error">type error</termref> is raised <errorref
-        class="TY" code="0004"/>.</p>
+    </div3>
 
     
 
@@ -1387,7 +1417,7 @@ declare context item as element(env:Envelope) external;</eg>
 
   <div2 id="FunctionDeclns">
     <head>Function Declaration</head>
-    <p diff="chg" at="variadicity">In addition to the <termref def="dt-built-in-function">built-in functions</termref>, XQuery
+    <p diff="chg" at="2022-11-01">In addition to the <termref def="dt-built-in-function">built-in functions</termref>, XQuery
       allows users to declare functions of their own. A function declaration declares a family of functions
       having the same name and similar parameters. The declaration specifies the name of
       the function, the names and datatypes of the parameters, and the datatype of the result. All
@@ -1402,7 +1432,7 @@ declare context item as element(env:Envelope) external;</eg>
  
  
 
-    <scrap diff="chg" at="variadicity">
+    <scrap diff="chg" at="2022-11-01">
       <head></head>
       <prodrecap ref="AnnotatedDecl"/>
       <prodrecap ref="Annotation"/>
@@ -1432,7 +1462,16 @@ declare context item as element(env:Envelope) external;</eg>
       and an implementation should raise a static error <errorref class="ST" code="0008"/> if an expression depends on the context item.
     </p>
     
-    <p diff="add" at="variadicity">The function declaration includes a list of zero or more function parameters. A parameter is
+    <note><p>In addition to <termref def="dt-udf">user-defined functions</termref>
+      and <termref def="dt-external-function">external functions</termref>, &language; allows anonymous
+      functions to be declared in the body of a query using <termref def="dt-inline-func">inline function expressions</termref>.</p></note>
+    
+    
+    <div3 id="id-function-signature">
+      <head>Function Signature</head>
+
+    
+    <p diff="add" at="2022-11-01">The function declaration includes a list of zero or more function parameters. A parameter is
     optional if a default value is supplied using the construct <code>:= ExprSingle</code>; otherwise it is required. If a parameter
     is optional, then all subsequent parameters in the list must also be optional. In other words, the parameter list includes
     zero or more required parameters followed by zero or more optional parameters.</p>
@@ -1441,29 +1480,122 @@ declare context item as element(env:Envelope) external;</eg>
     where <var>M</var> is the number of required parameters, and <var>N</var> is the total number of parameters (whether required or optional).
     This is refered to as the <termref def="dt-arity-range"/> of the <termref def="dt-function-definition"/>.</p>
     
-    <p>The properties of the <termref def="dt-function-definition"/> <var>F</var> are derived from the syntax of the
-    function declaration as follows:</p>
-    
-    <ulist>
-      <item><p>The name of <var>F</var> is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
-      that follows the keyword <code>function</code>.</p></item>
-      <item><p>The parameters of <var>F</var> are derived from the <code>ParamWithDefault</code> entries in the
-      <code>ParamListWithDefaults</code>:</p>
+    <p>The static context may include more than one declared function with the same name, but their arity ranges must not overlap 
+      <errorref class="ST" code="0034"/>.</p>
+      
+      <p>If a function parameter is declared using a name but no type, its default type is
+        <code>item()*</code>. If the result type is omitted from a function declaration, its default
+        result type is <code>item()*</code>.</p>
+      
+      <p diff="add" at="2022-11-01">The function body defines the implementation of the <termref def="dt-function-definition"/>. 
+        The rules for static function calls (see <specref ref="id-eval-static-function-call"/>)
+        ensure that a value is available for each parameter, whether required or optional.
+      </p>
+      <p>The parameters of a function declaration are considered to be variables whose scope is the
+        function body. It is an <termref def="dt-static-error">static error</termref>
+        <errorref class="ST" code="0039"/> for a function declaration to have more than one parameter
+        with the same name. The type of a function parameter can be any type that can be expressed as
+        a <termref def="dt-sequence-type">sequence type</termref>.</p>
+      
+      <p diff="add" at="2023-02-27">When a default value is supplied for a function parameter (using the syntax <code>:= ExprSingle</code>),
+      the static and dynamic context for evaluating the <code>ExprSingle</code> are the same as the static
+      and dynamic context for evaluating the <termref def="dt-initializing-expression"/> of a 
+        <termref def="dt-variable-declaration"/>, with one addition, a zero-arity function named <code>fn:caller-context</code>,
+      defined as follows:</p>
+      
+      <ulist>
+        <item><p>The name of the function has local part <code>caller-context</code> and namespace
+        <code>http://www.w3.org/2005/xpath-functions</code>.</p></item>
+        <item><p>The type of the function is:</p>
+        <eg>function() as record(
+   context-item? as (function() as item()), 
+   position? as (function() as xs:integer), 
+   last? as (function() as xs:integer),
+   default-collation? as (function() as xs:anyURI),
+   *)</eg></item>
+        <item><p>The function provides access to information about the static and dynamic context of the function
+        call or function reference that caused the function to be invoked. Specifically:</p>
         <ulist>
-          <item><p>The parameter name is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
-          that follows the <code>$</code> symbol.</p></item>
-          <item><p>The required type of the parameter is given by the <code>TypeDeclaration</code>, defaulting to <code>item()*</code>.</p></item>
-          <item><p>The default value of the parameter is given by the expression that follows the <code>:=</code> symbol; if there
-          is no default value, then the parameter is a required parameter.</p></item>
+          <item><p><code>$fn:caller-context()?context-item()</code> provides the context item of the caller.</p></item>
+          <item><p><code>$fn:caller-context()?position()</code> provides the context position of the caller.</p></item>
+          <item><p><code>$fn:caller-context()?last()</code> provides the context size of the caller.</p></item>
+          <item><p><code>$fn:caller-context()?default-collation()</code> provides the default collation of the caller.</p></item>
         </ulist>
-      </item>
-      <item><p>The return type of the function is given by the final <code>TypeDeclaration</code> that follows the <code>ParamListWithDefaults</code>
-        if present, defaulting to <code>item()*</code>.</p></item>
-      <item><p>The function annotations are derived from the annotations that follow the <code>%</code> symbol, if present.</p></item>
-      <item><p>The implementation of the function is given by the enclosed expression.</p></item>
-    </ulist>
+          <p>Note that if any of these values is absent, an attempt to retrieve the value will return an empty sequence.</p>
+        </item>
+
+      </ulist>
+      
+      <p>So, for example, a parameter whose default value is the context item of the caller can be declared as
+      <code>$input as item() := $fn:caller-context()?context-item()</code>.</p>
+      
+     <!-- <note diff="add" at="2023-02-27"><p>The initializing expression thus has a fixed value, which does not depend in any way on
+      the static or dynamic context of the caller. It is not possible to replicated the convention used
+      for built-in functions, whereby the default value of a parameter may be taken from the context
+      item or default collation of the caller.</p></note>-->
+      
+ 
+    </div3>
+    <div3 id="id-function-properties">
+      <head>Function Properties</head>
     
-    <p>The static context may include more than one declared function with the same name, but their arity ranges must not overlap <errorref class="ST" code="0034"/>.</p>
+      <p>The properties of the <termref def="dt-function-definition"/> <var>F</var> are derived from the syntax of the
+      function declaration as follows:</p>
+      
+      <ulist>
+        <item><p>The name of <var>F</var> is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
+        that follows the keyword <code>function</code>.</p></item>
+        <item><p>The parameters of <var>F</var> are derived from the <code>ParamWithDefault</code> entries in the
+        <code>ParamListWithDefaults</code>:</p>
+          <ulist>
+            <item><p>The parameter name is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
+            that follows the <code>$</code> symbol.</p></item>
+            <item><p>The required type of the parameter is given by the <code>TypeDeclaration</code>, defaulting to <code>item()*</code>.</p></item>
+            <item><p>The default value of the parameter is given by the expression that follows the <code>:=</code> symbol; if there
+            is no default value, then the parameter is a required parameter.</p></item>
+          </ulist>
+        </item>
+        <item><p>The return type of the function is given by the final <code>TypeDeclaration</code> that follows the <code>ParamListWithDefaults</code>
+          if present, defaulting to <code>item()*</code>.</p></item>
+        <item><p>The function annotations are derived from the annotations that follow the <code>%</code> symbol, if present.</p></item>
+        <item><p>The implementation of the function is given by the enclosed expression.</p></item>
+      </ulist>
+      
+    </div3>
+    <div3 id="id-function-annotations">
+      <head>Function Annotations</head>
+      
+      <p>A function declaration may use the <code>%private</code> or <code>%public</code> annotations
+        to specify that a function is public or private; if neither of these annotations is used, the
+        function is public. <termdef id="dt-private-function" term="private function">A <term>private
+          function</term> is a function with a <code>%private</code> annotation. A private function
+          is hidden from <termref def="dt-module-import">module import</termref>, which can not import
+          it into the <termref def="dt-statically-known-function-definitions"/> of another module. </termdef>
+        <termdef id="dt-public-function" term="public function">A <term>public function</term> is a
+          function without a <code>%private</code> annotation. A public function is accessible to
+          <termref def="dt-module-import">module import</termref>, which can import it into the
+          <termref def="dt-statically-known-function-definitions"/> of
+          another module. </termdef> Using <code>%public</code> and <code>%private</code> annotations
+        in a main module is not an error, but it does not affect module imports, since a main module
+        cannot be imported. It is a <termref def="dt-static-error">static error</termref>
+        <errorref class="ST" code="0106"/> if a function declaration contains both a
+        <code>%private</code> and a <code>%public</code> annotation, more than one
+        <code>%private</code> annotation, or more than one <code>%public</code> annotation. </p>
+      
+      <p>An implementation can define annotations, in its own namespace, to support functionality
+        beyond the scope of this specification. For instance, an implementation that supports external
+        Java functions might use an annotation to associate a Java function with an XQuery external
+        function:</p>
+      
+      <eg role="frag-prolog-parse-test">declare 
+        %java:method("java.lang.StrictMath.copySign") 
+        function smath:copySign($magnitude, $sign) 
+        external;</eg>
+      
+      
+    </div3>
+    <div3 id="id-external-functions">
+      <head>External Functions</head>
 
     <p>
       In function declarations, <termref def="dt-external-function">external functions</termref> are identified by the keyword
@@ -1471,27 +1603,8 @@ declare context item as element(env:Envelope) external;</eg>
       declare the datatypes of the function parameters and result, for use in type checking of the
       query that contains or imports the function declaration.</p>
 
-    <p>In addition to <termref def="dt-udf">user-defined functions</termref>
-    and <termref def="dt-external-function">external functions</termref>, &language; allows anonymous
-    functions to be declared in the body of a query using <termref def="dt-inline-func">inline function expressions</termref>.</p>
-
-    <p>A function declaration may use the <code>%private</code> or <code>%public</code> annotations
-      to specify that a function is public or private; if neither of these annotations is used, the
-      function is public. <termdef id="dt-private-function" term="private function">A <term>private
-          function</term> is a function with a <code>%private</code> annotation. A private function
-        is hidden from <termref def="dt-module-import">module import</termref>, which can not import
-        it into the <termref def="dt-statically-known-function-definitions"/> of another module. </termdef>
-      <termdef id="dt-public-function" term="public function">A <term>public function</term> is a
-        function without a <code>%private</code> annotation. A public function is accessible to
-          <termref def="dt-module-import">module import</termref>, which can import it into the
-        <termref def="dt-statically-known-function-definitions"/> of
-        another module. </termdef> Using <code>%public</code> and <code>%private</code> annotations
-      in a main module is not an error, but it does not affect module imports, since a main module
-      cannot be imported. It is a <termref def="dt-static-error">static error</termref>
-      <errorref class="ST" code="0106"/> if a function declaration contains both a
-        <code>%private</code> and a <code>%public</code> annotation, more than one
-        <code>%private</code> annotation, or more than one <code>%public</code> annotation. </p>
-
+ 
+    
     <p>An XQuery implementation may provide a facility whereby external functions can be implemented, 
       but it is not required to do so. If such a facility is
       provided, the protocols by which parameters are passed to an external function, and the result
@@ -1504,16 +1617,11 @@ declare context item as element(env:Envelope) external;</eg>
       These additional types, if defined, are considered to be derived by restriction from
         <code>xs:anyAtomicType</code>.</p>
 
-    <p>An implementation can define annotations, in its own namespace, to support functionality
-      beyond the scope of this specification. For instance, an implementation that supports external
-      Java functions might use an annotation to associate a Java function with an XQuery external
-      function:</p>
+    </div3>
+    <div3 id="id-function-namespaces">
+      <head>Function Namespaces</head>
 
-    <eg role="frag-prolog-parse-test">declare 
-   %java:method("java.lang.StrictMath.copySign") 
-   function smath:copySign($magnitude, $sign) 
-   external;</eg>
-
+    
     <p>Every declared function must be in a namespace; that is, every declared function name must
       (when expanded) have a non-null namespace URI <errorref class="ST" code="0060"/>. If the
       function name in a function declaration has no namespace prefix, it is considered to be in the
@@ -1568,69 +1676,11 @@ declare context item as element(env:Envelope) external;</eg>
       namespace <code>http://www.w3.org/2005/xquery-local-functions</code>. It is suggested (but not
       required) that this namespace be used for defining local functions.</p>
 
-    <p>If a function parameter is declared using a name but no type, its default type is
-        <code>item()*</code>. If the result type is omitted from a function declaration, its default
-      result type is <code>item()*</code>.</p>
-    
-    <p diff="add" at="variadicity">The function body defines the implementation of the <termref def="dt-function-definition"/>. 
-      The rules for static function calls (see <specref ref="id-eval-static-function-call"/>)
-    ensure that a value is available for each parameter, whether required or optional.
-    </p>
-    <p>The parameters of a function declaration are considered to be variables whose scope is the
-      function body. It is an <termref def="dt-static-error">static error</termref>
-      <errorref class="ST" code="0039"/> for a function declaration to have more than one parameter
-      with the same name. The type of a function parameter can be any type that can be expressed as
-      a <termref def="dt-sequence-type">sequence type</termref>.</p>
+  
+    </div3>
+    <div3 id="id-function-declaration-examples">
+      <head>Examples of Function Declarations</head>
 
-    <!--<p diff="chg" at="variadicity"> A <code>FunctionDecl</code> thus defines a <termref def="dt-function-definition"/> 
-      with the following properties: </p>
-    <ulist>
-      <item diff="add" at="variadicity">
-        <p>There is one function for each arity <var>A</var> within the <term>arity range</term> of 
-          the <termref def="dt-function-definition"/>. The properties of the function with arity <var>A</var>
-        are given below.</p>
-      </item>
-      <item>
-        <p>
-          <term>name</term>: The <code>EQName</code> of the <code>FunctionDecl</code>, expanded (if
-          necessary) using the <termref def="dt-static-namespaces">statically known
-            namespaces</termref> and the <term diff="chg" at="A">default function
-            namespace</term> of the module's static context. </p>
-      </item>
-
-      <item>
-        <p>
-          <term>parameter names</term>: The <code>EQName</code>s of the first <var>A</var> parameters in the <code>ParamListWithDefaults</code>,
-          expanded (if necessary) using the <termref def="dt-static-namespaces">statically known
-            namespaces</termref> of the module's static context. </p>
-      </item>
-
-      <item>
-        <p>
-          <term>signature</term>: A <code>FunctionTest</code> built from the
-            <code>SequenceType</code>s (explicit or implicit) in the <code>FunctionDecl</code> and
-          of the first <var>A</var> parameters in its <code>ParamListWithDefaults</code>, and from any <code>Annotation</code>s preceding the
-            <code>FunctionDecl</code>. </p>
-      </item>
-
-      <item>
-        <p>
-          <term>implementation</term>: If the function is declared external, this property is
-          implementation-dependent. Otherwise, this property is the <code>FunctionDecl</code>'s
-            <code>FunctionBody</code>. </p>
-      </item>
-
-      <item>
-        <p>
-          <term>nonlocal variable bindings</term>: Empty. </p>
-      </item>
-
-    </ulist>-->
-    
-    <!--<p diff="add" at="variadicity">[TODO: The above doesn't formally capture the fact that for those functions below the maximum arity,
-      i.e. functions called with one or more optional arguments omitted, the semantics are to execute the function
-      body with additional variable bindings in scope, representing the omitted arguments with their default values.]</p>
--->
     <p>The following example illustrates the declaration and use of a local function that accepts a
       sequence of <code>employee</code> elements, summarizes them by department, and returns a
       sequence of <code>dept</code> elements.</p>
@@ -1681,10 +1731,26 @@ local:depth(fn:doc("partlist.xml"))
 
     <!-- ============================================================ -->
 
-<p diff="add" at="variadicity">[TODO: add an example of a function with an optional parameter.]</p>
+<p diff="add" at="2023-02-27">The following example declares a function whose second argument
+defaults to an empty map:</p>
+      
+      <eg>declare function local:paraphrase (
+    $input as xs:string,
+    $options as map(*) := map{}) as xs:string {...}   
+        
+      </eg>
+      
+      <p diff="add" at="2023-02-27">The following example declares a function whose first argument
+        defaults to the context item of the caller:</p>
+      
+      <eg>declare function local:count-element-children (
+    $input as node() := fn:caller-context()?context-item()) as xs:integer {
+       count($input/*)   
+}  </eg> 
 
     <!-- ============================================================ -->
 
+    </div3>
   </div2>
   
   <div2 id="id-item-type-declaration" diff="add" at="A">

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -644,7 +644,7 @@
    <fos:function name="copy-of">
       <fos:signatures>
          <fos:proto name="copy-of" return-type="item()*">
-            <fos:arg name="input" type="item()*" default="." usage="absorption"/>
+            <fos:arg name="input" type="item()*" default="$context?item()" usage="absorption"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -735,7 +735,7 @@
    <fos:function name="snapshot">
       <fos:signatures>
          <fos:proto name="snapshot" return-type="item()*">
-            <fos:arg name="input" type="item()*" default="." usage="absorption"/>
+            <fos:arg name="input" type="item()*" default="$context?item()" usage="absorption"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -1059,7 +1059,7 @@
       <fos:signatures>
          <fos:proto name="unparsed-entity-uri" return-type="xs:anyURI">
             <fos:arg name="entity-name" type="xs:string" usage="absorption"/>
-            <fos:arg name="doc" type="node()" usage="inspection" default="."/>
+            <fos:arg name="doc" type="node()" usage="inspection" default="$context?item()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1123,7 +1123,7 @@
       <fos:signatures>
          <fos:proto name="unparsed-entity-public-id" return-type="xs:string">
             <fos:arg name="entity-name" type="xs:string" usage="absorption"/>
-            <fos:arg name="doc" type="node()" usage="inspection" default="."/>
+            <fos:arg name="doc" type="node()" usage="inspection" default="$context?item()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1186,7 +1186,7 @@
          <fos:proto name="key" return-type="node()*">
             <fos:arg name="key-name" type="union(xs:string, xs:QName)"/>
             <fos:arg name="key-value" type="xs:anyAtomicType*"/>
-            <fos:arg name="top" type="node()" default="/" usage="navigation"/>
+            <fos:arg name="top" type="node()" default="root($context?item()) treat as document-node()" usage="navigation"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -16190,48 +16190,126 @@ and <code>version="1.0"</code> otherwise.</p>
                         <code>yes</code>.</termdef> If a parameter is explicitly mandatory, then the
                      <elcode>xsl:param</elcode> element <rfc2119>must</rfc2119> be empty and
                      <rfc2119>must not</rfc2119> have a <code>select</code> attribute.</p>
-
-               <p diff="add" at="2022-01-01">The static context for evaluating the default value depends on where the
-               relevant expression appears in the stylesheet, in the usual way. Note however that
-               for <elcode>xsl:param</elcode> elements defining <termref def="dt-function-parameter">function parameters</termref>,
-                  the static context does not include variables bound in preceding-sibling <elcode>xsl:param</elcode> elements.</p>
                
-               <p diff="add" at="2022-01-01">The dynamic context is different for different kinds of parameter:</p>
-               
-               <ulist diff="add" at="2022-01-01">
-                  <item><p>For <termref def="dt-stylesheet-parameter">stylesheet parameters</termref>, the 
-                  context is the same as the context for evaluating global variables.</p></item>
-                  <item><p>For <termref def="dt-template-parameter">template parameters</termref>, the 
-                     context is that of the called template. This means that the evaluation of the
-                  default has access to the other parameters supplied in the call, provided they are declared
-                  earlier. It also means, for example, that if the evaluation of the default value invokes
-                  <elcode>xsl:next-match</elcode>, the <termref def="dt-current-template-rule"/> is the called
-                  template rather than the calling template.</p></item>
-                  <item><p>For <termref def="dt-function-parameter">function parameters</termref>, the dynamic
-                     context for evaluating defaults is the dynamic context of the caller, except that no
-                     local variables are in scope. This means that it is possible to declare a parameter
-                     with <code>&lt;xsl:param name="dot" required="no" select="."/></code> to take its
-                     default value from the context item of the caller.
-                     
-              </p>
-                  
-                  </item>
-               </ulist>
-
                <p>If a parameter is not <termref def="dt-explicitly-mandatory"/>, then it may have a
                   default value. The default value is obtained by evaluating the <termref def="dt-expression">expression</termref> given in the <code>select</code>
                   attribute or the contained <termref def="dt-sequence-constructor">sequence
                      constructor</termref>, as described in <specref ref="variable-values"/>.</p>
+               
 
-               <note>
+               <p diff="add" at="2023-03-10">The context for evaluating the default value depends on where the
+               relevant <elcode>xsl:param</elcode> element appears in the stylesheet:</p>
+               
+               <ulist diff="add" at="2023-03-10">
+                  <item><p>For a <termref def="dt-stylesheet-parameter"/>, the rules are the same as for the 
+                     initializing expression of a <termref def="dt-global-variable"/>. In particular, the default value
+                     expression may depend on the values of other global variables and stylesheet parameters, subject
+                     to the rules for handling <termref def="dt-circularity">circularities</termref>; there
+                     are further constraints in the case of <termref def="dt-static-parameter">static parameters</termref>.
+                  </p></item>
+                  <item><p>For a <termref def="dt-template-parameter"/>, the context is determined using the same rules
+                     as for instructions appearing within the template body. This means, for example:</p>
+                     <ulist>
+                        <item><p>The <code>select</code> expression for a template parameter can use "<code>.</code>"
+                        to refer to the context item of the calling template.</p></item>
+                        <item><p>The <code>select</code> expression for a template parameter can refer to the values
+                           of parameters declared in a preceding sibling <elcode>xsl:param</elcode> element.</p></item>
+                        <item><p>If the evaluation of the default value for a template parameter invokes
+                           <elcode>xsl:next-match</elcode>, the <termref def="dt-current-template-rule"/> is the called
+                           template rather than the calling template.</p>
+                        </item>
+                     </ulist>
+                  </item>
+                  <item>
+                     <p>For an optional <termref def="dt-function-parameter"/>, the static and dynamic context for evaluating
+                     the default value are the same as the static and dynamic context for the initializing expression of
+                     a <termref def="dt-global-variable"/>, with one addition: a variable named <code>context</code>,
+                     which provides access to information about the context of the function call (or function reference)
+                     that causes the default value to be evaluated.</p>
+                     
+                     <p diff="add" at="2023-03-10">More specifically:</p>
+                     
+                     <ulist diff="add" at="2023-03-10">
+                        <item><p>The <xtermref spec="XP40" ref="dt-in-scope-variables"/> component of the static context is augmented
+                           with a variable whose name is <code>context</code> (in no namespace) and whose type is:</p>
+                           <eg>record(
+   item as (function() as item()),
+   default-collation as (function() as xs:anyURI),
+   *)
+                           </eg>
+                           <ednote><edtext>I decided, after we reviewed this, to make the fields functions rather than simple values
+                              because it is easier to reproduce the behavior of core functions where a dynamic error is raised
+                              if the context item in the caller is absent.</edtext></ednote>
+                        </item>
+                        <item><p>The <xtermref spec="XP40" ref="dt-variable-values"/> component of the dynamic context is augmented
+                           with a value for this variable. The value is map, whose entries are as follows:</p>
+                           <table class="data">
+                              <thead>
+                                 <tr>
+                                    <th>key</th>
+                                    <th>value</th>
+                                 </tr>
+                              </thead>
+                              <tbody>
+                                 <tr>
+                                    <td><p>item</p></td>
+                                    <td><p>A zero-arity function that returns the <termref def="dt-context-item"/> 
+                                       from the dynamic context of the caller; if this is absent,
+                                       the function raises a dynamic error <errorref class="DY" code="0002"/>.</p>
+                                       <note><p>Using a context item expression (<code>.</code>) in the default
+                                          value expression is interpreted as a reference to the <termref def="dt-global-context-item"/>
+                                          which is not the same thing, and is probably a mistake.</p></note></td>
+                                 </tr>
+                                 <tr>
+                                    <td><p>default&#x2011;collation</p></td>
+                                    <td><p>A zero-arity function that returns the <termref def="dt-default-collation"/>
+                                       from the static context of the caller.</p></td>
+                                 </tr>
+                              </tbody>
+                           </table>
+                           
+                        </item>
+                        
+                     </ulist>
+                     
+                     <p diff="add" at="2023-03-10">So, for example, a parameter whose default value is the context item of the caller can be declared as
+                        <code>&lt;xsl:param name="input" as="item()" select="$context?item()"/></code>.</p>
+                     
+                     <note diff="add" at="2023-03-10"><p>This capability allows user-defined functions to mimic the behavior of 
+                        those core functions that take default argument values from the caller's static or dynamic context. It is not designed to 
+                        enable all core functions to be implemented in XSLT. For example (a) it does not provide access
+                        to all parts of the caller's context, such as the caller's in-scope namespaces or static base URI, 
+                        and (b) it allows access to context information only in an expression used to compute default values 
+                        of parameters, not in the body of the function implementation.</p></note>
+                     
+                     <note diff="add" at="2023-03-10"><p>Unlike template parameters, the default value expression for a 
+                        function parameter does not have access to the values of the other parameters of the function.</p></note>
+                     
+                     <note diff="add" at="2023-03-10"><p>If the default value expression for a function parameter
+                        uses a context item expression (<code>.</code>), this is a reference to the <termref def="dt-global-context-item"/>
+                        of the stylesheet, not to the context item of the function's caller.</p></note>
+                     
+                     <ednote diff="add" at="2023-03-10"><edtext>The mechanism is extensible, we could easily add more entries to the map. However,
+                        providing these two is sufficient for all functions in the core library that have context-dependent default arguments.</edtext></ednote>
+                     
+                  </item>
+                  <item>
+                     <p>The rules for an <elcode>xsl:param</elcode> element appearing as a child of <elcode>xsl:iterate</elcode>
+                     are given in <specref ref="iterate"/>.</p>
+                  </item>
+               </ulist>
+              
+
+               
+               <note diff="chg" at="2023-03-10">
                   <p>This specification does not dictate whether and when the default value of a
                      parameter is evaluated. For example, if the default is specified as
                         <code>&lt;xsl:param name="p"&gt;&lt;foo/&gt;&lt;/xsl:param&gt;</code>, then
                      it is not specified whether a distinct <code>foo</code> element node will be
-                     created on each invocation of the template, or whether the same
-                        <code>foo</code> element node will be used for each invocation. However, it
-                     is permissible for the default value to depend on the values of other
-                     parameters, or on the evaluation context, in which case the default must
+                     created on each invocation, or whether the same
+                        <code>foo</code> element node will be used for each invocation. However, in cases
+                     where the default value depends on the caller's dynamic context, or on the values of other
+                     parameters, the default must
                      effectively be evaluated on each invocation.</p>
                   
  
@@ -18534,7 +18612,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         the extension function is more efficient.</p>
                      <p>The <code>override-extension-function</code> attribute does <emph>not</emph>
                         affect the rules for deciding which of several <termref def="dt-stylesheet-function">stylesheet functions</termref> with the same
-                        name and <termref def="dt-arity">arity</termref> takes precedence.</p>
+                        name and arity takes precedence.</p>
                   </note>
                   <p>The <code>override</code> attribute is a <termref def="dt-deprecated"/> synonym of <code>override-extension-function</code>,
                      retained for compatibility with XSLT 2.0. If both attributes are present then they


### PR DESCRIPTION
This is an attempt to resolve issue #256 by providing details of the static and dynamic context for evaluating default parameter values, including providing a mechanism for accessing parts of the static and dynamic context of the caller.

If this PR is accepted we will need to follow up with (a) similar changes to XSLT, and (b) use of the new notation in the signatures of standard functions and operators that have context-dependent default values for parameters.

Note that the PR also breaks up the rather unwieldy sections for Function Declarations and Variable Declarations into more manageable subsections, which has involved some re-ordering; some of the change marking may therefore be spurious.