### PR TITLE
Fix problem rendering xnt elements

### DIFF
--- a/specifications/xslt-40/style/convert-grammar.xsl
+++ b/specifications/xslt-40/style/convert-grammar.xsl
@@ -42,6 +42,10 @@
   <xsl:template match="g:ref[@name=('LocalPart')]">
     <xnt spec="XP40" ref="prod-xpath40-NCName">NCName</xnt>
   </xsl:template>
+
+  <xsl:template match="g:ref[@name=('StringLiteral')]">
+    <xnt spec="XP40" ref="prod-xpath40-StringLiteral">StringLiteral</xnt>
+  </xsl:template>
   
   <xsl:template match="g:ref">
     <!--<xsl:message>** NT <xsl:value-of select="@name"/></xsl:message>-->

--- a/style/extract.xsl
+++ b/style/extract.xsl
@@ -22,7 +22,7 @@
   <xsl:apply-templates select="header/title"/>
   <xsl:apply-templates select="body/div1|back/div1|back/inform-div1"/>
   <xsl:apply-templates select="//termdef"/>
-  <xsl:apply-templates select="//nt"/>
+  <xsl:apply-templates select="//prod"/>
   <xsl:apply-templates select="//error"/>
 </xsl:template>
 
@@ -105,10 +105,13 @@
   </xsl:copy>
 </xsl:template>
 
-<xsl:template match="nt">
-  <xsl:copy copy-namespaces="no">
-    <xsl:copy-of select="@*, node()"/>
-  </xsl:copy>
+<xsl:template match="prod">
+  <xsl:if test="not(starts-with(@id, 'noid_'))">
+    <xsl:copy copy-namespaces="no">
+      <xsl:copy-of select="@*"/>
+      <xsl:sequence select="normalize-space(lhs)"/>
+    </xsl:copy>
+  </xsl:if>
 </xsl:template>
 
 <xsl:template match="elcode | xfunction">

--- a/style/xmlspec-override.xsl
+++ b/style/xmlspec-override.xsl
@@ -138,15 +138,27 @@
 
   <xsl:template name="link-text-with-check">
     <xsl:param name="ref-id"/>
+
     <xsl:variable name="role" 
       select="ancestor-or-self::*[@role='xpath' 
               or @role='xquery']/@role"/>
     <xsl:variable name="num-val" select="string(ancestor-or-self::prod/@num)"/>
     <xsl:variable name="idFound1" select="//*/@id[.=$ref-id]"/>
+
+    <xsl:variable name="alt-id"
+                  select="if (starts-with($ref-id, 'doc-x'))
+                          then 'prod-' || substring-after($ref-id, '-')
+                          else if (starts-with($ref-id, 'prod-x'))
+                               then 'doc-' || substring-after($ref-id, '-')
+                               else ()"/>
+
+    <xsl:variable name="idFound2" select="//*/@id[.=$alt-id]"/>
+
     <xsl:choose>
       <!-- The tests for "(XQuery)", etc. are a hack... this should be driven from 
            the prep stylesheets, but I'm not sure how at the moment. -->
-      <xsl:when test="($idFound1) or contains($num-val, '(XQuery)') or contains($num-val, '(XPath)')">
+      <xsl:when test="($idFound1 or $idFound2)
+                      or contains($num-val, '(XQuery)') or contains($num-val, '(XPath)')">
         <a>
           <xsl:attribute name="href">
             <xsl:choose>

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -818,9 +818,20 @@
   </xsl:template>
 
   <xsl:template match="xnt">
-    <xsl:variable name="ref" select="@ref"/>
+    <xsl:variable name="ref" select="normalize-space(@ref)"/>
     <xsl:variable name="doc" select="document(concat('../build/etc/', @spec, '.xml'))"/>
-    <xsl:variable name="nt" select="$doc//nt[@def=$ref]"/>
+    <!-- 2023-04-06, ndw changed extract.xsl to store the prod elements, not the nt elements
+         in the /etc files. There can be many nt's but they are all supposed to point to a
+         production. I don't know why the nt's were being put in the etc files instead of
+         the productions. Note that we still have to look for nt's as well because old
+         etc files (e.g., for XML 1.0) are still coded the old way. 
+
+         There's also some variation in how xnt is coded. The @ref is supposed to be the
+         ID value referenced, but sometimes it's just the name of the nonterminal. 
+         Since we can work out the ID from the name, let's not fuss at the authors
+         about that...
+    -->
+    <xsl:variable name="nt" select="($doc//prod[@id=$ref], $doc//prod[.=$ref], $doc//nt[@def=$ref])[1]"/>
     <xsl:variable name="uri" select="replace($doc/document-summary/@uri, '^http:', 'https:')"/>
 
     <xsl:choose>


### PR DESCRIPTION
Close #428

Hi @michaelhkay . I took a slightly different approach. For unknown reasons long since lost in the mists of time the 'etc' files that act as databases for cross-spec references stored `nt` elements. That's weird because the `nt` elements are supposed to point to `prod` elements. I expect someone (let's be candid, probably me) got confused by the fact that `nt` elements have a `def` attribute and thought they were definitions. They're not. I've changed things so that the `prod` elements are now stored in the database. There's only going to ever be one of those.

I had to tidy up a few things to make that work, and we can't abandon support for `nt` files in 'etc' documents because we have existing files that don't get regenerated.

I also cleaned up the cross-reference error to `StringLiteral` in the XSLT spec and patched over a problem with a few link in the XQuery specifications.

There's no useful information from PR formatting of PRs that change the stylesheets, so I'm just going to cross my fingers and merge this. Please pull the latest and let me know if you see any problems!
