### PR TITLE
125: array:partition

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22245,7 +22245,7 @@ return array:sort($in, $SWEDISH)
 
    <fos:function name="partition" prefix="array">
       <fos:signatures>
-         <fos:proto name="partition" return-type="array(*)+">
+         <fos:proto name="partition" return-type="array(item())*">
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="break-when" type="function(item()*, item()) as xs:boolean"/>
          </fos:proto>
@@ -22256,21 +22256,24 @@ return array:sort($in, $SWEDISH)
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Partitions a sequence of items into a sequence of arrays containing the same items,
+         <p>Partitions a sequence of items into a sequence of non-empty arrays containing the same items,
          starting a new partition when a supplied condition is true.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, the function processes the items in the input sequence in order, and for each item
-         it calls the supplied <code>$break-when</code> function with two arguments: the contents of the
-         current partition (initially an empty sequence), and the current item in the input sequence. If
-         the <code>$break-when</code> function returns true, the current partition is added to the result
-            and a new current partition is created, initially containing the current item. If the <code>$break-when</code> 
-            function returns false, the current item is added to the current partition.</p>
+         <p>Informally, the function starts by creating a partition containing the first item in the input sequence,
+            if any. For each of the remaining item <var>J</var> in the input sequence,
+            other than the first, it calls the supplied <code>$break-when</code> function with two 
+            arguments: the contents of the current partition, and the item <var>J</var>.</p>
+         <p>Each partition is a sequence of items; the function result wraps each partition as an array, and returns
+            the sequence of arrays.</p>
+         <p>If the <code>$break-when</code> function returns true, the current partition is wrapped as an array and added to the result,
+            and a new current partition is created, initially containing the item <var>J</var> only. If the <code>$break-when</code> 
+            function returns false, the item <var>J</var> is added to the current partition.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>fn:fold-left($input, (), function($a, $b) {
-   if (empty($a) or $break-when(array:slice($a, start:-1)?*, $b))
-   then ($a, [$b])
-   else array:replace($a, array:size($a), function($m){$m, $b})
+         <eg>fn:fold-left($input, (), function($partitions, $next) {
+   if (empty($partitions) or $break-when($partitions[last()]?*, $next))
+   then ($partitions, [$next])
+   else (fn:trunk($partitions), array{$partitions[last()], $next}) 
 }   
          </eg>  
       </fos:rules>
@@ -22285,34 +22288,38 @@ return array:sort($in, $SWEDISH)
                starts a new group whenever an item is encountered whose value is less than
                the value of the previous item.</p></item>
          </ulist>
+         <p>The callback function is not called to process the first item in the input sequence, because this will
+         always start a new partition. The first argument to the callback function (the current partition) is always
+         a non-empty sequence.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression>array:partition(("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
-                  ->($x, $y){fn:substring($x[last()],1,1) ne fn:substring($y,1,1)})</fos:expression>
+                  function($partition, $next){fn:substring($partitions[1],1,1) ne fn:substring($next,1,1)})</fos:expression>
                <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:partition((1, 2, 3, 4, 5, 6), function($a, $b){count($a) eq 2})</fos:expression>
-               <fos:result>([1, 2], [3, 4], [5, 6])</fos:result>
+               <fos:expression>array:partition((1, 2, 3, 4, 5, 6, 7), function($partition, $next){count($partition) eq 2})</fos:expression>
+               <fos:result>([1, 2], [3, 4], [5, 6], [7])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:partition((1, 4, 6, 3, 1, 1), function($a, $b){sum($a) ge 5})</fos:expression>
+               <fos:expression>array:partition((1, 4, 6, 3, 1, 1), function($partition, $next){sum($partition) ge 5})</fos:expression>
                <fos:result>([1, 4], [6], [3, 1, 1])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:partition(tokenize("In the beginning was the word"), function($a, $b){sum(($a,$b)!string-length() gt 10)}</fos:expression>
+               <fos:expression>array:partition(tokenize("In the beginning was the word"), 
+                                               function($partition, $next){sum(($partition, $next)!string-length()) gt 10}</fos:expression>
                <fos:result>(["In", "the"], ["beginning"], ["was", "the", "word"])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:partition((1, 2, 3, 6, 7, 9, 10), function($a, $b){$a ne $b[last()]+1})</fos:expression>
+               <fos:expression>array:partition((1, 2, 3, 6, 7, 9, 10), function($partition, $next){$next ne $partition[last()]+1})</fos:expression>
                <fos:result>([1, 2, 3], [6, 7], [9, 10])</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0. Not yet reviewed?</fos:version>
+         <fos:version version="4.0">Proposed for 4.0</fos:version>
       </fos:history>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22243,7 +22243,7 @@ return array:sort($in, $SWEDISH)
       </fos:history>
    </fos:function>
 
-   <fos:function name="partition" prefix="array">
+   <fos:function name="partition" prefix="fn">
       <fos:signatures>
          <fos:proto name="partition" return-type="array(item())*">
             <fos:arg name="input" type="item()*"/>
@@ -22261,7 +22261,7 @@ return array:sort($in, $SWEDISH)
       </fos:summary>
       <fos:rules>
          <p>Informally, the function starts by creating a partition containing the first item in the input sequence,
-            if any. For each of the remaining item <var>J</var> in the input sequence,
+            if any. For each remaining item <var>J</var> in the input sequence,
             other than the first, it calls the supplied <code>$break-when</code> function with two 
             arguments: the contents of the current partition, and the item <var>J</var>.</p>
          <p>Each partition is a sequence of items; the function result wraps each partition as an array, and returns
@@ -22280,11 +22280,11 @@ return array:sort($in, $SWEDISH)
       <fos:notes>
          <p>The function enables a variety of positional grouping problems to be solved. For example:</p>
          <ulist>
-            <item><p><code>array:partition($input, function($a, $b){count($a) eq 3}</code>
+            <item><p><code>fn:partition($input, function($a, $b){count($a) eq 3}</code>
             partitions a sequence into fixed size groups of length 3.</p></item>
-            <item><p><code>array:partition($input, function($a, $b){boolean($b/self::h1)}</code>
+            <item><p><code>fn:partition($input, function($a, $b){boolean($b/self::h1)}</code>
                starts a new group whenever an <code>h1</code> element is encountered.</p></item>
-            <item><p><code>array:partition($input, function($a, $b){$b lt $a[last()]}</code>
+            <item><p><code>fn:partition($input, function($a, $b){$b lt $a[last()]}</code>
                starts a new group whenever an item is encountered whose value is less than
                the value of the previous item.</p></item>
          </ulist>
@@ -22295,25 +22295,25 @@ return array:sort($in, $SWEDISH)
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:partition(("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
+               <fos:expression>fn:partition(("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
                   function($partition, $next){fn:substring($partitions[1],1,1) ne fn:substring($next,1,1)})</fos:expression>
                <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:partition((1, 2, 3, 4, 5, 6, 7), function($partition, $next){count($partition) eq 2})</fos:expression>
+               <fos:expression>fn:partition((1, 2, 3, 4, 5, 6, 7), function($partition, $next){count($partition) eq 2})</fos:expression>
                <fos:result>([1, 2], [3, 4], [5, 6], [7])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:partition((1, 4, 6, 3, 1, 1), function($partition, $next){sum($partition) ge 5})</fos:expression>
+               <fos:expression>fn:partition((1, 4, 6, 3, 1, 1), function($partition, $next){sum($partition) ge 5})</fos:expression>
                <fos:result>([1, 4], [6], [3, 1, 1])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:partition(tokenize("In the beginning was the word"), 
+               <fos:expression>fn:partition(tokenize("In the beginning was the word"), 
                                                function($partition, $next){sum(($partition, $next)!string-length()) gt 10}</fos:expression>
                <fos:result>(["In", "the"], ["beginning"], ["was", "the", "word"])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:partition((1, 2, 3, 6, 7, 9, 10), function($partition, $next){$next ne $partition[last()]+1})</fos:expression>
+               <fos:expression>fn:partition((1, 2, 3, 6, 7, 9, 10), function($partition, $next){$next ne $partition[last()]+1})</fos:expression>
                <fos:result>([1, 2, 3], [6, 7], [9, 10])</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7118,6 +7118,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-items-ending-where" diff="add" at="A">
                <head><?function fn:items-ending-where?></head>
             </div3>
+            <div3 id="func-partition" diff="add" at="A">
+               <head><?function fn:partition?></head>
+            </div3>           
             <div3 id="func-sort">
                <head><?function fn:sort?></head>
             </div3>
@@ -7435,9 +7438,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
             <div3 id="func-array-members" diff="add" at="2023-02-20">
                <head><?function array:members?></head>
-            </div3>
-            <div3 id="func-array-partition" diff="add" at="A">
-               <head><?function array:partition?></head>
             </div3>
             <div3 id="func-array-put">
                <head><?function array:put?></head>
@@ -11453,10 +11453,10 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:json</code></p></item>
               <item><p><code>fn:slice</code></p></item>
               <item><p><code>fn:stack-trace</code></p></item>
+              <item><p><code>fn:partition</code></p></item>             
               <item><p><code>map:filter</code></p></item>
               <item><p><code>map:replace</code></p></item>
               <item><p><code>map:substitute</code></p></item>
-              <item><p><code>array:partition</code></p></item>
               <item><p><code>array:replace</code></p></item>
               <item><p><code>array:slice</code></p></item>
               


### PR DESCRIPTION
This PR revisits array:partition, with extra editorial clarification of the spec; including but not confined to fixing issue #125.

I suggest we schedule this PR for discussion since we have not previously discussed it.

One question for the group is what the name of the function should be (including the choice of namespace).

Another is whether the polarity of the callback function should be changed (from `break-when` to `continue-when` or similar).

We could also consider returning an array of sequences rather than a sequence of arrays. (But in my view sequences of arrays are rather easier to manage at the moment.)