### PR TITLE
Editorial updates to XSLT spec

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -394,6 +394,17 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
   
+  <xs:element name="array" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="use" type="xsl:expression"/>
+          <xs:attribute name="_use" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  
   <xs:element name="assert" substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent mixed="true">
@@ -958,8 +969,12 @@ of problems processing the schema using various tools
     <xs:complexType>
       <xs:complexContent mixed="true">
         <xs:extension base="xsl:sequence-constructor">
-          <xs:attribute name="test" type="xsl:expression"/>
+          <xs:attribute name="test" type="xsl:expression"/>         
+          <xs:attribute name="then" type="xsl:expression"/>         
+          <xs:attribute name="else" type="xsl:expression"/>
           <xs:attribute name="_test" type="xs:string"/>
+          <xs:attribute name="_then" type="xs:string"/>
+          <xs:attribute name="_else" type="xs:string"/>
           <xs:assert test="exists(@test | @_test)"/>
         </xs:extension>
       </xs:complexContent>
@@ -1016,6 +1031,20 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
+  
+  <xs:element name="item-type" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="name" type="xs:QName"/>         
+          <xs:attribute name="as" type="xsl:item-type"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:assert test="exists(@href | @_href)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
 
   <xs:element name="iterate" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1057,9 +1086,16 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
   
-  <xs:element name="map"
-              type="xsl:sequence-constructor"
-              substitutionGroup="xsl:instruction"/>
+  <xs:element name="map" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="on-duplicates" type="xsl:expression"/>
+          <xs:attribute name="_on-duplicates" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
   
   <xs:element name="map-entry" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1258,6 +1294,10 @@ of problems processing the schema using various tools
   </xs:element>
 
   <xs:element name="non-matching-substring" type="xsl:sequence-constructor"/>
+  
+  <xs:element name="note" 
+              type="xsl:versioned-element-type" 
+              substitutionGroup="xsl:instruction xsl:declaration"/>
 
   <xs:element name="number" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1316,7 +1356,7 @@ of problems processing the schema using various tools
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor-or-select"/>
 
-  <xs:element name="otherwise" type="xsl:sequence-constructor"/>
+  <xs:element name="otherwise" type="xsl:sequence-constructor-or-select"/>
 
   <xs:element name="output" substitutionGroup="xsl:declaration">
     <xs:complexType>
@@ -1671,6 +1711,22 @@ of problems processing the schema using various tools
   </xs:element>
 
   <xs:element name="stylesheet" substitutionGroup="xsl:transform"/>
+  
+  <xs:element name="switch" substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:when" maxOccurs="unbounded"/>
+            <xs:element ref="xsl:otherwise" minOccurs="0"/>
+            <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="_select" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>     
+    </xs:complexType>
+  </xs:element>
 
   
   <xs:element name="template" substitutionGroup="xsl:declaration">
@@ -1992,7 +2048,7 @@ of problems processing the schema using various tools
   <xs:element name="when">
     <xs:complexType>
       <xs:complexContent mixed="true">
-        <xs:extension base="xsl:sequence-constructor">
+        <xs:extension base="xsl:sequence-constructor-or-select">
           <xs:attribute name="test" type="xsl:expression"/>
           <xs:attribute name="_test" type="xs:string"/>
           <xs:assert test="exists(@test | @_test)"/>
@@ -2187,7 +2243,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           An XPath 2.1 ItemType
+           An XPath ItemType
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2635,7 +2691,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           One of the values "yes" or "no" or "omit". The values "true" or "false",
+           One of the values "yes" or "no" or "maybe". The values "true" or "false",
            or "1" or "0" are accepted as synonyms of "yes" and "no" respectively.
         </p>
       </xs:documentation>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -160,7 +160,7 @@
             <emph>This document contains hyperlinks to specific sections or definitions within other
                documents in this family of specifications. These links are indicated visually by a
                superscript identifying the target specification: for example XP40 for XPath 4.0,
-               DM30 for the XDM data model version 3.0, FO40 for Functions and Operators version
+               DM40 for the XDM data model version 4.0, FO40 for Functions and Operators version
                4.0.</emph>
          </p>
          
@@ -684,6 +684,12 @@
                            <p>A string comprising a single Unicode character</p>
                         </def>
                      </gitem>
+                     <gitem diff="add" at="2023-04-18">
+                        <label><code>language</code></label>
+                        <def>
+                           <p>A string in the value space of <code>xs:language</code>, or a zero-length string.</p>
+                        </def>
+                     </gitem>
                      <gitem>
                         <label><code>integer</code></label>
                         <def>
@@ -706,10 +712,11 @@
                         </def>
                      </gitem>
                      <gitem>
-                        <label><code>prefix</code></label>
+                        <label><code>prefix</code><phrase diff="add" at="2023-04-18">; <code>prefixes</code></phrase></label>
                         <def>
                            <p>An <code>xs:NCName</code> representing a namespace prefix, which must
-                              be in scope for the element on which it appears</p>
+                              be in scope for the element on which it appears;
+                              <phrase diff="add" at="2022-01-01">a whitespace-separated list of such strings</phrase>.</p>
                         </def>
                      </gitem>
                      <gitem>
@@ -818,6 +825,25 @@
             <p>The rules in the element syntax summary (both for the
                element structure and for its attributes) apply to the stylesheet content after
                preprocessing as described in <specref ref="preprocessing"/>.</p>
+            
+            <p diff="add" at="2023-04-18"><termdef id="dt-effective-value" term="effective value">The <term>effective value</term>
+            of an attribute or text node in the stylesheet is the value after any required expansion or normalization.</termdef></p>
+            
+            <p diff="add" at="2023-04-18">More specifically, the effective value is the value after:</p>
+            <ulist diff="add" at="2023-04-18">
+               <item><p>Expanding shadow attributes as described in <specref ref="shadow-attributes"/>;</p></item>
+               <item><p>Expanding defaults (for example, if an <elcode>xsl:message</elcode> instruction has
+                  no <code>terminate</code> attribute, then the effective value of the <code>terminate</code> attribute
+                  is <code>no</code>);</p></item>
+               <item><p>Stripping ignored whitespace (for example, the effective value of a boolean attribute written as
+                  <code>terminate="  no  "</code> is <code>no</code>);</p></item>
+               <item><p>Replacing synonyms (for example in boolean attributes, <code>1</code> and <code>true</code>
+                  are synonyms of <code>yes</code>);</p></item>
+               <item><p>Expanding <termref def="dt-attribute-value-template">attribute value templates</termref> and 
+                  <termref def="dt-text-value-template">text value templates</termref>.</p></item>
+               <item><p>Applying rules from the static context: for example, the effective value of a <code>collation</code>
+                  attribute is the value after expanding a relative URI against the static base URI.</p></item>
+            </ulist>
             <p>Attributes are validated as follows. These rules apply to the value of the attribute
                after removing leading and trailing whitespace.</p>
             <ulist>
@@ -1204,7 +1230,7 @@
                            <elcode>xsl:package</elcode> element of <var>P</var>.</p></item>
                         <item><p><var>M</var> is declared in a package used by <var>P</var>, and is given <code>public</code> or <code>final</code>
                            <termref def="dt-visibility"/> in <var>P</var> by means of an <elcode>xsl:accept</elcode> declaration.</p></item>
-                        <item><p>The effective value of the <code>declared-modes</code> attribute of the explicit or implicit
+                        <item><p>The <termref def="dt-effective-value"/> of the <code>declared-modes</code> attribute of the explicit or implicit
                         <elcode>xsl:package</elcode> element of <var>P</var> is <code>no</code>, and <var>M</var> appears as 
                         a mode-name in the <code>mode</code> attribute of a <termref def="dt-template-rule"/> declared within <var>P</var>.</p></item>
                      </olist>
@@ -1477,7 +1503,7 @@
                   <item><p>A result tree may be constructed from the <termref def="dt-raw-result"/>.
                      By default, a result tree is constructed if the <code>build-tree</code>
                      attribute of the unnamed <termref def="dt-output-definition"/>
-                     has the effective value <code>yes</code>. An API for invoking transformations <rfc2119>may</rfc2119>
+                     has the <termref def="dt-effective-value"/> <code>yes</code>. An API for invoking transformations <rfc2119>may</rfc2119>
                      allow this setting to be overridden by the calling application. If result tree construction
                      is requested, it is performed as described in <specref ref="result-tree-construction"/>.
                    </p></item>
@@ -2963,7 +2989,7 @@
                <code>[xsl:]expand-text</code>, 
                <code>[xsl:]version</code>, and <code>[xsl:]xpath-default-namespace</code>, the value
                can be overridden by a different value for the same attribute appearing on a
-               descendant element. The effective value of the attribute for a particular stylesheet
+               descendant element. The <termref def="dt-effective-value"/> of the attribute for a particular stylesheet
                element is determined by the innermost ancestor-or-self element on which the
                attribute appears.</p>
             <p>In an <termref def="dt-embedded-stylesheet-module">embedded stylesheet
@@ -2973,7 +2999,7 @@
             <p>In the case of <code>[xsl:]exclude-result-prefixes</code> and
                   <code>[xsl:]extension-element-prefixes</code> the values are cumulative. For these
                attributes, the value is given as a whitespace-separated list of namespace prefixes,
-               and the effective value for an element is the combined set of namespace URIs
+               and the <termref def="dt-effective-value"/> for an element is the combined set of namespace URIs
                designated by the prefixes that appear in this attribute for that element and any of
                its ancestor elements. Again, the two forms with and without the XSLT namespace are
                equivalent.</p>
@@ -3171,8 +3197,8 @@
                         the package manifest just a single <elcode>xsl:import</elcode> or
                         <elcode>xsl:include</elcode> declaration as a reference to the effective
                         top-level stylesheet module; this approach is particularly suitable when
-                        writing code that is required to run under earlier releases of XSLT as well as
-                        under XSLT 3.0 <phrase diff="add" at="2023-02-24">and 4.0</phrase>. 
+                        writing code that is required to run under releases of XSLT 
+                        <phrase diff="add" at="2023-02-24">earlier than 3.0</phrase>. 
                         Another approach is to include the substance of the top-level
                         stylesheet module inline within the package manifest.</p></item>
                   </olist>
@@ -4675,7 +4701,7 @@
                                  (defaulting to <code>item()*</code>) are <termref def="dt-identical-types">identical</termref>.</p>
                            </item>
                            <item>
-                              <p>The effective value of the 
+                              <p>The <termref def="dt-effective-value"/> of the 
                                  <code>new-each-time</code> 
                                  attribute on the overriding function is the same as its value on the overridden function.</p>
                            </item>
@@ -4707,7 +4733,7 @@
                               <p>For every non-tunnel parameter on the overridden template, there is a
                                  non-tunnel parameter on the overriding template that has the same name, an
                                     <termref def="dt-identical-types">identical</termref> required
-                                 type, and the same effective value for the <code>required</code> attributes.</p>
+                                 type, and the same <termref def="dt-effective-value"/> for the <code>required</code> attributes.</p>
                            </item>
                            <item>
                               <p>For every tunnel parameter <var>P</var> on the overridden template, if there is a
@@ -5517,7 +5543,7 @@
                   <p>
                      <error spec="XT" type="static" class="SE" code="3085">
                         <p>It is a <termref def="dt-static-error">static error</termref>, 
-                           when the effective value of the <code>declared-modes</code> attribute of 
+                           when the <termref def="dt-effective-value"/> of the <code>declared-modes</code> attribute of 
                            an <elcode>xsl:package</elcode> element is <code>yes</code>, if the 
                            package contains an explicit reference to an undeclared mode, or if 
                            it implicitly uses the unnamed mode and the unnamed mode is undeclared.</p></error></p>
@@ -6581,7 +6607,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>More specifically, when an element <var>E</var> matches
                   the pattern <code>(xsl:template[@match] | xsl:apply-templates)[not(@mode) or
                      normalize-space(@mode) eq "#default"]</code> (using the Unicode codepoint
-                  collation), then the effective value of the <code>mode</code> attribute is taken
+                  collation), then the <termref def="dt-effective-value"/> of the <code>mode</code> attribute is taken
                   from the value of the <code>[xsl:]default-mode</code> attribute of the innermost
                   ancestor-or-self element of <var>E</var> that has such an attribute. If there is
                   no such element, then the default is the <termref def="dt-unnamed-mode">unnamed
@@ -7768,7 +7794,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>An attribute whose name begins with an underscore is
                   treated specially only when it appears on an element in the XSLT namespace. On a 
                   <termref def="dt-literal-result-element"/>, it is treated in the same way as any other attribute (that is,
-                  its effective value is copied to the result tree). On an
+                     its <termref def="dt-effective-value"/> is copied to the result tree). On an
                      <termref def="dt-extension-instruction"/> or
                   <termref def="dt-data-element"/>, as with other attributes
                   on these elements, its meaning is entirely <termref def="dt-implementation-defined"/>.</p>
@@ -8919,7 +8945,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      on the same element, then <code>[xsl:]default-type-namespace</code> wins.</p></note>
                   
                   <p>For any element in the <termref def="dt-stylesheet">stylesheet</termref>, the
-                     effective value of the default type namespace determines the value of the <emph>default
+                     <termref def="dt-effective-value"/> of the default type namespace determines the value of the <emph>default
                         namespace for type names</emph> in the static context of any XPath
                      expression contained in an attribute or text
                      node of that element (including XPath expressions in <termref def="dt-attribute-value-template">attribute value templates</termref>
@@ -8927,7 +8953,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         templates</termref>). The effect of this is specified in <bibref ref="xpath-40"/>; in summary, it determines the namespace used for any
                      unprefixed element name appearing in a path expression or in the <termref def="dt-sequence-type"/>
                      production.</p>
-                  <p>The effective value of this attribute similarly applies to any of the following
+                  <p>The <termref def="dt-effective-value"/> of this attribute similarly applies to any of the following
                      constructs appearing within its scope:</p>
                   <ulist>
                      <item>
@@ -8947,7 +8973,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      
                   </ulist>
                   
-                  <p>If the effective value of the attribute is a zero-length string, which will be the
+                  <p>If the <termref def="dt-effective-value"/> of the attribute is a zero-length string, which will be the
                      case if it is explicitly set to a zero-length string or if it is not specified at
                      all, then an unprefixed element name or type name refers to a name that is in no
                      namespace. The default namespace of the parent element (see <xspecref spec="DM30" ref="ElementNode"/>) 
@@ -10987,14 +11013,14 @@ and <code>version="1.0"</code> otherwise.</p>
                attribute is given below; however, the definitive explanations are given as part of the specification of
                <xfunction>format-number</xfunction>.</p>
             <p>For any named <termref def="dt-decimal-format">decimal format</termref>, the
-               effective value of each attribute is taken from an
+               <termref def="dt-effective-value"/> of each attribute is taken from an
                <elcode>xsl:decimal-format</elcode> declaration that has that name, and that
                specifies an explicit value for the required attribute. If there is no such
                declaration, the default value of the attribute is used. If there is more than one
                such declaration, the one with highest <termref def="dt-import-precedence">import
                   precedence</termref> is used.</p>
             <p>For any unnamed <termref def="dt-decimal-format">decimal format</termref>, the
-               effective value of each attribute is taken from an
+               <termref def="dt-effective-value"/> of each attribute is taken from an
                <elcode>xsl:decimal-format</elcode> declaration that is unnamed, and that
                specifies an explicit value for the required attribute. If there is no such
                declaration, the default value of the attribute is used. If there is more than one
@@ -11175,9 +11201,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      right curly bracket occurs in a fixed part of a value template.</p>
                </error>
             </p>
-            <p>
-               <termdef id="dt-effective-value" term="effective value">The result of evaluating a
-                  value template is referred to as its <term>effective value</term>.</termdef> The
+            <p>The result of evaluating a
+               value template is referred to as its <termref def="dt-effective-value"/>. The
                effective value is the string obtained by concatenating the expansions of the fixed
                and variable parts:</p>
             <ulist>
@@ -11303,7 +11328,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      (synonyms <code>true</code> or <code>1</code>) or <code>no</code> (synonyms
                         <code>false</code> or <code>0</code>). </p>
 
-               <p>This section describes how text nodes  are processed when the effective value is
+               <p>This section describes how text nodes  are processed when the <termref def="dt-effective-value"/> is
                      <code>yes</code>. Such text nodes are referred to as text value templates.</p>
 
                <p>
@@ -11316,7 +11341,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   whose value is a text value template results in the construction of a text node in
                   the result of the containing sequence
                      constructor or <elcode>xsl:text</elcode> instruction. The string value
-                  of that text node is obtained by computing the effective value of the value
+                  of that text node is obtained by computing the <termref def="dt-effective-value"/> of the value
                   template.</p>
 
                <note>
@@ -11413,14 +11438,14 @@ and <code>version="1.0"</code> otherwise.</p>
                      whitespace stripping: see <specref ref="stylesheet-stripping"/>) is processed as follows:</p>
                   <olist>
                      <item>
-                        <p>if the effective value of the standard attribute
+                        <p>if the <termref def="dt-effective-value"/> of the standard attribute
                               <code>[xsl:]expand-text</code> is <code>no</code>, or in the absence
                            of this attribute, the text node in the stylesheet is copied to create a
                            new parentless text node in the result of the sequence constructor.</p>
                         
                      </item>
                      <item>
-                        <p>Otherwise (the effective value of <code>[xsl:]expand-text</code> is
+                        <p>Otherwise (the <termref def="dt-effective-value"/> of <code>[xsl:]expand-text</code> is
                               <code>yes</code>), the text node in the stylesheet is processed as
                            described in <specref ref="text-value-templates"/>.</p>
                      </item>
@@ -13090,13 +13115,13 @@ and <code>version="1.0"</code> otherwise.</p>
                      an <elcode>xsl:mode</elcode> declaration with the attribute
                         <code>streamable="yes"</code>.</termdef>
                </p>
-               <p>For any named <termref def="dt-mode">mode</termref>, the effective value of each
+               <p>For any named <termref def="dt-mode">mode</termref>, the <termref def="dt-effective-value"/> of each
                   attribute is taken from an <elcode>xsl:mode</elcode> declaration that has a
                   matching name in its <code>name</code> attribute, and that specifies an explicit
                   value for the required attribute. If there is
                      no such declaration, the default value of the attribute is used. If
                   there is more than one such declaration, the one with highest <termref def="dt-import-precedence">import precedence</termref> is used.</p>
-               <p>For the <termref def="dt-unnamed-mode">unnamed mode</termref>, the effective value
+               <p>For the <termref def="dt-unnamed-mode">unnamed mode</termref>, the <termref def="dt-effective-value"/>
                   of each attribute is taken from an <elcode>xsl:mode</elcode> declaration that has
                   no <code>name</code> attribute, and that specifies an explicit value for the
                   required attribute. If there is no such declaration, the default value of the
@@ -20079,7 +20104,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>
                   <error spec="XT" type="dynamic" class="DE" code="0835">
                      <!--Text replaced by erratum E6 change 2"-->
-                     <p> It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value">effective value</termref> of the
+                     <p> It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value"/> of the
                            <code>namespace</code> attribute <error.extra>of the
                               <elcode>xsl:element</elcode> instruction</error.extra> is not in the
                         lexical space of the <code>xs:anyURI</code> datatype or if it is the string
@@ -20394,7 +20419,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   as described in <specref ref="text-value-templates"/>.</p>
 
                <p>In the absence of such an attribute, or if the
-                     effective value is <code>no</code>, the content of the
+                  <termref def="dt-effective-value"/> is <code>no</code>, the content of the
                      <elcode>xsl:text</elcode> element is a single text node whose value forms the
                      <termref def="dt-string-value">string value</termref> of the new text node. An
                      <elcode>xsl:text</elcode> element may be empty, in which case the result of
@@ -22016,11 +22041,11 @@ for $i in 1 to count($V) return
                      value</termref>
                   <code>text</code>, the atomized <termref def="dt-sort-key-value">sort key
                      values</termref> are converted to strings before being compared. If it has the
-                  effective value <code>number</code>, the atomized sort key values are converted to
+                  <termref def="dt-effective-value"/> <code>number</code>, the atomized sort key values are converted to
                   doubles before being compared. The conversion is done by using the
                      <xfunction>string</xfunction> or <xfunction>number</xfunction> function as
                   appropriate. If the <code>data-type</code> attribute has
-                     any other <termref def="dt-effective-value">effective value</termref>, then
+                     any other <termref def="dt-effective-value"/>, then
                      this value <rfc2119>must</rfc2119> be an <termref def="dt-eqname">EQName</termref> denoting an <termref def="dt-expanded-qname">expanded
                         QName</termref> with a non-absent namespace, and the effect of the
                   attribute is <termref def="dt-implementation-defined"/>.</p>
@@ -22158,8 +22183,8 @@ for $i in 1 to count($V) return
                <ulist>
                   <item>
                      <p>The <code>lang</code> attribute indicates that a collation suitable for a
-                        particular natural language <rfc2119>should</rfc2119> be used. The <termref def="dt-effective-value">effective value</termref> of the attribute
-                           <rfc2119>must</rfc2119>
+                        particular natural language <rfc2119>should</rfc2119> be used. 
+                        The <termref def="dt-effective-value"/> of the attribute <rfc2119>must</rfc2119>
                          either be a string in the value space of
                               <code>xs:language</code>, or a zero-length string. Supplying the
                            zero-length string has the same effect as omitting the attribute. If a
@@ -24040,9 +24065,10 @@ the same group, and the-->
                      have differing <termref def="dt-effective-value">effective values</termref> for
                      any of the attributes <code>lang</code>, <code>order</code>,
                         <code>collation</code>, <code>case-order</code>, or <code>data-type</code>.
-                     Values are considered to differ if the attribute is present on one element and
-                     not on the other, or if it is present on both elements with <termref def="dt-effective-value">effective values</termref> that are not equal to
-                     each other. In the case of the <code>collation</code> attribute, the values are
+                     Values are considered to differ if <phrase diff="del" at="2023-04-18">the attribute is present on one element and
+                     not on the other, or if it is present on both elements with</phrase> 
+                     they have different <termref def="dt-effective-value">effective values</termref>. 
+                     In the case of the <code>collation</code> attribute, the values are
                      compared as absolute URIs after resolving against the base URI. The error
                         <rfc2119>may</rfc2119> be reported statically if it is detected
                      statically.</p>
@@ -24757,7 +24783,7 @@ the same group, and the-->
             <?element xsl:non-matching-substring?>
             <p>The <elcode>xsl:analyze-string</elcode> instruction takes as input a string (the
                result of evaluating the expression in the <code>select</code> attribute) and a
-               regular expression (the effective value of the <code>regex</code> attribute).</p>
+               regular expression (the <termref def="dt-effective-value"/> of the <code>regex</code> attribute).</p>
             <p>If the result of evaluating the <code>select</code> expression <!--bug 7676-->is an empty sequence, it is treated as a zero-length string.
                   If the value is not a string, it is converted to a string by applying the
                   <termref def="dt-coercion-rules"/>.</p>
@@ -24818,7 +24844,8 @@ the same group, and the-->
                input string that match the regular expression supplied.</p>
             <p>
                <error spec="XT" type="dynamic" class="DE" code="1140">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value">effective value</termref> of the <code>regex</code>
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value"/>
+                     of the <code>regex</code>
                      attribute <error.extra>of the <elcode>xsl:analyze-string</elcode>
                         instruction</error.extra> does not conform to the
                         <rfc2119>required</rfc2119> syntax for regular expressions, as specified in
@@ -24829,7 +24856,7 @@ the same group, and the-->
             </p>
             <p>
                <error spec="XT" type="dynamic" class="DE" code="1145">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value">effective value</termref> of the <code>flags</code>
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value"/> of the <code>flags</code>
                      attribute <error.extra>of the <elcode>xsl:analyze-string</elcode>
                         instruction</error.extra> has a value other than the values defined in
                         <bibref ref="xpath-functions-40"/>. If the value of the attribute is known
@@ -25132,7 +25159,8 @@ the same group, and the-->
             <note><p>In earlier drafts of this specification the <elcode>xsl:source-document</elcode>
             element was named <code>xsl:stream</code>. The instruction has been generalised to handle both streamed and unstreamed
             input.</p></note>
-            <p>The document to be read is determined by the <termref def="dt-effective-value">effective value</termref> of the <code>href</code> attribute (which is defined as
+            <p>The document to be read is determined by the <termref def="dt-effective-value"/> 
+               of the <code>href</code> attribute (which is defined as
                an <termref def="dt-attribute-value-template">attribute value template</termref>).
                   This <rfc2119>must</rfc2119> be a valid URI reference.
                   If it is an absolute URI reference, it is used as is; if it is a relative URI
@@ -34217,8 +34245,8 @@ the same group, and the-->
 
                <p>If there are several <elcode>xsl:key</elcode> declarations in
                   the same package with the same key name, then
-                  they must all have the same effective value for their <code>composite</code>
-                  attribute. The effective value is the actual value of the attribute if present, or
+                  they must all have the same <termref def="dt-effective-value"/> for their <code>composite</code>
+                  attribute. The <termref def="dt-effective-value"/> is the actual value of the attribute if present, or
                   <code>"no"</code> if the attribute is absent.</p>
                <note>
                   <p>There is no requirement that all the values of a key should have the same
@@ -34272,7 +34300,7 @@ the same group, and the-->
                   <error spec="XT" type="static" class="SE" code="1222">
                      <p>It is a <termref def="dt-static-error">static error</termref> if there are
                         several <elcode>xsl:key</elcode> declarations in a <termref def="dt-package">package</termref> with the same key name and
-                        different effective values for the <code>composite</code> attribute.</p>
+                        different <termref def="dt-effective-value">effective values</termref> for the <code>composite</code> attribute.</p>
                   </error>
                </p>
                <p>It is possible to have:</p>
@@ -35584,7 +35612,7 @@ return ($m?price - $m?discount)</eg>
                   not predictable.</p>
             </note>
             <p>The <code>terminate</code> attribute is interpreted as an <termref def="dt-attribute-value-template">attribute value template</termref>.</p>
-            <p>If the <termref def="dt-effective-value">effective value</termref> of the
+            <p>If the <termref def="dt-effective-value"/> of the
                   <code>terminate</code> attribute is <code>yes</code>, then the <termref def="dt-processor">processor</termref>
                <rfc2119>must</rfc2119>
                signal a <termref def="dt-dynamic-error"> dynamic error</termref> after
@@ -35598,9 +35626,9 @@ return ($m?price - $m?discount)</eg>
                may be used to indicate the error code
                associated with the message. This may be used irrespective of the value of
                   <code>terminate</code>. The 
-               <termref def="dt-effective-value">effective value</termref> of the 
+               <termref def="dt-effective-value"/> of the 
                error code attribute is expected to be an <termref def="dt-eqname">EQName</termref>. If no error code is specified, or if
-               the effective value is not a valid EQName, the error code will have local part
+               the <termref def="dt-effective-value"/> is not a valid EQName, the error code will have local part
                   <code>XTMM9000</code> and namespace URI
                   <code>http://www.w3.org/2005/xqt-errors</code>. User-defined error codes
                   <rfc2119>should</rfc2119> be in a namespace other than
@@ -36097,7 +36125,7 @@ return ($m?price - $m?discount)</eg>
             
             <p>If the result is not serialized, then the decision whether to
                return the <termref def="dt-raw-result"/> or to construct a tree depends on the effective
-               value of the <code>build-tree</code> attribute. If the effective value of
+               value of the <code>build-tree</code> attribute. If the <termref def="dt-effective-value"/> of
                the <code>build-tree</code> attribute is <code>yes</code>, then 
                   a <termref def="dt-final-result-tree"/> is created
                by invoking the process of <xtermref spec="SER30" ref="sequence-normalization"/>. <phrase diff="del" at="2022-01-01">The default for the
@@ -36120,7 +36148,7 @@ return ($m?price - $m?discount)</eg>
             <p>Technically, the result of evaluating the <elcode>xsl:result-document</elcode>
                instruction is an empty sequence. This means it does not contribute anything to the
                result of the sequence constructor it is part of.</p>
-            <p>The <termref def="dt-effective-value">effective value</termref> of the
+            <p>The <termref def="dt-effective-value"/> of the
                   <code>format</code> attribute, if specified, <rfc2119>must</rfc2119> be an <termref def="dt-eqname">EQName</termref>. The value is
                expanded using the namespace declarations in scope for the
                   <elcode>xsl:result-document</elcode> element. The resulting <termref def="dt-expanded-qname">expanded QName</termref>
@@ -36131,7 +36159,7 @@ return ($m?price - $m?discount)</eg>
                serialization of the result tree.</p>
             <p>
                <error spec="XT" type="dynamic" class="DE" code="1460">
-                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value">effective value</termref> of the
+                  <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the <termref def="dt-effective-value"/> of the
                         <code>format</code> attribute <error.extra>of an
                            <elcode>xsl:result-document</elcode> element</error.extra> is not a valid
                         <termref def="dt-eqname">EQName</termref>, or if it does not match the
@@ -36183,7 +36211,7 @@ return ($m?price - $m?discount)</eg>
                defined as <termref def="dt-attribute-value-template">attribute value
                   templates</termref>, so their values may be set dynamically. For any of these
                attributes that is present on the <elcode>xsl:result-document</elcode> instruction,
-               the <termref def="dt-effective-value">effective value</termref> of the attribute
+               the <termref def="dt-effective-value"/> of the attribute
                overrides or supplements the corresponding value from the output definition. This
                works in the same way as when one <elcode>xsl:output</elcode> declaration overrides
                another. Some of the attributes have more specific
@@ -36203,13 +36231,13 @@ return ($m?price - $m?discount)</eg>
                </item>
                <item>
                   <p>In the case of <code>doctype-public</code> and <code>doctype-system</code>,
-                     setting the effective value of the attribute to a zero-length string has the
+                     setting the <termref def="dt-effective-value"/> of the attribute to a zero-length string has the
                      effect of overriding any value for these attributes obtained from the output
                      definition. The corresponding serialization parameter is not set (is
                      “absent”).</p>
                </item>
                <item>
-                  <p>In the case of <code>item-separator</code>, setting the effective value of the
+                  <p>In the case of <code>item-separator</code>, setting the <termref def="dt-effective-value"/> of the
                      attribute to the special value <code>"#absent"</code> has the effect of
                      overriding any value for this attribute obtained from the output definition.
                      The corresponding serialization parameter is not set (is “absent”). It is not
@@ -36217,7 +36245,7 @@ return ($m?price - $m?discount)</eg>
                      7-character string <code>"#absent"</code>. </p>
                </item>
                <item>
-                  <p>In all other cases, the effective value of an attribute actually present on
+                  <p>In all other cases, the <termref def="dt-effective-value"/> of an attribute actually present on
                      this instruction takes precedence over the value defined in the selected output
                      definition.</p>
                </item>
@@ -36225,7 +36253,7 @@ return ($m?price - $m?discount)</eg>
             <note>
                <p>In the case of the attributes <code>method</code>,
                      <code>cdata-section-elements</code>, <code>suppress-indentation</code>, and
-                     <code>use-character-maps</code>, the <termref def="dt-effective-value">effective value</termref> of the attribute contains a space-separated list of
+                     <code>use-character-maps</code>, the <termref def="dt-effective-value"/> of the attribute contains a space-separated list of
                      <termref def="dt-eqname">EQNames</termref>. If any of these is a <termref def="dt-lexical-qname">lexical QName</termref> with a prefix, the prefix is
                   expanded using the in-scope namespaces for the
                      <elcode>xsl:result-document</elcode> element. In the case of
@@ -36265,7 +36293,7 @@ return ($m?price - $m?discount)</eg>
             
             
             <p>The <code>href</code> attribute is optional. The default value is the zero-length
-               string. The <termref def="dt-effective-value">effective value</termref> of the
+               string. The <termref def="dt-effective-value"/> of the
                attribute <rfc2119>must</rfc2119> be a <termref def="dt-uri-reference">URI
                   Reference</termref>, which may be absolute or relative. If it is relative, then it is resolved against the <termref def="dt-base-output-uri"/>. There <rfc2119>may</rfc2119> be <termref def="dt-implementation-defined">implementation-defined</termref> restrictions on
                the form of absolute URI that may be used, but the implementation is not
@@ -36279,7 +36307,8 @@ return ($m?price - $m?discount)</eg>
                the form of this URI. </imp-def-feature>
             <p>If the implementation provides an API to access <termref def="dt-secondary-result">secondary results</termref>, then it
                   <rfc2119>must</rfc2119> allow a secondary result to be identified by means of the
-               absolutized value of the <code>href</code> attribute. In addition, if a <termref def="dt-final-result-tree"/> is constructed (that is, if the effective value of
+               absolutized value of the <code>href</code> attribute. In addition, if a <termref def="dt-final-result-tree"/> is constructed
+               (that is, if the <termref def="dt-effective-value"/> of
                   <code>build-tree</code> is <code>yes</code>), then this value is used as the base
                URI of the document node at the root of the <termref def="dt-final-result-tree">final
                   result tree</termref>. </p>
@@ -36768,7 +36797,7 @@ return ($m?price - $m?discount)</eg>
                               <elcode>xsl:copy</elcode>, <elcode>xsl:copy-of</elcode>, or
                               <elcode>xsl:result-document</elcode> instruction, or the
                               <code>xsl:validation</code> attribute of a literal result element, has
-                           the effective value <code>strict</code>, and schema validity assessment
+                           the <termref def="dt-effective-value"/> <code>strict</code>, and schema validity assessment
                            concludes that the validity of the element or attribute is invalid or
                            unknown, a <termref def="dt-type-error">type error</termref> occurs. As
                            with other type errors, the error <rfc2119>may</rfc2119> be signaled
@@ -36782,7 +36811,7 @@ return ($m?price - $m?discount)</eg>
                               <elcode>xsl:copy</elcode>, <elcode>xsl:copy-of</elcode>, or
                               <elcode>xsl:result-document</elcode> instruction, or the
                               <code>xsl:validation</code> attribute of a literal result element, has
-                           the effective value <code>strict</code>, and there is no matching
+                           the <termref def="dt-effective-value"/> <code>strict</code>, and there is no matching
                            top-level declaration in the schema, then a <termref def="dt-type-error">type error</termref> occurs. As with other type errors, the error
                               <rfc2119>may</rfc2119> be signaled statically if it can be detected
                            statically. </p>
@@ -36795,7 +36824,7 @@ return ($m?price - $m?discount)</eg>
                               <elcode>xsl:copy</elcode>, <elcode>xsl:copy-of</elcode>, or
                               <elcode>xsl:result-document</elcode> instruction, or the
                               <code>xsl:validation</code> attribute of a literal result element, has
-                           the effective value <code>lax</code>, and schema validity assessment
+                           the <termref def="dt-effective-value"/> <code>lax</code>, and schema validity assessment
                            concludes that the element or attribute is invalid, a <termref def="dt-type-error">type error</termref> occurs. As with other type
                            errors, the error <rfc2119>may</rfc2119> be signaled statically if it can
                            be detected statically. </p>
@@ -37229,7 +37258,7 @@ return ($m?price - $m?discount)</eg>
             serialized.</p>
          <p diff="add" at="2022-01-01">
             If the result is not serialized, then the decision whether to return the raw result 
-            or to construct a tree depends on the effective value of the <code>build-tree</code> attribute. 
+            or to construct a tree depends on the <termref def="dt-effective-value"/> of the <code>build-tree</code> attribute. 
             If the effective value of the <code>build-tree</code> attribute is <code>yes</code>, then a 
             final result tree is created by invoking the process of sequence normalization. Conversely, 
             if the result is serialized, then the decision whether or not to construct a tree depends 
@@ -37420,7 +37449,7 @@ return ($m?price - $m?discount)</eg>
                <note>
                   <p>The <code>item-separator</code> attribute has no
                      effect if the sequence being serialized contains only one item<phrase diff="del" at="2022-01-01">, which will
-                     always be the case if the effective value of <code>build-tree</code> is
+                     always be the case if the <termref def="dt-effective-value"/> of <code>build-tree</code> is
                         <code>yes</code></phrase>. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E14, bug 30208].</phrase></p>
                </note>
             </item>
@@ -38236,6 +38265,7 @@ return ($m?price - $m?discount)</eg>
             <blist>
                <bibl id="xpath-datamodel-30" key="XDM 3.0"/>
                <bibl id="xpath-datamodel-31" key="XDM 3.1"/>
+               <bibl id="xpath-datamodel-40" key="XDM 4.0"/>
                <bibl id="xpath-functions-30" key="Functions and Operators 3.0"/>
                <bibl id="xpath-functions-31" key="Functions and Operators 3.1"/>
                <bibl id="xpath-functions-40" key="Functions and Operators 4.0">
@@ -38593,28 +38623,18 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                      and certain other values to instances of the user-defined type.</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">Functions defined in XPath 3.0</td>
-                     <td rowspan="1" colspan="1"><bibref ref="xpath-functions-30"/></td>
+                     <td rowspan="1" colspan="1">Functions defined in XPath 4.0</td>
+                     <td rowspan="1" colspan="1" diff="add" at="2023-04-18"><bibref ref="xpath-functions-40"/></td>
                      <td rowspan="1" colspan="1"><var>R</var>, <var>S</var>, <var>D</var></td>
                      <td rowspan="1" colspan="1">Includes functions in the namespaces conventionally
                      referred to be the prefixes <code>fn</code> and <code>math</code>.</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">Additional functions defined in XPath 3.1 (where supported)</td>
-                     <td rowspan="1" colspan="1"><bibref ref="xpath-functions-31"/></td>
-                     <td rowspan="1" colspan="1"><var>R</var>, <var>S</var>, <var>D</var>.</td>
-                     <td rowspan="1" colspan="1">This category has an overlap with the set of XSLT-defined-functions. Where a function
-                     is defined both in this document and in XPath 3.1, the function is available in an XSLT 3.0
-                     stylesheet whether or not the processor supports XPath 3.1. This category includes functions
-                     in namespaces conventionally referred to by the prefixes <code>fn</code>, <code>map</code>, 
-                     and <code>array</code>.</td>
-                  </tr>
-                  <tr>
-                     <td rowspan="1" colspan="1">Functions defined in XSLT 3.0</td>
+                     <td rowspan="1" colspan="1">Functions defined in XSLT 4.0</td>
                      <td rowspan="1" colspan="1">This specification</td>
                      <td rowspan="1" colspan="1"><var>R</var>, <var>S</var> (see note), <var>D</var></td>
                      <td rowspan="1" colspan="1">See <specref ref="XSLT-defined-functions"/>. There is an overlap with
-                     the set of functions defined in XPath 3.1. The functions available in static expressions are:
+                     the set of functions defined in XPath 4.0. The functions available in static expressions are:
                      <function>element-available</function>, <function>function-available</function>,
                      <function>type-available</function>, <function>available-system-properties</function>,
                      and <function>system-property</function>.</td>
@@ -38645,7 +38665,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
          
          <p>For convenience, schemas are provided for validation of XSLT 3.0 stylesheets
          using the XSD 1.1 and Relax NG schema languages. These are non-normative. Neither will detect
-         every static error that might arise in an XSLT 3.0 stylesheet (for example, there is no attempt
+         every static error that might arise in an XSLT 4.0 stylesheet (for example, there is no attempt
          to check the syntax of XPath expressions); in addition, these schemas may reject some stylesheets
          that are valid, for example because they rely on <code>xsl:use-when</code> to eliminate sections of code
          that would otherwise be invalid.</p>
@@ -38657,7 +38677,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
             attempt to define a datatype that precisely represents attributes containing XPath
                <termref def="dt-expression">expressions</termref>). However, every valid stylesheet
             module conforms to this schema, unless it contains elements that invoke <termref def="dt-forwards-compatible-behavior"/>.</p>
-         <p>A copy of this schema is available at <loc href="schema-for-xslt30.xsd">schema-for-xslt30.xsd</loc>
+         <p>A copy of this schema is available at <phrase diff="chg" at="2023-04-18"><loc href="schema-for-xslt40.xsd">schema-for-xslt40.xsd</loc></phrase>
          </p>
 
          <note>
@@ -38697,16 +38717,17 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
          </div2>
          <div2 id="relax-ng-schema-for-xslt">
             <head>Relax-NG Schema for XSLT Stylesheets</head>
-            <p>The following Relax-NG schema may be used to validate XSLT 3.0 stylesheet modules. Similar
+            <p>The following Relax-NG schema may be used to validate XSLT 4.0 stylesheet modules. Similar
             caveats apply as for the XSD 1.1 version.</p>
             <p>A copy of this schema is available at <loc href="schema-for-xslt30.rnc">schema-for-xslt30.rnc</loc>
             </p>
+            <p diff="add" at="2023-04-18">TODO: Needs updating for 4.0.</p>
             <?rng-schema-for-xslt?>
          </div2>
       </inform-div1>
 
 
-      <inform-div1 id="acknowledgements">
+      <!--<inform-div1 id="acknowledgements">
          <head>Acknowledgements</head>
          <p>This specification was developed and approved for publication by the W3C XSLT Working
             Group (WG).</p>
@@ -38738,7 +38759,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
          <p>The Working Group also wishes to thank external reviewers who have provided feedback
          during the development of the specification.</p>
 
-      </inform-div1>
+      </inform-div1>-->
 
       <inform-div1 id="changes-since-3.0" diff="add" at="2022-01-01">
          <head>Changes since XSLT 3.0</head>
@@ -38851,6 +38872,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                <item><p>Add built-in template rules suitable for JSON processing</p></item>
                <item><p>Default namespace for elements: allow matching on local-name only,
                or on "XHTML or nothing".</p></item>
+               <item><p>Completing the XSD and RNG schemas for stylesheet modules.</p></item>
             </olist>
       </inform-div1>
 


### PR DESCRIPTION
This PR fixes editorial issues in the XSLT 4.0 spec: issue #373, issue #384, issue #423. It also updates the XSD schema for XSLT 4.0 to incorporate most of the syntax changes that have been made to date (though further checking is needed), and updates some 3.0/3.1 references to 4.0 references.