### PR TITLE
Fix examples, change filepath definition slightly

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23007,7 +23007,7 @@ return array:sort($in, $SWEDISH)
                            <code>stylesheet-base-uri</code>
                         </sitem>
                         <sitem><code>stylesheet-params</code> (defaults to an empty map)</sitem>
-                        <sitem><code>initial-mode</code> (defaults to the stylesheet’s default mode)</sitem>
+                        <sitem><code>initial-mode</code> (defaults to the stylesheet's default mode)</sitem>
                         <sitem><code>delivery-format</code> (defaults to <code>document</code>)</sitem>
                         <sitem><code>serialization-params</code> (defaults to an empty map)</sitem>
                         <sitem><code>enable-messages</code> (default is implementation-defined)</sitem>
@@ -23046,7 +23046,7 @@ return array:sort($in, $SWEDISH)
                            <p>
                               <code>source-node</code>
                            </p>
-                           <p>Optionally, <code>initial-mode</code> (defaults to the stylesheet’s default mode)</p>
+                           <p>Optionally, <code>initial-mode</code> (defaults to the stylesheet's default mode)</p>
                         </item>
                         <item>
                            <p>For call-template invocation, all of the following:</p>
@@ -25114,8 +25114,8 @@ declare function fn:some(
 
          <p>Processing begins with a <emph>string</emph> that is equal
          to the <code>$uri</code>. If the <emph>string</emph> contains
-         any backlashes (“<code>\</code>”), replace them with forward
-         slashes (“<code>/</code>”).</p>
+         any backlashes ("<code>\</code>"), replace them with forward
+         slashes ("<code>/</code>").</p>
 
          <p>If the <emph>string</emph> matches <code>^(.*)#([^#]*)$</code>,
          the <emph>string</emph> is the first match group and the
@@ -25134,9 +25134,9 @@ declare function fn:some(
                <p>If the <emph>string</emph> matches <code>^[a-zA-Z][:|].*$</code>:</p>
          <ulist>
             <item><p>the <emph>scheme</emph> is <code>file</code>;</p></item>
-            <item><p>if the second character in the <emph>string</emph> is “|”, it is changed to “:”;</p></item>
+            <item><p>if the second character in the <emph>string</emph> is "|", it is changed to ":";</p></item>
             <item><p>the <emph>filepath</emph> is the <emph>string</emph>; and</p></item>
-            <item><p>a leading slash (“/”) is added to the <emph>string</emph>.</p></item>
+            <item><p>a leading slash ("/") is added to the <emph>string</emph>.</p></item>
          </ulist></item>
          <item>
             <p>Otherwise, if the <emph>string</emph> matches
@@ -25172,7 +25172,7 @@ declare function fn:some(
          <emph>string</emph>. If the <emph>string</emph> is the empty string,
          <emph>hierarchical</emph> is the empty sequence (<emph>i.e.</emph> not known),
          otherwise <emph>hierarchical</emph> is
-         true if <emph>string</emph> begins with “/” and false otherwise.</p>
+         true if <emph>string</emph> begins with "/" and false otherwise.</p>
 
          <p>If the <emph>string</emph> matches <code>^//*([a-zA-Z]:.*)$</code>,
          the <emph>authority</emph> is empty and the <emph>string</emph> is
@@ -25224,7 +25224,7 @@ declare function fn:some(
             </item>
          </olist>
 
-         <p>This function doesn’t attempt to decode the components of the
+         <p>This function doesn't attempt to decode the components of the
          <emph>host</emph>.</p>
 
          <p>Similar care must be taken to match the port because an IPv6/IPvFuture
@@ -25248,7 +25248,7 @@ declare function fn:some(
             </item>
          </olist>
 
-         <p>If the “<code>omit-default-ports</code>” option is true then the port
+         <p>If the "<code>omit-default-ports</code>" option is true then the port
          is discarded and set to the empty sequence if the port number is the same
          as the default port for the given scheme. Implementations <rfc2119>should</rfc2119>
          recognize the default ports for <code>http</code> (80), <code>https</code> (443),
@@ -25264,30 +25264,30 @@ declare function fn:some(
          the empty sequence, <emph>filepath</emph> is also the whole <emph>string</emph>.</p>
 
          <p>The <emph>path separator</emph> is the value of the
-         “<code>path-separator</code>” option. A
+         "<code>path-separator</code>" option. A
          <emph>path-segments</emph> array is constructed as follows:
          tokenize the <emph>string</emph> on the <emph>path
          separator</emph>, apply <emph>uri decoding</emph> on each
          token, and convert the result to an array.</p>
 
          <p>Applying <emph>uri decoding</emph> replaces all occurrences of
-         plus (“<code>+</code>”) with spaces and all occurrences of
+         plus ("<code>+</code>") with spaces and all occurrences of
          <code>%[a-fA-F0-9][a-fA-F0-9]</code> with a single character with the
          codepoint represented by the two digit hexadecimal number that
-         follows the “<code>%</code>”. In other words, “<code>A%42C</code>” becomes
-         “<code>ABC</code>”. If there are any occurrences of <code>%</code> followed
+         follows the "<code>%</code>". In other words, "<code>A%42C</code>" becomes
+         "<code>ABC</code>". If there are any occurrences of <code>%</code> followed
          by up to two characters that are not hexadecimal digits, they are
          replaced by the character sequence <code>0xef</code>, <code>0xbf</code>, <code>0xbd</code>
          (that is, <code>0xfffd</code>, the Unicode replacement character, in UTF-8).
          After replacing all of the percent-escaped characters, the character sequence is
-         interpreted as UTF-8 to get the string. In other words “<code>A%XYC%Z%FO%9F%92%A9</code>” becomes
-         “<code>A&#xfffd;C&#xfffd;💩</code>”.</p>
+         interpreted as UTF-8 to get the string. In other words "<code>A%XYC%Z%FO%9F%92%A9</code>" becomes
+         "<code>A&#xfffd;C&#xfffd;💩</code>".</p>
 
          <p>The <emph>query separator</emph> is the value of the
-         “<code>query-separator</code>” option.
+         "<code>query-separator</code>" option.
          A <emph>query-segments</emph> value is constructed as follows: tokenize
          the <emph>query</emph> on the <emph>query separator</emph>. For each
-         token, construct a map. If the token contains an equal sign (“=”),
+         token, construct a map. If the token contains an equal sign ("="),
          the map contains a key named <code>key</code> with a value equal to the
          string preceding the first equal sign, uri decoded, and a key named <code>value</code>
          with a value equal to the string following the first equal sign, uri decoded. If the
@@ -25320,7 +25320,7 @@ declare function fn:some(
 }</eg>
 
          <p>The map should only be populated with keys that have a non-empty value (keys
-         who’s value is the empty sequence or an empty array <rfc2119>should</rfc2119>
+         who's value is the empty sequence or an empty array <rfc2119>should</rfc2119>
          be omitted).</p>
 
          <p>Implementations may implement additional or different rules for URIs that
@@ -25689,7 +25689,7 @@ specifically aware of the <code>jar:</code> scheme.</p>
   </fos:example>
   <fos:example>
 <p>This example demonstrates that parsing the URI treats non-URI characters in
-lexical IRIs as “unreserved characters”. The rationale for this is given in the
+lexical IRIs as "unreserved characters". The rationale for this is given in the
 description of <code>fn:resolve-uri</code>.</p>
     <fos:test>
       <fos:expression>parse-uri("http://www.example.org/Dürst")</fos:expression>
@@ -25864,7 +25864,7 @@ path with an explicit <code>file:</code> scheme.</p>
         empty sequence unless the
         <code>allow-deprecated-features</code> option is true.</p>
 
-        <p>If the “<code>omit-default-ports</code>” option is true
+        <p>If the "<code>omit-default-ports</code>" option is true
         then the <code>$port</code> is set to the empty sequence if
         the port number is the same as the default port for the given
         scheme. Implementations <rfc2119>should</rfc2119> recognize
@@ -25898,7 +25898,7 @@ path with an explicit <code>file:</code> scheme.</p>
         a sequence of strings is constructed from each segment in turn.
         If the segment contains both a <code>key</code> and a <code>value</code>,
         the string is the concatenation of the value of the <code>key</code>,
-        an equal sign (“<code>=</code>”), and the value of the <code>value</code>. If it contains
+        an equal sign ("<code>=</code>"), and the value of the <code>value</code>. If it contains
         only one of those keys, then it is the value of that key. If it contains
         neither, it is ignored. In any case, the keys and values, if present, are subject
         to encoding with <code>encode-for-uri</code>.
@@ -25906,12 +25906,12 @@ path with an explicit <code>file:</code> scheme.</p>
         strings into a single string, separated by <code>$options?query-separator</code>).
         If the <code>query-segments</code> key does not exist in the map, but
         the <code>query</code> key does, then the query is the value of the
-        <code>query</code> key. If there’s a query, it is added to the URI with
-        a preceding question mark (“<code>?</code>”).</p>
+        <code>query</code> key. If there's a query, it is added to the URI with
+        a preceding question mark ("<code>?</code>").</p>
 
         <p>If the <code>fragment</code> key exists in the map, then
         the value of that key is added to the URI with
-        a preceding hash mark (“<code>#</code>”).</p>
+        a preceding hash mark ("<code>#</code>").</p>
 
         <p>The resulting URI is returned.</p>
       </fos:rules>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -25259,7 +25259,9 @@ declare function fn:some(
 
          <p>If the <emph>string</emph> is the empty string, then
          <emph>path</emph> is the empty sequence, otherwise <emph>path</emph>
-         and <emph>filepath</emph> are the whole <emph>string</emph>.</p>
+         is the whole <emph>string</emph>. If the <emph>scheme</emph> is 
+         <code>file</code> or the empty sequence, and <emph>filepath</emph> is
+         the empty sequence, <emph>filepath</emph> is also the whole <emph>string</emph>.</p>
 
          <p>The <emph>path separator</emph> is the value of the
          “<code>path-separator</code>” option. A
@@ -25394,18 +25396,17 @@ are elided for editorial clarity.</p>
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance",
   "scheme": "https",
   "hierarchical": true(),
   "authority": "example.com:8080",
   "host": "example.com",
-  "port": "080",
+  "port": "8080",
   "path": "/path",
   "query": "s=%22hello world%22&amp;sort=relevance",
   "query-segments": array {
-    map { "key": "s", "value": "&quot;&quot;hello world&quot;&quot;" },
+    map { "key": "s", "value": "&quot;hello world&quot;" },
     map { "key": "sort", "value": "relevance" }
   },
   "path-segments": array { "", "path" }
@@ -25415,8 +25416,7 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("https://user@example.com/path/to/file")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "https://user@example.com/path/to/file",
   "scheme": "https",
   "hierarchical": true(),
@@ -25431,8 +25431,7 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
   "scheme": "ftp",
   "hierarchical": true(),
@@ -25446,8 +25445,7 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:////uncname/path/to/file")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "file:////uncname/path/to/file",
   "scheme": "file",
   "hierarchical": true(),
@@ -25461,65 +25459,65 @@ map {
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:///c:/path/to/file")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "file:///c:/path/to/file",
   "scheme": "file",
   "hierarchical": true(),
-  "path": "c:/path/to/file",
-  "path-segments": array { "c:", "path", "to", "file" }
+  "path": "/c:/path/to/file",
+  "filepath": "c:/path/to/file",
+  "path-segments": array { "", "c: ", "path", "to", "file" }
 }</eg></fos:result>
     </fos:test>
   </fos:example>
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:/C:/Program%20Files/test.jar")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "file:/C:/Program%20Files/test.jar",
   "scheme": "file",
   "hierarchical": true(),
-  "path": "C:/Program%20Files/test.jar",
-  "path-segments": array { "C:", "Program Files", "test.jar" }
+  "path": "/C:/Program%20Files/test.jar",
+  "filepath": "C:/Program Files/test.jar",
+  "path-segments": array { "", "C: ", "Program Files", "test.jar" }
 }</eg></fos:result>
     </fos:test>
   </fos:example>
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:\\c:\path\to\file")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "file:\\c:\path\to\file",
   "scheme": "file",
   "hierarchical": true(),
-  "path": "c:/path/to/file",
-  "path-segments": array { "c:", "path", "to", "file" }
+  "path": "/c:/path/to/file",
+  "filepath": "c:/path/to/file",
+  "path-segments": array { "", "c: ", "path", "to", "file" }
 }</eg></fos:result>
     </fos:test>
   </fos:example>
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:\c:\path\to\file")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "file:\c:\path\to\file",
   "scheme": "file",
   "hierarchical": true(),
-  "path": "c:/path/to/file",
-  "path-segments": array { "c:", "path", "to", "file" }
+  "path": "/c:/path/to/file",
+  "filepath": "c:/path/to/file",
+  "path-segments": array { "", "c: ", "path", "to", "file" }
 }</eg></fos:result>
     </fos:test>
   </fos:example>
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("c:\path\to\file")</fos:expression>
-      <fos:result><eg>
-map {
+      <fos:result><eg>map {
   "uri": "c:\path\to\file",
   "scheme": "file",
   "hierarchical": true(),
-  "path": "c:/path/to/file",
-  "path-segments": array { "c:", "path", "to", "file" }
+  "path": "/c:/path/to/file",
+  "filepath": "c:/path/to/file",
+  "path-segments": array { "", "c: ", "path", "to", "file" }
 }</eg></fos:result>
     </fos:test>
   </fos:example>
@@ -25529,6 +25527,7 @@ map {
       <fos:result>
 <eg>map {
   "uri": "/path/to/file",
+  "hierarchical": true(),
   "path": "/path/to/file",
   "path-segments": array { "", "path", "to", "file" }
 }</eg></fos:result>
@@ -25539,9 +25538,8 @@ map {
       <fos:expression>parse-uri("#testing")</fos:expression>
       <fos:result>
 <eg>map {
-  "uri": "#testing",
-  "path": "",
-  "fragment": "testing"
+ "uri": "#testing",
+ "fragment": "testing"
 }</eg></fos:result>
     </fos:test>
   </fos:example>
@@ -25551,7 +25549,6 @@ map {
       <fos:result>
 <eg>map {
   "uri": "?q=1",
-  "path": "",
   "query": "q=1",
   "query-segments": array {
     map { "key": "q", "value": "1" }
@@ -25625,9 +25622,9 @@ map {
   "uri": "telnet://192.0.2.16:80/",
   "scheme": "telnet",
   "hierarchical": true(),
-  "authority": "92.0.2.16:80",
-  "host": "92.0.2.16",
-  "port": "0",
+  "authority": "192.0.2.16:80",
+  "host": "192.0.2.16",
+  "port": "80",
   "path": "/",
   "path-segments": array { "", "" }
 }</eg></fos:result>
@@ -25651,12 +25648,12 @@ map {
       <fos:expression>parse-uri("tag:textalign.net,2015:ns")</fos:expression>
       <fos:result>
 <eg>map {
-    "uri": "tag:textalign.net,2015:ns",
-    "scheme": "tag",
-    "hierarchical": false(),
-    "path": "textalign.net,2015:ns",
-    "path-segments": [ "textalign.net,2015:ns" ]
-  }</eg>
+  "uri": "tag:textalign.net,2015:ns",
+  "scheme": "tag",
+  "hierarchical": false(),
+  "path": "textalign.net,2015:ns",
+  "path-segments": array { "textalign.net,2015:ns" }
+}</eg>
 </fos:result>
     </fos:test>
   </fos:example>
@@ -25665,11 +25662,11 @@ map {
       <fos:expression>parse-uri("tag:jan@example.com,1999-01-31:my-uri")</fos:expression>
       <fos:result>
 <eg>map {
-    "uri": "tag:jan@example.com,1999-01-31:my-uri"
-    "scheme": "tag",
-    "hierarchical": false(),
-    "path": "jan@example.com,1999-01-31:my-uri",
-    "path-segments": [ "jan@example.com,1999-01-31:my-uri" ],
+  "uri": "tag:jan@example.com,1999-01-31:my-uri",
+  "scheme": "tag",
+  "hierarchical": false(),
+  "path": "jan@example.com,1999-01-31:my-uri",
+  "path-segments": array { "jan@example.com,1999-01-31:my-uri" }
 }</eg>
 </fos:result>
     </fos:test>
@@ -25683,7 +25680,7 @@ specifically aware of the <code>jar:</code> scheme.</p>
 <eg>map {
   "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
   "scheme": "jar",
-  "hierarchical": true(),
+  "hierarchical": false(),
   "path": "file:/C:/Program%20Files/test.jar!/foo/bar",
   "path-segments": array { "file:", "C:", "Program Files", "test.jar!", "foo", "bar" }
 }</eg>
@@ -25698,13 +25695,13 @@ description of <code>fn:resolve-uri</code>.</p>
       <fos:expression>parse-uri("http://www.example.org/Dürst")</fos:expression>
       <fos:result>
 <eg>map {
-    "uri": "http://www.example.org/Dürst",
-    "scheme": "http",
-    "hierarchical": true(),
-    "authority": "www.example.org",
-    "host": "www.example.org",
-    "path": "/Dürst",
-    "path-segments": [ "","Dürst" ]
+  "uri": "http://www.example.org/Dürst",
+  "scheme": "http",
+  "hierarchical": true(),
+  "authority": "www.example.org",
+  "host": "www.example.org",
+  "path": "/Dürst",
+  "path-segments": array { "", "Dürst" }
 }</eg>
 </fos:result>
     </fos:test>
@@ -25721,11 +25718,11 @@ description of <code>fn:resolve-uri</code>.</p>
   "hierarchical": true(),
   "authority": "example.com:8080",
   "host": "example.com",
-  "port": "080",
+  "port": "8080",
   "path": "/path",
   "query": "s=%22hello world%22;sort=relevance",
   "query-segments": array {
-    map { "key": "s", "value": "&quot;&quot;hello world&quot;&quot;" },
+    map { "key": "s", "value": "&quot;hello world&quot;" },
     map { "key": "sort", "value": "relevance" }
   },
   "path-segments": array { "", "path" }
@@ -25740,6 +25737,36 @@ description of <code>fn:resolve-uri</code>.</p>
       <fos:error-result error-code="FOXX0000"/>
     </fos:test>
   </fos:example>
+<fos:example>
+<p>This example demonstrates the use of <code>|</code> instead of <code>:</code> in a Windows
+path.</p>
+    <fos:test>
+      <fos:expression>parse-uri("c|/path/to/file")</fos:expression>
+      <fos:result><eg>map {
+  "uri": "c|/path/to/file",
+  "scheme": "file",
+  "hierarchical": true(),
+  "path": "/c:/path/to/file",
+  "filepath": "c:/path/to/file",
+  "path-segments": array { "", "c:", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+</fos:example>
+<fos:example>
+<p>This example demonstrates the use of <code>|</code> instead of <code>:</code> in a Windows
+path with an explicit <code>file:</code> scheme.</p>
+    <fos:test>
+      <fos:expression>parse-uri("file://c|/path/to/file")</fos:expression>
+      <fos:result><eg>map {
+  "uri": "file://c|/path/to/file",
+  "scheme": "file",
+  "hierarchical": true(),
+  "path": "/c:/path/to/file",
+  "filepath": "c:/path/to/file",
+  "path-segments": array { "", "c:", "path", "to", "file" }
+}</eg></fos:result>
+    </fos:test>
+</fos:example>
       </fos:examples>
       <fos:history>
          <fos:version version="4.0">Proposed on 17 Oct 2022 to resolve


### PR DESCRIPTION
This PR fixes the examples in the `parse-uri()` function. It also makes a small change to the `filepath` property, eliding it when the scheme is known not to be file.