### PR TITLE
Fix more examples in the FO 4.0 spec

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -9794,11 +9794,11 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test>
                <fos:expression>QName("http://www.example.com/example", "person") => expanded-QName()</fos:expression>
-               <fos:result>Q{http://www.example.com/example}person</fos:result>
+               <fos:result>"Q{http://www.example.com/example}person"</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>QName("", "person") => expanded-QName()</fos:expression>
-               <fos:result>Q{}person</fos:result>
+               <fos:result>"Q{}person"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -11312,7 +11312,7 @@ let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>parse-xml('<a/>') ! (identity(/) is /)</fos:expression>
+               <fos:expression>parse-xml('&lt;a/>') ! (identity(/) is /)</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>If the argument is a node, the function returns the identical node, not a copy</fos:postamble>
             </fos:test>
@@ -12312,7 +12312,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return starts-with-sequence($p!ancestor::*, $p!parent::*, op("is"))]]></fos:expression>
+               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return starts-with-sequence($p!reverse(ancestor::*), $p!parent::*, op("is"))]]></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>       
             <fos:test>
@@ -12324,7 +12324,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>starts-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 3, ->($x, $y){ends-with($x, 'a')}</fos:expression>
+               <fos:expression>starts-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 3, ->($x, $y){ends-with($x, 'a')})</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the first three items in the input sequence end with "a".</fos:postamble>
             </fos:test>
@@ -12399,8 +12399,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return ends-with-sequence($p!ancestor::node(), $p!root(), op("is"))</fos:expression>
-               <fos:result>true()]]></fos:expression>
+               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return ends-with-sequence($p!reverse(ancestor::node()), $p!root(), op("is"))]]></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>       
             <fos:test>
@@ -12412,7 +12411,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>ends-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 2, ->($x, $y){string-length($x) eq 5}</fos:expression>
+               <fos:expression>ends-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 2, ->($x, $y){string-length($x) eq 5})</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the last two items in the input sequence have a string length of 5.</fos:postamble>
             </fos:test>
@@ -12508,7 +12507,7 @@ else if (fn:empty($input))
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(("Zero", "Alpha", "Beta", "Gamma", "Delta", "Epsilon"), 1 to 4, ->($x, $y){ends-with($x, 'a')}</fos:expression>
+               <fos:expression>contains-sequence(("Zero", "Alpha", "Beta", "Gamma", "Delta", "Epsilon"), 1 to 4, ->($x, $y){ends-with($x, 'a')})</fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because there is a run of 4 consecutive items ending in "a".</fos:postamble>
             </fos:test>
@@ -16975,7 +16974,7 @@ else
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>function-lookup(xs:QName('substring'), 2)('abcd',
+               <fos:expression>function-lookup(xs:QName('fn:substring'), 2)('abcd',
                   2)</fos:expression>
                <fos:result>'bcd'</fos:result>
             </fos:test>
@@ -18496,7 +18495,7 @@ return fn:fold-left($MAPS, map{},
                <fos:postamble>The function <code>map:of</code> is the inverse of <code>map:pairs</code>.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:of((map:entry(0, "no"), map:entry(1, "yes")))</fos:expression>
+               <fos:expression>map:of((map{"key":0, "value":"no"}, map{"key":1, "value":"yes"}))</fos:expression>
                <fos:result>map{0:"no", 1:"yes"}</fos:result>
                <fos:postamble>Returns a map with two entries</fos:postamble>
             </fos:test>
@@ -19440,14 +19439,14 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                   sequence concatenation.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:build(1 to 5, value := format-integer(?, "w")})</fos:expression>
+               <fos:expression>map:build(1 to 5, value := format-integer(?, "w"))</fos:expression>
                <fos:result>map{1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}</fos:result>
                <fos:postamble>Returns a map with five entries. The function to compute the key is an identity function, the
                   function to compute the value invokes <code>fn:format-integer</code>.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>map:build(("January", "February", "March", "April", "May",
-                  "June", "July", "August", "September", "October", "November", "December"), substring(?, 1, 1)})</fos:expression>
+                  "June", "July", "August", "September", "October", "November", "December"), substring(?, 1, 1))</fos:expression>
                <fos:result>map{"A": ("April", "August"), "D": ("December"), "F": ("February"), "J": ("January", "June", "July"), 
                   "M": ("March", "May"), "N": ("November"), "O": ("October"), "S": ("September")}</fos:result>
             </fos:test>
@@ -19929,7 +19928,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>json-to-xml('{"x": 1, "y": [3,4,5]}')</fos:expression>
+               <fos:expression>json-to-xml('{"x": 1, "y": [3,4,5]}', map{"validate":false()})</fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
   <number key="x">1</number>
@@ -19946,7 +19945,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                   ><![CDATA[<string xmlns="http://www.w3.org/2005/xpath-functions">abcd</string>]]></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json-to-xml('{"x": "\\", "y": "\u0025"}')</fos:expression>
+               <fos:expression>json-to-xml('{"x": "\\", "y": "\u0025"}', map{"validate":false()})</fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
   <string key="x">\</string>
@@ -19955,7 +19954,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
             <fos:test>
                <fos:expression>json-to-xml('{"x": "\\", "y": "\u0025"}', map{'escape':
-                  true()})</fos:expression>
+                  true(), 'validate':false()})</fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
   <string escaped="true" key="x">\\</string>
@@ -21307,8 +21306,7 @@ else $fallback($position)</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="3.1">First introduced in 3.1.</fos:version>
-         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+         <fos:version version="4.0">First introduced in 4.0.</fos:version>
       </fos:history>
    </fos:function>
    
@@ -21529,7 +21527,7 @@ else $fallback($position)</eg>
                <fos:result>(3, 4)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:index-where(array{1 to 10}, ->{. mod 2 = 0}))</fos:expression>
+               <fos:expression>array:index-where(array{1 to 10}, ->{. mod 2 = 0})</fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
             <fos:test>
@@ -22354,7 +22352,7 @@ else array:fold-left(array:tail($array),
                <fos:result>(1, 2, 3, 4, 5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:members([(1,1) (2,4), (3,9), (4,16), (5,25)])!sum(?value)</fos:expression>
+               <fos:expression>array:members([(1,1), (2,4), (3,9), (4,16), (5,25)])!sum(?value)</fos:expression>
                <fos:result>(2, 6, 12, 20, 30)</fos:result>
             </fos:test>
             <fos:test>
@@ -22403,7 +22401,7 @@ else array:fold-left(array:tail($array),
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of(map{'value',(1 to 5)})</fos:expression>
+               <fos:expression>array:of(map{'value':(1 to 5)})</fos:expression>
                <fos:result>[(1, 2, 3, 4, 5)]</fos:result>
             </fos:test>
             <fos:test>
@@ -22412,7 +22410,7 @@ else array:fold-left(array:tail($array),
             </fos:test>
             <fos:test>
                <fos:expression>array:of((1 to 5)!map{'value':(., .*.)})</fos:expression>
-               <fos:result>[(1,1) (2,4), (3,9), (4,16), (5,25)]</fos:result>
+               <fos:result>[(1,1), (2,4), (3,9), (4,16), (5,25)]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -23977,7 +23975,7 @@ declare function fn:all(
             </fos:test>
             <fos:test>
                <fos:expression>char("eth")</fos:expression>
-               <fos:result>"&#xD0;"</fos:result>
+               <fos:result>"&#xF0;"</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>char("NotEqualTilde")</fos:expression>
@@ -24132,13 +24130,13 @@ function($item){
          <fos:example>
             <fos:test use="v-highest-e">
                <fos:expression>highest($e/@*) ! name()</fos:expression>
-               <fos:result>("y")</fos:result>
-               <fos:postamble>The attribute values are compared as strings.</fos:postamble>
+               <fos:result>("x")</fos:result>
+               <fos:postamble>By default, untyped values are compared as numbers.</fos:postamble>
             </fos:test>
             <fos:test use="v-highest-e">
-               <fos:expression>highest($e/@*, (), number#1) ! name()</fos:expression>
-               <fos:result>("x")</fos:result>
-               <fos:postamble>Here the attribute values are compared as numbers.</fos:postamble>
+               <fos:expression>highest($e/@*, (), string#1) ! name()</fos:expression>
+               <fos:result>("y")</fos:result>
+               <fos:postamble>Here the attribute values are compared as string.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>highest(("red", "green", "blue"), (), string-length#1)</fos:expression>
@@ -24578,13 +24576,13 @@ function($item){
          <p>The third argument defaults to the function <code>data#1</code>.</p>
          
          <p>Let <code>$modified-key</code> be the function:</p>
-         <eg>
-            function($item){
-            $key($item) => fn:data() ! (
-            if (. instance of xs:untypedAtomic)
-            then xs:double(.)
-            else .)
-            }</eg>
+         <eg>function($item) {
+  $key($item) => fn:data() ! (
+                  if (. instance of xs:untypedAtomic)
+                  then xs:double(.)
+                  else .
+                 )
+}</eg>
          
          <p>That is, the supplied function for computing key values is wrapped in a function that
             converts any <code>xs:untypedAtomic</code> values in its result to <code>xs:double</code>. This makes
@@ -24633,13 +24631,13 @@ function($item){
          <fos:example>
             <fos:test use="v-lowest-e">
                <fos:expression>lowest($e/@*) ! name()</fos:expression>
-               <fos:result>("x")</fos:result>
-               <fos:postamble>The attribute values are compared as strings</fos:postamble>
+               <fos:result>("z")</fos:result>
+               <fos:postamble>By default untyped attribute values are compared as numbers</fos:postamble>
             </fos:test>
             <fos:test use="v-lowest-e">
-               <fos:expression>lowest($e/@*, (), number#1) ! name()</fos:expression>
-               <fos:result>("z")</fos:result>
-               <fos:postamble>Here the attribute values are compared as numbers</fos:postamble>
+               <fos:expression>lowest($e/@*, (), string#1) ! name()</fos:expression>
+               <fos:result>("x")</fos:result>
+               <fos:postamble>Here the attribute values are compared as strings</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>lowest(("red", "green", "blue"), (), string-length#1)</fos:expression>
@@ -24835,7 +24833,7 @@ declare function fn:some(
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some(-5 to +5, ->{. ge 0}))</fos:expression>
+               <fos:expression>some(-5 to +5, ->{. ge 0})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
@@ -25348,7 +25346,9 @@ declare function fn:some(
 <fos:examples>
   <fos:example>
     <p>In the examples that follow, keys with values that are null, or an empty array,
-are elided for editorial clarity.</p>
+are elided for editorial clarity. String literals that include an ampersand character
+    are written as string templates (for example <code>`Barnes&amp;Noble`</code>) to ensure
+    that the examples work in both XPath and XQuery.</p>
     <fos:test>
       <fos:expression>parse-uri("http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri")</fos:expression>
       <fos:result><eg>map {
@@ -25393,19 +25393,19 @@ are elided for editorial clarity.</p>
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>parse-uri("https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance")</fos:expression>
+      <fos:expression>parse-uri(`https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`)</fos:expression>
       <fos:result><eg>
 map {
-  "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance",
+  "uri": `https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`,
   "scheme": "https",
   "hierarchical": true(),
   "authority": "example.com:8080",
   "host": "example.com",
-  "port": "080",
+  "port": "8080",
   "path": "/path",
-  "query": "s=%22hello world%22&amp;sort=relevance",
+  "query": `s=%22hello world%22&amp;sort=relevance`,
   "query-segments": array {
-    map { "key": "s", "value": "&quot;&quot;hello world&quot;&quot;" },
+    map { "key": "s", "value": '"hello world"' },
     map { "key": "sort", "value": "relevance" }
   },
   "path-segments": array { "", "path" }
@@ -25898,7 +25898,7 @@ description of <code>fn:resolve-uri</code>.</p>
     "port": (),
     "path": "/specifications/index.html"
   })</eg></fos:expression>
-               <fos:result>https://qt4cg.org/specifications/index.html</fos:result>
+               <fos:result>"https://qt4cg.org/specifications/index.html"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12055,83 +12055,83 @@ let $newi := $o/tool</eg>
       <fos:examples>
          <fos:variable name="in" id="v-slice" as="xs:string*" select="('a', 'b', 'c', 'd', 'e')"/>
          <fos:example>
-            <fos:test>
-               <fos:expression>slice($in, start:2, end:4)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=2, end:=4)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=2)</fos:expression>
                <fos:result>("b", "c", "d", "e")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, end:2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, end:=2)</fos:expression>
                <fos:result>("a", "b")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:3, end:3)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=3, end:=3)</fos:expression>
                <fos:result>("c")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:4, end:3)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=4, end:=3)</fos:expression>
                <fos:result>("d", "c")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:2, end:5, step:2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=2, end:=5, step:=2)</fos:expression>
                <fos:result>("b", "d")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:5, end:2, step:-2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=5, end:=2, step:=-2)</fos:expression>
                <fos:result>("e", "c")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:2, end:5, step:-2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=2, end:=5, step:=-2)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:5, end:2, step:2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=5, end:=2, step:=2)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in)</fos:expression>
                <fos:result>("a", "b", "c", "d", "e")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:-1)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=-1)</fos:expression>
                <fos:result>("e")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:-3)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=-3)</fos:expression>
                <fos:result>("c", "d", "e")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, end:-2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, end:=-2)</fos:expression>
                <fos:result>("a", "b", "c", "d")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:2, end:-2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=2, end:=-2)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:-2, end:2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=-2, end:=2)</fos:expression>
                <fos:result>("d", "c", "b")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:-4, end:-2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=-4, end:=-2)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:-2, end:-4)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=-2, end:=-4)</fos:expression>
                <fos:result>("d", "c", "b")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:-4, end:-2, step:2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=-4, end:=-2, step:=2)</fos:expression>
                <fos:result>("b", "d")</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>slice($in, start:-2, end:-4, step:-2)</fos:expression>
+            <fos:test use="v-slice">
+               <fos:expression>slice($in, start:=-2, end:=-4, step:=-2)</fos:expression>
                <fos:result>("d", "b")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice(("a", "b", "c", "d"), 0)</fos:expression>
                <fos:result>("a", "b", "c", "d")</fos:result>
             </fos:test>
@@ -21577,83 +21577,83 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:variable name="in" id="a-slice" as="xs:string*" select="['a', 'b', 'c', 'd', 'e']"/>
          <fos:example>
-            <fos:test>
-               <fos:expression>array:slice($in, start:2, end:4)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=2, end:=4)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=2)</fos:expression>
                <fos:result>["b", "c", "d", "e"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, end:2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, end:=2)</fos:expression>
                <fos:result>["a", "b"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:3, end:3)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=3, end:=3)</fos:expression>
                <fos:result>["c"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:4, end:3)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=4, end:=3)</fos:expression>
                <fos:result>["d", "c"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:2, end:5, step:2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=2, end:=5, step:=2)</fos:expression>
                <fos:result>["b", "d"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:5, end:2, step:-2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=5, end:=2, step:=-2)</fos:expression>
                <fos:result>["e", "c"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:2, end:5, step:-2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=2, end:=5, step:=-2)</fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:5, end:2, step:2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=5, end:=2, step:=2)</fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in)</fos:expression>
                <fos:result>["a", "b", "c", "d", "e"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:-1)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=-1)</fos:expression>
                <fos:result>["e"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:-3)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=-3)</fos:expression>
                <fos:result>["c", "d", "e"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, end:-2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, end:=-2)</fos:expression>
                <fos:result>]"a", "b", "c", "d"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:2, end:-2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=2, end:=-2)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:-2, end:2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=-2, end:=2)</fos:expression>
                <fos:result>["d", "c", "b"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:-4, end:-2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=-4, end:=-2)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:-2, end:-4)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=-2, end:=-4)</fos:expression>
                <fos:result>["d", "c", "b"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:-4, end:-2, step:2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=-4, end:=-2, step:=2)</fos:expression>
                <fos:result>["b", "d"]</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression>array:slice($in, start:-2, end:-4, step:-2)</fos:expression>
+            <fos:test use="a-slice">
+               <fos:expression>array:slice($in, start:=-2, end:=-4, step:=-2)</fos:expression>
                <fos:result>["d", "b"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice(["a", "b", "c", "d"], 0)</fos:expression>
                <fos:result>["a", "b", "c", "d"]</fos:result>
             </fos:test>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21627,7 +21627,7 @@ else $fallback($position)</eg>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, end:=-2)</fos:expression>
-               <fos:result>]"a", "b", "c", "d"]</fos:result>
+               <fos:result>["a", "b", "c", "d"]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start:=2, end:=-2)</fos:expression>

--- a/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
@@ -139,6 +139,8 @@
 
   
   <xsl:mode name="strip-space" on-no-match="shallow-copy"/>
+  <xsl:template match="@escaped-key[. = false()]" mode="strip-space"/>
+  <xsl:template match="@escaped[. = false()]" mode="strip-space"/>
   <xsl:template match="text()[not(normalize-space())][not(parent::fn:match)][not(parent::fn:non-match)]" mode="strip-space"/>
 
 


### PR DESCRIPTION
Further corrections to example code in the F+O specification, found by testing (app-spec-examples in the test suite).