### PR TITLE
433: Allow select attribute on xsl:[non-]matching-substring

### DIFF
--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1571,6 +1571,9 @@
    </e:element-syntax>
 
    <e:element-syntax name="matching-substring">
+      <e:attribute name="select" required="no">
+         <e:data-type name="expression"/>
+      </e:attribute>
       <e:model name="sequence-constructor"/>
       <e:allowed-parents>
          <e:parent name="analyze-string"/>
@@ -1578,6 +1581,9 @@
    </e:element-syntax>
 
    <e:element-syntax name="non-matching-substring">
+      <e:attribute name="select" required="no">
+         <e:data-type name="expression"/>
+      </e:attribute>
       <e:model name="sequence-constructor"/>
       <e:allowed-parents>
          <e:parent name="analyze-string"/>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -1109,7 +1109,7 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="matching-substring" type="xsl:sequence-constructor"/>
+  <xs:element name="matching-substring" type="xsl:sequence-constructor-or-select"/>
 
   <xs:element name="merge" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1293,7 +1293,7 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="non-matching-substring" type="xsl:sequence-constructor"/>
+  <xs:element name="non-matching-substring" type="xsl:sequence-constructor-or-select"/>
   
   <xs:element name="note" 
               type="xsl:versioned-element-type" 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -14877,7 +14877,9 @@ and <code>version="1.0"</code> otherwise.</p>
                <termref def="dt-sequence-constructor"/>. These are
                mutually exclusive: if the <code>select</code> attribute is present then the
                sequence constructor must be empty, and if the sequence constructor is non-empty
-               then the <code>select</code> attribute must be absent. If the <code>select</code>
+               then the <code>select</code> attribute must be absent 
+               <phrase diff="add" at="2023-05-10"><errorref spec="XT" class="SE" code="3185"/></phrase>. 
+               If the <code>select</code>
                attribute is absent and the sequence constructor is empty, then the
                effective value is an empty sequence.</p>
             <p>When an <elcode>xsl:choose</elcode> element is processed, each of the
@@ -21127,9 +21129,13 @@ and <code>version="1.0"</code> otherwise.</p>
                other than <elcode>xsl:fallback</elcode> instructions. If there is no
                   <code>select</code> attribute and no contained <termref def="dt-sequence-constructor"/>, the result is an empty sequence.</p>
             <p>
-               <error spec="XT" type="static" class="SE" code="3185">
-                  <p>It is a <termref def="dt-static-error">static error</termref> if the
-                        <code>select</code> attribute of <elcode>xsl:sequence</elcode> is present
+               <error spec="XT" type="static" class="SE" code="3185" diff="chg" at="2023-05-10">
+                  <p>For the elements <elcode>xsl:sequence</elcode>, <elcode>xsl:on-empty</elcode>,
+                     <elcode>xsl:on-non-empty</elcode>, <elcode>xsl:when</elcode>,
+                     <elcode>xsl:otherwise</elcode>, <elcode>xsl:matching-substring</elcode>,
+                     and <elcode>xsl:non-matching-substring</elcode>,
+                     it is a <termref def="dt-static-error">static error</termref> if the
+                        <code>select</code> attribute is present
                      and the instruction has children other than <elcode>xsl:fallback</elcode>.</p>
                </error>
             </p>
@@ -24868,6 +24874,10 @@ the same group, and the-->
                   <elcode>xsl:analyze-string</elcode> instruction are ignored by an XSLT 2.0 or 3.0 processor, but allow fallback behavior to be
                defined when the stylesheet is used with an XSLT 1.0 processor operating with
                forwards-compatible behavior.</p>
+            <p diff="add" at="2023-05-10">For the <elcode>xsl:matching-substring</elcode> and
+               <elcode>xsl:non-matching-substring</elcode> elements, the <code>select</code> attribute and the contained sequence
+               constructor are mutually exclusive <errorref spec="XT" class="SE" code="3185"/>.</p>
+            
             <p>This instruction is designed to process all the non-overlapping substrings of the
                input string that match the regular expression supplied.</p>
             <p>
@@ -24921,16 +24931,18 @@ the same group, and the-->
                   <olist>
                      <item>
                         <p>If the current non-matching substring has length greater than zero,
-                           evaluate the <elcode>xsl:non-matching-substring</elcode> sequence
-                           constructor with the current non-matching substring as the context
+                           evaluate the <elcode>xsl:non-matching-substring</elcode> 
+                           <phrase diff="add" at="2023-05-10"><code>select</code> expression or </phrase>
+                           sequence constructor with the current non-matching substring as the context
                            item.</p>
                      </item>
                      <item>
                         <p>Reset the current non-matching substring to a zero-length string.</p>
                      </item>
                      <item>
-                        <p>Evaluate the <elcode>xsl:matching-substring</elcode> sequence constructor
-                           with the matching substring as the context item.</p>
+                        <p>Evaluate the <elcode>xsl:matching-substring</elcode> 
+                           <phrase diff="add" at="2023-05-10"><code>select</code> expression or </phrase>
+                           sequence constructor with the matching substring as the context item.</p>
                      </item>
                      <item>
                         <p>Do the appropriate one of the following:</p>
@@ -24965,8 +24977,9 @@ the same group, and the-->
                         <olist>
                            <item>
                               <p>If the current non-matching substring has length greater than zero,
-                                 evaluate the <elcode>xsl:non-matching-substring</elcode> sequence
-                                 constructor with the current non-matching substring as the context
+                                 evaluate the <elcode>xsl:non-matching-substring</elcode> 
+                                 <phrase diff="add" at="2023-05-10"><code>select</code> expression or </phrase>
+                                 sequence constructor with the current non-matching substring as the context
                                  item.</p>
                            </item>
                            <item>
@@ -24995,13 +25008,15 @@ the same group, and the-->
             <p>The input string is thus partitioned into a sequence of substrings, some of which
                match the regular expression, others which do not match it. Each non-matching substring will contain at least one character, but a matching
                   substring may be zero-length.  This sequence of substrings is processed
-               using the instructions within the contained
+               using the contained
                      <elcode>xsl:matching-substring</elcode> and
                      <elcode>xsl:non-matching-substring</elcode> elements. A matching
                substring is processed using the <elcode>xsl:matching-substring</elcode> element, a
                non-matching substring using the <elcode>xsl:non-matching-substring</elcode> element.
-               Each of these elements takes a <termref def="dt-sequence-constructor"/> as its
-               content. If the element is absent, the effect is the same as if it were present with
+               Each of these elements has 
+               <phrase diff="add" at="2023-05-10">either a <code>select</code> attribute or </phrase>
+               a contained <termref def="dt-sequence-constructor"/>. 
+               If the element is absent, the effect is the same as if it were present with
                empty content. In processing each substring, the contents of the substring will be
                the <termref def="dt-context-item">context item</termref> (as a value of type
                   <code>xs:string</code>); the position of the substring within the sequence of
@@ -38899,6 +38914,9 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                   and <elcode>xsl:transform</elcode>, enabling an XSLT editing tool to identify the top-level module
                   of a stylesheet, and hence the declarations of functions, templates, and global variables available
                   to a module that is being edited.</p></item>
+                  <item><p>The <elcode>xsl:matching-substring</elcode> and <elcode>xsl:non-matching-substring</elcode>
+                  elements within <elcode>xsl:analyze-string</elcode> may take a <code>select</code> attribute
+                  in place of a contained sequence constructor.</p></item>
                </olist>
             </div3>
          </div2>


### PR DESCRIPTION
Allow a `select` attribute on `xsl:[non-]matching-substring` in place of the contained sequence constructor.