### PR TITLE
Issue 400: ranking of type patterns

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -82,11 +82,11 @@ apply.
       <g:ref name="WrappedItemTest" lookahead="2"/>
       <g:ref name="AnyItemTest" lookahead="2"/>
       <g:ref name="FunctionTest" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
-      <g:ref name="MapTest" lookahead="2" if="xpath40 xquery40"/>
-      <g:ref name="ArrayTest" lookahead="2" if="xpath40 xquery40"/>
-      <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40"/>
-      <g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40"/>
-      <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40"/>
+      <g:ref name="MapTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="ArrayTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <!--<g:ref name="NamedItemType" lookahead="2" if="xpath40 xquery40"/>-->
     </g:choice>
     <g:ref name="PredicateList"/>
@@ -2599,12 +2599,12 @@ ErrorVal ::= "$" VarName
       <g:ref name="TypeName" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="KindTest" lookahead="2"/>
       <g:ref name="FunctionTest" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
-      <g:ref name="MapTest" lookahead="2" if="xpath40 xquery40"/>
-      <g:ref name="ArrayTest" lookahead="2" if="xpath40 xquery40"/>
+      <g:ref name="MapTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="ArrayTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="AtomicOrUnionType"/>
-      <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40"/>
-      <g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40"/>
-      <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40"/>
+      <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ParenthesizedItemType" if="xpath40 xquery40  xslt40-patterns"/>
     </g:choice>
   </g:production>
@@ -2785,21 +2785,21 @@ ErrorVal ::= "$" VarName
     <g:ref name="SequenceType"/>
   </g:production>
 
-  <g:production name="MapTest" if="xpath40 xquery40">
+  <g:production name="MapTest" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="AnyMapTest" lookahead="3"/>
       <g:ref name="TypedMapTest"/>
     </g:choice>
   </g:production>
 
-  <g:production name="AnyMapTest" if="xpath40 xquery40">
+  <g:production name="AnyMapTest" if="xpath40 xquery40 xslt40-patterns">
     <g:string>map</g:string>
     <g:string>(</g:string>
     <g:string>*</g:string>
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="TypedMapTest" if="xpath40 xquery40">
+  <g:production name="TypedMapTest" if="xpath40 xquery40 xslt40-patterns">
     <g:string>map</g:string>
     <g:string>(</g:string>
     <g:ref name="ItemType"/>
@@ -2855,7 +2855,7 @@ ErrorVal ::= "$" VarName
     <g:string>*</g:string>
   </g:production>
   
-  <g:production name="LocalUnionType" if="xpath40 xquery40">
+  <g:production name="LocalUnionType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>union</g:string>
     <g:string>(</g:string>
     <g:ref name="ItemType"/>
@@ -2866,7 +2866,7 @@ ErrorVal ::= "$" VarName
     <g:string>)</g:string>
   </g:production>
   
-  <g:production name="EnumerationType" if="xpath40 xquery40">
+  <g:production name="EnumerationType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>enum</g:string>
     <g:string>(</g:string>
     <g:ref name="StringLiteral"/>
@@ -2877,21 +2877,21 @@ ErrorVal ::= "$" VarName
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="ArrayTest" if="xpath40 xquery40">
+  <g:production name="ArrayTest" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="AnyArrayTest" lookahead="3"/>
       <g:ref name="TypedArrayTest"/>
     </g:choice>
   </g:production>
 
-  <g:production name="AnyArrayTest" if="xpath40 xquery40">
+  <g:production name="AnyArrayTest" if="xpath40 xquery40 xslt40-patterns">
     <g:string>array</g:string>
     <g:string>(</g:string>
     <g:string>*</g:string>
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="TypedArrayTest" if="xpath40 xquery40">
+  <g:production name="TypedArrayTest" if="xpath40 xquery40 xslt40-patterns">
     <g:string>array</g:string>
     <g:string>(</g:string>
     <g:ref name="SequenceType"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10566,7 +10566,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         <code>xs:integer</code></p></item>
                      <item><p><code>type(integer)[. gt 0]</code> matches
                         any positive integer.</p></item>
-                     <item><p><code>type(union(string, untypedAtomic))[matches(., '[0-9]+')]</code> matches
+                     <item><p><code>union(string, untypedAtomic)[matches(., '[0-9]+')]</code> matches
                         any instance of <code>xs:string</code> or <code>xs:untypedAtomic</code> that
                         contains a sequence of decimal digits.</p></item>
                      <item><p><code>type(node())</code> matches any node. (This is not the same as the pattern
@@ -10593,6 +10593,9 @@ and <code>version="1.0"</code> otherwise.</p>
                         nodes can usually be expressed more economically
                         as a <code>NodeTest</code>: for example <code>match="type(element(PERSON))"</code> has the same meaning as
                         <code>match="element(PERSON)"</code>, which in turn is usually abbreviated to <code>match="PERSON"</code>.</p>
+                     <p>Although <code>match="type(element(PERSON))"</code> matches exactly the same items as
+                     <code>match="PERSON"</code>, the priority relative to other template rules (in the absence of an explicit
+                     <code>priority</code> attribute) may be different.</p>
                   </note>
                   
                </div4>
@@ -12577,6 +12580,41 @@ and <code>version="1.0"</code> otherwise.</p>
                   </p>
 
                </item>
+               <item diff="add" at="2023-03-15">
+                  <p>Next, if each of the remaining matching rules has a match pattern in the form of a 
+                     <nt def="TypePattern">TypePattern</nt>, then this set of rules (call it <var>R</var>)
+                     is examined as follows:
+                  </p>
+                  <olist>
+                     <item><p>A <nt def="TypePattern">TypePattern</nt> comprises an <code>ItemType</code>
+                     and a possibly empty set of predicates.</p>
+                     </item>
+                     <item><p>Any rule in <var>R</var> whose <code>ItemType</code> is a strict supertype of 
+                     the <code>ItemType</code> of another rule in <var>R</var> is discarded. A type <var>T</var>
+                     is a strict supertype of another type <var>U</var> if <var>U</var> is a 
+                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>T</var> and
+                        <var>T</var> is not a 
+                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>U</var>.
+                     </p></item>
+                     <item><p>If there is a rule <var>P</var> in <var>R</var> whose <code>ItemType</code> is the same type as 
+                        the <code>ItemType</code> of another rule <var>Q</var> in <var>R</var>, and if <var>Q</var> 
+                        has one or more predicates while <var>P</var> has none, then <var>P</var> is discarded. A type <var>T</var>
+                        is the same type as another type <var>U</var> if <var>T</var> is a 
+                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>U</var> and
+                        <var>U</var> is a 
+                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>T</var>.
+                     </p></item>
+                     <item><p>If this process leaves a single rule, then that rule is chosen.</p></item>
+                  </olist>
+                  <note>
+                     <p>For example, this means that the pattern <code>type(xs:integer)</code> is chosen
+                  in preference to <code>type(xs:decimal)</code> which in turn is chosen in preference
+                  to <code>type(item())</code>; it also means that <code>type(xs:integer)[. gt 0]</code>
+                  is chosen in preference to <code>type(xs:integer)</code>.</p>
+                     <p>Similarly, the pattern <code>record(longitude, latitude, altitude)</code> will be
+                        chosen in preference to the pattern <code>record(longitude, latitude, *)</code></p>
+                  </note>
+               </item>
 
                <item>
                   <p>If this leaves more than one matching template rule, then:</p>
@@ -12808,9 +12846,10 @@ and <code>version="1.0"</code> otherwise.</p>
                      −0.5.</p>
                </item>
                <item>
-                  <p>In all other cases, the priority is +0.5. 
-                     <phrase diff="add" at="2022-01-01">TODO: define default priorities for type patterns,
-                     as suggested in https://www.saxonica.com/papers/xmlprague-2020mhk.pdf section 6.5.1</phrase></p>
+                  <p diff="add" at="2023-03-15">If the pattern is a <nt def="TypePattern">TypePattern</nt>, then the priority
+                  is 0 (zero).</p></item>
+               <item>
+                  <p>In all other cases, the priority is +0.5.</p>
                </item>
             </olist>
             <note>


### PR DESCRIPTION
Proposes how to handle type-based match patterns (record tests, in particular) in the absence of explicit priorities, basing the decision on the type hierarchy. Note: user-defined priorities are always considered before any inferred selectivity rules. Also fixes some grammar problems with type patterns. See Issue #400.