### PR TITLE
Fix issue #398 (clash with constructor functions)

### DIFF
--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1463,7 +1463,14 @@ declare context item as element(env:Envelope) external;</eg>
       <item><p>The implementation of the function is given by the enclosed expression.</p></item>
     </ulist>
     
-    <p>The static context may include more than one declared function with the same name, but their arity ranges must not overlap <errorref class="ST" code="0034"/>.</p>
+    <p>The static context may include more than one declared function with the same name, but their arity ranges must 
+      not overlap <errorref class="ST" code="0034"/>.</p>
+    
+    <note diff="add" at="2023-03-24">
+      <p>A consequence of this rule is that a function declaration must not declare a function that has arity 1 (one)
+      if its name is the same as the name of an imported atomic type, since the name would then clash with the
+      constructor function for that type.</p>
+    </note>
 
     <p>
       In function declarations, <termref def="dt-external-function">external functions</termref> are identified by the keyword

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -18590,6 +18590,19 @@ and <code>version="1.0"</code> otherwise.</p>
                      </error>
                   </p>
                   
+                  <p diff="add" at="2023-03-24">Similarly it is a static error
+                     <errorref spec="XT" class="DE" code="0770"/> for 
+                           a <termref def="dt-package">package</termref> to
+                           contain an <elcode>xsl:function</elcode>
+                     declaration <var>F</var> that is not <termref def="dt-eclipsed"/> by another 
+                     <elcode>xsl:function</elcode> declaration, if its name and arity range conflict
+                           with a constructor function in the static context. There will be a constructor
+                  function (with arity 1) in the static context for every atomic type or plain union type
+                  in the <termref def="dt-in-scope-schema-component">in-scope schema components</termref>.
+                  </p>
+                  
+           
+                  
                </div4>
                
                <div4 id="overriding-extension-functions">


### PR DESCRIPTION
Add clarification to XSLT and XQuery specs to say that a used-defined function must not clash with a constructor function for an imported atomic type.