### PR TITLE
Revises numeric literal syntax

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -4472,21 +4472,78 @@ ErrorVal ::= "$" VarName
     "The following symbols are used only in the definition of terminal symbols;
     they are not terminal symbols in the grammar of A.1 EBNF."
   -->
+  
+  <!--Digits       ::= Digit ((Digit | "_")* Digit)?
+      Digit        ::= [0-9]
+      HexDigits    ::= HexDigit ((HexDigit | "_")* HexDigit)?
+      HexDigit     ::= [0-9a-fA-F]
+      BinaryDigits ::= BinaryDigit ((BinaryDigit | "_")* BinaryDigit)?
+      BinaryDigit  ::= [01] -->
 
   <g:token name="Digits" delimiter-type="hide" inline="false" is-local-to-terminal-symbol="yes">   
       <g:sequence>
-        <g:oneOrMore>
-          <g:charClass>
-            <g:charRange minChar="0" maxChar="9"/>
-          </g:charClass>
-        </g:oneOrMore>
+        <g:ref name="DecDigit"/>
+        <g:optional>
+          <g:zeroOrMore>
+            <g:choice>
+              <g:ref name="DecDigit"/>
+              <g:string>_</g:string>
+            </g:choice>
+          </g:zeroOrMore>
+          <g:ref name="DecDigit"/>
+        </g:optional>
+      </g:sequence>
+  </g:token>
+  
+  <g:token name="DecDigit" delimiter-type="hide" inline="false" is-local-to-terminal-symbol="yes">   
+      <g:charClass>
+        <g:charRange minChar="0" maxChar="9"/>
+      </g:charClass>    
+  </g:token>
+  
+  <g:token name="HexDigits" delimiter-type="hide" inline="false" is-local-to-terminal-symbol="yes">   
+    <g:sequence>
+      <g:ref name="HexDigit"/>
+      <g:optional>
         <g:zeroOrMore>
-          <g:charClass>
-            <g:charRange minChar="0" maxChar="9"/>
-            <g:char>_</g:char>
-          </g:charClass>
+          <g:choice>
+            <g:ref name="HexDigit"/>
+            <g:string>_</g:string>
+          </g:choice>
         </g:zeroOrMore>
-      </g:sequence>     
+        <g:ref name="HexDigit"/>
+      </g:optional>
+    </g:sequence>
+  </g:token>
+  
+  <g:token name="HexDigit" delimiter-type="hide" inline="false" is-local-to-terminal-symbol="yes">   
+    <g:charClass>
+      <g:charRange minChar="0" maxChar="9"/>
+      <g:charRange minChar="a" maxChar="f"/>
+      <g:charRange minChar="A" maxChar="F"/>
+    </g:charClass>    
+  </g:token>
+  
+  <g:token name="BinaryDigits" delimiter-type="hide" inline="false" is-local-to-terminal-symbol="yes">   
+    <g:sequence>
+      <g:ref name="BinaryDigit"/>
+      <g:optional>
+        <g:zeroOrMore>
+          <g:choice>
+            <g:ref name="BinaryDigit"/>
+            <g:string>_</g:string>
+          </g:choice>
+        </g:zeroOrMore>
+        <g:ref name="BinaryDigit"/>
+      </g:optional>
+    </g:sequence>
+  </g:token>
+  
+  <g:token name="BinaryDigit" delimiter-type="hide" inline="false" is-local-to-terminal-symbol="yes">   
+    <g:charClass>
+      <g:char>0</g:char>
+      <g:char>1</g:char>
+    </g:charClass>  
   </g:token>
 
   <g:token name="CommentContents" exposition-only="yes" delimiter-type='hide' inline="false" if="xpath40 xquery40  xslt40-patterns" is-local-to-terminal-symbol="yes">
@@ -4502,26 +4559,6 @@ ErrorVal ::= "$" VarName
     productions above.
   --> 
 
-  <g:token name="HexDigits" inline="false" delimiter-type="hide"  is-local-to-terminal-symbol="yes">
-    <g:oneOrMore name="HexDigitsString">
-      <g:charClass>
-        <g:charRange minChar="0" maxChar="9"/>
-        <g:charRange minChar="a" maxChar="f"/>
-        <g:charRange minChar="A" maxChar="F"/>
-        <g:char>_</g:char>
-      </g:charClass>
-    </g:oneOrMore>
-  </g:token>
-  
-  <g:token name="BinaryDigits" inline="false" delimiter-type="hide"  is-local-to-terminal-symbol="yes">
-    <g:oneOrMore name="BinaryDigitsString">
-      <g:charClass>
-        <g:char>0</g:char>
-        <g:char>1</g:char>
-        <g:char>_</g:char>
-      </g:charClass>
-    </g:oneOrMore>
-  </g:token>
 
   <!-- It would be nice to not take character content runs one character
        at a time.  However, it seems difficult to say, "all these characters

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6611,8 +6611,11 @@ and <nt def="OrExpr"
                <prodrecap id="EscapeQuot" ref="EscapeQuot"/>
                <prodrecap id="EscapeApos" ref="EscapeApos"/>
                <prodrecap id="Digits" ref="Digits"/>
+               <prodrecap id="DecDigit" ref="DecDigit"/>
                <prodrecap id="HexDigits" ref="HexDigits"/>
+               <prodrecap id="HexDigit" ref="HexDigit"/>
                <prodrecap id="BinaryDigits" ref="BinaryDigits"/>
+               <prodrecap id="BinaryDigit" ref="BinaryDigit"/>
             </scrap>
             
             
@@ -6621,9 +6624,12 @@ and <nt def="OrExpr"
             <olist diff="chg" at="2023-04-07">
                <item><p>Underscore characters are stripped out. Underscores may be included in a numeric
                literal to aid readability, but have no effect on the value. For example, <code>1_000_000</code>
-               is equivalent to <code>1000000</code>.</p></item>
+               is equivalent to <code>1000000</code>.</p>
+                  <note><p diff="add" at="2023-04-25">Underscores must not appear at the beginning or end of a sequence of digits, only
+               in intermediate positions. Multiple adjacent underscores are allowed.</p></note>
+               </item>
                <item><p>A <code>HexIntegerLiteral</code> represents a non-negative integer
-               expressed in hexadecimal: for example <code>0xffff</code> represents the integer 65535, and
+                   expressed in hexadecimal: for example <code>0xffff</code> represents the integer 65535, and
                   <code>0xFFFF_FFFF</code> represents the integer 4294967295.</p>
                </item>
                <item><p>A <code>BinaryIntegerLiteral</code> represents a non-negative integer
@@ -6759,6 +6765,12 @@ ensure that they are expressible.</p>
                      <code role="parse-test"
                      >12</code> denotes the <code>xs:integer</code> value twelve.</p>
                </item>
+               
+               <item>
+                  <p>
+                     <code role="parse-test"
+                        >1_000_000</code> denotes the <code>xs:integer</code> value one million.</p>
+               </item>
 
 
                <item>
@@ -6773,6 +6785,18 @@ ensure that they are expressible.</p>
                      <code role="parse-test"
                      >125E2</code> denotes the <code>xs:double</code> value twelve thousand, five hundred.</p>
                </item>
+               
+               <item>
+                  <p>
+                     <code role="parse-test"
+                        >0xffff</code> denotes the <code>xs:integer</code> value 65535.</p>
+               </item>
+               
+               <item>
+                  <p>
+                     <code role="parse-test"
+                        >0b1000_0001</code> denotes the <code>xs:integer</code> value 129.</p>
+               </item>
 
                <item>
                   <p>
@@ -6782,6 +6806,11 @@ ensure that they are expressible.</p>
                      <p>When XPath expressions are embedded in contexts where quotation
 marks have special significance, such as inside XML attributes, additional
 escaping may be needed.</p>
+                     <p diff="add" at="2023-04-25">An alternative solution is to use a 
+                        <nt def="StringTemplate">StringTemplate</nt>, for example
+                     <code>`He said, "I don't like it."`</code>. Technically this is not a literal, but 
+                     a string template with no embedded expressions can be used in the same way as a string
+                     literal in nearly all contexts.</p>
                   </note>
                </item>
 


### PR DESCRIPTION
Following actions from review on 25 Apri 2023 (QT4CG-032-02), revises the new syntax of numeric literals to disallow trailing underscores. Also adds more notes and examples.