### PR TITLE
Fix problem in rendering empty <xnt> elements

### DIFF
--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -827,7 +827,7 @@
       <xsl:when test="contains(@spec, 'XP') and not($nt)">
         <!-- XP and XQ are a special case -->
         <xsl:variable name="ref2" select="concat('doc-xpath40-',@ref)"/>
-        <xsl:variable name="nt2" select="$doc//nt[@def=$ref2]"/>
+        <xsl:variable name="nt2" select="($doc//nt[@def=$ref2])[1]"/>
         <xsl:choose>
           <xsl:when test="$uri">
             <a href="{$uri}#{$ref2}">
@@ -853,7 +853,7 @@
       <xsl:when test="contains(@spec, 'XQ') and not($nt)">
         <!-- XP and XQ are a special case -->
         <xsl:variable name="ref2" select="concat('doc-xquery40-',@ref)"/>
-        <xsl:variable name="nt2" select="$doc//nt[@def=$ref2]"/>
+        <xsl:variable name="nt2" select="($doc//nt[@def=$ref2])[1]"/>
 
         <xsl:choose>
           <xsl:when test="$uri">


### PR DESCRIPTION
In the F&O spec, function `parse-QName`,  there is a link to `BracedURILiteral` repeated 6 times. This happens when an `<xnt>` element is written with empty content. There are 6 entries in the /etc/ XP40 file for the relevant grammar symbol, and each of them is output. I haven't tried to eliminate the redundancy in the /etc/XP40 file, I have simply changed the code for processing `<xnt>` so it only considers the first one.