### PR TITLE
435, 53, 436: lambda expressions, thin arrows

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1545,8 +1545,8 @@ ErrorVal ::= "$" VarName
       <g:postfix name="ArrowExpr" prefix-seq-type="*" condition="&gt; 1" if="xpath40 xquery40">
         <g:sequence>
           <g:choice>
-            <g:ref name="FatArrowTarget"/>
-            <g:ref name="ThinArrowTarget"/>
+            <g:ref name="SequenceArrowTarget"/>
+            <g:ref name="MappingArrowTarget"/>
           </g:choice>
         </g:sequence>
       </g:postfix>
@@ -1572,7 +1572,7 @@ ErrorVal ::= "$" VarName
     </g:level>
   </g:exprProduction>
   
-  <g:production name="FatArrowTarget" if="xpath40 xquery40">
+  <g:production name="SequenceArrowTarget" if="xpath40 xquery40">
     <g:string>=></g:string>
     <g:choice>
       <g:sequence>
@@ -1586,8 +1586,8 @@ ErrorVal ::= "$" VarName
     </g:choice>
   </g:production>
   
-  <g:production name="ThinArrowTarget" if="xpath40 xquery40">
-    <g:string>-></g:string>
+  <g:production name="MappingArrowTarget" if="xpath40 xquery40">
+    <g:string>=!></g:string>
     <g:choice>
       <g:sequence>
         <g:ref name="ArrowStaticFunction"/>
@@ -1597,7 +1597,6 @@ ErrorVal ::= "$" VarName
         <g:ref name="ArrowDynamicFunction"/>
         <g:ref name="PositionalArgumentList"/>
       </g:sequence>
-      <g:ref name="EnclosedExpr"/>
     </g:choice>
   </g:production>
 
@@ -2365,8 +2364,7 @@ ErrorVal ::= "$" VarName
     <g:choice lookahead="2">
       <g:ref name="NamedFunctionRef"/>
       <g:ref name="InlineFunctionExpr"/>
-      <!--<g:ref name="DotFunctionExpr" if="xpath40 xquery40"/>
-      <g:ref name="QuickFunctionExpr" if="xpath40 xquery40"/>-->
+      <g:ref name="LambdaExpr"/>
     </g:choice>
   </g:production>
 
@@ -2380,67 +2378,40 @@ ErrorVal ::= "$" VarName
     <g:zeroOrMore if="xquery40">
       <g:ref name="Annotation"/>
     </g:zeroOrMore>
-    <g:choice>
-      <g:sequence>
-        <g:string>function</g:string>
-        <g:ref name="FunctionSignature"/>
-      </g:sequence>
-      <g:sequence if="xpath40 xquery40 xslt40-patterns">
-        <g:string>-></g:string>
-        <g:optional>
-          <g:ref name="FunctionSignature"/>
-        </g:optional>
-      </g:sequence>
-    </g:choice>
-    <g:ref name="FunctionBody"/>
-  </g:production>
-  
- <!-- <g:production name="Signature">
-    <g:choice>
-      <g:ref name="FullSignature"/>
-      <g:ref name="ShortSignature"/>
-    </g:choice>
-  </g:production>
-  
-  <g:production name="FullSignature">
     <g:string>function</g:string>
-    <g:string>(</g:string>
-    <g:optional>
-      <g:ref name="ParamList"/>
-    </g:optional>
-    <g:string>)</g:string>   
-    <g:optional>
-      <g:ref name="TypeDeclaration"/>
-    </g:optional>
-  </g:production>
-  -->
- <!-- <g:production name="ShortSignature" if="xpath40 xquery40 xslt40-patterns">
-      <g:string>-></g:string>
-      <g:optional>
-        <g:string>(</g:string>
-        <g:optional>
-          <g:ref name="ParamList"/>
-        </g:optional>
-        <g:string>)</g:string>
-        <g:optional>
-          <g:ref name="TypeDeclaration"/>
-        </g:optional>
-      </g:optional>
--->
-    
-  <!--</g:production>-->
-  
- <!-- <g:production name="DotFunctionExpr" if="xpath40 xquery40 xslt40-patterns">
-    <g:string>.</g:string>
+    <g:ref name="FunctionSignature"/>
     <g:ref name="FunctionBody"/>
   </g:production>
   
-  <g:production name="QuickFunctionExpr" if="xpath40 xquery40 xslt40-patterns">
-    <g:string>#</g:string>
-    <g:ref name="IntegerLiteral"/>
-    <g:ref name="FunctionBody"/>
+  <g:production name="LambdaExpr" if="xpath40 xquery40  xslt40-patterns">
+    <g:ref name="LambdaParams"/>
+    <g:string>-></g:string>
+    <g:ref name="EnclosedExpr"/>
   </g:production>
--->
+  
+  <g:production name="LambdaParams" if="xpath40 xquery40  xslt40-patterns">
+    <g:choice>
+      <g:ref name="LambdaParam"/>
+      <g:string>(</g:string>
+      <g:sequence>
+         <g:optional>
+           <g:ref name="LambdaParam"/>
+           <g:zeroOrMore>
+             <g:string>,</g:string>
+             <g:ref name="LambdaParam"/>
+           </g:zeroOrMore>
+         </g:optional>
+      </g:sequence>
+      <g:string>)</g:string>
+    </g:choice>
+  </g:production>
+  
+  <g:production name="LambdaParam" if="xpath40 xquery40  xslt40-patterns">
+    <g:string>$</g:string>
+    <g:ref name="VarName"/>
+  </g:production>
+  
+
   <!-- ] end Function Items -->
 
   <g:production name="MapConstructor" if="xpath40 xquery40">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7338,7 +7338,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                </item>
                <item diff="add" at="A">
                   <p>
-                     <code role="parse-test">fn:sort(//employee, key := ->{xs:decimal(salary)})</code> is a static function 
+                     <code role="parse-test">fn:sort(//employee, key := $e->{xs:decimal($e/salary)})</code> is a static function 
                      call with one positional argument and one keyword argument. 
                      The corresponding function declaration defines three parameters,
                      a required parameter <code>$input</code>, an optional parameter <code>$collation</code>,
@@ -7347,7 +7347,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                      to take its default value. The default value of the <code>$collation</code> parameter
                      is given as <code>fn:default-collation()</code>, so the value supplied to the function is the
                      default collation from the dynamic context of the caller. It is equivalent to the call 
-                     <code>fn:sort(//employee, fn:default-collation(), ->{xs:decimal(salary)})</code>.
+                     <code>fn:sort(//employee, fn:default-collation(), $e->{xs:decimal($e/salary)})</code>.
                   </p>
                </item>
                <!--<item diff="add" at="A">
@@ -7602,9 +7602,9 @@ At evaluation time, the value of a variable reference is the value to which the 
                   in the static context: for example <code>fn:node-name#1</code>
                returns a function item whose effect is to call the static <code>fn:node-name</code> function
                with one argument.</p></item>
-               <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/>)
+               <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/> and <specref ref="id-lambda-expressions"/>)
                   constructs a function item whose <phrase diff="chg" at="2023-03-11">body</phrase> is defined locally. For example the
-               construct <code>->($x){$x+1}</code> returns a function item whose effect is to increment
+               construct <code>($x)->{$x+1}</code> returns a function item whose effect is to increment
                the value of the supplied argument.</p></item>
                <item><p>A <term>partial function application</term> (see 
                   <specref ref="id-partial-function-application"/>) derives one function item from another by supplying
@@ -8320,7 +8320,7 @@ return $a("A")]]></eg>
 
  
 
-            <note diff="add" at="A">
+            <!--<note diff="add" at="A">
                <p>A more concise notation is introduced for simple functions in &language; because it 
                   can improve the readability of code
            by reducing visual clutter. For example, a sort operation previously written as <code>sort(//employee, (), 
@@ -8329,11 +8329,11 @@ return $a("A")]]></eg>
                <p>The use of the notation <code>->{expr}</code> mirrors the use of <code>-></code>
                   as an <termref def="dt-arrow-operator"/>.</p>
       
-            </note>
+            </note>-->
 
    
 
-               <p>The full inline function syntax allows the names and types of the function argument to be declared, along
+               <p>The syntax allows the names and types of the function argument to be declared, along
            with the type of the result:</p>
 
                <eg>function($x as xs:integer, $y as xs:integer) as xs:integer {$x + $y}</eg>
@@ -8342,7 +8342,7 @@ return $a("A")]]></eg>
 
                <eg>function($x, $y) {$x + $y}</eg>
                
-               <p diff="add" at="A">For brevity, the keyword <code>function</code> can be replaced by the symbol <code>-></code>:</p>
+               <!--<p diff="add" at="A">For brevity, the keyword <code>function</code> can be replaced by the symbol <code>-></code>:</p>
                
                <eg diff="add" at="A">->($x, $y) {$x + $y}</eg>
                
@@ -8361,8 +8361,8 @@ return $a("A")]]></eg>
             
             <eg diff="add" at="A">fn:for-each(1 to 5, ->{.+1})</eg>
             
- 
-            <p diff="add" at="A">A zero-arity function can be written as, for example, <code>->(){current-date()}</code>.</p>
+ -->
+            <p diff="add" at="A">A zero-arity function can be written as, for example, <code>function(){current-date()}</code>.</p>
 
 
          
@@ -8477,7 +8477,7 @@ return $a("A")]]></eg>
                      </p>
                   </item>
                   <item>
-                     <p>This example creates a function that takes two xs:double arguments and returns their product:
+                     <p>This example creates a function that takes two <code>xs:double</code> arguments and returns their product:
                 <eg
                            role="parse-test"
                            ><![CDATA[function($a as xs:double, $b as xs:double) as xs:double { $a * $b }]]></eg>
@@ -8493,7 +8493,7 @@ return $incrementors[2](4)]]></eg>
                      </p>
                      <p>The result of this expression is <code>6</code></p>
                   </item>
-                  <item diff="add" at="A">
+                  <!--<item diff="add" at="A">
                      <p>This example creates a function that prepends "$" to a supplied value:
                         <eg
                            role="parse-test"
@@ -8509,11 +8509,77 @@ return $incrementors[2](4)]]></eg>
                            ><![CDATA[->{@name}]]></eg>
                      </p>
                      <p>It is equivalent to the function <code>function($x as item()) as item()* {$x ! @name}</code>.</p>
-                  </item>
+                  </item>-->
                   
    
                </ulist>    
          
+         </div4>
+         <div4 id="id-lambda-expressions" diff="add" at="2023-04-18">
+            <head>Lambda Expressions</head>
+            
+            <scrap>
+               <head/>
+               <prodrecap id="LambdaExpr" ref="LambdaExpr"/>
+               <prodrecap id="LambdaParams" ref="LambdaParams"/>
+               <prodrecap id="LambdaParam" ref="LambdaParam"/>
+               <prodrecap ref="EnclosedExpr" role="xpath"/>
+            </scrap>
+            
+            <p>Lambda expressions provide an abbreviated syntax for inline functions.</p>
+            
+            <p>For example, the expression <code>$a -> {$a+1}</code> is equivalent to 
+            <code>function($a){$a + 1}</code></p>
+            
+            <p>A lambda expression of the form <code>($x, $y, $z, ...) -> {EXPR}</code> has precisely the same effect, and is subject
+               to the same rules, as the expanded form <code>function($x, $y, $z, ...){EXPR}</code></p>
+            
+            <p>The parentheses around the parameter list may be omitted if the function takes exactly one argument.</p>
+            
+            <p>For example:</p>
+            
+            <ulist>
+               <item>
+                  <p>This example creates a function that prepends "£" to a supplied value:
+                     <eg role="parse-test"><![CDATA[$x -> {`£{$x}`}]]></eg>
+                  </p>
+                  <p>It is equivalent to the function <code>concat("£", ?)</code>.</p>
+               </item>
+               <item>
+                  <p>This example creates a function that returns the <code>name</code>
+                     attribute of a supplied element node:
+                     <eg
+                        role="parse-test"
+                        ><![CDATA[$e -> {$e!@name}]]></eg>
+                  </p>
+                  <p>It is equivalent to the function <code>function($x as item()) as item()* {$x ! @name}</code>.</p>
+               </item>
+               <item>
+                  <p>This example creates a arity-zero function that returns the value <code>INF</code> (positive infinity):
+                     <eg
+                        role="parse-test"
+                        ><![CDATA[() -> {xs:double('INF')}]]></eg>
+                  </p>
+                  <p>It is equivalent to the function <code>function() as item()* {xs:double('INF')}</code>.</p>
+               </item>
+               <item>
+                  <p>This example creates an arity-two function that adds the values of the supplied arguments:
+                     <eg
+                        role="parse-test"
+                        ><![CDATA[($x, $y) -> {$x + $y}]]></eg>
+                  </p>
+                  <p>It is equivalent to the function <code>op("+")</code>.</p>
+               </item>
+            </ulist>
+            
+            <note><p>The concise syntax is introduced in 4.0 because a compact notation aids readability
+            in simple higher-order function calls such as <code>fn:sort(//emp, (), $e -> {$e/@salary})</code>,
+            and also because it is familiar to users of other popular languages such as Java, C#, and Javascript.</p></note>
+            
+            <note><p>The grammar for lambda expressions involves unbounded lookahead: given an expression that starts
+            <code>($a, $b, $c, ...)</code> it is not possible to establish unambiguously that this introduces a lambda
+            expression until the arrow symbol (<code>-></code>) is encountered. Various strategies can be used
+            to address this difficulty.</p></note>
          </div4>
          </div3>
          
@@ -18190,7 +18256,7 @@ one <code>employee</code> element satisfies the given comparison expression:</p>
                   <code>every $emp in /emps/employee satisfies $emp/salary[@current='true']</code>, or even
                   more concisely as <code>empty(/emps/employee[not(salary/@current='true')]</code>.</p>
                <p>Another alternative in &language; is to use the higher-order functions <code>fn:some</code> and <code>fn:all</code>.
-               This example can be written <code>fn:all(/emps/employee, ->(){salary/@current='true'})</code></p>
+               This example can be written <code>fn:all(/emps/employee, $e->{$e/salary/@current='true'})</code></p>
                </note>
             </item>
 
@@ -19177,8 +19243,8 @@ raised <errorref
          <scrap>
             <head/>
             <prodrecap id="ArrowExpr" ref="ArrowExpr"/>
-            <prodrecap id="FatArrowTarget" ref="FatArrowTarget"/>
-            <prodrecap id="ThinArrowTarget" ref="ThinArrowTarget"/>
+            <prodrecap id="SequenceArrowTarget" ref="SequenceArrowTarget"/>
+            <prodrecap id="MappingArrowTarget" ref="MappingArrowTarget"/>
             <prodrecap id="ArrowStaticFunction" ref="ArrowStaticFunction"/>
             <prodrecap id="ArrowDynamicFunction" ref="ArrowDynamicFunction"/>
             <prodrecap ref="ArgumentList"/>
@@ -19189,7 +19255,7 @@ raised <errorref
             <termdef term="arrow operator" id="dt-arrow-operator"
                >An <term>arrow operator</term>  applies a function to the value of an expression, using the value as the first argument to the function.</termdef>  
          </p>
-         <p diff="add" at="A">The <term>fat arrow</term> operator <code>=></code> is defined as follows:
+         <p diff="chg" at="2023-04-18">The <term>sequence arrow</term> operator <code>=></code> is defined as follows:
             <ulist>
                <item><p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
                   <code>U</code>, an <nt def="ArrowStaticFunction">ArrowStaticFunction</nt>
@@ -19232,7 +19298,7 @@ raised <errorref
 
         
          
-         <p diff="add" at="A">The <term>thin arrow</term> operator <code>-></code> is defined as follows:</p>
+         <p diff="add" at="A">The <term>mapping arrow</term> operator <code>=!></code> is defined as follows:</p>
             
          <ulist diff="add" at="A">
             <item>
@@ -19240,8 +19306,8 @@ raised <errorref
                <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
                   <code>U</code>, an <nt def="ArrowStaticFunction">ArrowStaticFunction</nt>
                <code>F</code>, and an <nt def="ArgumentList">ArgumentList</nt>
-               <code>(A, B, C...)</code>, the expression <code>U -&gt; F(A, B, C...)</code> is equivalent to the
-               expression <code>(U ! F(., A, B, C...))</code>.</p>
+               <code>(A, B, C...)</code>, the expression <code>U -!&gt; F(A, B, C...)</code> is equivalent to the
+               expression <code>(for $u in U return F($u, A, B, C...))</code>.</p>
                
             </item>
             <item>
@@ -19249,11 +19315,11 @@ raised <errorref
                <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
                   <code>U</code>, an <nt def="ArrowDynamicFunction">ArrowDynamicFunction</nt>
                   <code>F</code>, and an <nt def="PositionalArgumentList">PositionalArgumentList</nt>
-                  <code>(A, B, C...)</code>, the expression <code>U -&gt; F(A, B, C...)</code> is equivalent to the
-                  expression <code>(U ! F(., A, B, C...))</code>.</p>
+                  <code>(A, B, C...)</code>, the expression <code>U =!&gt; F(A, B, C...)</code> is equivalent to the
+                  expression <code>(for $u in U return F($u, A, B, C...))</code>.</p>
                
             </item>
-            <item>
+            <!--<item>
                <p>If the arrow is followed by an <nt def="EnclosedExpr">EnclosedExpr</nt>:</p>
                <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
                   <code>U</code>, and an <nt def="EnclosedExpr">EnclosedExpr</nt> 
@@ -19269,20 +19335,22 @@ raised <errorref
                <note><p>The expression <code>$x -> {.+1}</code> can be considered as an abbreviation
                   for <code>$x -> (->{.+1})()</code>: that is, it calls the anonymous function
                   <code>->{.+1}</code> once for each item in <code>$x</code>.</p></note>
-            </item>
+            </item>-->
          </ulist>
          
             
          
             
-            <p diff="add" at="A">The fat arrow operator thus applies the supplied function to the result
-               of the left-hand operand as a whole, while the thin arrow operator applies the function 
-               (or enclosed expression) to
+            <p diff="add" at="A">The sequence arrow operator thus applies the supplied function to the result
+               of the left-hand operand as a whole, while the mapping arrow operator applies the function to
                each item in the value of the left-hand operand individually. In the case where the result
                of the left-hand operand is a single item, the two operators have almost the same effect;
                the only difference is that the thin arrow binds the <termref def="dt-focus"/>.</p>
+         
+         <note><p>The mapping arrow symbol <code>=!></code> is intended to suggest a combination of
+         function application (<code>=></code>) and sequence mapping (<code>!</code>) combined in a single operation.</p></note>
             
-    <p>This syntax is particularly helpful when applying multiple
+    <p>The arrow syntax is particularly helpful when applying multiple
     functions to a value in turn. For example, the following
     expression invites syntax errors due to misplaced parentheses:
   </p>
@@ -19293,33 +19361,34 @@ raised <errorref
          <p>In the following reformulation, it is easier to see that the parentheses are balanced:</p>
 
          <eg role="parse-test"
-            ><![CDATA[$string -> upper-case() -> normalize-unicode() -> tokenize("\s+")]]></eg>
+            ><![CDATA[$string => upper-case() => normalize-unicode() => tokenize("\s+")]]></eg>
             
             <p diff="add" at="A">Assuming that <code>$string</code> is a single string, the above example could
             equally be written:</p>
             
             <eg role="parse-test"
-               ><![CDATA[$string => upper-case() => normalize-unicode() => tokenize("\s+")]]></eg>
+               ><![CDATA[$string =!> upper-case() =!> normalize-unicode() =!> tokenize("\s+")]]></eg>
             
             <p diff="add" at="A">The difference between the two operators is seen when the left-hand
             operand evaluates to a sequence:</p>
             
             <eg role="parse-test"
-               ><![CDATA["The cat sat on the mat" => tokenize() -> concat(".") -> upper-case() => string-join(" ")]]></eg>
+               ><![CDATA["The cat sat on the mat" => tokenize() =!> concat(".") =!> upper-case() => string-join(" ")]]></eg>
             
             <p diff="add" at="A">which returns <code>"THE. CAT. SAT. ON. THE. MAT."</code>. The first arrow
-            could be written either as <code>=></code> or <code>-></code> because the operand is a singleton; the next two
-            arrows have to be <code>-></code> because the function is applied to each item in the tokenized
+            could be written either as <code>=></code> or <code>=!></code> because the operand is a singleton; the next two
+            arrows have to be <code>=!></code> because the function is applied to each item in the tokenized
             sequence individually; the final arrow must be <code>=></code> because the <code>string-join</code>
             function applies to the sequence as a whole.</p>
             
             <note diff="add" at="A"><p>It may be useful to think of this as a map/reduce pipeline. The functions
-            introduced by <code>-></code> are mapping operations; the function introduced by <code>=></code>
+            introduced by <code>=!></code> are mapping operations; the function introduced by <code>=></code>
             is a reduce operation.</p></note>
          
-         <p diff="add" at="A">The following example introduces an enclosed expression to the pipeline:</p>
+         <p diff="add" at="A">The following example introduces an inline function to the pipeline, in the form of
+            a lambda expression:</p>
          <eg role="parse-test" diff="add" at="A"
-            ><![CDATA[(1 to 5) -> xs:double() -> math:sqrt() -> {.+1} => sum()]]></eg>
+            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> ($a->{$a+1})() => sum()]]></eg>
          
          <p diff="add" at="A">This is equivalent to <code>sum((1 to 5) ! (math:sqrt(xs:double(.))+1))</code>.</p>
          


### PR DESCRIPTION
Addresses issue 436 by introducing syntax similar to Java, C#, and JS for anonymous inline functions (lamda expressions). This involves finding a new symbol for the existing "thin arrow" operator; it also gives an opportunity to show how lambda expressions can be used in pipelines.

Some points for WG consideration:

(a) Do we really want the curly braces around the function body to be mandatory?

(b) What symbol should we use for the mapping arrow? I've used `=!>` as it suggests to me the combination of function application and sequence mapping.

(c) Should we reinstate the special syntax for arity-one "focus functions" (`->{@salary})` ) which is dropped in this proposal

(d) I haven't necessarily worked through all the changes to examples needed, e.g.. in the XSLT and F+O specs.