### PR TITLE
Issue 357 Map composition and decomposition

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18189,6 +18189,102 @@ return fn:fold-left($MAPS, map{},
          </fos:example>
       </fos:examples>
    </fos:function>
+   
+   <fos:function name="of" prefix="map">
+      <fos:signatures>
+         <fos:proto name="of" return-type="map(*)">
+            <fos:arg name="key-value-pairs" type="record(key as xs:anyAtomicType, value as item()*, *)*" usage="inspection"/>
+            <fos:arg name="compine" type="function(item()*, item()*) as item()*" usage="inspection" default="fn:op(',')"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns a map that combines data from a sequence of key-value pairs.</p>
+      </fos:summary>
+      <fos:rules>
+         
+         <p>The function <code>map:of</code>
+            <phrase>returns a map</phrase> that
+            is formed by combining key-value records supplied in the <code>$key-value-pairs</code>
+            argument.</p>
+         
+         <p>The optional <code>$combine</code> argument can be used to define how
+         duplicate keys should be handled. The default is to form the sequence concatenation 
+         of the corresponding values, retaining their order in the input sequence.</p>
+         
+         <p>The effect of the function is equivalent to the expression:</p>
+         <eg>map:build($key-value-pairs, ->{?key}, ->{?value}, $combine)</eg>
+
+
+      </fos:rules>
+      <fos:errors>
+         <p>The function can be made to fail with a dynamic error in the event that
+         duplicate keys are present in the input sequence by supplying a <code>$combine</code>
+         function that invokes the <code>fn:error</code> function.</p>
+      </fos:errors>
+
+      <fos:notes>
+         <p>If the input is an empty sequence, the result is an empty map.</p>
+         <p>There is no requirement that the supplied key-value pairs should have the same or compatible
+            types. The type of a map (for example <code>map(xs:integer, xs:string)</code>) is
+            descriptive of the entries it currently contains, but is not a constraint on how the map
+            may be combined with other maps.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:variable name="week" id="v-map-merge-week"
+            select="map{0:&quot;Sonntag&quot;, 1:&quot;Montag&quot;, 2:&quot;Dienstag&quot;,&#xa;     3:&quot;Mittwoch&quot;, 4:&quot;Donnerstag&quot;, 5:&quot;Freitag&quot;, 6:&quot;Samstag&quot;}"/>
+         <fos:example>
+            <fos:test>
+               <fos:expression>map:of(())</fos:expression>
+               <fos:result>map{}</fos:result>
+               <fos:postamble>Returns an empty map</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:of(map:key-value-pairs($week))</fos:expression>
+               <fos:result>$week</fos:result>
+               <fos:postamble>The function <code>map:of</code> is the inverse of <code>map:key-value-pairs</code>.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:of((map:entry(0, "no"), map:entry(1, "yes")))</fos:expression>
+               <fos:result>map{0:"no", 1:"yes"}</fos:result>
+               <fos:postamble>Returns a map with two entries</fos:postamble>
+            </fos:test>
+            <fos:test use="v-map-merge-week">
+               <fos:expression>map:of((map:key-value-pairs($week), map{"key":7, "value":"Unbekannt"}))</fos:expression>
+               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
+                  5:"Freitag", 6:"Samstag", 7:"Unbekannt"}</fos:result>
+               <fos:postamble>The value of the existing map is unchanged; the returned map 
+                  contains all the entries from <code>$week</code>, supplemented with an additional
+                  entry.</fos:postamble>
+            </fos:test>
+            <fos:test use="v-map-merge-week">
+               <fos:expression>map:of((map:key-value-pairs($week), map{"key":6, "value":"Sonnabend"}))</fos:expression>
+               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
+                  5:"Freitag", 6:("Samstag", "Sonnabend")}</fos:result>
+               <fos:postamble>The value of the existing map is unchanged; the returned map
+                  contains all the entries from <code>$week</code>, with one entry replaced by a
+                  new entry. Both input maps contain an entry with the key <code>6</code>; the
+                  one used in the result combines the two supplied values into a single sequence.</fos:postamble>
+            </fos:test>
+            <fos:test use="v-map-merge-week">
+               <fos:expression>map:of((map:key-value-pairs($week), map{"key":6, "value":"Sonnabend"}), ->($old, $new){$new})</fos:expression>
+               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
+                  5:"Freitag", 6:"Sonnabend"}</fos:result>
+               <fos:postamble>The value of the existing map is unchanged; the returned map
+                  contains all the entries from <code>$week</code>, with one entry replaced by a
+                  new entry. Both input maps contain an entry with the key <code>6</code>; the
+                  supplied <code>$combine</code> function ensures that the one used in the result 
+                  is the one that comes last in the input sequence.</fos:postamble>
+            </fos:test>
+           
+
+         </fos:example>
+      </fos:examples>
+   </fos:function>
 
    <fos:function name="keys" prefix="map">
       <fos:signatures>
@@ -18227,6 +18323,49 @@ return fn:fold-left($MAPS, map{},
                <fos:result allow-permutation="true">(1,2)</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                      >implementation-dependent</termref> order.</fos:postamble>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+   
+   <fos:function name="key-value-pairs" prefix="map">
+      <fos:signatures>
+         <fos:proto name="key-value-pairs" return-type="record(key as xs:anyAtomicType, value as item()*)*">
+            <fos:arg name="map" type="map(*)" usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>nondeterministic-wrt-ordering</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns a sequence containing all the key-value pairs present in a map</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function <code>map:key-value-pairs</code> takes any <termref def="dt-map"
+            >map</termref>
+            as its <code>$map</code> argument and returns the keys that are present in the map as
+            a sequence of <term>key-value records</term>, in <termref
+               def="implementation-dependent">implementation-dependent</termref> order.
+            A key-value record is an instance of type <code>record(record(key as xs:anyAtomicType, value as item()*)</code>,
+         that is a map with two entries, one (with key "key") holding the key, and the other (with key "value")
+         holding the value.</p>
+         <p>The function is <term>non-deterministic with respect to ordering</term>
+            (see <specref
+               ref="properties-of-functions"
+            />). This means that two calls with the same argument
+            are not guaranteed to produce the results in the same order.</p>
+         <p>The effect of the function is equivalent to the expression:</p>
+         <eg>map:for-each($map, ->($k, $v){map{"key":$k, "value":$v}})</eg>
+      </fos:rules>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>map:key-value-pairs(map{1:"yes", 2:"no"})</fos:expression>
+               <fos:result allow-permutation="true">(map{"key":1, "value":"yes"}, map{"key":2, "value":"no"})</fos:result>
+               <fos:postamble>The result is in <termref def="implementation-dependent"
+                  >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7186,6 +7186,59 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <p>It is not necessary that all the keys in a map should be
             of the same type (for example, they can include a mixture of integers and strings).</p>
          
+         <p diff="add" at="2023-04-03">It is often useful to decompose a map into a sequence of key-value pairs (in which the key is an atomic value
+         and the value is an arbitrary sequence). There are two conventional representations of key-value pairs,
+         each with its own advantages and disadvantages:</p>
+         
+         <olist diff="add" at="2023-04-03">
+            <item><p>The <term>singleton map</term> representation: here a key-value pair is represented as
+            a map containing a single entry, containing the key and the value: for example the map
+               <code>map{"x":1, "y":2}</code> can be decomposed to the sequence <code>(map{"x":1}, map{"y":2})</code>.</p></item>
+            <item><p>The <term>key-value record</term> representation: here a key value pair is represented
+            as an instance of the type <code>record(key as xs:anyAtomicType, value as item()*)</code>. For example
+               the map <code>map{"x":1, "y":2}</code> can be decomposed as 
+               <code>(map{"key":"x", "value":1}, map{"key":"y", "value":2})</code></p></item>
+         </olist>
+         
+         <p diff="add" at="2023-04-03">The following table summarizes the way in which these two representations can be used to compose and decompose maps:</p>
+         
+         <table role="data" diff="add" at="2023-04-03">
+            <thead>
+               <tr>
+                  <th>Operation</th>
+                  <th>Singleton Maps</th>
+                  <th>Key-Value Records</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td><p>Decompose a map</p></td>
+                  <td><p><code>map:for-each($map, map:entry#2)</code></p></td>
+                  <td><p><code>map:key-value-pairs($map)</code></p></td>
+               </tr>
+               <tr>
+                  <td><p>Compose a map</p></td>
+                  <td><p><code>map:merge($entries)</code></p></td>
+                  <td><p><code>map:of($key-value-pairs)</code></p></td>
+               </tr>
+               <tr>
+                  <td><p>Create a single entry</p></td>
+                  <td><p><code>map:entry($key, $value)</code></p></td>
+                  <td><p><code>map{"key":$key, "value":$value}</code></p></td>
+               </tr>
+               <tr>
+                  <td><p>Extract the key part of a single entry</p></td>
+                  <td><p><code>map:keys($entry)</code></p></td>
+                  <td><p><code>$key-value-pair?key</code></p></td>
+               </tr>
+               <tr>
+                  <td><p>Extract the value part of a single entry</p></td>
+                  <td><p><code>$entry?*</code></p></td>
+                  <td><p><code>$key-value-pair?value</code></p></td>
+               </tr>
+            </tbody>
+         </table>
+         
          
          
          <div2 id="map-functions">
@@ -7225,52 +7278,56 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-atomic-equal">
                <head><?function fn:atomic-equal?></head>
             </div3>
-            <div3 id="func-map-merge">
-               <head><?function map:merge?></head>
-            </div3>
-            <div3 id="func-map-size">
-               <head><?function map:size?></head>
-            </div3>
-            <div3 id="func-map-keys">
-               <head><?function map:keys?></head>
+            <div3 id="func-map-build" diff="add" at="A">
+               <head><?function map:build?></head>
             </div3>
             <div3 id="func-map-contains">
                <head><?function map:contains?></head>
             </div3>
-            <div3 id="func-map-get">
-               <head><?function map:get?></head>
-            </div3>
-            <div3 id="func-map-find">
-               <head><?function map:find?></head>
-            </div3>
-            <div3 id="func-map-put">
-               <head><?function map:put?></head>
-            </div3>
-            
             <div3 id="func-map-entry">
                <head><?function map:entry?></head>
-            </div3>
-            <div3 id="func-map-remove">
-               <head><?function map:remove?></head>
             </div3>
             <div3 id="func-map-filter" diff="add" at="A">
                <head><?function map:filter?></head>
             </div3>
+            <div3 id="func-map-find">
+               <head><?function map:find?></head>
+            </div3>
             <div3 id="func-map-for-each">
                <head><?function map:for-each?></head>
+            </div3>
+            <div3 id="func-map-get">
+               <head><?function map:get?></head>
+            </div3>
+            <div3 id="func-map-key-value-pairs" diff="add" at="2023-04-03">
+               <head><?function map:key-value-pairs?></head>
+            </div3>
+            <div3 id="func-map-keys">
+               <head><?function map:keys?></head>
+            </div3>
+            <div3 id="func-map-merge">
+               <head><?function map:merge?></head>
+            </div3>
+            <div3 id="func-map-of" diff="add" at="2023-04-03">
+               <head><?function map:of?></head>
+            </div3>
+            <div3 id="func-map-put">
+               <head><?function map:put?></head>
+            </div3>
+            <div3 id="func-map-remove">
+               <head><?function map:remove?></head>
+            </div3>
+            <div3 id="func-map-replace" diff="add" at="A">
+               <head><?function map:replace?></head>
+            </div3> 
+            <div3 id="func-map-size">
+               <head><?function map:size?></head>
             </div3>
             <div3 id="func-map-substitute" diff="add" at="A">
                <head><?function map:substitute?></head>
             </div3>
-            <div3 id="func-map-replace" diff="add" at="A">
-               <head><?function map:replace?></head>
-            </div3>  
-            <div3 id="func-map-build" diff="add" at="A">
-               <head><?function map:build?></head>
-            </div3>
             
- 
-
+  
             
          </div2>
          

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -14216,9 +14216,38 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>In this example it is possible to use the expression <code>$array?*</code> to convert an array to a sequence.
                This works because the members of the array are all single items. In the more general case (a member
                of the array might be an empty sequence, corresponding to the JSON value <code>null</code>, or it
-               might be a sequence containing several items), the function <code>array:members</code> can be
-               used to deliver the contents of the array as a sequence of <emph>parcels</emph>, and the contents
-               of each parcel can be extracted (as a sequence) using the <function>unparcel</function> function.</p>
+               might be a sequence containing several items), <phrase diff="chg" at="2023-04-04">the function <code>array:members</code> can be
+               used to deliver the contents of the array as a sequence of <emph>value records</emph>. This is 
+               illustrated in the next example.</phrase></p>
+            </example>
+            <example diff="chg" at="2022-11-01">
+               <head>Using <elcode>xsl:for-each</elcode> to process an array containing nulls</head>
+               <p>Consider a JSON document of the form:</p>
+               <eg>[
+   { "city": "London", "data": [12.3, 15.6, null, 18.2] },
+   { "city": "Paris",  "data": [7.9, 19.1, 23.0, null] },
+   { "city": "Berlin", "data": [5.6, null, 14.6, 9.5] }                  
+]</eg>
+               <p>The requirement is to convert this to the following XML:</p>
+               <eg><![CDATA[<cities>
+  <city name="London" Q1="12.3" Q2="15.6" Q3="" Q4="18.2"/>
+  <city name="Paris" Q1="7.9" Q2="19.1" Q3="23.0" Q4=""/>
+  <city name="Berlin" Q1="5.6" Q2="" Q3="14.6" Q4="9.5"/>
+</cities>]]></eg>
+               <p>The following code achieves this transformation:</p>
+               <eg><![CDATA[<xsl:for-each select="json-doc('input.json')?*">
+   <city name="{?city}">
+     <xsl:for-each select="array:members(?data)">
+       <xsl:attribute name="Q{position()}" select="?value"/>
+     </xsl:for-each>
+   </city>  
+</xsl:for-each>]]></eg>
+               <p>In this example the expression <code>$array?*</code> cannot be used on the inner arrays
+                  because JSON nulls (which translate to an empty sequence in XDM) would be lost. Instead
+                  the function <xfunction>array:members</xfunction> is used to create a sequence of
+                  value records: a non-null entry is represented by a value such as <code>map{'value':12.3}</code>,
+                  while a null entry would be <code>map{'value':()}</code>.</p>
+                 
             </example>
             <example diff="add" at="2022-11-01">
                <head>Using <elcode>xsl:for-each</elcode> to process a map</head>
@@ -34529,6 +34558,14 @@ the same group, and the-->
                compatible types. The type of a map (for example <code>map(xs:integer,
                   xs:string)</code>) is descriptive of the entries it currently contains, but is not
                a constraint on how the map may be combined with other maps.</p>
+            
+            <note diff="add" at="2023-04-04">
+               <p>A common coding pattern is to supply the input as a set of singleton maps, that is,
+               maps containing a single entry. Moreover, it is often convenient to construct these
+               using the <elcode>xsl:map-entry</elcode> instruction. However, it is not required that
+               the input maps should be singletons, nor is it required that they should be constructed
+               using this instruction.</p>
+            </note>
 
             <p><error spec="XT" class="TE" code="3375" type="type">
                   <p>A type error occurs if the result of evaluating the sequence constructor
@@ -34616,6 +34653,33 @@ the same group, and the-->
 </eg>
             </example>
             
+            <example diff="add" at="2023-04-04">
+               <head>Modifying the keys in a map</head>
+               <p>The following example modifies a supplied map <code>$input</code> by changing
+                  all the keys to upper case. A dynamic error occurs if this results in duplicate
+                  keys:</p>
+               <eg role="xslt-declaration" xml:space="preserve">&lt;xsl:map&gt;
+  &lt;xsl:for-each select="map:key-value-pairs($map)"&gt;
+    &lt;xsl:map-entry key="upper-case(?key)" select="?value"/&gt;
+  &lt;/xsl:for-each&gt;
+&lt;/xsl:map&gt; 
+</eg>
+            </example>
+            
+            <example diff="add" at="2023-04-04">
+               <head>Modifying the values in a map</head>
+               <p>The following example modifies a supplied map <code>$input</code> by wrapping
+                  each of the values in an array:</p>
+               <eg role="xslt-declaration" xml:space="preserve">&lt;xsl:map&gt;
+  &lt;xsl:for-each select="map:key-value-pairs($map)"&gt;
+    &lt;xsl:map-entry key="?key"&gt;
+       &lt;xsl:array select="?value"/&gt;
+    &lt;/xsl:map-entry>
+  &lt;/xsl:for-each&gt;
+&lt;/xsl:map&gt; 
+</eg>
+            </example>
+            
             <div3 id="duplicate-keys" diff="add" at="2022-01-01">
                <head>Handling of duplicate keys</head>
                
@@ -34681,7 +34745,9 @@ the same group, and the-->
                      </tr>
                      <tr>
                         <td><code>function($a, $b){$a, $b}</code></td>
-                        <td>The sequence-concatenation of the duplicate values is used.</td>
+                        <td>The sequence-concatenation of the duplicate values is used. 
+                           <phrase diff="add" at="2023-04-04">This could
+                        also be expressed as <code>on-duplicates="op(',')"</code>.</phrase></td>
                      </tr>
                      <tr>
                         <td><code>function($a, $b){max(($a, $b))}</code></td>
@@ -34694,6 +34760,12 @@ the same group, and the-->
                      <tr>
                         <td><code>function($a, $b){string-join(($a, $b), ', ')}</code></td>
                         <td>The comma-separated string concatenation of the duplicate values is used.</td>
+                     </tr>
+                     <tr diff="add" at="2023-04-04">
+                        <td><code>function($a, $b){$a + $b)}</code></td>
+                        <td>The sum of the duplicate values is used.
+                           This could also be expressed as <code>on-duplicates="op('+')"</code>
+                        </td>
                      </tr>
                      <tr>
                         <td><code>function($a, $b){error()}</code></td>
@@ -34716,11 +34788,12 @@ the same group, and the-->
                   <eg><![CDATA[{"A23": [12, 2], "A24": [5], "A23": [9]}]]></eg>
                   <p>The logic is:</p>
                   <eg><![CDATA[<xsl:template match="data">
-   <xsl:map on-duplicates="function($a, $b){array:join(($a, $b))}">
-     <xsl:for-each select="event">
-        <xsl:map-entry key="@id" select="[xs:integer(@value)]"/>
-     </xsl:for-each>
-   </xsl:map>]]></eg>
+  <xsl:map on-duplicates="function($a, $b){array:join(($a, $b))}">
+    <xsl:for-each select="event">
+      <xsl:map-entry key="@id" select="[xs:integer(@value)]"/>
+    </xsl:for-each>
+  </xsl:map>
+</xsl:template>]]></eg>
                </example>
                
                


### PR DESCRIPTION
This PR addresses the issues concerned with map composition and decomposition in issue #357. It adds a function to decompose a map into key-value pairs (map:key-value-pairs), and its inverse (map:of). It adds explanatory material to F+O to explain how these functions relate to each other, and it adds examples to the XSLT spec to show how the interwork with the xsl:array, xsl:map, and xsl:for-each instructions. Note: the map functions have been sorted alphabetically, so the changes will appear more extensive than they are.