### PR TITLE
460: Fix math symbols

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1465,7 +1465,9 @@ ErrorVal ::= "$" VarName
       <g:binary name="MultiplicativeExpr" condition="&gt; 1">
         <g:choice name="MultiplicativeOps">
           <g:string>*</g:string>
+          <g:string>×</g:string>
           <g:string>div</g:string>
+          <g:string>÷</g:string>
           <g:string>idiv</g:string>
           <g:string>mod</g:string>
         </g:choice>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -147,13 +147,27 @@ operand must be of type <code>xs:gDay</code>.)</p>
 <tr><td>A * B</td><td>xs:dayTimeDuration</td><td>numeric</td><td>op:multiply-dayTimeDuration(A, B)</td><td>xs:dayTimeDuration</td></tr>
 <tr><td>A * B</td><td>numeric</td><td>xs:dayTimeDuration</td><td>op:multiply-dayTimeDuration(B, A)</td><td>xs:dayTimeDuration</td></tr>
 
+  <tr><td>A × B</td><td>numeric</td><td>numeric</td><td>op:numeric-multiply(A, B)</td><td>numeric</td></tr>
+  <tr><td>A × B</td><td>xs:yearMonthDuration</td><td>numeric</td><td>op:multiply-yearMonthDuration(A, B)</td><td>xs:yearMonthDuration</td></tr>
+  <tr><td>A × B</td><td>numeric</td><td>xs:yearMonthDuration</td><td>op:multiply-yearMonthDuration(B, A)</td><td>xs:yearMonthDuration</td></tr>
+  <tr><td>A × B</td><td>xs:dayTimeDuration</td><td>numeric</td><td>op:multiply-dayTimeDuration(A, B)</td><td>xs:dayTimeDuration</td></tr>
+  <tr><td>A × B</td><td>numeric</td><td>xs:dayTimeDuration</td><td>op:multiply-dayTimeDuration(B, A)</td><td>xs:dayTimeDuration</td></tr>
+  
+
 <tr><td>A idiv B</td><td>numeric</td><td>numeric</td><td>op:numeric-integer-divide(A, B)</td><td>xs:integer</td></tr>
-<tr><td>A div B</td><td>numeric</td><td>numeric</td><td>op:numeric-divide(A, B)</td><td>numeric; but xs:decimal if both operands are xs:integer</td></tr>
+
+  <tr><td>A div B</td><td>numeric</td><td>numeric</td><td>op:numeric-divide(A, B)</td><td>numeric; but xs:decimal if both operands are xs:integer</td></tr>
 <tr><td>A div B</td><td>xs:yearMonthDuration</td><td>numeric</td><td>op:divide-yearMonthDuration(A, B)</td><td>xs:yearMonthDuration</td></tr>
 <tr><td>A div B</td><td>xs:dayTimeDuration</td><td>numeric</td><td>op:divide-dayTimeDuration(A, B)</td><td>xs:dayTimeDuration</td></tr>
 <tr><td>A div B</td><td>xs:yearMonthDuration</td><td>xs:yearMonthDuration</td><td>op:divide-yearMonthDuration-by-yearMonthDuration (A, B)</td><td>xs:decimal</td></tr>
 <tr><td>A div B</td><td>xs:dayTimeDuration</td><td>xs:dayTimeDuration</td><td>op:divide-dayTimeDuration-by-dayTimeDuration (A, B)</td><td>xs:decimal</td></tr>
 
+  <tr><td>A ÷ B</td><td>numeric</td><td>numeric</td><td>op:numeric-divide(A, B)</td><td>numeric; but xs:decimal if both operands are xs:integer</td></tr>
+  <tr><td>A ÷ B</td><td>xs:yearMonthDuration</td><td>numeric</td><td>op:divide-yearMonthDuration(A, B)</td><td>xs:yearMonthDuration</td></tr>
+  <tr><td>A ÷ B</td><td>xs:dayTimeDuration</td><td>numeric</td><td>op:divide-dayTimeDuration(A, B)</td><td>xs:dayTimeDuration</td></tr>
+  <tr><td>A ÷ B</td><td>xs:yearMonthDuration</td><td>xs:yearMonthDuration</td><td>op:divide-yearMonthDuration-by-yearMonthDuration (A, B)</td><td>xs:decimal</td></tr>
+  <tr><td>A ÷ B</td><td>xs:dayTimeDuration</td><td>xs:dayTimeDuration</td><td>op:divide-dayTimeDuration-by-dayTimeDuration (A, B)</td><td>xs:decimal</td></tr>
+  
 <tr><td>A mod B</td><td>numeric</td><td>numeric</td><td>op:numeric-mod(A, B)</td><td>numeric</td></tr>
 
 
@@ -233,7 +247,7 @@ operand must be of type <code>xs:gDay</code>.)</p>
 
 </div2>
   
-  <div2 id="id-math-symbols" diff="add" at="A">
+  <!--<div2 id="id-math-symbols" diff="add" at="A">
     <head>Mathematical Operator Symbols</head>
     <p>Various operators written in the grammar using alphabetic keywords (such as <code>and</code>, <code>or</code>,
     <code>le</code>, <code>ge</code>) can instead be written using mathematical symbols. The equivalents are given
@@ -359,7 +373,7 @@ operand must be of type <code>xs:gDay</code>.)</p>
     </table>
     <p>For example, the expression <code>some $x in $X satisfies $x le 17</code> can equivalently be written
       <code>∃ $x in $X ⧴ $x ≤ 17</code></p>
-  </div2>
+  </div2>-->
 </div1>
 
 <div1 role="xquery" id="id-xq-context-components">

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -415,6 +415,21 @@
         <item><p>T is a numeric literal and U is ".", or vice versa.</p></item>
       </ulist>
     </div3>
+    <div3 id="id-lt-and-gt-characters" diff="add" at="2023-05-02">
+      <head>Less-Than and Greater-Than Characters</head>
+      
+      <p>In the operator symbols <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code>, <code>&gt;=</code>, 
+        <code>&lt;&lt;</code>, <code>&gt;&gt;</code>, <code>=&gt;</code>, and <code>-&gt;</code>, the <code>&lt;</code> character
+        may be written interchangeably using the codepoint x3C (less-than sign) or xFF1C (full-width less-than sign), while the <code>&gt;</code> character 
+        may be written interchangeably using the codepoint x3E (greater-than sign) or xFF1E (full-width greater-than sign). 
+        In order to avoid visual confusion these alternatives are not shown explicitly in the grammar.</p>
+      
+      <p>This option is provided to improve the readability of XPath expressions embedded in XML-based host languages such as XSLT; it
+      enables these operators to be depicted using characters that do not require escaping as XML entities or character references.</p>
+      
+      <p role="xquery">This rule does not apply to the <code>&lt;</code> and <code>&gt;</code> symbols used to delimit node constructor
+        expressions, which (because they mimic XML syntax) must use x3C (less-than sign) and x3E (greater-than sign) respectively.</p>
+    </div3>
     <div3 id="id-eol-handling">
       <head>End-of-Line Handling</head>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11233,9 +11233,12 @@ name, but <code
                role="parse-test">a - b</code> and <code role="parse-test"
                >a -b</code> will be interpreted as arithmetic expressions. (See <specref
                ref="whitespace-rules"/> for further details on whitespace handling.)</p>
-
+         <p diff="add" at="2023-05-02">The arithmetic operator symbols <code>*</code> and <code>×</code> (xD7) are interchangeable,
+         and denote multiplication.</p>
+         <p diff="add" at="2023-05-02">The arithmetic operator symbols <code>div</code> and <code>÷</code> (xF7) are interchangeable,
+            and denote division.</p>
          <p>
-If an AdditiveExpr contains more than two MultiplicativeExprs,
+If an <code>AdditiveExpr</code> contains more than two <code>MultiplicativeExprs</code>,
 they are grouped from left to right. So, for instance,
 <eg
                role="parse-test"><![CDATA[A - B + C - D]]></eg>
@@ -11243,7 +11246,7 @@ is equivalent to
 <eg
                role="parse-test"
             ><![CDATA[((A - B) + C) - D]]></eg>
-Similarly, the operands of a MultiplicativeExpr are grouped from left to right.
+Similarly, the operands of a <code>MultiplicativeExpr</code> are grouped from left to right.
 </p>
 
          <p>The first step in evaluating an arithmetic expression is to evaluate its operands. The order in which the operands are evaluated is <termref
@@ -11337,16 +11340,14 @@ type combination, including the dynamic errors that can be raised by the operato
          <p>If the types of the operands, after evaluation, are not a valid combination for the given operator, according to the rules in <specref
                ref="mapping"/>, a <termref def="dt-type-error"
                >type error</termref> is raised <errorref class="TY" code="0004"/>.</p>
-         <p>&language; supports two division operators named <code>div</code> and <code>idiv</code>. Each of these operators accepts two operands of any <termref
-               def="dt-numeric"
-               >numeric</termref> type. 
-
-The semantics of <code>div</code> are defined in <xspecref
-               spec="FO31" ref="func-numeric-integer-divide"
-               />.
-The semantics of <code>idiv</code> are defined in <xspecref spec="FO31"
-               ref="func-numeric-divide"/>.
-</p>
+         <p>&language; provides three division operators:</p>
+         <ulist>
+            <item><p>The <code>div</code> and <code>÷</code> operators are synonyms, and implement
+               numeric division as well as division of duration values; the semantics are defined in
+               <xspecref spec="FO40" ref="func-numeric-divide"/></p></item>
+            <item><p>The <code>idiv</code> operator implements integer division; the semantics are defined
+               in <xspecref spec="FO31" ref="func-numeric-integer-divide"/></p></item>
+         </ulist> 
 
          <p>Here are some examples of arithmetic expressions:</p>
 
@@ -11880,6 +11881,9 @@ is raised <errorref class="TY" code="0004"/>.</p>
             <head>General Comparisons</head>
             <p>The general comparison operators are <code>=</code>, <code>!=</code>, <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code>, and <code>&gt;=</code>. General comparisons are existentially quantified comparisons that may be applied to operand sequences of any length. The result of a general comparison that does not raise an error is
 always <code>true</code> or <code>false</code>.</p>
+            
+         
+            
             <p role="xpath">If <termref def="dt-xpath-compat-mode"
                   >XPath 1.0 compatibility mode</termref> is <code>true</code>, a general comparison is evaluated by applying the following rules, in order:</p>
 


### PR DESCRIPTION
(1) drops the mathematical operator symbols appendix, which allowed an extensive range of non-ASCII characters as synonyms for language keywords, (2) retains × and ÷ as synonyms for multiplication and division, (3) allows full-width `<` and `>` in operator symbols in place of the usual ASCII characters, to avoid the need for XML escaping.