### PR TITLE
Minor correction to fn:parse-uri

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24295,8 +24295,8 @@ declare function fn:some(
          sequence.</p>
 
          <p>If the <emph>string</emph> matches <code>^[a-zA-Z]:</code>,
-         the <emph>scheme</emph> is <code>file</code> and the
-         <emph>string</emph> is unchanged. Otherwise, if the
+         the <emph>scheme</emph> is <code>file</code> and a leading slash (“/”)
+         is added to the <emph>string</emph>. Otherwise, if the
          <emph>string</emph> matches
          <code>^([a-zA-Z][A-Za-z0-9\+\-\.]*):(.*)$</code>, the
          <emph>scheme</emph> is the first match group and the


### PR DESCRIPTION
The `fn:parse-uri()` function recognizes "URIs" of the form `c:/path/to/thing` as implicitly being `file:` URIs. This small change adds a leading "/" to make the fact that it is a path explicit.