### PR TITLE
Clarify explanations of functions/function items

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1096,17 +1096,23 @@ but they are never the less part of the data model.
 </p>
 
 <div3 id="function-items">
-<head>Functions</head>
+<head>Function Items</head>
 
 <p>
-<termdef term="function" id="dt-function-item">
-  A <term>function</term> is an item that can be <term>called</term>.
+<termdef term="function item" id="dt-function-item">
+  A <term>function item</term> is an item that can be <term>called</term>.
 </termdef>
-Functions  cannot be compared for
+Function items cannot be compared for
 identity, equality, or otherwise, and have no serialization.
 </p>
+  
+  <note diff="add" at="2023-03-11"><p>XDM 4.0 uses the term <term>function item</term> where XDM 3.1 used
+    <term>function</term>. There is no distinction
+    in meaning, but <term>function item</term> is preferred for clarity, because the unqualified
+    term <term>function</term> has additional meanings in relation to
+    <term>function definitions</term> in XSLT and XQuery.</p></note>
 
-<p>A function has the following properties:
+<p>A function item has the following properties:
 </p>
 
 <ulist>
@@ -1145,38 +1151,55 @@ will create functions in the data model with zero annotations.
     </p>
   </item>
   <item>
-    <p>
-      <term>implementation</term>
-      This enables the function, when it's called,
-      to map instances of its parameter types into an instance of its result type.
-      The implementation is either:
+    <p diff="chg" at="2023-03-11">
+      <term>body</term>:
+      The body of a function provides the logic
+      to map the arguments supplied in a function call into an instance of 
+      the function's result type.</p>
+    
+    <p diff="chg" at="2023-03-11"> 
+      The function body is generally one of the following:</p>
       <ulist>
         <item>
-          <p>a host language expression, which is always associated
-          with a static context, or
+          <p>a user-written construct in XPath, XQuery, XSLT, or some
+            other host language known to the processor.
           </p>
         </item>
         <item>
-          <p>an implementation-dependent function implementation,
-          which is optionally associated with both a static and a
-          dynamic context.</p>
+          <p>vendor-supplied logic internal to the processor.</p>
+        </item>
+        <item>
+          <p>external logic written in some third-party programming
+            language, to be invoked by the processor using implementation-dependent
+            mechanisms.</p>
         </item>
       </ulist>
-    </p>
+    <p>These categories are not mutually exclusive; they may be used in combination.</p> 
+    <ednote><edtext>The term "function body" replaces "function implementation", to avoid confusion with
+    the use of the term "implementation" in phrases such as "implementation-defined".</edtext></ednote>
   </item>
   <item>
-    <p>
-      <term>nonlocal variable bindings</term>
-      (a mapping from <code>xs:QName</code> to <code>item()*</code>):
-      This provides a value for each of the function's free variables
-      (i.e., variables referenced by the function's implementation, other than locals and parameters).
+    <p diff="chg" at="2023-03-11">
+      <term>captured context</term>: this includes a static and dynamic context for evaluation
+      of the function body, as described in <xspecref spec="XP40" ref="context"/>. In particular
+      it includes a set of <term>nonlocal variable bindings</term>
+      (a mapping from <code>xs:QName</code> to <code>item()*</code>),
+      which provides a value for each of the function's free variables
+      (i.e., variables referenced by the function's body, other than locals and parameters).
     </p>
+    <note diff="chg" at="2023-03-11">
+      <p>Where the function body is implemented in XPath, XQuery, or XSLT, the captured
+      context includes the static context for the user-written code (for example, its in-scope namespaces)
+      as well as any nonlocal variable bindings.</p>
+      <p>Functions implemented internally to the processor may capture specific parts of the static or dynamic context,
+      for example <code>fn:position#0</code> captures the value of the context position.</p>
+    </note>
   </item>
 </ulist>
 
 <p>
 <termdef term="function arity" id="dt-function-arity">
-  A function's <term>arity</term> is the number of its parameters.
+  The <term>arity</term> of a <termref def="dt-function-item"/> is the number of its parameters.
 </termdef>
 The number of names in a function's parameter names,
 and the number of parameter types in its signature,

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -914,6 +914,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <p>This section is concerned with the question of whether two calls on a function, with the same arguments, may
                produce different results.</p>
                
+               <p diff="add" at="2023-03-12">In this section the term <term>function</term>, unless otherwise specified,
+               applies equally to <xtermref spec="XP40" ref="dt-function-definition">function definitions</xtermref>
+               (which can be the target of a static function call) and <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>
+               (which can be the target of a dynamic function call).</p>
+               
                <p><termdef id="execution-scope" term="execution scope">An <term>execution scope</term> is a sequence of
                   calls to the function library during which certain aspects of the state are required to remain invariant.
                   For example, two calls to <code>fn:current-dateTime</code> within the same execution scope will return the same result.
@@ -956,7 +961,9 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                         whose signatures differ in this way will probably be deemed non-identical under rule (e) below, because they are likely to
                         have different effect when invoked with an argument of type <code>xs:untypedAtomic</code>.</p></note>
                         </item>
-                        <item><p>Both functions have the same nonlocal variable bindings (sometimes called the function's closure).</p></item>
+                        <item><p>Both functions have the same <phrase diff="chg" at="2023-03-12">captured context 
+                           (including any</phrase> nonlocal variable 
+                           bindings — sometimes called the function's closure).</p></item>
                         <item><p>The processor is able to determine that the implementations of the two functions are equivalent,
                         in the sense that for all possible combinations of arguments, the two functions have the same effect.</p>                       
                         </item>
@@ -977,28 +984,79 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <p>Some functions produce results that depend not only on their explicit arguments, 
                   but also on the static and dynamic context.</p>
                
-               <p><termdef id="dt-context-dependent" term="context-dependent">A function may have 
-                  the property of being <term>context-dependent</term>: the result of such a
+               <p><termdef id="dt-context-dependent" term="context-dependent">A 
+                  <phrase diff="chg" at="2023-03-12"><xtermref spec="XP40" ref="dt-function-definition">function definition</xtermref></phrase> 
+                  may have  the property of being <term>context-dependent</term>: the result of such a
                function depends on the values of properties in the static and dynamic
-               evaluation context as well as on the actual supplied arguments (if any).</termdef></p>
+               evaluation context <phrase diff="add" at="2023-03-12">of the caller</phrase>
+                  as well as on the actual supplied arguments (if any).</termdef></p>
                
-               <p><termdef id="dt-context-independent" term="context-independent">A function that is
-               not <termref def="dt-context-dependent">context-dependent</termref> is called 
+               <p><termdef id="dt-context-independent" term="context-independent">A 
+                  <phrase diff="chg" at="2023-03-12"><xtermref spec="XP40" ref="dt-function-definition">function definition</xtermref></phrase> 
+                  that is not <termref def="dt-context-dependent">context-dependent</termref> is called 
                   <term>context-independent</term>.</termdef></p>
                
-               <p>A function that is context-dependent can be used as a named
+               <p diff="add" at="2023-03-12">The main categories of context-dependent functions are:</p>
+               
+               <ulist diff="add" at="2023-03-12">
+                  <item><p>Functions that explicitly deliver the value of a component of the static or dynamic context,
+                  for example <code>fn:static-base-uri</code>, <code>fn:default-collation</code>,
+                  <code>fn:position</code>, or <code>fn:last</code>.</p></item>
+                  <item><p>Functions with an optional parameter whose default value is taken from the static
+                     or dynamic context of the caller, usually either the context item (for example, <code>fn:node-name</code>)
+                     or the default collation (for example, <code>fn:index-of</code>).</p></item>
+                  <item><p>Functions that use the static context of the caller to expand or disambiguate
+                  the values of supplied arguments: for example <code>fn:doc</code> expands its first
+                  argument using the static base URI of the caller, and <code>xs:QName</code> expands its first argument
+                  using the in-scope namespaces of the caller.</p></item>
+               </ulist>
+               
+               <p><termdef id="dt-focus-dependent" term="focus-dependent">A function is <term>focus-dependent</term>
+                  if its result depends on the <xtermref ref="dt-focus" spec="XP31">focus</xtermref>
+                  (that is, the context item, position, or size) 
+                  <phrase diff="add" at="2023-03-12">of the caller</phrase>.</termdef></p>
+               <p><termdef id="dt-focus-independent" term="focus-dependent">A function that
+                  is not <termref def="dt-focus-dependent">focus-dependent</termref> is called
+                  <term>focus-independent</term>.</termdef></p>
+               
+               <note diff="add" at="2023-03-12">
+                  <p>Some functions depend on aspects of the dynamic context that remain invariant
+                  within an <termref def="execution-scope"/>, such as the implicit timezone.
+                  Formally this is treated in the same way as any other context dependency, but
+                  internally, the implementation may be able to take advantage of the fact that the
+                  value is invariant.</p>
+               </note>
+               
+               <note diff="add" at="2023-03-12">
+                  <p>User-defined functions in XQuery and XSLT may depend on the static context
+                     of the function definition (for example, the in-scope namespaces) and also in a limited
+                     way on the dynamic context (for example, the values of global variables).
+                     However, the only way they can depend on the static or dynamic context
+                     of the caller — which is what concerns us here — is by defining optional
+                     parameters whose default values are context-dependent.</p>
+               </note>
+               
+               <p>A <phrase diff="chg" at="2023-03-12">function definition</phrase> that is context-dependent 
+                  can be used as <phrase diff="add" at="2023-03-12">the target of</phrase> a named
                function reference, can be partially applied, and can be found using <code>fn:function-lookup</code>. 
                The principle in such cases is that the static context used for the function evaluation
                is taken from the static context of the named function reference, partial function application, or the call
                on <code>fn:function-lookup</code>; and the dynamic context for the function evaluation is taken from the dynamic
                context of the evaluation of the named function reference, partial function application, or the call
-               of <code>fn:function-lookup</code>. In effect, the static and dynamic part of the context thus act
-               as part of the closure of the function item.</p>
+               of <code>fn:function-lookup</code>. <phrase diff="add" at="2023-03-12">These constructs all deliver a 
+                  <xtermref spec="DM40" ref="dt-function-item">function item</xtermref>
+                  having a <term>captured context</term> based on the static and dynamic
+                  context of the construct that created the function item. This captured context forms 
+               part of the closure of the function item.</phrase></p>
+               
+               <p diff="add" at="2023-03-12">The result of a dynamic call to a function item never 
+                  depends on the static or dynamic context of the dynamic function call, only (where relevant) 
+                  on the the captured context held within the function item itself.</p>
               
                
-               <p>Context-dependent functions fall into a number of categories:</p>
+               <p diff="del" at="2023-03-12">Context-dependent functions fall into a number of categories:</p>
                
-               <olist>
+               <olist diff="del" at="2023-03-12">
                
                <item><p>The functions <code>fn:current-date</code>, <code>fn:current-dateTime</code>, <code>fn:current-time</code>, 
                   <code>fn:default-language</code>, <code>fn:implicit-timezone</code>,
@@ -1018,16 +1076,17 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <code>fn:string-length#0</code> depend on the <xtermref ref="dt-focus" spec="XP31">focus</xtermref>. 
                      These functions will in general return
                different results on different calls if the focus is different.</p>
-                  <p><termdef id="dt-focus-dependent" term="focus-dependent">A function is <term>focus-dependent</term>
+                  <p>A function is <term>focus-dependent</term>
                      if its result depends on the <xtermref ref="dt-focus" spec="XP31">focus</xtermref>
-                     (that is, the context item, position, or size).</termdef></p>
-                     <p><termdef id="dt-focus-independent" term="focus-dependent">A function that
+                     (that is, the context item, position, or size).</p>
+                     <p>A function that
                         is not <termref def="dt-focus-dependent">focus-dependent</termref> is called
-                        <term>focus-independent</term></termdef></p></item>
+                        <term>focus-independent</term></p></item>
                         
  
                
-                  <item><p>The function <code>fn:default-collation</code> and many string-handling operators and functions depend
+                  <item><p>The function <code>fn:default-collation</code> and many 
+                     string-handling operators and functions depend
                on the default collation and the in-scope collations, which are both properties
                of the static context. If a particular call of one of these functions is
                evaluated twice with the same arguments then it will return the same result
@@ -1046,10 +1105,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p>The <code>fn:function-lookup</code> function is a special case because it is
                potentially dependent on everything in the static and dynamic context. This is because the static and dynamic
-               context of the call to <code>fn:function-lookup</code> are used as the static and dynamic context of the
-               function that <code>fn:function-lookup</code> returns.</p>
+               context of the call to <code>fn:function-lookup</code> 
+                  <phrase diff="chg" at="2023-03-12">form the captured context of the
+               function item</phrase> that <code>fn:function-lookup</code> returns.</p>
                
-               <p><termdef id="dt-implicit-arguments" term="implicit argument">For a
+               <p diff="del" at="2023-03-12"><termdef id="dt-implicit-arguments" term="implicit argument">For a
                   <termref def="dt-context-dependent">context-dependent</termref> function, 
                   the parts of the context on which it depends are
                referred to as <term>implicit arguments</term>.</termdef></p>
@@ -1058,7 +1118,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p><termdef id="dt-deterministic" term="deterministic">A function that is guaranteed to produce <termref def="dt-identical">identical</termref> results 
                   from repeated calls within a single <termref def="execution-scope">execution scope</termref>
-               if the explicit and implicit arguments are identical is referred to as
+               if the explicit and <termref def="dt-implicit-arguments">implicit</termref> arguments are identical is referred to as
                <term>deterministic</term>.</termdef></p>
                
                <p><termdef id="dt-nondeterministic" term="nondeterministic">A function that is not

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -67,11 +67,6 @@ Each node has a unique <term>node identity</term>, a <term>typed value</term>, a
          <p><termdef id="dt-function-item" term="function item">A <term>function item</term> is an item that can
          be called using a <termref def="dt-dynamic-function-call"/>.</termdef></p>
          
-         <note><p>This specification uses the term <term>function item</term> where XDM uses
-            <xtermref spec="DM31" ref="dt-function-item">function</xtermref>. There is no distinction
-            in meaning, but <term>function item</term> is preferred here for clarity, because the unqualified
-         term <term>function</term> has additional meanings in relation to
-         <termref def="dt-function-definition">function definitions</termref> in the <termref def="dt-static-context"/>.</p></note>
          
          <p>Maps (see <specref ref="id-maps"/>) and arrays (see <specref ref="id-arrays"/>) are
          specific kinds of <termref def="dt-function-item"/>.</p>
@@ -618,8 +613,7 @@ Within the body of an
 by the names and types of the <term>function
 parameters</term>.</p>
 
-                  <p role="xquery"
-                        >The static type of a variable may either be declared in a query or
+                  <p role="xquery">The static type of a variable may either be declared in a query or
 inferred by static type inference as discussed in  <specref
                         ref="id-static-analysis"/>.</p>
 
@@ -670,6 +664,44 @@ inferred by static type inference as discussed in  <specref
                   <p>The properties of a <termref def="dt-function-definition"/> include:</p>
                   
                   <ulist>
+                     <item>
+                        <p diff="add" at="2023-03-11">The function category, which is one of application, system, or external:</p>
+                        <ulist diff="add" at="2023-03-11">
+                           <item><p><termdef id="dt-application-function" term="application function">
+                              <term>Application functions</term> are function definitions written in a 
+                              host language such as XQuery or XSLT whose
+                           semantics are defined in this family of specifications. Their behavior 
+                           (including the rules determining the static and dynamic context) follows the
+                           rules for such functions in the relevant host language specification.</termdef>
+                           </p></item>
+                           <item><p><termdef id="dt-system-function" term="system function">
+                              <term>System functions</term> include the functions defined in <bibref
+                              ref="xpath-functions-40"/> and may also include additional functions provided
+                              by the implementation.</termdef></p>
+                              <p>The behavior of system functions follows the rules given for the individual
+                           function in this family of specifications, or in the specification of the
+                           particular processor implementation. System functions in some cases have behavior that depends on the
+                           static or dynamic context of the caller (for example, they may compare strings
+                           using the default collation from the static context of the caller): such
+                           functions are said to be <termref def="dt-context-dependent"/>.</p></item>
+                           <item><p><term>External functions</term> can be characterized as functions that are neither
+                           part of the processor implementation, nor written in a language whose semantics
+                           are under the control of this family of specifications. The semantics of external
+                           functions, including any context dependencies, are entirely implementation-defined.
+                           </p></item>
+                           
+                        </ulist>
+                        <p diff="add" at="2023-03-11"><termdef id="dt-context-dependent" term="context dependent">A 
+                           <termref def="dt-function-definition"/> is said to be <term>context dependent</term>
+                        if its result depends on the static or dynamic context of its caller.</termdef></p>
+                        
+                        <note diff="add" at="2023-03-11"><p>Some system functions, such as <code>fn:position</code>, <code>fn:last</code>,
+                        and <code>fn:static-base-uri</code>, exist for the sole purpose of providing information
+                        about the static or dynamic context of their caller.</p></note>
+                        <note><p diff="add" at="2023-03-11"><termref def="dt-application-function">Application functions</termref> 
+                           are only ever context dependent to the extent that they define optional parameters with default
+                           values that are context dependent.</p></note>
+                     </item>
                      <item><p>The function name, which is an <termref def="dt-expanded-qname"/>.</p></item>
                      <item><p>A (possibly empty) list of required parameters, each having:</p>
                         <ulist>
@@ -687,8 +719,9 @@ inferred by static type inference as discussed in  <specref
                      <item><p>A return type (a <termref def="dt-sequence-type"/>)</p></item>
                      <item><p>A (possibly empty) set of <term>function annotations</term></p>
                         <p role="xquery">In XQuery, function annotations are described in <specref ref="id-annotations"/>.</p></item>
-                     <item><p>An implementation. The function implementation contains the logic that enables the function
-                     result to be computed from the supplied parameters and information in the dynamic context.</p></item>
+                     <item><p diff="chg" at="2023-03-11">A body. The function 
+                        body contains the logic that enables the function
+                        result to be computed from the supplied arguments and information in the static and dynamic context.</p></item>
                   </ulist>
                   
                   <p>The names of the parameters must be distinct.</p>
@@ -718,8 +751,8 @@ inferred by static type inference as discussed in  <specref
                  
                   
                
-                  <p diff="chg" at="A">Function definitions in the static context may originate in a number of ways, for example they may be:</p>
-                  <ulist>
+                  <p diff="del" at="2023-03-11">Function definitions in the static context may originate in a number of ways, for example they may be:</p>
+                  <ulist diff="del" at="2023-03-11">
                      <item><p>User-written functions, implemented in a host language such as XQuery or XSLT.</p></item>
                      <item><p>Built-in functions, such as those specified in <bibref ref="xpath-functions-40"/>,
                      and <termref def="dt-constructor-function">constructor functions</termref> for built-in and user-defined
@@ -7174,12 +7207,13 @@ At evaluation time, the value of a variable reference is the value to which the 
                a dynamic context that provides values for all the declared parameters, initialized
                as described in <specref ref="id-eval-static-function-call"/> below.</p>
                
-               <p>Similarly, a function reference of the form <code>f#N</code> binds to a function in the
+               <p>Similarly, a function reference of the form <code>f#N</code> binds to a 
+                  <termref def="dt-function-definition"/> in the
                   static context whose name matches <var>f</var> where <code>MinP ≤ N and MaxP ≥ N</code>.
-               The result of evaluating a function reference is a (dynamic) function which can be called
-               using a dynamic function call. Dynamic functions are never variadic and their arguments
+               The result of evaluating a function reference is a <termref def="dt-function-item"/> which can be called
+               using a dynamic function call. Function items are never variadic and their arguments
                are always supplied positionally. For example, the function reference <code>fn:concat#3</code>
-               returns a function with arity 3, which is always called by supplying three positional
+               returns a function item with arity 3, which is always called by supplying three positional
                arguments, and whose effect is the same as a static call on <code>fn:concat</code> with
                three positional arguments. <!--The arity must not exceed the number of arguments that
                can be supplied positionally. Therefore, in the case of a function reference to a map-variadic functions
@@ -7364,7 +7398,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                   <item>
                      <p>
                           The <termref def="dt-function-definition"/> <var>FD</var> to be used is found in 
-                        >the <termref def="dt-statically-known-function-definitions"/> of <var>SC</var>.
+                        the <termref def="dt-statically-known-function-definitions"/> of <var>SC</var>.
                         </p>
                      
                      <p>The <term>required arity</term> is the total number of arguments in the
@@ -7451,7 +7485,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                  <ulist>
                                     <item>
                                        <p>
-                                          <var>FD</var>'s implementation is invoked
+                                          <var>FD</var>'s <phrase diff="chg" at="2023-03-11">body</phrase> is invoked
                                       in an implementation-dependent way.
                                       The processor makes the following information
                                       available to that invocation:
@@ -7461,20 +7495,17 @@ At evaluation time, the value of a variable reference is the value to which the 
                                           <item>
                                              <p>The converted argument values;</p>
                                           </item>
-                                          <item>
-                                             <p>
+                                          <item diff="del" at="2023-03-11">
+                                             <p diff="del" at="2023-03-11">
                                                 An empty set of nonlocal variable bindings; and</p>
                                           </item>
                                           <item>
-                                             <p>
-                                          A static context and dynamic context.
-                                          If <var>FD</var>'s implementation is associated with a static and a dynamic context,
-                                          then these are supplied,
-                                          otherwise <var>SC</var> and <var>DC</var> are supplied.
-                                        </p>
+                                             <p diff="chg" at="2023-03-11">If the function is <termref def="dt-context-dependent"/>,
+                                          the static context <var>SC</var> and dynamic context <var>DC</var> of the function call.
+                                           </p>
                                           </item>
                                        </ulist>
-                                       <p>
+                                       <p diff="del" at="2023-03-11">
                                       How this information is used is <termref
                                              def="dt-implementation-defined"
                                              >implementation-defined</termref>.
@@ -7569,18 +7600,18 @@ At evaluation time, the value of a variable reference is the value to which the 
                <item><p>A <term>named function reference</term> (see <specref ref="id-named-function-ref"/>)
                constructs a function item by reference to <termref def="dt-function-definition">function definitions</termref>
                   in the static context: for example <code>fn:node-name#1</code>
-               returns a function whose effect is to call the static <code>fn:node-name</code> function
+               returns a function item whose effect is to call the static <code>fn:node-name</code> function
                with one argument.</p></item>
                <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/>)
-                  constructs a function whose implementation is defined locally. For example the
-               construct <code>->($x){$x+1}</code> returns a function whose effect is to increment
+                  constructs a function item whose <phrase diff="chg" at="2023-03-11">body</phrase> is defined locally. For example the
+               construct <code>->($x){$x+1}</code> returns a function item whose effect is to increment
                the value of the supplied argument.</p></item>
                <item><p>A <term>partial function application</term> (see 
-                  <specref ref="id-partial-function-application"/>) derives one function from another by supplying
+                  <specref ref="id-partial-function-application"/>) derives one function item from another by supplying
                the values of some of its arguments. For example, <code>fn:ends-with(?, ".txt")</code> returns
-               a function with one argument that tests whether the supplied string ends with the substring
+               a function item with one argument that tests whether the supplied string ends with the substring
                   <code>".txt"</code>.</p></item>
-               <item><p>Maps and arrays are also functions. See <specref ref="id-map-constructors"/>
+               <item><p>Maps and arrays are also function items. See <specref ref="id-map-constructors"/>
                and <specref ref="id-array-constructors"/>.</p></item>
                <item diff="add" at="B"><p>The <code>fn:function-lookup</code> function can be called to discover functions
                that are present in the <termref def="dt-dynamic-context"/>.</p></item>
@@ -7623,9 +7654,9 @@ At evaluation time, the value of a variable reference is the value to which the 
                      <p>
                           The <termref def="dt-function-item"/> <var>F</var> to be called
                           is obtained by evaluating the base expression of the function call.
-                              If this yields a sequence consisting of a single function
+                              If this yields a sequence consisting of a single function item
                               whose arity matches the number of arguments in the <code>ArgumentList</code>,
-                              let <var>F</var> denote that function.
+                              let <var>F</var> denote that function item.
                               Otherwise, a type error is raised
                               <errorref
                                  class="TY" code="0004"/>.
@@ -7671,7 +7702,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                               <item>
                                  
                                  <p>
-                                  If <var>F</var>'s implementation is 
+                                  If <var>F</var>'s <phrase diff="chg" at="2023-03-11">body</phrase> is 
                                   
                                   an &language; expression
                                   
@@ -7693,7 +7724,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                  <olist>
                                     <item>
                                        <p>
-                                          <var>F</var>'s implementation 
+                                          <var>F</var>'s <phrase diff="chg" at="2023-03-11">body</phrase> 
                                       is evaluated.
                                       
                                         The static context for this evaluation
@@ -7835,7 +7866,7 @@ return $vat()
                                   <termref
                                        def="dt-partially-applied-function"
                                        >partial application</termref>
-                                       of such a function)--> the implementation of the function is
+                                       of such a function)--> the <phrase diff="chg" at="2023-03-11">body</phrase> of the function is
                                        evaluated, and the result is converted
                                        to the declared return type, in the same way as for a 
                                        static function call (see <specref ref="id-function-calls"/>).</p>
@@ -7851,7 +7882,7 @@ return $vat()
             </div4>
 
 
-            <div4 id="id-partial-function-application">
+            <div4 id="id-partial-function-application"  diff="chg" at="2023-03-12">
                <head>Partial Function Application</head>
                
                <p>
@@ -7861,28 +7892,171 @@ return $vat()
                      if one or more arguments is an <nt def="ArgumentPlaceholder">ArgumentPlaceholder</nt>.</termdef>
                </p>
                
+               <p>The rules for partial function application in static function calls and dynamic function
+               calls have a great deal in common, but they are stated separately below for clarity.</p>
                
-               <p>The result of a partial function application is a <termref def="dt-function-item"/>, whose
-               arity is equal to the number of placeholders in the call.</p>
+               <p>In each case, the result of a partial function application is a 
+                  <termref def="dt-function-item"/>, whose
+                  arity is equal to the number of placeholders in the call.</p>
+               
+               <p>More specifically, the result of the partial function application is 
+                  a <termref
+                  def="dt-partially-applied-function"
+                  >partially applied function</termref>.
+                  <termdef term="partially applied function"
+                  id="dt-partially-applied-function"
+                  >A <term>partially applied function</term>
+                  is a function created by  <termref
+                     def="dt-partial-function-application"
+                     >partial function application</termref>.</termdef>
+               </p>
+               
+               
+               <p>For static function calls,  the result is obtained as follows:</p>
+               
+               <olist>
+                  <item>
+                     <p>The <termref def="dt-function-definition"/> <var>F</var> to be partially applied
+                        is determined in the same way as for a static function call without placeholders, 
+                        as described in <specref ref="id-function-calls"/>.
+                        For this purpose an <code>ArgumentPlaceholder</code> contributes to the count of
+                        arguments.</p>
+                  </item>
+                  
+                  
+                  <item>
+                     <p>The parameters of <var>F</var> are classified into three categories:</p>
+                     <ulist>
+                        <item><p>Parameters that map to a placeholder, referred to as <term>placeholder parameters</term>.</p></item>
+                        <item><p>Parameters for which an explicit value is given in the function call (either
+                        positionally or by keyword), referred to as <term>explicitly supplied parameters</term>.</p></item>
+                        <item><p>Parameters (which are necessarily optional parameters) for which no corresponding
+                        argument is supplied, either as a placeholder or with an explicit value. These are referred to
+                        as <term>defaulted parameters</term>.</p></item>
+                     </ulist>
+                     
+                     <note>
+                        <p>A partial function application need not have any supplied parameters.</p>
+                        <p>For example, the partial function application <code>fn:string(?)</code>
+                        is allowed; it has exactly the same effect as the named function reference
+                        <code>fn:string#1</code>. </p></note>
+                  </item>
+                  <item>
+                     <p>Explicitly supplied parameters and defaulted parameters are evaluated and 
+                        converted to the required type using the rules for a static function call.</p>
+                  </item>
 
-               <p>The result is obtained as follows:</p>
+                  <item>
+                     <p>
+                        The result is a <termref
+                           def="dt-partially-applied-function"
+                           >partially applied function</termref> having
+                        the following properties (which are defined in <xspecref
+                           spec="DM31" ref="function-items"/>):
+                     </p>
+                     <ulist>
+                        <item>
+                           <p>
+                              <term>name</term>:
+                              Absent.
+                           </p>
+                        </item>
+                        <item>
+                           <p><term>arity</term>: the number of placeholders in the function call.</p>
+                        </item>
+                        <item>
+                           <p>
+                              <term>parameter names</term>:
+                              The names of the parameters of <var>F</var>
+                              that have been identified as placeholder parameters,
+                              retaining the order in which the placeholders appear in the
+                              function call.
+                           </p>
+                           <note><p>Partial function application can be used to change the order
+                           of parameters, for example <code>fn:contains(substring:=?, value:=?)</code>
+                           returns a function item that is equivalent to <code>fn:contains#2</code>,
+                           but with the order of arguments reversed.</p></note>
+                        </item>
+                        
+                        <item>
+                           <p>
+                              <term>signature</term>: the parameters in the returned function
+                              are the parameters of <var>F</var>
+                              that have been identified as placeholder parameters,
+                              retaining the order in which the placeholders appear in the
+                              function call. The result type of the returned function
+                              is the same as the result type of <var>F</var>.</p>
+                              
+                              <p>An implementation which can determine a more specific signature (for example, 
+                              through use of type analysis) is permitted to do so.
+                           </p>
+                        </item>
+                        
+                        <item>
+                           <p><term>body</term>: The body of <var>F</var>.</p>
+                        </item>
+                        
+                        <item>
+                           <p>
+                              <term>captured context</term>: the
+                              static and dynamic context of the function call, augmented,
+                              for each explicitly supplied parameter and each defaulted parameter, with
+                              a binding of the converted argument value
+                              to the corresponding parameter name.
+                           </p>
+                        </item>
+                     </ulist>
+ 
+                     <example>
+                        <head>Partial Application of a Built-In Function</head>
+                        
+                        <p>The following partial function application creates a function 
+                           item that computes the sum of squares of a sequence.</p>
+                        <eg role="parse-test"><![CDATA[let $sum-of-squares := fn:fold-right(?, 0, function($a, $b) { $a*$a + $b })
+return $sum-of-squares(1 to 3)]]></eg>
+                        <p>
+                           <code>$sum-of-squares</code> is an anonymous function. It has one parameter, named <code>$seq</code>, which is taken from the corresponding parameter in <code>fn:fold-right</code> (the other two parameters are fixed). The implementation is the implementation of <code>fn:fold-right</code>, which is a built-in context-independent function.  The nonlocal bindings contain the fixed bindings for the second and third parameters of <code>fn:fold-right</code>.</p>
+                     </example>
+              
+                  </item>
+                  
+                  
+               </olist>
+               
+               
+               <p>For dynamic function calls,  the result is obtained as follows:</p>
 
                <olist>
                   <item>
-               <p>The function <var>F</var> to be partially applied is determined in the same way as for a 
-                  (static or dynamic) function call without placeholders, as described in the preceding sections.
-                  For this purpose an <code>ArgumentPlaceholder</code> contributes to the count of
-                  arguments.</p>
+                     <p>The <termref def="dt-function-item"/> <var>F</var> to be partially applied is 
+                        determined in the same way as for a 
+                        dynamic function call without placeholders, as described in <specref ref="id-dynamic-function-invocation"/>.
+                        For this purpose an <code>ArgumentPlaceholder</code> contributes to the count of
+                        arguments.</p>
+                  </item>
+                  
+                  <item>
+                     <p>The parameters of <var>F</var> are classified into two categories:</p>
+                     <ulist>
+                        <item><p>Parameters that map to a placeholder, referred to as <term>placeholder parameters</term>.</p></item>
+                        <item><p>Parameters for which an explicit value is given in the function call, 
+                           referred to as <term>supplied parameters</term>.</p></item>
+                     </ulist>
+                     
+                     <note>
+                        <p>A partial function application need not have any supplied parameters.</p>
+                        <p>For example, if <code>$f</code> is a function with arity 2, then
+                           the partial function application <code>$f(?, ?)</code> returns
+                           a function that has exactly the same effect as <code>$f</code>. </p></note>
                   </item>
 
                   
                   <item>
-                     <p>Arguments other than placeholders are evaluated, mapped to corresponding
-                     parameters in the function signature of <var>F</var>, and converted to the required
-                     type of the parameter, using the rules for static and dynamic function calls as 
-                     appropriate. <phrase diff="add" at="variadicity">In the case of static function calls,
-                     this includes optional parameters for which no argument expression or placeholder is supplied in the
-                     call.</phrase></p>
+                     <p>Arguments corresponding to supplied parameters are evaluated
+                        and converted to the required
+                     type of the parameter, using the rules for dynamic function calls.</p>
+                     
+                     
                   </item>
 
 
@@ -7893,23 +8067,9 @@ return $vat()
                      
                         <item>
                            <p>
-                              The result of the partial function application is a new function, which is a <termref
+                              The result of the partial function application is a  <termref
                                  def="dt-partially-applied-function"
-                                 >partially applied function</termref>.
-                              <termdef
-                                 term="partially applied function"
-                                 id="dt-partially-applied-function"
-                                    >A <term>partially applied function</term>
-                              is a function created by  <termref
-                                    def="dt-partial-function-application"
-                                    >partial function application</termref>.</termdef>
-                              <termdef term="fixed position" id="dt-fixed-position" diff="chg" at="variadicity"
-                                    >In a partial function application, a <term>supplied parameter</term>
-                              is any parameter other than one for which the <code>ArgumentList</code> includes
-                              a placeholder.</termdef>
-                              A partial function application need not have any supplied parameters.  A <termref
-                                 def="dt-partially-applied-function"
-                                 >partially applied function</termref> has
+                                 >partially applied function</termref> with
                               the following properties (which are defined in <xspecref
                                  spec="DM31" ref="function-items"
                               />):
@@ -7921,17 +8081,17 @@ return $vat()
                                   Absent.
                                 </p>
                               </item>
-
+                              <item>
+                                 <p><term>arity</term>: the number of placeholders in the function call.</p>
+                              </item>
                               <item>
                                  <p>
                                     <term>parameter names</term>:
-                                  The parameter names of <var>F</var>,
-                                  removing the names of supplied parameters.
-                                  (So the function's arity is
-                                  the arity of F
-                                  minus
-                                  the number of fixed positions.)
+                                  The names of parameters in <var>F</var> that have
+                                    been identified as placeholder parameters, in order.
                                 </p>
+                                 <note><p>In a dynamic partial function application, argument keywords
+                                 are not available, so it is not possible to change the order of parameters.</p></note>
                               </item>
 
                               <item>
@@ -7940,29 +8100,21 @@ return $vat()
                                   The signature of <var>F</var>,
                                   removing the types of supplied parameters.
 				  
-				    An implementation which can determine a more specific signature (for example, through use of type analysis) is permitted to do so.
+				                      An implementation which can determine a more specific signature (for example, 
+				                      through use of type analysis) is permitted to do so.
+                                </p>
+                              </item>
+
+                              <item>
+                                 <p><term>body</term>: The body of <var>F</var>.
                                 </p>
                               </item>
 
                               <item>
                                  <p>
-                                    <term>implementation</term>:
-                                  
-                                  
-                                  The implementation of <var>F</var>.
-                                  If this is not an &language; expression
-                                  then the new function's implementation
-                                  is associated with a static context and a dynamic context in one of two ways:
-                                  if <var>F</var>'s implementation is already associated with contexts, then those are used; otherwise, <var>SC</var> and <var>DC</var> are used. 
-                                  
-                                </p>
-                              </item>
-
-                              <item>
-                                 <p>
-                                    <term>nonlocal variable bindings</term>:
-                                  The nonlocal variable bindings of <var>F</var>,
-                                  plus, for each supplied parameter,
+                                    <term>captured context</term>: the
+                                    captured context of <var>F</var>, augmented,
+                                  for each supplied parameter, with
                                   a binding of the converted argument value
                                   to the corresponding parameter name.
                                 </p>
@@ -7980,27 +8132,21 @@ return $paf(1 to 5)
                                  <code>$paf</code> is also an anonymous function.  It has one parameter, named <code>$delim</code>, which is taken from the corresponding parameter in <code>$f</code>
                               (the other parameter is fixed).  The implementation of <code>$paf</code> is the implementation of <code>$f</code>, which is <code>fn:fold-left($seq, "", fn:concat(?, $delim, ?))</code>.  This implementation is associated with the <code>SC</code> and <code>DC</code> of the original expression in <code>$f</code>.  The nonlocal bindings associate the value <code>"."</code> with the parameter <code>$delim</code>.</p>
                            </example>
-                           <example>
-                              <head>Partial Application of a Built-In Function</head>
-
-                              <p>The following partial function application creates a function that computes the sum of squares of a sequence.</p>
-                              <eg role="parse-test"><![CDATA[let $sum-of-squares := fn:fold-right(?, 0, function($a, $b) { $a*$a + $b })
-return $sum-of-squares(1 to 3)]]></eg>
-                              <p>
-                                 <code>$sum-of-squares</code> is an anonymous function. It has one parameter, named <code>$seq</code>, which is taken from the corresponding parameter in <code>fn:fold-right</code> (the other two parameters are fixed). The implementation is the implementation of <code>fn:fold-right</code>, which is a built-in context-independent function.  The nonlocal bindings contain the fixed bindings for the second and third parameters of <code>fn:fold-right</code>.</p>
-                           </example>
-                           <p>Partial function application never returns a map or an array.  If <code>$F</code> is a map or an array, then <code>$F(?)</code> is 
-                            a partial function application that returns a function, but the function it returns is not a map nor an array.</p>
-                           <example>
-                              <head>Partial Application of a Map</head>
-                              <p>The following partial function application converts a map to an equivalent function that is not a map.</p>
-                              <eg role="parse-test"><![CDATA[let $a := map {"A": 1, "B": 2}(?)
-return $a("A")]]></eg>
-                           </example>
+                          
                         </item>
 
 
                     </olist>
+               
+               
+               <p>Partial function application never returns a map or an array.  If <code>$F</code> is a map or an array, then <code>$F(?)</code> is 
+                  a partial function application that returns a function, but the function it returns is not a map nor an array.</p>
+               <example>
+                  <head>Partial Application of a Map</head>
+                  <p>The following partial function application converts a map to an equivalent function that is not a map.</p>
+                  <eg role="parse-test"><![CDATA[let $a := map {"A": 1, "B": 2}(?)
+return $a("A")]]></eg>
+               </example>
                   
                
                
@@ -8026,7 +8172,9 @@ return $a("A")]]></eg>
             <p>
                <termdef term="named function reference" id="dt-named-function-ref">
           A <term>named function reference</term> is an expression (written <code>name#arity</code>)
-                  which evaluates to a <termref def="dt-function-item"/>.</termdef></p>
+                  which evaluates to a <termref def="dt-function-item"/>, <phrase diff="add" at="2023-03-11">the details
+                  of the function item being based on the properties of a <termref def="dt-function-definition"/>
+                  in the <termref def="dt-static-context"/></phrase>.</termdef></p>
             
             <p>The name and arity of the required function are known statically.</p>
           
@@ -8040,10 +8188,17 @@ return $a("A")]]></eg>
                whose name matches <var>F</var>, and whose <termref def="dt-arity-range"/> includes <var>N</var></phrase>.
                Call this <termref def="dt-function-definition"/> <var>FD</var>.</p>
             
-            <p>If the function is
-          context dependent, then the returned function is associated
-          with the static context of the named function reference and
-          the dynamic context in which the named function reference is evaluated.</p>
+            <p diff="chg" at="2023-03-11">If the function is
+          <termref def="dt-context-dependent"/>, then the returned function has
+               a captured context comprising
+          the static and dynamic context of the named function reference.</p>
+            
+            <note diff="chg" at="2023-03-11"><p>In practice, it is only necessary to retain those
+            parts of the static and dynamic context that can affect the outcome. These means it is 
+            unnecessary to retain parts of the context that no <termref def="dt-system-function"/>
+            depends on (for example, local variables), or parts that are invariant within an
+            execution scope (for example, the implicit timezone).</p></note>
+            
             
             <example diff="add" at="B">
                <head>A Context-Dependent Named Function Reference</head>
@@ -8075,9 +8230,11 @@ return $a("A")]]></eg>
                   <item><p>The signature of <var>FI</var> is formed from the required types of the 
                      first <var>A</var> parameters of <var>FD</var>, and the function result type of <var>FD</var>.</p></item>
                   <item><p>The implementation of <var>FI</var> is the implementation of <var>FD</var>.</p></item>
-                  <item><p>The nonlocal variable bindings of <var>FI</var> comprise bindings of the names of parameters of <var>FD</var>
-                  beyond the <var>A</var>'th parameter, to their respective default values. The evaluation of the expressions
-                  that define these default values occurs in the dynamic context of the named function reference.</p></item>
+                  <item><p diff="chg" at="2023-03-12">The captured context of <var>FI</var> comprises the static and dynamic context of
+                     the named function reference, augmented with bindings of the names of parameters of <var>FD</var>
+                  beyond the <var>A</var>'th parameter, to their respective default values.</p>
+                     <note diff="chg" at="2023-03-12"><p>In practice it is only necessary to retain the parts of the context that the function
+                  actually depends on (if any).</p></note></item>
                </ulist>
             </p>
             
@@ -8088,7 +8245,7 @@ return $a("A")]]></eg>
                To obtain an arity-3 function that binds to arguments 1, 2, and 5 of <code>fn:format-date</code>,
             use the partial function application <code>format-date(?, ?, place:?)</code>.</p></note>
 
-            <p>
+            <p diff="del" at="2023-03-12">
             Furthermore, if the function returned by the evaluation of
             a <code>NamedFunctionRef</code> has an
             implementation-dependent implementation, then the
@@ -8149,7 +8306,7 @@ return $a("A")]]></eg>
 
             <p>
                <termdef term="inline function expression" id="dt-inline-func"
-                     >An <term>inline function expression</term> creates
+                     >An <term>inline function expression</term><phrase diff="add" at="2023-03-111">, when evaluated,</phrase> creates
           an <termref def="dt-anonymous-function">anonymous function</termref>
           defined directly in the inline function expression.</termdef> 
                An inline function expression specifies the names and SequenceTypes of the parameters to the function,
@@ -8295,14 +8452,15 @@ return $a("A")]]></eg>
             </p>
                      </item>
                      <item>
-                        <p>
-                           <term>nonlocal variable bindings</term>:
-              For each nonlocal variable,
-              a binding of it to its value in the
-              <termref
-                              def="dt-variable-values"
+                        <p diff="chg" at="2023-03-11">
+                           <term>captured context</term>: the static context
+                           is the static context of the inline function expression,
+                           with the exception of the static context item type which is
+                           <xtermref spec="DM31" ref="dt-absent"/>. The dynamic context has an absent
+                           <termref def="dt-focus"/>, and a set of variable bindings
+                           comprising the <termref def="dt-variable-values"
                               >variable values</termref> component
-              of the dynamic context of the <code>InlineFunctionExpr</code>.
+                           of the dynamic context of the <code>InlineFunctionExpr</code>.
             </p>
                      </item>
                   </ulist>
@@ -8324,6 +8482,16 @@ return $a("A")]]></eg>
                            role="parse-test"
                            ><![CDATA[function($a as xs:double, $b as xs:double) as xs:double { $a * $b }]]></eg>
                      </p>
+                  </item>
+                  <item>
+                     <p>This example creates and invokes a function that captures the value of a local variable in its scope:
+                        <eg role="parse-test"
+                           ><![CDATA[let $incrementors := 
+   for $x in 1 to 10
+   return function($y) as xs:integer { $x + $y }
+return $incrementors[2](4)]]></eg>
+                     </p>
+                     <p>The result of this expression is <code>6</code></p>
                   </item>
                   <item diff="add" at="A">
                      <p>This example creates a function that prepends "$" to a supplied value:


### PR DESCRIPTION
This PR is purely editorial in the sense that it does not attempt to make any changes that would affect an implementation. It's intended to clear up ambiguity and lack of clarity in the description of operations on functions, in particular the way that a function item captures static and dynamic context. It addresses issues #239 and issue #392.