### PR TITLE
485: Predeclare the prefixes math, map, array, and err

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1381,6 +1381,9 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       <item role="xquery"><p>Switch expressions now allow a <code>case</code> clause to match multiple atomic values.</p></item>
       <item><p>Numeric literals can now be written in hexadecimal or binary notation; and underscores can be included
       for readability.</p></item>
+      <item role="xquery"><p>All implementations must now predeclare the namespace prefixes
+      <code>math</code>, <code>map</code>, <code>array</code>, and <code>err</code>. In XQuery 3.1 it was permitted
+        but not required to predeclare these namespaces.</p></item>
         
 
     </olist>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -296,7 +296,7 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
                   ref="FunctionDeclns"/>.)</p>
          </item>
 
-         <item role="xpath">
+         <item diff="add" at="2023-05-10">
             <p>
                <code>err = http://www.w3.org/2005/xqt-errors</code> (see <specref
                   ref="id-identifying-errors"/>).</p>
@@ -304,9 +304,9 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
       </ulist>
 
       <p role="xquery"
-            >In addition to the prefixes in the above list, this document uses the prefix <code>err</code> to represent the namespace URI <code>http://www.w3.org/2005/xqt-errors</code> (see <specref
-            ref="id-identifying-errors"
-            />). This namespace prefix is not predeclared and its use in this document is not normative. It also uses the namespace URI <code>http://www.w3.org/2012/xquery</code> for which no prefix is used in this document, which is reserved for use in this specification. It is currently used for annotations and option declarations that are defined by the XML Query Working Group.</p>
+            >This document also uses the namespace URI <code>http://www.w3.org/2012/xquery</code> 
+         for which no prefix is used in this document, which is reserved for use in this specification. 
+         It is currently used for annotations and option declarations that are defined by the XML Query Working Group.</p>
 
       <p>
          <termdef term="URI" id="dt-URI"

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -826,6 +826,26 @@ declare variable $t as geometry:triangle := geo:make-triangle(); $t</eg>
           <code>fn = http://www.w3.org/2005/xpath-functions</code>
         </p>
       </item>
+      <item diff="add" at="2023-05-10">
+        <p>
+          <code>math = http://www.w3.org/2005/xpath-functions/math</code>
+        </p>
+      </item>
+      <item diff="add" at="2023-05-10">
+        <p>
+          <code>map = http://www.w3.org/2005/xpath-functions/map</code>
+        </p>
+      </item>
+      <item diff="add" at="2023-05-10">
+        <p>
+          <code>array = http://www.w3.org/2005/xpath-functions/array</code>
+        </p>
+      </item>
+      <item diff="add" at="2023-05-10">
+        <p>
+          <code>err = http://www.w3.org/2005/xqt-errors</code>
+        </p>
+      </item>
       <item>
         <p>
           <code>local = http://www.w3.org/2005/xquery-local-functions</code> (see <specref


### PR DESCRIPTION
In 3.1 XQuery processors were allowed to predeclare these prefixes; in 4.0 they are now required to do so.