### PR TITLE
409, QT4CG-027-01: xsl:next-match

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12599,11 +12599,14 @@ and <code>version="1.0"</code> otherwise.</p>
 
                </item>
                <item diff="add" at="2023-03-15">
-                  <p>Next, if each of the remaining matching rules has a match pattern in the form of a 
-                     <nt def="TypePattern">TypePattern</nt>, then this set of rules (call it <var>R</var>)
-                     is examined as follows:
+                  <p>Next, if any of the remaining matching rules has a match pattern in the form of a 
+                     <nt def="TypePattern">TypePattern</nt>, then this set of rules 
+                     is reduced as follows:
                   </p>
                   <olist>
+                     <item><p>Any rule with a match pattern that is not a type pattern is discarded. (That
+                     is, type patterns are chosen in preference to non-type patterns). Call the set
+                     of type patterns that remain <var>R</var>.</p></item>
                      <item><p>A <nt def="TypePattern">TypePattern</nt> comprises an <code>ItemType</code>
                      and a possibly empty set of predicates.</p>
                      </item>
@@ -12625,12 +12628,21 @@ and <code>version="1.0"</code> otherwise.</p>
                      <item><p>If this process leaves a single rule, then that rule is chosen.</p></item>
                   </olist>
                   <note>
-                     <p>For example, this means that the pattern <code>type(xs:integer)</code> is chosen
-                  in preference to <code>type(xs:decimal)</code> which in turn is chosen in preference
-                  to <code>type(item())</code>; it also means that <code>type(xs:integer)[. gt 0]</code>
-                  is chosen in preference to <code>type(xs:integer)</code>.</p>
-                     <p>Similarly, the pattern <code>record(longitude, latitude, altitude)</code> will be
-                        chosen in preference to the pattern <code>record(longitude, latitude, *)</code></p>
+                     <p>For example, this means that:</p>
+                     <ulist>
+                        <item><p>The match pattern <code>type(xs:integer)</code> is chosen
+                           in preference to <code>type(xs:decimal)</code> which in turn is chosen in preference
+                           to <code>type(item())</code>.</p></item>
+                        <item><p>The match pattern <code>type(xs:integer)[. gt 0]</code> is chosen
+                           in preference to <code>type(xs:integer)</code> which in turn is chosen in preference
+                           to <code>type(xs:decimal)</code>.</p></item>
+                        <item><p>The match pattern <code>type(xs:integer)</code> is chosen
+                           in preference to <code>union(xs:integer, xs:double)</code> which in turn is chosen in preference
+                           to <code>type(xs:numeric)</code>.</p></item>
+                        <item><p>The match pattern <code>record(longitude, latitude, altitude)</code> is
+                           chosen in preference to the pattern <code>record(longitude, latitude, *)</code>,
+                        which in turn is chosen in preference to the pattern <code>type(map(*))</code>.</p></item>
+                     </ulist>
                   </note>
                </item>
 
@@ -14057,10 +14069,8 @@ and <code>version="1.0"</code> otherwise.</p>
                   <elcode>xsl:apply-imports</elcode> or <elcode>xsl:next-match</elcode> instruction
                to invoke the overridden template rule. The <elcode>xsl:apply-imports</elcode>
                instruction only considers template rules in imported stylesheet modules; the
-                  <elcode>xsl:next-match</elcode> instruction considers all other template rules of
-               lower <termref def="dt-import-precedence">import precedence</termref> and/or
-               priority, and also declarations of the same
-                  precedence and priority that appear earlier in <termref def="dt-declaration-order"/>. Both instructions will invoke the built-in template rule for the
+                  <elcode>xsl:next-match</elcode> instruction considers all template rules that
+               have not already been used. Both instructions will invoke the built-in template rule for the
                   context item (see <specref ref="built-in-rule"/>) if no other template rule is found.</p>
             <p>
                <termdef id="dt-current-template-rule" term="current template rule">At any point in
@@ -14134,13 +14144,27 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>The <elcode>xsl:next-match</elcode> instruction considers as candidates all
                      those template rules that come after the <termref def="dt-current-template-rule">current template rule</termref> in the
                      ordering of template rules implied by the conflict resolution rules given in
-                        <specref ref="conflict"/>. That is, it considers all template rules with
-                     lower <termref def="dt-import-precedence">import precedence</termref> than the
-                        <termref def="dt-current-template-rule">current template rule</termref>,
-                     plus the template rules that are at the same import precedence that have lower
-                     priority than the current template rule, plus
-                        the template rules with the same import precedence and priority
-                     that occur before the current template rule in <termref def="dt-declaration-order">declaration order</termref>.</p>
+                        <specref ref="conflict"/>.</p>
+                  
+                  <p diff="add" at="2023-03-29">This process could be implemented by the following algorithm:</p>
+                  <olist diff="add" at="2023-03-29">
+                     <item><p>Set  a flag <var>active</var> to <code>false</code>.</p></item>
+                     <item><p>Follow the rules in <specref ref="conflict"/> to find the best matching rule,
+                     without raising any errors or warnings if there are multiple matches.</p></item>
+                     <item><p>If the template rule identified is the current template rule, discard this
+                     rule, and repeat the process from step 2 with the flag <var>active</var> set to <code>true</code>.</p></item>
+                     <item><p>Otherwise, if <var>active</var> is set to <code>false</code>, discard this rule, and repeat the process from 
+                        step 2, with the flag <var>active</var> still set to <code>false</code></p></item>
+                     <item><p>Otherwise (if <var>active</var> is set to <code>true</code>) use the selected rule.</p></item>
+                  </olist>
+                  <note diff="add" at="2023-03-29">
+                     <p>An alternative implementation would be to maintain, not just the current template rule, but a list
+                        of rules that have been used to process the context item. The implementation of <elcode>xsl:next-match</elcode>
+                        can then eliminate these rules from the search.</p>
+                     <p>In the absence of type patterns, it is possible to define a total ordering of template rules for each
+                     mode, and to exclude those rules that appear before the current template rule in this ordering. The introduction
+                     of type patterns makes this approach more challenging, since types are partially ordered.</p>
+                  </note>
                   <note>
                      <p>As explained in <specref ref="conflict"/>, a template rule with no <code>priority</code>
                            attribute, whose match pattern contains multiple alternatives
@@ -14161,6 +14185,18 @@ and <code>version="1.0"</code> otherwise.</p>
                   </note>
                </item>
             </ulist>
+            
+            <p diff="add" at="2023-03-29">If no matching template rule is found, both <elcode>xsl:apply-imports</elcode> and <elcode>xsl:next-match</elcode>
+            cause the built-in template rule for the mode to be invoked.</p>
+            
+            <p diff="add" at="2023-03-29">If multiple matching template rules with the same explicit or implicit priority are found, 
+               both <elcode>xsl:apply-imports</elcode> and <elcode>xsl:next-match</elcode>
+               respect the <code>on-multiple-match</code> and <code>warning-on-multiple-match</code> attributes of the 
+               mode declaration.</p>
+            
+            <note diff="add" at="2023-03-29"><p>If is entirely possible for <elcode>xsl:apply-templates</elcode> to identify a template
+               rule unambiguously, and for <elcode>xsl:apply-imports</elcode> or <elcode>xsl:next-match</elcode> 
+               then to fail because there is no unambiguous second-choice template rule.</p></note>
             
             <p>If a matching template rule <var>R</var> is found, then the result
                of the <elcode>xsl:next-match</elcode> or <elcode>xsl:apply-imports</elcode> instruction is the 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12599,31 +12599,15 @@ and <code>version="1.0"</code> otherwise.</p>
 
                </item>
                <item diff="add" at="2023-03-15">
-                  <p>Next, if each of the remaining matching rules has a match pattern in the form of a 
-                     <nt def="TypePattern">TypePattern</nt>, then this set of rules (call it <var>R</var>)
-                     is examined as follows:
+                  <p>Next, if any of the remaining matching rules has a match pattern in the form of a 
+                     <nt def="TypePattern">TypePattern</nt>, then 
+                     only those with the highest <termref def="dt-selectivity"/> are considered.
+                     Other matching template rules (those with type patterns having lower selectivity,
+                     and those for non-type patterns) are eliminated
+                     from consideration.
                   </p>
-                  <olist>
-                     <item><p>A <nt def="TypePattern">TypePattern</nt> comprises an <code>ItemType</code>
-                     and a possibly empty set of predicates.</p>
-                     </item>
-                     <item><p>Any rule in <var>R</var> whose <code>ItemType</code> is a strict supertype of 
-                     the <code>ItemType</code> of another rule in <var>R</var> is discarded. A type <var>T</var>
-                     is a strict supertype of another type <var>U</var> if <var>U</var> is a 
-                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>T</var> and
-                        <var>T</var> is not a 
-                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>U</var>.
-                     </p></item>
-                     <item><p>If there is a rule <var>P</var> in <var>R</var> whose <code>ItemType</code> is the same type as 
-                        the <code>ItemType</code> of another rule <var>Q</var> in <var>R</var>, and if <var>Q</var> 
-                        has one or more predicates while <var>P</var> has none, then <var>P</var> is discarded. A type <var>T</var>
-                        is the same type as another type <var>U</var> if <var>T</var> is a 
-                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>U</var> and
-                        <var>U</var> is a 
-                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>T</var>.
-                     </p></item>
-                     <item><p>If this process leaves a single rule, then that rule is chosen.</p></item>
-                  </olist>
+                  
+                  
                   <note>
                      <p>For example, this means that the pattern <code>type(xs:integer)</code> is chosen
                   in preference to <code>type(xs:decimal)</code> which in turn is chosen in preference
@@ -12631,6 +12615,11 @@ and <code>version="1.0"</code> otherwise.</p>
                   is chosen in preference to <code>type(xs:integer)</code>.</p>
                      <p>Similarly, the pattern <code>record(longitude, latitude, altitude)</code> will be
                         chosen in preference to the pattern <code>record(longitude, latitude, *)</code></p>
+                     <p>If the set of rules that remain at this stage includes both type patterns and non-type
+                     patterns, then a type pattern will always be preferred. The means, for example, that
+                        <code>match="type(element(x))"</code> is preferred over <code>match="element(x)"</code>
+                        or <code>match="x"</code>. However, this situation will only arise if duplicate priorities
+                        have been explicitly allocated.</p>
                   </note>
                </item>
 
@@ -12895,6 +12884,61 @@ and <code>version="1.0"</code> otherwise.</p>
                
             </note>
 
+         </div2>
+         <div2 id="selectivity" diff="add" at="2023-03-28">
+            <head>Selectivity of Type Patterns</head>
+            <p><termdef id="dt-selectivity" term="selectivity">If there are several 
+               <termref def="dt-type-pattern">type patterns</termref> that match
+            an item selected by <elcode>xsl:apply-templates</elcode>, and if no explicit priorities have been allocated,
+               then the one that is chosen
+               is determined based on the <term>selectivity</term> of the respective type patterns.</termdef></p>
+            <p>For purposes of exposition, the selectivity of a type pattern can be considered as a numeric value
+            allocated as follows:</p>
+            <ulist>
+               <item><p>The pattern <code>type(item())</code>, which matches any item, has selectivity
+               0 (zero).</p></item>
+               <item><p>For any two type patterns for types <var>T</var> and <var>U</var>, neither
+                  having any predicates, then:</p>
+                  <ulist>
+                     <item><p>The selectivity of <var>T</var> and <var>U</var> are represented by non-negative
+                     integer values.</p></item>
+                     <item><p>If neither <code>T ⊆ U</code> nor <code>U ⊆ T</code> holds, then
+                     both patterns have the same selectivity.</p>
+                        <note><p>The relation <code>⊆</code>, read as "is a subtype of", is defined in
+                           <xspecref spec="XP40" ref="id-itemtype-subtype"/>.</p></note></item>
+                     <item><p>If both <code>T ⊆ U</code> and <code>U ⊆ T</code> hold (that is,
+                        they are effectively the same type), then
+                        both patterns have the same selectivity.</p></item>
+                     <item><p>Otherwise, if <code>T ⊆ U</code>, then
+                        <var>T</var> has numerically higher selectivity
+                        than the pattern for <var>U</var>.</p></item>
+                  </ulist>
+               </item>
+               
+               <item><p>If a type pattern for a type <var>T</var> has one or more predicates then its selectivity
+                  is numerically the same as that of the pattern for the base type <var>T</var>, plus 0.5.</p></item>
+               
+               
+            </ulist>
+            <note><p>The specification does not define absolute numeric values to represent selectivity, only
+            relative values. An implementation might choose not to use a numeric representation at all.
+            An equally valid approach would be to represent the partial ordering of item types using a directed
+            graph. The numeric representation is chosen for purposes of exposition because it makes it easier
+            to explain the rules for <elcode>xsl:next-match</elcode>.</p></note>
+            <p>For example:</p>
+            <ulist>
+               <item><p><code>type(xs:long)</code> has higher selectivity than <code>type(xs:integer)</code>
+               which has higher selectivity than <code>type(xs:decimal)</code>.</p></item>
+               <item><p><code>type(xs:xs:dayTimeDuration)</code> has the same selectivity as <code>type(xs:yearMonthDuration)</code>;
+                  both have higher selectivity than <code>type(xs:duration)</code>.</p></item>
+               <item><p><code>union(xs:string, xs:boolean)</code> has the same selectivity as <code>union(xs:boolean, xs:string)</code>;
+                  both have higher selectivity than <code>union(xs:string, xs:boolean, xs:integer)</code>.</p></item>
+               <item><p><code>type(xs:integer)[. gt 0]</code> has the same selectivity as <code>type(xs:integer)[. gt 100]</code>
+               (despite the latter matching a subset of the value space of the former); both have higher selectivity
+               than <code>xs:integer</code>, but lower than <code>xs:long</code>.</p></item>
+               <item><p><code>record(longitude, latitude, altitude)</code> has higher 
+                  selectivity than <code>record(longitude, latitude, *)</code>.</p></item>
+            </ulist>
          </div2>
          <div2 id="modes">
             <head>Modes</head>
@@ -14042,7 +14086,8 @@ and <code>version="1.0"</code> otherwise.</p>
                         or <elcode>xsl:next-match</elcode> is used to process 
                         <phrase diff="chg" at="2022-01-01">an item</phrase> using a mode
                         whose declaration specifies <code>on-no-match="fail"</code> when there is no
-                           <termref def="dt-template-rule"/> in the <termref def="dt-stylesheet"/>
+                           <phrase diff="add" at="2023-03-28">applicable</phrase>
+                        <termref def="dt-template-rule"/> in the <termref def="dt-stylesheet"/>
                         whose match pattern matches that <phrase diff="chg" at="2022-01-01">item</phrase>. </p>
                   </error>
                </p>
@@ -14059,8 +14104,11 @@ and <code>version="1.0"</code> otherwise.</p>
                instruction only considers template rules in imported stylesheet modules; the
                   <elcode>xsl:next-match</elcode> instruction considers all other template rules of
                lower <termref def="dt-import-precedence">import precedence</termref> and/or
-               priority, and also declarations of the same
-                  precedence and priority that appear earlier in <termref def="dt-declaration-order"/>. Both instructions will invoke the built-in template rule for the
+               priority, <phrase diff="add" at="2023-03-28">template rules with type patterns
+                  referring to supertypes of the type matched in the current template rule,</phrase> 
+               and also declarations of the same
+                  precedence and priority that appear earlier in <termref def="dt-declaration-order"/>. 
+               Both instructions will invoke the built-in template rule for the
                   context item (see <specref ref="built-in-rule"/>) if no other template rule is found.</p>
             <p>
                <termdef id="dt-current-template-rule" term="current template rule">At any point in
@@ -14134,13 +14182,37 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>The <elcode>xsl:next-match</elcode> instruction considers as candidates all
                      those template rules that come after the <termref def="dt-current-template-rule">current template rule</termref> in the
                      ordering of template rules implied by the conflict resolution rules given in
-                        <specref ref="conflict"/>. That is, it considers all template rules with
-                     lower <termref def="dt-import-precedence">import precedence</termref> than the
-                        <termref def="dt-current-template-rule">current template rule</termref>,
-                     plus the template rules that are at the same import precedence that have lower
-                     priority than the current template rule, plus
-                        the template rules with the same import precedence and priority
-                     that occur before the current template rule in <termref def="dt-declaration-order">declaration order</termref>.</p>
+                        <specref ref="conflict"/>. That is, it considers (following the same ordering
+                     rules as <elcode>xsl:apply-templates</elcode>):</p>
+                  <olist diff="chg" at="2023-03-28">
+                     <item><p>template rules with the same <termref def="dt-import-precedence"/> and <termref def="dt-priority"/>
+                        that occur before the <termref def="dt-current-template-rule"/> in 
+                        <termref def="dt-declaration-order">declaration order</termref>, then
+                     </p></item>
+                     <item><p>if the current template rule uses a type pattern, all rules with type
+                        patterns that have the same precedence and priority but with equal or lower <termref def="dt-selectivity"/>, or in their
+                        absence any non-type patterns with the same priority; then</p></item>
+                     <item><p>template rules that are at the same import precedence that have lower
+                        priority than the current template rule; then</p></item>
+                     <item><p>all template rules with
+                        lower import precedence than the current template rule.</p></item>
+                     
+                     
+                     
+                  </olist>
+                  
+                  <p diff="add" at="2023-03-28">Both instructions (<elcode>xsl:apply-imports</elcode> and 
+                     <elcode>xsl:next-match</elcode>) may find that there are multiple
+                  matching template rules that can be distinguished only by their position in declaration order.
+                  Consider for example, three template rules all specifying <code>match="*"</code>, the first
+                  having an explicit priority of 10, and the other two having their default priority. An
+                  <code>xsl:apply-templates</code> instruction will unambiguously select the first of these rules; if this invokes
+                     <code>xsl:next-match</code>, a conflict then arises. The <elcode>xsl:apply-imports</elcode> and 
+                     <elcode>xsl:next-match</elcode> instructions handle such a conflict in exactly
+                  the same way as <elcode>xsl:apply-templates</elcode>, taking into account the 
+                     <code>on-multiple-match</code> and <code>warning-on-multiple-match</code>
+                  attributes of the <elcode>xsl:mode</elcode> declaration.</p>
+                  
                   <note>
                      <p>As explained in <specref ref="conflict"/>, a template rule with no <code>priority</code>
                            attribute, whose match pattern contains multiple alternatives

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12599,15 +12599,31 @@ and <code>version="1.0"</code> otherwise.</p>
 
                </item>
                <item diff="add" at="2023-03-15">
-                  <p>Next, if any of the remaining matching rules has a match pattern in the form of a 
-                     <nt def="TypePattern">TypePattern</nt>, then 
-                     only those with the highest <termref def="dt-selectivity"/> are considered.
-                     Other matching template rules (those with type patterns having lower selectivity,
-                     and those for non-type patterns) are eliminated
-                     from consideration.
+                  <p>Next, if each of the remaining matching rules has a match pattern in the form of a 
+                     <nt def="TypePattern">TypePattern</nt>, then this set of rules (call it <var>R</var>)
+                     is examined as follows:
                   </p>
-                  
-                  
+                  <olist>
+                     <item><p>A <nt def="TypePattern">TypePattern</nt> comprises an <code>ItemType</code>
+                     and a possibly empty set of predicates.</p>
+                     </item>
+                     <item><p>Any rule in <var>R</var> whose <code>ItemType</code> is a strict supertype of 
+                     the <code>ItemType</code> of another rule in <var>R</var> is discarded. A type <var>T</var>
+                     is a strict supertype of another type <var>U</var> if <var>U</var> is a 
+                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>T</var> and
+                        <var>T</var> is not a 
+                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>U</var>.
+                     </p></item>
+                     <item><p>If there is a rule <var>P</var> in <var>R</var> whose <code>ItemType</code> is the same type as 
+                        the <code>ItemType</code> of another rule <var>Q</var> in <var>R</var>, and if <var>Q</var> 
+                        has one or more predicates while <var>P</var> has none, then <var>P</var> is discarded. A type <var>T</var>
+                        is the same type as another type <var>U</var> if <var>T</var> is a 
+                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>U</var> and
+                        <var>U</var> is a 
+                        <xtermref ref="dt-subtype" spec="XP40">subtype</xtermref> of <var>T</var>.
+                     </p></item>
+                     <item><p>If this process leaves a single rule, then that rule is chosen.</p></item>
+                  </olist>
                   <note>
                      <p>For example, this means that the pattern <code>type(xs:integer)</code> is chosen
                   in preference to <code>type(xs:decimal)</code> which in turn is chosen in preference
@@ -12615,11 +12631,6 @@ and <code>version="1.0"</code> otherwise.</p>
                   is chosen in preference to <code>type(xs:integer)</code>.</p>
                      <p>Similarly, the pattern <code>record(longitude, latitude, altitude)</code> will be
                         chosen in preference to the pattern <code>record(longitude, latitude, *)</code></p>
-                     <p>If the set of rules that remain at this stage includes both type patterns and non-type
-                     patterns, then a type pattern will always be preferred. The means, for example, that
-                        <code>match="type(element(x))"</code> is preferred over <code>match="element(x)"</code>
-                        or <code>match="x"</code>. However, this situation will only arise if duplicate priorities
-                        have been explicitly allocated.</p>
                   </note>
                </item>
 
@@ -12884,61 +12895,6 @@ and <code>version="1.0"</code> otherwise.</p>
                
             </note>
 
-         </div2>
-         <div2 id="selectivity" diff="add" at="2023-03-28">
-            <head>Selectivity of Type Patterns</head>
-            <p><termdef id="dt-selectivity" term="selectivity">If there are several 
-               <termref def="dt-type-pattern">type patterns</termref> that match
-            an item selected by <elcode>xsl:apply-templates</elcode>, and if no explicit priorities have been allocated,
-               then the one that is chosen
-               is determined based on the <term>selectivity</term> of the respective type patterns.</termdef></p>
-            <p>For purposes of exposition, the selectivity of a type pattern can be considered as a numeric value
-            allocated as follows:</p>
-            <ulist>
-               <item><p>The pattern <code>type(item())</code>, which matches any item, has selectivity
-               0 (zero).</p></item>
-               <item><p>For any two type patterns for types <var>T</var> and <var>U</var>, neither
-                  having any predicates, then:</p>
-                  <ulist>
-                     <item><p>The selectivity of <var>T</var> and <var>U</var> are represented by non-negative
-                     integer values.</p></item>
-                     <item><p>If neither <code>T ⊆ U</code> nor <code>U ⊆ T</code> holds, then
-                     both patterns have the same selectivity.</p>
-                        <note><p>The relation <code>⊆</code>, read as "is a subtype of", is defined in
-                           <xspecref spec="XP40" ref="id-itemtype-subtype"/>.</p></note></item>
-                     <item><p>If both <code>T ⊆ U</code> and <code>U ⊆ T</code> hold (that is,
-                        they are effectively the same type), then
-                        both patterns have the same selectivity.</p></item>
-                     <item><p>Otherwise, if <code>T ⊆ U</code>, then
-                        <var>T</var> has numerically higher selectivity
-                        than the pattern for <var>U</var>.</p></item>
-                  </ulist>
-               </item>
-               
-               <item><p>If a type pattern for a type <var>T</var> has one or more predicates then its selectivity
-                  is numerically the same as that of the pattern for the base type <var>T</var>, plus 0.5.</p></item>
-               
-               
-            </ulist>
-            <note><p>The specification does not define absolute numeric values to represent selectivity, only
-            relative values. An implementation might choose not to use a numeric representation at all.
-            An equally valid approach would be to represent the partial ordering of item types using a directed
-            graph. The numeric representation is chosen for purposes of exposition because it makes it easier
-            to explain the rules for <elcode>xsl:next-match</elcode>.</p></note>
-            <p>For example:</p>
-            <ulist>
-               <item><p><code>type(xs:long)</code> has higher selectivity than <code>type(xs:integer)</code>
-               which has higher selectivity than <code>type(xs:decimal)</code>.</p></item>
-               <item><p><code>type(xs:xs:dayTimeDuration)</code> has the same selectivity as <code>type(xs:yearMonthDuration)</code>;
-                  both have higher selectivity than <code>type(xs:duration)</code>.</p></item>
-               <item><p><code>union(xs:string, xs:boolean)</code> has the same selectivity as <code>union(xs:boolean, xs:string)</code>;
-                  both have higher selectivity than <code>union(xs:string, xs:boolean, xs:integer)</code>.</p></item>
-               <item><p><code>type(xs:integer)[. gt 0]</code> has the same selectivity as <code>type(xs:integer)[. gt 100]</code>
-               (despite the latter matching a subset of the value space of the former); both have higher selectivity
-               than <code>xs:integer</code>, but lower than <code>xs:long</code>.</p></item>
-               <item><p><code>record(longitude, latitude, altitude)</code> has higher 
-                  selectivity than <code>record(longitude, latitude, *)</code>.</p></item>
-            </ulist>
          </div2>
          <div2 id="modes">
             <head>Modes</head>
@@ -14086,8 +14042,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         or <elcode>xsl:next-match</elcode> is used to process 
                         <phrase diff="chg" at="2022-01-01">an item</phrase> using a mode
                         whose declaration specifies <code>on-no-match="fail"</code> when there is no
-                           <phrase diff="add" at="2023-03-28">applicable</phrase>
-                        <termref def="dt-template-rule"/> in the <termref def="dt-stylesheet"/>
+                           <termref def="dt-template-rule"/> in the <termref def="dt-stylesheet"/>
                         whose match pattern matches that <phrase diff="chg" at="2022-01-01">item</phrase>. </p>
                   </error>
                </p>
@@ -14104,11 +14059,8 @@ and <code>version="1.0"</code> otherwise.</p>
                instruction only considers template rules in imported stylesheet modules; the
                   <elcode>xsl:next-match</elcode> instruction considers all other template rules of
                lower <termref def="dt-import-precedence">import precedence</termref> and/or
-               priority, <phrase diff="add" at="2023-03-28">template rules with type patterns
-                  referring to supertypes of the type matched in the current template rule,</phrase> 
-               and also declarations of the same
-                  precedence and priority that appear earlier in <termref def="dt-declaration-order"/>. 
-               Both instructions will invoke the built-in template rule for the
+               priority, and also declarations of the same
+                  precedence and priority that appear earlier in <termref def="dt-declaration-order"/>. Both instructions will invoke the built-in template rule for the
                   context item (see <specref ref="built-in-rule"/>) if no other template rule is found.</p>
             <p>
                <termdef id="dt-current-template-rule" term="current template rule">At any point in
@@ -14182,37 +14134,13 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>The <elcode>xsl:next-match</elcode> instruction considers as candidates all
                      those template rules that come after the <termref def="dt-current-template-rule">current template rule</termref> in the
                      ordering of template rules implied by the conflict resolution rules given in
-                        <specref ref="conflict"/>. That is, it considers (following the same ordering
-                     rules as <elcode>xsl:apply-templates</elcode>):</p>
-                  <olist diff="chg" at="2023-03-28">
-                     <item><p>template rules with the same <termref def="dt-import-precedence"/> and <termref def="dt-priority"/>
-                        that occur before the <termref def="dt-current-template-rule"/> in 
-                        <termref def="dt-declaration-order">declaration order</termref>, then
-                     </p></item>
-                     <item><p>if the current template rule uses a type pattern, all rules with type
-                        patterns that have the same precedence and priority but with equal or lower <termref def="dt-selectivity"/>, or in their
-                        absence any non-type patterns with the same priority; then</p></item>
-                     <item><p>template rules that are at the same import precedence that have lower
-                        priority than the current template rule; then</p></item>
-                     <item><p>all template rules with
-                        lower import precedence than the current template rule.</p></item>
-                     
-                     
-                     
-                  </olist>
-                  
-                  <p diff="add" at="2023-03-28">Both instructions (<elcode>xsl:apply-imports</elcode> and 
-                     <elcode>xsl:next-match</elcode>) may find that there are multiple
-                  matching template rules that can be distinguished only by their position in declaration order.
-                  Consider for example, three template rules all specifying <code>match="*"</code>, the first
-                  having an explicit priority of 10, and the other two having their default priority. An
-                  <code>xsl:apply-templates</code> instruction will unambiguously select the first of these rules; if this invokes
-                     <code>xsl:next-match</code>, a conflict then arises. The <elcode>xsl:apply-imports</elcode> and 
-                     <elcode>xsl:next-match</elcode> instructions handle such a conflict in exactly
-                  the same way as <elcode>xsl:apply-templates</elcode>, taking into account the 
-                     <code>on-multiple-match</code> and <code>warning-on-multiple-match</code>
-                  attributes of the <elcode>xsl:mode</elcode> declaration.</p>
-                  
+                        <specref ref="conflict"/>. That is, it considers all template rules with
+                     lower <termref def="dt-import-precedence">import precedence</termref> than the
+                        <termref def="dt-current-template-rule">current template rule</termref>,
+                     plus the template rules that are at the same import precedence that have lower
+                     priority than the current template rule, plus
+                        the template rules with the same import precedence and priority
+                     that occur before the current template rule in <termref def="dt-declaration-order">declaration order</termref>.</p>
                   <note>
                      <p>As explained in <specref ref="conflict"/>, a template rule with no <code>priority</code>
                            attribute, whose match pattern contains multiple alternatives


### PR DESCRIPTION
Clarifies the rules for xsl:next-match, especially for 4.0 type patterns, but also clarifying the exposition of rules unchanged since 3.0 or 2.0 (see issue 409)