### PR TITLE
Per comments on #465, improve presentation of multi-line expressions

### DIFF
--- a/specifications/css/qtspecs.css
+++ b/specifications/css/qtspecs.css
@@ -70,7 +70,7 @@ div.exampleInner { background-color: #d5dee3;
                    border-bottom-style: double;
                    border-bottom-color: #d3d3d3;
                    padding: 4px;
-		   margin-bottom: 4px;
+		   margin-bottom: 1em;
                  }
 
 div.issueBody    { margin-left: 0.25in;
@@ -158,9 +158,7 @@ div.exampleInner pre { margin-left: 1em;
 pre.small { font-size: small }                       
 div.exampleOuter {border: 4px double gray;
                   margin: 0em; padding: 0em}
-div.exampleInner { background-color: #d5dee3;
-                   padding: 4px; margin: 0em }
-                   
+
 div.exampleInner table { border: 0;
                          border-spacing: 0;
                        }

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16960,8 +16960,10 @@ else
 
          </fos:example>
          <fos:example>
-            <p>The expression <code>let $f := fn:function-lookup(xs:QName('zip:binary-entry'), 2)
-                  return if (exists($f)) then $f($href, $entry) else ()</code> returns the result of
+            <p>The expression
+         <eg>let $f := fn:function-lookup(xs:QName('zip:binary-entry'), 2)
+return if (exists($f)) then $f($href, $entry) else ()</eg>
+returns the result of
                calling <code>zip:binary-entry($href, $entry)</code> if the function is available, or
                an empty sequence otherwise.</p>
          </fos:example>
@@ -17488,22 +17490,22 @@ return fn:iterate-while(0, function($n) { $n = $input }, function($n) { $n + 1 }
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><![CDATA[fn:iterate-while(
+               <fos:expression><eg><![CDATA[fn:iterate-while(
   1 to 9,
   function($seq) { head($seq) < 5 },
   function($seq) { tail($seq) }
-)]]></fos:expression>
+)]]></eg></fos:expression>
                <fos:result>(5, 6, 7, 8, 9)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><![CDATA[let $input := 3936256
+               <fos:expression><eg><![CDATA[let $input := 3936256
 return fn:iterate-while(
   $input,
   function($result) { abs($result * $result - $input) >= 0.0000000001 },
   function($guess) { ($guess + $input div $guess) div 2 }
-)]]></fos:expression>
+)]]></eg></fos:expression>
                <fos:result>1984</fos:result>
                <fos:postamble>This computes the square root of a number.</fos:postamble>
             </fos:test>
@@ -19205,15 +19207,16 @@ return
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:filter(map{1:"Sunday", 2:"Monday", 3:"Tuesday", 4:"Wednesday",
-                  "5: "Thursday", 6:"Friday", 7:"Saturday"}, ->($k,
-                  $v){$k = (1, 7)})</fos:expression>
+               <fos:expression><eg>map:filter(map{1: "Sunday", 2: "Monday", 3: "Tuesday", 4:"Wednesday",
+               5: "Thursday", 6: "Friday", 7: "Saturday"},
+           ->($k, $v){$k = (1, 7)})</eg></fos:expression>
                <fos:result>map:filter(map{1:"Sunday", 7:"Saturday"}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:filter(map{1:"Sunday", 2:"Monday", 3:"Tuesday", 4:"Wednesday",
-                  "5: "Thursday", 6:"Friday", 7:"Saturday"}, ->($k,
-                  $v){$v = ("Saturday", "Sunday")})</fos:expression>
+               <fos:expression><eg>
+map:filter(map{1: "Sunday", 2: "Monday", 3: "Tuesday", 4: "Wednesday",
+               5: "Thursday", 6:"Friday", 7:"Saturday"},
+           ->($k, $v){$v = ("Saturday", "Sunday")})</eg></fos:expression>
                <fos:result>map:filter(map{1:"Sunday", 7:"Saturday"}</fos:result>
             </fos:test>
 
@@ -25655,8 +25658,7 @@ description of <code>fn:resolve-uri</code>.</p>
   <fos:example>
 <p>This example demonstrates a non-standard query separator.</p>
     <fos:test>
-      <fos:expression>
-fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
+      <fos:expression>fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
              map { "query-separator": ";" })</fos:expression>
       <fos:result>
 <eg>map {

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -694,7 +694,18 @@
             <xsl:value-of select="@diff"/>
           </xsl:attribute>
         </xsl:if>
-        <xsl:apply-templates/>
+
+        <!-- Remove trailing whitespace if we can... -->
+        <xsl:apply-templates select="node()[position() lt last()]"/>
+        <xsl:variable name="last-node" select="node()[last()]"/>
+        <xsl:choose>
+          <xsl:when test="$last-node/self::text()">
+            <xsl:value-of select="replace($last-node, '\s+$', '')"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates select="$last-node"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </pre>
     </xsl:variable>
     <xsl:choose>


### PR DESCRIPTION
This PR addresses points raised in the comments on #465.

If an `fos:expression` element is a code block, nest an `eg` inside it:

```xml
               <fos:expression><eg><![CDATA[let $input := 3936256
return fn:iterate-while(
  $input,
  function($result) { abs($result * $result - $input) >= 0.0000000001 },
  function($guess) { ($guess + $input div $guess) div 2 }
)]]></eg></fos:expression>
```

I found four examples where an `fos:expression` contained more than one newline and I added `eg` wrappers in those cases. 

There are many more `fos:expression` elements that contain a single newline, but automatically formatting them as code blocks was often unsuccessful. Many of those cases seem to be just newlines entered for authoring convenience.

I also fixed the CSS for code blocks and attempte to remove trailing newlines from code blocks.

