### PR TITLE
Update the localName and unparsed entity reference notes for parse-html

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6934,7 +6934,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   is an empty sequence.</p>
 
                <note>
-                  <p>The <bibref ref="html5"/> specification does not include unparsed entity references.
+                  <p>The <bibref ref="html5"/> specification does not include unknown entity references.
                      Section 13.2.5.73, <emph>Named character reference state</emph> reports an
                      <code>unknown-named-character-reference</code> error for these and places the
                      literal text of the entity reference in the content stream.</p>
@@ -6951,7 +6951,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   is an empty sequence.</p>
 
                <note>
-                  <p>The <bibref ref="html5"/> specification does not include unparsed entity references.
+                  <p>The <bibref ref="html5"/> specification does not include unknown entity references.
                      Section 13.2.5.73, <emph>Named character reference state</emph> reports an
                      <code>unknown-named-character-reference</code> error for these and places the
                      literal text of the entity reference in the content stream.</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6150,7 +6150,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                </note>
 
                <note>
-                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                  <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
                      <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
                      ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                </note>
@@ -6438,7 +6438,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   </note>
 
                   <note>
-                     <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                     <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
                         <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
                         ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                   </note>
@@ -6509,7 +6509,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                </note>
 
                <note>
-                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                  <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
                      <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
                      ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                </note>
@@ -6647,7 +6647,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                </note>
 
                <note>
-                  <p>The <code>Element.localName</code> property must be ASCII lowercase. The
+                  <p>The <code>Element.localName</code> property will be ASCII lowercase. The
                      <bibref ref="html5"/> section 13.2.5.8, <emph>Tag name state</emph> specifies that
                      ASCII upper alpha characters are appended to the attribute's name in lowercase.
                      This is used when processing the <emph>Tag open state</emph> and
@@ -6662,7 +6662,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                </note>
 
                <note>
-                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                  <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
                      <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
                      ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                </note>
@@ -6858,7 +6858,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                </note>
 
                <note>
-                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                  <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
                      <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
                      ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                </note>
@@ -6920,7 +6920,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                </note>
 
                <note>
-                  <p>The <code>Attr.localName</code> property must be ASCII lowercase. The
+                  <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
                      <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
                      ASCII upper alpha characters are appended to the attribute's name in lowercase.</p>
                </note>


### PR DESCRIPTION
This PR applies the following changes:
- [x] QT4CG-021-03: RD to change must to will in DOM notes about lowercase
- [x] QT4CG-021-04: RD to revise and move the note about unrecognized entities