### PR TITLE
Update FO test generation stylesheet

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -41,6 +41,15 @@
       </fos:record>
    </fos:type>
    
+   <fos:type id="parse-html-options">
+      <fos:record extensible="true">        
+         <fos:field name="method" type="xs:string" required="false"/>
+         <fos:field name="html-version" type="union(enum('LS'), xs:decimal)" required="false"/>
+         <fos:field name="encoding" type="xs:string?" required="false"/>
+         <fos:field name="include-template-content" type="xs:boolean?" required="false"/>
+      </fos:record>
+   </fos:type>
+   
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="node-name" return-type="xs:QName?">

--- a/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
@@ -12,6 +12,9 @@
   examples are correct.
   
   It is derived from the old generate-test-stylesheet.xsl stylesheet.
+  
+  Typical invocation, in directory qtspecs/specifications/xpath-functions-40 :
+  -t -xsl:style/generate-qt3-test-set.xsl -s:src/function-catalog.xml -val -o:/Users/mike/GitHub/qt4cg/qt4tests/app/fo-spec-examples.xml
 -->
 
   <xsl:namespace-alias result-prefix="xsl" stylesheet-prefix="x"/>
@@ -19,11 +22,15 @@
 
   <xsl:output method="xml" indent="yes" saxon:double-space="test-case"
     cdata-section-elements="assert-xml"/>
+  
+  <xsl:param name="qt4tests-dir" static="yes" select="'file:/Users/mike/GitHub/qt4cg/qt4tests/'"/>
 
   <xsl:import-schema namespace="http://www.w3.org/xpath-functions/spec/namespace"
     schema-location="../src/fos.xsd"/>
+  <xsl:import-schema namespace="http://www.w3.org/2005/xpath-functions"
+    schema-location="../src/xpath-functions.xsd"/>
   <xsl:import-schema namespace="http://www.w3.org/2010/09/qt-fots-catalog"
-    schema-location="file:/Users/mike/w3c/qt3t/QT3-test-suite/catalog-schema.xsd"/>
+    _schema-location="{$qt4tests-dir}catalog-schema.xsd"/>
   
   <xsl:param name="run-by" select="'Michael Kay'"/>
 


### PR DESCRIPTION
Updates the stylesheet that generates tests from examples in the FO spec; plus supply a missing record definition in the function catalog so that it becomes ID/IDREF valid.