### PR TITLE
471 (3): Render false/true/NaN/INF/-INF/+INF as code

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -127,7 +127,7 @@
       </fos:properties>
 
       <fos:summary>
-         <p>Returns true for an element that is <term>nilled</term>.</p>
+         <p>Returns <code>true</code> for an element that is <term>nilled</term>.</p>
       </fos:summary>
       <fos:rules>
          <p>If the argument is omitted, it defaults to the context item (<code>.</code>). <phrase diff="del" at="2022-11-29">The
@@ -157,7 +157,7 @@
       <fos:notes>
          <p>If <code>$node</code> is not an element node, the function returns the empty
             sequence.</p>
-         <p>If <code>$node</code> is an untyped element node, the function returns false.</p>
+         <p>If <code>$node</code> is an untyped element node, the function returns <code>false</code>.</p>
          <p>In practice, the function returns <code>true</code> only for an element node that has
             the attribute <code>xsi:nil="true"</code> and that is successfully validated against a
             schema that defines the element to be nillable; the detailed rules, however, are defined
@@ -474,7 +474,7 @@
             function, or a document node at the root of a tree containing a node returned by the
                <code>fn:collection</code> function, it will always be true that either
                <code>fn:document-uri($D)</code> returns the empty sequence, or that the following
-            expression is true: <code>fn:doc(fn:document-uri($D))</code> is <code>$D</code>. It is
+            expression is <code>true</code>: <code>fn:doc(fn:document-uri($D))</code> is <code>$D</code>. It is
                <termref
                def="implementation-defined"
             >implementation-defined</termref> whether this guarantee also holds for
@@ -784,7 +784,7 @@
 
          <p>Otherwise, subject to limits of precision and overflow/underflow conditions, the result
             is the largest (furthest from zero) <code>xs:integer</code> value <code>$N</code> such
-            that the following expression is true:</p>
+            that the following expression is <code>true</code>:</p>
 
          <eg>fn:abs($N * $arg2) le fn:abs($arg1) 
                and fn:compare($N * $arg2, 0) eq fn:compare($arg1, 0).</eg>
@@ -1020,7 +1020,7 @@
          the "eq" operator when applied to two numeric values, and is also used in defining the
          semantics of "ne", "le" and "ge".</fos:opermap>
       <fos:summary>
-         <p>Returns true if and only if the value of <code>$arg1</code> is equal to the value of
+         <p>Returns <code>true</code> if and only if the value of <code>$arg1</code> is equal to the value of
                <code>$arg2</code>.</p>
       </fos:summary>
       <fos:rules>
@@ -1059,7 +1059,7 @@
                ref="xmlschema-2"
                />. If the
          ordering relation of the two values is <code>imcomparable</code> (which happens when one or both
-         of them is <code>NaN</code>, then the result is false.</p>
+         of them is <code>NaN</code>, then the result is <code>false</code>.</p>
 
       </fos:rules>
       <fos:notes>
@@ -1243,7 +1243,7 @@
          <p>When <code>$value</code> is of type <code>xs:float</code> and <code>xs:double</code>:</p>
          <olist>
             <item>
-               <p>If <code>$value</code> is NaN, positive or negative zero, or positive or negative
+               <p>If <code>$value</code> is <code>NaN</code>, positive or negative zero, or positive or negative
                   infinity, then the result is the same as the argument.</p>
             </item>
             <item>
@@ -3525,7 +3525,7 @@ return if (fn:starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></e
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if two strings are equal, considered codepoint-by-codepoint.</p>
+         <p>Returns <code>true</code> if two strings are equal, considered codepoint-by-codepoint.</p>
       </fos:summary>
       <fos:rules>
          <p>If either argument is the empty sequence, the function returns the empty sequence. </p>
@@ -4535,7 +4535,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the string <code>$value</code> contains <code>$substring</code> as a
+         <p>Returns <code>true</code> if the string <code>$value</code> contains <code>$substring</code> as a
             substring, taking collations into account.</p>
       </fos:summary>
       <fos:rules>
@@ -4640,7 +4640,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the string <code>$value</code> contains <code>$substring</code> as a leading
+         <p>Returns <code>true</code> if the string <code>$value</code> contains <code>$substring</code> as a leading
             substring, taking collations into account.</p>
       </fos:summary>
       <fos:rules>
@@ -4749,7 +4749,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the string <code>$value</code> contains <code>$substring</code> as a trailing
+         <p>Returns <code>true</code> if the string <code>$value</code> contains <code>$substring</code> as a trailing
             substring, taking collations into account.</p>
       </fos:summary>
       <fos:rules>
@@ -5059,7 +5059,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the supplied string matches a given regular expression.</p>
+         <p>Returns <code>true</code> if the supplied string matches a given regular expression.</p>
       </fos:summary>
       <fos:rules>
          <p>The effect of calling the first version of this function (omitting the argument
@@ -5722,7 +5722,7 @@ Tak, tak, tak! - da kommen sie.
             is a zero-length string, the function returns <code>false</code>.</p>
          <p>The collation used by this function is determined according to the rules in <specref
                ref="choosing-a-collation"/>.</p>
-         <p>The function returns true if and only if there is string in <code>$value</code> which, 
+         <p>The function returns <code>true</code> if and only if there is string in <code>$value</code> which, 
             after tokenizing at whitespace boundaries, contains a token
          that is equal to the trimmed value of <code>$token</code> under
          the rules of the selected collation.</p>
@@ -5961,7 +5961,7 @@ Tak, tak, tak! - da kommen sie.
          semantics of the "lt" operator when applied to two <code>xs:boolean</code> values. Also
          used in the definition of the "ge" operator.</fos:opermap>
       <fos:summary>
-         <p>Returns true if the first argument is false and the second is true.</p>
+         <p>Returns <code>true</code> if the first argument is <code>false</code> and the second is <code>true</code>.</p>
       </fos:summary>
       <fos:rules>
          <p>The function returns <code>true</code> if <code>$arg1</code> is <code>false</code> and
@@ -6112,12 +6112,12 @@ Tak, tak, tak! - da kommen sie.
          the semantics of the "lt" operator when applied to two <code>xs:yearMonthDuration</code>
          values. Also used in the definition of the "ge" operator.</fos:opermap>
       <fos:summary>
-         <p>Returns true if <code>$arg1</code> is a shorter duration than <code>$arg2</code>.</p>
+         <p>Returns <code>true</code> if <code>$arg1</code> is a shorter duration than <code>$arg2</code>.</p>
       </fos:summary>
       <fos:rules>
          <p>If the number of months in <code>$arg1</code> is numerically less than the
-            number of months in <code>$arg2</code>, the function returns true.</p>
-         <p>Otherwise, the function returns false.</p>
+            number of months in <code>$arg2</code>, the function returns <code>true</code>.</p>
+         <p>Otherwise, the function returns <code>false</code>.</p>
       </fos:rules>
       <fos:notes>
          <p>Either or both durations may be negative.</p>
@@ -6136,12 +6136,12 @@ Tak, tak, tak! - da kommen sie.
          semantics of the "lt" operator when applied to two <code>xs:dayTimeDuration</code> values.
          Also used in the definition of the "ge" operator.</fos:opermap>
       <fos:summary>
-         <p>Returns true if <code>$arg1</code> is a shorter duration than <code>$arg2</code>.</p>
+         <p>Returns <code>true</code> if <code>$arg1</code> is a shorter duration than <code>$arg2</code>.</p>
       </fos:summary>
       <fos:rules>
          <p>If the number of seconds in <code>$arg1</code> is numerically less than the
-            number of seconds in <code>$arg2</code>, the function returns true.</p>
-         <p>Otherwise, the function returns false.</p>
+            number of seconds in <code>$arg2</code>, the function returns <code>true</code>.</p>
+         <p>Otherwise, the function returns <code>false</code>.</p>
       </fos:rules>
       <fos:notes>
          <p>Either or both durations may be negative</p>
@@ -6160,7 +6160,7 @@ Tak, tak, tak! - da kommen sie.
          semantics of the "eq" operators when applied to two <code>xs:duration</code> values. Also
          used in the definition of the "ne" operator.</fos:opermap>
       <fos:summary>
-         <p>Returns true if <code>$arg1</code> and <code>$arg2</code> are durations of the same
+         <p>Returns <code>true</code> if <code>$arg1</code> and <code>$arg2</code> are durations of the same
             length.</p>
       </fos:summary>
       <fos:rules>
@@ -6168,7 +6168,7 @@ Tak, tak, tak! - da kommen sie.
                <code>$arg2</code> are equal and the <code>xs:dayTimeDuration</code> components of
                <code>$arg1</code> and <code>$arg2</code> are equal, the function returns
                <code>true</code>.</p>
-         <p>Otherwise, the function returns false.</p>
+         <p>Otherwise, the function returns <code>false</code>.</p>
          <p>The semantics of this function are:</p>
          <eg xml:space="preserve">
 xs:yearMonthDuration($arg1) div xs:yearMonthDuration('P1M')  eq
@@ -6977,7 +6977,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the two supplied <code>xs:dateTime</code> values refer to the same
+         <p>Returns <code>true</code> if the two supplied <code>xs:dateTime</code> values refer to the same
             instant in time.</p>
       </fos:summary>
       <fos:rules>
@@ -7320,7 +7320,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the two <code>xs:gYearMonth</code> values have the same starting
+         <p>Returns <code>true</code> if the two <code>xs:gYearMonth</code> values have the same starting
             instant.</p>
       </fos:summary>
       <fos:rules>
@@ -7367,7 +7367,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the two <code>xs:gYear</code> values have the same starting instant.</p>
+         <p>Returns <code>true</code> if the two <code>xs:gYear</code> values have the same starting instant.</p>
       </fos:summary>
       <fos:rules>
          <p>The starting instants of <code>$arg1</code> and <code>$arg2</code> are calculated by
@@ -7416,7 +7416,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the two <code>xs:gMonthDay</code> values have the same starting instant,
+         <p>Returns <code>true</code> if the two <code>xs:gMonthDay</code> values have the same starting instant,
             when considered as days in the same year.</p>
       </fos:summary>
       <fos:rules>
@@ -7470,7 +7470,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the two <code>xs:gMonth</code> values have the same starting instant,
+         <p>Returns <code>true</code> if the two <code>xs:gMonth</code> values have the same starting instant,
             when considered as months in the same year.</p>
       </fos:summary>
       <fos:rules>
@@ -7523,7 +7523,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the two <code>xs:gDay</code> values have the same starting instant, when
+         <p>Returns <code>true</code> if the two <code>xs:gDay</code> values have the same starting instant, when
             considered as days in the same month of the same year.</p>
       </fos:summary>
       <fos:rules>
@@ -10063,7 +10063,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          the "eq" and "ne" operators when applied to two <code>xs:hexBinary</code>
          values.</fos:opermap>
       <fos:summary>
-         <p>Returns true if two <code>xs:hexBinary</code> values contain the same octet
+         <p>Returns <code>true</code> if two <code>xs:hexBinary</code> values contain the same octet
             sequence.</p>
       </fos:summary>
       <fos:rules>
@@ -10084,10 +10084,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          the "lt" operator when applied to two <code>xs:hexBinary</code> values. Also used in the
          definition of the "ge" operator.</fos:opermap>
       <fos:summary>
-         <p>Returns true if the first argument is less than the second.</p>
+         <p>Returns <code>true</code> if the first argument is less than the second.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns <code>true</code> if any of the following conditions is true:</p>
+         <p>The function returns <code>true</code> if any of the following conditions is <code>true</code>:</p>
          <olist>
             <item>
                <p><code>$arg1</code> is zero-length (contains no octets) and <code>$arg2</code> is
@@ -10123,7 +10123,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          of the "eq" and "ne" operators when applied to two <code>xs:base64Binary</code>
          values.</fos:opermap>
       <fos:summary>
-         <p>Returns true if two <code>xs:base64Binary</code> values contain the same octet
+         <p>Returns <code>true</code> if two <code>xs:base64Binary</code> values contain the same octet
             sequence.</p>
       </fos:summary>
       <fos:rules>
@@ -10144,10 +10144,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          of the "lt" operator when applied to two <code>xs:base64Binary</code> values. Also used in
          the definition of the "ge" operator.</fos:opermap>
       <fos:summary>
-         <p>Returns true if the first argument is less than the second.</p>
+         <p>Returns <code>true</code> if the first argument is less than the second.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns <code>true</code> if any of the following conditions is true:</p>
+         <p>The function returns <code>true</code> if any of the following conditions is <code>true</code>:</p>
          <olist>
             <item>
                <p><code>$arg1</code> is zero-length (contains no octets) and <code>$arg2</code> is
@@ -10833,7 +10833,7 @@ let $newi := $o/tool</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the supplied node has one or more child nodes (of any kind).</p>
+         <p>Returns <code>true</code> if the supplied node has one or more child nodes (of any kind).</p>
       </fos:summary>
       <fos:rules>
          <p>If the argument is omitted, it defaults to the context item (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
@@ -10861,7 +10861,7 @@ let $newi := $o/tool</eg>
 
       </fos:errors>
       <fos:notes>
-         <p>If <code>$node</code> is an empty sequence the result is false.</p>
+         <p>If <code>$node</code> is an empty sequence the result is <code>false</code>.</p>
          <p>The motivation for this function is to support streamed evaluation. According to the
             streaming rules in <bibref
                ref="xslt-40"/>, the following construct is not
@@ -11006,8 +11006,8 @@ let $newi := $o/tool</eg>
             <code>$input</code> matches <code>$search</code>, then the function returns the empty
             sequence.</p>
          <p>No error occurs if non-comparable values are encountered. So when comparing two atomic
-            values, the effective boolean value of <code>fn:index-of($a, $b)</code> is true if
-               <code>$a</code> and <code>$b</code> are equal, false if they are not equal or not
+            values, the effective boolean value of <code>fn:index-of($a, $b)</code> is <code>true</code> if
+               <code>$a</code> and <code>$b</code> are equal, <code>false</code> if they are not equal or not
             comparable.</p>
       </fos:notes>
       <fos:examples>
@@ -11064,7 +11064,7 @@ let $newi := $o/tool</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the argument is the empty sequence.</p>
+         <p>Returns <code>true</code> if the argument is the empty sequence.</p>
       </fos:summary>
       <fos:rules>
          <p>If <code>$input</code> is the empty sequence, the function returns
@@ -11123,7 +11123,7 @@ let $newi := $o/tool</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the argument is a non-empty sequence.</p>
+         <p>Returns <code>true</code> if the argument is a non-empty sequence.</p>
       </fos:summary>
       <fos:rules>
          <p>If <code>$input</code> is a non-empty sequence, the function returns
@@ -11195,7 +11195,7 @@ let $newi := $o/tool</eg>
             but one of a set of values that are considered equal to one another. 
             <phrase>Two items <var>$J</var> and <var>$K</var> in the input sequence 
                (after atomization, as required by the function signature)
-            are considered equal if <code>fn:deep-equal($J, $K, $coll)</code> is true,
+            are considered equal if <code>fn:deep-equal($J, $K, $coll)</code> is <code>true</code>,
             where <code>$coll</code> is the collation selected according to the rules in <specref
                   ref="choosing-a-collation"
             />.</phrase> This collation is used when string comparison is
@@ -11895,7 +11895,7 @@ let $newi := $o/tool</eg>
          <p>As a consequence of the general rules, if <code>$start</code> is
                <code>-INF</code> and <code>$length</code> is <code>+INF</code>, then
                <code>fn:round($start) + fn:round($length)</code> is <code>NaN</code>; since
-               <code>position() lt NaN</code> is always false, the result is an empty sequence.</p>
+               <code>position() lt NaN</code> always returns <code>false</code>, the result is an empty sequence.</p>
 
          <p>The reason the function accepts arguments of type <code>xs:double</code> is that many
             computations on untyped data return an <code>xs:double</code> result; and the reason for
@@ -12269,7 +12269,7 @@ let $newi := $o/tool</eg>
          <p>Determines whether one sequence starts with another, using a supplied callback function to compare items.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, the function returns true if <code>$input</code> starts with <code>$subsequence</code>,
+         <p>Informally, the function returns <code>true</code> if <code>$input</code> starts with <code>$subsequence</code>,
          when items are compared using the supplied (or default) <code>$compare</code> function.</p>
          <p>More formally, the function returns the value of the expression:</p>
          <eg><![CDATA[fn:count($input) ge fn:count($subsequence) 
@@ -12357,7 +12357,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
          <p>Determines whether one sequence ends with another, using a supplied callback function to compare items.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, the function returns true if <code>$input</code> ends with <code>$subsequence</code>,
+         <p>Informally, the function returns <code>true</code> if <code>$input</code> ends with <code>$subsequence</code>,
             when items are compared using the supplied (or default) <code>$compare</code> function.</p>
          <p>More formally, the function returns the value of the expression:</p>
          <eg><![CDATA[fn:starts-with-sequence(fn:reverse($input), fn:reverse($subsequence), $compare)]]></eg>
@@ -12445,7 +12445,7 @@ and fn:all(fn:for-each-pair($input, $subsequence, $compare))]]></eg>
          <p>Determines whether one sequence contains another as a contiguous subsequence, using a supplied callback function to compare items.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, the function returns true if <code>$input</code> contains a consecutive subsequence matching <code>$subsequence</code>,
+         <p>Informally, the function returns <code>true</code> if <code>$input</code> contains a consecutive subsequence matching <code>$subsequence</code>,
             when items are compared using the supplied (or default) <code>$compare</code> function.</p>
          <p>More formally, the function returns the value of the expression:</p>
          <eg><![CDATA[if (fn:starts-with-sequence($input, $subsequence, $compare))
@@ -12691,7 +12691,7 @@ else if (fn:empty($input))
                   <fos:default>false</fos:default>
                </fos:option>
                <fos:option key="debug">
-                  <fos:meaning>Requests diagnostics in the case where the function returns false.
+                  <fos:meaning>Requests diagnostics in the case where the function returns <code>false</code>.
                      When this option is set and the two inputs are found to be not equal, the implementation
                      <rfc2119>should</rfc2119> output messages (in an implementation-dependent format and to
                      an implementation-dependent destination) indicating the nature of the differences that
@@ -12701,8 +12701,8 @@ else if (fn:empty($input))
                   <fos:default>false</fos:default>
                </fos:option>
                <fos:option key="false-on-error">
-                  <fos:meaning>If true, then in the event of a dynamic error occurring in the course of
-                     the comparison, the function will return false rather than throwing the error. (This option does
+                  <fos:meaning>If <code>true</code>, then in the event of a dynamic error occurring in the course of
+                     the comparison, the function will return <code>false</code> rather than throwing the error. (This option does
                      not affect the handling of errors in the supplied values of the <code>$collation</code>
                      and <code>$options</code> arguments.)
                   </fos:meaning>
@@ -12810,7 +12810,7 @@ else if (fn:empty($input))
                </fos:option>
             </fos:options>
          
-         <note><p>As a general rule for boolean options (but not invariably), the value true indicates 
+         <note><p>As a general rule for boolean options (but not invariably), the value <code>true</code> indicates 
             that the comparison is more strict. </p></note>
 
          <p>In the following rules, where a recursive call on <code>fn:deep-equal</code> is made, this is assumed
@@ -12819,7 +12819,7 @@ else if (fn:empty($input))
          <p>The rules reference a function <code>equal-strings</code> which compares two strings as follows:</p>
          
          <olist>
-            <item><p>If the <code>normalize-space</code> option is true, each string is processed
+            <item><p>If the <code>normalize-space</code> option is <code>true</code>, each string is processed
                by calling the <code>fn:normalize-space</code> function.</p></item>
             <item><p>If the <code>normalization-form</code> option is present, each string is then normalized
             by calling the <code>fn:normalize-unicode</code> function, supplying the specified normalization
@@ -12843,7 +12843,7 @@ else if (fn:empty($input))
          
          <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
             are as follows. The two items are deep-equal
-            if one or more of the following conditions is true:</p>
+            if one or more of the following conditions are true:</p>
          <olist>
             <item>
                <p>All of the following conditions are true:</p>
@@ -12853,7 +12853,7 @@ else if (fn:empty($input))
                   <item>
                      <p><code>$i2</code> is an atomic value.</p></item>
                   <item>
-                     <p>Either the <code>type-annotations</code> option is false, or both atomic values have
+                     <p>Either the <code>type-annotations</code> option is <code>false</code>, or both atomic values have
                      the same type annotation.</p>
                   </item>
                   <item>
@@ -12862,7 +12862,7 @@ else if (fn:empty($input))
                         <item><p><code>$i1</code> is an instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p></item>
                         <item><p><code>$i2</code> is an instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p></item>
                      </ulist>
-                     <p>then the function <code>equal-strings($i1, $i2, $collation, $options)</code> returns true.</p>
+                     <p>then the function <code>equal-strings($i1, $i2, $collation, $options)</code> returns <code>true</code>.</p>
                      <p>Otherwise (at least one of the items is of some other type), either:</p>
                      <ulist>
                         <item><p><code>$i1</code> and <code>$i2</code> are comparable,
@@ -12871,13 +12871,13 @@ else if (fn:empty($input))
                      </ulist>
                      <note><p>If <code>$i1</code> and <code>$i2</code> are not comparable, that is,
                         if the expression <code>($i1 eq $i2)</code> would raise an error, then the function
-                     returns false; it does not report an error.</p></note>
+                     returns <code>false</code>; it does not report an error.</p></note>
                   </item>
                   
                   <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
-                        <item><p>Option <code>namespace-prefixes</code> is false.</p></item>
+                        <item><p>Option <code>namespace-prefixes</code> is <code>false</code>.</p></item>
                         <item><p>Neither <code>$i1</code> nor <code>$i2</code> is of type
                         <code>xs:QName</code> or <code>xs:NOTATION</code>.</p></item>
                         <item><p><code>$i1</code> and <code>$i2</code> are qualified names with the same namespace prefix.</p></item>
@@ -12886,7 +12886,7 @@ else if (fn:empty($input))
                   <item>
                      <p>One of the following conditions is true:</p>
                      <olist>
-                        <item><p>Option <code>timezones</code> is false.</p></item>
+                        <item><p>Option <code>timezones</code> is <code>false</code>.</p></item>
                         <item><p>Neither <code>$i1</code> nor <code>$i2</code> is of type
                            <code>xs:date</code>, <code>xs:time</code>, <code>xs:dateTime</code>, 
                            <code>xs:gYear</code>, <code>xs:gYearMonth</code>, <code>xs:gMonth</code>, 
@@ -12948,15 +12948,15 @@ else if (fn:empty($input))
                   <item><p><code>$i1</code> is a node.</p></item>
                   <item><p><code>$i2</code> is a node.</p></item>
                   <item><p>Both nodes have the same node kind.</p></item>
-                  <item><p>Either the <code>base-uri</code> option is false, or both nodes have the same value
+                  <item><p>Either the <code>base-uri</code> option is <code>false</code>, or both nodes have the same value
                      for their base URI property, or both nodes have an absent base URI.</p></item>
                   <item><p>Let <code>significant-children($parent)</code> be the sequence of nodes applying the following
                   steps to the children of <code>$parent</code>, in turn:</p>
                      <olist>
-                        <item><p>Comment nodes are discarded if the option <code>comments</code> is false.</p></item>
-                        <item><p>Processing instruction nodes are discarded if the option <code>processing-instructions</code> is false.</p></item>
-                        <item><p>Adjacent text nodes are merged if the option <code>text-boundaries</code> is false.</p></item>
-                        <item><p>Whitespace-only text nodes are discarded if the option <code>preserve-space</code> is false,
+                        <item><p>Comment nodes are discarded if the option <code>comments</code> is <code>false</code>.</p></item>
+                        <item><p>Processing instruction nodes are discarded if the option <code>processing-instructions</code> is <code>false</code>.</p></item>
+                        <item><p>Adjacent text nodes are merged if the option <code>text-boundaries</code> is <code>false</code>.</p></item>
+                        <item><p>Whitespace-only text nodes are discarded if the option <code>preserve-space</code> is <code>false</code>,
                            or if <code>$parent</code> is an element node whose type annotation is a complex type with an element-only
                            or empty content model.</p></item>
                  
@@ -12978,33 +12978,33 @@ else if (fn:empty($input))
                                     node-name($i2))</code>.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>namespace-prefixes</code> is false, or both element
+                                 <p>Either the option <code>namespace-prefixes</code> is <code>false</code>, or both element
                                     names have the same prefix.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>in-scope-namespaces</code> is false, or both element
+                                 <p>Either the option <code>in-scope-namespaces</code> is <code>false</code>, or both element
                                     nodes have the same in-scope namespace bindings.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>type-annotations</code> is false, or both
+                                 <p>Either the option <code>type-annotations</code> is <code>false</code>, or both
                                     element nodes have the same type annotation.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>id-property</code> is false, or both element
+                                 <p>Either the option <code>id-property</code> is <code>false</code>, or both element
                                     nodes have the same value for their <code>is-id</code> property.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>idrefs-property</code> is false, or both element
+                                 <p>Either the option <code>idrefs-property</code> is <code>false</code>, or both element
                                     nodes have the same value for their <code>is-idrefs</code> property.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>nilled-property</code> is false, or both element
+                                 <p>Either the option <code>nilled-property</code> is <code>false</code>, or both element
                                     nodes have the same value for their <code>nilled</code> property.</p>
                               </item>
                               <item>
                                  <p>One of the following conditions is true:</p>
                                  <olist>
-                                    <item><p>The option <code>type-variety</code> is false.</p></item>
+                                    <item><p>The option <code>type-variety</code> is <code>false</code>.</p></item>
                                     <item><p>Both nodes are annotated as having simple content.
                                        For this purpose <term>simple content</term>
                                        means either a simple type or a complex type with simple content.</p></item>
@@ -13031,7 +13031,7 @@ else if (fn:empty($input))
                                  <olist>
                                     <item>
                                        <p>Both element nodes are annotated as having simple content (as defined
-                                          above), the <code>typed-values</code> option is true, 
+                                          above), the <code>typed-values</code> option is <code>true</code>, 
                                           and the typed value of <code>$i1</code> is deep-equal
                                           to the typed value of <code>$i2</code>.</p>
                                        <note><p>The typed value of an element node is used only when the element
@@ -13040,8 +13040,8 @@ else if (fn:empty($input))
                                     </item>
                                     <item>
                                        <p>Both element nodes are annotated as having simple content (as defined
-                                          above), the <code>typed-values</code> option is false, 
-                                          and the <code>equal-strings</code> function returns true when
+                                          above), the <code>typed-values</code> option is <code>false</code>, 
+                                          and the <code>equal-strings</code> function returns <code>true</code> when
                                           applied to the string value of <code>$i1</code> 
                                           and the string value of <code>$i2</code>.</p>
                                     </item>
@@ -13080,29 +13080,29 @@ else if (fn:empty($input))
                                        node-name($i2))</code>.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>namespace-prefixes</code> is false, or both
+                                 <p>Either the option <code>namespace-prefixes</code> is <code>false</code>, or both
                                  attribute names have the same prefix.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>type-annotations</code> is false, or both
+                                 <p>Either the option <code>type-annotations</code> is <code>false</code>, or both
                                  attribute nodes have the same type annotation.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>id-property</code> is false, or both attribute nodes
+                                 <p>Either the option <code>id-property</code> is <code>false</code>, or both attribute nodes
                                     have the same value for their <code>is-id</code> property.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>idrefs-property</code> is false, or both attribute nodes
+                                 <p>Either the option <code>idrefs-property</code> is <code>false</code>, or both attribute nodes
                                     have the same value for their <code>is-idrefs</code> property.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>typed-value</code> is false, or 
+                                 <p>Either the option <code>typed-value</code> is <code>false</code>, or 
                                     the typed value of <code>$i1</code> is deep-equal to the typed value of
                                        <code>$i2</code>.</p>
                               </item>
                               <item>
-                                 <p>Either the option <code>typed-value</code> is true, or 
-                                    the <code>equal-strings</code> function returns true when applied to the string value of <code>$i1</code> 
+                                 <p>Either the option <code>typed-value</code> is <code>true</code>, or 
+                                    the <code>equal-strings</code> function returns <code>true</code> when applied to the string value of <code>$i1</code> 
                                     and the string value of <code>$i2</code>.</p>
                               </item>
                               
@@ -13117,7 +13117,7 @@ else if (fn:empty($input))
                                           node-name($i2))</code>.</p>
                                  </item>
                                  <item>
-                                    <p>The <code>equal-strings</code> function returns true when applied to 
+                                    <p>The <code>equal-strings</code> function returns <code>true</code> when applied to 
                                        the string value of <code>$i1</code> 
                                        and the string value of <code>$i2</code>.</p>
                                  </item>
@@ -13140,11 +13140,11 @@ else if (fn:empty($input))
                         </item>
                         <item>
                            <p>Both nodes are comment nodes, and the <code>equal-strings</code> function 
-                              returns true when applied to their string values.</p>
+                              returns <code>true</code> when applied to their string values.</p>
                         </item>
                         <item>
                            <p>Both nodes are text nodes, and the <code>equal-strings</code> function 
-                              returns true when applied to their string values.</p>
+                              returns <code>true</code> when applied to their string values.</p>
                            <note>
                               <p>The handling of whitespace is controlled by a number of options:</p>
                               <ulist>
@@ -13156,10 +13156,10 @@ else if (fn:empty($input))
                                  <item><p>The decision whether a text node is whitespace is made after
                                  stripping comments and processing instructions. However, the text nodes
                                  either side of a comment or processing instruction are merged only if the
-                                 <code>text-boundaries</code> option is true (it is false by default).
+                                 <code>text-boundaries</code> option is <code>true</code> (it is <code>false</code> by default).
                                  </p></item>
                                  <item><p>If the <code>preserve-space</code> option and the
-                                 <code>normalize-space</code> option are both true, then a whitespace-only
+                                 <code>normalize-space</code> option are both <code>true</code>, then a whitespace-only
                                  text node will be reduced to zero length; this means that all whitespace-only
                                  text nodes will compare equal regardless of their actual content, but the
                                  presence of the node is still considered significant.</p></item>
@@ -13179,15 +13179,15 @@ else if (fn:empty($input))
                </olist>
             </item>
          </olist>
-         <p>In all other cases the result is false.</p>
+         <p>In all other cases the result is <code>false</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A type error is raised <errorref class="TY" code="0015" type="type"
                /> if either input
             sequence contains a function item <phrase>that is not a map or
                array</phrase>. </p>
-         <p>However, the above error is not raised if the <code>false-on-error</code> option has the
-         value true; in this case, the function returns false rather than raising an error.</p>
+         <p>However, the above error is not raised if the <code>false-on-error</code> option is
+         <code>true</code>; in this case, the function returns <code>false</code> rather than raising an error.</p>
          <p>A type error is raised <xerrorref spec="XP" class="TY"
             code="0004" type="type"/> if the value of 
             <code>$options</code> includes an entry whose key is defined 
@@ -13214,7 +13214,7 @@ else if (fn:empty($input))
             or processing instruction, if it causes a text node to be split into two text nodes, may
             affect the result.</p>
          <p>Comparing items of different kind (for example, comparing an atomic
-            value to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns false, 
+            value to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns <code>false</code>, 
             it does not return an error. So
             the result of <code>fn:deep-equal(1, current-dateTime())</code> is <code>false</code>.</p>
          <p>Comparing a function (other than a map or array) to any other value raises a type error,
@@ -13409,7 +13409,7 @@ else if (fn:empty($input))
             <item><p><term>Name</term>: the name of the rule. This is used in two ways: in the result of the
             function, it identifies which rule was not satisfied. In the <code>$options</code> argument to the 
                function, it can be used to suppress checking of a particular rule by setting the corresponding
-            option to false. For example, setting <code>map{"ATTRIBUTES":false()}</code> means that
+            option to <code>false</code>. For example, setting <code>map{"ATTRIBUTES":false()}</code> means that
                the test named <code>"ATTRIBUTES"</code> is not applied, which means that attributes
             are not considered when comparing two elements.</p></item>
             <item><p><term>Condition</term>: indicates what kind of values the rule applies to. The condition
@@ -13418,8 +13418,8 @@ else if (fn:empty($input))
                is applicable to items that are instances of that <code>SequenceType</code>.</p></item>
             <item><p><term>Test</term>: the test that is applied to the two values. In many cases the
             test is expressed as an XPath expression, in which the two values are denoted as <code>$A</code>
-            and <code>$B</code>. The test is satisfied if the expression returns true; it fails if the expression
-            returns false or fails with a dynamic error.</p>
+            and <code>$B</code>. The test is satisfied if the expression returns <code>true</code>; it fails if the expression
+            returns <code>false</code> or fails with a dynamic error.</p>
                <p>If the test is satisfied, no output is generated. If the test fails, a difference record
                is appended to the output of the function.</p>
                <p>Some tests invoke recursive application of the rules. The recursive call appends a string
@@ -13758,10 +13758,10 @@ else if (fn:empty($input))
          also useful to be able to control which properties of the results are compared, for example, whether
          namespace prefixes, in-scope namespaces, and whitespace text nodes are considered significant.</p>
          <p>Broadly speaking, the function returns an empty sequence in situations where <code>fn:deep-equal</code>
-         returns true. However, the two functions differ slightly in what properties of the supplied input values
+         returns <code>true</code>. However, the two functions differ slightly in what properties of the supplied input values
          are considered significant. A reasonably close (but not exact) approximation to the rules for 
             <code>fn:deep-equal</code> is achieved by setting the normalization options <code>ignore-comments</code> and 
-            <code>ignore-processing-instructions</code> to true, and by suppressing the tests
+            <code>ignore-processing-instructions</code> to <code>true</code>, and by suppressing the tests
          <code>ATOMIC-TYPE</code>, <code>PREFIX</code>, <code>NODE-TYPE-ANNOTATION</code>, and
          <code>NAMESPACES</code>.</p>
          <p>The function is specified to achieve a high level of interoperability between implementations, but
@@ -14288,7 +14288,7 @@ else
          <p diff="add" at="2023-01-17">The explicit or implicit value of 
             the <code>$zero</code> argument is used only when the input sequence is empty, not
             when a non-empty sequence sums to zero. For example, <code>sum((-1, +1), xs:double('NaN'))</code>
-            returns the <code>xs:integer</code> value 0, not NaN.</p>
+            returns the <code>xs:integer</code> value <code>0</code>, not <code>NaN</code>.</p>
          <p> If the converted sequence contains exactly one value then that value is returned.</p>
       </fos:notes>
       <fos:examples>
@@ -14449,7 +14449,7 @@ else
                         <item>
                            <p>The <code>is-id</code> property (See <xspecref spec="DM40"
                                  ref="dm-is-id"
-                                 />.) of the element node is true, and the typed value
+                                 />.) of the element node is <code>true</code>, and the typed value
                               of the element node is equal to <code>V</code> under the rules of the
                                  <code>eq</code> operator using the Unicode codepoint collation
                                  (<code>http://www.w3.org/2005/xpath-functions/collation/codepoint</code>).</p>
@@ -14458,7 +14458,7 @@ else
                            <p>The element has an attribute node whose <code>is-id</code> property
                               (See <xspecref
                                  spec="DM40" ref="dm-is-id"
-                                 />.) is true and whose typed
+                                 />.) is <code>true</code> and whose typed
                               value is equal to <code>V</code> under the rules of the
                                  <code>eq</code> operator using the Unicode code point collation
                                  (<code>http://www.w3.org/2005/xpath-functions/collation/codepoint</code>).</p>
@@ -14631,7 +14631,7 @@ else
                            <p>The element has an child element node whose <code>is-id</code>
                               property (See <xspecref
                                  spec="DM40" ref="dm-is-id"
-                                 />.) is true and
+                                 />.) is <code>true</code> and
                               whose typed value is equal to <code>V</code> under the rules of the
                                  <code>eq</code> operator using the Unicode code point collation
                                  (<code>http://www.w3.org/2005/xpath-functions/collation/codepoint</code>).</p>
@@ -14640,7 +14640,7 @@ else
                            <p>The element has an attribute node whose <code>is-id</code> property
                               (See <xspecref
                                  spec="DM40" ref="dm-is-id"
-                                 />.) is true and whose typed
+                                 />.) is <code>true</code> and whose typed
                               value is equal to <code>V</code> under the rules of the
                                  <code>eq</code> operator using the Unicode code point collation
                                  (<code>http://www.w3.org/2005/xpath-functions/collation/codepoint</code>).</p>
@@ -14858,7 +14858,7 @@ else
             such nodes. However, each matching node will be returned at most once, regardless how
             many candidate <code>ID</code> values it matches.</p>
          <p> It is possible in a well-formed but invalid document to have a node whose
-               <code>is-idrefs</code> property is true but that does not conform to the lexical
+               <code>is-idrefs</code> property is <code>true</code> but that does not conform to the lexical
             rules for the <code>xs:IDREF</code> type. The effect of the above rules is that
             ill-formed candidate <code>ID</code> values and ill-formed <code>IDREF</code> values are
             ignored.</p>
@@ -14941,7 +14941,7 @@ else
             >deterministic</termref>. Two
             calls on this function return the same document node if the same URI Reference (after
             resolution to an absolute URI Reference) is supplied to both calls. Thus, the following
-            expression (if it does not raise an error) will always be true:</p>
+            expression (if it does not raise an error) will always return <code>true</code>:</p>
          <eg xml:space="preserve">doc("foo.xml") is doc("foo.xml")</eg>
          <p>However, for performance reasons, implementations may provide a user option to evaluate
             the function without a guarantee of determinism. The manner in which any such option is
@@ -15058,7 +15058,7 @@ else
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>The function returns true if and only if the function call <code>fn:doc($href)</code>
+         <p>The function returns <code>true</code> if and only if the function call <code>fn:doc($href)</code>
             would return a document node.</p>
       </fos:summary>
       <fos:rules>
@@ -15521,10 +15521,10 @@ else
          <p>The <code>fn:unparsed-text-available</code> function determines whether a call
             on the <code>fn:unparsed-text</code> function with identical arguments would
             return a string.</p>
-         <p>If the first argument is an empty sequence, the function returns false. </p>
-         <p>In other cases, the function returns true if a call on
+         <p>If the first argument is an empty sequence, the function returns <code>false</code>. </p>
+         <p>In other cases, the function returns <code>true</code> if a call on
                <code>fn:unparsed-text</code> with the same arguments would succeed, and
-            false if a call on <code>fn:unparsed-text</code> with the same arguments would
+            <code>false</code> if a call on <code>fn:unparsed-text</code> with the same arguments would
             fail with a non-recoverable dynamic error.</p>
          <p>The functions <code>fn:unparsed-text</code> and
                <code>fn:unparsed-text-available</code> have the same requirement for
@@ -15684,8 +15684,8 @@ else
              <termref
                   def="execution-scope"
                   >execution scope</termref>, 
-               <code>fn:codepoint-equal(fn:generate-id($N), fn:generate-id($M))</code> returns true 
-               if and only if <code>($M is $N)</code> returns true.</phrase></p>
+               <code>fn:codepoint-equal(fn:generate-id($N), fn:generate-id($M))</code> returns <code>true</code> 
+               if and only if <code>($M is $N)</code> returns <code>true</code>.</phrase></p>
 
          <p>The returned identifier <rfc2119>must</rfc2119> consist of ASCII alphanumeric characters
             and <rfc2119>must</rfc2119> start with an alphabetic character. Thus, the string is
@@ -16062,9 +16062,9 @@ else
                defined for the parameter in the schema for serialization parameters:</p>
                <olist>
                   <item><p>Where the type is <code>yes-no-type</code>, then an <code>xs:boolean</code> value
-                  where true represents "yes" and false represents "no".</p></item>
+                  where <code>true</code> represents <code>"yes"</code> and <code>false</code> represents <code>"no"</code>.</p></item>
                   <item><p>Where the type is <code>yes-no-omit-type</code>, then an optional <code>xs:boolean</code> value
-                     where true represents "yes", false represents "no", and the empty sequence represents "omit".</p></item>
+                     where <code>true</code> represents <code>"yes"</code>, <code>false</code> represents <code>"no"</code>, and the empty sequence represents <code>"omit"</code>.</p></item>
                   <item><p>For any other type derived from <code>xs:string</code>, an instance of <code>xs:string</code> that is
                   castable to the required type.</p></item>
                   <item><p>For the union type <code>method-type</code>, an instance of either <code>xs:string</code> or <code>xs:QName</code>
@@ -17171,7 +17171,7 @@ declare function fn:for-each($input, $action) {
       </fos:properties>
       <fos:summary>
          <p>Returns those items from the sequence <code>$input</code> for which the supplied function
-               <code>$predicate</code> returns true.</p>
+               <code>$predicate</code> returns <code>true</code>.</p>
       </fos:summary>
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
@@ -17314,8 +17314,8 @@ declare function fn:fold-left(
                <fos:expression>fold-left((true(), false(), false()), false(), function($a, $b) {
                   $a or $b })</fos:expression>
                <fos:result>true()</fos:result>
-               <fos:postamble>This returns true if any item in the sequence has an effective boolean
-                  value of true</fos:postamble>
+               <fos:postamble>This returns <code>true</code> if any item in the sequence has an effective boolean
+                  value of <code>true</code></fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -17323,8 +17323,8 @@ declare function fn:fold-left(
                <fos:expression>fold-left((true(), false(), false()), false(), function($a, $b) {
                   $a and $b })</fos:expression>
                <fos:result>false()</fos:result>
-               <fos:postamble>This returns true only if every item in the sequence has an effective
-                  boolean value of true</fos:postamble>
+               <fos:postamble>This returns <code>true</code> only if every item in the sequence has an effective
+                  boolean value of <code>true</code></fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -17913,7 +17913,7 @@ return fn:sort($in, $SWEDISH)
          has the following properties (which do not all apply to the <code>eq</code> operator):</p>
          <ulist>
             <item><p>Any two atomic values can be compared, regardless of their type.</p></item>
-            <item><p>No dynamic error is ever raised (the result is either true or false).</p></item>
+            <item><p>No dynamic error is ever raised (the result is either <code>true</code> or <code>false</code>).</p></item>
             <item><p>The result of the comparison never depends on the static or dynamic context.</p></item>
             <item><p>Every value (including <code>NaN</code>) is equal to itself.</p></item>
             <item><p>The comparison is symmetric: if <var>A</var> equals <var>B</var>, then <var>B</var> equals <var>A</var>.</p></item>
@@ -17921,7 +17921,7 @@ return fn:sort($in, $SWEDISH)
                then <var>A</var> equals <var>C</var>.</p></item>
          </ulist>
          
-         <p>The function returns true if and only if one of the following conditions is true:</p>
+         <p>The function returns <code>true</code> if and only if one of the following conditions is true:</p>
 
          <olist>
             <item>
@@ -18072,7 +18072,7 @@ return fn:sort($in, $SWEDISH)
                <p><term>Context-free</term>: there is no dependency on the static or dynamic context</p>
             </item>
             <item>
-               <p><term>Error-free</term>: any two atomic values can be compared, and the result is either true or false, never an error</p>
+               <p><term>Error-free</term>: any two atomic values can be compared, and the result is either <code>true</code> or <code>false</code>, never an error</p>
             </item>
             <item>
                <p><term>Transitive</term>: if <var>A</var> is the same key as <var>B</var>, and <var>B</var> is the same key as <var>C</var>, 
@@ -18781,9 +18781,9 @@ return map:keys-where($numbers, function($string) { $string = 'two' })
          <p>Tests whether a supplied map contains an entry for a given key</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:contains</code> returns true if the <termref def="dt-map"
+         <p>The function <code>map:contains</code> returns <code>true</code> if the <termref def="dt-map"
                >map</termref> supplied as <code>$map</code> contains an entry with the <termref
-                  def="dt-same-key">same key</termref> as <code>$key</code>; otherwise it returns false.</p>
+                  def="dt-same-key">same key</termref> as <code>$key</code>; otherwise it returns <code>false</code>.</p>
 
 
 
@@ -19283,7 +19283,7 @@ return
          <p>The function <code>map:filter</code> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map; the result is a new map containing those entries for which
-            the function returns true.</p>
+            the function returns <code>true</code>.</p>
 
          <p>The function supplied as <code>$predicate</code> takes two arguments. It is called
             supplying the key of the map entry as the first argument, and the associated value as
@@ -20113,7 +20113,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                         the <code>fn:number</code> element to an <code>xs:double</code>, and then converting
                         the result to a string using the casting rules. Note that this will result in exponential
                         notation being used for values outside the range 1e-6 to 1e+6. A dynamic error occurs
-                        for values such as infinity and NaN where the resulting JSON would be invalid.
+                        for values such as infinity and <code>NaN</code> where the resulting JSON would be invalid.
                      </fos:value>
                </fos:values>
             </fos:option>
@@ -20190,7 +20190,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </p>
             </item>
             <item>
-               <p>Otherwise (the <code>escaped-key</code> attribute of <var>C</var> is absent or set to false), 
+               <p>Otherwise (the <code>escaped-key</code> attribute of <var>C</var> is absent or set to <code>false</code>), 
                the value of the <code>key</code> attribute of <var>C</var>.</p>
             </item>
          </ulist>
@@ -20229,7 +20229,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                         greater precision than an <code>xs:double</code>.</p></item>
                      <item><p>To improve the human readability of the output, for example by calling <code>fn:format-number</code>
                         to limit the number of decimal places in the result.</p></item>
-                     <item><p>To avoid errors when dealing with values that JSON cannot handle, such as Infinity and NaN 
+                     <item><p>To avoid errors when dealing with values that JSON cannot handle, such as Infinity and <code>NaN</code> 
                         (for example, by emitting these as strings within quotation marks).</p></item>
                   </ulist>   
                </note>
@@ -20340,7 +20340,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </item>
             <item>
                <p>Numeric values are restricted to those that are valid in JSON: 
-            the schema disallows positive and negative infinity and NaN.</p>
+            the schema disallows positive and negative infinity and <code>NaN</code>.</p>
             </item>
             <item>
                <p>Duplicate key values are not permitted. <phrase>Most cases of duplicate keys are prevented by the rules in the schema; 
@@ -21110,10 +21110,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the supplied array contains no members.</p>
+         <p>Returns <code>true</code> if the supplied array contains no members.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns true if and only if <code>$array</code> contains no members, that is,
+         <p>The function returns <code>true</code> if and only if <code>$array</code> contains no members, that is,
             if <code>array:size($array) eq 0</code>.</p>
       </fos:rules>
       <fos:notes>
@@ -21159,17 +21159,17 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the supplied array contains one or more members.</p>
+         <p>Returns <code>true</code> if the supplied array contains one or more members.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns true if and only if <code>$array</code> contains one or more members, that is,
+         <p>The function returns <code>true</code> if and only if <code>$array</code> contains one or more members, that is,
             if <code>array:size($array) gt 0</code>.</p>
       </fos:rules>
       <fos:notes>
          <p>The function name is chosen by analogy with <code>fn:exists</code>. Note that the function tests whether
          any array members exist, not whether the array itself exists. A function such as:</p>
          <eg>function($a as array(*)?) as xs:boolean { return array:exists($a) }</eg>
-            <p>will raise a type error (rather than returning false) if the argument <code>$a</code> is
+            <p>will raise a type error (rather than returning <code>false</code>) if the argument <code>$a</code> is
             an empty sequence, because <code>array:exists</code> does not allow the argument to be
             an empty sequence.</p>
       </fos:notes>
@@ -21564,7 +21564,7 @@ else $fallback($position)</eg>
          
          <p>The result of the function is a sequence of integers, in monotonic ascending order, representing
             the 1-based positions in the input array of those members for which the supplied predicate function
-            returns true.</p>
+            returns <code>true</code>.</p>
          <p>More formally, the function returns the result of the expression:</p>
          <eg>fn:index-of(array:for-each($input, $predicate)?*, true())</eg>
       </fos:rules>
@@ -22107,7 +22107,7 @@ else $fallback($position)</eg>
       </fos:properties>
       <fos:summary>
          <p>Returns an array containing those members of the <code>$array</code> for which 
-            <code>$predicate</code> returns true.</p>
+            <code>$predicate</code> returns <code>true</code>.</p>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function returns an array containing those members of the input
@@ -22639,9 +22639,9 @@ return array:sort($in, $SWEDISH)
          <p>Informally, the function processes the items in the input sequence in order, and for each item
          it calls the supplied <code>$break-when</code> function with two arguments: the contents of the
          current partition (initially an empty sequence), and the current item in the input sequence. If
-         the <code>$break-when</code> function returns true, the current partition is added to the result
+         the <code>$break-when</code> function returns <code>true</code>, the current partition is added to the result
             and a new current partition is created, initially containing the current item. If the <code>$break-when</code> 
-            function returns false, the current item is added to the current partition.</p>
+            function returns <code>false</code>, the current item is added to the current partition.</p>
          <p>More formally, the function returns the result of the expression:</p>
          <eg>fn:fold-left($input, (), function($a, $b) {
    if (empty($a) or $break-when(array:slice($a, start:-1)?*, $b))
@@ -23237,7 +23237,7 @@ return array:sort($in, $SWEDISH)
                            <code>delivery-format</code>
                         </sitem>
                         <sitem><code>serialization-params</code> (defaults to an empty map)</sitem>
-                        <sitem><code>enable-assertions</code> (default is false)</sitem>
+                        <sitem><code>enable-assertions</code> (default is <code>false</code>)</sitem>
                         <sitem><code>enable-messages</code> (default is implementation-defined)</sitem>
                         <sitem><code>enable-trace</code> (default is implementation-defined)</sitem>
                         <sitem><code>requested-properties</code> (default is an empty map)</sitem>
@@ -23462,7 +23462,7 @@ return array:sort($in, $SWEDISH)
                         processor that supports XML Schema version 1.1.</p></item>
                   </ulist> Setting a boolean property such as <code>xsl:supports-dynamic-evaluation</code>
             to <code>false()</code> is interpreted as an explicit request for a processor in which
-            the value of the property is false. The effect if the requests cannot be precisely met
+            the value of the property is <code>false</code>. The effect if the requests cannot be precisely met
             is implementation-defined. In some cases it may be appropriate to ignore the request or
             to provide an alternative (for example, a later version of the product than the one
             requested); in other cases it may be more appropriate to raise an error <errorref
@@ -23877,7 +23877,7 @@ r:random-sequence(200);
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if all items in the input sequence match a supplied predicate.</p>
+         <p>Returns <code>true</code> if all items in the input sequence match a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
@@ -23901,7 +23901,7 @@ declare function fn:all(
          <p>If the second argument is omitted, the first argument must be a sequence of
          <code>xs:boolean</code> values.</p>
          <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for which the predicate
-            returns false; it is not required to evaluate the predicate for every item.</p>
+            returns <code>false</code>; it is not required to evaluate the predicate for every item.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -24239,7 +24239,7 @@ function($item){
 
          <p>The result of the function is a sequence of integers, in monotonic ascending order, representing
             the 1-based positions in the input sequence of those items for which the supplied predicate function
-            returns true.</p>
+            returns <code>true</code>.</p>
          <p>More formally, the function returns the result of the expression:</p>
          <eg>fn:index-of($input!$predicate(.), true())</eg>
       </fos:rules>
@@ -24282,12 +24282,12 @@ function($item){
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if the argument is the <code>xs:float</code> or <code>xs:double</code> value NaN.</p>
+         <p>Returns <code>true</code> if the argument is the <code>xs:float</code> or <code>xs:double</code> value <code>NaN</code>.</p>
       </fos:summary>
       <fos:rules>
 
-         <p>The function returns true if the argument is the <code>xs:float</code> or <code>xs:double</code> value NaN;
-            otherwise it returns false.</p>
+         <p>The function returns <code>true</code> if the argument is the <code>xs:float</code> or <code>xs:double</code> value <code>NaN</code>;
+            otherwise it returns <code>false</code>.</p>
 
       </fos:rules>
 
@@ -24841,7 +24841,7 @@ function($item){
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns true if at least one item in the input sequence matches a supplied predicate.</p>
+         <p>Returns <code>true</code> if at least one item in the input sequence matches a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
@@ -24865,7 +24865,7 @@ declare function fn:some(
          <p>If the second argument is omitted, the first argument must be a sequence of <code>xs:boolean</code>
          values.</p>
          <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for which the predicate
-         returns true; it is not required to evaluate the predicate for every item.</p>
+         returns <code>true</code>; it is not required to evaluate the predicate for every item.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -24949,7 +24949,7 @@ declare function fn:some(
 
 
       <fos:summary>
-         <p>Returns true if all items in a supplied sequence (after atomization) are equal.</p>
+         <p>Returns <code>true</code> if all items in a supplied sequence (after atomization) are equal.</p>
       </fos:summary>
 
       <fos:rules>
@@ -24959,8 +24959,8 @@ declare function fn:some(
                ref="choosing-a-collation"/>.</p>
 
 
-         <p>The result of the function <code>fn:all-equal($values, $collation)</code> is true if and only if the result
-            of <code>fn:count(fn:distinct-values($values, $collation)) le 1</code> is true (that is, if the sequence
+         <p>The result of the function <code>fn:all-equal($values, $collation)</code> is <code>true</code> if and only if the result
+            of <code>fn:count(fn:distinct-values($values, $collation)) le 1</code> is <code>true</code> (that is, if the sequence
             is empty, or if all the items in the sequence are equal under the rules of the 
             <code>fn:distinct-values</code> function).</p>
       </fos:rules>
@@ -24998,12 +24998,12 @@ declare function fn:some(
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>The expression <code>fn:all-equal(//p/@class)</code> returns true if all
+            <p>The expression <code>fn:all-equal(//p/@class)</code> returns <code>true</code> if all
                 <code>p</code> elements have the same value for <code>@class</code>.
             </p>
          </fos:example>
          <fos:example>
-            <p>The expression <code>fn:all-equal(*!fn:node-name())</code> returns true if all
+            <p>The expression <code>fn:all-equal(*!fn:node-name())</code> returns <code>true</code> if all
                element children of the context node have the same name.
             </p>
          </fos:example>
@@ -25029,7 +25029,7 @@ declare function fn:some(
 
 
       <fos:summary>
-         <p>Returns true if no two items in a supplied sequence are equal.</p>
+         <p>Returns <code>true</code> if no two items in a supplied sequence are equal.</p>
       </fos:summary>
 
       <fos:rules>
@@ -25039,8 +25039,8 @@ declare function fn:some(
                ref="choosing-a-collation"/>.</p>
 
 
-         <p>The result of the function <code>fn:all-different($values, $collation)</code> is true if and only if the result
-            of <code>fn:count(fn:distinct-values($values, $collation)) eq fn:count($values)</code> is true 
+         <p>The result of the function <code>fn:all-different($values, $collation)</code> is <code>true</code> if and only if the result
+            of <code>fn:count(fn:distinct-values($values, $collation)) eq fn:count($values)</code> is <code>true</code> 
             (that is, if the sequence
             is empty, or if all the items in the sequence are distinct under the rules of the 
             <code>fn:distinct-values</code> function).</p>
@@ -25079,11 +25079,11 @@ declare function fn:some(
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>The expression <code>fn:all-different(//employee/@ssn)</code> is true if no two employees have the same value for their
+            <p>The expression <code>fn:all-different(//employee/@ssn)</code> is <code>true</code> if no two employees have the same value for their
             <code>@ssn</code> attribute.</p>
          </fos:example>
          <fos:example>
-            <p>The expression <code>fn:all-different(*!fn:node-name())</code> returns true if all
+            <p>The expression <code>fn:all-different(*!fn:node-name())</code> returns <code>true</code> if all
                element children of the context node have distinct names.
             </p>
          </fos:example>
@@ -25208,7 +25208,7 @@ declare function fn:some(
          </ulist>
 
          <p>If the <emph>scheme</emph> is the empty sequence, the
-         <code>unc-path</code> option is true, and the <emph>string</emph>
+         <code>unc-path</code> option is <code>true</code>, and the <emph>string</emph>
          matches <code>^//[^/].*$</code>, then the scheme is <code>file</code>
          and the <emph>filepath</emph> is the <emph>string</emph>.
          </p>
@@ -25223,7 +25223,7 @@ declare function fn:some(
          <emph>string</emph>. If the <emph>string</emph> is the empty string,
          <emph>hierarchical</emph> is the empty sequence (<emph>i.e.</emph> not known),
          otherwise <emph>hierarchical</emph> is
-         true if <emph>string</emph> begins with "/" and false otherwise.</p>
+         <code>true</code> if <emph>string</emph> begins with <code>/</code> and <code>false</code> otherwise.</p>
 
          <p>If the <emph>string</emph> matches <code>^//*([a-zA-Z]:.*)$</code>,
          the <emph>authority</emph> is empty and the <emph>string</emph> is
@@ -25240,7 +25240,7 @@ declare function fn:some(
          <emph>userinfo</emph> is the empty sequence. If
          <emph>userinfo</emph> is present and contains a non-empty password, then
          <emph>userinfo</emph> is discarded and set to the empty sequence
-         unless the <code>allow-deprecated-features</code> option is true.</p>
+         unless the <code>allow-deprecated-features</code> option is <code>true</code>.</p>
 
          <p>When parsing the <emph>authority</emph> to find the <emph>host</emph>,
          there are four possibilities: the host can be a registered name (e.g.,
@@ -25299,7 +25299,7 @@ declare function fn:some(
             </item>
          </olist>
 
-         <p>If the "<code>omit-default-ports</code>" option is true then the port
+         <p>If the "<code>omit-default-ports</code>" option is <code>true</code> then the port
          is discarded and set to the empty sequence if the port number is the same
          as the default port for the given scheme. Implementations <rfc2119>should</rfc2119>
          recognize the default ports for <code>http</code> (80), <code>https</code> (443),
@@ -25896,7 +25896,7 @@ path with an explicit <code>file:</code> scheme.</p>
         (In other words, schemes are hierarchical by default.)</p>
 
         <p>If the <code>scheme</code> is <code>file</code> and the <code>unc-path</code>
-        option is true, the scheme is delimited by a trailing <code>:////</code>,
+        option is <code>true</code>, the scheme is delimited by a trailing <code>:////</code>,
         otherwise, if the URI is non-hierarchical, the scheme is delimited by
         a trailing <code>:</code>. For all other schemes, it is delimited by
         a trailing <code>://</code>. Exactly which schemes are known to be
@@ -25913,9 +25913,9 @@ path with an explicit <code>file:</code> scheme.</p>
         <p>If <code>$userinfo</code> is non-empty and contains a
         non-empty password, then <code>$userinfo</code> is set to the
         empty sequence unless the
-        <code>allow-deprecated-features</code> option is true.</p>
+        <code>allow-deprecated-features</code> option is <code>true</code>.</p>
 
-        <p>If the "<code>omit-default-ports</code>" option is true
+        <p>If the "<code>omit-default-ports</code>" option is <code>true</code>
         then the <code>$port</code> is set to the empty sequence if
         the port number is the same as the default port for the given
         scheme. Implementations <rfc2119>should</rfc2119> recognize

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1643,7 +1643,7 @@ This differs from <bibref ref="xmlschema-2"/> which defines
             attempts to call a function with an argument that is outside the function's domain (for example,
             <code>sqrt(-1)</code> or <code>log(-1)</code>). 
                Although IEEE defines these as exceptions, it also defines "default non-stop exception handling" in 
-                  which the operation returns a defined result, typically positive or negative infinity, or NaN. With this 
+                  which the operation returns a defined result, typically positive or negative infinity, or <code>NaN</code>. With this 
                   function library,
                these IEEE exceptions do not cause a dynamic error
             at the application level; rather they result in the relevant function or operator returning
@@ -1652,9 +1652,9 @@ This differs from <bibref ref="xmlschema-2"/> which defines
             or to the user by some <termref def="implementation-defined">implementation-defined</termref>
                warning condition, but the observable effect on an application 
                using the functions and operators defined in this specification is simply to return
-               the defined result (typically -INF, +INF, or NaN) with no error.</p>
-            <p>The <bibref ref="ieee754-2008"/> specification distinguishes two NaN values,
-               a quiet NaN and a signaling NaN. These two values are not distinguishable in the XDM model:
+               the defined result (typically <code>-INF</code>, <code>+INF</code>, or <code>NaN</code>) with no error.</p>
+            <p>The <bibref ref="ieee754-2008"/> specification distinguishes two <code>NaN</code> values,
+               a quiet <code>NaN</code> and a signaling <code>NaN</code>. These two values are not distinguishable in the XDM model:
                the value spaces of <code>xs:float</code> and <code>xs:double</code> each include only a single
                <code>NaN</code> value. This does not prevent the implementation distinguishing them internally,
                and triggering different <termref def="implementation-defined">implementation-defined</termref>
@@ -1751,7 +1751,7 @@ This differs from <bibref ref="xmlschema-2"/> which defines
                </item>
                <item>
                   <p>For <code>xs:float</code> and <code>xs:double</code> arguments, if the
-                            argument is "NaN", "NaN" is returned.</p>
+                            argument is <code>"NaN"</code>, <code>NaN</code> is returned.</p>
                </item>
                <item>
                   <p>Except for <code>fn:abs</code>, for <code>xs:float</code> and
@@ -2207,7 +2207,7 @@ the <code>fn:format-number</code> function.</p>
                <p>The algorithm for this second stage of processing is as follows:</p>
                <olist>
                   <item>
-                     <p>If the input number is NaN (not a number), the result is the 
+                     <p>If the input number is <code>NaN</code> (not a number), the result is the 
 							 value of the <xtermref spec="XP31" ref="id-static-decimal-format-NaN">pattern separator</xtermref> property (with no
 <var>prefix</var> or <var>suffix</var>).</p>
                   </item>
@@ -2365,7 +2365,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
 		          influencing it are <termref def="implementation-defined"/>.</p></item>
 		       <item><p>Certain operations (such as taking the square root of a negative number)
 		          are defined in IEEE to signal the invalid operation exception and return a
-		          quiet NaN. In this specification, such operations return <code>NaN</code>
+		          quiet <code>NaN</code>. In this specification, such operations return <code>NaN</code>
 		          and do not raise an error. The same policy applies to operations (such as taking
 		          the logarithm of zero) that raise a divide-by-zero exception. Any diagnostic 
 		          information is outside the scope of this specification. </p></item>
@@ -2878,8 +2878,8 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                     depend strongly on the properties of the collation that is used.</p>
 				<p>In addition,
                     collations may specify that some collation units should be ignored during matching. If hyphen is an ignored
-					collation unit, then <code>fn:contains("code-point", "codepoint")</code> will be true, 
-					and <code>fn:contains("codepoint", "-")</code> will also be true.</p>
+					collation unit, then <code>fn:contains("code-point", "codepoint")</code> will be <code>true</code>, 
+					and <code>fn:contains("codepoint", "-")</code> will also be <code>true</code>.</p>
             <p> In the definitions below, we refer to the terms <term>match</term> and
                     <term>minimal match</term> as defined in definitions DS2 and DS4 of 
                     <bibref ref="UNICODE-TR10"/>. In applying these definitions:</p>
@@ -3505,7 +3505,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
          <p>This section defines functions and operators on the <code>xs:boolean</code> datatype.</p>
          <div2 id="boolean-constructors">
             <head>Boolean constant functions</head>
-            <p>Since no literals are defined in XPath to reference the constant boolean values true and false,
+            <p>Since no literals are defined in XPath to reference the constant boolean values <code>true</code> and <code>false</code>,
 			two functions are provided for the purpose.</p>
             <?local-function-index?>
             <div3 id="func-true">
@@ -6346,20 +6346,20 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                            <olist>
                               <item>
                                  <p>If the <code>Attr.value</code> is castable to an <code>xs:NCName</code>,
-                                    the result is true;</p>
+                                    the result is <code>true</code>;</p>
                               </item>
                               <item>
-                                 <p>Otherwise, the result is false;</p>
+                                 <p>Otherwise, the result is <code>false</code>;</p>
                               </item>
                            </olist>
                         </item>
                         <item>
-                           <p>Otherwise, the result is false;</p>
+                           <p>Otherwise, the result is <code>false</code>;</p>
                         </item>
                      </olist>
                   </item>
                   <item>
-                     <p>Otherwise, the result is false.</p>
+                     <p>Otherwise, the result is <code>false</code>.</p>
                   </item>
                </olist>
 
@@ -7166,7 +7166,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <p><termdef id="dt-same-key" term="same key">Within a map, no two entries have the <term>same key</term>. 
             Two atomic values <code>K1</code> and <code>K2</code> are the <term>same key</term>
             for this purpose if the <phrase diff="chg" at="2023-01-25">function call <code>fn:atomic-equal($K1, $K2)</code></phrase>
-            returns true.</termdef></p>
+            returns <code>true</code>.</termdef></p>
          
          <p>It is not necessary that all the keys in a map should be
             of the same type (for example, they can include a mixture of integers and strings).</p>
@@ -9075,7 +9075,7 @@ characters except the first "P" and the optional negative sign in <emph>TDT</emp
 								<p>If <emph>ST</emph> is <code>date</code>, <code>gYearMonth</code>, <code>gYear</code>, <code>gMonthDay</code>, <code>gDay</code>, or <code>gMonth</code>, then <emph>TV</emph> is the lexical representation of <emph>SV</emph>, as defined by <bibref ref="xmlschema-2"/>.</p>
 							</item>
 							<item>
-								<p>If <emph>ST</emph> is <code>boolean</code>, then <emph>TV</emph> is <quote>true</quote> if <emph>SV</emph> is true and <quote>false</quote> if <emph>SV</emph> is false.</p>
+								<p>If <emph>ST</emph> is <code>boolean</code>, then <emph>TV</emph> is <quote>true</quote> if <emph>SV</emph> is <code>true</code> and <quote>false</quote> if <emph>SV</emph> is <code>false</code>.</p>
 							</item>
 							<item>
 								<p>If <emph>ST</emph> is <code>hexBinary</code>, then <emph>TV</emph> is the canonical representation of <emph>SV</emph>, as defined by <bibref ref="xmlschema-2"/>.</p>
@@ -10013,7 +10013,7 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                <item><p>The types <code>xs:untypedAtomic</code>, <code>xs:integer</code>, <code>xs:yearMonthDuration</code>,
                and <code>xs:dayTimeDuration</code> are treated as primitive types (alongside the 19 primitive types defined in XSD).</p></item>
                <item><p>For any atomic type <var>T</var>, let <var>P(T)</var> denote the most specific primitive type
-               such that <code>itemType-subtype(T, P(T))</code> is true.</p></item>
+               such that <code>itemType-subtype(T, P(T))</code> is <code>true</code>.</p></item>
             </ulist>
             <p>The rules are then:</p>
             <olist>
@@ -10021,7 +10021,7 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   <p>When <var>ST</var> is the same type as <var>TT</var>: this case always succeeds, returning <var>SV</var> unchanged.</p>
                </item>
                <item>
-                  <p>When <code>itemType-subtype(ST, TT)</code> is true: This case is described in <specref ref="casting-from-derived-to-parent"/>. </p>
+                  <p>When <code>itemType-subtype(ST, TT)</code> is <code>true</code>: This case is described in <specref ref="casting-from-derived-to-parent"/>. </p>
                </item>
                <item>
                   <p>When <var>P(ST)</var> is the same type as <var>P(TT)</var>: This case is described in <specref ref="casting-within-branch"/>.</p>
@@ -10153,7 +10153,7 @@ purposes of this rule that casting to <code>xs:NOTATION</code> succeeds.
                   
                </item>
                <item><p>A value that is castable to one or more of the atomic types in the transitive membership
-                  of the union type (in the sense that the <code>castable as</code> operator returns true).</p>
+                  of the union type (in the sense that the <code>castable as</code> operator returns <code>true</code>).</p>
                   <p>In this case the supplied value is cast to each atomic type in the transitive membership
                      of the union type in turn (in the order in which the member types appear in the declaration)
                      until one of these casts is successful; if none of them is successful, a dynamic error occurs
@@ -10547,7 +10547,7 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="CA" code="0002" label="Invalid lexical value." type="dynamic">
                <p>Raised by <code>fn:resolve-QName</code> and <code>fn:QName</code> when a supplied value does not have the lexical
-               form of a QName or URI respectively; and when casting to decimal, if the supplied value is NaN or Infinity.</p>
+               form of a QName or URI respectively; and when casting to decimal, if the supplied value is <code>NaN</code> or Infinity.</p>
             </error>
             <error class="CA" code="0003" label="Input value too large for integer."
                    type="dynamic">
@@ -10556,7 +10556,7 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="CA" code="0005" label="NaN supplied as float/double value."
                    type="dynamic">
-               <p>Raised when multiplying or dividing a duration by a number, if the number supplied is NaN.</p>
+               <p>Raised when multiplying or dividing a duration by a number, if the number supplied is <code>NaN</code>.</p>
             </error>
             <error class="CA" code="0006"
                    label="String to be cast to decimal has too many digits of precision."

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -70,7 +70,7 @@
       <error spec="XP" code="0010" class="ST" type="static" role="xpath">
          <p> An implementation that does not support the namespace axis must raise a <termref
                def="dt-static-error">static error</termref> if it encounters a reference to the
-            namespace axis and XPath 1.0 compatibility mode is false. </p>
+            namespace axis and XPath 1.0 compatibility mode is <code>false</code>. </p>
       </error>
 
       <error spec="XQ" role="xquery" code="0012" class="ST" type="static">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1107,7 +1107,7 @@ items that would result from calling the <code>fn:collection</code> function wit
                         <p>
                            <termdef id="id-static-decimal-format-NaN" term="NaN">
                               <term>NaN</term> is the string used to
-		          represent the double value NaN (not-a-number); the default value is the string "NaN"</termdef>
+		          represent the double value <code>NaN</code> (not-a-number); the default value is the string <code>"NaN"</code></termdef>
                         </p>
                      </item>
 
@@ -1923,7 +1923,7 @@ is <code>xs:anyAtomicType</code>.</p>
                   and that no element of this type can have an attribute named <code>@sallary</code> (sic), then
                   a type error may be reported if the expression <code>$emp/@sallary</code> is encountered.</p>
                   <note><p>A static error <rfc2119>must not</rfc2119> be reported simply because a predicate
-                  will always return false: the expression <code>a[name()='b']</code> will always return
+                  will always return <code>false</code>: the expression <code>a[name()='b']</code> will always return
                   an empty sequence, but it is not an error.</p></note>
                   </item>  
                   
@@ -2834,7 +2834,7 @@ would raise an error because it has an <code>id</code> child whose value is not 
                <item><p>In a filter expression of the form <code>E[P]</code>, the predicate <code>P</code> is guarded by
                   the existence of the relevant context item in the result of evaluating <code>E</code>.</p>
                <p>This rule has the consequence that in a filter expression with multiple predicates, such as <code>E[P1][P2]</code>,
-               evaluation of <code>P2</code> must not raise a dynamic error unless <code>P1</code> returns true. This rule does
+               evaluation of <code>P2</code> must not raise a dynamic error unless <code>P1</code> returns <code>true</code>. This rule does
                not prevent reordering of predicates (for example, to take advantage of indexes), but it does require that any
                such reordering must not result in errors that would not otherwise occur.</p>
                </item>
@@ -4217,7 +4217,7 @@ the schema type named <code>us:address</code>.</p>
                            allows the attribute <code>@when</code> to be either a date, or a dateTime.</p>
                            <p>An <code>instance of</code> expression can be used to test whether a value belongs to one
                            of a number of specified types: <code>$x instance of union(xs:string, xs:anyURI, xs:untypedAtomic)</code>
-                           returns true if <code>$x</code> is an instance of any of these three atomic types.</p>
+                           returns <code>true</code> if <code>$x</code> is an instance of any of these three atomic types.</p>
                         </note>
                   </div4>
                   
@@ -4241,7 +4241,7 @@ the schema type named <code>us:address</code>.</p>
                         matching of an <code>EnumerationType</code> is based purely on value comparison, and not on type
                         annotations. For example, if <code>color</code> is a schema-defined atomic type derived from
                         <code>xs:string</code> with an enumeration facet permitting the values ("red", "green", "blue"),
-                        the expression <code>"green" instance of color</code> is false, because the type annotation
+                        the expression <code>"green" instance of color</code> returns <code>false</code>, because the type annotation
                         does not match. By contrast, <code>"green" instance of enum("red", "green", "blue")</code>
                         is true.</p>
                         <p>An <term>EnumerationType</term> only matches <code>xs:string</code> values, not
@@ -4640,7 +4640,7 @@ matches any nilled or non-nilled element node whose type annotation is
                   </item>
 
                   <item>
-                     <p>If the schema element declaration named <emph>N</emph> is not nillable, then the nilled property of the candidate node is false.</p>
+                     <p>If the schema element declaration named <emph>N</emph> is not nillable, then the nilled property of the candidate node is <code>false</code>.</p>
                   </item>
 
                </olist>
@@ -5449,7 +5449,7 @@ declare function flatten($tree as tree) as item()* {
                      <item>
                         <p>
                            <code role="parse-test"
-                              >$x instance of xs:error</code> always returns false, regardless of the value of <code>$x</code>.</p>
+                              >$x instance of xs:error</code> always returns <code>false</code>, regardless of the value of <code>$x</code>.</p>
                      </item>
                      <item>
                         <p>

--- a/specifications/xquery-40/src/xpath-backwards-compat.xml
+++ b/specifications/xquery-40/src/xpath-backwards-compat.xml
@@ -11,20 +11,20 @@
     <olist>
         <item>
             <p>Incompatibilities that exist when source documents have no schema, and when running
-                with XPath 1.0 compatibility mode set to true. This specification has been designed
+                with XPath 1.0 compatibility mode set to <code>true</code>. This specification has been designed
                 to reduce the number of incompatibilities in this situation to an absolute minimum,
                 but some differences remain and are listed individually.</p>
         </item>
 
         <item>
-            <p>Incompatibilities that arise when XPath 1.0 compatibility mode is set to false. In
+            <p>Incompatibilities that arise when XPath 1.0 compatibility mode is set to <code>false</code>. In
                 this case, the number of expressions where compatibility is lost is rather
                 greater.</p>
         </item>
 
         <item>
             <p>Incompatibilities that arise when the source document is processed using a schema
-                (whether or not XPath 1.0 compatibility mode is set to true). Processing the
+                (whether or not XPath 1.0 compatibility mode is set to <code>true</code>). Processing the
                 document with a schema changes the way that the values of nodes are interpreted, and
                 this can cause an XPath expression to return different results.</p>
         </item>
@@ -34,7 +34,7 @@
         <head>Incompatibilities when Compatibility Mode is true</head>
 
         <p>The list below contains all known areas, within the scope of this specification, where an
-            XPath 4.0 processor running with compatibility mode set to true will produce different
+            XPath 4.0 processor running with compatibility mode set to <code>true</code> will produce different
             results from an XPath 1.0 processor evaluating the same expression, assuming that the
             expression was valid in XPath 1.0, and that the nodes in the source document have no
             type annotations other than <code>xs:untyped</code> and
@@ -72,7 +72,7 @@
                     were accepted by XPath 1.0 as representations of the floating-point values
                     positive and negative infinity, are no longer recognized. They are converted to
                         <code>NaN</code> when running under <phrase diff="chg" at="bug28782">XPath 4.0</phrase> with compatibility mode set to
-                    true, and cause a dynamic error when compatibility mode is set to false.</p>
+                    <code>true</code>, and cause a dynamic error when compatibility mode is set to <code>false</code>.</p>
             </item>
 
             <item>
@@ -110,12 +110,12 @@
             <item>
                 <p>If one operand in a general comparison is a single atomic value of type
                         <code>xs:boolean</code>, the other operand is converted to
-                        <code>xs:boolean</code> when XPath 1.0 compatibility mode is set to true. In
+                        <code>xs:boolean</code> when XPath 1.0 compatibility mode is set to <code>true</code>. In
                     XPath 1.0, if neither operand of a comparison operation using the &lt;, &lt;=,
                     &gt; or &gt;= operator was a node set, both operands were converted to numbers.
                     The result of the expression <code>true() &gt; number('0.5')</code> is therefore
-                    true in XPath 1.0, but is false in <phrase diff="chg" at="bug28782">XPath 4.0</phrase> even when compatibility mode is set
-                    to true.</p>
+                    <code>true</code> in XPath 1.0, but is <code>false</code> in <phrase diff="chg" at="bug28782">XPath 4.0</phrase> even when compatibility mode is set
+                    to <code>true</code>.</p>
             </item>
 
 
@@ -131,14 +131,14 @@
     </div3>
 
     <div3 id="id-incompat-in-false-mode">
-        <head>Incompatibilities when Compatibility Mode is false</head>
+        <head>Incompatibilities when Compatibility Mode is <code>false</code></head>
 
-        <p>Even when the setting of the XPath 1.0 compatibility mode is false, many XPath
+        <p>Even when the setting of the XPath 1.0 compatibility mode is <code>false</code>, many XPath
             expressions will still produce the same results under XPath 4.0 as under XPath 1.0. The
             exceptions are described in this section.</p>
 
         <p>In all cases it is assumed that the expression in question was valid under XPath 1.0,
-            that XPath 1.0 compatibility mode is false, and that all elements and attributes are
+            that XPath 1.0 compatibility mode is <code>false</code>, and that all elements and attributes are
             annotated with the types <code>xs:untyped</code> and <code>xs:untypedAtomic</code>
             respectively.</p>
 
@@ -167,7 +167,7 @@
 
             <item>
                 <p>When an empty node-set is supplied as an argument to a function or operator that
-                    expects a number, the value is no longer converted implicitly to NaN. The XPath
+                    expects a number, the value is no longer converted implicitly to <code>NaN</code>. The XPath
                     1.0 behavior can always be restored by using the <code>number</code> function to
                     perform an explicit conversion.</p>
             </item>
@@ -232,7 +232,7 @@
                     to a function that expects a number no longer converts unrecognized strings to
                     the value <code>NaN</code>; instead, it reports a dynamic error. This is in
                     addition to the differences that apply when backwards compatibility mode is set
-                    to true.</p>
+                    to <code>true</code>.</p>
             </item>
 
             <item>
@@ -306,7 +306,7 @@
 
         <p>Similarly, consider the expression <code role="parse-test">@birth &lt; @death</code>
             applied to the element <code>&lt;person birth="1901-06-06"
-                death="1991-05-09"/&gt;</code>. With XPath 1.0, this expression would return false,
+                death="1991-05-09"/&gt;</code>. With XPath 1.0, this expression would return <code>false</code>,
             because both attributes are converted to numbers, which returns <code>NaN</code> in each
             case. With XPath 4.0, in the presence of a schema that annotates these attributes as
             dates, the expression returns <code>true</code>.</p>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -789,7 +789,7 @@
                <var>N</var>, and that has copies of the attributes, namespaces and accumulator values of the
                corresponding ancestor of <var>N</var>. But the ancestor has a type annotation of
                   <code>xs:anyType</code>, has the properties <code>nilled</code>,
-                  <code>is-id</code>, and <code>is-idref</code> set to false, and has no children
+                  <code>is-id</code>, and <code>is-idref</code> set to <code>false</code>, and has no children
                other than the child that is a copy of <var>N</var> or one of its
                ancestors.</termdef>
          </p>
@@ -1712,18 +1712,18 @@
             the expanded QName.</p>
          <p><phrase diff="chg" at="2023-02-16">When the <code>$arity</code> argument is present and non-empty,</phrase>
             the <function>function-available</function> function returns
-            true if and only if there is an available function whose name matches the value of the
+            <code>true</code> if and only if there is an available function whose name matches the value of the
                <code>$function-name</code> argument and whose <termref def="dt-arity-range">arity range</termref> 
             includes the value of the <code>$arity</code> argument. </p>
          <p><phrase diff="chg" at="2023-02-16">When the <code>$arity</code> argument is omitted or empty,</phrase>
             the <function>function-available</function> function
-            returns true if and only if there is at least one available function (with some arity)
+            returns <code>true</code> if and only if there is at least one available function (with some arity)
             whose name matches the value of the <code>$name</code> argument. </p>
 
 
 
          <p>When the containing expression is evaluated with <termref def="dt-xpath-compat-mode">XPath 1.0 compatibility mode</termref> set to
-               true, the <function>function-available</function> function returns false in
+               <code>true</code>, the <function>function-available</function> function returns <code>false</code> in
             respect of a function name and arity for which no implementation is available (other
             than the fallback error function that raises a dynamic error whenever it is called).
             This means that it is possible (as in XSLT 1.0) to use logic such as the following to
@@ -1776,7 +1776,7 @@
             functionality (for example, if the system has been configured for security reasons so
             that <xfunction>available-environment-variables</xfunction> returns no information),
             then <function>function-available</function> when applied to that function should return
-            false.</p>
+            <code>false</code>.</p>
          <p>It is not necessary that there be a direct equivalence between the
             results of <function>function-available</function> and
                <xfunction>function-lookup</xfunction> in all cases. For example, there may be
@@ -1873,20 +1873,20 @@
 
          <p> If the resulting <termref def="dt-expanded-qname">expanded
                QName</termref> is in the <termref def="dt-xslt-namespace"/>, the function returns
-            true if and only if the local name matches the name of an XSLT element that is defined
+            <code>true</code> if and only if the local name matches the name of an XSLT element that is defined
             in this specification and implemented by the XSLT processor.</p>
 
          <p>If the <termref def="dt-expanded-qname">expanded QName</termref> has a null namespace
-            URI, the <function>element-available</function> function will return false. </p>
+            URI, the <function>element-available</function> function will return <code>false</code>. </p>
 
-         <p>If the <termref def="dt-expanded-qname">expanded QName</termref> is not in the <termref def="dt-xslt-namespace">XSLT namespace</termref>, the function returns true if and
+         <p>If the <termref def="dt-expanded-qname">expanded QName</termref> is not in the <termref def="dt-xslt-namespace">XSLT namespace</termref>, the function returns <code>true</code> if and
             only if the processor has an <phrase diff="add" at="2022-01-01">external</phrase> implementation 
             available of an <termref def="dt-extension-instruction">extension instruction</termref> with the given
             expanded QName. This applies whether or not the namespace has been designated as an
                <termref def="dt-extension-namespace">extension namespace</termref>.</p>
          <p diff="add" at="2022-01-01">The term <term>external implementation</term> excludes the use of a 
             <termref def="dt-named-template"/> as the instruction's implementation. The function does not return
-         true simply because the name matches the name of a <termref def="dt-named-template"/>.</p>
+         <code>true</code> simply because the name matches the name of a <termref def="dt-named-template"/>.</p>
          <p>If the processor does not have an implementation of a particular extension instruction
             available, and such an extension instruction is evaluated, then the processor
                <rfc2119>must</rfc2119> perform fallback for the element as specified in <specref ref="fallback"/>. An implementation <rfc2119>must not</rfc2119> signal an error
@@ -1922,7 +1922,7 @@
             </item>
             <item>
                <p>In earlier versions of this specification,
-                     <function>element-available</function> was defined to return true only for
+                     <function>element-available</function> was defined to return <code>true</code> only for
                   elements classified as instructions. The distinction between instructions and
                   other elements, however, is sometimes rather technical, and in XSLT 3.0 the effect
                   of the function has therefore been aligned to do what its name might suggest.</p>
@@ -1932,7 +1932,7 @@
                   functionality (for example, if the system has been configured for security reasons
                   so that <elcode>xsl:evaluate</elcode> always raises an error), then
                      <function>element-available</function> when applied to that instruction
-                     <rfc2119>should</rfc2119> return false.</p>
+                     <rfc2119>should</rfc2119> return <code>false</code>.</p>
             </item>
 
          </ulist>
@@ -1986,7 +1986,7 @@
             an <termref def="dt-expanded-qname">expanded QName</termref> using the namespace declarations in
             scope for the <termref def="dt-expression">expression</termref>. If the value is an
             unprefixed lexical QName, then the default namespace is used in the expanded QName.</p>
-         <p>The function returns true if and only if there is an available type whose name matches
+         <p>The function returns <code>true</code> if and only if there is an available type whose name matches
             the value of the <code>$name</code> argument. </p>
 
 
@@ -2064,7 +2064,7 @@
          <p>Like <elcode>xsl:source-document</elcode> itself, the function is not deterministic, which means that multiple calls during the execution
          of a stylesheet will not necessarily return the same result. The caller cannot make any inferences about the point in time at which
          the input conditions for <function>stream-available</function> are present, and in particular there is no guarantee that because
-         <function>stream-available</function> returns true, <elcode>xsl:source-document</elcode> will necessarily succeed.</p>
+         <function>stream-available</function> returns <code>true</code>, <elcode>xsl:source-document</elcode> will necessarily succeed.</p>
          
          <p>The value of the <code>$uri</code> argument <rfc2119>must</rfc2119> be a URI in the form of a string. If it is a relative URI,
             it is resolved relative to the static base URI of the function call.</p>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -528,7 +528,7 @@
                            <term>XPath 1.0 compatibility mode</term> is defined in 
                         <xspecref spec="XP40" ref="static_context"/>. This is a setting in the static
                         context of an XPath expression; it has two values, <code>true</code> and
-                           <code>false</code>. When the value is set to true, the semantics of
+                           <code>false</code>. When the value is set to <code>true</code>, the semantics of
                         function calls and certain other operations are adjusted to give a greater
                         degree of backwards compatibility between XPath
                         <phrase diff="chg" at="2023-02-24">4.0</phrase> and XPath 1.0.</termdef>
@@ -2130,8 +2130,8 @@
                   <xfunction>substring</xfunction> function) and other constructs may produce
                different results depending on the datatype (for example, given the element
                   <code>&lt;product price="10.00" discount="2.00"/&gt;</code>, the expression
-                  <code>@price gt @discount</code> will return true if the attributes have type
-                  <code>xs:decimal</code>, but will return false if they are untyped).</p>
+                  <code>@price gt @discount</code> will return <code>true</code> if the attributes have type
+                  <code>xs:decimal</code>, but will return <code>false</code> if they are untyped).</p>
             <p>There is a standard set of type definitions that are always available as <termref def="dt-in-scope-schema-component">in-scope schema components</termref> in every
                stylesheet. These are defined in <specref ref="built-in-types"/>. </p>
             <p>The remainder of this section describes facilities that are available only with a
@@ -7664,7 +7664,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <code>xsl:use-when</code> attribute.      
                   If the attribute is
                   present and the <xtermref spec="XP40" ref="dt-ebv">effective boolean
-                     value</xtermref> of the expression is false, then the element, together with
+                     value</xtermref> of the expression is <code>false</code>, then the element, together with
                   all the nodes having that element as an ancestor, is effectively excluded from the
                      <termref def="dt-stylesheet-module">stylesheet module</termref>. When a node is
                   effectively excluded from a stylesheet module the stylesheet module has the same
@@ -9201,7 +9201,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <termdef id="dt-coercion-rules" term="coercion rules"> When
                   used in this specification without further qualification, the term <term>coercion rules</term> 
                   means the coercion rules defined in <bibref ref="xpath-40"/>, applied with XPath 1.0 
-                  compatibility mode set to false.</termdef>
+                  compatibility mode set to <code>false</code>.</termdef>
             </p>
             
             <note diff="add" at="2022-01-01">
@@ -9218,7 +9218,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   template. They are also used when parameters are supplied to a template using
                      <elcode>xsl:with-param</elcode>. In all such cases, the rules that apply are
                   the XPath 4.0 rules without XPath 1.0 compatibility mode. The rules with XPath 1.0
-                  compatibility mode set to true are used only for XPath function calls, and for the
+                  compatibility mode set to <code>true</code> are used only for XPath function calls, and for the
                   operands of certain XPath operators. </p>
             </note>
 
@@ -9311,7 +9311,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <item>
                      <p>
                         <termref def="dt-xpath-compat-mode">XPath 1.0 compatibility mode</termref>
-                        is set to true if and only if the containing element is processed with
+                        is set to <code>true</code> if and only if the containing element is processed with
                            <termref def="dt-xslt-10-behavior">XSLT 1.0 behavior</termref> (see
                            <specref ref="backwards"/>).</p>
                   </item>
@@ -10323,7 +10323,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            <item>
                               <p><code>type(function($x as xs:integer) as xs:boolean)[.(42)]</code> matches any function that
                                  accepts an <code>xs:integer</code> argument and returns a boolean result, provided
-                                 that the result of calling the function with the argument value <code>42</code> is true.</p>
+                                 that the result of calling the function with the argument value <code>42</code> is <code>true</code>.</p>
                            </item>
                            <item>
                               <p><code>union(xs:date, xs:dateTime, xs:time)</code> matches any atomic value
@@ -10793,7 +10793,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         behavior</termref> (see <specref ref="backwards"/>), then the
                   semantics of the pattern are defined on the basis that the equivalent XPath
                   expression is evaluated with <termref def="dt-xpath-compat-mode">XPath 1.0
-                     compatibility mode</termref> set to true.</p>
+                     compatibility mode</termref> set to <code>true</code>.</p>
 
 
                <example>
@@ -12560,7 +12560,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <item><p>The available documents, available text resources, available collections, and available URI
                collections are all empty.</p></item>
             </olist>
-            <p>If the test condition evaluates to false, or if evaluation fails, then the template rule is not a candidate
+            <p>If the test condition evaluates to <code>false</code>, or if evaluation fails, then the template rule is not a candidate
             for matching.</p>
             <note>
                <p>When an <elcode>xsl:apply-templates</elcode> instruction selects multiple items for processing, the values
@@ -14792,7 +14792,7 @@ and <code>version="1.0"</code> otherwise.</p>
                value of an expression are given in <bibref ref="xpath-40"/>: they are the same as
                the rules used for XPath conditional expressions.</p>
             <p diff="add" at="2022-01-01">If the effective boolean value of the <termref def="dt-expression"
-               >expression</termref> is true, then:</p>
+               >expression</termref> is <code>true</code>, then:</p>
             <ulist diff="add" at="2022-01-01">
                <item><p>If there is a <code>then</code> attribute, the expression in the <code>then</code>
                   attribute is evaluated, and the resulting value is returned as the result of the 
@@ -14805,7 +14805,7 @@ and <code>version="1.0"</code> otherwise.</p>
             </ulist>
             
             <p diff="add" at="2022-01-01">If the effective boolean value of the <code>test</code> <termref def="dt-expression"
-               >expression</termref> is false, then:</p>
+               >expression</termref> is <code>false</code>, then:</p>
             <ulist diff="add" at="2022-01-01">
                <item><p>If there is an <code>else</code> attribute, the expression in the <code>else</code>
                   attribute is evaluated, and the resulting value is returned as the result of the 
@@ -15691,7 +15691,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   has child nodes without consuming the children. However, use of
                      <xfunction>has-children</xfunction> has the drawback that the function is
                   unselective: it cannot be used to test whether there are any children of relevance
-                  to the application. In particular, it returns true if an element contains comments
+                  to the application. In particular, it returns <code>true</code> if an element contains comments
                   or whitespace text nodes that the application might consider to be
                   insignificant.</p>
             </note>
@@ -15718,7 +15718,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <item>
                      <p>The result of the instruction is the value of the expression
                            <code>$R[not(deemed-empty(.))]</code> where the function
-                           <code>deemed-empty($item as item())</code> returns true if and only if
+                           <code>deemed-empty($item as item())</code> returns <code>true</code> if and only if
                            <code>$item</code> is one of the following:</p>
 
                      <ulist>
@@ -15927,7 +15927,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         Initially empty.</p>
                   </item>
                   <item>
-                     <p><var>F</var> : a boolean flag, initially false, to indicate whether any
+                     <p><var>F</var> : a boolean flag, initially <code>false</code>, to indicate whether any
                            <termref def="dt-vacuous">non-vacuous</termref> items have been written to <var>R</var> by
                            <term>ordinary instructions</term>. The term <term>ordinary instruction</term>
                         means any node in the sequence constructor other than an
@@ -15971,7 +15971,7 @@ and <code>version="1.0"</code> otherwise.</p>
                                     appended to <var>R</var>.</p>
                               </item>
                               <item>
-                                 <p><var>F</var> is set to true.</p>
+                                 <p><var>F</var> is set to <code>true</code>.</p>
                               </item>
                            </olist>
                         </item>
@@ -17091,7 +17091,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            <function>function-available</function> will return <code>false</code> in
                         respect of such functions, and <xfunction>function-lookup</xfunction> will
                         fail to find them. The effect of this rule is to ensure that
-                           <function>function-available</function> returns true in respect of
+                           <function>function-available</function> returns <code>true</code> in respect of
                         functions that can be called within the static expression. It also has the
                         effect that these extension functions will be recognized within the static
                         expression itself; however, the fact that a function is available in this
@@ -18811,13 +18811,13 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <p>The <function>function-available</function> function, when
                   called with a particular <termref def="dt-expanded-qname">expanded QName</termref>
-                  and arity, returns true if and only if a call on
+                  and arity, returns <code>true</code> if and only if a call on
                      <xfunction>function-lookup</xfunction> with the same arguments, in the same
                   static context, would return a function item.</p>
 
                <note>
                   <p>For legacy reasons there is also a single-argument version of
-                        <function>function-available</function>, which returns true if there is a
+                        <function>function-available</function>, which returns <code>true</code> if there is a
                      function with the given name regardless of arity.</p>
                </note>
 
@@ -18851,7 +18851,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   constructed nodes have distinct identity. This means that when a function that
                   creates a new node is called, two calls on the function will return nodes that can
                   be distinguished: for example, with such a function, <code>f:make-node() is
-                     f:make-node()</code> will return false.</p>
+                     f:make-node()</code> will return <code>false</code>.</p>
 
                <p>Three classes of functions can be identified:</p>
 
@@ -19355,7 +19355,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <ulist>
                   <item>
-                     <p>A call to <code>element-available('xsl:evaluate')</code> returns false,
+                     <p>A call to <code>element-available('xsl:evaluate')</code> returns <code>false</code>,
                         wherever it appears;</p>
                   </item>
                   <item>
@@ -19379,11 +19379,11 @@ and <code>version="1.0"</code> otherwise.</p>
                   <item>
                      <p>A call to <code>element-available('xsl:evaluate')</code> appearing in a
                            <termref def="dt-static-expression">static expression</termref> (for
-                        example, in an <code>[xsl:]use-when</code> attribute) returns true;</p>
+                        example, in an <code>[xsl:]use-when</code> attribute) returns <code>true</code>;</p>
                   </item>
                   <item>
                      <p>A call to <code>element-available('xsl:evaluate')</code> appearing anywhere
-                        else returns false;</p>
+                        else returns <code>false</code>;</p>
                   </item>
                   <item>
                      <p>A call to <code>system-property('xsl:supports-dynamic-evaluation')</code>
@@ -21379,14 +21379,14 @@ for $i in 1 to count($V) return
                sequence will either be empty or contain a single number; where <code>level</code> is
                   <code>multiple</code>, the sequence may be of any length. The sequence is
                constructed as follows:</p>
-            <p>Let <code>matches-count($node)</code> be a function that returns true if and only if
+            <p>Let <code>matches-count($node)</code> be a function that returns <code>true</code> if and only if
                the given node <code>$node</code> matches the pattern given in the <code>count</code>
                attribute, or the implied pattern (according to the rules given above) if the
                   <code>count</code> attribute is omitted.</p>
-            <p>Let <code>matches-from($node)</code> be a function that returns true if and only if
+            <p>Let <code>matches-from($node)</code> be a function that returns <code>true</code> if and only if
                the given node <code>$node</code> matches the pattern given in the <code>from</code>
                attribute, or if <code>$node</code> is the root node of a tree. If the
-                  <code>from</code> attribute is omitted, then the function returns true if and only
+                  <code>from</code> attribute is omitted, then the function returns <code>true</code> if and only
                if <code>$node</code> is the root node of a tree.</p>
             <p>Let <code>$S</code> be the selected node.</p>
             <p>When <code>level="single"</code>: </p>
@@ -22139,7 +22139,7 @@ for $i in 1 to count($V) return
                   and/or type promotion. For example, if the sequence contains both
                      <code>xs:decimal</code> and <code>xs:double</code> values, then the values are
                   compared using <code>xs:double</code> comparison, even when comparing two
-                     <code>xs:decimal</code> values. NaN values, for sorting purposes, are
+                     <code>xs:decimal</code> values. <code>NaN</code> values, for sorting purposes, are
                   considered to be equal to each other, and less than any other numeric value.
                   Special rules also apply to the <code>xs:string</code> and <code>xs:anyURI</code>
                   types, and types derived by restriction therefrom, as described in the next
@@ -23227,7 +23227,7 @@ the same group, and the-->
                <head>Grouping Alternating Sequences of Elements</head>
                <p>In this example, the membership of a node within a group is based both on
                   adjacency of the nodes in document order, and on common values. In this case, the
-                  grouping key is a boolean condition, true or false, so the effect is that a
+                  grouping key is a boolean condition, <code>true</code> or <code>false</code>, so the effect is that a
                   grouping establishes a maximal sequence of nodes for which the condition is true,
                   followed by a maximal sequence for which it is false, and so on.</p>
                <p>Source XML document:</p>
@@ -23251,7 +23251,7 @@ the same group, and the-->
                   sibling nodes that does not include a <code>ul</code> or <code>ol</code>
                   element.</p>
                <p>This can be done by using <code>group-adjacent</code>, with a grouping key that is
-                  true if the element is a <code>ul</code> or <code>ol</code> element, and false
+                  <code>true</code> if the element is a <code>ul</code> or <code>ol</code> element, and <code>false</code>
                   otherwise:</p>
                <eg xml:space="preserve" role="xslt-declaration">&lt;xsl:template match="p"&gt;
     &lt;xsl:for-each-group select="node()" 
@@ -24230,7 +24230,7 @@ the same group, and the-->
 
             <p><phrase diff="chg" at="2022-01-01">Comparison of merge key values follows the rules for 
                <elcode>xsl:sort</elcode> given in <specref ref="comparing-sort-keys"/>. 
-               This means that except for special cases such as empty sequences and NaN</phrase>, 
+               This means that except for special cases such as empty sequences and <code>NaN</code></phrase>, 
                two sets of merge key values are distinct if any corresponding items in
                the two sets of values do not compare equal under the rules for the XPath
                   <code>eq</code> operator, under the collating rules for the corresponding merge
@@ -26912,7 +26912,7 @@ the same group, and the-->
                analysis only needs to know the static type of XPath expressions, so the rules here
                are largely confined to that case. For <termref def="dt-pattern">patterns</termref>, the <termref def="dt-static-type"/> is
                   deemed to be <var>U{xs:boolean}</var>, reflecting the fact that a pattern is
-                  essentially a function that can be applied to items to deliver a true or false
+                  essentially a function that can be applied to items to deliver a <code>true</code> or <code>false</code>
                   (matching or non-matching) result.
                For constructs other than <termref def="dt-expression">expressions</termref>
                   and <termref def="dt-pattern">patterns</termref>, the <termref def="dt-static-type"/> for the
@@ -33007,8 +33007,8 @@ the same group, and the-->
                <note>
                   <p>Patterns differ from other kinds of construct in that they are not composable
                      in the same way. It is best to think of a pattern as specialized syntax for a
-                     function that takes an item as its argument and returns a boolean: true if the
-                     pattern matches the item, otherwise false. The <termref def="dt-static-type"/> of a pattern is therefore taken as
+                     function that takes an item as its argument and returns a boolean: <code>true</code> if the
+                     pattern matches the item, otherwise <code>false</code>. The <termref def="dt-static-type"/> of a pattern is therefore taken as
                            <var>U{xs:boolean}</var> (this is not to be confused with the type of the
                         items that the pattern is capable of matching).</p>
                </note>
@@ -34315,7 +34315,7 @@ the same group, and the-->
                   two strings are equal for the purposes of key matching. Specifically, two key
                   values <code>$a</code> and <code>$b</code> are considered equal if the result of
                   the function call <code>deep-equal($a, $b,
-                        $collation)</code> is true. The effective collation for an
+                        $collation)</code> returns <code>true</code>. The effective collation for an
                      <elcode>xsl:key</elcode> declaration is the collation specified in its
                      <code>collation</code> attribute if present, resolved against the base URI of
                   the <elcode>xsl:key</elcode> element, or the <termref def="dt-default-collation">default collation</termref> that is in scope for the <elcode>xsl:key</elcode>
@@ -34728,7 +34728,7 @@ the same group, and the-->
                <p>This section describes what happens when two or more maps returned by the sequence constructor
                within an <elcode>xsl:map</elcode> instruction contain duplicate keys: that is, when one of these
                maps contains an entry with key <var>K</var>, and another contains an entry with key <var>L</var>,
-                  and <code diff="chg" at="2023-01-25">fn:atomic-equal(K, L)</code> is true.</p>
+                  and <code diff="chg" at="2023-01-25">fn:atomic-equal(K, L)</code> returns <code>true</code>.</p>
                
                <p><error spec="XT" class="DE" code="3365" type="dynamic">
                   <p>In the absence of the <code>on-duplicates</code> attribute, 
@@ -35784,7 +35784,7 @@ return ($m?price - $m?discount)</eg>
             <head>Assertions</head>
 
             <p>The <elcode>xsl:assert</elcode> instruction is used to assert that the value of a
-               particular expression is true; if the value of the expression is false, and
+               particular expression is <code>true</code>; if the value of the expression is <code>false</code>, and
                assertions are enabled, then a dynamic error occurs.</p>
 
             <?element xsl:assert?>
@@ -35804,7 +35804,7 @@ return ($m?price - $m?discount)</eg>
             <item><p diff="del" at="M">The optional <code>enabled</code> attribute contains an expression which is evaluated
                to determine whether assertion checking is enabled. Checking is disabled if the attribute is present
                and the effective boolean value
-               of the expression is false. This mechanism can be used, for example, to enable or disable a group of assertions
+               of the expression is <code>false</code>. This mechanism can be used, for example, to enable or disable a group of assertions
                by the setting of a <termref def="dt-stylesheet-parameter"/>.</p></item>
          </olist>-->
 
@@ -35818,7 +35818,7 @@ return ($m?price - $m?discount)</eg>
                   <p>The expression in the <code>test</code> attribute is evaluated. If the
                      effective boolean value of the result is <code>true</code>, the assertion
                      succeeds, and no further action is taken. If the effective boolean value is
-                     false, or if a dynamic error occurs during evaluation of the expression, then
+                     <code>false</code>, or if a dynamic error occurs during evaluation of the expression, then
                      the assertion fails.</p>
                </item>
 
@@ -35887,7 +35887,7 @@ return ($m?price - $m?discount)</eg>
                <head>Using Assertions with Static Parameters</head>
                <p>The following example shows a stylesheet function that checks that the value of
                   its supplied argument is in range. The check is performed only if the <termref def="dt-static-parameter"/>
-                  <code>$DEBUG</code> is set to true.</p>
+                  <code>$DEBUG</code> is set to <code>true</code>.</p>
                <eg role="xslt-declarations" xml:space="preserve">
 &lt;xsl:param name="DEBUG" as="xs:boolean" select="false()" 
            static="yes" required="no"/&gt;


### PR DESCRIPTION
`NaN`, `INF`, `-INF` and `+INF` was easy, boolean values were trickier:

* I used `<code>` for “The result/value/option/property is true/false”, “is set to true/false” and similar.
* I didn’t tag “This is true/false”, “The condition is true/false”  and similar.

I hope there won’t be too many conflicts if this is directly merged after #509.