### PR TITLE
Fix typographic quotes in XPath Data Model

### DIFF
--- a/specifications/xpath-datamodel-40/src/attribute.xml
+++ b/specifications/xpath-datamodel-40/src/attribute.xml
@@ -48,7 +48,7 @@ present then a prefix <rfc2119>must</rfc2119> also be present.
 </olist>
 
 <p>For convenience, the &elementNode; that owns this attribute is called
-its "parent" even though an &attributeNode; is not a "child" of its
+its “parent” even though an &attributeNode; is not a “child” of its
 parent element. </p>
 
 </div3>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -231,7 +231,7 @@ which is the data model of <bibref ref="xpath-40"/>, <bibref ref="xslt-40"/>, an
 
 
 
-<p>The &language; (henceforth "data model")
+<p>The &language; (henceforth “data model”)
 serves two purposes.
 First, it defines the information contained in the input to an
 XSLT or XQuery processor.  Second, it defines all permissible values of
@@ -243,7 +243,7 @@ the data model.</p>
 
 <p>The data model describes items similar to those of
 the <bibref ref="xml-infoset"/>
-(henceforth "Infoset").
+(henceforth “Infoset”).
  It is written to provide a data model suitable for XPath, XQuery and XSLT, which was not a goal of the Infoset,
  and this leads to a number of differences, some of which are:
 
@@ -295,7 +295,7 @@ they relate to values in the Infoset and PSVI.</p>
 <p>This section outlines a number of general concepts that apply throughout
 this specification.</p>
 
-<p>In this document, examples and material labeled as "Note" are provided for
+<p>In this document, examples and material labeled as “Note” are provided for
 explanatory purposes and are not normative.</p>
 
 <div2 id="terminology">
@@ -338,7 +338,7 @@ examples as <termref def="dt-instance">instances of the data model</termref>.
     example of such a case is the namespace URI property of an
     <termref def="dt-expanded-qname">expanded QName</termref>
     that is not in any namespace. For such properties, it is
-    convenient to be able to speak of "the state of having no value".
+    convenient to be able to speak of “the state of having no value”.
     <termdef id="dt-absent" term="absent">When a property has no value, we
       say that it is <term>absent</term>.</termdef>
   </p>
@@ -1175,8 +1175,8 @@ will create functions in the data model with zero annotations.
         </item>
       </ulist>
     <p>These categories are not mutually exclusive; they may be used in combination.</p> 
-    <ednote><edtext>The term "function body" replaces "function implementation", to avoid confusion with
-    the use of the term "implementation" in phrases such as "implementation-defined".</edtext></ednote>
+    <ednote><edtext>The term “function body” replaces “function implementation”, to avoid confusion with
+    the use of the term “implementation” in phrases such as “implementation-defined”.</edtext></ednote>
   </item>
   <item>
     <p diff="chg" at="2023-03-11">
@@ -1713,12 +1713,12 @@ the node content. For example, consider the following element:</p>
 <eg>&lt;offset xsi:type="xs:integer"&gt;0030&lt;/offset&gt;</eg>
 
 <p>Assuming that the node is valid, it has a typed value of 30 as an
-<code>xs:integer</code>. An implementation may return either "30" or
-"0030" as the string value of the node. Any string that is a valid
+<code>xs:integer</code>. An implementation may return either “<code>30</code>” or
+“<code>0030</code>” as the string value of the node. Any string that is a valid
 lexical representation of the typed value is acceptable. In this
 specification, we express this rule by saying that the relationship
 between the string value of a node and its typed value must be
-"consistent with schema validation."</p>
+“consistent with schema validation.”</p>
 
 <p>If an implementation stores only the string-value of a node, the
 following considerations apply:</p>
@@ -1730,8 +1730,8 @@ the typed-value as an instance of the appropriate member type. For
 example, if the type of 
 an element node is <code>my:integer-or-string</code>, which is
 defined as a union of <code>xs:integer</code> and <code>xs:string</code>, and the string-value
-of the node is "47", the implementation must be able to deliver the
-typed-value of the node as either the integer 47 or the string "47",
+of the node is “47”, the implementation must be able to deliver the
+typed-value of the node as either the integer <code>47</code> or the string <code>"47"</code>,
 depending on which member type validated the element.</p>
 </item>
 <item>

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -621,6 +621,11 @@
     <em><xsl:apply-templates/></em>
   </xsl:template>
 
+  <xsl:template match="quote/emph">
+    <em><xsl:apply-templates/></em>
+    <xsl:text> </xsl:text>
+  </xsl:template>
+
   <!-- rfc2119: identifies RFC 2119 keywords -->
   <xsl:template match="rfc2119">
     <strong><xsl:apply-templates/></strong>
@@ -1602,9 +1607,9 @@
   <!-- it would be nice to use HTML <q> elements, but browser support
        is abysmal -->
   <xsl:template match="quote">
-    <xsl:text>"</xsl:text>
+    <xsl:text>“</xsl:text>
     <xsl:apply-templates/>
-    <xsl:text>"</xsl:text>
+    <xsl:text>”</xsl:text>
   </xsl:template>
 
   <!-- raises: -->


### PR DESCRIPTION
Close #500 

On closer inspection, there were only a few places where typographic quotes *were not* used in prose. I've fixed those. I think the DM spec could probably use an editorial pass to add `code` around some literals, but I'm not doing that in this PR.

I've left typographic quotes around code and literals because I don't think straight quotes would be an improvement: the literal `“<code>3</code>”` doesn't need straight quotes because the quotes are not part of the literal.
