### PR TITLE
237: Revise tokenisation appendix

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2497,7 +2497,7 @@ ErrorVal ::= "$" VarName
   <g:production name="StringConstructorContent" if="xquery40" whitespace-spec="explicit">
     <g:ref name="StringConstructorChars"/>
     <g:zeroOrMore>
-      <g:ref name="StringConstructorInterpolation"/>
+      <g:ref name="StringInterpolation"/>
       <g:ref name="StringConstructorChars"/>
     </g:zeroOrMore>
   </g:production>
@@ -2508,12 +2508,12 @@ ErrorVal ::= "$" VarName
     </g:zeroOrMore>
   </g:production>
 
-  <g:production name="StringConstructorInterpolation" if="xquery40">
-    <g:ref name="StringConstructorInterpolationStart"/>
+  <g:production name="StringInterpolation" if="xquery40" whitespace-spec="explicit">
+    <g:ref name="StringInterpolationStart"/>
     <g:optional>
       <g:ref name="Expr"/>
     </g:optional>
-    <g:ref name="StringConstructorInterpolationEnd"/>
+    <g:ref name="StringInterpolationEnd"/>
   </g:production>
 
   <g:production name="UnaryLookup" if="xpath40 xquery40">
@@ -4188,11 +4188,11 @@ ErrorVal ::= "$" VarName
     <g:string>]``</g:string>
   </g:token>
 
-  <g:token name="StringConstructorInterpolationStart" if="xquery40">
+  <g:token name="StringInterpolationStart" if="xquery40">
     <g:string>`{</g:string>
   </g:token>
 
-  <g:token name="StringConstructorInterpolationEnd" if="xquery40">
+  <g:token name="StringInterpolationEnd" if="xquery40">
     <g:string>}`</g:string>
   </g:token>
 
@@ -4202,18 +4202,18 @@ ErrorVal ::= "$" VarName
     because they are marked with inline="false".
   -->
 
-  <g:token name="IntegerLiteral" inline="false" value-type="number" delimiter-type="nondelimiting">
+  <g:token name="IntegerLiteral" inline="false" value-type="number" whitespace-spec="explicit" delimiter-type="nondelimiting">
     <g:ref name="Digits"/>
   </g:token>
   
-  <g:token name="HexIntegerLiteral" inline="false" value-type="number" delimiter-type="nondelimiting">
+  <g:token name="HexIntegerLiteral" inline="false" value-type="number" whitespace-spec="explicit" delimiter-type="nondelimiting">
     <g:sequence>
       <g:string>0x</g:string>
       <g:ref name="HexDigits"/>
     </g:sequence>
   </g:token>
   
-  <g:token name="BinaryIntegerLiteral" inline="false" value-type="number" delimiter-type="nondelimiting">
+  <g:token name="BinaryIntegerLiteral" inline="false" value-type="number" whitespace-spec="explicit" delimiter-type="nondelimiting">
     <g:sequence>
       <g:string>0b</g:string>
       <g:ref name="BinaryDigits"/>
@@ -4345,11 +4345,11 @@ ErrorVal ::= "$" VarName
     <g:string>;</g:string>
   </g:token>
 
-  <g:token name="EscapeQuot" inline="false" delimiter-type="hide" >
+  <g:token name="EscapeQuot" inline="false" whitespace-spec="explicit" delimiter-type="hide" >
     <g:string>""</g:string>
   </g:token>
 
-  <g:token name="EscapeApos" inline="false" delimiter-type="hide" >
+  <g:token name="EscapeApos" inline="false" whitespace-spec="explicit" delimiter-type="hide" >
     <g:string>''</g:string>
   </g:token>
 
@@ -5015,7 +5015,7 @@ ErrorVal ::= "$" VarName
         <g:tref name="StringConstructorStart"/>
       </g:transition>
       <g:transition next-state="STRING_CONSTRUCTOR" if="xquery40">
-        <g:tref name="StringConstructorInterpolationEnd"/>
+        <g:tref name="StringInterpolationEnd"/>
       </g:transition>
       <g:transition action="popState">
         <g:tref name="Rbrace"/>
@@ -5312,7 +5312,7 @@ ErrorVal ::= "$" VarName
         <g:tref name="StringConstructorEnd"/>
       </g:transition>
       <g:transition next-state="DEFAULT">
-        <g:tref name="StringConstructorInterpolationStart"/>
+        <g:tref name="StringInterpolationStart"/>
       </g:transition>
       <g:transition>
         <g:tref name="Char"/>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -33,7 +33,9 @@
       </item>
     </ulist>
     <p>The terminal symbols for this grammar include the quoted strings used in the production rules
-      below, and the terminal symbols defined in section <specref ref="terminal-symbols"/>.</p>
+      below, and the terminal symbols defined in section <specref ref="terminal-symbols"/>.
+    <phrase diff="add" at="2023-05-22">The grammar is a little unusual in that parsing and tokenization
+    are somewhat intertwined: for more details see <specref ref="lexical-structure"/>.</phrase></p>
     <p>The EBNF notation is described in more detail in <specref ref="EBNFNotation"/>.</p>
     
     <scrap id="BNF-Grammar" role="non-terminal-structure-expand">
@@ -215,22 +217,23 @@
             >ElementTest</nt>. Therefore, an unprefixed function name must not be any of the names in
             <specref ref="id-reserved-fn-names"/>.</p>
 
-        <p>A function named "if" can be called by binding its namespace to a prefix and using the
-          prefixed form: "library:if(foo)" instead of "if(foo)".</p>
+        <p>A function named <code>if</code> can be called by binding its namespace to a prefix and using the
+          prefixed form: <code>library:if(foo)</code> instead of <code>if(foo)</code>.</p>
       </constraintnote>
       <constraintnote id="parse-note-occurrence-indicators" type="xgc">
         <head>occurrence-indicators</head>
-        <p>As written, the grammar in <specref ref="nt-bnf"/> is ambiguous for some forms using the
-          '+' and '*' occurrence indicators. The ambiguity is resolved as follows: these operators are
+        <p diff="chg" at="2023-05-22">As written, the grammar in <specref ref="nt-bnf"/> is ambiguous for some forms using the
+          <code>"+"</code>, <code>"?"</code> and <code>"*"</code> <nt def="OccurrenceIndicator">OccurrenceIndicators</nt>. 
+          The ambiguity is resolved as follows: these operators are
           tightly bound to the <nt def="SequenceType">SequenceType</nt> expression, and have higher
-          precedence than other uses of these symbols. Any occurrence of '+' and '*', as well as
-          '?', following a sequence type is assumed to be an occurrence indicator, which binds to
+          precedence than other uses of these symbols. Any occurrence of <code>"+"</code>, 
+          <code>"?"</code> or <code>"*"</code>, that follows a sequence type is assumed to be an occurrence indicator, which binds to
           the last <nt def="ItemType">ItemType</nt> in the <nt def="SequenceType"
           >SequenceType</nt>.</p>
 
         <p>Thus, <code role="parse-test">4 treat as item() + - 5</code> must be interpreted as <code
             role="parse-test">(4 treat as item()+) - 5</code>, taking the '+' as an
-          OccurrenceIndicator and the '-' as a subtraction operator. To force the interpretation of
+          occurrence indicator and the '-' as a subtraction operator. To force the interpretation of
           "+" as an addition operator (and the corresponding interpretation of the "-" as a unary
           minus), parentheses may be used: the form <code role="parse-test">(4 treat as item()) +
             -5</code> surrounds the <nt def="SequenceType">SequenceType</nt> expression with
@@ -242,7 +245,7 @@
           shown to force the latter interpretation.</p>
 
         <p>This rule has as a consequence that certain forms which would otherwise be syntactically
-          valid and unambiguous are not recognized: in "4 treat as item() + 5", the "+" is taken as
+          valid and unambiguous are not recognized: in <code>4 treat as item() + 5</code>, the <code>"+"</code> is taken as
           an <nt def="OccurrenceIndicator">OccurrenceIndicator</nt>, and not as an operator, which
           means this is not a syntactically valid expression.</p>
       </constraintnote>
@@ -258,8 +261,8 @@
           <gitem id="parse-note-parens">
             <label>grammar-note: parens</label>
             <def>
-              <p>Look-ahead is required to distinguish <nt def="FunctionCall">FunctionCall</nt> from
-                a EQName or keyword followed by a <phrase role="xquery">
+              <p>Lookahead is required to distinguish a <nt def="FunctionCall">FunctionCall</nt> from
+                an EQName or keyword followed by a <phrase role="xquery">
                   <nt def="Pragma">Pragma</nt> or </phrase>
                 <nt def="Comment">Comment</nt>. For example: <code role="parse-test">address (: this
                   may be empty :)</code> may be mistaken for a call to a function named "address"
@@ -277,11 +280,11 @@
                 production). See <specref ref="DefaultWhitespaceHandling"/>. <phrase role="xquery"
                   >Note that comments are not allowed in direct constructor content, though they are
                   allowed in nested <nt def="EnclosedExpr"> EnclosedExprs</nt>.</phrase></p>
-              <p>A comment can contain nested comments, as long as all "(:" and ":)" patterns are
+              <p>A comment can contain nested comments, as long as all <code>"(:"</code> and <code>":)"</code> patterns are
                 balanced, no matter where they occur within the outer comment.</p>
               <note>
                 <p>Lexical analysis may typically handle nested comments by incrementing a counter
-                  for each "(:" pattern, and decrementing the counter for each ":)" pattern. The
+                  for each <code>"(:"</code> pattern, and decrementing the counter for each <code>":)"</code> pattern. The
                   comment does not terminate until the counter is back to zero.</p>
               </note>
               <p>Some illustrative examples:</p>
@@ -289,7 +292,7 @@
                 <item>
                   <p>
                     <code>(: commenting out a (: comment :) may be confusing, but often helpful
-                      :)</code> is a syntactically valid Comment, since balanced nesting of comments
+                      :)</code> is a syntactically valid <nt def="Comment">Comment</nt>, since balanced nesting of comments
                     is allowed.</p>
                 </item>
                 <item>
@@ -331,36 +334,141 @@
       </note>
     </div3>
   </div2>
-  <div2 id="lexical-structure">
-    <head>Lexical structure</head>
-    <p>The terminal symbols assumed by the grammar above are described in this section.</p>
-    <p>Quoted strings appearing in production rules are terminal symbols.</p>
-    <p>Other terminal symbols are defined in <specref ref="terminal-symbols"/>.</p>
-
+  <div2 id="productions-derived-from-XML">
+    <head>Productions Derived from XML</head>
     <p>Some productions are defined by reference to the XML and XML Names specifications (e.g.
-        <bibref ref="XML"/> and <bibref ref="XMLNAMES"/>, or <bibref ref="XML1.1"/> and <bibref
-        ref="XMLNAMES11"/> . <phrase role="xpath">A host language may choose</phrase><phrase
-        role="xquery">It is implementation-defined</phrase> which version of these specifications is
+      <bibref ref="XML"/> and <bibref ref="XMLNAMES"/>, or <bibref ref="XML1.1"/> and <bibref
+        ref="XMLNAMES11"/>. <phrase role="xpath">A host language may choose</phrase><phrase
+          role="xquery">It is implementation-defined</phrase> which version of these specifications is
       used; it is recommended that the latest applicable version be used (even if it is published
       later than this specification).</p>
-
+    
     <p role="xpath">A <term>host language</term> may choose whether the lexical rules of <bibref
-        ref="XML"/> and <bibref ref="XMLNAMES"/> are followed, or alternatively, the lexical rules
+      ref="XML"/> and <bibref ref="XMLNAMES"/> are followed, or alternatively, the lexical rules
       of <bibref ref="XML1.1"/> and <bibref ref="XMLNAMES11"/> are followed.</p>
-
+    
     <p role="xquery">It is <termref def="dt-implementation-defined">
-        implementation-defined</termref> whether the lexical rules of <bibref ref="XML"/> and
-        <bibref ref="XMLNAMES"/> are followed, or alternatively, the lexical rules of <bibref
+      implementation-defined</termref> whether the lexical rules of <bibref ref="XML"/> and
+      <bibref ref="XMLNAMES"/> are followed, or alternatively, the lexical rules of <bibref
         ref="XML1.1"/> and <bibref ref="XMLNAMES11"/> are followed. Implementations that support the
       full <bibref ref="XML1.1"/> character set <termref def="should">SHOULD</termref>, for purposes
       of interoperability, provide a mode that follows only the <bibref ref="XML"/> and <bibref
         ref="XMLNAMES"/> lexical rules.</p>
+    
+  </div2>
+  <div2 id="lexical-structure">
+    <head>Lexical structure</head>
+    <p diff="del" at="2023-05-22">The terminal symbols assumed by the grammar above are described in this section.</p>
+    <p diff="del" at="2023-05-22">Quoted strings appearing in production rules are terminal symbols.</p>
+    <p diff="del" at="2023-05-22">Other terminal symbols are defined in <specref ref="terminal-symbols"/>.</p>
+    <p diff="del" at="2023-05-22">When tokenizing, the longest possible match that is consistent with the EBNF is used.</p>
 
-    <p>When tokenizing, the longest possible match that is consistent with the EBNF is used.</p>
-
+    
+    
+    <p diff="add" at="2023-05-22">This section describes how an &language; text is tokenized prior to parsing.</p>
+    
     <p>All keywords are case sensitive. Keywords are not reserved&#8212;that is, any <termref
-        def="dt-qname">lexical QName</termref> may duplicate a keyword except as noted in <specref
+      def="dt-qname">lexical QName</termref> may duplicate a keyword except as noted in <specref
         ref="id-reserved-fn-names"/>.</p>
+    
+    <p diff="add" at="2023-05-22">Tokenizing an input string is a process that follows the following rules:</p>
+    
+    <ulist diff="add" at="2023-05-22">
+      <item><p><termdef id="dt-ordinary-production-rule" term="ordinary production rule">An <term>ordinary production rule</term> 
+        is a production rule in <specref ref="id-grammar"/> that is not annotated <code>ws:explicit</code>.</termdef></p></item>
+      <item><p><termdef id="dt-literal-terminal" term="literal terminal">A <term>literal terminal</term> is a token appearing as a string 
+        in quotation marks on the right-hand side of an <termref def="dt-ordinary-production-rule"/>.</termdef>
+      </p>
+        <note><p>Strings that appear in other production rules do not qualify.
+        <phrase role="xquery">For example, <code>"]]&gt;"</code> is not a literal terminal, because it appears only in the rule
+        <nt def="CDataSection">CDataSection</nt>, which is not an ordinary production rule; similarly <nt def="BracedURILiteral">BracedURILiteral</nt>
+          does not qualify because it appears only in <nt def="URIQualifiedName">URIQualifiedName</nt>, and <code>"0x"</code> does not qualify
+        because it appears only in <nt def="HexIntegerLiteral"/>.</phrase>
+          <phrase role="xpath">For example, <nt def="BracedURILiteral">BracedURILiteral</nt>
+            does not quality because it appears only in <nt def="URIQualifiedName">URIQualifiedName</nt>, and <code>"0x"</code> does not qualify
+            because it appears only in <nt def="HexIntegerLiteral">HexIntegerLiteral</nt>.</phrase></p></note>
+      
+        <p>
+          The <termref def="dt-literal-terminal">literal terminals</termref>  in &language; are: <phrase role="literal-terminals">[This section to
+              be filled in by assemble-spec.xsl]</phrase>
+        </p>
+      
+      </item>
+      <item><p><termdef id="dt-variable-terminal" term="variable terminal">A <term>variable terminal</term> is an instance
+        of a production rule that is not itself an <termref def="dt-ordinary-production-rule"/> but that is named (directly) on the right-hand
+        side of an <termref def="dt-ordinary-production-rule"/>.</termdef></p>
+        <p>
+          The <termref def="dt-variable-terminal">variable terminals</termref> in &language; are: <phrase role="variable-terminals">[This section to
+            be filled in by assemble-spec.xsl]</phrase>
+        </p>
+      </item>
+      <item><p><termdef id="dt-complex-terminal" term="complex terminal">A <term>complex terminal</term> is
+        a <termref def="dt-variable-terminal"/> whose production rule references, directly or indirectly, an 
+        <termref def="dt-ordinary-production-rule"/>.</termdef></p>
+        <p>
+          The <termref def="dt-complex-terminal">complex terminals</termref>  in &language; are: <phrase role="complex-terminals">[This section to
+            be filled in by assemble-spec.xsl]</phrase>
+        </p>
+      <note><p>The significance of complex terminals is that at one level, a complex terminal is treated as a single
+      token, but internally it may contain arbitrary expressions that must be parsed using the full EBNF grammar.</p></note>
+      </item>
+      <item><p>Tokenization is the process of splitting the supplied input string into a sequence of terminals, where each
+      terminal is either a <termref def="dt-literal-terminal"/> or a <termref def="dt-variable-terminal"/> (which may itself
+      be a <termref def="dt-complex-terminal"/>). Tokenization is done by repeating the following steps:</p>
+      <olist>
+        <item><p>Starting at the current position, skip any whitespace and comments.</p></item>
+        <item><p>If the current position is not the end of the input, then
+          return the longest <termref def="dt-literal-terminal"/> or <termref def="dt-variable-terminal"/> 
+        that can be matched starting at the current position, regardless whether this terminal is valid at this point
+        in the grammar. If no such terminal can be identified starting at the current position, or if the terminal that
+        is identified is not a valid continuation of the grammar rules, then a syntax error is reported.</p>
+        <note><p>Here are some examples showing the effect of the longest token rule:</p>
+          <ulist>
+            <item><p>The expression <code>map{a:b}</code> is a syntax error. Although there is a 
+              tokenization of this string that satisfies the grammar (by treating <code>a</code> and <code>b</code>
+              as separate expressions), this tokenization does not satisfy the longest token rule,
+              which requires that <code>a:b</code> is interpreted as a single <code>QName</code>.</p></item>
+            
+            <item><p>The expression <code>10 div3</code> is a syntax error. The longest token rule requires that this
+              be interpreted as two tokens (<code>"10"</code> and <code>"div3"</code>) even though it would
+              be a valid expression if treated as three tokens (<code>"10"</code>, <code>"div"</code>, and <code>"3"</code>).</p></item>
+            
+            <item><p>The expression <code>$x-$y</code> is a syntax error. This is interpreted as four tokens,
+              (<code>"$"</code>, <code>"x-"</code>, <code>"$"</code>, and <code>"y"</code>).</p></item>
+          </ulist>
+        </note>
+        <note><p>The lexical production rules for <termref def="dt-variable-terminal">variable terminals</termref>
+        have been designed so that there is minimal need for backtracking. For example, if the next terminal
+        starts with <code>"0x"</code>, then it can only be either a <nt def="HexIntegerLiteral">HexIntegerLiteral</nt> or an error;
+        if it starts with <code>"`"</code> (and not with <code>"```"</code>) then it can only be a
+          <nt def="StringTemplate">StringTemplate</nt> or an error.</p>
+        <p>This convention, together with the rules for whitespace separation of tokens (see <specref ref="id-terminal-delimitation"/>) 
+          means that the longest-token rule does not normally result in any need for backtracking. For example, suppose 
+          that a <termref def="dt-variable-terminal"/> has been identified as a <nt def="StringTemplate">StringTemplate</nt> by examining
+          its first few characters. If the construct turns out not to be a valid <nt def="StringTemplate">StringTemplate</nt>, 
+          an error can be reported without first considering whether there is some shorter token that might be returned instead.</p>
+        </note></item>
+      </olist>
+      </item>
+      <item><p>Tokenization unambiguously identifies the boundaries of the terminals in the input, and this
+        can be achieved without backtracking or lookahead. However, tokenization does
+      not unambiguously classify each terminal. For example, it might identify the string <code>"div"</code> as a terminal, but it does not
+      resolve whether this is the operator symbol <code>div</code>, or an <code>NCName</code> 
+        or <code>QName</code> used as a 
+      node test or as a variable or function name. Classification of terminals generally requires information about the
+      grammatical context, and in some cases requires lookahead.</p>
+      <note><p>Operationally, classification of terminals may be done either in the tokenizer or the parser, or
+      in some combination of the two. For example, according to the EBNF, the expression 
+        <code>"parent::x"</code> is made up of three
+      tokens, <code>"parent"</code>, <code>"::"</code>, and <code>"x"</code>. The name <code>"parent"</code>
+        can be classified as an axis name as soon as the following token <code>"::"</code> is recognized, and this
+      might be done either in the tokenizer or in the parser. (Note that whitespace and comments are allowed
+      both before and after <code>"::"</code>.)</p></note></item>
+      <item><p>In the case of a <termref def="dt-complex-terminal"/>, identifying the end of the complex terminal
+      typically involves invoking the parser to process any embedded expressions. Tokenization, as described
+      here, is therefore a recursive process. But other implementations are possible.</p></item>
+    </ulist>
+    
 
     <div3 id="terminal-symbols">
       <head>Terminal Symbols</head>
@@ -379,8 +487,9 @@
       <head>Terminal Delimitation</head>
       <p>&language; expressions consist of <loc href="#terminal-symbols">terminal symbols</loc> and
           <termref def="symbolseparators">symbol separators</termref>.</p>
-      <p>Terminal symbols that are not used exclusively in <loc href="#ws-explicit">/* ws: explicit
-          */</loc> productions are of two kinds: delimiting and non-delimiting.</p>
+      <p><phrase diff="add" at="2023-05-22"><termref def="dt-literal-terminal">Literal</termref> 
+        and <termref def="dt-variable-terminal">variable</termref> </phrase>
+        terminal symbols are of two kinds: delimiting and non-delimiting.</p>
       <!-- The next paragraph is "filled in" by various stylesheets used to generate the "assembled" source files. -->
       <p>
         <termdef id="delimiting-token" term="delimiting terminal symbol">The <term>delimiting
@@ -405,7 +514,8 @@
       </p>
       
       <p>
-        One or more <termref def="symbolseparators">symbol separators</termref>
+        <phrase diff="add" at="2023-05-22">As a consequence of the longest token rule (see <specref ref="lexical-structure"/>), </phrase>
+        one or more <termref def="symbolseparators">symbol separators</termref>
         are required between two consecutive terminal symbols
         T and U (where T precedes U) when any of the following is true:
       </p>
@@ -420,8 +530,8 @@
       
       <p>In the operator symbols <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code>, <code>&gt;=</code>, 
         <code>&lt;&lt;</code>, <code>&gt;&gt;</code>, <code>=&gt;</code>, and <code>-&gt;</code>, the <code>&lt;</code> character
-        may be written interchangeably using the codepoint x3C (less-than sign) or xFF1C (full-width less-than sign), while the <code>&gt;</code> character 
-        may be written interchangeably using the codepoint x3E (greater-than sign) or xFF1E (full-width greater-than sign). 
+        may be written interchangeably using the codepoint x3C (less-than sign, &lt;) or xFF1C (full-width less-than sign, &#xFF1C;), while the <code>&gt;</code> character 
+        may be written interchangeably using the codepoint x3E (greater-than sign, &gt;) or xFF1E (full-width greater-than sign, &#xFF1E;). 
         In order to avoid visual confusion these alternatives are not shown explicitly in the grammar.</p>
       
       <p>This option is provided to improve the readability of XPath expressions embedded in XML-based host languages such as XSLT; it
@@ -436,6 +546,12 @@
       <p role="xpath">The host language must specify whether the &language; processor normalizes all
         line breaks on input, before parsing, and if it does so, whether it uses the rules of
           <bibref ref="XML"/> or <bibref ref="XML1.1"/>. </p>
+      
+      <note role="xpath" diff="add" at="2023-05-22"><p>XML-based host languages such as XSLT and XSD
+      do not normalize line breaks at the XPath level, because it will already have been done by the host XML parser. 
+      Use of character or entity references suppresses normalization of line breaks, so
+      the string literal <code>&amp;#x0D;</code> written within an XSLT-hosted XPath expression
+      represents a string containing a single <code>CR</code> character.</p></note>
 
       <p role="xquery">Prior to parsing, the &language; processor must normalize all line breaks.
         The rules for line breaking follow the rules of <bibref ref="XML"/> or <bibref ref="XML1.1"

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11637,7 +11637,7 @@ return `The months with 31 days are: {$longMonths}.`]]></eg>
                <prodrecap id="StringConstructor" ref="StringConstructor"/>
                <prodrecap id="StringConstructorContent" ref="StringConstructorContent"/>
                <prodrecap ref="StringConstructorChars" id="StringConstructorChars"/>
-               <prodrecap id="StringConstructorInterpolation" ref="StringConstructorInterpolation"/>
+               <prodrecap id="StringInterpolation" ref="StringInterpolation"/>
             </scrap>
             
             <note diff="add" at="2023-01-29">
@@ -11660,7 +11660,7 @@ return `The months with 31 days are: {$longMonths}.`]]></eg>
                To evaluate a string constructor, each sequence of adjacent string
                constructor characters is converted to a string containing the same
                characters, and each <nt
-                  def="StringConstructorInterpolation">string
+                  def="StringInterpolation">string
                   constructor interpolation</nt>
                <code>$i</code> is evaluated, then
                converted to a string using the expression <code

--- a/style/assemble-spec.xsl
+++ b/style/assemble-spec.xsl
@@ -267,6 +267,39 @@
     <xsl:message>DEBUG: Exiting template phrase[@role='defined-tokens-nondelimiting']. </xsl:message>
     -->
   </xsl:template>
+  
+  <!-- This template "fills in" a paragraph in the EBNF section of document source files -->
+  <xsl:template match="phrase[@role='literal-terminals']">
+    <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
+    <xsl:variable name="grammar" select="document($fn,.)"/>
+    <xsl:for-each select="$grammar">
+      <xsl:call-template name="show-defined-tokens">
+        <xsl:with-param name="type" select="'literal-terminals'"/>
+      </xsl:call-template>
+    </xsl:for-each>
+  </xsl:template>
+  
+  <!-- This template "fills in" a paragraph in the EBNF section of document source files -->
+  <xsl:template match="phrase[@role='variable-terminals']">
+    <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
+    <xsl:variable name="grammar" select="document($fn,.)"/>
+    <xsl:for-each select="$grammar">
+      <xsl:call-template name="show-defined-tokens">
+        <xsl:with-param name="type" select="'variable-terminals'"/>
+      </xsl:call-template>
+    </xsl:for-each>
+  </xsl:template>
+  
+  <!-- This template "fills in" a paragraph in the EBNF section of document source files -->
+  <xsl:template match="phrase[@role='complex-terminals']">
+    <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
+    <xsl:variable name="grammar" select="document($fn,.)"/>
+    <xsl:for-each select="$grammar">
+      <xsl:call-template name="show-defined-tokens">
+        <xsl:with-param name="type" select="'complex-terminals'"/>
+      </xsl:call-template>
+    </xsl:for-each>
+  </xsl:template>
 
   <!--========= Language phrase substitution ========== -->
 


### PR DESCRIPTION
This PR is an extensive revision to the rules for tokenisation that corrects a number of errors: 

- The problem mentioned in issue 237, namely the lack of clarity in the "longest token rule". This PR fixes this by clarifying what this rule means and where it applies. In particular it tackles the issue of "complex terminals" such as element constructor expressions and string templates where a symbol that is a single token at one level (in the sense that whitespace is constrained) also contains enclosed expressions.
- Some productions/tokens were misclassified or omitted from the relevant lists of tokens in the appendix. This has been fixed in part by using general rules in the grammar2spec stylesheet to generate lists of tokens, rather than relying on annotations in the grammar file.

The PR includes changes to the grammar2spec stylesheet.