### PR TITLE
520: add function identity and use it in deep-equal

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1102,8 +1102,8 @@ but they are never the less part of the data model.
 <termdef term="function item" id="dt-function-item">
   A <term>function item</term> is an item that can be <term>called</term>.
 </termdef>
-Function items cannot be compared for
-identity, equality, or otherwise, and have no serialization.
+Function items <phrase diff="del" at="2023-05-25">cannot be compared for
+identity, equality, or otherwise, and</phrase> have no serialization.
 </p>
   
   <note diff="add" at="2023-03-11"><p>XDM 4.0 uses the term <term>function item</term> where XDM 3.1 used
@@ -1123,6 +1123,21 @@ identity, equality, or otherwise, and have no serialization.
       An expanded QName, possibly
       <termref def="dt-absent">absent</termref>. 
     </p>
+  </item>
+  <item>
+    <p diff="add" at="2023-05-25">
+      <term>identity</term>: an abstract property that can be used to test whether
+      two variables refer to the same function or to different functions. This property
+      is exposed only for this purpose.
+    </p>
+    <note><p>Currently, the concept of function identity is used for two purposes: firstly,
+    when functions appear in the arguments supplied to the <code>fn:deep-equal</code> function;
+    and secondly, in establishing whether the arguments and results of a function are "the same"
+    when deciding whether the function is deterministic.</p></note>
+    
+    <note><p>Function identity is not currently defined for maps and arrays, because in the circumstances
+    where function identity would otherwise be used, maps and arrays are compared by examining their 
+    content.</p></note>
   </item>
   <item>
     <p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12948,6 +12948,15 @@ else if (empty($input))
                   </item>
                </olist>
             </item>
+            <item diff="add" at="2023-05-25">
+               <p>All the following conditions are true:</p>
+               <olist>
+                  <item><p><code>$i1</code> is a function item and is not a map or array.</p></item>
+                  <item><p><code>$i2</code> is a function item and is not a map or array.</p></item>
+                  <item><p><code>$i1</code> and <code>$i2</code> have the same function identity.
+                     The concept of function identity is explained in <xspecref spec="DM40" ref="function-items"/>.</p></item>                 
+               </olist>
+            </item>
             <item>
                <p>All the following conditions are true:</p>
                <olist>
@@ -16906,33 +16915,26 @@ else
          <fos:property>special-streaming-rules</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the function having a given name and arity, if there is one.</p>
+         <p>Returns <phrase diff="chg" at="2023-05-26">a function item</phrase> having a given name and arity, if there is one.</p>
       </fos:summary>
       <fos:rules>
-         <p>A call to <code>fn:function-lookup</code> returns the function obtained by looking up
-            the expanded QName supplied as <code>$name</code> and the arity supplied as
-               <code>$arity</code> in the named functions component of the dynamic context
-            (specifically, the dynamic context of the call to <code>fn:function-lookup</code>).</p>
-
-         <p>Furthermore, if that function has an implementation-dependent implementation (see note
-            below), then the implementation of the function returned by
-               <code>fn:function-lookup</code> is associated with the static and dynamic context of
-            the call to <code>fn:function-lookup</code>.</p>
-
-         <note>
-            <p>The above rule deliberately uses the same wording as the corresponding rule for Named
-               Function References. The term "a function [with] an implementation-dependent
-               implementation" essentially means a function whose implementation is provided by the
-               language processor rather than by the stylesheet or query author. This rule is
-               therefore relevant to built-in functions and vendor-supplied extension functions
-               whose result depends on the context of the function call.</p>
-         </note>
-
-
-
-         <p>Otherwise (if no known function can be identified by name and arity), an empty sequence
+         <p diff="chg" at="2023-05-26">A call to <code>fn:function-lookup</code> starts by looking for a 
+            <xtermref spec="XP40" ref="dt-function-definition">function definition</xtermref>
+             in the named functions component of the dynamic context
+            (specifically, the dynamic context of the call to <code>fn:function-lookup</code>),
+            using the expanded QName supplied as <code>$name</code> and the arity supplied as
+            <code>$arity</code>. There can be at most one such function definition.</p>
+         
+         <p>If no function definition can be identified (by name and arity), then an empty sequence
             is returned.</p>
+         
+         <p diff="chg" at="2023-05-26">If a function definition is identified, then a function item is obtained from the function
+         definition using the same rules as for evaluation of a named function reference 
+         (see <xspecref spec="XP40" ref="id-named-function-ref"/>). The captured context of
+         the returned function item (if it is context dependent) is the static and dynamic context of 
+         the call on <code>fn:function-lookup</code>.</p>
 
+ 
          <p>If the arguments to <code>fn:function-lookup</code> identify a function that is present
             in the static context of the function call, the function will always return the same
             function that a static reference to this function would bind to. If there is no such
@@ -16968,12 +16970,19 @@ else
             functions never depend on the static or dynamic context of the function call. The rule
             applies recursively, since <code>fn:function-lookup</code> is itself a context-dependent
             built-in function. </p>
+         <p diff="add" at="2023-05-26">However, the static and dynamic context of the call to <code>fn:function-lookup</code>
+            may play a role even when the selected function definition is not itself context dependent,
+            if the expressions used to establish default parameter values are context dependent.</p>
+         <p diff="add" at="2023-05-26">The function identity is determined in the same way as for
+         a named function reference. Specifically, if there is no context dependency, two calls
+         on <code>fn:function-lookup</code> with the same name and arity must return the same function.</p>
          <p>These specifications do not define any circumstances in which the dynamic context will
             contain functions that are not present in the static context, but neither do they rule
             this out. For example an API <rfc2119>may</rfc2119> provide the ability to add functions
             to the dynamic context. Equally, these specifications do not define any mechanism for
             creating context-dependent functions other than the built-in context-dependent
             functions, but neither do they rule out the existence of such functions. </p>
+         
          <p>The mere fact that a function exists and has a name does not of itself mean that the
          function is present in the dynamic context. For example, functions obtained through
          use of the <code>fn:load-xquery-module</code> function are not added to the dynamic context.</p>
@@ -17899,6 +17908,70 @@ return sort($in, $SWEDISH)
          <fos:version version="4.0">New in 4.0. Accepted 2022-10-11.</fos:version>
       </fos:history>
    </fos:function>
+   <!--<fos:function name="equivalent" prefix="fn" diff="add" at="2023-05-25">
+      <fos:signatures>
+         <fos:proto name="equivalent" return-type="xs:boolean">
+            <fos:arg name="value1" type="item()*"/>
+            <fos:arg name="value2" type="item()*"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary><p>Determines whether two values (sequences) are deemed equivalent for the purposes
+         of testing set membership.</p></fos:summary>
+      <fos:rules>
+         <p>Two sequences are equivalent if they have the same number of items and the items are pairwise equivalent.</p>
+         <note><p>The empty sequence is equivalent to itself.</p></note>
+         <p>Two items <code>$P</code> and <code>$Q</code> are identical if one of the following conditions is true:</p>
+         <ulist>
+            <item><p>Both <code>$P</code> and <code>$Q</code> are nodes, and <code>$P is $Q</code>.</p></item>
+            <item><p>Both <code>$P</code> and <code>$Q</code> are atomic values, and <code>atomic-equal($P, $Q)</code>
+               is true.</p></item>
+            <item><p>Both <code>$P</code> and <code>$Q</code> are arrays, both have the same number of members,
+               and the members are pairwise equivalent.</p></item>
+            <item><p>Both <code>$P</code> and <code>$Q</code> are maps, both have the same number of entries,
+               and for every key <code>$K</code> contained in <code>$P</code>, the following are true:</p>
+                  <ulist>
+                     <item><p><code>map:contains($Q, $K)</code></p></item>
+                     <item><p><code>equivalent(map:get($P, $K), map:get($Q, $K))</code></p></item>
+                  </ulist>
+            </item>
+            <item><p>Both <code>$P</code> and <code>$Q</code> are function items, neither is a map nor an array,
+            and both have the same function identity.</p></item>
+         </ulist>
+      </fos:rules>
+      <fos:notes>
+         <p>The <code>equivalent</code> relation (in constrast with other methods of comparing equality) has the
+         following characteristics:</p>
+         <ulist>
+            <item>
+               <p>It applies to any values (sequences) and always returns a true/false answer, never an error.</p>
+            </item>
+            <item>
+               <p>It has no context dependencies.</p>
+            </item>
+            <item>
+               <p>It is reflexive (<code>equivalent($A, $B)</code> implies <code>equivalent($B, $A)</code>.</p>
+            </item>
+            <item>
+               <p>It is transitive (<code>equivalent($A, $B) and equivalent($B, $C)</code> implies <code>equivalent($A, $C)</code>.</p>
+            </item>
+         </ulist>
+         <p>There are cases where two items that are deemed equivalent are nevertheless distinguishable:</p>
+         <ulist>
+            <item><p>For atomic values, the type annotation is disregarded: <code>xs:integer(1)</code>
+               and <code>xs:decimal(1.0)</code> are considered equivalent. Moreover, an <code>xs:string</code>
+               value is considered equivalent to an <code>xs:untypedAtomic</code> value representing the same
+            sequence of characters.</p></item>
+            <item><p>Positive and negative zero are considered equivalent.</p></item>
+         </ulist>
+         <p>The equivalence relation is the one chosen for deciding whether two values can co-exist as keys in a map,
+         or as members of a set. [TODO: this anticipates generalization of maps and sets].</p>
+      </fos:notes>
+   </fos:function>-->
    <fos:function name="atomic-equal" prefix="fn" diff="chg" at="2023-01-25">
       <fos:signatures>
          <fos:proto name="atomic-equal" return-type="xs:boolean">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -930,10 +930,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p>The following definition explains more precisely what it means for two function calls to return the same result:</p>
                
-               <p><termdef id="dt-identical" term="identical"></termdef>Two values are
-                  defined to be <term>identical</term> if they
-                  contain the same number of items and the items are pairwise identical. Two items are identical
-                  if and only if one of the following conditions applies:</p>
+               <p><termdef id="dt-identical" term="identical" diff="chg" at="2023-05-25">Two values <code>$V1</code> and <code>$V2</code> are
+                  defined to be <term>identical</term> if they contain the same number of items and the items are pairwise identical. Two items are identical
+                  if and only if one of the following conditions applies:</termdef></p>
+                  
+              
                
                <olist>
                   <item><p>Both items are atomic values, of precisely the same type, and the values are equal as defined using the <code>eq</code> operator,
@@ -946,40 +947,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   <item><p>Both items are arrays, both arrays have the same number of members, and the members
                      are pairwise <termref def="dt-identical"/>.</p></item>
                   <item><p>Both items are function items, 
-                     neither item is a map or array, and all the following conditions apply:</p>
-                     <olist>
-                        <item><p>Either both functions have the same name, or both names are 
-                           <xtermref ref="dt-absent" spec="DM31">absent</xtermref>.</p></item>
-                        <item><p>Both functions have the same arity.</p></item>
-                        <item><p>Both functions have the same function signature. Two
-                        function signatures are defined to be the same if the declared result types are identical and the declared
-                        argument types are pairwise identical. Two types <var>S</var> and <var>T</var> are defined to be
-                           identical if and only if <code>subtype(S, T)</code> and <code>subtype(T, S)</code>
-                           both hold, where the subtype relation is defined in <xspecref spec="XP31" ref="id-seqtype-subtype"/>.</p>
-                        <note><p>Under this definition, a union type with <code>memberTypes="xs:double xs:decimal"</code>
-                           is identical to a union type with <code>memberTypes="xs:decimal xs:double"</code>. However, two functions
-                        whose signatures differ in this way will probably be deemed non-identical under rule (e) below, because they are likely to
-                        have different effect when invoked with an argument of type <code>xs:untypedAtomic</code>.</p></note>
-                        </item>
-                        <item><p>Both functions have the same <phrase diff="chg" at="2023-03-12">captured context 
-                           (including any</phrase> nonlocal variable 
-                           bindings — sometimes called the function's closure).</p></item>
-                        <item><p>The processor is able to determine that the implementations of the two functions are equivalent,
-                        in the sense that for all possible combinations of arguments, the two functions have the same effect.</p>                       
-                        </item>
-                     </olist>
-                     <note><p>There is no function or operator defined in the specification that tests whether two function items 
-                        are identical. Where the specification requires two function items to be identical, for example in the 
-                        results of repeated calls of a function whose result is a function, then the processor must ensure that 
-                        it returns functions that are indistinguishable in their observable effect. Where the specification defines 
-                        behavior conditional on two function items being identical, the determination of identity is to some degree 
-                        implementation-dependent. There are cases where function items are definitely not identical (for example 
-                        if they have different name or arity), but positive determination of identity is possible only using 
-                        implementation-dependent techniques, for example when both items contain references to the same piece of 
-                        code representing the function's implementation.
-                     </p></note>
+                     neither item is a map or array, and the two function items have the same function identity.
+                  The concept of function identity is explained in <xspecref spec="DM40" ref="function-items"/>.</p>
                   </item>
                </olist>
+  
                
                <p>Some functions produce results that depend not only on their explicit arguments, 
                   but also on the static and dynamic context.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8039,8 +8039,12 @@ return $vat()
                               Absent.
                            </p>
                         </item>
+                        <item><p diff="add" at="2023-05-25"><term>identity</term>: A new function
+                           identity distinct from the identity of any other function item.</p>
+                           <note><p>See also <specref ref="id-function-identity"/>.</p></note>
+                        </item>
                         <item>
-                           <p><term>arity</term>: the number of placeholders in the function call.</p>
+                           <p><term>arity</term>: The number of placeholders in the function call.</p>
                         </item>
                         <item>
                            <p>
@@ -8058,7 +8062,7 @@ return $vat()
                         
                         <item>
                            <p>
-                              <term>signature</term>: the parameters in the returned function
+                              <term>signature</term>: The parameters in the returned function
                               are the parameters of <var>F</var>
                               that have been identified as placeholder parameters,
                               retaining the order in which the placeholders appear in the
@@ -8076,7 +8080,7 @@ return $vat()
                         
                         <item>
                            <p>
-                              <term>captured context</term>: the
+                              <term>captured context</term>: The
                               static and dynamic context of the function call, augmented,
                               for each explicitly supplied parameter and each defaulted parameter, with
                               a binding of the converted argument value
@@ -8303,6 +8307,15 @@ return $a("A")]]></eg>
                as follows:
                <ulist>
                   <item><p>The name of <var>FI</var> is the name of <var>FD</var>.</p></item>
+                  <item><p diff="add" at="2023-05-25">The identity of <var>FI</var> is as follows:</p>
+                     <ulist>
+                        <item><p>If <var>FD</var> is <termref def="dt-context-dependent"/>, then a new function
+                        identity distinct from the identity of any other function item.</p></item>
+                        <item><p>Otherwise, a function identity that is the same as that produced by the evaluation
+                           of any other named function reference with the same function name and arity.</p></item>
+                     </ulist>
+                     <note><p>See also <specref ref="id-function-identity"/>.</p></note>
+                  </item>
                   <item><p>The parameter names of <var>FI</var> are the first <var>A</var> parameter names of <var>FD</var>,
                   where <var>A</var> is the required arity.</p></item>
                   <item><p>The signature of <var>FI</var> is formed from the required types of the 
@@ -8503,6 +8516,10 @@ return $a("A")]]></eg>
               Absent.
             </p>
                      </item>
+                     <item><p diff="add" at="2023-05-25"><term>identity</term>: a new function
+                              identity distinct from the identity of any other function item.</p>
+                        <note><p>See also <specref ref="id-function-identity"/>.</p></note>
+                     </item>
                      <item>
                         <p>
                            <term>parameter names</term>:
@@ -8659,6 +8676,33 @@ return $incrementors[2](4)]]></eg>
             expression until the arrow symbol (<code>-></code>) is encountered. Various strategies can be used
             to address this difficulty.</p></note>
          </div4>
+            
+            <div4 id="id-function-identity" diff="add" at="2023-05-25">
+               <head>Function Identity</head>
+               <p>It is sometimes useful to be able to establish whether two variables refer to the same function
+               or to different functions. For this purpose, every function item has an identity. Functions with the
+               same identity are indistinguishable in every way; in particular, any function call with identical
+               arguments will produce an identical result.</p>
+               <p>In general, evaluation of an expression that returns a new function item (one that was
+               not present in its operands) delivers a function item whose identity is unique, and thus distinct
+               from any other function item. There are two exceptions to this rule:</p>
+               
+               <ulist>
+                  <item><p>Evaluating a function reference such as <code>count#1</code> returns the same function
+                  every time. Specifically, if the function name identifies a <termref def="dt-function-definition"/>
+                  that is not <termref def="dt-context-dependent"/> (which is the most usual case), then all 
+                     function references using this function name and arity return the same function.</p>
+                  </item>
+                  <item><p>An optimizer is permitted to rewrite expressions in such a way that repeated
+                  evaluation is avoided if it can be established that the result will be the same each time,
+                  and this may be done without consideration of function identity. For example, if the
+                  expression <code>contains(?, "e")</code> appears within the body of a <code>for</code>
+                  expression, or if the same expression is written repeatedly in a query, then an optimizer
+                  may decide to evaluate it once only, and thus return the same function item each time.</p>
+                  <p>Similarly, optimizers are allowed to replace any expression with an equivalent
+                  expression, for example <code>count(?)</code> may be rewritten as <code>count#1</code>.</p></item>
+               </ulist>
+            </div4>
          </div3>
          
                      <div3 id="id-coercion-rules">
@@ -8944,6 +8988,10 @@ return $incrementors[2](4)]]></eg>
             The name of <var>F</var> <phrase diff="add" at="B">(if not absent)</phrase>.
           </p>
                            </item>
+           <item><p diff="add" at="2023-05-25"><term>identity</term>: A new function
+              identity distinct from the identity of any other function item.</p>
+              <note><p>See also <specref ref="id-function-identity"/>.</p></note>
+           </item>
                            <item>
                               <p>
                                  <term>parameter names</term>:

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -18904,7 +18904,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      <code>new-each-time="yes"</code> means it is proactive; and the value
                      <code>new-each-time="maybe"</code> means it is elidable.</p>
 
-               <p>The definition of <xtermref spec="FO40" ref="dt-deterministic">determinism</xtermref> requires a definition of what it means for a function
+               <p>The definition of <xtermref spec="FO40" ref="dt-deterministic">determinism</xtermref> 
+                  requires a definition of what it means for a function
                   to be called twice with “the same” arguments and to return “the same” result. This
                   is defined in <bibref ref="xpath-functions-31"/>, specifically by the definition
                   of the term <xtermref spec="FO40" ref="dt-identical">identical</xtermref>.</p>
@@ -18972,7 +18973,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      example, that one call passes the <code>xs:string</code> value <code>"Paris"</code>, while
                      another passes the <code>xs:untypedAtomic</code> value <code>"Paris"</code>? If the function
                      is declared with <code>new-each-time="maybe"</code>, then the rules say that
-                     these cannot be treated as “the same arguments”: the definition of <xtermref spec="FO40" ref="dt-identical"/> requires them to have exactly the same type
+                     these cannot be treated as “the same arguments”: the definition of 
+                     <xtermref spec="FO40" ref="dt-identical"/> requires them to have the same type
                      as well as being equal. However, an implementation that is able to determine
                      that all references to the argument within the function body only make use of
                      its string value might be able to take advantage of this fact, and thus perform


### PR DESCRIPTION
I believe this PR resolves issues

issue #520 - function identity
issue #333 - equality of function items
issue #381 - deep-equal comparison without errors

The PR introduces a concept of function identity in the data model, and for all expressions that create functions, explains what the identity of the returned function is.

The concept of function identity is used initially in two places: in fn:deep-equal(), when the operands include function items; and in the F+O prose defining the concept of determinism, which in turn is relied on by the definition of memo functions in XSLT.

I had hoped to go further and address issue #119, generalising what kinds of values are allowed as keys in maps, but as explained in a comment on that issue, I hit obstacles.
