### PR TITLE
Update the example background color in serialization

### DIFF
--- a/specifications/css/xslt-xquery-serialization-40.css
+++ b/specifications/css/xslt-xquery-serialization-40.css
@@ -3,6 +3,6 @@
 dd.indent { margin-left: 2em; }
 p.element-syntax { border: solid thin; background-color: #ffccff }
 div.proto { border: solid thin; background-color: #ffccff }
-div.example { border: solid thin; background-color: blue; padding: 1em }
+div.example { border: solid thin; background-color: #40e0d0; padding: 1em }
 span.verb { font: small-caps 100% sans-serif }
 span.error { font-size: small }


### PR DESCRIPTION
This PR completes my action to fix the dark blue background in examples in the serialization spec. I've made them the same as the examples in the XSLT spec which seem to have been satisfactory. 