### PR TITLE
Make the (non-)hierarchical nature of URIs explicit

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24304,6 +24304,15 @@ declare function fn:some(
          <emph>string</emph> does not match either expression, the <emph>scheme</emph>
          is the empty sequence and the <emph>string</emph> is unchanged.</p>
 
+         <p>If the <emph>scheme</emph> is known to be hierarchical, or known
+         not to be hierarchical, then <emph>hierarchical</emph> is set accordingly.
+         Exactly which schemes are known to be hierarchical or
+         non-hierarchical is
+         <termref def="implementation-defined">implementation-defined</termref>.
+         If the implementation does not know if a <emph>scheme</emph> is or is not
+         hierarchical, <emph>hierarchical</emph> is
+         true if <emph>string</emph> begins with “/” and false otherwise.</p>
+
          <p>If the <emph>string</emph> matches <code>^//*([a-zA-Z]:.*)$</code>,
          the <emph>authority</emph> is empty and the <emph>string</emph> is
          the first match group. Otherwise, if the <emph>string</emph>
@@ -24427,6 +24436,7 @@ declare function fn:some(
          <eg>{
   "uri": $uri,
   "scheme": <emph>scheme</emph>,
+  "hierarchical": <emph>hierarchical</emph>,
   "authority": <emph>authority</emph>,
   "userinfo": <emph>userinfo</emph>,
   "host": <emph>host</emph>,
@@ -24475,6 +24485,7 @@ are elided for editorial clarity.</p>
       <fos:result><eg>map {
   "uri": "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri",
   "scheme": "http",
+  "hierarchical": true(),
   "authority": "qt4cg.org",
   "host": "qt4cg.org",
   "path": "/specifications/xpath-functions-40/Overview.html",
@@ -24489,6 +24500,7 @@ are elided for editorial clarity.</p>
       <fos:result><eg>map {
   "uri": "http://www.ietf.org/rfc/rfc2396.txt",
   "scheme": "http",
+  "hierarchical": true(),
   "authority": "www.ietf.org",
   "host": "www.ietf.org",
   "path": "/rfc/rfc2396.txt",
@@ -24502,6 +24514,7 @@ are elided for editorial clarity.</p>
       <fos:result><eg>map {
   "uri": "https://example.com/path/to/file",
   "scheme": "https",
+  "hierarchical": true(),
   "authority": "example.com",
   "host": "example.com",
   "path": "/path/to/file",
@@ -24516,6 +24529,7 @@ are elided for editorial clarity.</p>
 map {
   "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance",
   "scheme": "https",
+  "hierarchical": true(),
   "authority": "example.com:8080",
   "host": "example.com",
   "port": "080",
@@ -24536,6 +24550,7 @@ map {
 map {
   "uri": "https://user@example.com/path/to/file",
   "scheme": "https",
+  "hierarchical": true(),
   "authority": "user@example.com",
   "userinfo": "user",
   "host": "example.com",
@@ -24551,6 +24566,7 @@ map {
 map {
   "uri": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
   "scheme": "ftp",
+  "hierarchical": true(),
   "authority": "ftp.is.co.za",
   "host": "ftp.is.co.za",
   "path": "/rfc/rfc1808.txt",
@@ -24565,6 +24581,7 @@ map {
 map {
   "uri": "file:////uncname/path/to/file",
   "scheme": "file",
+  "hierarchical": true(),
   "authority": "uncname",
   "host": "uncname",
   "path": "/path/to/file",
@@ -24579,6 +24596,7 @@ map {
 map {
   "uri": "file:///c:/path/to/file",
   "scheme": "file",
+  "hierarchical": true(),
   "path": "c:/path/to/file",
   "path-segments": array { "c:", "path", "to", "file" }
 }</eg></fos:result>
@@ -24591,6 +24609,7 @@ map {
 map {
   "uri": "file:/C:/Program%20Files/test.jar",
   "scheme": "file",
+  "hierarchical": true(),
   "path": "C:/Program%20Files/test.jar",
   "path-segments": array { "C:", "Program Files", "test.jar" }
 }</eg></fos:result>
@@ -24603,6 +24622,7 @@ map {
 map {
   "uri": "file:\\c:\path\to\file",
   "scheme": "file",
+  "hierarchical": true(),
   "path": "c:/path/to/file",
   "path-segments": array { "c:", "path", "to", "file" }
 }</eg></fos:result>
@@ -24615,6 +24635,7 @@ map {
 map {
   "uri": "file:\c:\path\to\file",
   "scheme": "file",
+  "hierarchical": true(),
   "path": "c:/path/to/file",
   "path-segments": array { "c:", "path", "to", "file" }
 }</eg></fos:result>
@@ -24627,6 +24648,7 @@ map {
 map {
   "uri": "c:\path\to\file",
   "scheme": "file",
+  "hierarchical": true(),
   "path": "c:/path/to/file",
   "path-segments": array { "c:", "path", "to", "file" }
 }</eg></fos:result>
@@ -24675,6 +24697,7 @@ map {
 <eg>map {
   "uri": "ldap://[2001:db8::7]/c=GB?objectClass?one",
   "scheme": "ldap",
+  "hierarchical": true(),
   "authority": "[2001:db8::7]",
   "host": "[2001:db8::7]",
   "path": "/c=GB",
@@ -24693,6 +24716,7 @@ map {
 <eg>map {
   "uri": "mailto:John.Doe@example.com",
   "scheme": "mailto",
+  "hierarchical": false(),
   "path": "John.Doe@example.com",
   "path-segments": array { "John.Doe@example.com" }
 }</eg></fos:result>
@@ -24705,6 +24729,7 @@ map {
 <eg>map {
   "uri": "news:comp.infosystems.www.servers.unix",
   "scheme": "news",
+  "hierarchical": false(),
   "path": "comp.infosystems.www.servers.unix",
   "path-segments": array { "comp.infosystems.www.servers.unix" }
 }</eg></fos:result>
@@ -24717,6 +24742,7 @@ map {
 <eg>map {
   "uri": "tel:+1-816-555-1212",
   "scheme": "tel",
+  "hierarchical": false(),
   "path": "+1-816-555-1212",
   "path-segments": array { " 1-816-555-1212" }
 }</eg></fos:result>
@@ -24729,6 +24755,7 @@ map {
 <eg>map {
   "uri": "telnet://192.0.2.16:80/",
   "scheme": "telnet",
+  "hierarchical": true(),
   "authority": "92.0.2.16:80",
   "host": "92.0.2.16",
   "port": "0",
@@ -24744,6 +24771,7 @@ map {
 <eg>map {
   "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
   "scheme": "urn",
+  "hierarchical": false(),
   "path": "oasis:names:specification:docbook:dtd:xml:4.1.2",
   "path-segments": array { "oasis:names:specification:docbook:dtd:xml:4.1.2" }
 }</eg></fos:result>
@@ -24756,6 +24784,7 @@ map {
 <eg>map {
     "uri": "tag:textalign.net,2015:ns",
     "scheme": "tag",
+    "hierarchical": false(),
     "path": "textalign.net,2015:ns",
     "path-segments": [ "textalign.net,2015:ns" ]
   }</eg>
@@ -24769,6 +24798,7 @@ map {
 <eg>map {
     "uri": "tag:jan@example.com,1999-01-31:my-uri"
     "scheme": "tag",
+    "hierarchical": false(),
     "path": "jan@example.com,1999-01-31:my-uri",
     "path-segments": [ "jan@example.com,1999-01-31:my-uri" ],
 }</eg>
@@ -24784,6 +24814,7 @@ specifically aware of the <code>jar:</code> scheme.</p>
 <eg>map {
   "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
   "scheme": "jar",
+  "hierarchical": true(),
   "path": "file:/C:/Program%20Files/test.jar!/foo/bar",
   "path-segments": array { "file:", "C:", "Program Files", "test.jar!", "foo", "bar" }
 }</eg>
@@ -24800,6 +24831,7 @@ description of <code>fn:resolve-uri</code>.</p>
 <eg>map {
     "uri": "http://www.example.org/Dürst",
     "scheme": "http",
+    "hierarchical": true(),
     "authority": "www.example.org",
     "host": "www.example.org",
     "path": "/Dürst",
@@ -24818,6 +24850,7 @@ fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
 <eg>map {
   "uri": "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
   "scheme": "https",
+  "hierarchical": true(),
   "authority": "example.com:8080",
   "host": "example.com",
   "port": "080",
@@ -24899,14 +24932,16 @@ fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
         map in the following way:</p>
 
         <p>If the <code>scheme</code> key is present in the map, the URI begins
-        with the value of that key. For schemes that are known to be non-hierarchical
-        (<code>urn</code>, <code>mailto</code>, etc.), the scheme is delimited by
+        with the value of that key. A URI is considered to be non-hierarchical
+        if either the <code>hierarchical</code> key is present in the 
+        <code>$parts</code> map with the value
+        <code>false()</code> or if the scheme is known to be non-hierarchical.
+        (In other words, schemes are hierarchical by default.)
+        If the URI is non-hierarchical, the scheme is delimited by
         a trailing <code>:</code>, for all other schemes, it is delimited by
         a trailing <code>://</code>. Exactly which schemes are known to be
         non-hierarchical is
-        <termref def="implementation-defined">implementation-defined</termref>.
-        If the <code>scheme</code> key is not present
-        in the map, the URI begins with <code>//</code>.</p>
+        <termref def="implementation-defined">implementation-defined</termref>.</p>
 
         <p>For simplicity of exposition, we take the
         <code>userinfo</code>, <code>host</code>, and

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24310,7 +24310,10 @@ declare function fn:some(
          non-hierarchical is
          <termref def="implementation-defined">implementation-defined</termref>.
          If the implementation does not know if a <emph>scheme</emph> is or is not
-         hierarchical, <emph>hierarchical</emph> is
+         hierarchical, the <emph>hierarchical</emph> setting depends on the
+         <emph>string</emph>. If the <emph>string</emph> is the empty string,
+         <emph>hierarchical</emph> is the empty sequence (<emph>i.e.</emph> not known),
+         otherwise <emph>hierarchical</emph> is
          true if <emph>string</emph> begins with “/” and false otherwise.</p>
 
          <p>If the <emph>string</emph> matches <code>^//*([a-zA-Z]:.*)$</code>,


### PR DESCRIPTION
The `fn:parse-uri` function will parse hierarchical or non-hierarchical URIs, however, the parse cannot be reversed if the `fn:build-uri` function doesn't know whether the scheme is hierarchical. Consider `fn:parse-uri("querty:abc")`:

```
map {
  "path":"abc",
  "scheme":"querty",
  "path-segments":["abc"],
  "uri":"querty:abc"
}
```

When `fn:build-uri` parses that map, it produces: `querty://abc` because the scheme is not known to be non-hierarchical.

This PR changes `fn:parse-uri` so that it records whether or not the URI was hierarchical and `fn:build-uri` to use that information.

It's possible that we could finesse this by setting the `authority` to the empty string for hierarchical URIs, but it seems clearer to be explicit.

This PR also fixes a bug. Previously, if the `scheme` was not present when building a URI, the URI began with `//`. That's an error. If the scheme isn't present, there should be no *scheme separator*.
