### PR TITLE
Fix residual reference to op:A2S which is no longer defined

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -20689,8 +20689,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <p diff="chg" at="2022-12-16">The default <code>$fallback</code> function raises a dynamic error. The call on <code>fn:error</code>
          shown as the default is for illustrative purposes only; apart from the error code (<code>err:FOAY0001</code>)
             the details of the error (such as the error message) are <termref def="implementation-dependent">implementation-dependent</termref>.</p>
-         <p diff="chg" at="2022-12-16">More formally, the function returns the value of <code role="example">if ($position = 1 to array:size($array))
-            then op:A2S($array)[$position]() else $fallback($position)</code>.</p>
+         <p diff="chg" at="2022-12-16">More formally, the function returns the value of:</p> 
+            <eg>if ($position = (1 to array:size($array)))
+then array:members($array)[$position]?value 
+else $fallback($position)</eg>
       </fos:rules>
       <fos:errors>
          <p><phrase diff="add" at="2022-12-16">In the absence of a <code>$fallback</code> function</phrase>,


### PR DESCRIPTION
The changes made to redefine array functions in terms of `array:members` and `array:of` rather than `op:A2S` and `op:S2A` weren't applied to array:get because that was the subject of a separate PR to add the `fallback` option. This PR corrects the omission.