### PR TITLE
Use natural language sort order for glossary

### DIFF
--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -474,7 +474,7 @@
   <xsl:template match="processing-instruction('glossary')">
     <dl>
       <xsl:apply-templates select="//termdef" mode="glossary-list">
-        <xsl:sort select="@term" data-type="text" order="ascending"/>
+        <xsl:sort select="@term" data-type="text" order="ascending" lang="en"/>
       </xsl:apply-templates>
     </dl>
   </xsl:template>


### PR DESCRIPTION
This is a small stylesheet change which has the effect that the glossary in the XQuery specification (and elsewhere) now uses natural language sort order, so upper-case terms like `Gregorian` and `NaN` now appear in their proper alphabetic sequence.