### PR TITLE
333: Deep-equal, no failure when comparing functions

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12434,7 +12434,7 @@ else if (fn:empty($input))
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
                </fos:option>
-               <fos:option key="false-on-error">
+               <!--<fos:option key="false-on-error">
                   <fos:meaning>If true, then in the event of a dynamic error occurring in the course of
                      the comparison, the function will return false rather than throwing the error. (This option does
                      not affect the handling of errors in the supplied values of the <code>$collation</code>
@@ -12442,7 +12442,7 @@ else if (fn:empty($input))
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
-               </fos:option>
+               </fos:option>-->
                <fos:option key="id-property">
                   <fos:meaning>Determines whether the <code>id</code> property of elements and attributes is significant.
                   </fos:meaning>
@@ -12675,6 +12675,53 @@ else if (fn:empty($input))
                            $collation, $options).</code></p>
                   </item>
                </olist>
+            </item>
+            <item diff="add" at="2023-03-13">
+               <p diff="add" at="2023-03-13">All the following conditions are true:</p>
+               <olist diff="add" at="2023-03-13">
+                  <item><p><code>$i1</code> is a function item other than an array or a map.</p></item>
+                  <item><p><code>$i2</code> is a function item other than an array or a map.</p></item>
+                  <item><p>The two functions are <termref def="dt-identical"/>.</p></item>
+               </olist>
+               <note diff="add" at="2023-03-13">
+                  <p>Determining whether two functions are identical is 
+                     <termref def="implementation-dependent">implementation-dependent</termref>, except
+                  that in any situation where the two functions can be distinguished by means of
+                  operations available within the language,
+                  the result <rfc2119>must</rfc2119> be false.</p>
+                  <p>Situations where an implementation <rfc2119>may</rfc2119> (but will not necessarily)
+                     compare two functions as deep-equal include the following:</p>
+                  <ulist>
+                     <item><p>When comparing a value to itself: <code>fn:deep-equal($f, $f)</code>.</p></item>
+                     <item><p>When the arguments self-evidently refer to the same function: 
+                        <code>fn:deep-equal(fn:name#1, fn:name#1)</code>.</p></item>
+                     <item><p>When the arguments represent different ways of arriving at the same function:
+                     <code>fn:deep-equal(fn:name#1, function-lookup(xs:QName('fn:name'), 1)</code></p></item>
+                     <item><p>When the two functions have arity zero and deliver results that are themselves
+                        deep-equal: <code>fn:deep-equal(->(){1 to 5}, ->(){1, 2, 3, 4, 5})</code>.</p></item>
+                     <item><p>When the processor understands the semantics of two functions in sufficient
+                     detail to determine that they are equivalent: 
+                        <code>fn:deep-equal(->($x){fn:empty($x)}, ->($x){fn:count($x)=0})</code>.</p></item>
+                  </ulist>
+                  <p>Situations where an implementation must compare two functions as being not deep-equal
+                  include (but are not limited to) the following:</p>
+                  <ulist>
+                     <item><p>When the functions produce different results for the same inputs:
+                     <code>fn:deep-equal(fn:op("+"), fn:op("-"))</code></p></item>
+                     <item><p>When the functions have different names, even though they produce the same results.</p></item>
+                     <item><p>When the functions have different signatures, even though they produce the same results.</p></item>
+                     <item><p>When two function items differ in their captured context:
+                     <code>fn:deep-equal(&lt;a/>!fn:name#0, &lt;b/>!fn:name#0)</code></p></item>
+                     <!--<item><p>TODO: what about the parameter names? XDM identifies the parameter names of a function-item
+                     as a property of the item, but there is no functionality that can make use of the parameter names, and therefore
+                     no reason for an implementation to retain them, or to treat two items with different parameter names
+                     as distinct. This could change if we allow dynamic function calls to use argument keywords.</p></item>-->
+                  </ulist>
+                  <p>A function may be deemed deep-equal to itself even if it is <termref def="dt-nondeterministic"/>,
+                  for example <code>fn:deep-equal(fn:parse-xml#1, fn:parse-xml#1)</code>. The significant test is that 
+                  it is not possible to distinguish the behavior of the two supplied functions.</p>
+ 
+               </note>
             </item>
             <item>
                <p>All the following conditions are true:</p>
@@ -12916,12 +12963,6 @@ else if (fn:empty($input))
          <p>In all other cases the result is false.</p>
       </fos:rules>
       <fos:errors>
-         <p>A type error is raised <errorref class="TY" code="0015" type="type"
-               /> if either input
-            sequence contains a function item <phrase>that is not a map or
-               array</phrase>. </p>
-         <p>However, the above error is not raised if the <code>false-on-error</code> option has the
-         value true; in this case, the function returns false rather than raising an error.</p>
          <p>A type error is raised <xerrorref spec="XP" class="TY"
             code="0004" type="type"/> if the value of 
             <code>$options</code> includes an entry whose key is defined 
@@ -12930,6 +12971,8 @@ else if (fn:empty($input))
          /> if the value of 
             <code>$options</code> includes an entry whose key is defined 
             in this specification, and whose value is not a permitted value for that key.</p>
+         <p diff="chg" at="2023-03-13">Assuming that the supplied <code>$collation</code> and <code>$options</code> are valid, 
+            the function will always return true or false, never an error.</p>
       </fos:errors>
       <fos:notes>
          <p>By default, two nodes are not required to have the same type annotation, and they are not
@@ -12944,15 +12987,25 @@ else if (fn:empty($input))
          <p>By default, the contents of comments and processing instructions are significant only if these nodes
             appear directly as items in the two sequences being compared. The content of a comment
             or processing instruction that appears as a descendant of an item in one of the
-            sequences being compared does not affect the result. However, the presence of a comment
+            sequences being compared does not affect the result. 
+            <phrase diff="del" at="2023-03-13">However, the presence of a comment
             or processing instruction, if it causes a text node to be split into two text nodes, may
-            affect the result.</p>
+            affect the result.</phrase></p>
          <p>Comparing items of different kind (for example, comparing an atomic
             value to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns false, 
             it does not return an error. So
             the result of <code>fn:deep-equal(1, current-dateTime())</code> is <code>false</code>.</p>
-         <p>Comparing a function (other than a map or array) to any other value raises a type error,
+         <p diff="del" at="2023-03-13">Comparing a function (other than a map or array) to any other value raises a type error,
          unless the error is suppressed using the <code>false-on-error</code> option.</p>
+         <p diff="add" at="2023-03-13">Apart from the introduction of the <code>$options</code> parameter, there are two main differences
+         from the behavior of the function in version 3.1:</p>
+         <ulist>
+            <item><p>When a comment or processing instruction is skipped, the text nodes on either side are now
+            merged before comparison.</p></item>
+            <item><p>The presence of a function item now leads to the result being implementation-dependent
+            rather than an error. An effect of this change is that a processor may if it chooses treat
+            any sequence as being deep equal to itself, without checking the contents.</p></item>
+         </ulist>
       </fos:notes>
       <fos:examples>
          <fos:variable name="at" id="v-deep-equal-at" as="element()"


### PR DESCRIPTION
Refines the spec of fn:deep-equal so it no longer fails when comparing function items, rather it returns a result which in general is implementation-dependent, though it must be false unless the functions are provably equivalent.