### PR TITLE
Add hex and binary literals and allow underscores

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2016,6 +2016,8 @@ ErrorVal ::= "$" VarName
   <g:production name="NumericLiteral" node-type="void">
     <g:choice name="NumericLitChoice">
       <g:ref name="IntegerLiteral"/>
+      <g:ref name="HexIntegerLiteral"/>
+      <g:ref name="BinaryIntegerLiteral"/>
       <g:ref name="DecimalLiteral"/>
       <g:ref name="DoubleLiteral" />
     </g:choice>
@@ -4237,6 +4239,20 @@ ErrorVal ::= "$" VarName
   <g:token name="IntegerLiteral" inline="false" value-type="number" delimiter-type="nondelimiting">
     <g:ref name="Digits"/>
   </g:token>
+  
+  <g:token name="HexIntegerLiteral" inline="false" value-type="number" delimiter-type="nondelimiting">
+    <g:sequence>
+      <g:string>0x</g:string>
+      <g:ref name="HexDigits"/>
+    </g:sequence>
+  </g:token>
+  
+  <g:token name="BinaryIntegerLiteral" inline="false" value-type="number" delimiter-type="nondelimiting">
+    <g:sequence>
+      <g:string>0b</g:string>
+      <g:ref name="BinaryDigits"/>
+    </g:sequence>
+  </g:token>
 
   <g:token name="DecimalLiteral" inline="false" value-type="number" whitespace-spec="explicit" delimiter-type="nondelimiting">
     <g:choice name="DecimalString">
@@ -4457,12 +4473,20 @@ ErrorVal ::= "$" VarName
     they are not terminal symbols in the grammar of A.1 EBNF."
   -->
 
-  <g:token name="Digits" delimiter-type="hide" inline="false" is-local-to-terminal-symbol="yes">
-    <g:oneOrMore name="DigitsString">
-      <g:charClass>
-        <g:charRange minChar="0" maxChar="9"/>
-      </g:charClass>
-    </g:oneOrMore>
+  <g:token name="Digits" delimiter-type="hide" inline="false" is-local-to-terminal-symbol="yes">   
+      <g:sequence>
+        <g:oneOrMore>
+          <g:charClass>
+            <g:charRange minChar="0" maxChar="9"/>
+          </g:charClass>
+        </g:oneOrMore>
+        <g:zeroOrMore>
+          <g:charClass>
+            <g:charRange minChar="0" maxChar="9"/>
+            <g:char>_</g:char>
+          </g:charClass>
+        </g:zeroOrMore>
+      </g:sequence>     
   </g:token>
 
   <g:token name="CommentContents" exposition-only="yes" delimiter-type='hide' inline="false" if="xpath40 xquery40  xslt40-patterns" is-local-to-terminal-symbol="yes">
@@ -4478,12 +4502,23 @@ ErrorVal ::= "$" VarName
     productions above.
   --> 
 
-  <g:token name="HexDigits" inline="false" if="xquery40" show="no">
+  <g:token name="HexDigits" inline="false" delimiter-type="hide"  is-local-to-terminal-symbol="yes">
     <g:oneOrMore name="HexDigitsString">
       <g:charClass>
         <g:charRange minChar="0" maxChar="9"/>
         <g:charRange minChar="a" maxChar="f"/>
         <g:charRange minChar="A" maxChar="F"/>
+        <g:char>_</g:char>
+      </g:charClass>
+    </g:oneOrMore>
+  </g:token>
+  
+  <g:token name="BinaryDigits" inline="false" delimiter-type="hide"  is-local-to-terminal-symbol="yes">
+    <g:oneOrMore name="BinaryDigitsString">
+      <g:charClass>
+        <g:char>0</g:char>
+        <g:char>1</g:char>
+        <g:char>_</g:char>
       </g:charClass>
     </g:oneOrMore>
   </g:token>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1376,6 +1376,8 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       </p></item>
       <item><p>Support for higher-order functions is now a mandatory feature (in 3.1 it was optional).</p></item>
       <item role="xquery"><p>Switch expressions now allow a <code>case</code> clause to match multiple atomic values.</p></item>
+      <item><p>Numeric literals can now be written in hexadecimal or binary notation; and underscores can be included
+      for readability.</p></item>
         
 
     </olist>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6602,6 +6602,8 @@ and <nt def="OrExpr"
                <prodrecap id="Literal" ref="Literal"/>
                <prodrecap id="NumericLiteral" ref="NumericLiteral"/>
                <prodrecap id="IntegerLiteral" ref="IntegerLiteral"/>
+               <prodrecap id="HexIntegerLiteral" ref="HexIntegerLiteral"/>
+               <prodrecap id="BinaryIntegerLiteral" ref="BinaryIntegerLiteral"/>
                <prodrecap id="DecimalLiteral" ref="DecimalLiteral"/>
                <prodrecap id="DoubleLiteral" ref="DoubleLiteral"/>
                <prodrecap id="StringLiteral" ref="StringLiteral"/>
@@ -6609,14 +6611,49 @@ and <nt def="OrExpr"
                <prodrecap id="EscapeQuot" ref="EscapeQuot"/>
                <prodrecap id="EscapeApos" ref="EscapeApos"/>
                <prodrecap id="Digits" ref="Digits"/>
+               <prodrecap id="HexDigits" ref="HexDigits"/>
+               <prodrecap id="BinaryDigits" ref="BinaryDigits"/>
             </scrap>
-            <p> The value of a <term>numeric literal</term> containing no "<code>.</code>" and no <code>e</code> or <code>E</code> character is  an atomic value of type <code>xs:integer</code>. The value of a numeric literal containing "<code>.</code>" but no <code>e</code> or <code>E</code> character is an atomic value of type <code>xs:decimal</code>. The value of a numeric literal containing an <code>e</code> or <code>E</code> character is an atomic value of type <code>xs:double</code>. The value of the numeric literal is determined by casting it to the
-appropriate type according to the rules for casting from <code>xs:untypedAtomic</code>
-to a numeric type as specified in <xspecref
-                  spec="FO31" ref="casting-from-strings"/>.</p>
-
+            
+            
+            <p diff="add" at="2023-04-07">The value of a numeric literal is determined as follows (taking the rules in order):</p>
+            
+            <olist diff="chg" at="2023-04-07">
+               <item><p>Underscore characters are stripped out. Underscores may be included in a numeric
+               literal to aid readability, but have no effect on the value. For example, <code>1_000_000</code>
+               is equivalent to <code>1000000</code>.</p></item>
+               <item><p>A <code>HexIntegerLiteral</code> represents a non-negative integer
+               expressed in hexadecimal: for example <code>0xffff</code> represents the integer 65535, and
+                  <code>0xFFFF_FFFF</code> represents the integer 4294967295.</p>
+               </item>
+               <item><p>A <code>BinaryIntegerLiteral</code> represents a non-negative integer
+                  expressed in binary: for example <code>0b101</code> represents the integer 5, and
+                  <code>0b1111_1111</code> represents the integer 255.</p>
+               </item>
+               <item><p>The value of a <term>numeric literal</term> containing no "<code>.</code>" and 
+                  no <code>e</code> or <code>E</code> character is an atomic value of type <code>xs:integer</code>;
+                  the value is obtained by casting from <code>xs:string</code> to <code>xs:integer</code> as specified in
+                  <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+               </item>
+               <item><p>The value of a numeric literal containing "<code>.</code>" but no <code>e</code> or <code>E</code> 
+                  character is an atomic value of type <code>xs:decimal</code>;
+                  the value is obtained by casting from <code>xs:string</code> to <code>xs:decimal</code> as specified in
+                  <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+               </item>
+               <item><p>The value of a numeric literal 
+                  containing an <code>e</code> or <code>E</code> character is an atomic value of type 
+                  <code>xs:double</code>;
+                  the value is obtained by casting from <code>xs:string</code> to <code>xs:double</code> as specified in
+                  <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+               </item>
+            </olist>
+            
+            <note diff="add" at="2023-04-07"><p>The value of a numeric literal is always non-negative. An expression may
+               appear to include a negative number such as <code>-1</code>, but this is technically
+               an arithmetic expression comprising a unary minus operator followed by a numeric literal.</p></note>
+ 
             <note>
-               <p>The effect of the above rule is that in the case of an integer or decimal literal, a dynamic error <xerrorref
+               <p>The effect of the above rules is that in the case of an integer or decimal literal, a dynamic error <xerrorref
                      spec="FO31" class="AR" code="0002"
                      /> will generally be raised if the literal is outside the range of values supported by the implementation (other options are available: see <xspecref
                      spec="FO31" ref="op.numeric"/> for details.)</p>


### PR DESCRIPTION
Addresses issue #429. The grammar is extended to allow hex and binary integer literals, and all numeric literals may contain underscores for readability.