### PR TITLE
Attempt to clearify XML serialization of control characters

### DIFF
--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -1576,8 +1576,8 @@ SEPARATOR characters in text nodes <rfc2119>MUST</rfc2119> be output respectivel
 LINE SEPARATOR characters in attribute nodes <rfc2119>MUST</rfc2119> be output respectively
 as "<code>&amp;#xD;</code>", "<code>&amp;#xA;</code>", "<code>&amp;#x9;</code>",
 "<code>&amp;#x85;</code>", and "<code>&amp;#x2028;</code>", or their equivalents.
-In addition, the non-whitespace control characters
-#x1 through #x1F and #x7F through #x9F in text nodes and attribute nodes <rfc2119>MUST</rfc2119> be
+In addition, control characters
+#x1 through #x1F (except #x9, #xA, and #xD) and #x7F through #x9F (except #x85) in text nodes and attribute nodes <rfc2119>MUST</rfc2119> be
 output as character references.
 </p>
 <p>For example, an attribute with the value "x" followed by "y"


### PR DESCRIPTION
Fix #438 

Clarify that the control characters #x1 through X1f and #x7f through #x9f must be output as character references except for the whitespace characters #x9, #xA, #xD, and #85.