### PR TITLE
Revise xsl:array instruction and examples

### DIFF
--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1712,8 +1712,8 @@
       <e:attribute name="select" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="composite" required="no">
-         <e:data-type name="boolean"/>
+      <e:attribute name="use" required="no">
+         <e:data-type name="expression"/>
       </e:attribute>
       <e:model name="sequence-constructor"/>
       <e:allowed-parents>
@@ -1721,7 +1721,7 @@
       </e:allowed-parents>
    </e:element-syntax>
    
-   <e:element-syntax name="array-member">
+   <!--<e:element-syntax name="array-member">
       <e:in-category name="instruction"/>
       <e:attribute name="select">
          <e:data-type name="expression"/>
@@ -1730,7 +1730,7 @@
       <e:allowed-parents>
          <e:parent-category name="sequence-constructor"/>
       </e:allowed-parents>
-   </e:element-syntax>
+   </e:element-syntax>-->
    
 
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35077,7 +35077,7 @@ return ($m?price - $m?discount)</eg>
                <p>The following example constructs an array whose members are sequences:</p>
                <eg><![CDATA[<xsl:array use="?value">
    <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
-     <xsl:map key="'value'" select="current-group()"/>
+     <xsl:map-entry key="'value'" select="current-group()"/>
    </xsl:for-each-group>
 </xsl:array>]]></eg>
                <p>The result is the array <code>[(0,1,2,3), (4,5,6,7), (8,9,10,11), (12,13,14,15), (16,17,18,19)]</code>.</p>
@@ -35093,6 +35093,8 @@ return ($m?price - $m?discount)</eg>
                   <code>current-group#0</code>, which is then applied using the expression <code>.()</code> 
                   to yield the actual value.
                </p>
+               <note><p>TODO: this example only works if we fix issue #407. Without that fix, calling <code>current-group#0</code> 
+                  raises XTDE1061.</p></note>
                <p>A third approach would be to capture the member sequences as arrays:</p>
                <eg><![CDATA[<xsl:array use="?*">
    <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
@@ -35107,8 +35109,16 @@ return ($m?price - $m?discount)</eg>
                of an existing array. For example, the following code combines two arrays and sorts the result:</p>
                <eg><![CDATA[<xsl:array use="?value">
    <xsl:perform-sort select="array:members($input-1), array:members($input-2)">
-      <xsl:sort-key select="count(?value)"/>
+      <xsl:sort select="count(?value)"/>
    </xsl:perform-sort>
+</xsl:array>]]></eg>
+               <p>The following code inverts a nested array (such as <code>[[1,2,3], [4,5,6], [7,8,9]]</code>)
+               so the result is organized by columns rather than rows (<code>[[1,4,7], [2,5,8], [3,6,9]]</code>):</p>
+               <eg><![CDATA[<xsl:array>
+   <xsl:for-each select="1 to array:size($input?1)">
+      <xsl:variable name="index" select="."/>
+      <xsl:array select="array:members($input)?value?($index)"/>
+   </xsl:for-each>
 </xsl:array>]]></eg>
             </example>
             

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35035,105 +35035,84 @@ return ($m?price - $m?discount)</eg>
             <head>Array Construction</head>
             <p>The instruction <elcode>xsl:array</elcode> constructs and returns a new array.</p>
             <?element xsl:array?>
-            <p>If the <code>composite</code> attribute is omitted or set to <code>no</code>, the resulting
+            <p diff="chg" at="2023-03-22">If the <code>use</code> attribute is omitted, the resulting
             array has one singleton member for each item returned by the <code>select</code> attribute or
             sequence constructor. For example <code>&lt;xsl:array select="1 to 5"/></code> returns
             an array with five members: <code>[1, 2, 3, 4, 5]</code>.</p>
-            <p>If the <code>composite</code> attribute is present with the value <code>yes</code>, then
-               each item returned by the <code>select</code> attribute or
-               sequence constructor must be an zero-arity function, and the sequences that result from
-            the evaluation of these zero-arity functions become the members of the array. For example, 
-               <code>&lt;xsl:array select="function(){1 to 3}, function(){8 to 10}" composite="yes"/></code>
-            returns an array with two members: <code>[(1,2,3), (8,9,10)]</code>.</p>
+            <p diff="chg" at="2023-03-22">If the <code>use</code> attribute is present then it is evaluated
+               once for each item in the sequence returned by the <code>select</code> attribute or
+               sequence constructor, with a <termref def="dt-singleton-focus"/> based on that item,
+               to produce the value of the corresponding array member.</p>
+            <p diff="chg" at="2023-03-22">For example, <code>&lt;xsl:array select="'red', 'green', 'blue'" use="characters(.)"/></code>
+               returns an array with three members: <code>[("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e")] </code>.</p>
+            <p diff="chg" at="2023-03-22">A useful convention is to construct each array member as a <term>value record</term>
+               (a singleton map whose single entry has the key <code>"value"</code>): 
+               <code>&lt;xsl:array select="map:entry('value', 1 to 3), map:entry('value': 8 to 10)" use="?value"/></code>
+            returns an array with two members: <code>[(1,2,3), (8,9,10)]</code>. This is essentially equivalent to
+            the effect of the <function>array:of</function> function.</p>
             <p>The <code>select</code> attribute and the contained sequence constructor are mutually
             exclusive: if the <code>select</code> attribute is present, then the only permitted child
             element is <elcode>xsl:fallback</elcode>.</p>
-            <p>For convenience and readability, the instruction <elcode>xsl:array-member</elcode>
+            <p diff="del" at="2023-03-22">For convenience and readability, the instruction <code>xsl:array-member</code>
             can be used to construct a zero-arity function suitable for use with <elcode>xsl:array</elcode>.</p>
-            <?element xsl:array-member?>
-            <p>For example:</p>
-            <eg><![CDATA[
-<xsl:array composite="yes">
-  <xsl:for-each select="'jane', 'mary', 'pete', 'andy'">
-     <xsl:array-member select="lower-case(.), upper-case(.)"/>
-  </xsl:for-each>
+            
+            
+            
+            <example>
+               <head>Constructing an array whose members are single items</head>
+               <p>The following example constructs an array by tokenizing a string:</p>
+               <eg><![CDATA[<xsl:array select="tokenize('The cat sat on the mat')"/>]]></eg>
+               <p>The result is the array <code>["The", "cat", "sat", "on", "the", "mat"]</code>.</p>
+               <p>The following example constructs an array containing items computed using nested instructions:</p>
+               <eg><![CDATA[<xsl:array>
+   <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
+     <xsl:sequence select="string-join(current-group(), '-')"/>
+   </xsl:for-each-group>
 </xsl:array>]]></eg>
-            <p>The result of this instruction is the array <code>[('jane', "JANE"), ('mary', 'MARY'), '('pete', 'PETE'), ('andy', 'ANDY')]</code>:
-            that is, an array with four members, each of which is a sequence of two items.</p>
-            <p>Although the syntax is designed to be intuitive, the underlying mechanism is non-obvious. The effect of the
-            <elcode>xsl:array-member</elcode> instruction is to return a zero-arity anonymous function which, on evaluation,
-            delivers the result of its <code>select</code> attribute or contained sequence constructor. That is, the 
-               <elcode>xsl:array-member</elcode> instruction in this example is actually equivalent to:</p>
-            <eg><![CDATA[
- <xsl:sequence select="let $member := (lower-case(.), upper-case(.)) 
-                       return function(){$member}"/>              
-               ]]></eg>
-            <p>Specifically, the <elcode>xsl:array-member</elcode> instruction evaluates its <code>select</code>
-               expression or contained <termref def="dt-sequence-constructor"/> (which are mutually exclusive),
-               to obtain a value <var>V</var>, and returns a zero-arity anonymous function
-               with signature <code>function() as item()*</code>, which when invoked returns <var>V</var>.</p>
+               <p>The result is the array <code>["0-1-2-3", "4-5-6-7", "8-9-10-11", "12-13-14-15", "16-17-18-19"]</code>.</p>
+            </example>
             
-            <note><p>The reason for this rather obscure formulation is to prevent the flattening of nested sequences that would
-               normally occur when instructions within a sequence constructor deliver sequences rather than individual items.
-               Wrapping the individual sequences within anonymous functions prevents this flattening.</p></note>
-            
-            <p>More formally, the semantics of the <elcode>xsl:array</elcode> instruction are as follows:</p>
-            
-            <olist>
-               <item>
-                  <p>When there is no <code>composite</code> attribute, or when <code>composite="no"</code>:</p>
-                  <olist>
-                     <item><p>The <code>select</code> expression or contained sequence constructor
-                     is evaluated, in the same way as for the <elcode>xsl:sequence</elcode> instruction,
-                     to yield a value <var>V</var>.</p></item>
-                     <item><p>An array is constructed, containing one member for each item in <var>V</var>,
-                     whose value is that item.</p></item>
-                     <item><p>This array is returned as the result of the <code>xsl:array</code> instruction.</p></item>
-                  </olist>
-               </item>
-               <item>
-                  <p>When <code>composite="yes" is specified</code>:</p>
-                  <olist>
-                     <item><p>The <code>select</code> expression or contained sequence constructor
-                        is evaluated, in the same way as for the <elcode>xsl:sequence</elcode> instruction,
-                        to yield a value <var>V</var>.</p></item>
-                     <item><p>A type error is raised if <var>V</var> is not an instance of 
-                        <code>(function() as item()*)*</code>. [TODO: add error code]</p></item>
-                     <item><p>An array is constructed, containing one member for each item <code>$v</code>
-                        in <var>V</var>, the value of the array member being <code>$v()</code>.</p></item>
-                     <item><p>This array is returned as the result of the <code>xsl:array</code> instruction.</p></item>
-                  </olist>
-               </item>
-            </olist>
-            
-            <p>The semantics of the <elcode>xsl:array-member</elcode> instruction are as follows:</p>
-            
-            <olist>
-               <item><p>The <code>select</code> expression or contained sequence constructor
-                  is evaluated, in the same way as for the <elcode>xsl:sequence</elcode> instruction,
-                  to yield a value <var>V</var>.</p></item>
-               <item><p>The <elcode>xsl:array-member</elcode> instruction returns a zero-arity anonymous
-                  function with signature <code>function() as item()*</code>, whose evaluation
-                  returns <var>V</var>.</p></item>
-            </olist>
-            
-            <p>The <code>select</code> attribute and the contained sequence constructor of <elcode>xsl:array</elcode>
-               are mutually exclusive [Error condition TBA].</p>
- 
-            <p>The <code>select</code> attribute and the contained sequence constructor of <elcode>xsl:array-member</elcode>
-            are mutually exclusive [Error condition TBA].</p>
+            <example>
+               <head>Constructing an array whose members are arbitrary sequences</head>
+               <p>The following example constructs an array whose members are sequences:</p>
+               <eg><![CDATA[<xsl:array use="?value">
+   <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
+     <xsl:map key="'value'" select="current-group()"/>
+   </xsl:for-each-group>
+</xsl:array>]]></eg>
+               <p>The result is the array <code>[(0,1,2,3), (4,5,6,7), (8,9,10,11), (12,13,14,15), (16,17,18,19)]</code>.</p>
+               <p>The technique used here is to capture each member sequence in a singleton map (known as a <term>value record</term>)
+               with the conventional key <code>"value"</code>.</p> 
+               <p>The following example delivers the same result in a different way:</p>
+               <eg><![CDATA[<xsl:array use=".()">
+   <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
+     <xsl:sequence select="current-group#0"/>
+   </xsl:for-each-group>
+</xsl:array>]]></eg>
+               <p>In this approach, the member sequence is captured in the value of the zero-arity function
+                  <code>current-group#0</code>, which is then applied using the expression <code>.()</code> 
+                  to yield the actual value.
+               </p>
+               <p>A third approach would be to capture the member sequences as arrays:</p>
+               <eg><![CDATA[<xsl:array use="?*">
+   <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
+     <xsl:array select="current-group()"/>
+   </xsl:for-each-group>
+</xsl:array>]]></eg>               
+            </example>
+            <example>
+               <head>Constructing an array based on an existing array</head>
+               <p>The <elcode>xsl:array</elcode> instruction can be used in conjunction with
+               the <xfunction>array:members</xfunction> function to construct an array from the members
+               of an existing array. For example, the following code combines two arrays and sorts the result:</p>
+               <eg><![CDATA[<xsl:array use="?value">
+   <xsl:perform-sort select="array:members($input-1), array:members($input-2)">
+      <xsl:sort-key select="count(?value)"/>
+   </xsl:perform-sort>
+</xsl:array>]]></eg>
+            </example>
             
             
-            <note><p>XPath offers two constructs for creating arrays, the so called square and curly array constructors.
-            The square array constructor (for example <code>[1, 3, 5, (7 to 10)]</code> can only construct an array where
-            the number of members is statically known (in this case there are four members). The curly array constructor
-            (for example <code>array{1, 3, 5, (7 to 10)}</code> can only construct an array whose members are singleton items 
-            (in this case there are seven members, each being a single integer).</p>
-               <p>The combination of 
-            <elcode>xsl:array</elcode> and <elcode>xsl:array-member</elcode>, by contrast, can deliver an array
-            whose size is determined dynamically and whose members can be arbitrary XDM values.</p>
-               <p>An equivalent construct using array functions would be <code>['jane', 'mary', 'pete', 'andy'] =>
-               array:for-each(function($s){lower-case($s), upper-case($s)})</code>.</p></note>
             
          </div2>
          
@@ -38759,12 +38738,9 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                functions from multiple different namespaces to be called without using a namespace prefix.</p></item>
                <item><p>The default namespace for element names and the default namespace for types can now be
                different, allowing built-in types to be referenced in unprefixed form (<code>as="integer"</code>).</p></item>
-               <item><p>New instructions <elcode>xsl:array</elcode> and <elcode>xsl:array-member</elcode> allow
+               <item><p>The new instruction <elcode>xsl:array</elcode> allows
                the construction of arrays.</p></item>
-               <item><p>The instructions <elcode>xsl:for-each</elcode>, <elcode>xsl:iterate</elcode>, and 
-                  <elcode>xsl:for-each-group</elcode> have attributes <code>array</code> and <code>map</code>
-                  which can be used in place of the <code>select</code> attribute to allow iteration over arrays or maps
-                  rather than sequences.</p></item>
+               
                
                <item><p>New pattern syntax ( <code>type(T)</code>, <code>record(N, M, N)</code>) 
                   allows matching of items by item type.</p></item>


### PR DESCRIPTION
This PR revises the design of the xsl:array instruction to align it with the recently agreed specs for the functions `array:members` and `array:of`. The `composite` attribute and the `xsl:array-member` instruction are dropped; instead the instruction takes a `use` attribute which is an expression used to compute each array member value from the corresponding item in the value of the select expression or sequence constructor.