### PR TITLE
503: reinstate focus functions

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2376,7 +2376,9 @@ ErrorVal ::= "$" VarName
       <g:ref name="Annotation"/>
     </g:zeroOrMore>
     <g:string>function</g:string>
-    <g:ref name="FunctionSignature"/>
+    <g:optional>
+      <g:ref name="FunctionSignature"/>
+    </g:optional>
     <g:ref name="FunctionBody"/>
   </g:production>
   

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1397,10 +1397,18 @@ specification since the publication of XPath 3.1 Recommendation.</p>
         <code>ancestor::(section|appendix)</code>.</p></item>
       <item><p>String templates provide a new way of constructing strings: for example <code>`{$greeting}, {$planet}!`</code>
       is equivalent to <code>$greeting || ', ' || $planet || '!'</code></p></item>
+      <item><p>New abbreviated syntax is introduced (<termref def="dt-focus-function"/>) 
+        for simple inline functions taking a single argument. 
+        An example is <code>function{../@code}</code></p></item>
+      <item><p>The arrow operator <code>=></code> is now complemented by a “mapping arrow” operator <code>=!></code>
+        which applies a the supplied function to each item in the input sequence independently.</p></item>
       <item><p>The “function conversion rules” are now renamed “coercion rules”.</p></item>
       <item><p>The coercion rules allow “relabeling” of a supplied atomic value where
         the required type is a derived atomic type: for example, it is now permitted to supply
         the value 3 when calling a function that expects an instance of <code>xs:positiveInteger</code>.</p></item>
+      <item><p>Function coercion allows a function with arity <var>N</var> to be supplied where a function of arity 
+        greater than <var>N</var> is expected. For example this allows the function <code>true#0</code> 
+        to be supplied where a predicate function is required.</p></item>
       <item><p>The rules for “errors and optimization” have been tightened up to disallow
         many cases of optimizations that alter error behavior. In particular
         there are restrictions on reordering the operands of <code>and</code> and <code>or</code>,
@@ -1411,6 +1419,9 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       <item role="xquery"><p>Switch expressions now allow a <code>case</code> clause to match multiple atomic values.</p></item>
       <item><p>Numeric literals can now be written in hexadecimal or binary notation; and underscores can be included
       for readability.</p></item>
+      <item><p>The symbols <code>×</code> and <code>÷</code> can be used for multiplication and division,
+        and operators such as <code>&lt;</code> and <code>&gt;</code> can use the full-width forms
+        <code>&#xFF1C;</code> and <code>&#xFF1E;</code> to avoid the need for XML escaping.</p></item>
       <item role="xquery"><p>The <code>start</code> clause in window expressions has become optional, as well as
       the <code>when</code> keyword and its associated expression.</p></item>
       <item role="xquery"><p>All implementations must now predeclare the namespace prefixes
@@ -1443,20 +1454,18 @@ specification since the publication of XPath 3.1 Recommendation.</p>
     and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
     including a wildcard.</p></item>
     
-    <item><p>New abbreviated syntax is introduced for simple inline functions.</p></item>
+    
     <item><p>The lookup operator <code>?</code> can now be followed by a string literal, for cases where
     map keys are strings other than NCNames.</p></item>
     
-    <item><p>The arrow operator <code>=></code> is now complemented by a "thin arrow" operator <code>-></code>
-    which applies a function to each item in the input sequence independently.</p></item>
+    
     <item><p>The rules for value comparisons when comparing values of different types (for example, decimal and double)
     have changed to be transitive. A decimal value is no longer converted to double, instead the double is converted
     to a decimal without loss of precision. This may affect compatibility in edge cases involving comparison of
     values that are numerically very close.</p></item>
     <item><p>A <code>for member</code> clause is added to FLWOR expressions to allow iteration over
     an array.</p></item>
-    <item><p>Mathematical operator symbols are available as alternatives to alphabetic operator names, for example
-    <code>div</code> can be written as <code>÷</code>, while <code>intersect</code> can be written as <code></code>.</p></item>
+    
  
   </olist>
   </div3>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7682,7 +7682,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                with one argument.</p></item>
                <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/> and <specref ref="id-lambda-expressions"/>)
                   constructs a function item whose <phrase diff="chg" at="2023-03-11">body</phrase> is defined locally. For example the
-               construct <code>($x)->{$x+1}</code> returns a function item whose effect is to increment
+               construct <code>$x->{$x+1}</code> returns a function item whose effect is to increment
                the value of the supplied argument.</p></item>
                <item><p>A <term>partial function application</term> (see 
                   <specref ref="id-partial-function-application"/>) derives one function item from another by supplying
@@ -8383,12 +8383,16 @@ return $a("A")]]></eg>
 
 
             <p>
-               <termdef term="inline function expression" id="dt-inline-func"
-                     >An <term>inline function expression</term><phrase diff="add" at="2023-03-111">, when evaluated,</phrase> creates
+               <termdef term="inline function expression" id="dt-inline-func">An 
+                  <term>inline function expression</term><phrase diff="add" at="2023-03-111">, when evaluated,</phrase> creates
           an <termref def="dt-anonymous-function">anonymous function</termref>
           defined directly in the inline function expression.</termdef> 
                An inline function expression specifies the names and SequenceTypes of the parameters to the function,
-          the SequenceType of the result, and the body of the function.</p> 
+          the SequenceType of the result, and the body of the function.</p>
+            <p diff="add" at="2023-05-25">An <termref def="dt-inline-func"/> whose 
+               <nt def="FunctionSignature">FunctionSignature</nt> is omitted
+               is known as a <termref def="dt-focus-function"/>. Focus functions are 
+               described in <specref ref="id-focus-functions"/>.</p>
             <p><termdef
                   id="dt-anonymous-function" term="anonymous function">
              An <term>anonymous function</term> is a <termref def="dt-function-item"/> with no name.  
@@ -8420,26 +8424,9 @@ return $a("A")]]></eg>
 
                <eg>function($x, $y) {$x + $y}</eg>
                
-               <!--<p diff="add" at="A">For brevity, the keyword <code>function</code> can be replaced by the symbol <code>-></code>:</p>
                
-               <eg diff="add" at="A">->($x, $y) {$x + $y}</eg>
-               
-               <p diff="add" at="A">This avoids visual clutter when a function is used as an argument to another
-               function:</p>
-               
-               <eg diff="add" at="A">for-each-pair($A, $B, ->($a, $b) {$a + $b})</eg>
-               
-            <p diff="add" at="A">The common case where a function accepts a single argument of type
-               <code>item()</code> can be further abbreviated to <code>->{EXPR}</code>. This is equivalent to the 
-               expanded syntax <code>function($x as item()} as item()* {$x -> {EXPR}}</code>,
-               where <code>x</code> is a system-allocated name that does not conflict with any user-defined variables. That is,
-               it defines an anonymous arity-one function, accepting any single item as its argument value, and returns the
-               result of evaluating the supplied expression with that item as the <termref def="dt-singleton-focus"/>.
-            For example, the following function call returns the sequence <code>(2, 3, 4, 5, 6)</code>.</p>
             
-            <eg diff="add" at="A">for-each(1 to 5, ->{.+1})</eg>
-            
- -->
+ 
             <p diff="add" at="A">A zero-arity function can be written as, for example, <code>function(){current-date()}</code>.</p>
 
 
@@ -8571,28 +8558,39 @@ return $incrementors[2](4)]]></eg>
                      </p>
                      <p>The result of this expression is <code>6</code></p>
                   </item>
-                  <!--<item diff="add" at="A">
-                     <p>This example creates a function that prepends the string <code>"$"</code> to a supplied value:
-                        <eg
-                           role="parse-test"
-                           ><![CDATA[->{"$" || .}]]></eg>
-                     </p>
-                     <p>It is equivalent to the function <code>concat("$", ?)</code>.</p>
-                  </item>
-                  <item diff="add" at="A">
-                     <p>This example creates a function that returns the <code>name</code>
-                        attribute of a supplied element node:
-                        <eg
-                           role="parse-test"
-                           ><![CDATA[->{@name}]]></eg>
-                     </p>
-                     <p>It is equivalent to the function <code>function($x as item()) as item()* {$x ! @name}</code>.</p>
-                  </item>-->
+                  
                   
    
                </ulist>    
          
          </div4>
+            <div4 id="id-focus-functions" diff="add" at="2023-05-25">
+               <head>Focus Functions</head>
+               <p><termdef id="dt-focus-function" term="focus function">A <term>focus function</term>
+               is an inline function expression in which the function signature is implicit: the function takes
+               a single argument of type <code>item()</code>, and binds this to the context item when evaluating
+               the function body, which returns a result of type <code>item()*</code>.</termdef></p>
+               <p>Here are some examples of focus functions:</p>
+               <ulist>
+                  <item><p><code>function{@age}</code> - a function that expects a node as its argument, and returns
+                  the <code>@age</code> attribute of that node.</p></item>
+                  <item><p><code>function{.+1}</code> - a function that expects a number as its argument, and returns
+                  that number plus one.</p></item>
+                  <item><p><code>function{`${.}`}</code> - a function that expects a string as its argument, and prepends
+                     a <code>"$"</code> character.</p></item>
+               </ulist>
+               <p>Focus functions are often useful as arguments to simple higher-order functions such as <code>fn:sort</code>.
+               For example, to sort employees by salary, write <code>sort(//employee, (), function{+@salary})</code>.
+               (The unary plus has the effect of converting the attribute's value to a number, for numeric sorting).</p>
+               <p>Focus functions can also be useful on the right-hand side of the <termref def="dt-arrow-operator"/>.
+               For example, <code>$s => tokenize() => (function{`"{.}"`})()</code> first tokenizes the string <code>$s</code>,
+               then wraps each token in double quotation marks.</p>
+               <p>The expression <code>function{EXPR}</code> is a syntactic shorthand for the expression
+               <code>function($Z as item()) as item()* {$Z!(EXPR)}</code>, where <code>$Z</code> is a variable name that is
+               otherwise unused. Note that the function body (<code>EXPR</code>) is evaluated with a singleton focus: 
+                  the context position and context size will always be 1 (one).</p>
+            </div4>
+            
          <div4 id="id-lambda-expressions" diff="add" at="2023-04-18">
             <head>Lambda Expressions</head>
             
@@ -18368,7 +18366,7 @@ one <code>employee</code> element satisfies the given comparison expression:</p>
                   <code>every $emp in /emps/employee satisfies $emp/salary[@current='true']</code>, or even
                   more concisely as <code>empty(/emps/employee[not(salary/@current='true')]</code>.</p>
                <p>Another alternative in &language; is to use the higher-order functions <code>fn:some</code> and <code>fn:all</code>.
-               This example can be written <code>fn:all(/emps/employee, $e->{$e/salary/@current='true'})</code></p>
+               This example can be written <code diff="chg" at="2023-04-25">fn:all(/emps/employee, function{salary/@current='true'})</code></p>
                </note>
             </item>
 


### PR DESCRIPTION
This PR reinstates "focus functions", using the syntax `function{EXPR}` rather than `->{EXPR}`. If accepted, this resolves issue #503.