### PR TITLE
Remove the note from the parse-html unparsed-entity sections.

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6992,15 +6992,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>The result of the <xspecref spec="DM40" ref="dm-unparsed-entity-public-id"/>
                   <code>dm:unparsed-entity-public-id($node)</code> for an HTML DOM <code>Node</code>
                   is an empty sequence.</p>
-
-               <note>
-                  <p>The <bibref ref="html5"/> specification does not include unknown entity references.
-                     Section 13.2.5.73, <emph>Named character reference state</emph> reports an
-                     <code>unknown-named-character-reference</code> error for these and places the
-                     literal text of the entity reference in the content stream.</p>
-                  <p>The XDM should treat these unknown named character references as starting with
-                     <code>&amp;amp;</code> so that the text is valid XML.</p>
-               </note>
             </div3>
             <div3 id="html-unparsed-entity-system-id-accessor">
                <head>unparsed-entity-system-id Accessor</head>
@@ -7009,15 +7000,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>The result of the <xspecref spec="DM40" ref="dm-unparsed-entity-system-id"/>
                   <code>dm:unparsed-entity-system-id($node)</code> for an HTML DOM <code>Node</code>
                   is an empty sequence.</p>
-
-               <note>
-                  <p>The <bibref ref="html5"/> specification does not include unknown entity references.
-                     Section 13.2.5.73, <emph>Named character reference state</emph> reports an
-                     <code>unknown-named-character-reference</code> error for these and places the
-                     literal text of the entity reference in the content stream.</p>
-                  <p>The XDM should treat these unknown named character references as starting with
-                     <code>&amp;amp;</code> so that the text is valid XML.</p>
-               </note>
             </div3>
          </div2>
       </div1>


### PR DESCRIPTION
This applies the review action:
> RD to remove the note in 15.5.15 of functions and operators.