### PR TITLE
Removed CDATA sections around markup

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -10842,10 +10842,10 @@ let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
             <p>Assuming <code>$in</code> is an element with no children:</p>
-            <eg><![CDATA[
+            <eg>
                let $break := &lt;br/&gt;
                return fn:empty($break)
-            ]]></eg>
+            </eg>
             <p>The result is <code>false()</code>.</p>
          </fos:example>
       </fos:examples>
@@ -10901,10 +10901,10 @@ let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
             <p>Assuming <code>$in</code> is an element with no children:</p>
-            <eg><![CDATA[
+            <eg>
                let $break := &lt;br/>
                return fn:exists($break)
-            ]]></eg>
+            </eg>
             <p>The result is <code>true()</code>.</p>
          </fos:example>
       </fos:examples>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11415,11 +11415,11 @@ Well, 6000 dollars, after taxes.]]></eg>
             
             <p>This is the output of the above function :</p>
             
-            <eg><![CDATA[&lt;div&gt;
+            <eg>&lt;div&gt;
   &lt;h1&gt;Hello Chris&lt;/h1&gt;
   &lt;p&gt;You have just won 10000 dollars!&lt;/p&gt;
   &lt;p&gt;Well, 6000 dollars, after taxes.&lt;/p&gt; 
-&lt;/div&gt;]]></eg>
+&lt;/div&gt;</eg>
             
             <p>This function creates a similar string in JSON syntax.</p>
             
@@ -11606,9 +11606,9 @@ is raised <errorref class="TY" code="0004"/>.</p>
                <item role="xquery">
                   <p>The following comparisons are true because, in each case, the two constructed nodes have the same value after atomization, even though they have different identities and/or names:</p>
                   <eg role="parse-test"
-                     ><![CDATA[&lt;a&gt;5&lt;/a&gt; eq &lt;a&gt;5&lt;/a&gt;]]></eg>
+                     >&lt;a&gt;5&lt;/a&gt; eq &lt;a&gt;5&lt;/a&gt;</eg>
                   <eg role="parse-test"
-                     ><![CDATA[&lt;a&gt;5&lt;/a&gt; eq &lt;b&gt;5&lt;/b&gt;]]></eg>
+                     >&lt;a&gt;5&lt;/a&gt; eq &lt;b&gt;5&lt;/b&gt;</eg>
                </item>
 
                <item>
@@ -11893,7 +11893,7 @@ evaluate to exactly the same single node:</p>
                <item role="xquery">
                   <p>The following comparison is false because each constructed node has its own identity:</p>
                   <eg role="parse-test"
-                     ><![CDATA[&lt;a&gt;5&lt;/a&gt; is &lt;a&gt;5&lt;/a&gt;]]></eg>
+                     >&lt;a&gt;5&lt;/a&gt; is &lt;a&gt;5&lt;/a&gt;</eg>
                </item>
 
 
@@ -11901,7 +11901,7 @@ evaluate to exactly the same single node:</p>
                   <p>The following comparison is true only if the node identified by the left
 side occurs before the node identified by the right side in document order:</p>
                   <eg role="parse-test"
-                     ><![CDATA[/transactions/purchase[parcel="28-451"] &lt;&lt; /transactions/sale[parcel="33-870"]]]></eg>
+                     >/transactions/purchase[parcel="28-451"] &lt;&lt; /transactions/sale[parcel="33-870"]</eg>
                </item>
             </ulist>
          </div3>
@@ -12345,32 +12345,32 @@ character (that is, the pair "<code>{{</code>" represents the
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;shoe size="7"/&gt;]]></eg>
+                     <eg role="parse-test">&lt;shoe size="7"/&gt;</eg>
                      <p>The string value of the <code>size</code> attribute is "<code>7</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;shoe size="{7}"/&gt;]]></eg>
+                     <eg role="parse-test">&lt;shoe size="{7}"/&gt;</eg>
                      <p>The string value of the <code>size</code> attribute is "<code>7</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;shoe size="{()}"/&gt;]]></eg>
+                     <eg role="parse-test">&lt;shoe size="{()}"/&gt;</eg>
                      <p>The string value of the <code>size</code> attribute is the zero-length string.</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;chapter ref="[{1, 5 to 7, 9}]"/&gt;]]></eg>
+                     <eg role="parse-test">&lt;chapter ref="[{1, 5 to 7, 9}]"/&gt;</eg>
                      <p>The string value of the <code>ref</code> attribute is "<code>[1 5 6 7 9]</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test"
-                        ><![CDATA[&lt;shoe size="As big as {$hat/@size}"/&gt;]]></eg>
+                        >&lt;shoe size="As big as {$hat/@size}"/&gt;</eg>
                      <p>The string value of the <code>size</code> attribute is the
 string "<code>As big as </code>", concatenated with the string value of the
 node denoted by the expression
@@ -12948,45 +12948,45 @@ raised <errorref class="TY"
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;a&gt;{1}&lt;/a&gt;]]></eg>
+                     <eg role="parse-test">&lt;a&gt;{1}&lt;/a&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value "<code>1</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;a&gt;{1, 2, 3}&lt;/a&gt;]]></eg>
+                     <eg role="parse-test">&lt;a&gt;{1, 2, 3}&lt;/a&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value "<code>1 2 3</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;c&gt;{1}{2}{3}&lt;/c&gt;]]></eg>
+                     <eg role="parse-test">&lt;c&gt;{1}{2}{3}&lt;/c&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value "<code>123</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;b&gt;{1, "2", "3"}&lt;/b&gt;]]></eg>
+                     <eg role="parse-test">&lt;b&gt;{1, "2", "3"}&lt;/b&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value "<code>1 2 3</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;fact&gt;I saw 8 cats.&lt;/fact&gt;]]></eg>
+                     <eg role="parse-test">&lt;fact&gt;I saw 8 cats.&lt;/fact&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value "<code>I saw 8 cats.</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test"
-                        ><![CDATA[&lt;fact&gt;I saw {5 + 3} cats.&lt;/fact&gt;]]></eg>
+                        >&lt;fact&gt;I saw {5 + 3} cats.&lt;/fact&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value "<code>I saw 8 cats.</code>".</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test"
-                        ><![CDATA[&lt;fact&gt;I saw &lt;howmany&gt;{5 + 3}&lt;/howmany&gt; cats.&lt;/fact&gt;]]></eg>
+                        >&lt;fact&gt;I saw &lt;howmany&gt;{5 + 3}&lt;/howmany&gt; cats.&lt;/fact&gt;</eg>
                      <p>The constructed element node has three children: a text node containing "<code>I saw </code> ", a child element node named <code>howmany</code>, and a text node containing "<code> cats.</code>". The child element node in turn has a single text node child containing the value "<code>8</code>".</p>
                   </item>
                </ulist>
@@ -13032,10 +13032,10 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;cat&gt;
+                     <eg role="parse-test">&lt;cat&gt;
    &lt;breed&gt;{$b}&lt;/breed&gt;
    &lt;color&gt;{$c}&lt;/color&gt;
-&lt;/cat&gt;]]></eg>
+&lt;/cat&gt;</eg>
                      <p>The constructed
    <code>cat</code> element node has two child element nodes named
    <code>breed</code> and <code>color</code>. Whitespace surrounding
@@ -13046,7 +13046,7 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;a&gt;  {"abc"}  &lt;/a&gt;]]></eg>
+                     <eg role="parse-test">&lt;a&gt;  {"abc"}  &lt;/a&gt;</eg>
                      <p>If
    boundary-space policy is <code>strip</code>, this example is equivalent to <code
                            role="parse-test"
@@ -13059,7 +13059,7 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;a&gt; z {"abc"}&lt;/a&gt;]]></eg>
+                     <eg role="parse-test">&lt;a&gt; z {"abc"}&lt;/a&gt;</eg>
                      <p>Since the
    whitespace surrounding the <code>z</code> is not boundary
    whitespace, it is always preserved. This example is equivalent to
@@ -13069,7 +13069,7 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;a&gt;&amp;#x20;{"abc"}&lt;/a&gt;]]></eg>
+                     <eg role="parse-test">&lt;a&gt;&amp;#x20;{"abc"}&lt;/a&gt;</eg>
                      <p>This
    example is equivalent to <code role="parse-test"
                            >&lt;a&gt;&nbsp;abc&lt;/a&gt;</code>, regardless
@@ -13080,7 +13080,7 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test"><![CDATA[&lt;a&gt;{"  "}&lt;/a&gt;]]></eg>
+                     <eg role="parse-test">&lt;a&gt;{"  "}&lt;/a&gt;</eg>
                      <p>This example constructs an element containing two space characters,
    regardless of the boundary-space policy, because whitespace inside an enclosed expression is never considered to be boundary whitespace.</p>
                   </item>
@@ -13088,7 +13088,7 @@ end of the content, or by a <nt
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test"
-                        ><![CDATA[&lt;a&gt;{ [ "one", "little", "fish" ] }&lt;/a&gt;]]></eg>
+                        >&lt;a&gt;{ [ "one", "little", "fish" ] }&lt;/a&gt;</eg>
                      <p>This example constructs an element containing the text <code>one little fish</code>, because the array is flattened, and the resulting sequence of atomic values is converted to a text node with a single blank between values.</p>
                   </item>
 
@@ -13122,7 +13122,7 @@ because it invalidates the document.-->
                   def="DirPIContents"
                   >DirPIContents</nt> of a processing instruction must not contain the string "<code>?&gt;</code>".</p>
             <p>The following example illustrates a direct processing instruction constructor:</p>
-            <eg role="parse-test"><![CDATA[&lt;?format role="output" ?&gt;]]></eg>
+            <eg role="parse-test">&lt;?format role="output" ?&gt;</eg>
             <p>A direct comment constructor creates a comment node whose  <code>content</code> property is <nt
                   def="DirCommentContents"
                >DirCommentContents</nt>. Its <code>parent</code> property is empty.</p>
@@ -13130,7 +13130,7 @@ because it invalidates the document.-->
                >DirCommentContents</nt> of a comment must not contain two consecutive hyphens or end with a hyphen. These rules are syntactically enforced by the grammar shown above.</p>
             <p>The following example illustrates a direct comment constructor:</p>
             <eg role="parse-test"
-               ><![CDATA[&lt;!-- Tags are ignored in the following section --&gt;]]></eg>
+               >&lt;!-- Tags are ignored in the following section --&gt;</eg>
             <note>
                <p>A direct comment constructor is different from a <nt def="Comment"
                      >comment</nt>, since a direct comment constructor actually constructs a comment node, whereas a <nt
@@ -13769,11 +13769,11 @@ attribute node.</p>
                   <item>
                      <p>Example:</p>
 
-                     <eg role="parse-test"><![CDATA[
+                     <eg role="parse-test">
 attribute
    { if ($sex = "M") then "husband" else "wife" }
    { &lt;a&gt;Hello&lt;/a&gt;, 1 to 3, &lt;b&gt;Goodbye&lt;/b&gt; }
-]]></eg>
+</eg>
 
                      <p>The name of the constructed attribute is
      either <code>husband</code> or
@@ -13802,12 +13802,12 @@ attribute
                <p>All document node constructors are computed constructors. The result of a document node constructor is a new document node, with its own node identity.</p>
                <p>A document node constructor is useful when the result of a query is to be a document in its own right. The following example illustrates a query that returns an XML document containing a root element named <code>author-list</code>:</p>
 
-               <eg role="parse-test"><![CDATA[document
+               <eg role="parse-test">document
   {
       &lt;author-list&gt;
          {fn:doc("bib.xml")/bib/book/author}
       &lt;/author-list&gt;
-  }]]></eg>
+  }</eg>
 
                <p>The <termref def="dt-content-expression"
                      >content expression</termref> of a document node constructor is processed in exactly the same way as an enclosed expression in the content of a <termref
@@ -14009,7 +14009,7 @@ attribute
     $content := "beep"
 return processing-instruction {$target} {$content}]]></eg>
                <p>The processing instruction node constructed by this example might be serialized as follows:</p>
-               <eg><![CDATA[&lt;?audio-output beep?&gt;]]></eg>
+               <eg>&lt;?audio-output beep?&gt;</eg>
             </div4>
 
             <div4 id="id-computed-comments">
@@ -14058,7 +14058,7 @@ return processing-instruction {$target} {$content}]]></eg>
                <eg role="parse-test"><![CDATA[let $homebase := "Houston"
 return comment {fn:concat($homebase, ", we have a problem.")}]]></eg>
                <p>The comment node constructed by this example might be serialized as follows:</p>
-               <eg><![CDATA[&lt;!--Houston, we have a problem.--&gt;]]></eg>
+               <eg>&lt;!--Houston, we have a problem.--&gt;</eg>
             </div4>
 
 
@@ -14367,12 +14367,12 @@ For instance, the following computed constructor raises an error because the ele
 
             <p>The following query illustrates the in-scope namespaces of a constructed element:</p>
 
-            <eg role="parse-test"><![CDATA[declare namespace p="http://example.com/ns/p";
+            <eg role="parse-test">declare namespace p="http://example.com/ns/p";
 declare namespace q="http://example.com/ns/q";
 declare namespace f="http://example.com/ns/f";
 
 &lt;p:a q:b="{f:func(2)}" xmlns:r="http://example.com/ns/r"/&gt;
-]]></eg>
+</eg>
             <p>The <termref def="dt-in-scope-namespaces"
                   >in-scope namespaces</termref> of the resulting <code>p:a</code> element consists of the following namespace bindings:</p>
             <ulist>
@@ -14415,14 +14415,14 @@ element because it is defined by a <termref
 
             <p>Note that the following constructed element, if nested within a <code>validate</code> expression, cannot be validated:
 </p>
-            <eg role="parse-test"><![CDATA[&lt;p xsi:type="xs:integer"&gt;3&lt;/p&gt;]]></eg>
+            <eg role="parse-test">&lt;p xsi:type="xs:integer"&gt;3&lt;/p&gt;</eg>
 
             <p>The constructed element will have namespace bindings for the prefixes <code>xsi</code> (because it is used in a name) and <code>xml</code> (because it is defined for every constructed element node). During validation of the constructed element, the validator will be unable to interpret the namespace prefix <code>xs</code> because it is has no namespace binding. Validation of this constructed element could be made possible by providing a <termref
                   def="dt-namespace-decl-attr"
                >namespace declaration attribute</termref>, as in the following example:</p>
 
-            <eg role="parse-test"><![CDATA[&lt;p xmlns:xs="http://www.w3.org/2001/XMLSchema"
-   xsi:type="xs:integer"&gt;3&lt;/p&gt;]]></eg>
+            <eg role="parse-test">&lt;p xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   xsi:type="xs:integer"&gt;3&lt;/p&gt;</eg>
          </div3>
       </div2>
 
@@ -15726,10 +15726,10 @@ return .($k)
                >XDM instance</termref>.</termdef> Each tuple stream is homogeneous in the sense that all its  tuples contain variables with the same names and the same <termref
                def="dt-static-type"
                >static types</termref>. The following example illustrates a tuple stream consisting of four tuples, each containing three variables named <code>$x</code>, <code>$y</code>, and <code>$z</code>:</p>
-         <eg><![CDATA[($x = 1003, $y = "Fred", $z = &lt;age&gt;21&lt;/age&gt;)
+         <eg>($x = 1003, $y = "Fred", $z = &lt;age&gt;21&lt;/age&gt;)
 ($x = 1017, $y = "Mary", $z = &lt;age&gt;35&lt;/age&gt;)
 ($x = 1020, $y = "Bill", $z = &lt;age&gt;18&lt;/age&gt;)
-($x = 1024, $y = "John", $z = &lt;age&gt;29&lt;/age&gt;)]]></eg>
+($x = 1024, $y = "John", $z = &lt;age&gt;29&lt;/age&gt;)</eg>
          <note>
             <p>In this section, tuple streams are represented as shown in the above example. Each tuple is on a separate line and is enclosed in parentheses, and the variable bindings inside each tuple are separated by commas. This notation does not represent XQuery syntax, but is simply a representation of a tuple stream for the purpose of defining the semantics of  FLWOR expressions.</p>
          </note>
@@ -16333,8 +16333,8 @@ Typically, the <nt
                   >WindowStartCondition</nt> might be used to start a new window for every item in the <termref
                   def="dt-binding-sequence"
                >binding sequence</termref> that is larger than both the previous item and the following item:</p>
-            <eg><![CDATA[start $s previous $sprev next $snext
-   when $s &gt; $sprev and $s &gt; $snext]]></eg>
+            <eg>start $s previous $sprev next $snext
+   when $s &gt; $sprev and $s &gt; $snext</eg>
             <p>The scoping rules for the variables bound by a <code>window</code> clause are as follows:</p>
             <ulist>
 
@@ -16592,7 +16592,7 @@ order in which their start items appear in the <termref
   <closing> <date>2008-01-06</date> <price>104</price> </closing>
 </stock>]]></eg>
                <p>A user wishes to find "run-ups," which are defined as sequences of dates that begin with a "low" and end with a "high" price (that is, the stock price begins to rise on the first day of the run-up, and continues to rise or remain even through the last day of the run-up.) The following query uses a tumbling window to find run-ups in the input data:</p>
-               <eg role="parse-test"><![CDATA[for tumbling window $w in //closing
+               <eg role="parse-test">for tumbling window $w in //closing
    start $first next $second when $first/price &lt; $second/price
    end $last next $beyond when $last/price &gt; $beyond/price
 return
@@ -16601,9 +16601,9 @@ return
       &lt;start-price&gt;{fn:data($first/price)}&lt;/start-price&gt;
       &lt;end-date&gt;{fn:data($last/date)}&lt;/end-date&gt;
       &lt;end-price&gt;{fn:data($last/price)}&lt;/end-price&gt;
-   &lt;/run-up&gt;]]></eg>
+   &lt;/run-up&gt;</eg>
                <p>For our sample input data, this <code>tumbling window</code> clause generates a tuple stream consisting of two tuples, each representing a window and containing five bound variables named <code>$w</code>, <code>$first</code>, <code>$second</code>, <code>$last</code>, and <code>$beyond</code>. The <code>return</code> clause is evaluated for each of these tuples, generating the following query result:</p>
-               <eg><![CDATA[&lt;run-up&gt;
+               <eg>&lt;run-up&gt;
    &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
    &lt;start-price&gt;101&lt;/start-price&gt;
    &lt;end-date&gt;2008-01-04&lt;/end-date&gt;
@@ -16614,7 +16614,7 @@ return
    &lt;start-price&gt;102&lt;/start-price&gt;
    &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
    &lt;end-price&gt;104&lt;/end-price&gt;
-&lt;/run-up&gt;]]></eg>
+&lt;/run-up&gt;</eg>
                <p>The following example illustrates a <code>window</code> clause that is an intermediate clause in a FLWOR expression. In this example, the input data contains closing stock prices for several different companies, each identified by a three-letter symbol. We assume the following input data (again assuming that the type of the <code>price</code> element is <code>xs:decimal</code>):</p>
                <eg><![CDATA[<stocks>
   <closing> <symbol>ABC</symbol> <date>2008-01-01</date> <price>105</price> </closing>
@@ -16631,7 +16631,7 @@ return
   <closing> <symbol>DEF</symbol> <date>2008-01-06</date> <price>059</price> </closing>
 </stocks>]]></eg>
                <p>As in the previous example, we want to find "run-ups," which are defined as sequences of dates that begin with a "low" and end with a "high" price for a specific company. In this example, however, the input data consists of stock prices for multiple companies. Therefore it is necessary to isolate the stock prices of each company before forming windows. This can be accomplished by an initial <code>for</code> and <code>let</code> clause, followed by a <code>window</code> clause, as follows:</p>
-               <eg role="parse-test"><![CDATA[for $symbol in fn:distinct-values(//symbol)
+               <eg role="parse-test">for $symbol in fn:distinct-values(//symbol)
 let $closings := //closing[symbol = $symbol]
 for tumbling window $w in $closings
    start $first next $second when $first/price &lt; $second/price
@@ -16642,7 +16642,7 @@ return
       &lt;start-price&gt;{fn:data($first/price)}&lt;/start-price&gt;
       &lt;end-date&gt;{fn:data($last/date)}&lt;/end-date&gt;
       &lt;end-price&gt;{fn:data($last/price)}&lt;/end-price&gt;
-   &lt;/run-up&gt;]]></eg>
+   &lt;/run-up&gt;</eg>
                <note>
                   <p>In the above example, the <code>for</code> and <code>let</code> clauses could be rewritten as follows:</p>
                   <eg><![CDATA[for $closings in //closing
@@ -16653,7 +16653,7 @@ group by $symbol]]></eg>
                </note>
                <p>The <code>for</code> and <code>let</code> clauses in this query generate an initial tuple stream consisting of two tuples. In the first tuple, <code>$symbol</code> is bound to "ABC" and <code>$closings</code> is bound to the sequence of <code>closing</code> elements for company ABC. In the second tuple, <code>$symbol</code> is bound to "DEF" and <code>$closings</code> is bound to the sequence of <code>closing</code> elements for company DEF.</p>
                <p>The <code>window</code> clause operates on this initial tuple stream, generating two windows for the first tuple and two windows for the second tuple. The result is a tuple stream consisting of four tuples, each with the following bound variables: <code>$symbol</code>, <code>$closings</code>, <code>$w</code>, <code>$first</code>, <code>$second</code>, <code>$last</code>, and <code>$beyond</code>. The <code>return</code> clause is then evaluated for each of these tuples, generating the following query result:</p>
-               <eg><![CDATA[&lt;run-up symbol="ABC"&gt;
+               <eg>&lt;run-up symbol="ABC"&gt;
    &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
    &lt;start-price&gt;101&lt;/start-price&gt;
    &lt;end-date&gt;2008-01-04&lt;/end-date&gt;
@@ -16676,7 +16676,7 @@ group by $symbol]]></eg>
    &lt;start-price&gt;052&lt;/start-price&gt;
    &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
    &lt;end-price&gt;059&lt;/end-price&gt;
-&lt;/run-up&gt;]]></eg>
+&lt;/run-up&gt;</eg>
             </div4>
          </div3>
 
@@ -16706,7 +16706,7 @@ where-expression is <code>true</code>, the tuple is retained in the output tuple
 ($a = 85, $b = 63)]]></eg>
                   <p>
                      <code>where</code> clause:</p>
-                  <eg><![CDATA[where $a &gt; $b]]></eg>
+                  <eg>where $a &gt; $b</eg>
                   <p>Output tuple stream:</p>
                   <eg><![CDATA[($a = 91, $b = 42)
 ($a = 85, $b = 63)]]></eg>
@@ -16778,16 +16778,16 @@ and the number of bound variables in each tuple is unchanged.</p>
 
                <item>
                   <p>This example illustrates how a counter might be used to filter the result of a query. The query ranks products in order by decreasing sales, and returns the three products with the highest sales. Assume that the variable <code>$products</code> is bound to a sequence of <code>product</code> elements, each of which has <code>name</code> and <code>sales</code> child-elements.</p>
-                  <eg role="parse-test"><![CDATA[for $p in $products
+                  <eg role="parse-test">for $p in $products
 order by $p/sales descending
 count $rank
 where $rank &lt;= 3
 return
    &lt;product rank="{$rank}"&gt;
       {$p/name, $p/sales}
-   &lt;/product&gt;]]></eg>
+   &lt;/product&gt;</eg>
                   <p>The result of this query has the following structure:</p>
-                  <eg><![CDATA[&lt;product rank="1"&gt;
+                  <eg>&lt;product rank="1"&gt;
    &lt;name&gt;Toaster&lt;/name&gt;
    &lt;sales&gt;968&lt;/sales&gt;
 &lt;/product&gt;
@@ -16798,7 +16798,7 @@ return
 &lt;product rank="3"&gt;
    &lt;name&gt;Can Opener&lt;/name&gt;
    &lt;sales&gt;475&lt;/sales&gt;
-&lt;/product&gt;]]></eg>
+&lt;/product&gt;</eg>
                </item>
             </ulist>
          </div3>
@@ -17050,11 +17050,11 @@ individual pre-grouping tuples.</p>
 
                   <p>Input tuple stream:</p>
 
-                  <eg><![CDATA[($storeno = &lt;storeno&gt;S101&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P78395&lt;/itemno&gt;)
+                  <eg>($storeno = &lt;storeno&gt;S101&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P78395&lt;/itemno&gt;)
 ($storeno = &lt;storeno&gt;S102&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P94738&lt;/itemno&gt;)
 ($storeno = &lt;storeno&gt;S101&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P41653&lt;/itemno&gt;)
 ($storeno = &lt;storeno&gt;S102&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P70421&lt;/itemno&gt;)
-]]></eg>
+</eg>
 
                   <p>
                      <code>group by</code> clause:</p>
@@ -17063,8 +17063,8 @@ individual pre-grouping tuples.</p>
 
                   <p>Output tuple stream:</p>
 
-                  <eg><![CDATA[($storeno = S101, $itemno = (&lt;itemno&gt;P78395&lt;/itemno&gt;, &lt;itemno&gt;P41653&lt;/itemno&gt;))
-($storeno = S102, $itemno = (&lt;itemno&gt;P94738&lt;/itemno&gt;, &lt;itemno&gt;P70421&lt;/itemno&gt;))]]></eg>
+                  <eg>($storeno = S101, $itemno = (&lt;itemno&gt;P78395&lt;/itemno&gt;, &lt;itemno&gt;P41653&lt;/itemno&gt;))
+($storeno = S102, $itemno = (&lt;itemno&gt;P94738&lt;/itemno&gt;, &lt;itemno&gt;P70421&lt;/itemno&gt;))</eg>
                </item>
             </ulist>
             <ulist>
@@ -17073,27 +17073,27 @@ individual pre-grouping tuples.</p>
 
                <item>
                   <p>This example and the ones that follow are based on two separate sequences of elements, named <code>$sales</code> and <code>$products</code>. We assume that the variable <code>$sales</code> is bound to a sequence of elements with the following structure:</p>
-                  <eg><![CDATA[&lt;sales&gt;
+                  <eg>&lt;sales&gt;
    &lt;storeno&gt;S101&lt;/storeno&gt;
    &lt;itemno&gt;P78395&lt;/itemno&gt;
    &lt;qty&gt;125&lt;/qty&gt;
-&lt;/sales&gt;]]></eg>
+&lt;/sales&gt;</eg>
                   <p>We also assume that the variable <code>$products</code> is bound to a sequence of  elements with the following structure:</p>
-                  <eg><![CDATA[&lt;product&gt;
+                  <eg>&lt;product&gt;
    &lt;itemno&gt;P78395&lt;/itemno&gt;
    &lt;price&gt;25.00&lt;/price&gt;
    &lt;category&gt;Men's Wear&lt;/category&gt;
-&lt;/product&gt;]]></eg>
+&lt;/product&gt;</eg>
                   <p>The simplest kind of grouping query has a single <termref
                         def="dt-grouping-variable"
                      >grouping variable</termref>. The query in this example finds the total quantity of items sold by each store:</p>
-                  <eg role="parse-test"><![CDATA[for $s in $sales
+                  <eg role="parse-test">for $s in $sales
 let $storeno := $s/storeno
 group by $storeno
-return &lt;store number="{$storeno}" total-qty="{sum($s/qty)}"/&gt;]]></eg>
+return &lt;store number="{$storeno}" total-qty="{sum($s/qty)}"/&gt;</eg>
                   <p>The result of this query is a sequence of elements with the following structure:</p>
-                  <eg><![CDATA[&lt;store number="S101" total-qty="1550" /&gt;
-&lt;store number="S102" total-qty="2125" /&gt;]]></eg>
+                  <eg>&lt;store number="S101" total-qty="1550" /&gt;
+&lt;store number="S102" total-qty="2125" /&gt;</eg>
                </item>
 
 
@@ -17102,7 +17102,7 @@ return &lt;store number="{$storeno}" total-qty="{sum($s/qty)}"/&gt;]]></eg>
                   <p>In a more realistic example, a user might be interested in the total revenue generated by each store for each product category. Revenue depends on both the quantity sold of various items and the price of each item. The following query joins the two input sequences and groups the resulting tuples by two <termref
                         def="dt-grouping-variable">grouping variables</termref>:</p>
 
-                  <eg role="parse-test"><![CDATA[
+                  <eg role="parse-test">
 for $s in $sales,
     $p in $products[itemno = $s/itemno]
 let $revenue := $s/qty * $p/price
@@ -17112,22 +17112,22 @@ return
     &lt;summary storeno="{$storeno}"
               category="{$category}"
               revenue="{sum($revenue)}"/>
-]]></eg>
+</eg>
 
 
                   <p>The result of this query is a sequence of elements with the following structure:</p>
-                  <eg><![CDATA[&lt;summary storeno="S101" category="Men's Wear" revenue="10185"/&gt;
+                  <eg>&lt;summary storeno="S101" category="Men's Wear" revenue="10185"/&gt;
 &lt;summary storeno="S101" category="Stationery" revenue="4520"/&gt;
 &lt;summary storeno="S102" category="Men's Wear" revenue="9750"/&gt;
 &lt;summary storeno="S102" category="Appliances" revenue="22650"/&gt;
-&lt;summary storeno="S102" category="Jewelry" revenue="30750"/&gt;]]></eg>
+&lt;summary storeno="S102" category="Jewelry" revenue="30750"/&gt;</eg>
                </item>
 
 
 
                <item>
                   <p>The result of the previous example was a "flat" list of elements. A user might prefer the query result to be presented in the form of a  hierarchical report, grouped primarily by store (in order by store number) and secondarily by product category. Within each store, the user might want to see only those product categories whose total revenue exceeds $10,000, presented in descending order by their total revenue. This report is generated by the following query:</p>
-                  <eg role="parse-test"><![CDATA[for $s1 in $sales
+                  <eg role="parse-test">for $s1 in $sales
 let $storeno := $s1/storeno
 group by $storeno
 order by $storeno
@@ -17144,15 +17144,15 @@ return
      return &lt;category name="{$category}" revenue="{$group-revenue}"/&gt;
     }
   &lt;/store&gt;
-]]></eg>
+</eg>
                   <p>The result of this example query has the following structure:</p>
-                  <eg><![CDATA[&lt;store storeno="S101"&gt;
+                  <eg>&lt;store storeno="S101"&gt;
    &lt;category name="Men's Wear" revenue="10185"/&gt;
 &lt;/store&gt;
 &lt;store storeno="S102"&gt;
    &lt;category name="Jewelry" revenue="30750"/&gt;
    &lt;category name="Appliances" revenue="22650"/&gt;
-&lt;/store&gt;]]></eg>
+&lt;/store&gt;</eg>
                </item>
 
 
@@ -17166,22 +17166,22 @@ pre-grouping tuples from which the group was formed. For instance, in
 the following query, <code>$high-price</code> is bound to a sequence
 of items in the post-grouping tuple.</p>
 
-                  <eg role="parse-test"><![CDATA[let $high-price := 1000
+                  <eg role="parse-test">let $high-price := 1000
 for $p in $products[price &gt; $high-price]
 let $category := $p/category
 group by $category
 return
    &lt;category name="{$category}"&gt;
       {fn:count($p)} products have price greater than {$high-price}.
-   &lt;/category&gt;]]></eg>
+   &lt;/category&gt;</eg>
                   <p>If three products in the "Men's Wear" category have prices greater than 1000, the result of this query might look (in part) like this:</p>
-                  <eg><![CDATA[&lt;category name="Men's Wear"&gt;
+                  <eg>&lt;category name="Men's Wear"&gt;
    3 products have price greater than 1000 1000 1000.
-&lt;/category&gt;]]></eg>
+&lt;/category&gt;</eg>
                   <p>The repetition of "1000" in this query result is due to the fact that <code>$high-price</code> is not a <termref
                         def="dt-grouping-variable"
                         >grouping variable</termref>. One way to avoid this repetition is to move the binding of <code>$high-price</code> to an outer-level FLWOR expression, as follows:</p>
-                  <eg role="parse-test"><![CDATA[let $high-price := 1000
+                  <eg role="parse-test">let $high-price := 1000
 return
    for $p in $products[price &gt; $high-price]
    let $category := $p/category
@@ -17189,11 +17189,11 @@ return
    return
       &lt;category name="{$category}"&gt;
          {fn:count($p)} products have price greater than {$high-price}.
-      &lt;/category&gt;]]></eg>
+      &lt;/category&gt;</eg>
                   <p>The result of the revised query might contain the following element:</p>
-                  <eg><![CDATA[&lt;category name="Men's Wear"&gt;
+                  <eg>&lt;category name="Men's Wear"&gt;
    3 products have price greater than 1000.
-&lt;/category&gt;]]></eg>
+&lt;/category&gt;</eg>
                </item>
             </ulist>
          </div3>
@@ -17469,18 +17469,18 @@ return $e/name]]></eg>
                <p>
 An alternative way of sorting is available from XQuery 3.1 using the <code>fn:sort</code> function. In previous versions of the language, a set of books might be sorted into alphabetic order by title using the FLWOR expression:</p>
 
-               <eg role="parse-test"><![CDATA[for $b in $books/book[price &lt; 100]
+               <eg role="parse-test">for $b in $books/book[price &lt; 100]
 order by $b/title
-return $b]]></eg>
+return $b</eg>
 
                <p>In XQuery 3.1 the same effect can be achieved using the expression:</p>
 
-               <eg role="parse-test"><![CDATA[
+               <eg role="parse-test">
 sort(
   $books/book[price &lt; 100],
   function($book){ $book/title }
 )
-]]></eg>
+</eg>
             </note>
 
 
@@ -17518,13 +17518,13 @@ return
                      <p>The order in which items appear in the result of a FLWOR expression depends on the ordering of the input tuple stream to the <code>return</code> clause, which in turn is influenced by <code>order by</code> clauses and by <termref
                            def="dt-ordering-mode"
                         >ordering mode</termref>. For example, consider the following query, which is based on the same two input documents as the previous example:</p>
-                     <eg role="parse-test"><![CDATA[for $d in fn:doc("depts.xml")//dept
+                     <eg role="parse-test">for $d in fn:doc("depts.xml")//dept
 order by $d/deptno
 for $e in fn:doc("emps.xml")//emp[deptno eq $d/deptno]
 return
    &lt;assignment&gt;
       {$d/deptno, $e/name}
-   &lt;/assignment&gt;]]></eg>
+   &lt;/assignment&gt;</eg>
                      <p>The result of this query is a sequence of <code>assignment</code> elements, each containing a <code>deptno</code> element and a <code>name</code> element. The sequence will be ordered primarily by the <code>deptno</code> values because of the <code>order by</code> clause. If <termref
                            def="dt-ordering-mode"
                            >ordering mode</termref> is <code>ordered</code>, subsequences of <code>assignment</code> elements with equal <code>deptno</code> values will be ordered by the document order of their <code>name</code> elements within the <code>emps.xml</code> document; otherwise the ordering of these subsequences will be <termref
@@ -17715,9 +17715,9 @@ the value of the else-expression is returned.</p>
 
             <item>
                <p>In this example, the test expression is a comparison expression:</p>
-               <eg role="parse-test"><![CDATA[if ($widget1/unit-cost &lt; $widget2/unit-cost)
+               <eg role="parse-test">if ($widget1/unit-cost &lt; $widget2/unit-cost)
   then $widget1
-  else $widget2]]></eg>
+  else $widget2</eg>
             </item>
 
 
@@ -17980,8 +17980,8 @@ errors, as illustrated in the examples below.</p>
             <item>
                <p>This expression is <code>true</code> if at least
 one <code>employee</code> element satisfies the given comparison expression:</p>
-               <eg role="parse-test"><![CDATA[some $emp in /emps/employee satisfies
-     ($emp/bonus &gt; 0.25 * $emp/salary)]]></eg>
+               <eg role="parse-test">some $emp in /emps/employee satisfies
+     ($emp/bonus &gt; 0.25 * $emp/salary)</eg>
             </item>
             
             <item>


### PR DESCRIPTION
Fix #377 

I took a minimal approach here. I've removed CDATA sections where the section contained an `&` but not a `<`.

1. If the section contains `<`, then it's  (presumably) necessary to escape the markup
2. If the section *does not* contain an `&`, then it's irrelevant. But not removing it limits the number of places changed by the script
