### PR TITLE
80: fn:iterate-while: Examples revised

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17270,38 +17270,32 @@ declare function fn:iterate-while(
             </fos:test>
          </fos:example>
          <fos:example>
-            <fos:test>
-               <fos:expression><![CDATA[let $input := (0 to 4, 6 to 10)
-return fn:iterate-while(0, function($n) { $n = $input }, function($n) { $n + 1 })]]></fos:expression>
-               <fos:result>5</fos:result>
-               <fos:postamble>This returns the first positive number missing in a sequence.</fos:postamble>
-            </fos:test>
+            <p>Return the first positive number that is missing in a sequence (the result is 5):</p>
+            <eg><![CDATA[
+let $input := (0 to 4, 6 to 10)
+return fn:iterate-while(0, function($n) { $n = $input }, function($n) { $n + 1 })]]></eg>
          </fos:example>
          <fos:example>
-            <fos:test>
-               <fos:expression><![CDATA[fn:iterate-while(
+            <p>Return the first number in a sequence greater than 5 and all remaining numbers:</p>
+            <eg><![CDATA[
+fn:iterate-while(
   1 to 9,
-  function($seq) { head($seq) < 5 },
+  function($seq) { head($seq) <= 5 },
   function($seq) { tail($seq) }
-)]]></fos:expression>
-               <fos:result>(5, 6, 7, 8, 9)</fos:result>
-            </fos:test>
+)]]></eg>
          </fos:example>
          <fos:example>
-            <fos:test>
-               <fos:expression><![CDATA[let $input := 3936256
+            <p>Approximate the square root of a number:</p>
+            <eg><![CDATA[
+let $input := 3936256
 return fn:iterate-while(
   $input,
   function($result) { abs($result * $result - $input) >= 0.0000000001 },
   function($guess) { ($guess + $input div $guess) div 2 }
-)]]></fos:expression>
-               <fos:result>1984</fos:result>
-               <fos:postamble>This computes the square root of a number.</fos:postamble>
-            </fos:test>
+)]]></eg>
          </fos:example>
          <fos:example>
-            <p>The following example generates random doubles. It is interrupted once a number
-               exceeds a given limit:</p>
+            <p>Generate random doubles, interrupt once a number exceeds a given limit:</p>
             <eg><![CDATA[
 let $r := random-number-generator()
 let $map := fn:iterate-while(
@@ -17313,8 +17307,7 @@ let $map := fn:iterate-while(
     map:put($r?next(), 'numbers', ($r?numbers, $r?number))
   }
 )
-return $map?numbers
-            ]]></eg>
+return $map?numbers]]></eg>
          </fos:example>
       </fos:examples>
       <fos:history>


### PR DESCRIPTION
This PR is editorial. I’ve reformatted the examples for `fn:iterate-while`…

![image](https://user-images.githubusercontent.com/196589/235667578-896f8ef3-8d11-49fb-81b5-352d522a99a3.png)

…to make them better readable.
