### PR TITLE
471 (2): Remove more fn: prefixes

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -786,8 +786,8 @@
             is the largest (furthest from zero) <code>xs:integer</code> value <code>$N</code> such
             that the following expression is true:</p>
 
-         <eg>fn:abs($N * $arg2) le fn:abs($arg1) 
-               and fn:compare($N * $arg2, 0) eq fn:compare($arg1, 0).</eg>
+         <eg>abs($N * $arg2) le abs($arg1) 
+               and compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
          <note>
             <p>The second term in this condition ensures that the result has the correct sign.</p>
          </note>
@@ -2168,13 +2168,13 @@
          <code>A-Z</code> may be used in place of their lower-case equivalents.</p>
          <p>The value of a generalized digit corresponds to its position in this alphabet.
          More formally, in non-error cases the result of the function is given by the XQuery expression:</p>
-         <eg><![CDATA[let $alphabet := fn:characters("0123456789abcdefghijklmnopqrstuvwxyz")
-let $preprocessed-value := fn:translate($value, "_ &#x9;&#xa;&#xd;", "")
-let $digits := fn:translate($preprocessed-value, "+-", "")
-let $abs := fn:sum(
-  for $char at $p in fn:reverse(fn:characters($digits))
-  return (fn:index-of($alphabet, $char) - 1) * xs:integer(math:pow($radix, $p - 1)))
-return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
+         <eg><![CDATA[let $alphabet := characters("0123456789abcdefghijklmnopqrstuvwxyz")
+let $preprocessed-value := translate($value, "_ &#x9;&#xa;&#xd;", "")
+let $digits := translate($preprocessed-value, "+-", "")
+let $abs := sum(
+  for $char at $p in reverse(characters($digits))
+  return (index-of($alphabet, $char) - 1) * xs:integer(math:pow($radix, $p - 1)))
+return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0011"/>
@@ -2203,7 +2203,7 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
          be converted to the required digits using <code>fn:translate</code>.</p>
          <p>A string in the lexical space of <code>xs:hexBinary</code> will always
          be an acceptable input, provided it is not too long. So, for example, the expression
-         <code>"1DE=" => xs:base64Binary() => xs:hexBinary() => xs:string() => fn:parse-integer(16)</code>
+         <code>"1DE=" => xs:base64Binary() => xs:hexBinary() => xs:string() => parse-integer(16)</code>
          can be used to convert the Base 64 value <code>1DE=</code> to the integer 54321, via the 
          hexadecimal string <code>D431</code>.</p>
       </fos:notes>
@@ -5272,7 +5272,7 @@ Tak, tak, tak! - da kommen sie.
          <p> If two alternatives within the pattern both match at the same position in the
                <code>$input</code>, then the match that is chosen is the one matched by the first
             alternative. For example:</p>
-         <eg xml:space="preserve"> fn:replace("abcd", "(ab)|(a)", "[1=$1][2=$2]") returns "[1=ab][2=]cd"</eg>
+         <eg xml:space="preserve"> replace("abcd", "(ab)|(a)", "[1=$1][2=$2]") returns "[1=ab][2=]cd"</eg>
 
       </fos:rules>
       <fos:errors>
@@ -5429,7 +5429,7 @@ Tak, tak, tak! - da kommen sie.
                <p>If two alternatives within the supplied <code>$pattern</code> both match at the same
                   position in the <code>$value</code> string, then the match that is chosen is the first.
                   For example:</p>
-               <eg xml:space="preserve"> fn:tokenize("abracadabra", "(ab)|(a)") returns ("", "r", "c", "d", "r", "")</eg>
+               <eg xml:space="preserve"> tokenize("abracadabra", "(ab)|(a)") returns ("", "r", "c", "d", "r", "")</eg>
             </item>
          </ulist>
 
@@ -5727,8 +5727,8 @@ Tak, tak, tak! - da kommen sie.
          that is equal to the trimmed value of <code>$token</code> under
          the rules of the selected collation.</p>
          <p>That is, the function returns the value of the expression:</p>
-         <eg><![CDATA[some $t in $input!fn:tokenize(.) satisfies 
-                 compare($t, fn:replace($token, '^\s*|\s*$', ''), $collation) eq 0)]]></eg>
+         <eg><![CDATA[some $t in $input!tokenize(.) satisfies 
+                 compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0)]]></eg>
       </fos:rules>
       <fos:notes>
          <p>Interior whitespace within <code>$token</code> will cause the function to return <code>false</code>,
@@ -7198,8 +7198,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <code>op:dateTime-equal</code>.</p>
          <p>The result of the function is thus the same as the value of the expression:</p>
          <eg xml:space="preserve">op:dateTime-equal(
-        fn:dateTime(xs:date('1972-12-31'), $arg1), 
-        fn:dateTime(xs:date('1972-12-31'), $arg2))</eg>
+        dateTime(xs:date('1972-12-31'), $arg1), 
+        dateTime(xs:date('1972-12-31'), $arg2))</eg>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -7271,8 +7271,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <code>op:dateTime-less-than</code>.</p>
          <p>The result of the function is thus the same as the value of the expression:</p>
          <eg xml:space="preserve">op:dateTime-less-than(
-        fn:dateTime(xs:date('1972-12-31'), $arg1), 
-        fn:dateTime(xs:date('1972-12-31'), $arg2))</eg>
+        dateTime(xs:date('1972-12-31'), $arg1), 
+        dateTime(xs:date('1972-12-31'), $arg2))</eg>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -8649,8 +8649,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:rules>
          <p>The function returns the result of the expression:</p>
          <eg xml:space="preserve">op-subtract-dateTimes(
-        fn:dateTime(xs:date('1972-12-31'), $arg1),
-        fn:dateTime(xs:date('1972-12-31'), $arg2))</eg>
+        dateTime(xs:date('1972-12-31'), $arg1),
+        dateTime(xs:date('1972-12-31'), $arg2))</eg>
       </fos:rules>
       <fos:notes>
          <p>Any other reference date would work equally well.</p>
@@ -9607,8 +9607,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:notes>
          <p>Sometimes the requirement is to construct an <code>xs:QName</code> without using the
             default namespace. This can be achieved by writing:</p>
-         <eg xml:space="preserve"> if (contains($qname, ":")) then fn:resolve-QName($qname, $element) else
-            fn:QName("", $qname)</eg>
+         <eg xml:space="preserve"> if (contains($qname, ":")) then resolve-QName($qname, $element) else
+            QName("", $qname)</eg>
          <p>If the requirement is to construct an <code>xs:QName</code> using the namespaces in the
             static context, then the <code>xs:QName</code> constructor should be used.</p>
       </fos:notes>
@@ -11105,7 +11105,7 @@ let $newi := $o/tool</eg>
             <p>Assuming <code>$in</code> is an element with no children:</p>
             <eg>
                let $break := &lt;br/&gt;
-               return fn:empty($break)
+               return empty($break)
             </eg>
             <p>The result is <code>false()</code>.</p>
          </fos:example>
@@ -11164,7 +11164,7 @@ let $newi := $o/tool</eg>
             <p>Assuming <code>$in</code> is an element with no children:</p>
             <eg>
                let $break := &lt;br/>
-               return fn:exists($break)
+               return exists($break)
             </eg>
             <p>The result is <code>true()</code>.</p>
          </fos:example>
@@ -11868,10 +11868,10 @@ let $newi := $o/tool</eg>
       <fos:rules>
          <p>In the two-argument case <phrase diff="add" at="2022-12-19">(or where the 
             third argument is an empty sequence),</phrase> the function returns:</p>
-         <eg xml:space="preserve">$input[fn:round($start) le position()]</eg>
+         <eg xml:space="preserve">$input[round($start) le position()]</eg>
          <p>In the three-argument case, the function returns:</p>
-         <eg xml:space="preserve">$input[fn:round($start) le position() 
-         and position() lt fn:round($start) + fn:round($length)]</eg>
+         <eg xml:space="preserve">$input[round($start) le position() 
+         and position() lt round($start) + round($length)]</eg>
 
       </fos:rules>
       <fos:notes>
@@ -12170,7 +12170,7 @@ let $newi := $o/tool</eg>
          the following item, the <code>fn:tail</code> function can be applied to the result.</p>
          <p>The function can be combined with <code>fn:range-to</code>, for example the following
             might be used to select elements based on the value of an attribute:</p>
-         <eg>$input => fn:range-from(->{@time=$startTime}) => fn:range-to(->{@time=$endTime})</eg>
+         <eg>$input => range-from(->{@time=$startTime}) => range-to(->{@time=$endTime})</eg>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -12220,7 +12220,7 @@ let $newi := $o/tool</eg>
       </fos:rules>
       <fos:notes>
          <p>To exclude the item that matches the predicate, write 
-            <code>fn:range-to($input, $condition) => fn:slice(end: -2)</code>.</p>
+            <code>range-to($input, $condition) => slice(end: -2)</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -12272,8 +12272,8 @@ let $newi := $o/tool</eg>
          <p>Informally, the function returns true if <code>$input</code> starts with <code>$subsequence</code>,
          when items are compared using the supplied (or default) <code>$compare</code> function.</p>
          <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[fn:count($input) ge fn:count($subsequence) 
-and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
+         <eg><![CDATA[count($input) ge count($subsequence) 
+and all(for-each-pair($input, $subsequence, $compare))]]></eg>
       </fos:rules>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
@@ -12360,7 +12360,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
          <p>Informally, the function returns true if <code>$input</code> ends with <code>$subsequence</code>,
             when items are compared using the supplied (or default) <code>$compare</code> function.</p>
          <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[fn:starts-with-sequence(fn:reverse($input), fn:reverse($subsequence), $compare)]]></eg>
+         <eg><![CDATA[starts-with-sequence(reverse($input), reverse($subsequence), $compare)]]></eg>
       </fos:rules>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
@@ -12448,11 +12448,11 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
          <p>Informally, the function returns true if <code>$input</code> contains a consecutive subsequence matching <code>$subsequence</code>,
             when items are compared using the supplied (or default) <code>$compare</code> function.</p>
          <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[if (fn:starts-with-sequence($input, $subsequence, $compare))
+         <eg><![CDATA[if (starts-with-sequence($input, $subsequence, $compare))
 then true()
-else if (fn:empty($input))
+else if (empty($input))
      then false()
-     else fn:contains-sequence(fn:tail($input, $subsequence, $compare))]]></eg>
+     else contains-sequence(tail($input, $subsequence, $compare))]]></eg>
       </fos:rules>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
@@ -12832,13 +12832,13 @@ else if (fn:empty($input))
          <eg><![CDATA[function ($s1 as xs:string, $s2 as xs:string, 
                    $collation as xs:string, $options as map(*)) as xs:boolean {
     let $n1 := if (exists($options?normalization-form))
-               then fn:normalize-unicode(?, $options?normalization-form) 
-               else fn:identity#1,
+               then normalize-unicode(?, $options?normalization-form) 
+               else identity#1,
         $n2 := if ($options?normalize-space)
-               then fn:normalize-space#1 
-               else fn:identity#1               
+               then normalize-space#1 
+               else identity#1               
     }
-    return fn:compare($n1($n2($s1)), $n1($n2($s2)), $collation) eq 0    
+    return compare($n1($n2($s1)), $n1($n2($s2)), $collation) eq 0    
 }]]></eg>
          
          <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
@@ -13999,7 +13999,7 @@ else if (fn:empty($input))
          <eg xml:space="preserve">
    if (every $v in $c satisfies $c[1] ge $v)
    then $c[1] 
-   else fn:max(fn:tail($c))</eg>
+   else max(tail($c))</eg>
          <p>evaluated with <code>$collation</code> as the default collation if specified, and with
                <code>$c</code> as the converted sequence.</p>
 
@@ -14147,7 +14147,7 @@ else if (fn:empty($input))
          <eg xml:space="preserve">
    if (every $v in $c satisfies $c[1] le $v) 
    then $c[1] 
-   else fn:min(fn:tail($c))</eg>
+   else min(tail($c))</eg>
          <p>evaluated with <code>$collation</code> as the default collation if specified, and with
                <code>$c</code> as the converted sequence.</p>
 
@@ -14262,12 +14262,12 @@ else if (fn:empty($input))
          <p>The result of the function is the value of the
             expression:</p>
          <eg xml:space="preserve">
-if (fn:count($c) eq 0) then
+if (count($c) eq 0) then
     $zero
-else if (fn:count($c) eq 1) then
+else if (count($c) eq 1) then
     $c[1]
 else
-    $c[1] + fn:sum(subsequence($c, 2))</eg>
+    $c[1] + sum(subsequence($c, 2))</eg>
          <p>where <code>$c</code> is the converted sequence.</p>
          <p>The result of the function <phrase diff="chg" at="2023-01-17">when a single argument is supplied</phrase> is the result of the expression:
                <code>fn:sum($arg, 0)</code>.</p>
@@ -14476,7 +14476,7 @@ else
                            <code>IDREF</code> values are the strings in the sequence given by the
                         expression:</p>
                      <eg xml:space="preserve">for $s in $values return 
-    fn:tokenize(fn:normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
+    tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 
                   </item>
                </ulist>
@@ -14658,7 +14658,7 @@ else
                            <code>IDREF</code> values are the strings in the sequence given by the
                         expression:</p>
                      <eg xml:space="preserve">for $s in $arg return 
-   fn:tokenize(fn:normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
+   tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   </item>
                </ulist>
             </item>
@@ -14799,7 +14799,7 @@ else
                         </item>
                         <item>
                            <p>The sequence <!--Text replaced by erratum E29 change 1"--></p>
-                           <eg xml:space="preserve">fn:tokenize(fn:normalize-space(fn:string($N)), ' ')</eg>
+                           <eg xml:space="preserve">tokenize(normalize-space(string($N)), ' ')</eg>
                            <!--End of text replaced by erratum E29-->
                            <p>contains a string that is
                               equal to <code>V</code> under the rules of the <code>eq</code>
@@ -15749,7 +15749,7 @@ else
             </p>
             <p>and then testing for membership of the node-set using:</p>
             <p>
-               <code>map:contains($SMap, fn:generate-id($N))</code>
+               <code>map:contains($SMap, generate-id($N))</code>
             </p>
          </fos:example>
       </fos:examples>
@@ -16994,7 +16994,7 @@ else
          </fos:example>
          <fos:example>
             <p>The expression
-         <eg>let $f := fn:function-lookup(xs:QName('zip:binary-entry'), 2)
+         <eg>let $f := function-lookup(xs:QName('zip:binary-entry'), 2)
 return if (exists($f)) then $f($href, $entry) else ()</eg>
 returns the result of
                calling <code>zip:binary-entry($href, $entry)</code> if the function is available, or
@@ -17107,18 +17107,18 @@ returns the result of
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function fn:for-each($input, $action) {
-  if (fn:empty($input))
+declare function for-each($input, $action) {
+  if (empty($input))
   then ()
-  else ($action(fn:head($input)), fn:for-each(fn:tail($input), $action))
+  else ($action(head($input)), for-each(tail($input), $action))
 };]]></eg>
          <p>or its equivalent in XSLT:</p>
          <eg><![CDATA[
-<xsl:function name="fn:for-each">
+<xsl:function name="for-each">
   <xsl:param name="iinput"/>
   <xsl:param name="action"/>
-  <xsl:if test="fn:exists($input)">
-    <xsl:sequence select="$action(fn:head($input)), fn:for-each(fn:tail($input), $action)"/>
+  <xsl:if test="exists($input)">
+    <xsl:sequence select="$action(head($input)), for-each(tail($input), $action)"/>
   </xsl:if>
 </xsl:function>]]>
          </eg>
@@ -17176,23 +17176,23 @@ declare function fn:for-each($input, $action) {
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function fn:filter(
+declare function filter(
         $input as item()*,
         $predicate as function(item()) as xs:boolean)
         as item()* {
-  if (fn:empty($input))
+  if (empty($input))
   then ()
-  else ( fn:head($input)[$predicate(.) eq fn:true()], 
-         fn:filter(fn:tail($input), $predicate)
+  else ( head($input)[$predicate(.) eq true()], 
+         filter(tail($input), $predicate)
        )
 };]]></eg>
          <p>or its equivalent in XSLT:</p>
          <eg><![CDATA[
-<xsl:function name="fn:filter" as="item()*">
+<xsl:function name="filter" as="item()*">
   <xsl:param name="input" as="item()*"/>
   <xsl:param name="predicate" as="function(item()) as xs:boolean"/>
-  <xsl:if test="fn:exists($input)">
-    <xsl:sequence select="fn:head($input)[$f(.) eq fn:true()], fn:filter(fn:tail($input), $f)"/>
+  <xsl:if test="exists($input)">
+    <xsl:sequence select="head($input)[$f(.) eq true()], filter(tail($input), $f)"/>
   </xsl:if>
 </xsl:function>]]>
          </eg>
@@ -17249,27 +17249,27 @@ declare function fn:filter(
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function fn:fold-left(
+declare function fold-left(
         $input as item()*,
         $zero as item()*,
         $action as function(item()*, item()) as item()*) 
         as item()* {
-  if (fn:empty($input))
+  if (empty($input))
   then $zero
-  else fn:fold-left(fn:tail($input), $action($zero, fn:head($input)), $action)
+  else fold-left(tail($input), $action($zero, head($input)), $action)
 };]]></eg>
          <p>or its equivalent in XSLT:</p>
          <eg><![CDATA[
-<xsl:function name="fn:fold-left" as="item()*">
+<xsl:function name="fold-left" as="item()*">
   <xsl:param name="input" as="item()*"/>
   <xsl:param name="zero" as="item()*"/>
   <xsl:param name="action" as="function(item()*, item()) as item()*"/>
   <xsl:choose>
-    <xsl:when test="fn:empty($input)">
+    <xsl:when test="empty($input)">
       <xsl:sequence select="$zero"/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:sequence select="fn:fold-left(fn:tail($input), $action($zero, fn:head($input)), $action)"/>
+      <xsl:sequence select="fold-left(tail($input), $action($zero, head($input)), $action)"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:function>]]>
@@ -17377,27 +17377,27 @@ declare function fn:fold-left(
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function fn:fold-right(
+declare function fold-right(
         $input as item()*, 
         $zero as item()*, 
         $action as function(item(), item()*) as item()*) 
         as item()* {
-  if (fn:empty($input))
+  if (empty($input))
   then $zero
-  else $action(fn:head($input), fn:fold-right(fn:tail($input), $zero, $action))
+  else $action(head($input), fold-right(tail($input), $zero, $action))
 };]]></eg>
          <p>or its equivalent in XSLT:</p>
          <eg><![CDATA[
-<xsl:function name="fn:fold-right" as="item()*">
+<xsl:function name="fold-right" as="item()*">
   <xsl:param name="input" as="item()*"/>
   <xsl:param name="zero" as="item()*"/>
   <xsl:param name="action" as="function(item(), item()*) as item()*"/>
   <xsl:choose>
-    <xsl:when test="fn:empty($input)">
+    <xsl:when test="empty($input)">
       <xsl:sequence select="$zero"/>
     </xsl:when>
     <xsl:otherwise>
-      <xsl:sequence select="$action(fn:head($input), fn:fold-right(fn:tail($input), $zero, $action))"/>
+      <xsl:sequence select="$action(head($input), fold-right(tail($input), $zero, $action))"/>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:function>]]>
@@ -17718,9 +17718,9 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
                      <eg
 >if ($k1 instance of union(xs:string, xs:anyURI, xs:untypedAtomic)
         and $k2 instance of union(xs:string, xs:anyURI, xs:untypedAtomic))
-    then fn:compare($k1, $k2, $C)
-    else if ($k1 eq $k2 or (fn:is-NaN($k1) and fn:is-NaN($k2))) then 0
-    else if (fn:is-NaN($k1) or $k2 lt $k2) then -1
+    then compare($k1, $k2, $C)
+    else if ($k1 eq $k2 or (is-NaN($k1) and is-NaN($k2))) then 0
+    else if (is-NaN($k1) or $k2 lt $k2) then -1
     else +1</eg>
                      <note><p>This raises an error if two keys are not comparable, for example
                      if one is a string and the other is a number, or if both belong to a non-ordered
@@ -17772,14 +17772,14 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
             <p>To sort a set of strings <code>$in</code> using Swedish collation:</p>
             <eg>
 let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
-return fn:sort($in, $SWEDISH)
+return sort($in, $SWEDISH)
             </eg>
          </fos:example>
          <fos:example>
             <p>To sort a sequence of employees by last name as the major sort key and first name as the minor sort key,
                using the default collation:
             </p>
-            <eg>fn:sort($employees, (), function($emp) {$emp/name ! (last, first)})</eg>
+            <eg>sort($employees, (), function($emp) {$emp/name ! (last, first)})</eg>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -17826,7 +17826,7 @@ return fn:sort($in, $SWEDISH)
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>The expression <code>fn:apply($f, array:subarray(["a", "b", "c", "d", "e", "f"], 1, fn:function-arity($f)))</code> 
+            <p>The expression <code>apply($f, array:subarray(["a", "b", "c", "d", "e", "f"], 1, function-arity($f)))</code> 
                calls the supplied function <code>$f</code> supplying the number of arguments required by its arity.</p>
          </fos:example>
       </fos:examples>
@@ -18324,13 +18324,13 @@ $duplicates-handler := map {
 },
 
 $combine-maps := function($A as map(*), $B as map(*), $deduplicator as function(*)) {
-    fn:fold-left(map:keys($B), $A, function($z, $k){ 
+    fold-left(map:keys($B), $A, function($z, $k){ 
         if (map:contains($z, $k))
         then map:put($z, $k, $deduplicator($z($k), $B($k)))
         else map:put($z, $k, $B($k))
     })
 }
-return fn:fold-left($MAPS, map{}, 
+return fold-left($MAPS, map{}, 
     $combine-maps(?, ?, $duplicates-handler(($OPTIONS?duplicates, "use-first")[1]))
             
             ]]></eg>
@@ -19521,18 +19521,18 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values represent the number of employees at each distinct location. Any employees that
                lack an <code>@location</code> attribute will be excluded from the result.</p>
-            <eg>map:build(//employee, ->{@location}, ->{1}, fn:op("+"))</eg>
+            <eg>map:build(//employee, ->{@location}, ->{1}, op("+"))</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values contain the employee node for the highest-paid employee at each distinct location:</p>
             <eg>map:build(//employee, ->{@location}, 
-               combine := ->($a, $b){fn:highest(($a, $b), ->{xs:decimal(@salary)}))</eg>
+               combine := ->($a, $b){highest(($a, $b), ->{xs:decimal(@salary)}))</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map allowing efficient access to every element in a document by means
                of its <code>fn:generate-id</code> value:</p>
-            <eg>map:build(//*, fn:generate-id#1)</eg>
+            <eg>map:build(//*, generate-id#1)</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -21566,7 +21566,7 @@ else $fallback($position)</eg>
             the 1-based positions in the input array of those members for which the supplied predicate function
             returns true.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>fn:index-of(array:for-each($input, $predicate)?*, true())</eg>
+         <eg>index-of(array:for-each($input, $predicate)?*, true())</eg>
       </fos:rules>
       
       <fos:examples>
@@ -22279,7 +22279,7 @@ else array:fold-left(array:tail($array),
       <fos:rules>
          <p>The function returns the result of the expression:</p>
          <eg><code>array:of(
-    fn:for-each-pair(array:members($array1), 
+    for-each-pair(array:members($array1), 
                      array:members($array2), 
                      function($m, $n) {map{'value': $action($m?value, $n?value)}}))</code>
          </eg>
@@ -22515,7 +22515,7 @@ else array:fold-left(array:tail($array),
                ref="choosing-a-collation"/>.</p>
          
          <p diff="chg" at="A">The result of <code>array:sort#3</code> is the value of the expression
-            <code role="example">array:of(array:members($array) => fn:sort($collation, function($x){$key($x?value)}))</code></p>
+            <code role="example">array:of(array:members($array) => sort($collation, function($x){$key($x?value)}))</code></p>
 
         
       </fos:rules>
@@ -22643,7 +22643,7 @@ return array:sort($in, $SWEDISH)
             and a new current partition is created, initially containing the current item. If the <code>$break-when</code> 
             function returns false, the current item is added to the current partition.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>fn:fold-left($input, (), function($a, $b) {
+         <eg>fold-left($input, (), function($a, $b) {
    if (empty($a) or $break-when(array:slice($a, start:-1)?*, $b))
    then ($a, [$b])
    else array:replace($a, array:size($a), function($m){$m, $b})
@@ -23699,10 +23699,10 @@ return array:sort($in, $SWEDISH)
                applies it to a document loaded from <code>test.xml</code>, and uses an XPath expression
                to examine the result:</p>
             <eg><![CDATA[
-let $result := fn:transform(
+let $result := transform(
   map {
     "stylesheet-location" : "render.xsl",
-    "source-node"    : fn:doc('test.xml')
+    "source-node"    : doc('test.xml')
   })
 return $result?output//body  
                ]]></eg>
@@ -23845,7 +23845,7 @@ return $result?output//body
             values in the range zero to one, of specified length:</p>
             <eg>
 declare %public function r:random-sequence($length as xs:integer) as xs:double* {
-  r:random-sequence($length, fn:random-number-generator())
+  r:random-sequence($length, random-number-generator())
 };
 
 declare %private function r:random-sequence($length as xs:integer, 
@@ -24132,7 +24132,7 @@ declare function fn:all(
          <p>Let <code>$modified-key</code> be the function:</p>
          <eg>
 function($item){
-   $key($item) => fn:data() ! (
+   $key($item) => data() ! (
       if (. instance of xs:untypedAtomic)
       then xs:double(.)
       else .)
@@ -24212,7 +24212,7 @@ function($item){
          <fos:example>
             <p>To find employees having the highest salary:
             </p>
-            <eg>fn:highest($employees, (), ->{xs:decimal(salary)})</eg>
+            <eg>highest($employees, (), ->{xs:decimal(salary)})</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -24241,7 +24241,7 @@ function($item){
             the 1-based positions in the input sequence of those items for which the supplied predicate function
             returns true.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>fn:index-of($input!$predicate(.), true())</eg>
+         <eg>index-of($input!$predicate(.), true())</eg>
       </fos:rules>
 
       <fos:examples>
@@ -24631,7 +24631,7 @@ function($item){
          <p>Let <code>$modified-key</code> be the function:</p>
          <eg>
             function($item){
-            $key($item) => fn:data() ! (
+            $key($item) => data() ! (
             if (. instance of xs:untypedAtomic)
             then xs:double(.)
             else .)
@@ -24713,7 +24713,7 @@ function($item){
          <fos:example>
             <p>To find employees having the lowest salary:
             </p>
-            <eg>fn:lowest($employees, (), ->{xs:decimal(salary)})</eg>
+            <eg>lowest($employees, (), ->{xs:decimal(salary)})</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -24773,7 +24773,7 @@ function($item){
          <p> If two alternatives within the pattern both match at the same position in the
             <code>$input</code>, then the match that is chosen is the one matched by the first
             alternative. For example:</p>
-         <eg xml:space="preserve"> fn:replace-with("abcd", "(ab)|(a)", ->{'#' || . || '#'}) returns "#ab#cd"</eg>
+         <eg xml:space="preserve"> replace-with("abcd", "(ab)|(a)", ->{'#' || . || '#'}) returns "#ab#cd"</eg>
 
       </fos:rules>
       <fos:errors>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -641,7 +641,7 @@ for transition to Proposed Recommendation. </p>'>
             the function is evaluated. Maps are a new datatype introduced in XPath 3.1.</p>
             <p>For example, the function <code>fn:xml-to-json</code> has an options parameter
             allowing specification of whether the output is to be indented. A call might be written:</p>
-            <eg><![CDATA[fn:xml-to-json($input, map{'indent':true()})]]></eg>
+            <eg><![CDATA[xml-to-json($input, map{'indent':true()})]]></eg>
             <p><termdef id="option-parameter-conventions" term="option parameter conventions">Functions
             that take an options parameter adopt common conventions on how the
             options are used. These are referred to as the <term>option parameter conventions</term>. These
@@ -9420,15 +9420,15 @@ characters except the first "P" and the optional negative sign in <emph>TDT</emp
 declare function eg:convertYearToString($year as xs:integer) as xs:string
 {
    let $plusMinus := if ($year >= 0) then "" else "-"
-   let $yearString := fn:abs($year) cast as xs:string
-   let $length := fn:string-length($yearString)
+   let $yearString := abs($year) cast as xs:string
+   let $length := string-length($yearString)
    return
-     if ($length = 1)  then fn:concat($plusMinus, "000", $yearString)
+     if ($length = 1)  then concat($plusMinus, "000", $yearString)
      else
-     if ($length = 2)  then fn:concat($plusMinus, "00", $yearString)
+     if ($length = 2)  then concat($plusMinus, "00", $yearString)
        else
-       if ($length = 3)  then fn:concat($plusMinus, "0", $yearString)
-       else fn:concat($plusMinus, $yearString)
+       if ($length = 3)  then concat($plusMinus, "0", $yearString)
+       else concat($plusMinus, $yearString)
 }
                     ]]></eg>
                <eg xml:space="preserve"><![CDATA[
@@ -9436,7 +9436,7 @@ declare function eg:convertTo2CharString($value as xs:integer) as xs:string
 {
    let $string := $value cast as xs:string
    return 
-     if (fn:string-length($string) = 1) then fn:concat("0", $string)
+     if (string-length($string) = 1) then concat("0", $string)
      else $string
 }
                     ]]></eg>
@@ -9444,9 +9444,9 @@ declare function eg:convertTo2CharString($value as xs:integer) as xs:string
 declare function eg:convertSecondsToString($seconds as xs:decimal) as xs:string
 {
    let $string := $seconds cast as xs:string
-   let $intLength := fn:string-length(($seconds cast as xs:integer) cast as xs:string)
+   let $intLength := string-length(($seconds cast as xs:integer) cast as xs:string)
    return 
-     if ($intLength = 1) then fn:concat("0", $string)
+     if ($intLength = 1) then concat("0", $string)
      else $string
 }
                     ]]></eg>
@@ -9458,12 +9458,12 @@ declare function eg:convertTZtoString($tz as xs:dayTimeDuration?) as xs:string
    else if ($tz eq xs:dayTimeDuration('PT0S'))
      then "Z"
    else 
-     let $tzh := fn:hours-from-duration($tz)
-     let $tzm := fn:minutes-from-duration($tz)
+     let $tzh := hours-from-duration($tz)
+     let $tzm := minutes-from-duration($tz)
      let $plusMinus := if ($tzh >= 0) then "+" else "-"
-     let $tzhString := eg:convertTo2CharString(fn:abs($tzh))
-     let $tzmString := eg:convertTo2CharString(fn:abs($tzm))
-     return fn:concat($plusMinus, $tzhString, ":", $tzmString)
+     let $tzhString := eg:convertTo2CharString(abs($tzh))
+     let $tzmString := eg:convertTo2CharString(abs($tzm))
+     return concat($plusMinus, $tzhString, ":", $tzmString)
 }
 
                     ]]></eg>
@@ -9476,15 +9476,15 @@ declare function eg:convertTZtoString($tz as xs:dayTimeDuration?) as xs:string
                                 <code>xs:gYear</code>, <code>xs:gMonthDay</code>,
                                 <code>xs:gDay</code>, or <code>xs:gMonth</code>,</p>
                             <p> let <emph>CYR</emph> be <code>eg:convertYearToString(
-                                    fn:year-from-dateTime( fn:current-dateTime() ))</code>,</p>
+                                    year-from-dateTime( current-dateTime() ))</code>,</p>
                             <p> let <emph>CMO</emph> be <code>eg:convertTo2CharString(
-                                    fn:month-from-dateTime( fn:current-dateTime() ))</code>, </p>
+                                    month-from-dateTime( current-dateTime() ))</code>, </p>
                             <p> let <emph>CDA</emph> be <code>eg:convertTo2CharString(
-                                    fn:day-from-dateTime( fn:current-dateTime() )) </code>.</p>
+                                    day-from-dateTime( current-dateTime() )) </code>.</p>
                             and </p>
 <p>
 let <emph>CTZ</emph> be <code>eg:convertTZtoString(
-	    fn:timezone-from-dateTime( fn:current-dateTime()
+	    timezone-from-dateTime( current-dateTime()
 	    )</code>. </p> 
                         </item> --><item>
                      <p>When a value of any primitive type is cast as
@@ -9497,11 +9497,11 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                                         <emph>TV</emph> is <emph>SV</emph>. </p>
                         </item>
                         <!--		<item>
-								<p>If <emph>ST</emph> is <code>xs:time</code>, then let <emph>SHR</emph> be <code>eg:convertTo2CharString( fn:hours-from-time(</code>
-									<emph>SV</emph>	<code>)) </code>, let <emph>SMI</emph> be <code>eg:convertTo2CharString( fn:minutes-from-time(</code>
-									<emph>SV</emph><code>))</code>, let <emph>SSE</emph> be <code>eg:convertSecondsToString( fn:seconds-from-time(</code>
-									<emph>SV</emph><code>))</code> and let <emph>STZ</emph> be <code>eg:convertTZtoString( fn:timezone-from-time(</code><emph>SV</emph><code>))</code>
-; <emph>TV</emph> is <code>xs:dateTime( fn:concat(</code>
+								<p>If <emph>ST</emph> is <code>xs:time</code>, then let <emph>SHR</emph> be <code>eg:convertTo2CharString( hours-from-time(</code>
+									<emph>SV</emph>	<code>)) </code>, let <emph>SMI</emph> be <code>eg:convertTo2CharString( minutes-from-time(</code>
+									<emph>SV</emph><code>))</code>, let <emph>SSE</emph> be <code>eg:convertSecondsToString( seconds-from-time(</code>
+									<emph>SV</emph><code>))</code> and let <emph>STZ</emph> be <code>eg:convertTZtoString( timezone-from-time(</code><emph>SV</emph><code>))</code>
+; <emph>TV</emph> is <code>xs:dateTime( concat(</code>
 									<emph>CYR</emph>
 									<code>, '-', </code>
 									<emph>CMO</emph>
@@ -9516,18 +9516,18 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
 									<code>) )</code>. </p>
 							</item> --><item>
                            <p>If <emph>ST</emph> is <code>xs:date</code>, then let
-                                        <emph>SYR</emph> be <code>eg:convertYearToString( fn:year-from-date(</code>
+                                        <emph>SYR</emph> be <code>eg:convertYearToString( year-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code>, let <emph>SMO</emph> be
-                                            <code>eg:convertTo2CharString( fn:month-from-date(</code>
+                                            <code>eg:convertTo2CharString( month-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code>, let <emph>SDA</emph> be
-                                            <code>eg:convertTo2CharString( fn:day-from-date(</code>
+                                            <code>eg:convertTo2CharString( day-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-date(</code>
+                                            <code>eg:convertTZtoString( timezone-from-date(</code>
                                         <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:dateTime( fn:concat(</code>
+                                        <code>))</code>; <emph>TV</emph> is <code>xs:dateTime( concat(</code>
                                         <emph>SYR</emph>
                                         <code>, '-', </code>
                                         <emph>SMO</emph>
@@ -9554,14 +9554,14 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then
-                                        <emph>TV</emph> is <code>xs:time( fn:concat(
-                                            eg:convertTo2CharString( fn:hours-from-dateTime(</code>
+                                        <emph>TV</emph> is <code>xs:time( concat(
+                                            eg:convertTo2CharString( hours-from-dateTime(</code>
                                         <emph>SV</emph>
-                                        <code>)), ':', eg:convertTo2CharString( fn:minutes-from-dateTime(</code>
+                                        <code>)), ':', eg:convertTo2CharString( minutes-from-dateTime(</code>
                                         <emph>SV</emph>
-                                        <code>)), ':', eg:convertSecondsToString( fn:seconds-from-dateTime(</code>
+                                        <code>)), ':', eg:convertSecondsToString( seconds-from-dateTime(</code>
                                         <emph>SV</emph>
-                                        <code>)), eg:convertTZtoString( fn:timezone-from-dateTime(</code>
+                                        <code>)), eg:convertTZtoString( timezone-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>)) ))</code>. </p>
                         </item>
@@ -9583,17 +9583,17 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
-                                        <emph>SYR</emph> be <code>eg:convertYearToString( fn:year-from-dateTime(</code>
+                                        <emph>SYR</emph> be <code>eg:convertYearToString( year-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code>, let <emph>SMO</emph> be
-                                            <code>eg:convertTo2CharString( fn:month-from-dateTime(</code>
+                                            <code>eg:convertTo2CharString( month-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code>, let <emph>SDA</emph> be
-                                            <code>eg:convertTo2CharString( fn:day-from-dateTime(</code>
+                                            <code>eg:convertTo2CharString( day-from-dateTime(</code>
                                         <emph>SV</emph>
-                                        <code>))</code> and let <emph>STZ</emph> be <code>eg:convertTZtoString(fn:timezone-from-dateTime(</code>
+                                        <code>))</code> and let <emph>STZ</emph> be <code>eg:convertTZtoString(timezone-from-dateTime(</code>
                                         <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:date( fn:concat(</code>
+                                        <code>))</code>; <emph>TV</emph> is <code>xs:date( concat(</code>
                                         <emph>SYR</emph>
                                         <code>, '-', </code>
                                         <emph>SMO</emph>
@@ -9620,15 +9620,15 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
-                                        <emph>SYR</emph> be <code>eg:convertYearToString( fn:year-from-dateTime(</code>
+                                        <emph>SYR</emph> be <code>eg:convertYearToString( year-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code>, let <emph>SMO</emph> be
-                                            <code>eg:convertTo2CharString( fn:month-from-dateTime(</code>
+                                            <code>eg:convertTo2CharString( month-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-dateTime(</code>
+                                            <code>eg:convertTZtoString( timezone-from-dateTime(</code>
                                         <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( fn:concat(</code>
+                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( concat(</code>
                                         <emph>SYR</emph>
                                         <code>, '-', </code>
                                         <emph>SMO</emph>, <emph>STZ</emph>
@@ -9636,15 +9636,15 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:date</code>, then let
-                                        <emph>SYR</emph> be <code>eg:convertYearToString( fn:year-from-date(</code>
+                                        <emph>SYR</emph> be <code>eg:convertYearToString( year-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code>, let <emph>SMO</emph> be
-                                            <code>eg:convertTo2CharString( fn:month-from-date(</code>
+                                            <code>eg:convertTo2CharString( month-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-date(</code>
+                                            <code>eg:convertTZtoString( timezone-from-date(</code>
                                         <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( fn:concat(</code>
+                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( concat(</code>
                                         <emph>SYR</emph>
                                         <code>, '-', </code>
                                         <emph>SMO</emph>, <emph>STZ</emph>
@@ -9668,23 +9668,23 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:dateTime</code>, let
-                                        <emph>SYR</emph> be <code>eg:convertYearToString( fn:year-from-dateTime(</code>
+                                        <emph>SYR</emph> be <code>eg:convertYearToString( year-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-dateTime(</code>
+                                            <code>eg:convertTZtoString( timezone-from-dateTime(</code>
                                         <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYear(fn:concat(</code>
+                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYear(concat(</code>
                                         <emph>SYR</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:date</code>, let
-                                        <emph>SYR</emph> be <code>eg:convertYearToString( fn:year-from-date(</code>
+                                        <emph>SYR</emph> be <code>eg:convertYearToString( year-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code>; and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-date(</code>
+                                            <code>eg:convertTZtoString( timezone-from-date(</code>
                                         <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYear(fn:concat(</code>
+                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYear(concat(</code>
                                         <emph>SYR</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
@@ -9707,15 +9707,15 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
-                                        <emph>SMO</emph> be <code>eg:convertTo2CharString( fn:month-from-dateTime(</code>
+                                        <emph>SMO</emph> be <code>eg:convertTo2CharString( month-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code>, let <emph>SDA</emph> be
-                                            <code>eg:convertTo2CharString( fn:day-from-dateTime(</code>
+                                            <code>eg:convertTo2CharString( day-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-dateTime(</code>
+                                            <code>eg:convertTZtoString( timezone-from-dateTime(</code>
                                         <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( fn:concat(</code>
+                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( concat(</code>
                                         <code> '--', </code>
                                         <emph>SMO</emph>
                                         <code> '-', </code>
@@ -9724,15 +9724,15 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:date</code>, then let
-                                        <emph>SMO</emph> be <code>eg:convertTo2CharString( fn:month-from-date(</code>
+                                        <emph>SMO</emph> be <code>eg:convertTo2CharString( month-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code>, let <emph>SDA</emph> be
-                                            <code>eg:convertTo2CharString( fn:day-from-date(</code>
+                                            <code>eg:convertTo2CharString( day-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-date(</code>
+                                            <code>eg:convertTZtoString( timezone-from-date(</code>
                                         <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( fn:concat(</code>
+                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( concat(</code>
                                         <code> '--', </code>
                                         <emph>SMO</emph>
                                         <code>, '-', </code>
@@ -9757,24 +9757,24 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
-                                        <emph>SDA</emph> be <code>eg:convertTo2CharString( fn:day-from-dateTime(</code>
+                                        <emph>SDA</emph> be <code>eg:convertTo2CharString( day-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-dateTime(</code>
+                                            <code>eg:convertTZtoString( timezone-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code>; <emph>TV</emph> is <code>xs:gDay(
-                                            fn:concat( '---'</code>, <emph>SDA</emph>, <emph>STZ</emph>
+                                            concat( '---'</code>, <emph>SDA</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:date</code>, then let
-                                        <emph>SDA</emph> be <code>eg:convertTo2CharString( fn:day-from-date(</code>
+                                        <emph>SDA</emph> be <code>eg:convertTo2CharString( day-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-date(</code>
+                                            <code>eg:convertTZtoString( timezone-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code>; <emph>TV</emph> is <code>xs:gDay(
-                                            fn:concat( '---'</code>, <emph>SDA</emph>, <emph>STZ</emph>
+                                            concat( '---'</code>, <emph>SDA</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
@@ -9795,24 +9795,24 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
-                                        <emph>SMO</emph> be <code>eg:convertTo2CharString( fn:month-from-dateTime(</code>
+                                        <emph>SMO</emph> be <code>eg:convertTo2CharString( month-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-dateTime(</code>
+                                            <code>eg:convertTZtoString( timezone-from-dateTime(</code>
                                         <emph>SV</emph>
                                         <code>))</code>; <emph>TV</emph> is <code>xs:gMonth(
-                                            fn:concat( '--' </code>, <emph>SMO</emph>, <emph>STZ</emph>
+                                            concat( '--' </code>, <emph>SMO</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
                            <p>If <emph>ST</emph> is <code>xs:date</code>, then let
-                                        <emph>SMO</emph> be <code>eg:convertTo2CharString( fn:month-from-date(</code>
+                                        <emph>SMO</emph> be <code>eg:convertTo2CharString( month-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code> and let <emph>STZ</emph> be
-                                            <code>eg:convertTZtoString( fn:timezone-from-date(</code>
+                                            <code>eg:convertTZtoString( timezone-from-date(</code>
                                         <emph>SV</emph>
                                         <code>))</code>; <emph>TV</emph> is <code>xs:gMonth(
-                                            fn:concat( '--'</code>, <emph>SMO</emph>, <emph>STZ</emph>
+                                            concat( '--'</code>, <emph>SMO</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -2653,7 +2653,7 @@ function call raises a dynamic
 error, providing a QName that identifies the error, a descriptive string, and a diagnostic value (assuming that the prefix <code>app</code> is bound to a namespace containing application-defined error codes):</p>
 
             <eg role="parse-test"
-               ><![CDATA[fn:error(xs:QName("app:err057"), "Unexpected value", fn:string($v))]]></eg>
+               ><![CDATA[error(xs:QName("app:err057"), "Unexpected value", string($v))]]></eg>
 
          </div3>
          <div3 id="id-errors-and-opt">
@@ -7394,7 +7394,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                </item>
                <item diff="add" at="A">
                   <p>
-                     <code role="parse-test">fn:lang(node:=$n, language:='de')</code> is a static function 
+                     <code role="parse-test">lang(node:=$n, language:='de')</code> is a static function 
                      call with two keyword arguments. The corresponding function declaration defines two parameters,
                      a required parameter <code>language</code> and an optional parameter <code>node</code>.
                      This call supplies values for both parameters. It is equivalent to the call 
@@ -7404,7 +7404,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                </item>
                <item diff="add" at="A">
                   <p>
-                     <code role="parse-test">fn:sort(//employee, key := ->{xs:decimal(salary)})</code> is a static function 
+                     <code role="parse-test">sort(//employee, key := ->{xs:decimal(salary)})</code> is a static function 
                      call with one positional argument and one keyword argument. 
                      The corresponding function declaration defines three parameters,
                      a required parameter <code>$input</code>, an optional parameter <code>$collation</code>,
@@ -7636,7 +7636,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                   <bibref
                                           ref="xpath-functions-40"/>.</p>
 
-                                    <eg role="parse-test"><![CDATA[fn:base-uri()]]></eg>
+                                    <eg role="parse-test"><![CDATA[base-uri()]]></eg>
 
                                  </example>
                              
@@ -8078,7 +8078,7 @@ return $vat()
                         
                         <p>The following partial function application creates a function 
                            item that computes the sum of squares of a sequence.</p>
-                        <eg role="parse-test"><![CDATA[let $sum-of-squares := fn:fold-right(?, 0, function($a, $b) { $a*$a + $b })
+                        <eg role="parse-test"><![CDATA[let $sum-of-squares := fold-right(?, 0, function($a, $b) { $a*$a + $b })
 return $sum-of-squares(1 to 3)]]></eg>
                         <p>
                            <code>$sum-of-squares</code> is an anonymous function. It has one parameter, named <code>$seq</code>, which is taken from the corresponding parameter in <code>fn:fold-right</code> (the other two parameters are fixed). The implementation is the implementation of <code>fn:fold-right</code>, which is a built-in context-independent function.  The nonlocal bindings contain the fixed bindings for the second and third parameters of <code>fn:fold-right</code>.</p>
@@ -8190,7 +8190,7 @@ return $sum-of-squares(1 to 3)]]></eg>
                               <head>Partial Application of an Anonymous Function</head>
                               <p>In the following example, <code>$f</code> is an anonymous function, and <code>$paf</code> is a partially applied function created from <code>$f</code>.</p>
                               <eg role="parse-test"><![CDATA[
-let $f := function ($seq, $delim) { fn:fold-left($seq, "", fn:concat(?, $delim, ?)) },
+let $f := function ($seq, $delim) { fold-left($seq, "", concat(?, $delim, ?)) },
     $paf := $f(?, ".")
 return $paf(1 to 5)
 ]]></eg>
@@ -8415,7 +8415,7 @@ return $a("A")]]></eg>
                <p diff="add" at="A">This avoids visual clutter when a function is used as an argument to another
                function:</p>
                
-               <eg diff="add" at="A">fn:for-each-pair($A, $B, ->($a, $b) {$a + $b})</eg>
+               <eg diff="add" at="A">for-each-pair($A, $B, ->($a, $b) {$a + $b})</eg>
                
             <p diff="add" at="A">The common case where a function accepts a single argument of type
                <code>item()</code> can be further abbreviated to <code>->{EXPR}</code>. This is equivalent to the 
@@ -8425,7 +8425,7 @@ return $a("A")]]></eg>
                result of evaluating the supplied expression with that item as the <termref def="dt-singleton-focus"/>.
             For example, the following function call returns the sequence <code>(2, 3, 4, 5, 6)</code>.</p>
             
-            <eg diff="add" at="A">fn:for-each(1 to 5, ->{.+1})</eg>
+            <eg diff="add" at="A">for-each(1 to 5, ->{.+1})</eg>
             
  
             <p diff="add" at="A">A zero-arity function can be written as, for example, <code>->(){current-date()}</code>.</p>
@@ -9025,7 +9025,7 @@ let $m := map {
   "Sunday" : false()
 },
 $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-return fn:filter($days,$m)
+return filter($days,$m)
       ]]></eg>
 
                <p>
@@ -9083,7 +9083,7 @@ let $m := map {
    "Sunday" : false()
 }
 let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-return fn:filter($days,$m)
+return filter($days,$m)
       ]]></eg>
 
                <p>The result of the expression is the sequence <code>("Monday", "Wednesday", "Friday")</code>
@@ -9180,14 +9180,14 @@ return fn:filter($days,$m)
 
                <item>
                   <p>The following example returns the fifth through ninth items in the sequence bound to variable <code>$orders</code>.</p>
-                  <eg role="parse-test"><![CDATA[$orders[fn:position() = (5 to 9)]]]></eg>
+                  <eg role="parse-test"><![CDATA[$orders[position() = (5 to 9)]]]></eg>
                </item>
 
                <item>
                   <p>The following example illustrates the use of a filter expression as a <termref
                         def="dt-step">step</termref> in a <termref def="dt-path-expression"
                         >path expression</termref>. It returns the last chapter or appendix within the book bound to variable <code>$book</code>:</p>
-                  <eg role="parse-test"><![CDATA[$book/(chapter | appendix)[fn:last()]]]></eg>
+                  <eg role="parse-test"><![CDATA[$book/(chapter | appendix)[last()]]]></eg>
                </item>
 
             </ulist>
@@ -10484,41 +10484,41 @@ the <code>member</code> elements that have a <code>list</code> parent and that a
                <item>
                   <p>
                      <code role="parse-test"
-                        >child::para[fn:position() = 1]</code> selects the first <code>para</code> child of the context node</p>
+                        >child::para[position() = 1]</code> selects the first <code>para</code> child of the context node</p>
                </item>
 
 
                <item>
                   <p>
                      <code role="parse-test"
-                        >child::para[fn:position() = fn:last()]</code> selects the last <code>para</code> child of the context node</p>
+                        >child::para[position() = last()]</code> selects the last <code>para</code> child of the context node</p>
                </item>
 
 
                <item>
                   <p>
                      <code role="parse-test"
-                        >child::para[fn:position() = fn:last()-1]</code> selects the last but one <code>para</code> child of the context node</p>
+                        >child::para[position() = last()-1]</code> selects the last but one <code>para</code> child of the context node</p>
                </item>
 
 
                <item>
                   <p>
                      <code role="parse-test"
-                        >child::para[fn:position() &gt; 1]</code> selects all the <code>para</code> children of the context node other than the first <code>para</code> child of the context node</p>
+                        >child::para[position() &gt; 1]</code> selects all the <code>para</code> children of the context node other than the first <code>para</code> child of the context node</p>
                </item>
 
 
                <item>
                   <p>
                      <code role="parse-test"
-                        >following-sibling::chapter[fn:position() = 1]</code> selects the next <code>chapter</code> sibling of the context node</p>
+                        >following-sibling::chapter[position() = 1]</code> selects the next <code>chapter</code> sibling of the context node</p>
                </item>
                
                <item diff="add" at="2022-12-13">
                   <p>
                      <code role="parse-test"
-                        >following-sibling::(chapter|appendix)[fn:position() = 1]</code> selects the next sibling of the context node
+                        >following-sibling::(chapter|appendix)[position() = 1]</code> selects the next sibling of the context node
                         that is either a <code>chapter</code> or an <code>appendix</code></p>
                </item>
 
@@ -10526,21 +10526,21 @@ the <code>member</code> elements that have a <code>list</code> parent and that a
                <item>
                   <p>
                      <code role="parse-test"
-                        >preceding-sibling::chapter[fn:position() = 1]</code> selects the previous <code>chapter</code> sibling of the context node</p>
+                        >preceding-sibling::chapter[position() = 1]</code> selects the previous <code>chapter</code> sibling of the context node</p>
                </item>
 
 
                <item>
                   <p>
                      <code role="parse-test"
-                        >/descendant::figure[fn:position() = 42]</code> selects the forty-second <code>figure</code> element in the document containing the context node</p>
+                        >/descendant::figure[position() = 42]</code> selects the forty-second <code>figure</code> element in the document containing the context node</p>
                </item>
 
 
                <item>
                   <p>
                      <code role="parse-test"
-                        >/child::book/child::chapter[fn:position() = 5]/child::section[fn:position() = 2]</code> selects the
+                        >/child::book/child::chapter[position() = 5]/child::section[position() = 2]</code> selects the
 second <code>section</code> of the fifth <code>chapter</code> of the <code>book</code> whose parent is the document node that contains the context node</p>
                </item>
 
@@ -10557,7 +10557,7 @@ all <code>para</code> children of the context node that have a <code>type</code>
                <item>
                   <p>
                      <code role="parse-test"
-                        >child::para[attribute::type eq 'warning'][fn:position() = 5]</code> selects the fifth <code>para</code> child of the context node that has a <code>type</code> attribute with value <code>warning</code>
+                        >child::para[attribute::type eq 'warning'][position() = 5]</code> selects the fifth <code>para</code> child of the context node that has a <code>type</code> attribute with value <code>warning</code>
                   </p>
                </item>
 
@@ -10565,7 +10565,7 @@ all <code>para</code> children of the context node that have a <code>type</code>
                <item>
                   <p>
                      <code role="parse-test"
-                        >child::para[fn:position() = 5][attribute::type eq "warning"]</code> selects the fifth <code>para</code> child of the context node if that child has a <code>type</code> attribute with value <code>warning</code>
+                        >child::para[position() = 5][attribute::type eq "warning"]</code> selects the fifth <code>para</code> child of the context node if that child has a <code>type</code> attribute with value <code>warning</code>
                   </p>
                </item>
 
@@ -10603,7 +10603,7 @@ selects the <code>chapter</code> and <code>appendix</code> children of the conte
                <item diff="chg" at="2022-12-13">
                   <p>
                      <code role="parse-test"
-                        >child::*[self::(chapter|appendix)][fn:position() = fn:last()]</code> selects the
+                        >child::*[self::(chapter|appendix)][position() = last()]</code> selects the
 last <code>chapter</code> or <code>appendix</code> child of the context node</p>
                </item>
             </ulist>
@@ -10776,7 +10776,7 @@ the <code>name</code> attribute of the context node</p>
                <item>
                   <p>
                      <code role="parse-test"
-                        >para[fn:last()]</code> selects the last <code>para</code> child of the context node</p>
+                        >para[last()]</code> selects the last <code>para</code> child of the context node</p>
                </item>
 
 
@@ -11053,7 +11053,7 @@ every integer between the two operands, in increasing order. </p>
                <p>This example selects the first four items from an input sequence:</p>
                <eg role="parse-test">$input[position() = 1 to 4]</eg>
                <!--<p>This example selects the first four items from an input sequence, in reverse order:</p>
-               <eg role="parse-test">fn:slice($input, 1 to 4 by -1)</eg>
+               <eg role="parse-test">slice($input, 1 to 4 by -1)</eg>
                <p>This example returns the array <code>["b", "c"]</code>:</p>
                <eg role="parse-test">array:slice(["a", "b", "c", "d"], 2 to 3)</eg>
                <p>This example returns the array <code>["d", "b"]</code>:</p>
@@ -11062,17 +11062,17 @@ every integer between the two operands, in increasing order. </p>
                <eg role="parse-test">$x = (100 to 200 by 2)</eg>-->
                <p>This example returns the sequence (0, 0.1, 0.2, 0.3, 0.5):</p>
                <eg role="parse-test">$x = (1 to 5)!.*0.1</eg>
-               <!--<p>This example returns the same result as <code>fn:reverse($input)</code>:</p>
+               <!--<p>This example returns the same result as <code>reverse($input)</code>:</p>
                <eg role="parse-test">$input by -1</eg>
                <p>This example returns <code>"ACE"</code>:</p>
-               <eg role="parse-test">(fn:characters("ABCDE") by 2) => fn:string-join()</eg>-->
+               <eg role="parse-test">(characters("ABCDE") by 2) => string-join()</eg>-->
                <p>This example constructs a sequence of length one containing the single integer 10.</p>
                <eg role="parse-test">10 to 10</eg>
                <p>The result of this example is a sequence of length zero.</p>
                <eg role="parse-test">15 to 10</eg>
                <p>This example uses the <code>fn:reverse</code> function to construct a sequence of six integers in decreasing order. 
                   It evaluates to the sequence 15, 14, 13, 12, 11, 10.</p>
-               <eg role="parse-test">fn:reverse(10 to 15)</eg>
+               <eg role="parse-test">reverse(10 to 15)</eg>
             </example>
           
             <!--<note>
@@ -11873,7 +11873,7 @@ is raised <errorref class="TY" code="0004"/>.</p>
                <item>
                   <p>The following comparison is true. The <code>eq</code> operator compares two QNames by performing codepoint-comparisons of their namespace URIs and their local names, ignoring their namespace prefixes.</p>
                   <eg role="parse-test"
-                     ><![CDATA[fn:QName("http://example.com/ns1", "this:color") eq fn:QName("http://example.com/ns1", "that:color")]]></eg>
+                     ><![CDATA[QName("http://example.com/ns1", "this:color") eq QName("http://example.com/ns1", "that:color")]]></eg>
                </item>
             </ulist>
          </div3>
@@ -13692,8 +13692,8 @@ if the EQName is a  <termref
    element with the same name and attributes as <code>$e</code> and
    with numeric content equal to twice the value of
    <code>$e</code>:</p>
-               <eg role="parse-test"><![CDATA[element {fn:node-name($e)}
-   {$e/@*, 2 * fn:data($e)}]]></eg>
+               <eg role="parse-test"><![CDATA[element {node-name($e)}
+   {$e/@*, 2 * data($e)}]]></eg>
                <p>In this example, if <code>$e</code> is
    bound by the expression <code>let $e := &lt;length
    units="inches"&gt;{5}&lt;/length&gt;</code>, then the result of the
@@ -14060,7 +14060,7 @@ attribute
                <eg role="parse-test">document
   {
       &lt;author-list&gt;
-         {fn:doc("bib.xml")/bib/book/author}
+         {doc("bib.xml")/bib/book/author}
       &lt;/author-list&gt;
   }</eg>
 
@@ -14311,7 +14311,7 @@ return processing-instruction {$target} {$content}]]></eg>
                <p>The <code>parent</code> property of the constructed comment node is set to empty.</p>
                <p>The following example illustrates a computed comment constructor:</p>
                <eg role="parse-test"><![CDATA[let $homebase := "Houston"
-return comment {fn:concat($homebase, ", we have a problem.")}]]></eg>
+return comment {concat($homebase, ", we have a problem.")}]]></eg>
                <p>The comment node constructed by this example might be serialized as follows:</p>
                <eg>&lt;!--Houston, we have a problem.--&gt;</eg>
             </div4>
@@ -14779,7 +14779,7 @@ context item is the <code>bib</code> element in the input
 document.</p>
 
 
-         <eg role="parse-test"><phrase role="parse-test">for $a in fn:distinct-values(book/author)
+         <eg role="parse-test"><phrase role="parse-test">for $a in distinct-values(book/author)
 return ((book/author[. = $a])[1], book[author = $a]/title)</phrase>
          </eg>
 
@@ -14824,12 +14824,12 @@ following example, which attempts to find the total value of a set of
 order-items, is therefore incorrect:
 
 </p>
-            <eg role="error"><![CDATA[fn:sum(for $i in order-item return @price * @qty)]]></eg>
+            <eg role="error"><![CDATA[sum(for $i in order-item return @price * @qty)]]></eg>
             <p>
 
 Instead, the expression must be written to use the variable bound in the <code>for</code> clause:</p>
             <eg role="parse-test"
-               ><![CDATA[fn:sum(for $i in order-item return $i/@price * $i/@qty)]]></eg>
+               ><![CDATA[sum(for $i in order-item return $i/@price * $i/@qty)]]></eg>
          </note>
          <note diff="add" at="2023-02-16">
             <p>XPath 4.0 allows the format:</p>
@@ -14897,9 +14897,9 @@ return $y[@value gt $x/@min]
                for example, to write:</p>
             <eg role="parse-test"><![CDATA[
 let $x := "[A fine romance]"
-let $x := fn:substring-after($x, "[")
-let $x := fn:substring-before($x, "]")
-return fn:upper-case($x)
+let $x := substring-after($x, "[")
+let $x := substring-before($x, "]")
+return upper-case($x)
 ]]></eg>
             <p>which returns the result <code>"A FINE ROMANCE"</code>. Note that this expression declares
             three separate variables which happen to have the same name; it should not be read as declaring
@@ -15422,7 +15422,7 @@ map {
                               def="ParenthesizedExpr">ParenthesizedExpr</nt> <phrase diff="add" at="A">or <nt def="VarRef">VarRef</nt></phrase>:</p>
 
                      <eg><![CDATA[
-for $k in fn:data(KS)
+for $k in data(KS)
 return .($k)  
 ]]></eg>
                   </item>
@@ -15471,7 +15471,7 @@ return .($k)
                               def="ParenthesizedExpr">ParenthesizedExpr</nt> <phrase diff="add" at="A">or <nt def="VarRef">VarRef</nt></phrase>:</p>
 
                      <eg><![CDATA[
-for $k in fn:data(KS)
+for $k in data(KS)
 return .($k)  
 ]]></eg>
                   </item>
@@ -15576,7 +15576,7 @@ return .($k)
                      </item>
                      <item>
                         <p>If the <code>KeySpecifier</code> is a <code>ParenthesizedExpr</code>, then the expression <code>E?(S)</code> is equivalent to</p>
-                           <eg><![CDATA[for $e in E, $s in fn:data(S) return $e($s)]]></eg>
+                           <eg><![CDATA[for $e in E, $s in data(S) return $e($s)]]></eg>
                         <note>
                            <p>The focus for evaluating <code>S</code> is the same as the focus for the <code>Lookup</code> expression itself.</p>
                         </note>
@@ -16405,8 +16405,8 @@ let $y := $expr2]]></eg>
                   >type declarations</termref>, identified by the keyword <code>as</code>. The semantics of type declarations are defined in <specref
                   ref="id-binding-rules"/>.</p>
             <p>The following code fragment illustrates how a <code>for</code> clause and a <code>let</code> clause can be used together. The <code>for</code> clause produces an initial tuple stream containing a binding for variable <code>$d</code> to each department number found in a given input document. The <code>let</code> clause adds an additional binding to each tuple, binding variable <code>$e</code> to a sequence of employees whose department number matches the value of <code>$d</code> in that tuple.</p>
-            <eg><![CDATA[for $d in fn:doc("depts.xml")/depts/deptno
-let $e := fn:doc("emps.xml")/emps/emp[deptno eq $d]]]></eg>
+            <eg><![CDATA[for $d in doc("depts.xml")/depts/deptno
+let $e := doc("emps.xml")/emps/emp[deptno eq $d]]]></eg>
          </div3>
 
 
@@ -16665,7 +16665,7 @@ to the item before the next window's starting item, or the end of the
                   <item>
                      <p>Show non-overlapping windows of three items.</p>
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s when fn:true()
+    start at $s when true()
     only end at $e when $e - $s eq 2
 return <window>{ $w }</window>]]></eg>
 
@@ -16680,7 +16680,7 @@ return <window>{ $w }</window>]]></eg>
                      <p>Show averages of non-overlapping three-item windows.</p>
                      <eg role="parse-test"><![CDATA[
 for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s when fn:true()
+    start at $s when true()
     only end at $e when $e - $s eq 2
 return avg($w)]]></eg>
 
@@ -16693,7 +16693,7 @@ return avg($w)]]></eg>
                   <item>
                      <p>Show first and last items in each window of three items.</p>
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start $first at $s when fn:true()
+    start $first at $s when true()
     only end $last at $e when $e - $s eq 2
 return <window>{ $first, $last }</window>]]></eg>
 
@@ -16707,7 +16707,7 @@ return <window>{ $first, $last }</window>]]></eg>
                   <item>
                      <p>Show non-overlapping windows of up to three items (illustrates <code>end</code> clause without the <code>only</code> keyword).</p>
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s when fn:true()
+    start at $s when true()
     end at $e when $e - $s eq 2
 return <window>{ $w }</window>]]></eg>
 
@@ -16776,7 +16776,7 @@ item may be found in multiple windows drawn from the same <termref
                   <item>
                      <p>Show windows of three items.</p>
                      <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s when fn:true()
+    start at $s when true()
     only end at $e when $e - $s eq 2
 return <window>{ $w }</window>]]></eg>
 
@@ -16795,7 +16795,7 @@ return <window>{ $w }</window>]]></eg>
                      <p>Show moving averages of three items.</p>
 
                      <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s when fn:true()
+    start at $s when true()
     only end at $e when $e - $s eq 2
 return avg($w)]]></eg>
 
@@ -16809,7 +16809,7 @@ return avg($w)]]></eg>
                      <p>Show overlapping windows of up to three items (illustrates <code>end</code> clause without the <code>only</code> keyword).</p>
 
                      <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s when fn:true()
+    start at $s when true()
     end at $e when $e - $s eq 2
 return <window>{ $w }</window>]]></eg>
 
@@ -16866,10 +16866,10 @@ order in which their start items appear in the <termref
    end $last next $beyond when $last/price &gt; $beyond/price
 return
    &lt;run-up&gt;
-      &lt;start-date&gt;{fn:data($first/date)}&lt;/start-date&gt;
-      &lt;start-price&gt;{fn:data($first/price)}&lt;/start-price&gt;
-      &lt;end-date&gt;{fn:data($last/date)}&lt;/end-date&gt;
-      &lt;end-price&gt;{fn:data($last/price)}&lt;/end-price&gt;
+      &lt;start-date&gt;{data($first/date)}&lt;/start-date&gt;
+      &lt;start-price&gt;{data($first/price)}&lt;/start-price&gt;
+      &lt;end-date&gt;{data($last/date)}&lt;/end-date&gt;
+      &lt;end-price&gt;{data($last/price)}&lt;/end-price&gt;
    &lt;/run-up&gt;</eg>
                <p>For our sample input data, this <code>tumbling window</code> clause generates a tuple stream consisting of two tuples, each representing a window and containing five bound variables named <code>$w</code>, <code>$first</code>, <code>$second</code>, <code>$last</code>, and <code>$beyond</code>. The <code>return</code> clause is evaluated for each of these tuples, generating the following query result:</p>
                <eg>&lt;run-up&gt;
@@ -16900,17 +16900,17 @@ return
   <closing> <symbol>DEF</symbol> <date>2008-01-06</date> <price>059</price> </closing>
 </stocks>]]></eg>
                <p>As in the previous example, we want to find "run-ups," which are defined as sequences of dates that begin with a "low" and end with a "high" price for a specific company. In this example, however, the input data consists of stock prices for multiple companies. Therefore it is necessary to isolate the stock prices of each company before forming windows. This can be accomplished by an initial <code>for</code> and <code>let</code> clause, followed by a <code>window</code> clause, as follows:</p>
-               <eg role="parse-test">for $symbol in fn:distinct-values(//symbol)
+               <eg role="parse-test">for $symbol in distinct-values(//symbol)
 let $closings := //closing[symbol = $symbol]
 for tumbling window $w in $closings
    start $first next $second when $first/price &lt; $second/price
    end $last next $beyond when $last/price &gt; $beyond/price
 return
    &lt;run-up symbol="{$symbol}"&gt;
-      &lt;start-date&gt;{fn:data($first/date)}&lt;/start-date&gt;
-      &lt;start-price&gt;{fn:data($first/price)}&lt;/start-price&gt;
-      &lt;end-date&gt;{fn:data($last/date)}&lt;/end-date&gt;
-      &lt;end-price&gt;{fn:data($last/price)}&lt;/end-price&gt;
+      &lt;start-date&gt;{data($first/date)}&lt;/start-date&gt;
+      &lt;start-price&gt;{data($first/price)}&lt;/start-price&gt;
+      &lt;end-date&gt;{data($last/date)}&lt;/end-date&gt;
+      &lt;end-price&gt;{data($last/price)}&lt;/end-price&gt;
    &lt;/run-up&gt;</eg>
                <note>
                   <p>In the above example, the <code>for</code> and <code>let</code> clauses could be rewritten as follows:</p>
@@ -17441,7 +17441,7 @@ let $category := $p/category
 group by $category
 return
    &lt;category name="{$category}"&gt;
-      {fn:count($p)} products have price greater than {$high-price}.
+      {count($p)} products have price greater than {$high-price}.
    &lt;/category&gt;</eg>
                   <p>If three products in the "Men's Wear" category have prices greater than 1000, the result of this query might look (in part) like this:</p>
                   <eg>&lt;category name="Men's Wear"&gt;
@@ -17457,7 +17457,7 @@ return
    group by $category
    return
       &lt;category name="{$category}"&gt;
-         {fn:count($p)} products have price greater than {$high-price}.
+         {count($p)} products have price greater than {$high-price}.
       &lt;/category&gt;</eg>
                   <p>The result of the revised query might contain the following element:</p>
                   <eg>&lt;category name="Men's Wear"&gt;
@@ -17766,16 +17766,16 @@ sort(
                   def="dt-comma-operator"
                >comma operator</termref>, to form the result of the FLWOR expression.</p>
             <p>The following example illustrates a FLWOR expression containing several clauses. The <code>for</code> clause iterates over all the departments in an input document named <code>depts.xml</code>, binding the variable <code>$d</code> to each department  in turn. For each binding of <code>$d</code>, the <code>let</code> clause binds variable <code>$e</code> to all the employees in the given department, selected from another input document named <code>emps.xml</code> (the relationship between employees and departments is represented by matching their <code>deptno</code> values). Each tuple in the resulting tuple stream contains a pair of bindings for <code>$d</code> and <code>$e</code> (<code>$d</code> is bound to a department and <code>$e</code> is bound to a set of employees in that department). The <code>where</code> clause filters the tuple stream, retaining only those tuples that represent departments having at least ten employees. The <code>order by</code> clause orders the surviving tuples in descending order by the average salary of the employees in the department. The <code>return</code> clause constructs a new <code>big-dept</code> element for each surviving tuple, containing the department number, headcount, and average salary.</p>
-            <eg role="parse-test"><![CDATA[for $d in fn:doc("depts.xml")//dept
-let $e := fn:doc("emps.xml")//emp[deptno eq $d/deptno]
-where fn:count($e) >= 10
-order by fn:avg($e/salary) descending
+            <eg role="parse-test"><![CDATA[for $d in doc("depts.xml")//dept
+let $e := doc("emps.xml")//emp[deptno eq $d/deptno]
+where count($e) >= 10
+order by avg($e/salary) descending
 return
    <big-dept>
       {
       $d/deptno,
-      <headcount>{fn:count($e)}</headcount>,
-      <avgsal>{fn:avg($e/salary)}</avgsal>
+      <headcount>{count($e)}</headcount>,
+      <avgsal>{avg($e/salary)}</avgsal>
       }
    </big-dept>]]></eg>
             <notes>
@@ -17787,9 +17787,9 @@ return
                      <p>The order in which items appear in the result of a FLWOR expression depends on the ordering of the input tuple stream to the <code>return</code> clause, which in turn is influenced by <code>order by</code> clauses and by <termref
                            def="dt-ordering-mode"
                         >ordering mode</termref>. For example, consider the following query, which is based on the same two input documents as the previous example:</p>
-                     <eg role="parse-test">for $d in fn:doc("depts.xml")//dept
+                     <eg role="parse-test">for $d in doc("depts.xml")//dept
 order by $d/deptno
-for $e in fn:doc("emps.xml")//emp[deptno eq $d/deptno]
+for $e in doc("emps.xml")//emp[deptno eq $d/deptno]
 return
    &lt;assignment&gt;
       {$d/deptno, $e/name}
@@ -17883,8 +17883,8 @@ Also, within a <termref def="dt-path-expression"
                def="dt-document-order"
                >document order</termref> of <code>suppliers.xml</code>. However, this might not be the most efficient way to process the query if the ordering of the result is not important. An XQuery implementation might be able to process the query more efficiently by using an index to find the red parts, or by using <code>suppliers.xml</code> rather than <code>parts.xml</code> to control the primary ordering of the result. The <code>unordered</code> expression gives the query evaluator freedom to make these kinds of optimizations.</p>
          <eg role="parse-test"><![CDATA[unordered {
-  for $p in fn:doc("parts.xml")/parts/part[color = "Red"],
-      $s in fn:doc("suppliers.xml")/suppliers/supplier
+  for $p in doc("parts.xml")/parts/part[color = "Red"],
+      $s in doc("suppliers.xml")/suppliers/supplier
   where $p/suppno = $s/suppno
   return
     <ps>
@@ -19237,13 +19237,13 @@ raised <errorref
                </item>
                <item>
                   <p>
-                     <code role="parse-test">fn:string-join((1 to $n)!"*")</code>
+                     <code role="parse-test">string-join((1 to $n)!"*")</code>
                   </p>
                   <p>Returns a string containing <code>$n</code> asterisks.</p>
                </item>
                <item>
                   <p>
-                     <code role="parse-test">$values!(.*.) =&gt; fn:sum()</code>
+                     <code role="parse-test">$values!(.*.) =&gt; sum()</code>
                   </p>
                   <p>Returns the sum of the squares of a sequence of numbers.</p>
                </item>

--- a/specifications/xquery-40/src/query-examples.xml
+++ b/specifications/xquery-40/src/query-examples.xml
@@ -45,9 +45,9 @@
 			secondarily by supplier name.</p>
 		<eg role="parse-test"><![CDATA[<descriptive-catalog>
    { 
-     for $i in fn:doc("catalog.xml")/items/item,
-         $p in fn:doc("parts.xml")/parts/part[partno = $i/partno],
-         $s in fn:doc("suppliers.xml")/suppliers
+     for $i in doc("catalog.xml")/items/item,
+         $p in doc("parts.xml")/parts/part[partno = $i/partno],
+         $s in doc("suppliers.xml")/suppliers
                   /supplier[suppno = $i/suppno]
      order by $p/description, $s/suppname
      return
@@ -69,15 +69,15 @@
 		<p>The following query demonstrates a left outer join. It returns names of all the suppliers
 			in alphabetic order, including those that supply no parts. In the result, each supplier
 			element contains the descriptions of all the parts it supplies, in alphabetic order.</p>
-		<eg role="parse-test"><![CDATA[for $s in fn:doc("suppliers.xml")/suppliers/supplier
+		<eg role="parse-test"><![CDATA[for $s in doc("suppliers.xml")/suppliers/supplier
 order by $s/suppname
 return
    <supplier>
       { 
         $s/suppname,
-        for $i in fn:doc("catalog.xml")/items/item
+        for $i in doc("catalog.xml")/items/item
                  [suppno = $s/suppno],
-            $p in fn:doc("parts.xml")/parts/part
+            $p in doc("parts.xml")/parts/part
                  [partno = $i/partno]
         order by $p/description
         return $p/description 
@@ -96,15 +96,15 @@ return
 
 		<eg role="parse-test"><![CDATA[<master-list>
  {
-    for $s in fn:doc("suppliers.xml")/suppliers/supplier
+    for $s in doc("suppliers.xml")/suppliers/supplier
     order by $s/suppname
     return
         <supplier>
            { 
              $s/suppname,
-             for $i in fn:doc("catalog.xml")/items/item
+             for $i in doc("catalog.xml")/items/item
                      [suppno = $s/suppno],
-                 $p in fn:doc("parts.xml")/parts/part
+                 $p in doc("parts.xml")/parts/part
                      [partno = $i/partno]
              order by $p/description
              return
@@ -119,8 +119,8 @@ return
     ,
     (: parts that have no supplier :)
     <orphan-parts>
-       { for $p in fn:doc("parts.xml")/parts/part
-         where fn:empty(fn:doc("catalog.xml")/items/item
+       { for $p in doc("parts.xml")/parts/part
+         where empty(doc("catalog.xml")/items/item
                [partno = $p/partno] )
          order by $p/description
          return $p/description 
@@ -170,7 +170,7 @@ return $i]]></eg>
    {
       $a << $b
         and
-      fn:empty($a//node() intersect $b) 
+      empty($a//node() intersect $b) 
    };
 ]]></eg>
 
@@ -182,7 +182,7 @@ return $i]]></eg>
    {
       $a >> $b
         and
-      fn:empty($b//node() intersect $a) 
+      empty($b//node() intersect $a) 
    };
 ]]></eg>
 
@@ -204,7 +204,7 @@ return $i]]></eg>
 
 		<eg role="parse-test"><![CDATA[for $proc in /report/procedure
 where some $i in $proc//incision satisfies
-         fn:empty($proc//anesthesia[. << $i])
+         empty($proc//anesthesia[. << $i])
 return $proc]]></eg>
 		<p>In some documents, particular sequences of elements may indicate a logical hierarchy.
 			This is most commonly true of HTML. The following query returns the introduction of an
@@ -218,7 +218,7 @@ return
    <div>
      {
        $intro,
-       if (fn:empty($next-h))
+       if (empty($next-h))
          then //node()[. >> $intro]
          else //node()[. >> $intro and . << $next-h]
      }
@@ -241,19 +241,19 @@ return
 			the element. This might be accomplished by the following recursive function:</p>
 		<eg role="frag-prolog-parse-test">
 declare function local:sections-and-titles($n as node()) as node()? { 
-   if (fn:local-name($n) = "section") then 
-      element { fn:local-name($n) } { 
+   if (local-name($n) = "section") then 
+      element { local-name($n) } { 
          for $c in $n/* 
          return local:sections-and-titles($c) 
       } 
-   else if (fn:local-name($n) = "title") then 
+   else if (local-name($n) = "title") then 
       $n 
    else ( ) 
 };</eg>
 		<p>The "skeleton" of a given document, containing only its sections and titles, can then be
 			obtained by invoking the <code>local:sections-and-titles</code> function on the root
 			node of the document, as follows:</p>
-		<eg role="parse-test">local:sections-and-titles(fn:doc("cookbook.xml"))</eg>
+		<eg role="parse-test">local:sections-and-titles(doc("cookbook.xml"))</eg>
 		<p>As another example of a recursive transformation, suppose that we wish to scan over a
 			document, transforming every attribute named <code>color</code> to an element named
 				<code>color</code>, and every element named <code>size</code> to an attribute named
@@ -264,12 +264,12 @@ declare function local:sections-and-titles($n as node()) as node()? {
 declare function local:swizzle($n as node()) as node() {
    typeswitch($n) 
    case $a as attribute(color) 
-      return element color { fn:string($a) } 
+      return element color { string($a) } 
    case $es as element(size) 
-      return attribute size { fn:string($es) } 
+      return attribute size { string($es) } 
    case $e as element() 
       return element 
-         { fn:local-name($e) } 
+         { local-name($e) } 
          { for $c in 
             ($e/@* except $e/@color,    (: attr -&gt; attr :) 
              $e/size,                   (: elem -&gt; attr :) 
@@ -284,7 +284,7 @@ declare function local:swizzle($n as node()) as node() {
 		<p>The transformation can be applied to a whole document by invoking the
 				<code>local:swizzle</code> function on the root node of the document, as
 			follows:</p>
-		<eg role="parse-test">local:swizzle(fn:doc("plans.xml"))</eg>
+		<eg role="parse-test">local:swizzle(doc("plans.xml"))</eg>
 	</div2>
 	<div2 id="id-select-distinct">
 		<head>Selecting Distinct Combinations</head>
@@ -304,12 +304,12 @@ declare function local:swizzle($n as node()) as node() {
 				<code>product</code>, <code>size</code>, and <code>color</code> that occur together
 			in an <code>order</code>. The following query returns this list, enclosing each distinct
 			combination in a new element named <code>option</code>:</p>
-		<eg role="parse-test" diff="chg" at="2022-12-07">for $p in fn:distinct-values(/orders/order/product), 
-    $s in fn:distinct-values(/orders/order/size), 
-    $c in fn:distinct-values(/orders/order/color)
+		<eg role="parse-test" diff="chg" at="2022-12-07">for $p in distinct-values(/orders/order/product), 
+    $s in distinct-values(/orders/order/size), 
+    $c in distinct-values(/orders/order/color)
 order by $p, $s, $c 
 return 
-   if (fn:exists(/orders/order[product eq $p 
+   if (exists(/orders/order[product eq $p 
          and size eq $s and color eq $c])) { 
       &lt;option&gt; 
          &lt;product&gt;{$p}&lt;/product&gt;

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1666,20 +1666,20 @@ declare context item as element(env:Envelope) external;</eg>
         <p>Using a function, prepare a summary of employees that are located in Denver.</p>
         <eg role="parse-test">declare function local:summary($emps as element(employee)*) as element(dept)* 
 { 
-  for $d in fn:distinct-values($emps/deptno) 
+  for $d in distinct-values($emps/deptno) 
   let $e := $emps[deptno = $d]
   return 
      &lt;dept&gt; 
        &lt;deptno&gt;{$d}&lt;/deptno&gt; 
-       &lt;headcount&gt; {fn:count($e)}
+       &lt;headcount&gt; {count($e)}
        &lt;/headcount&gt; 
        &lt;payroll&gt; 
-       {fn:sum($e/salary)} 
+       {sum($e/salary)} 
        &lt;/payroll&gt; 
      &lt;/dept&gt; 
 };
           
-local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
+local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       </item>
     </ulist>
 
@@ -1697,11 +1697,11 @@ declare function local:depth($e as node()) as xs:integer
 {
    (: A node with no children has depth 1 :)
    (: Otherwise, add 1 to max depth of children :)
-   if (fn:empty($e/*)) then 1
-   else fn:max(for $c in $e/* return local:depth($c)) + 1
+   if (empty($e/*)) then 1
+   else max(for $c in $e/* return local:depth($c)) + 1
 };
 
-local:depth(fn:doc("partlist.xml"))
+local:depth(doc("partlist.xml"))
         </eg>
       </item>
     </ulist>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35572,7 +35572,7 @@ return ($m?price - $m?discount)</eg>
                the function is evaluated. Maps are a new data type introduced in XSLT 3.0.</p>
             <p>For example, the function <code>fn:xml-to-json</code> has an options parameter
                allowing specification of whether the output is to be indented. A call might be written:</p>
-            <eg role="xpath" xml:space="preserve">fn:xml-to-json($input, map{'indent':true()})</eg>
+            <eg role="xpath" xml:space="preserve">xml-to-json($input, map{'indent':true()})</eg>
             <p><termdef id="option-parameter-conventions" term="option parameter conventions">Functions
                that take an options parameter adopt common conventions on how the
                options are used. These are referred to as the <term>option parameter conventions</term>. These


### PR DESCRIPTION
I’ve removed additional `fn:` prefixes from examples and `eg` code blocks. I have kept prefixes in the rules and formal code snippets untouched.

In the initial comment of #471, I have listed the remaining cleanups for which I want to prepare PRs.
I’ll wait until this and possibly some other PRs have been merged.
