### PR TITLE
471: fn: prefix removed from function calls in the examples

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -567,7 +567,7 @@
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:error()</fos:expression>
+               <fos:expression>error()</fos:expression>
                <fos:error-result error-code="FOER0000"/>
                <fos:postamble>This returns the URI
                      <code>http://www.w3.org/2005/xqt-errors#FOER0000</code> (or the corresponding
@@ -577,7 +577,7 @@
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:error(fn:QName('http://www.example.com/HR', 'myerr:toohighsal'),
+               <fos:expression>error(QName('http://www.example.com/HR', 'myerr:toohighsal'),
                   'Does not apply because salary is too high')</fos:expression>
                <fos:error-result error-code="myerr:toohighsal"/>
                <fos:postamble>This returns <code>http://www.example.com/HR#toohighsal</code> and the
@@ -1095,13 +1095,13 @@
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:abs(10.5)</fos:expression>
+               <fos:expression>abs(10.5)</fos:expression>
                <fos:result>10.5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:abs(-10.5)</fos:expression>
+               <fos:expression>abs(-10.5)</fos:expression>
                <fos:result>10.5</fos:result>
             </fos:test>
          </fos:example>
@@ -1140,13 +1140,13 @@
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ceiling(10.5)</fos:expression>
+               <fos:expression>ceiling(10.5)</fos:expression>
                <fos:result>11</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ceiling(-10.5)</fos:expression>
+               <fos:expression>ceiling(-10.5)</fos:expression>
                <fos:result>-10</fos:result>
             </fos:test>
          </fos:example>
@@ -1185,13 +1185,13 @@
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:floor(10.5)</fos:expression>
+               <fos:expression>floor(10.5)</fos:expression>
                <fos:result>10</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:floor(-10.5)</fos:expression>
+               <fos:expression>floor(-10.5)</fos:expression>
                <fos:result>-11</fos:result>
             </fos:test>
          </fos:example>
@@ -1262,38 +1262,38 @@
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round(2.5)</fos:expression>
+               <fos:expression>round(2.5)</fos:expression>
                <fos:result>3.0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round(2.4999)</fos:expression>
+               <fos:expression>round(2.4999)</fos:expression>
                <fos:result>2.0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round(-2.5)</fos:expression>
+               <fos:expression>round(-2.5)</fos:expression>
                <fos:result>-2.0</fos:result>
                <fos:postamble>Not the possible alternative, <code>-3</code></fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test xslt-version="3.0">
-               <fos:expression>fn:round(1.125, 2)</fos:expression>
+               <fos:expression>round(1.125, 2)</fos:expression>
                <fos:result>1.13</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test xslt-version="3.0">
-               <fos:expression>fn:round(8452, -2)</fos:expression>
+               <fos:expression>round(8452, -2)</fos:expression>
                <fos:result>8500</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test xslt-version="3.0">
-               <fos:expression>fn:round(3.1415e0, 2)</fos:expression>
+               <fos:expression>round(3.1415e0, 2)</fos:expression>
                <fos:result>3.14e0</fos:result>
             </fos:test>
          </fos:example>
@@ -1363,37 +1363,37 @@
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round-half-to-even(0.5)</fos:expression>
+               <fos:expression>round-half-to-even(0.5)</fos:expression>
                <fos:result>0.0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round-half-to-even(1.5)</fos:expression>
+               <fos:expression>round-half-to-even(1.5)</fos:expression>
                <fos:result>2.0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round-half-to-even(2.5)</fos:expression>
+               <fos:expression>round-half-to-even(2.5)</fos:expression>
                <fos:result>2.0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round-half-to-even(3.567812e+3, 2)</fos:expression>
+               <fos:expression>round-half-to-even(3.567812e+3, 2)</fos:expression>
                <fos:result>3567.81e0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round-half-to-even(4.7564e-3, 2)</fos:expression>
+               <fos:expression>round-half-to-even(4.7564e-3, 2)</fos:expression>
                <fos:result>0.0e0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round-half-to-even(35612.25, -2)</fos:expression>
+               <fos:expression>round-half-to-even(35612.25, -2)</fos:expression>
                <fos:result>35600</fos:result>
             </fos:test>
          </fos:example>
@@ -2201,39 +2201,39 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:parse-integer(" 200 ")</fos:expression>
+               <fos:expression>parse-integer(" 200 ")</fos:expression>
                <fos:result>200</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-integer("-20")</fos:expression>
+               <fos:expression>parse-integer("-20")</fos:expression>
                <fos:result>-20</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-integer(" +100")</fos:expression>
+               <fos:expression>parse-integer(" +100")</fos:expression>
                <fos:result>100</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-integer("ff", 16)</fos:expression>
+               <fos:expression>parse-integer("ff", 16)</fos:expression>
                <fos:result>255</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-integer("FFFF FFFF", 16)</fos:expression>
+               <fos:expression>parse-integer("FFFF FFFF", 16)</fos:expression>
                <fos:result>4294967295</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-integer("-FFFF_FFFF", 16)</fos:expression>
+               <fos:expression>parse-integer("-FFFF_FFFF", 16)</fos:expression>
                <fos:result>-4294967295</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-integer("377", 8)</fos:expression>
+               <fos:expression>parse-integer("377", 8)</fos:expression>
                <fos:result>255</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-integer("101", 2)</fos:expression>
+               <fos:expression>parse-integer("101", 2)</fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-integer("vv", 32)</fos:expression>
+               <fos:expression>parse-integer("vv", 32)</fos:expression>
                <fos:result>1023</fos:result>
             </fos:test>
          </fos:example>
@@ -3366,19 +3366,19 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:codepoints-to-string((66, 65, 67, 72))</fos:expression>
+               <fos:expression>codepoints-to-string((66, 65, 67, 72))</fos:expression>
                <fos:result>"BACH"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:codepoints-to-string((2309, 2358, 2378, 2325))</fos:expression>
+               <fos:expression>codepoints-to-string((2309, 2358, 2378, 2325))</fos:expression>
                <fos:result>"अशॊक"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:codepoints-to-string(())</fos:expression>
+               <fos:expression>codepoints-to-string(())</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:codepoints-to-string(0)</fos:expression>
+               <fos:expression>codepoints-to-string(0)</fos:expression>
                <fos:error-result error-code="FOCH0001"/>
             </fos:test>
          </fos:example>
@@ -3410,7 +3410,7 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:string-to-codepoints("Thérèse")</fos:expression>
+               <fos:expression>string-to-codepoints("Thérèse")</fos:expression>
                <fos:result>(84, 104, 233, 114, 232, 115, 101)</fos:result>
             </fos:test>
          </fos:example>
@@ -3453,14 +3453,14 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:compare('abc', 'abc')</fos:expression>
+               <fos:expression>compare('abc', 'abc')</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test
                default-collation="http://www.w3.org/2013/collation/UCA?lang=de;strength=primary">
-               <fos:expression>fn:compare('Strasse', 'Straße')</fos:expression>
+               <fos:expression>compare('Strasse', 'Straße')</fos:expression>
                <fos:result>0</fos:result>
                <fos:postamble>Assuming the default collation includes provisions that equate
                      <quote>ss</quote> and the (German) character <quote>ß</quote>
@@ -3470,7 +3470,7 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:compare('Strasse', 'Straße',
+               <fos:expression>compare('Strasse', 'Straße',
                   'http://www.w3.org/2013/collation/UCA?lang=de;strength=primary')</fos:expression>
                <fos:result>0</fos:result>
                <fos:postamble>The specified collation equates
@@ -3480,7 +3480,7 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
          </fos:example>
          <fos:example>
             <fos:test default-collation="http://www.w3.org/2013/collation/UCA?lang=de">
-               <fos:expression>fn:compare('Strassen', 'Straße')</fos:expression>
+               <fos:expression>compare('Strassen', 'Straße')</fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>Assuming the default collation includes provisions that treat
                   differences between <quote>ss</quote> and the (German) character <quote>ß</quote>
@@ -3520,23 +3520,23 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:codepoint-equal("abcd", "abcd")</fos:expression>
+               <fos:expression>codepoint-equal("abcd", "abcd")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:codepoint-equal("abcd", "abcd ")</fos:expression>
+               <fos:expression>codepoint-equal("abcd", "abcd ")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:codepoint-equal("", "")</fos:expression>
+               <fos:expression>codepoint-equal("", "")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:codepoint-equal("", ())</fos:expression>
+               <fos:expression>codepoint-equal("", ())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:codepoint-equal((), ())</fos:expression>
+               <fos:expression>codepoint-equal((), ())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -3601,32 +3601,32 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:concat('un', 'grateful')</fos:expression>
+               <fos:expression>concat('un', 'grateful')</fos:expression>
                <fos:result>"ungrateful"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:concat('Thy ', (), 'old ', "groans", "", ' ring',
+               <fos:expression>concat('Thy ', (), 'old ', "groans", "", ' ring',
                   ' yet', ' in', ' my', ' ancient',' ears.')</fos:expression>
                <fos:result>"Thy old groans ring yet in my ancient ears."</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:concat('Ciao!',())</fos:expression>
+               <fos:expression>concat('Ciao!',())</fos:expression>
                <fos:result>"Ciao!"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:concat('Ingratitude, ', 'thou ', 'marble-hearted', ' fiend!')</fos:expression>
+               <fos:expression>concat('Ingratitude, ', 'thou ', 'marble-hearted', ' fiend!')</fos:expression>
                <fos:result>"Ingratitude, thou marble-hearted fiend!"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:concat(01, 02, 03, 04, true())</fos:expression>
+               <fos:expression>concat(01, 02, 03, 04, true())</fos:expression>
                <fos:result>"1234true"</fos:result>
             </fos:test>
          </fos:example>
@@ -3673,33 +3673,33 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:string-join(1 to 9)</fos:expression>
+               <fos:expression>string-join(1 to 9)</fos:expression>
                <fos:result>"123456789"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:string-join(('Now', 'is', 'the', 'time', '...'),
+               <fos:expression>string-join(('Now', 'is', 'the', 'time', '...'),
                   ' ')</fos:expression>
                <fos:result>"Now is the time ..."</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:string-join(('Blow, ', 'blow, ', 'thou ', 'winter ', 'wind!'),
+               <fos:expression>string-join(('Blow, ', 'blow, ', 'thou ', 'winter ', 'wind!'),
                   '')</fos:expression>
                <fos:result>"Blow, blow, thou winter wind!"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:string-join((), 'separator')</fos:expression>
+               <fos:expression>string-join((), 'separator')</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:string-join(1 to 5, ', ')</fos:expression>
+               <fos:expression>string-join(1 to 5, ', ')</fos:expression>
                <fos:result>"1, 2, 3, 4, 5"</fos:result>
             </fos:test>
          </fos:example>
@@ -3712,13 +3712,13 @@ return normalize-unicode(concat($v1, $v2))</eg>
 &lt;/doc&gt;</fos:variable>
          <fos:example>
             <fos:test use="v-string-join-doc">
-               <fos:expression>$doc//@xml:id ! fn:string-join((node-name(), '="', ., '"'))</fos:expression>
+               <fos:expression>$doc//@xml:id ! string-join((node-name(), '="', ., '"'))</fos:expression>
                <fos:result>'xml:id="xyz"'</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-string-join-doc">
-               <fos:expression>$doc//section ! fn:string-join(ancestor-or-self::*/name(), '/')</fos:expression>
+               <fos:expression>$doc//section ! string-join(ancestor-or-self::*/name(), '/')</fos:expression>
                <fos:result>"doc/chap/section"</fos:result>
             </fos:test>
          </fos:example>
@@ -3783,7 +3783,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("motor car", 6)</fos:expression>
+               <fos:expression>substring("motor car", 6)</fos:expression>
                <fos:result>" car"</fos:result>
                <fos:postamble>Characters starting at position 6 to the end of
                      <code>$sourceString</code> are selected.</fos:postamble>
@@ -3792,7 +3792,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("metadata", 4, 3)</fos:expression>
+               <fos:expression>substring("metadata", 4, 3)</fos:expression>
                <fos:result>"ada"</fos:result>
                <fos:postamble>Characters at positions greater than or equal to 4 and less than 7 are
                   selected.</fos:postamble>
@@ -3800,7 +3800,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("12345", 1.5, 2.6)</fos:expression>
+               <fos:expression>substring("12345", 1.5, 2.6)</fos:expression>
                <fos:result>"234"</fos:result>
                <fos:postamble>Characters at positions greater than or equal to 2 and less than 5 are
                   selected.</fos:postamble>
@@ -3808,7 +3808,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("12345", 0, 3)</fos:expression>
+               <fos:expression>substring("12345", 0, 3)</fos:expression>
                <fos:result>"12"</fos:result>
                <fos:postamble>Characters at positions greater than or equal to 0 and less than 3 are
                   selected. Since the first position is 1, these are the characters at positions 1
@@ -3817,7 +3817,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("12345", 5, -3)</fos:expression>
+               <fos:expression>substring("12345", 5, -3)</fos:expression>
                <fos:result>""</fos:result>
                <fos:postamble>Characters at positions greater than or equal to 5 and less than 2 are
                   selected.</fos:postamble>
@@ -3825,7 +3825,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("12345", -3, 5)</fos:expression>
+               <fos:expression>substring("12345", -3, 5)</fos:expression>
                <fos:result>"1"</fos:result>
                <fos:postamble>Characters at positions greater than or equal to -3 and less than 2
                   are selected. Since the first position is 1, this is the character at position
@@ -3834,7 +3834,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("12345", 0 div 0E0, 3)</fos:expression>
+               <fos:expression>substring("12345", 0 div 0E0, 3)</fos:expression>
                <fos:result>""</fos:result>
                <fos:postamble>Since <code>0 div 0E0</code> returns <code>NaN</code>, and
                      <code>NaN</code> compared to any other number returns <code>false</code>, no
@@ -3843,20 +3843,20 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("12345", 1, 0 div 0E0)</fos:expression>
+               <fos:expression>substring("12345", 1, 0 div 0E0)</fos:expression>
                <fos:result>""</fos:result>
                <fos:postamble>As above.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring((), 1, 3)</fos:expression>
+               <fos:expression>substring((), 1, 3)</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("12345", -42, 1 div 0E0)</fos:expression>
+               <fos:expression>substring("12345", -42, 1 div 0E0)</fos:expression>
                <fos:result>"12345"</fos:result>
                <fos:postamble>Characters at positions greater than or equal to -42 and less than
                      <code>INF</code> are selected.</fos:postamble>
@@ -3864,7 +3864,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring("12345", -1 div 0E0, 1 div 0E0)</fos:expression>
+               <fos:expression>substring("12345", -1 div 0E0, 1 div 0E0)</fos:expression>
                <fos:result>""</fos:result>
                <fos:postamble>Since the value of <code>-INF + INF</code> is <code>NaN</code>, no
                   characters are selected.</fos:postamble>
@@ -3921,13 +3921,13 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:string-length("Harp not on that string, madam; that is past.")</fos:expression>
+               <fos:expression>string-length("Harp not on that string, madam; that is past.")</fos:expression>
                <fos:result>45</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:string-length(())</fos:expression>
+               <fos:expression>string-length(())</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -3981,14 +3981,14 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression xml:space="preserve">fn:normalize-space(" The    wealthy curled darlings
+               <fos:expression xml:space="preserve">normalize-space(" The    wealthy curled darlings
                                         of    our    nation. ")</fos:expression>
                <fos:result>"The wealthy curled darlings of our nation."</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:normalize-space(())</fos:expression>
+               <fos:expression>normalize-space(())</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
@@ -4175,7 +4175,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:upper-case("abCd0")</fos:expression>
+               <fos:expression>upper-case("abCd0")</fos:expression>
                <fos:result>"ABCD0"</fos:result>
             </fos:test>
          </fos:example>
@@ -4234,7 +4234,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:lower-case("ABc!D")</fos:expression>
+               <fos:expression>lower-case("ABc!D")</fos:expression>
                <fos:result>"abc!d"</fos:result>
             </fos:test>
          </fos:example>
@@ -4294,19 +4294,19 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:translate("bar","abc","ABC")</fos:expression>
+               <fos:expression>translate("bar","abc","ABC")</fos:expression>
                <fos:result>"BAr"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:translate("--aaa--","abc-","ABC")</fos:expression>
+               <fos:expression>translate("--aaa--","abc-","ABC")</fos:expression>
                <fos:result>"AAA"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:translate("abcdabc", "abc", "AB")</fos:expression>
+               <fos:expression>translate("abcdabc", "abc", "AB")</fos:expression>
                <fos:result>"ABdAB"</fos:result>
             </fos:test>
          </fos:example>
@@ -4356,7 +4356,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:encode-for-uri("http://www.example.com/00/Weather/CA/Los%20Angeles#ocean")</fos:expression>
+               <fos:expression>encode-for-uri("http://www.example.com/00/Weather/CA/Los%20Angeles#ocean")</fos:expression>
                <fos:result>"http%3A%2F%2Fwww.example.com%2F00%2FWeather%2FCA%2FLos%2520Angeles%23ocean"</fos:result>
                <fos:postamble>This is probably not what the user intended because all of the
                   delimiters have been encoded.</fos:postamble>
@@ -4431,14 +4431,14 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:iri-to-uri
+               <fos:expression>iri-to-uri
                   ("http://www.example.com/00/Weather/CA/Los%20Angeles#ocean")</fos:expression>
                <fos:result>"http://www.example.com/00/Weather/CA/Los%20Angeles#ocean"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:iri-to-uri ("http://www.example.com/~bébé")</fos:expression>
+               <fos:expression>iri-to-uri ("http://www.example.com/~bébé")</fos:expression>
                <fos:result>"http://www.example.com/~b%C3%A9b%C3%A9"</fos:result>
             </fos:test>
          </fos:example>
@@ -4482,13 +4482,13 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:escape-html-uri("http://www.example.com/00/Weather/CA/Los Angeles#ocean")</fos:expression>
+               <fos:expression>escape-html-uri("http://www.example.com/00/Weather/CA/Los Angeles#ocean")</fos:expression>
                <fos:result>"http://www.example.com/00/Weather/CA/Los Angeles#ocean"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:escape-html-uri("javascript:if (navigator.browserLanguage == 'fr') window.open('http://www.example.com/~bébé');")</fos:expression>
+               <fos:expression>escape-html-uri("javascript:if (navigator.browserLanguage == 'fr') window.open('http://www.example.com/~bébé');")</fos:expression>
                <fos:result>"javascript:if (navigator.browserLanguage == 'fr') window.open('http://www.example.com/~b%C3%A9b%C3%A9');"</fos:result>
             </fos:test>
          </fos:example>
@@ -4549,19 +4549,19 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains ( "tattoo", "t")</fos:expression>
+               <fos:expression>contains ( "tattoo", "t")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains ( "tattoo", "ttt")</fos:expression>
+               <fos:expression>contains ( "tattoo", "ttt")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains ( "", ())</fos:expression>
+               <fos:expression>contains ( "", ())</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The first rule is applied, followed by the second
                   rule.</fos:postamble>
@@ -4569,28 +4569,28 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains ( "abcdefghi", "-d-e-f-",
+               <fos:expression>contains ( "abcdefghi", "-d-e-f-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains ( "a*b*c*d*e*f*g*h*i*", "d-ef-",
+               <fos:expression>contains ( "a*b*c*d*e*f*g*h*i*", "d-ef-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains ( "abcd***e---f*--*ghi", "def",
+               <fos:expression>contains ( "abcd***e---f*--*ghi", "def",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains ( (), "--***-*---",
+               <fos:expression>contains ( (), "--***-*---",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -4653,46 +4653,46 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with("tattoo", "tat")</fos:expression>
+               <fos:expression>starts-with("tattoo", "tat")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with ( "tattoo", "att")</fos:expression>
+               <fos:expression>starts-with ( "tattoo", "att")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with ((), ())</fos:expression>
+               <fos:expression>starts-with ((), ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with ( "abcdefghi", "-a-b-c-",
+               <fos:expression>starts-with ( "abcdefghi", "-a-b-c-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with ( "a*b*c*d*e*f*g*h*i*", "a-bc-",
+               <fos:expression>starts-with ( "a*b*c*d*e*f*g*h*i*", "a-bc-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with ( "abcd***e---f*--*ghi", "abcdef",
+               <fos:expression>starts-with ( "abcd***e---f*--*ghi", "abcdef",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with ( (), "--***-*---",
+               <fos:expression>starts-with ( (), "--***-*---",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -4701,7 +4701,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with ( "-abcdefghi", "-abc",
+               <fos:expression>starts-with ( "-abcdefghi", "-abc",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -4763,46 +4763,46 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with ( "tattoo", "tattoo")</fos:expression>
+               <fos:expression>ends-with ( "tattoo", "tattoo")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with ( "tattoo", "atto")</fos:expression>
+               <fos:expression>ends-with ( "tattoo", "atto")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with ((), ())</fos:expression>
+               <fos:expression>ends-with ((), ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with ( "abcdefghi", "-g-h-i-",
+               <fos:expression>ends-with ( "abcdefghi", "-g-h-i-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with ( "abcd***e---f*--*ghi", "defghi",
+               <fos:expression>ends-with ( "abcd***e---f*--*ghi", "defghi",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with ( "abcd***e---f*--*ghi", "defghi",
+               <fos:expression>ends-with ( "abcd***e---f*--*ghi", "defghi",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with ( (), "--***-*---",
+               <fos:expression>ends-with ( (), "--***-*---",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -4811,7 +4811,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with ( "abcdefghi", "ghi-",
+               <fos:expression>ends-with ( "abcdefghi", "ghi-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -4872,46 +4872,46 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-before ( "tattoo", "attoo")</fos:expression>
+               <fos:expression>substring-before ( "tattoo", "attoo")</fos:expression>
                <fos:result>"t"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-before ( "tattoo", "tatto")</fos:expression>
+               <fos:expression>substring-before ( "tattoo", "tatto")</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-before ((), ())</fos:expression>
+               <fos:expression>substring-before ((), ())</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-before ( "abcdefghi", "--d-e-",
+               <fos:expression>substring-before ( "abcdefghi", "--d-e-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>"abc"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-before ( "abc--d-e-fghi", "--d-e-",
+               <fos:expression>substring-before ( "abc--d-e-fghi", "--d-e-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>"abc--"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-before ( "a*b*c*d*e*f*g*h*i*", "***cde",
+               <fos:expression>substring-before ( "a*b*c*d*e*f*g*h*i*", "***cde",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>"a*b*"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-before ( "Eureka!", "--***-*---",
+               <fos:expression>substring-before ( "Eureka!", "--***-*---",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>""</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -4975,46 +4975,46 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-after("tattoo", "tat")</fos:expression>
+               <fos:expression>substring-after("tattoo", "tat")</fos:expression>
                <fos:result>"too"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-after("tattoo", "tattoo")</fos:expression>
+               <fos:expression>substring-after("tattoo", "tattoo")</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-after((), ())</fos:expression>
+               <fos:expression>substring-after((), ())</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression> fn:substring-after("abcdefghi", "--d-e-",
+               <fos:expression> substring-after("abcdefghi", "--d-e-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>"fghi"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-after("abc--d-e-fghi", "--d-e-",
+               <fos:expression>substring-after("abc--d-e-fghi", "--d-e-",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>"-fghi"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-after ( "a*b*c*d*e*f*g*h*i*", "***cde***",
+               <fos:expression>substring-after ( "a*b*c*d*e*f*g*h*i*", "***cde***",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>"*f*g*h*i*"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:substring-after ( "Eureka!", "--***-*---",
+               <fos:expression>substring-after ( "Eureka!", "--***-*---",
                   "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
                <fos:result>"Eureka!"</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -5077,19 +5077,19 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:matches("abracadabra", "bra")</fos:expression>
+               <fos:expression>matches("abracadabra", "bra")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:matches("abracadabra", "^a.*a$")</fos:expression>
+               <fos:expression>matches("abracadabra", "^a.*a$")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:matches("abracadabra", "^bra")</fos:expression>
+               <fos:expression>matches("abracadabra", "^bra")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -5109,31 +5109,31 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test use="v-matches-poem">
-               <fos:expression>fn:matches($poem, "Kaum.*krähen")</fos:expression>
+               <fos:expression>matches($poem, "Kaum.*krähen")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-matches-poem">
-               <fos:expression>fn:matches($poem, "Kaum.*krähen", "s")</fos:expression>
+               <fos:expression>matches($poem, "Kaum.*krähen", "s")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-matches-poem">
-               <fos:expression>fn:matches($poem, "^Kaum.*gesehen,$", "m")</fos:expression>
+               <fos:expression>matches($poem, "^Kaum.*gesehen,$", "m")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-matches-poem">
-               <fos:expression>fn:matches($poem, "^Kaum.*gesehen,$")</fos:expression>
+               <fos:expression>matches($poem, "^Kaum.*gesehen,$")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-matches-poem">
-               <fos:expression>fn:matches($poem, "kiki", "i")</fos:expression>
+               <fos:expression>matches($poem, "kiki", "i")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -5292,56 +5292,56 @@ Tak, tak, tak! - da kommen sie.
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replace("abracadabra", "bra", "*")</fos:expression>
+               <fos:expression>replace("abracadabra", "bra", "*")</fos:expression>
                <fos:result>"a*cada*"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:replace("abracadabra", "a.*a", "*")</fos:expression>
+               <fos:expression>replace("abracadabra", "a.*a", "*")</fos:expression>
                <fos:result>"*"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:replace("abracadabra", "a.*?a", "*")</fos:expression>
+               <fos:expression>replace("abracadabra", "a.*?a", "*")</fos:expression>
                <fos:result>"*c*bra"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:replace("abracadabra", "a", "")</fos:expression>
+               <fos:expression>replace("abracadabra", "a", "")</fos:expression>
                <fos:result>"brcdbr"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:replace("abracadabra", "a(.)", "a$1$1")</fos:expression>
+               <fos:expression>replace("abracadabra", "a(.)", "a$1$1")</fos:expression>
                <fos:result>"abbraccaddabbra"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:replace("AAAA", "A+", "b")</fos:expression>
+               <fos:expression>replace("AAAA", "A+", "b")</fos:expression>
                <fos:result>"b"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:replace("AAAA", "A+?", "b")</fos:expression>
+               <fos:expression>replace("AAAA", "A+?", "b")</fos:expression>
                <fos:result>"bbbb"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:replace("darted", "^(.*?)d(.*)$", "$1c$2")</fos:expression>
+               <fos:expression>replace("darted", "^(.*?)d(.*)$", "$1c$2")</fos:expression>
                <fos:result>"carted"</fos:result>
                <fos:postamble>The first <code>d</code> is replaced.</fos:postamble>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>fn:replace("abracadabra", "bra", action: ->{"*"})</fos:expression>
+               <fos:expression>replace("abracadabra", "bra", action: ->{"*"})</fos:expression>
                <fos:result>"a*cada*"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>fn:replace("abracadabra", "bra", action: fn:upper-case#1)</fos:expression>
+               <fos:expression>replace("abracadabra", "bra", action: upper-case#1)</fos:expression>
                <fos:result>aBRAcadaBRA</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>fn:replace("Chapter 9", "[0-9]+", action: ->{string(number(.)+1)})</fos:expression>
+               <fos:expression>replace("Chapter 9", "[0-9]+", action: ->{string(number(.)+1)})</fos:expression>
                <fos:result>"Chapter 10"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>fn:replace("LHR to LAX", "[A-Z]{3}", action: map{'LAX': 'Los Angeles', 'LHR': 'London'})</fos:expression>
+               <fos:expression>replace("LHR to LAX", "[A-Z]{3}", action: map{'LAX': 'Los Angeles', 'LHR': 'London'})</fos:expression>
                <fos:result>"London to Los Angeles"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>fn:replace("57°43′30″", "([0-9]+)°([0-9]+)′([0-9]+)″)", action: ->($s, $groups){string(number($groups[1]) + number($groups[2])÷60 + number($groups[3])÷3600)||'°'})</fos:expression>
+               <fos:expression>replace("57°43′30″", "([0-9]+)°([0-9]+)′([0-9]+)″)", action: ->($s, $groups){string(number($groups[1]) + number($groups[2])÷60 + number($groups[3])÷3600)||'°'})</fos:expression>
                <fos:result>"57.725°"</fos:result>
             </fos:test>
          </fos:example>
@@ -5447,31 +5447,31 @@ Tak, tak, tak! - da kommen sie.
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tokenize(" red green blue ")</fos:expression>
+               <fos:expression>tokenize(" red green blue ")</fos:expression>
                <fos:result>("red", "green", "blue")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tokenize("The cat sat on the mat", "\s+")</fos:expression>
+               <fos:expression>tokenize("The cat sat on the mat", "\s+")</fos:expression>
                <fos:result>("The", "cat", "sat", "on", "the", "mat")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tokenize(" red green blue ", "\s+")</fos:expression>
+               <fos:expression>tokenize(" red green blue ", "\s+")</fos:expression>
                <fos:result>("", "red", "green", "blue", "")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tokenize("1, 15, 24, 50", ",\s*")</fos:expression>
+               <fos:expression>tokenize("1, 15, 24, 50", ",\s*")</fos:expression>
                <fos:result>("1", "15", "24", "50")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tokenize("1,15,,24,50,", ",")</fos:expression>
+               <fos:expression>tokenize("1,15,,24,50,", ",")</fos:expression>
                <fos:result>("1", "15", "", "24", "50", "")</fos:result>
             </fos:test>
          </fos:example>
@@ -5481,7 +5481,7 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tokenize("Some unparsed &lt;br&gt; HTML &lt;BR&gt; text",
+               <fos:expression>tokenize("Some unparsed &lt;br&gt; HTML &lt;BR&gt; text",
                   "\s*&lt;br&gt;\s*", "i")</fos:expression>
                <fos:result>("Some unparsed", "HTML", "text")</fos:result>
             </fos:test>
@@ -5622,7 +5622,7 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:analyze-string("The cat sat on the mat.", "\w+")</fos:expression>
+               <fos:expression>analyze-string("The cat sat on the mat.", "\w+")</fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true" as="element()"><![CDATA[
 <analyze-string-result xmlns="http://www.w3.org/2005/xpath-functions">
   <match>The</match>
@@ -5642,7 +5642,7 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:analyze-string("2008-12-03",
+               <fos:expression>analyze-string("2008-12-03",
                   "^(\d+)\-(\d+)\-(\d+)$")</fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true" as="element()"><![CDATA[
 <analyze-string-result xmlns="http://www.w3.org/2005/xpath-functions">
@@ -5653,7 +5653,7 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:analyze-string("A1,C15,,D24, X50,",
+               <fos:expression>analyze-string("A1,C15,,D24, X50,",
                   "([A-Z])([0-9]+)")</fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true" as="element()"><![CDATA[
 <analyze-string-result xmlns="http://www.w3.org/2005/xpath-functions">                  
@@ -5725,19 +5725,19 @@ Tak, tak, tak! - da kommen sie.
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains-token("red green blue ", "red")</fos:expression>
+               <fos:expression>contains-token("red green blue ", "red")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-token(("red", "green", "blue"), " red ")</fos:expression>
+               <fos:expression>contains-token(("red", "green", "blue"), " red ")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-token("red, green, blue", "red")</fos:expression>
+               <fos:expression>contains-token("red, green, blue", "red")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-token("red green blue", "RED", "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
+               <fos:expression>contains-token("red green blue", "RED", "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -5878,7 +5878,7 @@ Tak, tak, tak! - da kommen sie.
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:true()</fos:expression>
+               <fos:expression>true()</fos:expression>
                <fos:result>xs:boolean(1)</fos:result>
             </fos:test>
          </fos:example>
@@ -5902,7 +5902,7 @@ Tak, tak, tak! - da kommen sie.
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:false()</fos:expression>
+               <fos:expression>false()</fos:expression>
                <fos:result>xs:boolean(0)</fos:result>
             </fos:test>
          </fos:example>
@@ -6009,19 +6009,19 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test use="v-boolean-abc">
-               <fos:expression>fn:boolean($abc[1])</fos:expression>
+               <fos:expression>boolean($abc[1])</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-boolean-abc">
-               <fos:expression>fn:boolean($abc[0])</fos:expression>
+               <fos:expression>boolean($abc[0])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-boolean-abc">
-               <fos:expression>fn:boolean($abc[3])</fos:expression>
+               <fos:expression>boolean($abc[3])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -6055,19 +6055,19 @@ Tak, tak, tak! - da kommen sie.
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:not(fn:true())</fos:expression>
+               <fos:expression>not(true())</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:not(())</fos:expression>
+               <fos:expression>not(())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:not("false")</fos:expression>
+               <fos:expression>not("false")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -6256,19 +6256,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:years-from-duration(xs:yearMonthDuration("P20Y15M"))</fos:expression>
+               <fos:expression>years-from-duration(xs:yearMonthDuration("P20Y15M"))</fos:expression>
                <fos:result>21</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:years-from-duration(xs:yearMonthDuration("-P15M"))</fos:expression>
+               <fos:expression>years-from-duration(xs:yearMonthDuration("-P15M"))</fos:expression>
                <fos:result>-1</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:years-from-duration(xs:dayTimeDuration("-P2DT15H"))</fos:expression>
+               <fos:expression>years-from-duration(xs:dayTimeDuration("-P2DT15H"))</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -6299,19 +6299,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:months-from-duration(xs:yearMonthDuration("P20Y15M"))</fos:expression>
+               <fos:expression>months-from-duration(xs:yearMonthDuration("P20Y15M"))</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:months-from-duration(xs:yearMonthDuration("-P20Y18M"))</fos:expression>
+               <fos:expression>months-from-duration(xs:yearMonthDuration("-P20Y18M"))</fos:expression>
                <fos:result>-6</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:months-from-duration(xs:dayTimeDuration("-P2DT15H0M0S"))</fos:expression>
+               <fos:expression>months-from-duration(xs:dayTimeDuration("-P2DT15H0M0S"))</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -6342,19 +6342,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:days-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
+               <fos:expression>days-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:days-from-duration(xs:dayTimeDuration("P3DT55H"))</fos:expression>
+               <fos:expression>days-from-duration(xs:dayTimeDuration("P3DT55H"))</fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:days-from-duration(xs:yearMonthDuration("P3Y5M"))</fos:expression>
+               <fos:expression>days-from-duration(xs:yearMonthDuration("P3Y5M"))</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -6385,25 +6385,25 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
+               <fos:expression>hours-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
                <fos:result>10</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-duration(xs:dayTimeDuration("P3DT12H32M12S"))</fos:expression>
+               <fos:expression>hours-from-duration(xs:dayTimeDuration("P3DT12H32M12S"))</fos:expression>
                <fos:result>12</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-duration(xs:dayTimeDuration("PT123H"))</fos:expression>
+               <fos:expression>hours-from-duration(xs:dayTimeDuration("PT123H"))</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-duration(xs:dayTimeDuration("-P3DT10H"))</fos:expression>
+               <fos:expression>hours-from-duration(xs:dayTimeDuration("-P3DT10H"))</fos:expression>
                <fos:result>-10</fos:result>
             </fos:test>
          </fos:example>
@@ -6434,13 +6434,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:minutes-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
+               <fos:expression>minutes-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:minutes-from-duration(xs:dayTimeDuration("-P5DT12H30M"))</fos:expression>
+               <fos:expression>minutes-from-duration(xs:dayTimeDuration("-P5DT12H30M"))</fos:expression>
                <fos:result>-30</fos:result>
             </fos:test>
          </fos:example>
@@ -6472,13 +6472,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:seconds-from-duration(xs:dayTimeDuration("P3DT10H12.5S"))</fos:expression>
+               <fos:expression>seconds-from-duration(xs:dayTimeDuration("P3DT10H12.5S"))</fos:expression>
                <fos:result>12.5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:seconds-from-duration(xs:dayTimeDuration("-PT256S"))</fos:expression>
+               <fos:expression>seconds-from-duration(xs:dayTimeDuration("-PT256S"))</fos:expression>
                <fos:result>-16.0</fos:result>
             </fos:test>
          </fos:example>
@@ -6866,7 +6866,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:round-half-to-even( op:divide-dayTimeDuration-by-dayTimeDuration(
+               <fos:expression>round-half-to-even( op:divide-dayTimeDuration-by-dayTimeDuration(
                   xs:dayTimeDuration("P2DT53M11S"), xs:dayTimeDuration("P1DT10H")),
                   4)</fos:expression>
                <fos:result>1.4378</fos:result>
@@ -6922,14 +6922,14 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:dateTime(xs:date("1999-12-31"),
+               <fos:expression>dateTime(xs:date("1999-12-31"),
                   xs:time("12:00:00"))</fos:expression>
                <fos:result>xs:dateTime("1999-12-31T12:00:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:dateTime(xs:date("1999-12-31"),
+               <fos:expression>dateTime(xs:date("1999-12-31"),
                   xs:time("24:00:00"))</fos:expression>
                <fos:result>xs:dateTime("1999-12-31T00:00:00")</fos:result>
                <fos:postamble>This is because <code>"24:00:00"</code> is an alternate lexical form
@@ -7564,31 +7564,31 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:year-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression>year-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
                <fos:result>1999</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:year-from-dateTime(xs:dateTime("1999-05-31T21:30:00-05:00"))</fos:expression>
+               <fos:expression>year-from-dateTime(xs:dateTime("1999-05-31T21:30:00-05:00"))</fos:expression>
                <fos:result>1999</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:year-from-dateTime(xs:dateTime("1999-12-31T19:20:00"))</fos:expression>
+               <fos:expression>year-from-dateTime(xs:dateTime("1999-12-31T19:20:00"))</fos:expression>
                <fos:result>1999</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:year-from-dateTime(xs:dateTime("1999-12-31T24:00:00"))</fos:expression>
+               <fos:expression>year-from-dateTime(xs:dateTime("1999-12-31T24:00:00"))</fos:expression>
                <fos:result>2000</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:year-from-dateTime(xs:dateTime("-0002-06-06T00:00:00"))</fos:expression>
+               <fos:expression>year-from-dateTime(xs:dateTime("-0002-06-06T00:00:00"))</fos:expression>
                <fos:result>-2</fos:result>
                <fos:postamble>The result is the same whether XSD 1.0 or 1.1 is in use, despite
                   the absence of a year 0 in the XSD 1.0 value space.</fos:postamble>
@@ -7618,19 +7618,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:month-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression>month-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:month-from-dateTime(xs:dateTime("1999-12-31T19:20:00-05:00"))</fos:expression>
+               <fos:expression>month-from-dateTime(xs:dateTime("1999-12-31T19:20:00-05:00"))</fos:expression>
                <fos:result>12</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:month-from-dateTime(fn:adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T19:20:00-05:00"),
+               <fos:expression>month-from-dateTime(adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T19:20:00-05:00"),
                   xs:dayTimeDuration("PT0S")))</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
@@ -7659,19 +7659,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:day-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression>day-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
                <fos:result>31</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:day-from-dateTime(xs:dateTime("1999-12-31T20:00:00-05:00"))</fos:expression>
+               <fos:expression>day-from-dateTime(xs:dateTime("1999-12-31T20:00:00-05:00"))</fos:expression>
                <fos:result>31</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:day-from-dateTime(fn:adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T19:20:00-05:00"),
+               <fos:expression>day-from-dateTime(adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T19:20:00-05:00"),
                   xs:dayTimeDuration("PT0S")))</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
@@ -7700,32 +7700,32 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-dateTime(xs:dateTime("1999-05-31T08:20:00-05:00"))</fos:expression>
+               <fos:expression>hours-from-dateTime(xs:dateTime("1999-05-31T08:20:00-05:00"))</fos:expression>
                <fos:result>8</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-dateTime(xs:dateTime("1999-12-31T21:20:00-05:00"))</fos:expression>
+               <fos:expression>hours-from-dateTime(xs:dateTime("1999-12-31T21:20:00-05:00"))</fos:expression>
                <fos:result>21</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-dateTime(fn:adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T21:20:00-05:00"),
+               <fos:expression>hours-from-dateTime(adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T21:20:00-05:00"),
                   xs:dayTimeDuration("PT0S")))</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-dateTime(xs:dateTime("1999-12-31T12:00:00"))</fos:expression>
+               <fos:expression>hours-from-dateTime(xs:dateTime("1999-12-31T12:00:00"))</fos:expression>
                <fos:result>12</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-dateTime(xs:dateTime("1999-12-31T24:00:00"))</fos:expression>
+               <fos:expression>hours-from-dateTime(xs:dateTime("1999-12-31T24:00:00"))</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -7754,13 +7754,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:minutes-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression>minutes-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
                <fos:result>20</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:minutes-from-dateTime(xs:dateTime("1999-05-31T13:30:00+05:30"))</fos:expression>
+               <fos:expression>minutes-from-dateTime(xs:dateTime("1999-05-31T13:30:00+05:30"))</fos:expression>
                <fos:result>30</fos:result>
             </fos:test>
          </fos:example>
@@ -7789,7 +7789,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:seconds-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression>seconds-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -7820,19 +7820,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:timezone-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression>timezone-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
                <fos:result>xs:dayTimeDuration("-PT5H")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:timezone-from-dateTime(xs:dateTime("2000-06-12T13:20:00Z"))</fos:expression>
+               <fos:expression>timezone-from-dateTime(xs:dateTime("2000-06-12T13:20:00Z"))</fos:expression>
                <fos:result>xs:dayTimeDuration("PT0S")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:timezone-from-dateTime(xs:dateTime("2004-08-27T00:00:00"))</fos:expression>
+               <fos:expression>timezone-from-dateTime(xs:dateTime("2004-08-27T00:00:00"))</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -7865,19 +7865,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:year-from-date(xs:date("1999-05-31"))</fos:expression>
+               <fos:expression>year-from-date(xs:date("1999-05-31"))</fos:expression>
                <fos:result>1999</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:year-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
+               <fos:expression>year-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
                <fos:result>2000</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:year-from-date(xs:date("-0002-06-01"))</fos:expression>
+               <fos:expression>year-from-date(xs:date("-0002-06-01"))</fos:expression>
                <fos:result>-2</fos:result>
                <fos:postamble>The result is the same whether XSD 1.0 or 1.1 is in use, despite
                the absence of a year 0 in the XSD 1.0 value space.</fos:postamble>
@@ -7908,13 +7908,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:month-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
+               <fos:expression>month-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:month-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
+               <fos:expression>month-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -7943,13 +7943,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:day-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
+               <fos:expression>day-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
                <fos:result>31</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:day-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
+               <fos:expression>day-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -7980,13 +7980,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:timezone-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
+               <fos:expression>timezone-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
                <fos:result>xs:dayTimeDuration("-PT5H")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:timezone-from-date(xs:date("2000-06-12Z"))</fos:expression>
+               <fos:expression>timezone-from-date(xs:date("2000-06-12Z"))</fos:expression>
                <fos:result>xs:dayTimeDuration("PT0S")</fos:result>
             </fos:test>
          </fos:example>
@@ -8019,32 +8019,32 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-time(xs:time("11:23:00"))</fos:expression>
+               <fos:expression>hours-from-time(xs:time("11:23:00"))</fos:expression>
                <fos:result>11</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-time(xs:time("21:23:00"))</fos:expression>
+               <fos:expression>hours-from-time(xs:time("21:23:00"))</fos:expression>
                <fos:result>21</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-time(xs:time("01:23:00+05:00"))</fos:expression>
+               <fos:expression>hours-from-time(xs:time("01:23:00+05:00"))</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-time(fn:adjust-time-to-timezone(xs:time("01:23:00+05:00"),
+               <fos:expression>hours-from-time(adjust-time-to-timezone(xs:time("01:23:00+05:00"),
                   xs:dayTimeDuration("PT0S")))</fos:expression>
                <fos:result>20</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:hours-from-time(xs:time("24:00:00"))</fos:expression>
+               <fos:expression>hours-from-time(xs:time("24:00:00"))</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -8073,7 +8073,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:minutes-from-time(xs:time("13:00:00Z"))</fos:expression>
+               <fos:expression>minutes-from-time(xs:time("13:00:00Z"))</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -8102,7 +8102,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:seconds-from-time(xs:time("13:20:10.5"))</fos:expression>
+               <fos:expression>seconds-from-time(xs:time("13:20:10.5"))</fos:expression>
                <fos:result>10.5</fos:result>
             </fos:test>
          </fos:example>
@@ -8133,13 +8133,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:timezone-from-time(xs:time("13:20:00-05:00"))</fos:expression>
+               <fos:expression>timezone-from-time(xs:time("13:20:00-05:00"))</fos:expression>
                <fos:result>xs:dayTimeDuration("-PT5H")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:timezone-from-time(xs:time("13:20:00"))</fos:expression>
+               <fos:expression>timezone-from-time(xs:time("13:20:00"))</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -8200,54 +8200,54 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             select="xs:dayTimeDuration(&quot;-PT10H&quot;)"/>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>fn:adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'))</fos:expression>
+               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'))</fos:expression>
                <fos:result>xs:dateTime('2002-03-07T10:00:00-05:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-dateTime-to-timezone-tz10">
-               <fos:expression>fn:adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'))</fos:expression>
+               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'))</fos:expression>
                <fos:result>xs:dateTime('2002-03-07T12:00:00-05:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-dateTime-to-timezone-tz10">
-               <fos:expression>fn:adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'),
+               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'),
                   $tz-10)</fos:expression>
                <fos:result>xs:dateTime('2002-03-07T10:00:00-10:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-dateTime-to-timezone-tz10">
-               <fos:expression>fn:adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
+               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
                   $tz-10)</fos:expression>
                <fos:result>xs:dateTime('2002-03-07T07:00:00-10:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
+               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
                   xs:dayTimeDuration("PT10H"))</fos:expression>
                <fos:result>xs:dateTime('2002-03-08T03:00:00+10:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T00:00:00+01:00'),
+               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T00:00:00+01:00'),
                   xs:dayTimeDuration("-PT8H"))</fos:expression>
                <fos:result>xs:dateTime('2002-03-06T15:00:00-08:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'),
+               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'),
                   ())</fos:expression>
                <fos:result>xs:dateTime('2002-03-07T10:00:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
+               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
                   ())</fos:expression>
                <fos:result>xs:dateTime('2002-03-07T10:00:00')</fos:result>
             </fos:test>
@@ -8321,13 +8321,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             select="xs:dayTimeDuration(&quot;-PT10H&quot;)"/>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>fn:adjust-date-to-timezone(xs:date("2002-03-07"))</fos:expression>
+               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07"))</fos:expression>
                <fos:result>xs:date("2002-03-07-05:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>fn:adjust-date-to-timezone(xs:date("2002-03-07-07:00"))</fos:expression>
+               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07-07:00"))</fos:expression>
                <fos:result>xs:date("2002-03-07-05:00")</fos:result>
                <fos:postamble><code>$value</code> is converted to
                      <code>xs:dateTime("2002-03-07T00:00:00-07:00")</code>. This is adjusted to the
@@ -8337,14 +8337,14 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-date-to-timezone-tz10">
-               <fos:expression>fn:adjust-date-to-timezone(xs:date("2002-03-07"),
+               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07"),
                   $tz-10)</fos:expression>
                <fos:result>xs:date("2002-03-07-10:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-date-to-timezone-tz10">
-               <fos:expression>fn:adjust-date-to-timezone(xs:date("2002-03-07-07:00"),
+               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07-07:00"),
                   $tz-10)</fos:expression>
                <fos:result>xs:date("2002-03-06-10:00")</fos:result>
                <fos:postamble><code>$value</code> is converted to the <code>xs:dateTime
@@ -8354,14 +8354,14 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-date-to-timezone(xs:date("2002-03-07"),
+               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07"),
                   ())</fos:expression>
                <fos:result>xs:date("2002-03-07")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-date-to-timezone(xs:date("2002-03-07-07:00"),
+               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07-07:00"),
                   ())</fos:expression>
                <fos:result>xs:date("2002-03-07")</fos:result>
             </fos:test>
@@ -8436,46 +8436,46 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             select="xs:dayTimeDuration(&quot;-PT10H&quot;)"/>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>fn:adjust-time-to-timezone(xs:time("10:00:00"))</fos:expression>
+               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00"))</fos:expression>
                <fos:result>xs:time("10:00:00-05:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-time-to-timezone(xs:time("10:00:00-07:00"))</fos:expression>
+               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00-07:00"))</fos:expression>
                <fos:result>xs:time("12:00:00-05:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-time-to-timezone-tz10">
-               <fos:expression>fn:adjust-time-to-timezone(xs:time("10:00:00"),
+               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00"),
                   $tz-10)</fos:expression>
                <fos:result>xs:time("10:00:00-10:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-time-to-timezone-tz10">
-               <fos:expression>fn:adjust-time-to-timezone(xs:time("10:00:00-07:00"),
+               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00-07:00"),
                   $tz-10)</fos:expression>
                <fos:result>xs:time("07:00:00-10:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-time-to-timezone(xs:time("10:00:00"), ())</fos:expression>
+               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00"), ())</fos:expression>
                <fos:result>xs:time("10:00:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-time-to-timezone(xs:time("10:00:00-07:00"),
+               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00-07:00"),
                   ())</fos:expression>
                <fos:result>xs:time("10:00:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:adjust-time-to-timezone(xs:time("10:00:00-07:00"),
+               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00-07:00"),
                   xs:dayTimeDuration("PT10H"))</fos:expression>
                <fos:result>xs:time("03:00:00+10:00")</fos:result>
             </fos:test>
@@ -9514,23 +9514,23 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:parse-ietf-date("Wed, 06 Jun 1994 07:29:35 GMT")</fos:expression>
+               <fos:expression>parse-ietf-date("Wed, 06 Jun 1994 07:29:35 GMT")</fos:expression>
                <fos:result>xs:dateTime("1994-06-06T07:29:35Z")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-ietf-date("Wed, 6 Jun 94 07:29:35 GMT")</fos:expression>
+               <fos:expression>parse-ietf-date("Wed, 6 Jun 94 07:29:35 GMT")</fos:expression>
                <fos:result>xs:dateTime("1994-06-06T07:29:35Z")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-ietf-date("Wed Jun 06 11:54:45 EST 2013")</fos:expression>
+               <fos:expression>parse-ietf-date("Wed Jun 06 11:54:45 EST 2013")</fos:expression>
                <fos:result>xs:dateTime("2013-06-06T11:54:45-05:00")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-ietf-date("Sunday, 06-Nov-94 08:49:37 GMT")</fos:expression>
+               <fos:expression>parse-ietf-date("Sunday, 06-Nov-94 08:49:37 GMT")</fos:expression>
                <fos:result>xs:dateTime("1994-11-06T08:49:37Z")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:parse-ietf-date("Wed, 6 Jun 94 07:29:35 +0500")</fos:expression>
+               <fos:expression>parse-ietf-date("Wed, 6 Jun 94 07:29:35 +0500")</fos:expression>
                <fos:result>xs:dateTime("1994-06-06T07:29:35+05:00")</fos:result>
             </fos:test>
          </fos:example>
@@ -9771,11 +9771,11 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:QName("http://www.example.com/example", "person") => fn:expandedQName()</fos:expression>
+               <fos:expression>QName("http://www.example.com/example", "person") => expandedQName()</fos:expression>
                <fos:result>Q{http://www.example.com/example}person</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:QName("", "person") => fn:expandedQName()</fos:expression>
+               <fos:expression>QName("", "person") => expandedQName()</fos:expression>
                <fos:result>Q{}person</fos:result>
             </fos:test>
          </fos:example>
@@ -9863,7 +9863,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:local-name-from-QName(fn:QName("http://www.example.com/example",
+               <fos:expression>local-name-from-QName(QName("http://www.example.com/example",
                   "person"))</fos:expression>
                <fos:result>"person"</fos:result>
             </fos:test>
@@ -9894,7 +9894,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:namespace-uri-from-QName(fn:QName("http://www.example.com/example",
+               <fos:expression>namespace-uri-from-QName(QName("http://www.example.com/example",
                   "person"))</fos:expression>
                <fos:result>xs:anyURI("http://www.example.com/example")</fos:result>
             </fos:test>
@@ -9928,19 +9928,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
 </z:a>]]></fos:variable>
          <fos:example>
             <fos:test use="v-namespace-uri-for-prefix-e">
-               <fos:expression>fn:namespace-uri-for-prefix("z", $e)</fos:expression>
+               <fos:expression>namespace-uri-for-prefix("z", $e)</fos:expression>
                <fos:result>"http://example.org/two"</fos:result>
             </fos:test>
             <fos:test use="v-namespace-uri-for-prefix-e">
-               <fos:expression>fn:namespace-uri-for-prefix("", $e)</fos:expression>
+               <fos:expression>namespace-uri-for-prefix("", $e)</fos:expression>
                <fos:result>"http://example.org/one"</fos:result>
             </fos:test>
             <fos:test use="v-namespace-uri-for-prefix-e">
-               <fos:expression>fn:namespace-uri-for-prefix((), $e)</fos:expression>
+               <fos:expression>namespace-uri-for-prefix((), $e)</fos:expression>
                <fos:result>"http://example.org/one"</fos:result>
             </fos:test>
             <fos:test use="v-namespace-uri-for-prefix-e">
-               <fos:expression>fn:namespace-uri-for-prefix("xml", $e)</fos:expression>
+               <fos:expression>namespace-uri-for-prefix("xml", $e)</fos:expression>
                <fos:result>"http://www.w3.org/XML/1998/namespace"</fos:result>
             </fos:test>
 
@@ -9990,7 +9990,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
 </z:a>]]></fos:variable>
          <fos:example>
             <fos:test use="v-in-scope-namespaces-e">
-               <fos:expression>fn:in-scope-namespaces($e)</fos:expression>
+               <fos:expression>in-scope-namespaces($e)</fos:expression>
                <fos:result>map{"": "http://example.org/one", "z": "http://example.org/two",
                   "xml": "http://www.w3.org/XML/1998/namespace"}</fos:result>
             </fos:test>
@@ -10403,13 +10403,13 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test use="v-po v-item1">
-               <fos:expression>fn:number($item1/quantity)</fos:expression>
+               <fos:expression>number($item1/quantity)</fos:expression>
                <fos:result>5.0e0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-po v-item2">
-               <fos:expression>fn:number($item2/description)</fos:expression>
+               <fos:expression>number($item2/description)</fos:expression>
                <fos:result>xs:double('NaN')</fos:result>
             </fos:test>
          </fos:example>
@@ -10646,27 +10646,27 @@ Himmlische, dein Heiligtum.</p>}]]>
          </fos:variable>
          <fos:example>
             <fos:test use="v-path-e">
-               <fos:expression>fn:path($e)</fos:expression>
+               <fos:expression>path($e)</fos:expression>
                <fos:result>'/'</fos:result>
             </fos:test>
             <fos:test use="v-path-e">
-               <fos:expression>fn:path($e/*:p)</fos:expression>
+               <fos:expression>path($e/*:p)</fos:expression>
                <fos:result>'/Q{http://example.com/one}p[1]'</fos:result>
             </fos:test>
             <fos:test use="v-path-e">
-               <fos:expression>fn:path($e/*:p/@xml:lang)</fos:expression>
+               <fos:expression>path($e/*:p/@xml:lang)</fos:expression>
                <fos:result>'/Q{http://example.com/one}p[1]/@Q{http://www.w3.org/XML/1998/namespace}lang'</fos:result>
             </fos:test>
             <fos:test use="v-path-e">
-               <fos:expression>fn:path($e/*:p/@author)</fos:expression>
+               <fos:expression>path($e/*:p/@author)</fos:expression>
                <fos:result>'/Q{http://example.com/one}p[1]/@author'</fos:result>
             </fos:test>
             <fos:test use="v-path-e">
-               <fos:expression>fn:path($e/*:p/*:br[2])</fos:expression>
+               <fos:expression>path($e/*:p/*:br[2])</fos:expression>
                <fos:result>'/Q{http://example.com/one}p[1]/Q{http://example.com/one}br[2]'</fos:result>
             </fos:test>
             <fos:test use="v-path-e">
-               <fos:expression>fn:path($e//text()[starts-with(normalize-space(),
+               <fos:expression>path($e//text()[starts-with(normalize-space(),
                   'Tochter')])</fos:expression>
                <fos:result>'/Q{http://example.com/one}p[1]/text()[2]'</fos:result>
             </fos:test>
@@ -10680,15 +10680,15 @@ Himmlische, dein Heiligtum.</p>}]]>
          </fos:variable>
          <fos:example>
             <fos:test use="v-path-emp">
-               <fos:expression>fn:path($emp)</fos:expression>
+               <fos:expression>path($emp)</fos:expression>
                <fos:result>'Q{http://www.w3.org/2005/xpath-functions}root()'</fos:result>
             </fos:test>
             <fos:test use="v-path-emp">
-               <fos:expression>fn:path($emp/@xml:id)</fos:expression>
+               <fos:expression>path($emp/@xml:id)</fos:expression>
                <fos:result>'Q{http://www.w3.org/2005/xpath-functions}root()/@Q{http://www.w3.org/XML/1998/namespace}id'</fos:result>
             </fos:test>
             <fos:test use="v-path-emp">
-               <fos:expression>fn:path($emp/empnr)</fos:expression>
+               <fos:expression>path($emp/empnr)</fos:expression>
                <fos:result>'Q{http://www.w3.org/2005/xpath-functions}root()/Q{}empnr[1]'</fos:result>
             </fos:test>
          </fos:example>
@@ -10991,32 +10991,32 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:index-of((10, 20, 30, 40), 35)</fos:expression>
+               <fos:expression>index-of((10, 20, 30, 40), 35)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:index-of((10, 20, 30, 30, 20, 10), 20)</fos:expression>
+               <fos:expression>index-of((10, 20, 30, 30, 20, 10), 20)</fos:expression>
                <fos:result>(2, 5)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:index-of(("a", "sport", "and", "a", "pastime"),
+               <fos:expression>index-of(("a", "sport", "and", "a", "pastime"),
                   "a")</fos:expression>
                <fos:result>(1, 4)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:index-of(current-date(), 23)</fos:expression>
+               <fos:expression>index-of(current-date(), 23)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:index-of([1, [5, 6], [6, 7]], 6)</fos:expression>
+               <fos:expression>index-of([1, [5, 6], [6, 7]], 6)</fos:expression>
                <fos:result>(3, 4)</fos:result>
                <fos:postamble>The array is atomized to a sequence of five integers</fos:postamble>
             </fos:test>
@@ -11051,31 +11051,31 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:empty((1,2,3)[10])</fos:expression>
+               <fos:expression>empty((1,2,3)[10])</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:empty(fn:remove(("hello", "world"), 1))</fos:expression>
+               <fos:expression>empty(remove(("hello", "world"), 1))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:empty([])</fos:expression>
+               <fos:expression>empty([])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:empty(map{})</fos:expression>
+               <fos:expression>empty(map{})</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:empty("")</fos:expression>
+               <fos:expression>empty("")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -11110,31 +11110,31 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:exists(fn:remove(("hello"), 1))</fos:expression>
+               <fos:expression>exists(remove(("hello"), 1))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:exists(fn:remove(("hello", "world"), 1))</fos:expression>
+               <fos:expression>exists(remove(("hello", "world"), 1))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:exists([])</fos:expression>
+               <fos:expression>exists([])</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:exists(map{})</fos:expression>
+               <fos:expression>exists(map{})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:exists("")</fos:expression>
+               <fos:expression>exists("")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -11235,14 +11235,14 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:distinct-values((1, 2.0, 3, 2))</fos:expression>
+               <fos:expression>distinct-values((1, 2.0, 3, 2))</fos:expression>
                <fos:result allow-permutation="true">(1, 3, 2.0)</fos:result>
                <fos:postamble>The result may include either the <code>xs:integer</code> 2 or the <code>xs:decimal</code> 2.0</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:distinct-values((xs:untypedAtomic("cherry"),
+               <fos:expression>distinct-values((xs:untypedAtomic("cherry"),
                   xs:untypedAtomic("plum"), xs:untypedAtomic("plum")))</fos:expression>
                <fos:result allow-permutation="true"
                   >(xs:untypedAtomic("cherry"),
@@ -11278,25 +11278,25 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:identity(0)</fos:expression>
+               <fos:expression>identity(0)</fos:expression>
                <fos:result>(0)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:identity(1 to 10)</fos:expression>
+               <fos:expression>identity(1 to 10)</fos:expression>
                <fos:result>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:identity(/) is /</fos:expression>
+               <fos:expression>identity(/) is /</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:identity(())</fos:expression>
+               <fos:expression>identity(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -11343,31 +11343,31 @@ let $newi := $o/tool</eg>
             select="(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;)"/>
          <fos:example>
             <fos:test use="v-insert-before-abc">
-               <fos:expression>fn:insert-before($abc, 0, "z")</fos:expression>
+               <fos:expression>insert-before($abc, 0, "z")</fos:expression>
                <fos:result>("z", "a", "b", "c")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-insert-before-abc">
-               <fos:expression>fn:insert-before($abc, 1, "z")</fos:expression>
+               <fos:expression>insert-before($abc, 1, "z")</fos:expression>
                <fos:result>("z", "a", "b", "c")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-insert-before-abc">
-               <fos:expression>fn:insert-before($abc, 2, "z")</fos:expression>
+               <fos:expression>insert-before($abc, 2, "z")</fos:expression>
                <fos:result>("a", "z", "b", "c")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-insert-before-abc">
-               <fos:expression>fn:insert-before($abc, 3, "z")</fos:expression>
+               <fos:expression>insert-before($abc, 3, "z")</fos:expression>
                <fos:result>("a", "b", "z", "c")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-insert-before-abc">
-               <fos:expression>fn:insert-before($abc, 4, "z")</fos:expression>
+               <fos:expression>insert-before($abc, 4, "z")</fos:expression>
                <fos:result>("a", "b", "c", "z")</fos:result>
             </fos:test>
          </fos:example>
@@ -11405,37 +11405,37 @@ let $newi := $o/tool</eg>
             select="(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;)"/>
          <fos:example>
             <fos:test use="v-remove-abc">
-               <fos:expression>fn:remove($abc, 0)</fos:expression>
+               <fos:expression>remove($abc, 0)</fos:expression>
                <fos:result>("a", "b", "c")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-remove-abc">
-               <fos:expression>fn:remove($abc, 1)</fos:expression>
+               <fos:expression>remove($abc, 1)</fos:expression>
                <fos:result>("b", "c")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-remove-abc">
-               <fos:expression>fn:remove($abc, 6)</fos:expression>
+               <fos:expression>remove($abc, 6)</fos:expression>
                <fos:result>("a", "b", "c")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-remove-abc">
-               <fos:expression>fn:remove((), 3)</fos:expression>
+               <fos:expression>remove((), 3)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-remove-abc">
-               <fos:expression>fn:remove($abc, 2 to 3)</fos:expression>
+               <fos:expression>remove($abc, 2 to 3)</fos:expression>
                <fos:result>"a"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-remove-abc">
-               <fos:expression>fn:remove($abc, ())</fos:expression>
+               <fos:expression>remove($abc, ())</fos:expression>
                <fos:result>("a", "b", "c")</fos:result>
             </fos:test>
          </fos:example>
@@ -11468,25 +11468,25 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:head(1 to 5)</fos:expression>
+               <fos:expression>head(1 to 5)</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:head(("a", "b", "c"))</fos:expression>
+               <fos:expression>head(("a", "b", "c"))</fos:expression>
                <fos:result>"a"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:head(())</fos:expression>
+               <fos:expression>head(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:head([1,2,3])</fos:expression>
+               <fos:expression>head([1,2,3])</fos:expression>
                <fos:result>[1,2,3]</fos:result>
             </fos:test>
          </fos:example>
@@ -11517,31 +11517,31 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tail(1 to 5)</fos:expression>
+               <fos:expression>tail(1 to 5)</fos:expression>
                <fos:result>(2, 3, 4, 5)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tail(("a", "b", "c"))</fos:expression>
+               <fos:expression>tail(("a", "b", "c"))</fos:expression>
                <fos:result>("b", "c")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tail("a")</fos:expression>
+               <fos:expression>tail("a")</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tail(())</fos:expression>
+               <fos:expression>tail(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:tail([1,2,3])</fos:expression>
+               <fos:expression>tail([1,2,3])</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -11572,31 +11572,31 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:trunk(1 to 5)</fos:expression>
+               <fos:expression>trunk(1 to 5)</fos:expression>
                <fos:result>(1, 2, 3, 4)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:trunk(("a", "b", "c"))</fos:expression>
+               <fos:expression>trunk(("a", "b", "c"))</fos:expression>
                <fos:result>("a", "b")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:trunk("a")</fos:expression>
+               <fos:expression>trunk("a")</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:trunk(())</fos:expression>
+               <fos:expression>trunk(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:trunk([1,2,3])</fos:expression>
+               <fos:expression>trunk([1,2,3])</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -11639,31 +11639,31 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replicate(0, 6)</fos:expression>
+               <fos:expression>replicate(0, 6)</fos:expression>
                <fos:result>(0, 0, 0, 0, 0, 0)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replicate(("A", "B", "C"), 3)</fos:expression>
+               <fos:expression>replicate(("A", "B", "C"), 3)</fos:expression>
                <fos:result>("A", "B", "C", "A", "B", "C", "A", "B", "C")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replicate((), 5)</fos:expression>
+               <fos:expression>replicate((), 5)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replicate(("A", "B", "C"), 1)</fos:expression>
+               <fos:expression>replicate(("A", "B", "C"), 1)</fos:expression>
                <fos:result>("A", "B", "C")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replicate(("A", "B", "C"), 0)</fos:expression>
+               <fos:expression>replicate(("A", "B", "C"), 0)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>        
@@ -11700,23 +11700,23 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:intersperse(1 to 5, "|")</fos:expression>
+               <fos:expression>intersperse(1 to 5, "|")</fos:expression>
                <fos:result>(1, "|", 2, "|" , 3, "|", 4, "|", 5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:intersperse((), "|")</fos:expression>
+               <fos:expression>intersperse((), "|")</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:intersperse("A", "|")</fos:expression>
+               <fos:expression>intersperse("A", "|")</fos:expression>
                <fos:result>"A"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:intersperse(1 to 5, ())</fos:expression>
+               <fos:expression>intersperse(1 to 5, ())</fos:expression>
                <fos:result>(1, 2, 3, 4, 5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:intersperse(1 to 5, ("⅓", "⅔"))</fos:expression>
+               <fos:expression>intersperse(1 to 5, ("⅓", "⅔"))</fos:expression>
                <fos:result>(1, "⅓", "⅔", 2, "⅓", "⅔", 3, "⅓", "⅔", 4, "⅓", "⅔", 5)</fos:result>
             </fos:test>
          </fos:example>
@@ -11750,11 +11750,11 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:foot(1 to 5)</fos:expression>
+               <fos:expression>foot(1 to 5)</fos:expression>
                <fos:result>(5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:foot(())</fos:expression>
+               <fos:expression>foot(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -11792,32 +11792,32 @@ let $newi := $o/tool</eg>
             select="(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;)"/>
          <fos:example>
             <fos:test use="v-reverse-abc">
-               <fos:expression>fn:reverse($abc)</fos:expression>
+               <fos:expression>reverse($abc)</fos:expression>
                <fos:result>("c", "b", "a")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:reverse(("hello"))</fos:expression>
+               <fos:expression>reverse(("hello"))</fos:expression>
                <fos:result>("hello")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:reverse(())</fos:expression>
+               <fos:expression>reverse(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:reverse([1,2,3])</fos:expression>
+               <fos:expression>reverse([1,2,3])</fos:expression>
                <fos:result>[1,2,3]</fos:result>
                <fos:postamble>The input is a sequence containing a single item (the array)</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:reverse(([1,2,3],[4,5,6]))</fos:expression>
+               <fos:expression>reverse(([1,2,3],[4,5,6]))</fos:expression>
                <fos:result>([4,5,6],[1,2,3])</fos:result>
             </fos:test>
          </fos:example>
@@ -11885,13 +11885,13 @@ let $newi := $o/tool</eg>
             select="(&quot;item1&quot;, &quot;item2&quot;, &quot;item3&quot;, &quot;item4&quot;, &quot;item5&quot;)"/>
          <fos:example>
             <fos:test use="v-reverse-seq">
-               <fos:expression>fn:subsequence($seq, 4)</fos:expression>
+               <fos:expression>subsequence($seq, 4)</fos:expression>
                <fos:result>("item4", "item5")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-reverse-seq">
-               <fos:expression>fn:subsequence($seq, 3, 2)</fos:expression>
+               <fos:expression>subsequence($seq, 3, 2)</fos:expression>
                <fos:result>("item3", "item4")</fos:result>
             </fos:test>
          </fos:example>
@@ -11938,31 +11938,31 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:items-at(11 to 20, 4)</fos:expression>
+               <fos:expression>items-at(11 to 20, 4)</fos:expression>
                <fos:result>14</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-at(11 to 20, 4 to 6)</fos:expression>
+               <fos:expression>items-at(11 to 20, 4 to 6)</fos:expression>
                <fos:result>14, 15, 16</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-at(11 to 20, (7, 3))</fos:expression>
+               <fos:expression>items-at(11 to 20, (7, 3))</fos:expression>
                <fos:result>17, 13</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-at(11 to 20, fn:index-of(("a", "b", "c"), "b"))</fos:expression>
+               <fos:expression>items-at(11 to 20, index-of(("a", "b", "c"), "b"))</fos:expression>
                <fos:result>12</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-at(fn:characters("quintessential"), (4, 8, 3))</fos:expression>
+               <fos:expression>items-at(characters("quintessential"), (4, 8, 3))</fos:expression>
                <fos:result>("n", "s", "i")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-at((), 832)</fos:expression>
+               <fos:expression>items-at((), 832)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-at((), ())</fos:expression>
+               <fos:expression>items-at((), ())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>           
          </fos:example>
@@ -12033,83 +12033,83 @@ let $newi := $o/tool</eg>
          <fos:variable name="in" id="v-slice" as="xs:string*" select="('a', 'b', 'c', 'd', 'e')"/>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:slice($in, start:2, end:4)</fos:expression>
+               <fos:expression>slice($in, start:2, end:4)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:2)</fos:expression>
+               <fos:expression>slice($in, start:2)</fos:expression>
                <fos:result>("b", "c", "d", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, end:2)</fos:expression>
+               <fos:expression>slice($in, end:2)</fos:expression>
                <fos:result>("a", "b")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:3, end:3)</fos:expression>
+               <fos:expression>slice($in, start:3, end:3)</fos:expression>
                <fos:result>("c")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:4, end:3)</fos:expression>
+               <fos:expression>slice($in, start:4, end:3)</fos:expression>
                <fos:result>("d", "c")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:2, end:5, step:2)</fos:expression>
+               <fos:expression>slice($in, start:2, end:5, step:2)</fos:expression>
                <fos:result>("b", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:5, end:2, step:-2)</fos:expression>
+               <fos:expression>slice($in, start:5, end:2, step:-2)</fos:expression>
                <fos:result>("e", "c")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:2, end:5, step:-2)</fos:expression>
+               <fos:expression>slice($in, start:2, end:5, step:-2)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:5, end:2, step:2)</fos:expression>
+               <fos:expression>slice($in, start:5, end:2, step:2)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in)</fos:expression>
+               <fos:expression>slice($in)</fos:expression>
                <fos:result>("a", "b", "c", "d", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:-1)</fos:expression>
+               <fos:expression>slice($in, start:-1)</fos:expression>
                <fos:result>("e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:-3)</fos:expression>
+               <fos:expression>slice($in, start:-3)</fos:expression>
                <fos:result>("c", "d", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, end:-2)</fos:expression>
+               <fos:expression>slice($in, end:-2)</fos:expression>
                <fos:result>("a", "b", "c", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:2, end:-2)</fos:expression>
+               <fos:expression>slice($in, start:2, end:-2)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:-2, end:2)</fos:expression>
+               <fos:expression>slice($in, start:-2, end:2)</fos:expression>
                <fos:result>("d", "c", "b")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:-4, end:-2)</fos:expression>
+               <fos:expression>slice($in, start:-4, end:-2)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:-2, end:-4)</fos:expression>
+               <fos:expression>slice($in, start:-2, end:-4)</fos:expression>
                <fos:result>("d", "c", "b")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:-4, end:-2, step:2)</fos:expression>
+               <fos:expression>slice($in, start:-4, end:-2, step:2)</fos:expression>
                <fos:result>("b", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice($in, start:-2, end:-4, step:-2)</fos:expression>
+               <fos:expression>slice($in, start:-2, end:-4, step:-2)</fos:expression>
                <fos:result>("d", "b")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:slice(("a", "b", "c", "d"), 0)</fos:expression>
+               <fos:expression>slice(("a", "b", "c", "d"), 0)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             
@@ -12152,19 +12152,19 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:range-from((), matches(?, "c"))</fos:expression>
+               <fos:expression>range-from((), matches(?, "c"))</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:range-from(("a", "b", "c", "d", "e"), matches(?, "c"))</fos:expression>
+               <fos:expression>range-from(("a", "b", "c", "d", "e"), matches(?, "c"))</fos:expression>
                <fos:result>("c", "d", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:range-from(("a", "b", "c", "d", "e"), matches(?, "c")) => fn:tail()</fos:expression>
+               <fos:expression>range-from(("a", "b", "c", "d", "e"), matches(?, "c")) => tail()</fos:expression>
                <fos:result>("d", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:range-from(("a", "b", "c", "d", "e"), matches(?, "z"))</fos:expression>
+               <fos:expression>range-from(("a", "b", "c", "d", "e"), matches(?, "z"))</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -12202,19 +12202,19 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:range-to((), matches(?, "c"))</fos:expression>
+               <fos:expression>range-to((), matches(?, "c"))</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:range-to(("a", "b", "c", "d", "e"), matches(?, "c"))</fos:expression>
+               <fos:expression>range-to(("a", "b", "c", "d", "e"), matches(?, "c"))</fos:expression>
                <fos:result>("a", "b", "c")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:range-to(("a", "b", "c", "d", "e"), matches(?, "c")) => fn:trunk()</fos:expression>
+               <fos:expression>range-to(("a", "b", "c", "d", "e"), matches(?, "c")) => trunk()</fos:expression>
                <fos:result>("a", "b")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:range-to(("a", "b", "c", "d", "e"), matches(?, "z"))</fos:expression>
+               <fos:expression>range-to(("a", "b", "c", "d", "e"), matches(?, "z"))</fos:expression>
                <fos:result>("a", "b", "c", "d", "e")</fos:result>
             </fos:test>
          </fos:example>
@@ -12261,47 +12261,47 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:starts-with-sequence((), ())</fos:expression>
+               <fos:expression>starts-with-sequence((), ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>    
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(1 to 10, 1 to 5)</fos:expression>
+               <fos:expression>starts-with-sequence(1 to 10, 1 to 5)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(1 to 10, ())</fos:expression>
+               <fos:expression>starts-with-sequence(1 to 10, ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(1 to 10, 1 to 10)</fos:expression>
+               <fos:expression>starts-with-sequence(1 to 10, 1 to 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(1 to 10, 1)</fos:expression>
+               <fos:expression>starts-with-sequence(1 to 10, 1)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(1 to 10, 101 to 105, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
+               <fos:expression>starts-with-sequence(1 to 10, 101 to 105, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(("A", "B", "C"), ("a", "b"), ->($x, $y){fn:compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
+               <fos:expression>starts-with-sequence(("A", "B", "C"), ("a", "b"), ->($x, $y){compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return fn:starts-with-sequence($p!ancestor::*, $p!parent::*, op("is"))]]></fos:expression>
+               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return starts-with-sequence($p!ancestor::*, $p!parent::*, op("is"))]]></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>       
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(10 to 20, 1 to 5, op("gt"))</fos:expression>
+               <fos:expression>starts-with-sequence(10 to 20, 1 to 5, op("gt"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(("Alpha", "Beta", "Gamma"), ("A", "B"), fn:starts-with#2)</fos:expression>
+               <fos:expression>starts-with-sequence(("Alpha", "Beta", "Gamma"), ("A", "B"), starts-with#2)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:starts-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 3, ->($x, $y){fn:ends-with($x, 'a')}</fos:expression>
+               <fos:expression>starts-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 3, ->($x, $y){ends-with($x, 'a')}</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the first three items in the input sequence end with "a".</fos:postamble>
             </fos:test>
@@ -12348,48 +12348,48 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:ends-with-sequence((), ())</fos:expression>
+               <fos:expression>ends-with-sequence((), ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>    
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(1 to 10, 5 to 10)</fos:expression>
+               <fos:expression>ends-with-sequence(1 to 10, 5 to 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(1 to 10, ())</fos:expression>
+               <fos:expression>ends-with-sequence(1 to 10, ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(1 to 10, 1 to 10)</fos:expression>
+               <fos:expression>ends-with-sequence(1 to 10, 1 to 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(1 to 10, 10)</fos:expression>
+               <fos:expression>ends-with-sequence(1 to 10, 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(1 to 10, 108 to 110, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
+               <fos:expression>ends-with-sequence(1 to 10, 108 to 110, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(("A", "B", "C"), ("b", "c"), ->($x, $y){fn:compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
+               <fos:expression>ends-with-sequence(("A", "B", "C"), ("b", "c"), ->($x, $y){compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return fn:ends-with-sequence($p!ancestor::node(), $p!root(), op("is"))</fos:expression>
+               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return ends-with-sequence($p!ancestor::node(), $p!root(), op("is"))</fos:expression>
                <fos:result>true()]]></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>       
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(10 to 20, 1 to 5, op("gt"))</fos:expression>
+               <fos:expression>ends-with-sequence(10 to 20, 1 to 5, op("gt"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(("Alpha", "Beta", "Gamma"), ("B", "G"), fn:starts-with#2)</fos:expression>
+               <fos:expression>ends-with-sequence(("Alpha", "Beta", "Gamma"), ("B", "G"), starts-with#2)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:ends-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 2, ->($x, $y){fn:string-length($x) eq 5}</fos:expression>
+               <fos:expression>ends-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 2, ->($x, $y){string-length($x) eq 5}</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the last two items in the input sequence have a string length of 5.</fos:postamble>
             </fos:test>
@@ -12440,52 +12440,52 @@ else if (fn:empty($input))
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:contains-sequence((), ())</fos:expression>
+               <fos:expression>contains-sequence((), ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>    
             <fos:test>
-               <fos:expression>fn:contains-sequence(1 to 10, 3 to 6)</fos:expression>
+               <fos:expression>contains-sequence(1 to 10, 3 to 6)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-sequence(1 to 10, (2, 4, 6))</fos:expression>
+               <fos:expression>contains-sequence(1 to 10, (2, 4, 6))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-sequence(1 to 10, ())</fos:expression>
+               <fos:expression>contains-sequence(1 to 10, ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-sequence(1 to 10, 1 to 10)</fos:expression>
+               <fos:expression>contains-sequence(1 to 10, 1 to 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-sequence(1 to 10, 5)</fos:expression>
+               <fos:expression>contains-sequence(1 to 10, 5)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-sequence(1 to 10, 103 to 105, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
+               <fos:expression>contains-sequence(1 to 10, 103 to 105, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-sequence(("A", "B", "C", "D"), ("b", "c"), ->($x, $y){fn:compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
+               <fos:expression>contains-sequence(("A", "B", "C", "D"), ("b", "c"), ->($x, $y){compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[let $chap := parse-xml("<doc><chap><h1/><p/><p/><footnote/></chap></doc>")//chap return fn:contains-sequence($chap!child::*, $chap!child::p, op("is"))]]></fos:expression>
+               <fos:expression><![CDATA[let $chap := parse-xml("<doc><chap><h1/><p/><p/><footnote/></chap></doc>")//chap return contains-sequence($chap!child::*, $chap!child::p, op("is"))]]></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the <code>p</code> children of the <code>chap</code> element form a contiguous subsequence.</fos:postamble>
             </fos:test>       
             <fos:test>
-               <fos:expression>fn:contains-sequence(10 to 20, (5, 3, 1), op("gt"))</fos:expression>
+               <fos:expression>contains-sequence(10 to 20, (5, 3, 1), op("gt"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-sequence(("Alpha", "Beta", "Gamma", "Delta"), ("B", "G"), fn:starts-with#2)</fos:expression>
+               <fos:expression>contains-sequence(("Alpha", "Beta", "Gamma", "Delta"), ("B", "G"), starts-with#2)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:contains-sequence(("Zero", "Alpha", "Beta", "Gamma", "Delta", "Epsilon"), 1 to 4, ->($x, $y){fn:ends-with($x, 'a')}</fos:expression>
+               <fos:expression>contains-sequence(("Zero", "Alpha", "Beta", "Gamma", "Delta", "Epsilon"), 1 to 4, ->($x, $y){ends-with($x, 'a')}</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because there is a run of 4 consecutive items ending in "a".</fos:postamble>
             </fos:test>
@@ -12524,7 +12524,7 @@ else if (fn:empty($input))
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:unordered((1, 2, 3, 4, 5))</fos:expression>
+               <fos:expression>unordered((1, 2, 3, 4, 5))</fos:expression>
                <fos:result allow-permutation="true">(1, 2, 3, 4, 5)</fos:result>
             </fos:test>
          </fos:example>
@@ -13204,49 +13204,49 @@ else if (fn:empty($input))
             first='Peter'/&gt; &lt;/attendees&gt;</fos:variable>
          <fos:example>
             <fos:test use="v-deep-equal-at">
-               <fos:expression>fn:deep-equal($at, $at/*)</fos:expression>
+               <fos:expression>deep-equal($at, $at/*)</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-deep-equal-at">
-               <fos:expression>fn:deep-equal($at/name[1], $at/name[2])</fos:expression>
+               <fos:expression>deep-equal($at/name[1], $at/name[2])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-deep-equal-at">
-               <fos:expression>fn:deep-equal($at/name[1], $at/name[3])</fos:expression>
+               <fos:expression>deep-equal($at/name[1], $at/name[3])</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-deep-equal-at">
-               <fos:expression>fn:deep-equal($at/name[1], 'Peter Parker')</fos:expression>
+               <fos:expression>deep-equal($at/name[1], 'Peter Parker')</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:deep-equal(map{1:'a', 2:'b'}, map{2:'b', 1:'a'})</fos:expression>
+               <fos:expression>deep-equal(map{1:'a', 2:'b'}, map{2:'b', 1:'a'})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:deep-equal([1, 2, 3], [1, 2, 3])</fos:expression>
+               <fos:expression>deep-equal([1, 2, 3], [1, 2, 3])</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:deep-equal((1, 2, 3), [1, 2, 3])</fos:expression>
+               <fos:expression>deep-equal((1, 2, 3), [1, 2, 3])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[fn:deep-equal(
+               <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<a xmlns='AA'/>"),
     parse-xml("<p:a xmlns:p='AA'/>"))]]></eg></fos:expression>
                <fos:result>true()</fos:result>
@@ -13255,7 +13255,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[fn:deep-equal(
+               <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<a xmlns='AA'/>"),
     parse-xml("<p:a xmlns:p='AA'/>"),
     options := map{'prefixes':true()})]]></eg></fos:expression>
@@ -13265,7 +13265,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[fn:deep-equal(
+               <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<a xmlns='AA'/>"),
     parse-xml("<p:a xmlns:p='AA'/>"),
     options := map{'in-scope-namespaces':true()})]]></eg></fos:expression>
@@ -13275,7 +13275,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[fn:deep-equal(
+               <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<a><b/><c/></a>"),
     parse-xml("<a><c/><b/></a>"))]]></eg></fos:expression>
                <fos:result>false()</fos:result>
@@ -13284,10 +13284,10 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[fn:deep-equal(
+               <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<a><b/><c/></a>"),
     parse-xml("<a><c/><b/></a>"),
-    options := map{'unordered-elements': fn:QName('a')})]]></eg></fos:expression>
+    options := map{'unordered-elements': QName('a')})]]></eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The <code>unordered-elements</code> option means that the ordering of the children
                of <code>a</code> is ignored.</fos:postamble>
@@ -13295,7 +13295,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[fn:deep-equal(
+               <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<para style="bold"><span>x</span></para>"),
     parse-xml("<para style=" bold"> <span>x</span></para>"))]]></eg></fos:expression>
                <fos:result>false()</fos:result>
@@ -13305,7 +13305,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[fn:deep-equal(
+               <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<para style="bold"><span>x</span></para>"),
     parse-xml("<para style=" bold"> <span>x</span></para>"),
     options := map{'normalize-space': true(), 'whitespace-text-nodes': false())]]></eg></fos:expression>
@@ -13776,37 +13776,37 @@ else if (fn:empty($input))
          <fos:variable name="seq3" id="v-count-seq3" select="()"/>
          <fos:example>
             <fos:test use="v-po v-item1 v-item2 v-count-seq1">
-               <fos:expression>fn:count($seq1)</fos:expression>
+               <fos:expression>count($seq1)</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-count-seq3">
-               <fos:expression>fn:count($seq3)</fos:expression>
+               <fos:expression>count($seq3)</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-count-seq2">
-               <fos:expression>fn:count($seq2)</fos:expression>
+               <fos:expression>count($seq2)</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-count-seq2">
-               <fos:expression>fn:count($seq2[. &gt; 100])</fos:expression>
+               <fos:expression>count($seq2[. &gt; 100])</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:count([])</fos:expression>
+               <fos:expression>count([])</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:count([1,2,3])</fos:expression>
+               <fos:expression>count([1,2,3])</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -13862,14 +13862,14 @@ else if (fn:empty($input))
          <fos:variable id="v-avg-seq3" name="seq3" select="(3, 4, 5)"/>
          <fos:example>
             <fos:test use="v-avg-seq3">
-               <fos:expression>fn:avg($seq3)</fos:expression>
+               <fos:expression>avg($seq3)</fos:expression>
                <fos:result>4.0</fos:result>
                <fos:postamble>The result is of type <code>xs:decimal</code>.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-avg-d1 v-avg-d2">
-               <fos:expression>fn:avg(($d1, $d2))</fos:expression>
+               <fos:expression>avg(($d1, $d2))</fos:expression>
                <fos:result>xs:yearMonthDuration("P10Y5M")</fos:result>
             </fos:test>
          </fos:example>
@@ -13879,19 +13879,19 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:avg(())</fos:expression>
+               <fos:expression>avg(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:avg((xs:float('INF'), xs:float('-INF')))</fos:expression>
+               <fos:expression>avg((xs:float('INF'), xs:float('-INF')))</fos:expression>
                <fos:result>xs:float('NaN')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-avg-seq3">
-               <fos:expression>fn:avg(($seq3, xs:float('NaN')))</fos:expression>
+               <fos:expression>avg(($seq3, xs:float('NaN')))</fos:expression>
                <fos:result>xs:float('NaN')</fos:result>
             </fos:test>
          </fos:example>
@@ -14008,20 +14008,20 @@ else if (fn:empty($input))
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:max((3,4,5))</fos:expression>
+               <fos:expression>max((3,4,5))</fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:max([3,4,5])</fos:expression>
+               <fos:expression>max([3,4,5])</fos:expression>
                <fos:result>5</fos:result>
                <fos:postamble>Arrays are atomized</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:max((xs:integer(5), xs:float(5.0), xs:double(0)))</fos:expression>
+               <fos:expression>max((xs:integer(5), xs:float(5.0), xs:double(0)))</fos:expression>
                <fos:result>xs:double(5.0e0)</fos:result>
             </fos:test>
          </fos:example>
@@ -14031,7 +14031,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:max((fn:current-date(), xs:date("2100-01-01")))</fos:expression>
+               <fos:expression>max((current-date(), xs:date("2100-01-01")))</fos:expression>
                <fos:result>xs:date("2100-01-01")</fos:result>
                <fos:postamble>Assuming that the current date is during the 21st
                   century.</fos:postamble>
@@ -14039,7 +14039,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:max(("a", "b", "c"))</fos:expression>
+               <fos:expression>max(("a", "b", "c"))</fos:expression>
                <fos:result>"c"</fos:result>
                <fos:postamble>Assuming a typical default collation.</fos:postamble>
             </fos:test>
@@ -14157,20 +14157,20 @@ else if (fn:empty($input))
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:min((3,4,5))</fos:expression>
+               <fos:expression>min((3,4,5))</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:min([3,4,5])</fos:expression>
+               <fos:expression>min([3,4,5])</fos:expression>
                <fos:result>3</fos:result>
                <fos:postamble>Arrays are atomized</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:min((xs:integer(5), xs:float(5), xs:double(10)))</fos:expression>
+               <fos:expression>min((xs:integer(5), xs:float(5), xs:double(10)))</fos:expression>
                <fos:result>xs:double(5.0e0)</fos:result>
             </fos:test>
          </fos:example>
@@ -14186,7 +14186,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:min((fn:current-date(), xs:date("1900-01-01")))</fos:expression>
+               <fos:expression>min((current-date(), xs:date("1900-01-01")))</fos:expression>
                <fos:result>xs:date("1900-01-01")</fos:result>
                <fos:postamble>Assuming that the current date is set to a reasonable
                   value.</fos:postamble>
@@ -14194,7 +14194,7 @@ else if (fn:empty($input))
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:min(("a", "b", "c"))</fos:expression>
+               <fos:expression>min(("a", "b", "c"))</fos:expression>
                <fos:result>"a"</fos:result>
                <fos:postamble>Assuming a typical default collation.</fos:postamble>
             </fos:test>
@@ -14275,38 +14275,38 @@ else
          <fos:variable name="seq3" id="v-sum-seq3" select="(3, 4, 5)"/>
          <fos:example>
             <fos:test use="v-sum-d1 v-sum-d2">
-               <fos:expression>fn:sum(($d1, $d2))</fos:expression>
+               <fos:expression>sum(($d1, $d2))</fos:expression>
                <fos:result>xs:yearMonthDuration("P20Y10M")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-sum-d1 v-sum-d2 v-sum-seq1">
-               <fos:expression>fn:sum($seq1[. lt xs:yearMonthDuration('P3M')],
+               <fos:expression>sum($seq1[. lt xs:yearMonthDuration('P3M')],
                   xs:yearMonthDuration('P0M'))</fos:expression>
                <fos:result>xs:yearMonthDuration("P0M")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-sum-seq3">
-               <fos:expression>fn:sum($seq3)</fos:expression>
+               <fos:expression>sum($seq3)</fos:expression>
                <fos:result>12</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:sum(())</fos:expression>
+               <fos:expression>sum(())</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:sum((),())</fos:expression>
+               <fos:expression>sum((),())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:sum((1 to 100)[. lt 0], 0) </fos:expression>
+               <fos:expression>sum((1 to 100)[. lt 0], 0) </fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -14316,7 +14316,7 @@ else
          </fos:example>
          <fos:example>
             <fos:test use="v-sum-d1 v-sum-d2">
-               <fos:expression>fn:sum(($d1, $d2), "ein Augenblick")</fos:expression>
+               <fos:expression>sum(($d1, $d2), "ein Augenblick")</fos:expression>
                <fos:result>xs:yearMonthDuration("P20Y10M")</fos:result>
                <fos:postamble>There is no requirement that the <code>$zero</code> value should be
                   the same type as the items in <code>$value</code>, or even that it should belong to
@@ -14325,14 +14325,14 @@ else
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:sum([1, 2, 3])</fos:expression>
+               <fos:expression>sum([1, 2, 3])</fos:expression>
                <fos:result>6</fos:result>
                <fos:postamble>Atomizing an array returns the sequence obtained by atomizing its members.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:sum([[1, 2], [3, 4]])</fos:expression>
+               <fos:expression>sum([[1, 2], [3, 4]])</fos:expression>
                <fos:result>10</fos:result>
                <fos:postamble>Atomizing an array returns the sequence obtained by atomizing its members.</fos:postamble>
             </fos:test>
@@ -14710,7 +14710,7 @@ else
          </fos:variable>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-element-with-id-emp">
-               <fos:expression>$emp/fn:element-with-id('ID21256')/name()</fos:expression>
+               <fos:expression>$emp/element-with-id('ID21256')/name()</fos:expression>
                <fos:result>"employee"</fos:result>
                <fos:postamble>The <code>xml:id</code> attribute has the <code>is-id</code> property,
                   so the employee element is selected.</fos:postamble>
@@ -14718,7 +14718,7 @@ else
          </fos:example>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-element-with-id-emp">
-               <fos:expression>$emp/fn:element-with-id('E21256')/name()</fos:expression>
+               <fos:expression>$emp/element-with-id('E21256')/name()</fos:expression>
                <fos:result>"employee"</fos:result>
                <fos:postamble>Assuming the <code>empnr</code> element is given the type
                      <code>xs:ID</code> as a result of schema validation, the element will have the
@@ -14872,7 +14872,7 @@ else
          </fos:variable>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-idref-emp">
-               <fos:expression>$emp/(element-with-id('ID21256')/@xml:id => fn:idref())/ancestor::employee/last => string()</fos:expression>
+               <fos:expression>$emp/(element-with-id('ID21256')/@xml:id => idref())/ancestor::employee/last => string()</fos:expression>
                <fos:result>"Brown"</fos:result>
                <fos:postamble>Assuming that <code>manager</code> has the is-idref property, the call on <code>fn:idref</code> selects
                   the <code>manager</code> element. If, instead, the <code>manager</code> had a <code>ref</code>
@@ -14881,7 +14881,7 @@ else
          </fos:example>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-idref-emp">
-               <fos:expression>$emp/(element-with-id('E30561')/empnr => fn:idref())/ancestor::employee/last => string()</fos:expression>
+               <fos:expression>$emp/(element-with-id('E30561')/empnr => idref())/ancestor::employee/last => string()</fos:expression>
                <fos:result>"Singh"</fos:result>
                <fos:postamble>Assuming that <code>employee/deputy</code> has the is-idref property, the call on <code>fn:idref</code> selects
                   the <code>deputy</code> element.</fos:postamble>
@@ -15776,7 +15776,7 @@ else
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:unparcel(fn:parcel(1 to 5))</fos:expression>
+               <fos:expression>unparcel(parcel(1 to 5))</fos:expression>
                <fos:result>(1, 2, 3 ,4, 5)</fos:result>
             </fos:test>
             <fos:test>
@@ -16410,7 +16410,7 @@ else
          </fos:example>
          <fos:example>
             <fos:test use="v-serialize-data v-serialize-params">
-               <fos:expression><![CDATA[fn:serialize($data, $params)]]></fos:expression>
+               <fos:expression><![CDATA[serialize($data, $params)]]></fos:expression>
                <fos:result><![CDATA['<a b="3"/>']]></fos:result>
             </fos:test>
          </fos:example>
@@ -16420,7 +16420,7 @@ else
          </fos:example>
          <fos:example>
             <fos:test use="v-serialize-data">
-               <fos:expression><![CDATA[fn:serialize($data, map{"method":"xml", "omit-xml-declaration":true()})]]></fos:expression>
+               <fos:expression><![CDATA[serialize($data, map{"method":"xml", "omit-xml-declaration":true()})]]></fos:expression>
                <fos:result><![CDATA['<a b="3"/>']]></fos:result>
             </fos:test>
          </fos:example>
@@ -16644,7 +16644,7 @@ else
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>(1 to 20)[fn:last() - 1]</fos:expression>
+               <fos:expression>(1 to 20)[last() - 1]</fos:expression>
                <fos:result>19</fos:result>
             </fos:test>
          </fos:example>
@@ -16942,7 +16942,7 @@ else
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:function-lookup(xs:QName('fn:substring'), 2)('abcd',
+               <fos:expression>function-lookup(xs:QName('substring'), 2)('abcd',
                   2)</fos:expression>
                <fos:result>'bcd'</fos:result>
             </fos:test>
@@ -16997,7 +16997,7 @@ returns the result of
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:function-name(fn:substring#2)</fos:expression>
+               <fos:expression>function-name(substring#2)</fos:expression>
                <fos:result>fn:QName("http://www.w3.org/2005/xpath-functions",
                   "fn:substring")</fos:result>
                <fos:postamble>The namespace prefix of the returned QName is not
@@ -17006,7 +17006,7 @@ returns the result of
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:function-name(function($node){count($node/*)})</fos:expression>
+               <fos:expression>function-name(function($node){count($node/*)})</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -17035,20 +17035,20 @@ returns the result of
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:function-arity(fn:substring#2)</fos:expression>
+               <fos:expression>function-arity(substring#2)</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:function-arity(function($node){name($node)})</fos:expression>
+               <fos:expression>function-arity(function($node){name($node)})</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>let $initial := fn:substring(?, 1, 1) return
-                  fn:function-arity($initial)</fos:expression>
+               <fos:expression>let $initial := substring(?, 1, 1) return
+                  function-arity($initial)</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -17100,20 +17100,20 @@ declare function fn:for-each($input, $action) {
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:for-each(1 to 5, function($a) { $a * $a })</fos:expression>
+               <fos:expression>for-each(1 to 5, function($a) { $a * $a })</fos:expression>
                <fos:result>(1, 4, 9, 16, 25)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:for-each(("john", "jane"),
-                  fn:string-to-codepoints#1)</fos:expression>
+               <fos:expression>for-each(("john", "jane"),
+                  string-to-codepoints#1)</fos:expression>
                <fos:result>(106, 111, 104, 110, 106, 97, 110, 101)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:for-each(("23", "29"), xs:int#1)</fos:expression>
+               <fos:expression>for-each(("23", "29"), xs:int#1)</fos:expression>
                <fos:result>(23, 29)</fos:result>
             </fos:test>
          </fos:example>
@@ -17183,13 +17183,13 @@ declare function fn:filter(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:filter(1 to 10, function($a) {$a mod 2 = 0})</fos:expression>
+               <fos:expression>filter(1 to 10, function($a) {$a mod 2 = 0})</fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:filter((), fn:lang("en", ?))</fos:expression>
+               <fos:expression>filter((), lang("en", ?))</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -17262,7 +17262,7 @@ declare function fn:fold-left(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-left(1 to 5, 0, function($a, $b) { $a + $b
+               <fos:expression>fold-left(1 to 5, 0, function($a, $b) { $a + $b
                   })</fos:expression>
                <fos:result>15</fos:result>
                <fos:postamble>This returns the sum of the items in the sequence</fos:postamble>
@@ -17270,7 +17270,7 @@ declare function fn:fold-left(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-left((2,3,5,7), 1, function($a, $b) { $a * $b
+               <fos:expression>fold-left((2,3,5,7), 1, function($a, $b) { $a * $b
                   })</fos:expression>
                <fos:result>210</fos:result>
                <fos:postamble>This returns the product of the items in the sequence</fos:postamble>
@@ -17278,7 +17278,7 @@ declare function fn:fold-left(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-left((true(), false(), false()), false(), function($a, $b) {
+               <fos:expression>fold-left((true(), false(), false()), false(), function($a, $b) {
                   $a or $b })</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>This returns true if any item in the sequence has an effective boolean
@@ -17287,7 +17287,7 @@ declare function fn:fold-left(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-left((true(), false(), false()), false(), function($a, $b) {
+               <fos:expression>fold-left((true(), false(), false()), false(), function($a, $b) {
                   $a and $b })</fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>This returns true only if every item in the sequence has an effective
@@ -17296,7 +17296,7 @@ declare function fn:fold-left(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-left(1 to 5, (), function($a, $b) {($b,
+               <fos:expression>fold-left(1 to 5, (), function($a, $b) {($b,
                   $a)})</fos:expression>
                <fos:result>(5,4,3,2,1)</fos:result>
                <fos:postamble>This reverses the order of the items in a sequence</fos:postamble>
@@ -17304,19 +17304,19 @@ declare function fn:fold-left(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-left(1 to 5, "", fn:concat(?, ".", ?))</fos:expression>
+               <fos:expression>fold-left(1 to 5, "", concat(?, ".", ?))</fos:expression>
                <fos:result>".1.2.3.4.5"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-left(1 to 5, "$zero", fn:concat("$f(", ?, ", ", ?, ")"))</fos:expression>
+               <fos:expression>fold-left(1 to 5, "$zero", concat("$f(", ?, ", ", ?, ")"))</fos:expression>
                <fos:result>"$f($f($f($f($f($zero, 1), 2), 3), 4), 5)"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-left(1 to 5, map{}, function($map, $n) {map:put($map, $n, $n*2)})</fos:expression>
+               <fos:expression>fold-left(1 to 5, map{}, function($map, $n) {map:put($map, $n, $n*2)})</fos:expression>
                <fos:result>map{1:2, 2:4, 3:6, 4:8, 5:10}</fos:result>
             </fos:test>
          </fos:example>
@@ -17394,7 +17394,7 @@ declare function fn:fold-right(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-right(1 to 5, 0, function($a, $b) { $a + $b
+               <fos:expression>fold-right(1 to 5, 0, function($a, $b) { $a + $b
                   })</fos:expression>
                <fos:result>15</fos:result>
                <fos:postamble>This returns the sum of the items in the sequence</fos:postamble>
@@ -17402,13 +17402,13 @@ declare function fn:fold-right(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-right(1 to 5, "", fn:concat(?, ".", ?))</fos:expression>
+               <fos:expression>fold-right(1 to 5, "", concat(?, ".", ?))</fos:expression>
                <fos:result>"1.2.3.4.5."</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:fold-right(1 to 5, "$zero", concat("$f(", ?, ", ", ?,
+               <fos:expression>fold-right(1 to 5, "$zero", concat("$f(", ?, ", ", ?,
                   ")"))</fos:expression>
                <fos:result>"$f(1, $f(2, $f(3, $f(4, $f(5, $zero)))))"</fos:result>
             </fos:test>
@@ -17476,32 +17476,33 @@ declare function fn:iterate-while(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><![CDATA[fn:iterate-while(2, -> { . < 100 }, -> { . * . })]]></fos:expression>
+               <fos:expression><![CDATA[iterate-while(2, -> { . < 100 }, -> { . * . })]]></fos:expression>
                <fos:result>256</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression><![CDATA[let $input := (0 to 4, 6 to 10)
-return fn:iterate-while(0, function($n) { $n = $input }, function($n) { $n + 1 })]]></fos:expression>
+return iterate-while(0, function($n) { $n = $input }, function($n) { $n + 1 })]]></fos:expression>
                <fos:result>5</fos:result>
                <fos:postamble>This returns the first positive number missing in a sequence.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg><![CDATA[fn:iterate-while(
+               <fos:expression><eg><![CDATA[iterate-while(
   1 to 9,
   function($seq) { head($seq) < 5 },
   function($seq) { tail($seq) }
 )]]></eg></fos:expression>
                <fos:result>(5, 6, 7, 8, 9)</fos:result>
+               <fos:postamble>The first number of a sequence is removed as long as it is smaller than 5.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[let $input := 3936256
-return fn:iterate-while(
+return iterate-while(
   $input,
   function($result) { abs($result * $result - $input) >= 0.0000000001 },
   function($guess) { ($guess + $input div $guess) div 2 }
@@ -17515,7 +17516,7 @@ return fn:iterate-while(
                exceeds a given limit:</p>
             <eg><![CDATA[
 let $r := random-number-generator()
-let $map := fn:iterate-while(
+let $map := iterate-while(
   $r,
   function($r) {
     $r?number < 0.8
@@ -17582,27 +17583,27 @@ declare function fn:for-each-pair($input1, $input2, $action)
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:for-each-pair(("a", "b", "c"), ("x", "y", "z"),
+               <fos:expression>for-each-pair(("a", "b", "c"), ("x", "y", "z"),
                   concat#2)</fos:expression>
                <fos:result>("ax", "by", "cz")</fos:result>
             </fos:test>
          </fos:example>
          <!--<fos:example>
             <fos:test>
-               <fos:expression><![CDATA[fn:for-each-pair(function($a, $b){<e a="{$a}" b="{$b}"/>}, (1 to 3), ("x", "y", "z"))]]></fos:expression>
+               <fos:expression><![CDATA[for-each-pair(function($a, $b){<e a="{$a}" b="{$b}"/>}, (1 to 3), ("x", "y", "z"))]]></fos:expression>
                <fos:result as="element()*"><![CDATA[(<e a="1" b="x"/>, <e a="2" b="y"/>, <e a="3" b="z"/>)]]></fos:result>
                <fos:postamble>This example uses XQuery syntax</fos:postamble>
             </fos:test>
          </fos:example>-->
          <fos:example>
             <fos:test>
-               <fos:expression>fn:for-each-pair(1 to 5, 1 to 5, function($a, $b){10*$a + $b})</fos:expression>
+               <fos:expression>for-each-pair(1 to 5, 1 to 5, function($a, $b){10*$a + $b})</fos:expression>
                <fos:result>(11, 22, 33, 44, 55)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>let $s := 1 to 8 return fn:for-each-pair($s, tail($s), function($a, $b){$a*$b})</fos:expression>
+               <fos:expression>let $s := 1 to 8 return for-each-pair($s, tail($s), function($a, $b){$a*$b})</fos:expression>
                <fos:result>(2, 6, 12, 20, 30, 42, 56)</fos:result>
             </fos:test>
          </fos:example>
@@ -17726,11 +17727,11 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:sort((1, 4, 6, 5, 3))</fos:expression>
+               <fos:expression>sort((1, 4, 6, 5, 3))</fos:expression>
                <fos:result>(1, 3, 4, 5, 6)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:sort((1, -2, 5, 10, -10, 10, 8), (), fn:abs#1)</fos:expression>
+               <fos:expression>sort((1, -2, 5, 10, -10, 10, 8), (), abs#1)</fos:expression>
                <fos:result>(1, -2, 5, 8, 10, -10, 10)</fos:result>
             </fos:test>
          </fos:example>
@@ -17787,7 +17788,7 @@ return fn:sort($in, $SWEDISH)
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:apply(fn:concat#3, ["a", "b", "c"])</fos:expression>
+               <fos:expression>apply(concat#3, ["a", "b", "c"])</fos:expression>
                <fos:result>"abc"</fos:result>
             </fos:test>
          </fos:example>
@@ -17844,13 +17845,13 @@ return fn:sort($in, $SWEDISH)
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:for-each-pair(21 to 25, 1 to 5, fn:op("+"))</fos:expression>
+               <fos:expression>for-each-pair(21 to 25, 1 to 5, op("+"))</fos:expression>
                <fos:result>22, 24, 26, 28, 30</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:for-each-pair(21 to 25, 1 to 5, fn:op("-"))</fos:expression>
+               <fos:expression>for-each-pair(21 to 25, 1 to 5, op("-"))</fos:expression>
                <fos:result>20, 20, 20, 20, 20</fos:result>
             </fos:test>
          </fos:example>
@@ -18056,35 +18057,35 @@ return fn:sort($in, $SWEDISH)
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:atomic-equal(3, 3)</fos:expression>
+               <fos:expression>atomic-equal(3, 3)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:atomic-equal(3, 3e0)</fos:expression>
+               <fos:expression>atomic-equal(3, 3e0)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:atomic-equal(xs:double('NaN'), xs:float('NaN'))</fos:expression>
+               <fos:expression>atomic-equal(xs:double('NaN'), xs:float('NaN'))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:atomic-equal("a", "a")</fos:expression>
+               <fos:expression>atomic-equal("a", "a")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:atomic-equal("a", "A")</fos:expression>
+               <fos:expression>atomic-equal("a", "A")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:atomic-equal("a", xs:untypedAtomic("a"))</fos:expression>
+               <fos:expression>atomic-equal("a", xs:untypedAtomic("a"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:atomic-equal("https://www.w3.org/", xs:anyURI("https://www.w3.org/"))</fos:expression>
+               <fos:expression>atomic-equal("https://www.w3.org/", xs:anyURI("https://www.w3.org/"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:atomic-equal(12, "12")</fos:expression>
+               <fos:expression>atomic-equal(12, "12")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -19266,11 +19267,11 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:replace(map{1:"alpha", 2:"beta"}, 1, fn:upper-case#1)</fos:expression>
+               <fos:expression>map:replace(map{1:"alpha", 2:"beta"}, 1, upper-case#1)</fos:expression>
                <fos:result>map{1:"ALPHA", 2:"beta"}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:replace(map{1:"alpha", 2:"beta"}, 3, fn:upper-case#1)</fos:expression>
+               <fos:expression>map:replace(map{1:"alpha", 2:"beta"}, 3, upper-case#1)</fos:expression>
                <fos:result>map{1:"alpha", 2:"beta" 3:""}</fos:result>
             </fos:test>
             <fos:test>
@@ -19395,7 +19396,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:build((), fn:string#1)</fos:expression>
+               <fos:expression>map:build((), string#1)</fos:expression>
                <fos:result>map{}</fos:result>
             </fos:test>
             <fos:test>
@@ -19406,20 +19407,20 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                   sequence concatenation.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:build(1 to 5, value := fn:format-integer(?, "w")})</fos:expression>
+               <fos:expression>map:build(1 to 5, value := format-integer(?, "w")})</fos:expression>
                <fos:result>map{1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}</fos:result>
                <fos:postamble>Returns a map with five entries. The function to compute the key is an identity function, the
                   function to compute the value invokes <code>fn:format-integer</code>.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>map:build(("January", "February", "March", "April", "May",
-                  "June", "July", "August", "September", "October", "November", "December"), fn:substring(?, 1, 1)})</fos:expression>
+                  "June", "July", "August", "September", "October", "November", "December"), substring(?, 1, 1)})</fos:expression>
                <fos:result>map{"A": ("April", "August"), "D": ("December"), "F": ("February"), "J": ("January", "June", "July"), 
                   "M": ("March", "May"), "N": ("November"), "O": ("October"), "S": ("September")}</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>map:build(("apple", "apricot", "banana", "blueberry", "cherry"), 
-                  fn:substring(?, 1, 1), fn:string-length#1, fn:op("+"))</fos:expression>
+                  substring(?, 1, 1), string-length#1, op("+"))</fos:expression>
                <fos:result>map{"a": 12, "b": 15, "c": 6}</fos:result>
                <fos:postamble>Constructs a map where the key is the first character of an input item, and where the corresponding value
                   is the total string-length of the items starting with that character.</fos:postamble>
@@ -20926,40 +20927,40 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:json(())</fos:expression>
+               <fos:expression>json(())</fos:expression>
                <fos:result>'null'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:json(12)</fos:expression>
+               <fos:expression>json(12)</fos:expression>
                <fos:result>'12'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:json((12, "December"))</fos:expression>
+               <fos:expression>json((12, "December"))</fos:expression>
                <fos:result>'[12,"December"]'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:json(true())</fos:expression>
+               <fos:expression>json(true())</fos:expression>
                <fos:result>'true'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:json(map{"a":1,"b":number('NaN'),"c":(1,2,3)})</fos:expression>
+               <fos:expression>json(map{"a":1,"b":number('NaN'),"c":(1,2,3)})</fos:expression>
                <fos:result>'{"a":1,"b":"NaN","c":[1,2,3]}'</fos:result>
                <fos:postamble>(or some permutation thereof)</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[fn:json(<a x="2">banana</a>)]]></fos:expression>
+               <fos:expression><![CDATA[json(<a x="2">banana</a>)]]></fos:expression>
                <fos:result>'{"#element":"a","@x":"2","#value":"banana"}'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[fn:json(<a><b/><c>2</c></a>)]]></fos:expression>
+               <fos:expression><![CDATA[json(<a><b/><c>2</c></a>)]]></fos:expression>
                <fos:result>'{"#element":"a","#content":{"b":null,"c":"2"}}'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[fn:json(<a><b/><b/><c/></a>)]]></fos:expression>
+               <fos:expression><![CDATA[json(<a><b/><b/><c/></a>)]]></fos:expression>
                <fos:result>'{"#name":"a","#content":[{"#name":"b"},{"#name":"b"},{"#name":"c}]}'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[fn:json(<a>A <i>nice</i> one!</a>)]]></fos:expression>
+               <fos:expression><![CDATA[json(<a>A <i>nice</i> one!</a>)]]></fos:expression>
                <fos:result>'{"#name":"a","#content":["A ",{"#name":"i", "#value":"nice"}," one!"]}'</fos:result>
             </fos:test>
          </fos:example>
@@ -21267,7 +21268,7 @@ else $fallback($position)</eg>
                <fos:result>["a", "bx", "c"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:replace([("a", "b"), ("c", "d")], 2, fn:reverse#1)</fos:expression>
+               <fos:expression>array:replace([("a", "b"), ("c", "d")], 2, reverse#1)</fos:expression>
                <fos:result>[("a", "b"), ("d", "c")]</fos:result>
             </fos:test>
          </fos:example>
@@ -21487,11 +21488,11 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:index-where([], fn:boolean#1)</fos:expression>
+               <fos:expression>array:index-where([], boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:index-where([0, (), 4, 9], fn:boolean#1)</fos:expression>
+               <fos:expression>array:index-where([0, (), 4, 9], boolean#1)</fos:expression>
                <fos:result>(3, 4)</fos:result>
             </fos:test>
             <fos:test>
@@ -21500,7 +21501,7 @@ else $fallback($position)</eg>
             </fos:test>
             <fos:test>
                <fos:expression>array:index-where(["January", "February", "March", "April", "May",
-                  "June", "July", "August", "September", "October", "November", "December"], fn:contains(?, "r"))</fos:expression>
+                  "June", "July", "August", "September", "October", "November", "December"], contains(?, "r"))</fos:expression>
                <fos:result>(1, 2, 3, 4, 9, 10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
@@ -21996,7 +21997,7 @@ else $fallback($position)</eg>
                <fos:result>[false(), false(), true(), true()]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:for-each(["the cat", "sat", "on the mat"], fn:tokenize#1)</fos:expression>
+               <fos:expression>array:for-each(["the cat", "sat", "on the mat"], tokenize#1)</fos:expression>
                <fos:result>[("the", "cat"), "sat", ("on", "the", "mat")]</fos:result>
             </fos:test>
             <fos:test>
@@ -22053,7 +22054,7 @@ else $fallback($position)</eg>
                <fos:result>[1, 2]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:filter(["the cat", "sat", "on the mat"], function($s){fn:count(fn:tokenize($s)) gt 1})</fos:expression>
+               <fos:expression>array:filter(["the cat", "sat", "on the mat"], function($s){count(tokenize($s)) gt 1})</fos:expression>
                <fos:result>["the cat", "on the mat"]</fos:result>
             </fos:test>
             <fos:test>
@@ -22278,7 +22279,7 @@ else array:fold-left(array:tail($array),
                <fos:result>[1, (1,2), (1,2,3), (1,2,3,4), (1,2,3,4,5)]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(("red", "green", "blue"), fn:characters#1)</fos:expression>
+               <fos:expression>array:build(("red", "green", "blue"), characters#1)</fos:expression>
                <fos:result>[("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e)]</fos:result>
             </fos:test>
             <fos:test>
@@ -22334,11 +22335,11 @@ else array:fold-left(array:tail($array),
                <fos:result>(1, 2, 3, 4, 5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:members([(1,1) (2,4), (3,9), (4,16), (5,25)])!fn:sum(?value))</fos:expression>
+               <fos:expression>array:members([(1,1) (2,4), (3,9), (4,16), (5,25)])!sum(?value))</fos:expression>
                <fos:result>(2, 6, 12, 20, 30)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:deep-equal($array, array:of(array:members($array)))</fos:expression>
+               <fos:expression>deep-equal($array, array:of(array:members($array)))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -22460,7 +22461,7 @@ else array:fold-left(array:tail($array),
                <fos:result>[1, 3, 4, 5, 6]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:sort([1, -2, 5, 10, -10, 10, 8], (), fn:abs#1)</fos:expression>
+               <fos:expression>array:sort([1, -2, 5, 10, -10, 10, 8], (), abs#1)</fos:expression>
                <fos:result>[1, -2, 5, 8, 10, -10, 10]</fos:result>
             </fos:test>
             <fos:test>
@@ -22595,7 +22596,7 @@ return array:sort($in, $SWEDISH)
          <fos:example>
             <fos:test>
                <fos:expression>array:partition(("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
-                  ->($x, $y){fn:substring($x[last()],1,1) ne fn:substring($y,1,1)})</fos:expression>
+                  ->($x, $y){substring($x[last()],1,1) ne substring($y,1,1)})</fos:expression>
                <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
             </fos:test>
             <fos:test>
@@ -23801,32 +23802,32 @@ declare function fn:all(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all(())</fos:expression>
+               <fos:expression>all(())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:all((1=1, 2=2, 3=4))</fos:expression>
+               <fos:expression>all((1=1, 2=2, 3=4))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:all((), fn:boolean#1)</fos:expression>
+               <fos:expression>all((), boolean#1)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:all((1, 3, 7), ->{. mod 2 = 1})</fos:expression>
+               <fos:expression>all((1, 3, 7), ->{. mod 2 = 1})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:all(-5 to +5, ->{. ge 0}))</fos:expression>
+               <fos:expression>all(-5 to +5, ->{. ge 0}))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:all(("January", "February", "March", "April", 
+               <fos:expression>all(("January", "February", "March", "April", 
                   "September", "October", "November", "December"), contains(?, "r"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:all(("January", "February", "March", "April", 
+               <fos:expression>all(("January", "February", "March", "April", 
                   "September", "October", "November", "December")!contains(., "r"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -23900,33 +23901,33 @@ declare function fn:all(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:char("#32")</fos:expression>
+               <fos:expression>char("#32")</fos:expression>
                <fos:result>" "</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:char("#x20")</fos:expression>
+               <fos:expression>char("#x20")</fos:expression>
                <fos:result>" "</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:char("\t")</fos:expression>
+               <fos:expression>char("\t")</fos:expression>
                <fos:result>fn:codepoints-to-string(9)</fos:result>
                <fos:postamble>The character <emph>tab</emph></fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:char("#x1D1CA")</fos:expression>
+               <fos:expression>char("#x1D1CA")</fos:expression>
                <fos:result>&#x1D1CA;</fos:result>
                <fos:postamble>The character <emph>Tempus Imperfectum Cum Prolatione Perfecta</emph></fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:char("aacute")</fos:expression>
+               <fos:expression>char("aacute")</fos:expression>
                <fos:result>&#xE1;</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:char("eth")</fos:expression>
+               <fos:expression>char("eth")</fos:expression>
                <fos:result>&#xD0;</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:char("NotEqualTilde")</fos:expression>
+               <fos:expression>char("NotEqualTilde")</fos:expression>
                <fos:result>fn:codepoints-to-string((8770, 824))</fos:result>
                <fos:postamble>This HTML5 character reference name expands to multiple codepoints.</fos:postamble>
             </fos:test>
@@ -23963,27 +23964,27 @@ declare function fn:all(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:characters("Thérèse")</fos:expression>
+               <fos:expression>characters("Thérèse")</fos:expression>
                <fos:result>("T", "h", "é", "r", "è", "s", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:characters("")</fos:expression>
+               <fos:expression>characters("")</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:characters(())</fos:expression>
+               <fos:expression>characters(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:characters("Banana") => fn:index-of("a")</fos:expression>
+               <fos:expression>characters("Banana") => index-of("a")</fos:expression>
                <fos:result>(2, 4, 6)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:characters("stretch") => fn:string-join("-")</fos:expression>
+               <fos:expression>characters("stretch") => string-join("-")</fos:expression>
                <fos:result>"s-t-r-e-t-c-h"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>"Banana" => fn:characters() => fn:reverse() => fn:string-join()</fos:expression>
+               <fos:expression>"Banana" => characters() => reverse() => string-join()</fos:expression>
                <fos:result>"ananaB"</fos:result>
             </fos:test>
          </fos:example>
@@ -24077,30 +24078,30 @@ function($item){
          <fos:variable name="e" id="v-highest-e"><![CDATA[<a x="10" y="5" z="2"/>]]></fos:variable>
          <fos:example>
             <fos:test use="v-highest-e">
-               <fos:expression>fn:highest($e/@*) ! name()</fos:expression>
+               <fos:expression>highest($e/@*) ! name()</fos:expression>
                <fos:result>("y")</fos:result>
                <fos:postamble>The attribute values are compared as strings.</fos:postamble>
             </fos:test>
             <fos:test use="v-highest-e">
-               <fos:expression>fn:highest($e/@*, (), fn:number#1) ! name()</fos:expression>
+               <fos:expression>highest($e/@*, (), number#1) ! name()</fos:expression>
                <fos:result>("x")</fos:result>
                <fos:postamble>Here the attribute values are compared as numbers.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:highest(("red", "green", "blue"), (), fn:string-length#1)</fos:expression>
+               <fos:expression>highest(("red", "green", "blue"), (), string-length#1)</fos:expression>
                <fos:result>("green")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:highest(("red", "green", "blue"), (),
+               <fos:expression>highest(("red", "green", "blue"), (),
                   map{"red": xs:hexBinary('FF0000'), "green": xs:hexBinary('008000'), "blue": xs:hexBinary('0000FF')})</fos:expression>
                <fos:result>("red")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:highest(("red", "orange", "yellow", "green", "blue", "indigo", "violet"), (), fn:string-length#1)</fos:expression>
+               <fos:expression>highest(("red", "orange", "yellow", "green", "blue", "indigo", "violet"), (), string-length#1)</fos:expression>
                <fos:result>("orange", "yellow", "indigo", "violet")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:highest(1 to 25, (), ->{. idiv 10})</fos:expression>
+               <fos:expression>highest(1 to 25, (), ->{. idiv 10})</fos:expression>
                <fos:result>(20, 21, 22, 23, 24, 25)</fos:result>
             </fos:test>
          </fos:example>
@@ -24142,20 +24143,20 @@ function($item){
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:index-where((), fn:boolean#1)</fos:expression>
+               <fos:expression>index-where((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:index-where((0, 4, 9), fn:boolean#1)</fos:expression>
+               <fos:expression>index-where((0, 4, 9), boolean#1)</fos:expression>
                <fos:result>(2, 3)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:index-where(1 to 10, ->{. mod 2 = 0}))</fos:expression>
+               <fos:expression>index-where(1 to 10, ->{. mod 2 = 0}))</fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:index-where(("January", "February", "March", "April", "May",
-                  "June", "July", "August", "September", "October", "November", "December"), fn:contains(?, "r"))</fos:expression>
+               <fos:expression>index-where(("January", "February", "March", "April", "May",
+                  "June", "July", "August", "September", "October", "November", "December"), contains(?, "r"))</fos:expression>
                <fos:result>(1, 2, 3, 4, 9, 10, 11, 12)</fos:result>
             </fos:test>
          </fos:example>
@@ -24191,19 +24192,19 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>fn:is-NaN(23)</fos:expression>
+               <fos:expression>is-NaN(23)</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:is-NaN("NaN")</fos:expression>
+               <fos:expression>is-NaN("NaN")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:is-NaN(fn:number("twenty-three"))</fos:expression>
+               <fos:expression>is-NaN(number("twenty-three"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:is-NaN(math:sqrt(-1))</fos:expression>
+               <fos:expression>is-NaN(math:sqrt(-1))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -24249,15 +24250,15 @@ function($item){
             
             <fos:example>
                <fos:test>
-                  <fos:expression>fn:item-at(10 to 20, 5)</fos:expression>
+                  <fos:expression>item-at(10 to 20, 5)</fos:expression>
                   <fos:result>14</fos:result>
                </fos:test>
                <fos:test>
-                  <fos:expression>fn:item-at(10 to 20, 12)</fos:expression>
+                  <fos:expression>item-at(10 to 20, 12)</fos:expression>
                   <fos:result>()</fos:result>
                </fos:test>
                <fos:test>
-                  <fos:expression>fn:item-at(10 to 20, 0)</fos:expression>
+                  <fos:expression>item-at(10 to 20, 0)</fos:expression>
                   <fos:result>()</fos:result>
                </fos:test>
             </fos:example>
@@ -24294,23 +24295,23 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>fn:items-after(10 to 20, ->{. gt 12})</fos:expression>
+               <fos:expression>items-after(10 to 20, ->{. gt 12})</fos:expression>
                <fos:result>(14, 15, 16, 17, 18, 19, 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-after(("January", "February", "March", "April", "May"), fn:starts-with(?, "A"))</fos:expression>
+               <fos:expression>items-after(("January", "February", "March", "April", "May"), starts-with(?, "A"))</fos:expression>
                <fos:result>("May")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-after(10 to 20, ->{. gt 100})</fos:expression>
+               <fos:expression>items-after(10 to 20, ->{. gt 100})</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-after((), fn:boolean#1)</fos:expression>
+               <fos:expression>items-after((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => fn:items-after(->{fn:boolean(self::h2)})]]></fos:expression>
+               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-after(->{boolean(self::h2)})]]></fos:expression>
                <fos:result><![CDATA[<img/>]]></fos:result>
             </fos:test>
          </fos:example>
@@ -24349,27 +24350,27 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>fn:items-before(10 to 20, ->{. gt 12})</fos:expression>
+               <fos:expression>items-before(10 to 20, ->{. gt 12})</fos:expression>
                <fos:result>(10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-before(("January", "February", "March", "April", "May"), fn:starts-with(?, "A"))</fos:expression>
+               <fos:expression>items-before(("January", "February", "March", "April", "May"), starts-with(?, "A"))</fos:expression>
                <fos:result>("January", "February", "March")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-before(10 to 20, ->{. gt 100})</fos:expression>
+               <fos:expression>items-before(10 to 20, ->{. gt 100})</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-before((), fn:boolean#1)</fos:expression>
+               <fos:expression>items-before((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => fn:items-before(->{fn:boolean(self::h2)})]]></fos:expression>
+               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-before(->{boolean(self::h2)})]]></fos:expression>
                <fos:result><![CDATA[<p/>,<p/>]]></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>("Aardvark", "Antelope", "Bison", "Buffalo", "Camel", "Dingo") => fn:items-starting-where(->{fn:starts-with("B")}) => fn:items-before(->{fn:starts-with("D")})</fos:expression>
+               <fos:expression>("Aardvark", "Antelope", "Bison", "Buffalo", "Camel", "Dingo") => items-starting-where(->{starts-with("B")}) => items-before(->{starts-with("D")})</fos:expression>
                <fos:result>"Bison", "Buffalo", "Camel"</fos:result>
             </fos:test>
          </fos:example>
@@ -24408,23 +24409,23 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>fn:items-starting-where(10 to 20, ->{. gt 12})</fos:expression>
+               <fos:expression>items-starting-where(10 to 20, ->{. gt 12})</fos:expression>
                <fos:result>(13, 14, 15, 16, 17, 18, 19, 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-starting-where(("January", "February", "March", "April", "May"), fn:starts-with(?, "A"))</fos:expression>
+               <fos:expression>items-starting-where(("January", "February", "March", "April", "May"), starts-with(?, "A"))</fos:expression>
                <fos:result>("April", "May")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-starting-where(10 to 20, ->{. gt 100})</fos:expression>
+               <fos:expression>items-starting-where(10 to 20, ->{. gt 100})</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-starting-where((), fn:boolean#1)</fos:expression>
+               <fos:expression>items-starting-where((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => fn:items-starting-where(->{fn:boolean(self::h2)})]]></fos:expression>
+               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-starting-where(->{boolean(self::h2)})]]></fos:expression>
                <fos:result><![CDATA[(<h2/>,<img/>)]]></fos:result>
             </fos:test>
          </fos:example>
@@ -24464,23 +24465,23 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>fn:items-ending-where(10 to 20, ->{. gt 12})</fos:expression>
+               <fos:expression>items-ending-where(10 to 20, ->{. gt 12})</fos:expression>
                <fos:result>(10, 11, 12, 13)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-ending-where(("January", "February", "March", "April", "May"), fn:starts-with(?, "A"))</fos:expression>
+               <fos:expression>items-ending-where(("January", "February", "March", "April", "May"), starts-with(?, "A"))</fos:expression>
                <fos:result>("January", "February", "March", "April")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-ending-where(10 to 20, ->{. gt 100})</fos:expression>
+               <fos:expression>items-ending-where(10 to 20, ->{. gt 100})</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:items-ending-where((), fn:boolean#1)</fos:expression>
+               <fos:expression>items-ending-where((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => fn:items-ending-where(->{fn:boolean(self::h2)})]]></fos:expression>
+               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-ending-where(->{boolean(self::h2)})]]></fos:expression>
                <fos:result><![CDATA[<p/>,<p/>,<h2/>]]></fos:result>
             </fos:test>
          </fos:example>
@@ -24578,30 +24579,30 @@ function($item){
          <fos:variable name="e" id="v-lowest-e"><![CDATA[<a x="10" y="5" z="2"/>]]></fos:variable>
          <fos:example>
             <fos:test use="v-lowest-e">
-               <fos:expression>fn:lowest($e/@*) ! name()</fos:expression>
+               <fos:expression>lowest($e/@*) ! name()</fos:expression>
                <fos:result>("x")</fos:result>
                <fos:postamble>The attribute values are compared as strings</fos:postamble>
             </fos:test>
             <fos:test use="v-lowest-e">
-               <fos:expression>fn:lowest($e/@*, (), fn:number#1) ! name()</fos:expression>
+               <fos:expression>lowest($e/@*, (), number#1) ! name()</fos:expression>
                <fos:result>("z")</fos:result>
                <fos:postamble>Here the attribute values are compared as numbers</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:lowest(("red", "green", "blue"), (), fn:string-length#1)</fos:expression>
+               <fos:expression>lowest(("red", "green", "blue"), (), string-length#1)</fos:expression>
                <fos:result>("red")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:lowest(("red", "green", "blue"), (),
+               <fos:expression>lowest(("red", "green", "blue"), (),
                   map{"red": xs:hexBinary('FF0000'), "green": xs:hexBinary('008000'), "blue": xs:hexBinary('0000FF')})</fos:expression>
                <fos:result>("blue")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:lowest(("April", "June", "July", "August"), (), fn:string-length#1)</fos:expression>
+               <fos:expression>lowest(("April", "June", "July", "August"), (), string-length#1)</fos:expression>
                <fos:result>("June", "July")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:lowest(1 to 25, (), ->{. idiv 10})</fos:expression>
+               <fos:expression>lowest(1 to 25, (), ->{. idiv 10})</fos:expression>
                <fos:result>(1, 2, 3, 4, 5, 6, 7, 8, 9)</fos:result>
             </fos:test>
          </fos:example>
@@ -24694,25 +24695,25 @@ function($item){
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replace-with("abracadabra", "bra", ->{"*"})</fos:expression>
+               <fos:expression>replace-with("abracadabra", "bra", ->{"*"})</fos:expression>
                <fos:result>"a*cada*"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replace-with("abracadabra", "bra", fn:upper-case#1)</fos:expression>
+               <fos:expression>replace-with("abracadabra", "bra", upper-case#1)</fos:expression>
                <fos:result>aBRAcadaBRA</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replace-with("Chapter 9", "[0-9]+", "->{string(number(.)+1)}")</fos:expression>
+               <fos:expression>replace-with("Chapter 9", "[0-9]+", "->{string(number(.)+1)}")</fos:expression>
                <fos:result>"Chapter 10"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:replace-with("LHR to LAX", "[A-Z]{3}", map{'LAX': 'Los Angeles', 'LHR': 'London'})</fos:expression>
+               <fos:expression>replace-with("LHR to LAX", "[A-Z]{3}", map{'LAX': 'Los Angeles', 'LHR': 'London'})</fos:expression>
                <fos:result>"London to Los Angeles"</fos:result>
             </fos:test>
          </fos:example>
@@ -24765,32 +24766,32 @@ declare function fn:some(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:some(())</fos:expression>
+               <fos:expression>some(())</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:some((1=1, 2=2, 3=4))</fos:expression>
+               <fos:expression>some((1=1, 2=2, 3=4))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:some((), fn:boolean#1)</fos:expression>
+               <fos:expression>some((), boolean#1)</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:some((1, 3, 7), ->{. mod 2 = 1})</fos:expression>
+               <fos:expression>some((1, 3, 7), ->{. mod 2 = 1})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:some(-5 to +5, ->{. ge 0}))</fos:expression>
+               <fos:expression>some(-5 to +5, ->{. ge 0}))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:some(("January", "February", "March", "April", 
+               <fos:expression>some(("January", "February", "March", "April", 
                   "September", "October", "November", "December"), contains(?, "z"))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fn:some(("January", "February", "March", "April", 
+               <fos:expression>some(("January", "February", "March", "April", 
                   "September", "October", "November", "December")!contains(., "r"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -24864,31 +24865,31 @@ declare function fn:some(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-equal((1,2,3))</fos:expression>
+               <fos:expression>all-equal((1,2,3))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-equal((1, 1.0, 1.0e0))</fos:expression>
+               <fos:expression>all-equal((1, 1.0, 1.0e0))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-equal("one")</fos:expression>
+               <fos:expression>all-equal("one")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-equal(())</fos:expression>
+               <fos:expression>all-equal(())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-equal(("ABC", "abc"), "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
+               <fos:expression>all-equal(("ABC", "abc"), "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -24945,31 +24946,31 @@ declare function fn:some(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-different((1,2,3))</fos:expression>
+               <fos:expression>all-different((1,2,3))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-different((1, 1.0, 1.0e0))</fos:expression>
+               <fos:expression>all-different((1, 1.0, 1.0e0))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-different("one")</fos:expression>
+               <fos:expression>all-different("one")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-different(())</fos:expression>
+               <fos:expression>all-different(())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fn:all-different(("ABC", "abc"), "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
+               <fos:expression>all-different(("ABC", "abc"), "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -25296,7 +25297,7 @@ declare function fn:some(
     <p>In the examples that follow, keys with values that are null, or an empty array,
 are elided for editorial clarity.</p>
     <fos:test>
-      <fos:expression>fn:parse-uri("http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri")</fos:expression>
+      <fos:expression>parse-uri("http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri")</fos:expression>
       <fos:result><eg>map {
   "uri": "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri",
   "scheme": "http",
@@ -25311,7 +25312,7 @@ are elided for editorial clarity.</p>
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("http://www.ietf.org/rfc/rfc2396.txt")</fos:expression>
+      <fos:expression>parse-uri("http://www.ietf.org/rfc/rfc2396.txt")</fos:expression>
       <fos:result><eg>map {
   "uri": "http://www.ietf.org/rfc/rfc2396.txt",
   "scheme": "http",
@@ -25325,7 +25326,7 @@ are elided for editorial clarity.</p>
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("https://example.com/path/to/file")</fos:expression>
+      <fos:expression>parse-uri("https://example.com/path/to/file")</fos:expression>
       <fos:result><eg>map {
   "uri": "https://example.com/path/to/file",
   "scheme": "https",
@@ -25339,7 +25340,7 @@ are elided for editorial clarity.</p>
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance")</fos:expression>
+      <fos:expression>parse-uri("https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance",
@@ -25360,7 +25361,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("https://user@example.com/path/to/file")</fos:expression>
+      <fos:expression>parse-uri("https://user@example.com/path/to/file")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "https://user@example.com/path/to/file",
@@ -25376,7 +25377,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")</fos:expression>
+      <fos:expression>parse-uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
@@ -25391,7 +25392,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("file:////uncname/path/to/file")</fos:expression>
+      <fos:expression>parse-uri("file:////uncname/path/to/file")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "file:////uncname/path/to/file",
@@ -25406,7 +25407,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("file:///c:/path/to/file")</fos:expression>
+      <fos:expression>parse-uri("file:///c:/path/to/file")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "file:///c:/path/to/file",
@@ -25419,7 +25420,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("file:/C:/Program%20Files/test.jar")</fos:expression>
+      <fos:expression>parse-uri("file:/C:/Program%20Files/test.jar")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "file:/C:/Program%20Files/test.jar",
@@ -25432,7 +25433,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("file:\\c:\path\to\file")</fos:expression>
+      <fos:expression>parse-uri("file:\\c:\path\to\file")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "file:\\c:\path\to\file",
@@ -25445,7 +25446,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("file:\c:\path\to\file")</fos:expression>
+      <fos:expression>parse-uri("file:\c:\path\to\file")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "file:\c:\path\to\file",
@@ -25458,7 +25459,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("c:\path\to\file")</fos:expression>
+      <fos:expression>parse-uri("c:\path\to\file")</fos:expression>
       <fos:result><eg>
 map {
   "uri": "c:\path\to\file",
@@ -25471,7 +25472,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("/path/to/file")</fos:expression>
+      <fos:expression>parse-uri("/path/to/file")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "/path/to/file",
@@ -25482,7 +25483,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("#testing")</fos:expression>
+      <fos:expression>parse-uri("#testing")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "#testing",
@@ -25493,7 +25494,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("?q=1")</fos:expression>
+      <fos:expression>parse-uri("?q=1")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "?q=1",
@@ -25507,7 +25508,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("ldap://[2001:db8::7]/c=GB?objectClass?one")</fos:expression>
+      <fos:expression>parse-uri("ldap://[2001:db8::7]/c=GB?objectClass?one")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "ldap://[2001:db8::7]/c=GB?objectClass?one",
@@ -25526,7 +25527,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("mailto:John.Doe@example.com")</fos:expression>
+      <fos:expression>parse-uri("mailto:John.Doe@example.com")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "mailto:John.Doe@example.com",
@@ -25539,7 +25540,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("news:comp.infosystems.www.servers.unix")</fos:expression>
+      <fos:expression>parse-uri("news:comp.infosystems.www.servers.unix")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "news:comp.infosystems.www.servers.unix",
@@ -25552,7 +25553,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("tel:+1-816-555-1212")</fos:expression>
+      <fos:expression>parse-uri("tel:+1-816-555-1212")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "tel:+1-816-555-1212",
@@ -25565,7 +25566,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("telnet://192.0.2.16:80/")</fos:expression>
+      <fos:expression>parse-uri("telnet://192.0.2.16:80/")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "telnet://192.0.2.16:80/",
@@ -25581,7 +25582,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")</fos:expression>
+      <fos:expression>parse-uri("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
@@ -25594,7 +25595,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("tag:textalign.net,2015:ns")</fos:expression>
+      <fos:expression>parse-uri("tag:textalign.net,2015:ns")</fos:expression>
       <fos:result>
 <eg>map {
     "uri": "tag:textalign.net,2015:ns",
@@ -25608,7 +25609,7 @@ map {
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>fn:parse-uri("tag:jan@example.com,1999-01-31:my-uri")</fos:expression>
+      <fos:expression>parse-uri("tag:jan@example.com,1999-01-31:my-uri")</fos:expression>
       <fos:result>
 <eg>map {
     "uri": "tag:jan@example.com,1999-01-31:my-uri"
@@ -25624,7 +25625,7 @@ map {
 <p>This example uses the algorithm described above, not an algorithm that is
 specifically aware of the <code>jar:</code> scheme.</p>
     <fos:test>
-      <fos:expression>fn:parse-uri("jar:file:/C:/Program%20Files/test.jar!/foo/bar")</fos:expression>
+      <fos:expression>parse-uri("jar:file:/C:/Program%20Files/test.jar!/foo/bar")</fos:expression>
       <fos:result>
 <eg>map {
   "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
@@ -25641,7 +25642,7 @@ specifically aware of the <code>jar:</code> scheme.</p>
 lexical IRIs as “unreserved characters”. The rationale for this is given in the
 description of <code>fn:resolve-uri</code>.</p>
     <fos:test>
-      <fos:expression>fn:parse-uri("http://www.example.org/Dürst")</fos:expression>
+      <fos:expression>parse-uri("http://www.example.org/Dürst")</fos:expression>
       <fos:result>
 <eg>map {
     "uri": "http://www.example.org/Dürst",
@@ -25658,7 +25659,7 @@ description of <code>fn:resolve-uri</code>.</p>
   <fos:example>
 <p>This example demonstrates a non-standard query separator.</p>
     <fos:test>
-      <fos:expression>fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
+      <fos:expression>parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
              map { "query-separator": ";" })</fos:expression>
       <fos:result>
 <eg>map {
@@ -25681,7 +25682,7 @@ description of <code>fn:resolve-uri</code>.</p>
   <fos:example>
 <p>This example uses an invalid query separator so raises an error.</p>
     <fos:test>
-      <fos:expression>fn:parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance",
+      <fos:expression>parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance",
              map { "query-separator": ";;" })</fos:expression>
       <fos:error-result error-code="FOXX0000"/>
     </fos:test>
@@ -25838,7 +25839,7 @@ description of <code>fn:resolve-uri</code>.</p>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>fn:build-uri(map {
+               <fos:expression><eg>build-uri(map {
     "scheme": "https",
     "host": "qt4cg.org",
     "port": (),

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6347,20 +6347,20 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                            <olist>
                               <item>
                                  <p>If the <code>Attr.value</code> is castable to an <code>xs:NCName</code>,
-                                    the result is <code>fn:true()</code>;</p>
+                                    the result is true;</p>
                               </item>
                               <item>
-                                 <p>Otherwise, the result is <code>fn:false()</code>;</p>
+                                 <p>Otherwise, the result is false;</p>
                               </item>
                            </olist>
                         </item>
                         <item>
-                           <p>Otherwise, the result is <code>fn:false()</code>;</p>
+                           <p>Otherwise, the result is false;</p>
                         </item>
                      </olist>
                   </item>
                   <item>
-                     <p>Otherwise, the result is <code>fn:false()</code>.</p>
+                     <p>Otherwise, the result is false.</p>
                   </item>
                </olist>
 


### PR DESCRIPTION
#471: I’ve removed the `fn:` prefixes from the function calls in the examples.

I have left pretty much all `true`/`false` strings untouched, since I’m not sure what would be the most consistent approach to clean them up. It will be better anyway to create a separate PR for that.