### PR TITLE
125: Rename array:partition as fn:partition

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17031,10 +17031,8 @@ returns the result of
          <fos:example>
             <fos:test>
                <fos:expression>function-name(substring#2)</fos:expression>
-               <fos:result>fn:QName("http://www.w3.org/2005/xpath-functions",
-                  "fn:substring")</fos:result>
-               <fos:postamble>The namespace prefix of the returned QName is not
-                  predictable.</fos:postamble>
+               <fos:result>QName("http://www.w3.org/2005/xpath-functions", "fn:substring")</fos:result>
+               <fos:postamble>The namespace prefix of the returned QName is not predictable.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -22618,81 +22616,7 @@ return array:sort($in, $SWEDISH)
          <fos:version version="4.0">Retained unchanged.</fos:version>
       </fos:history>
    </fos:function>
-
-   <fos:function name="partition" prefix="array">
-      <fos:signatures>
-         <fos:proto name="partition" return-type="array(*)+">
-            <fos:arg name="input" type="item()*"/>
-            <fos:arg name="break-when" type="function(item()*, item()) as xs:boolean"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Partitions a sequence of items into a sequence of arrays containing the same items,
-         starting a new partition when a supplied condition is true.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>Informally, the function processes the items in the input sequence in order, and for each item
-         it calls the supplied <code>$break-when</code> function with two arguments: the contents of the
-         current partition (initially an empty sequence), and the current item in the input sequence. If
-         the <code>$break-when</code> function returns true, the current partition is added to the result
-            and a new current partition is created, initially containing the current item. If the <code>$break-when</code> 
-            function returns false, the current item is added to the current partition.</p>
-         <p>More formally, the function returns the result of the expression:</p>
-         <eg>fn:fold-left($input, (), function($a, $b) {
-   if (empty($a) or $break-when(array:slice($a, start:-1)?*, $b))
-   then ($a, [$b])
-   else array:replace($a, array:size($a), function($m){$m, $b})
-}   
-         </eg>  
-      </fos:rules>
-      <fos:notes>
-         <p>The function enables a variety of positional grouping problems to be solved. For example:</p>
-         <ulist>
-            <item><p><code>array:partition($input, function($a, $b){count($a) eq 3}</code>
-            partitions a sequence into fixed size groups of length 3.</p></item>
-            <item><p><code>array:partition($input, function($a, $b){boolean($b/self::h1)}</code>
-               starts a new group whenever an <code>h1</code> element is encountered.</p></item>
-            <item><p><code>array:partition($input, function($a, $b){$b lt $a[last()]}</code>
-               starts a new group whenever an item is encountered whose value is less than
-               the value of the previous item.</p></item>
-         </ulist>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>array:partition(("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
-                  ->($x, $y){substring($x[last()],1,1) ne substring($y,1,1)})</fos:expression>
-               <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>array:partition((1, 2, 3, 4, 5, 6), function($a, $b){count($a) eq 2})</fos:expression>
-               <fos:result>([1, 2], [3, 4], [5, 6])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>array:partition((1, 4, 6, 3, 1, 1), function($a, $b){sum($a) ge 5})</fos:expression>
-               <fos:result>([1, 4], [6], [3, 1, 1])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>array:partition(tokenize("In the beginning was the word"), function($a, $b){sum(($a,$b)!string-length() gt 10)}</fos:expression>
-               <fos:result>(["In", "the"], ["beginning"], ["was", "the", "word"])</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>array:partition((1, 2, 3, 6, 7, 9, 10), function($a, $b){$a ne $b[last()]+1})</fos:expression>
-               <fos:result>([1, 2, 3], [6, 7], [9, 10])</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-      <fos:history>
-         <fos:version version="4.0">Proposed for 4.0. Not yet reviewed?</fos:version>
-      </fos:history>
-   </fos:function>
-
-   
+ 
    <fos:function name="values" prefix="array">
       <fos:signatures>
          <fos:proto name="values" return-type="item()*">
@@ -24014,7 +23938,7 @@ declare function fn:all(
             </fos:test>
             <fos:test>
                <fos:expression>char("\t")</fos:expression>
-               <fos:result>fn:codepoints-to-string(9)</fos:result>
+               <fos:result>codepoints-to-string(9)</fos:result>
                <fos:postamble>The character <emph>tab</emph></fos:postamble>
             </fos:test>
             <fos:test>
@@ -24032,7 +23956,7 @@ declare function fn:all(
             </fos:test>
             <fos:test>
                <fos:expression>char("NotEqualTilde")</fos:expression>
-               <fos:result>fn:codepoints-to-string((8770, 824))</fos:result>
+               <fos:result>codepoints-to-string((8770, 824))</fos:result>
                <fos:postamble>This HTML5 character reference name expands to multiple codepoints.</fos:postamble>
             </fos:test>
  
@@ -25990,4 +25914,86 @@ path with an explicit <code>file:</code> scheme.</p>
          FIXME: the examples need to be updated.</fos:version>
       </fos:history>
    </fos:function>
+   
+   
+   <fos:function name="partition" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="partition" return-type="array(item())*">
+            <fos:arg name="input" type="item()*"/>
+            <fos:arg name="break-when" type="function(item()*, item()) as xs:boolean"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Partitions a sequence of items into a sequence of non-empty arrays containing the same items,
+            starting a new partition when a supplied condition is true.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>Informally, the function starts by creating a partition containing the first item in the input sequence,
+            if any. For each remaining item <var>J</var> in the input sequence,
+            other than the first, it calls the supplied <code>$break-when</code> function with two 
+            arguments: the contents of the current partition, and the item <var>J</var>.</p>
+         <p>Each partition is a sequence of items; the function result wraps each partition as an array, and returns
+            the sequence of arrays.</p>
+         <p>If the <code>$break-when</code> function returns true, the current partition is wrapped as an array and added to the result,
+            and a new current partition is created, initially containing the item <var>J</var> only. If the <code>$break-when</code> 
+            function returns false, the item <var>J</var> is added to the current partition.</p>
+         <p>More formally, the function returns the result of the expression:</p>
+         <eg>fold-left($input, (), function($partitions, $next) {
+              if (empty($partitions) or $break-when(foot($partitions)?*, $next))
+              then ($partitions, [$next])
+              else (trunk($partitions), array{foot($partitions)?*, $next}) 
+            })   
+         </eg>  
+      </fos:rules>
+      <fos:notes>
+         <p>The function enables a variety of positional grouping problems to be solved. For example:</p>
+         <ulist>
+            <item><p><code>partition($input, function($a, $b){count($a) eq 3}</code>
+               partitions a sequence into fixed size groups of length 3.</p></item>
+            <item><p><code>partition($input, function($a, $b){boolean($b/self::h1)}</code>
+               starts a new group whenever an <code>h1</code> element is encountered.</p></item>
+            <item><p><code>partition($input, function($a, $b){$b lt foot($a)}</code>
+               starts a new group whenever an item is encountered whose value is less than
+               the value of the previous item.</p></item>
+         </ulist>
+         <p>The callback function is not called to process the first item in the input sequence, because this will
+            always start a new partition. The first argument to the callback function (the current partition) is always
+            a non-empty sequence.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>partition(("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
+                  function($partition, $next){substring($partitions[1],1,1) ne substring($next,1,1)})</fos:expression>
+               <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>partition((1, 2, 3, 4, 5, 6, 7), function($partition, $next){count($partition) eq 2})</fos:expression>
+               <fos:result>([1, 2], [3, 4], [5, 6], [7])</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>partition((1, 4, 6, 3, 1, 1), function($partition, $next){sum($partition) ge 5})</fos:expression>
+               <fos:result>([1, 4], [6], [3, 1, 1])</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>partition(tokenize("In the beginning was the word"), 
+                  function($partition, $next){sum(($partition, $next)!string-length()) gt 10}</fos:expression>
+               <fos:result>(["In", "the"], ["beginning"], ["was", "the", "word"])</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>partition((1, 2, 3, 6, 7, 9, 10), function($partition, $next){$next ne foot($partition)+1})</fos:expression>
+               <fos:result>([1, 2, 3], [6, 7], [9, 10])</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0</fos:version>
+      </fos:history>
+   </fos:function>
+   
 </fos:functions>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7102,12 +7102,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-index-where" diff="add" at="A">
                <head><?function fn:index-where?></head>
             </div3>
-            <!--<div3 id="func-range-from" diff="add" at="A">
-               <head><?function fn:range-from?></head>
-            </div3>
-            <div3 id="func-range-to" diff="add" at="A">
-               <head><?function fn:range-to?></head>
-            </div3>-->
             <div3 id="func-items-after" diff="add" at="A">
                <head><?function fn:items-after?></head>
             </div3>
@@ -7119,6 +7113,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
             <div3 id="func-items-ending-where" diff="add" at="A">
                <head><?function fn:items-ending-where?></head>
+            </div3>
+            <div3 id="func-partition" diff="add" at="A">
+               <head><?function fn:partition?></head>
             </div3>
             <div3 id="func-sort">
                <head><?function fn:sort?></head>
@@ -7466,9 +7463,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
             <div3 id="func-array-members" diff="add" at="2023-02-20">
                <head><?function array:members?></head>
-            </div3>
-            <div3 id="func-array-partition" diff="add" at="A">
-               <head><?function array:partition?></head>
             </div3>
             <div3 id="func-array-put">
                <head><?function array:put?></head>
@@ -11489,6 +11483,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:op</code></p></item>
               <item><p><code>fn:parse-QName</code></p></item>
               <item><p><code>fn:parse-uri</code></p></item>
+              <item><p><code>fn:partition</code></p></item>
               <item><p><code>fn:replicate</code></p></item>
               <item><p><code>fn:some</code></p></item>
               <item><p><code>fn:starts-with-sequence</code></p></item>


### PR DESCRIPTION
Reworked this PR to deal with merge conflicts. Technical change was already accepted. Made a correction to the "equivalent expression" published in the spec, which has now been tested (and was found wanting...)