### PR TITLE
321: Add new note and examples demonstrating adaptive serialization method

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16431,8 +16431,8 @@ else
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>The expression<code>fn:serialize(map{"a":"AB", "b": "BC"}, map{"method":"adaptive"})</code> returns <code>"map{"a":"AB","b":"BC"}"</code></p>
-            <p>The expression<code>fn:serialize(array{"a",3, attribute test {"true"}}, map{"method":"adaptive"})</code> returns <code>"["a",3,test="true"]"</code></p>
+            <p>The expression <code>fn:serialize(map{"a":"AB", "b": "BC"}, map{"method":"adaptive"})</code> returns <code>"map{"a":"AB","b":"BC"}"</code></p>
+            <p>The expression <code>fn:serialize(array{"a",3, attribute test {"true"}}, map{"method":"adaptive"})</code> returns <code>"["a",3,test="true"]"</code></p>
          </fos:example>
       </fos:examples>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16381,6 +16381,12 @@ else
             comment). See <code>fn:parse-xml</code> for further details.</p>
          <p>Another use case arises when there is a need to call an extension function that expects
             a lexical XML document as input.</p>
+         <p>Another use case for this function is serializing instances of the data model into a human
+            readable format for the purposes of debugging. Using the <xspecref
+               spec="SER31" ref="adaptive-output"
+            /> by specifying it as the output method defined in the second argument via 
+            <code>output:serialization-parameters</code>, allows for serializing any valid
+            XDM instance without raising a serialization error.</p>
          <p>There are also use cases where the application wants to post-process the output of a
             query or transformation, for example by adding an internal DTD subset, or by inserting
             proprietary markup delimiters such as the <code>&lt;% ... %&gt;</code> used by some
@@ -16423,6 +16429,10 @@ else
                <fos:expression><![CDATA[fn:serialize($data, map{"method":"xml", "omit-xml-declaration":true()})]]></fos:expression>
                <fos:result><![CDATA['<a b="3"/>']]></fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>The expression<code>fn:serialize(map{"a":"AB", "b": "BC"}, map{"method":"adaptive"})</code> returns <code>"map{"a":"AB","b":"BC"}"</code></p>
+            <p>The expression<code>fn:serialize(array{"a",3, attribute test {"true"}}, map{"method":"adaptive"})</code> returns <code>"["a",3,test="true"]"</code></p>
          </fos:example>
       </fos:examples>
    </fos:function>


### PR DESCRIPTION
Per [Issue 321](https://github.com/qt4cg/qtspecs/issues/321), I've added a new note and two additional simple examples noting the adaptive serialization method to draw attention to this feature in the existing specs.