### PR TITLE
Editorial: more corrections to F+O examples

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -5347,23 +5347,23 @@ Tak, tak, tak! - da kommen sie.
                <fos:postamble>The first <code>d</code> is replaced.</fos:postamble>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("abracadabra", "bra", action: ->{"*"})</fos:expression>
+               <fos:expression>replace("abracadabra", "bra", action:= function{"*"})</fos:expression>
                <fos:result>"a*cada*"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("abracadabra", "bra", action: upper-case#1)</fos:expression>
+               <fos:expression>replace("abracadabra", "bra", action:= upper-case#1)</fos:expression>
                <fos:result>aBRAcadaBRA</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("Chapter 9", "[0-9]+", action: ->{string(number(.)+1)})</fos:expression>
+               <fos:expression>replace("Chapter 9", "[0-9]+", action:= function{string(number(.)+1)})</fos:expression>
                <fos:result>"Chapter 10"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("LHR to LAX", "[A-Z]{3}", action: map{'LAX': 'Los Angeles', 'LHR': 'London'})</fos:expression>
+               <fos:expression>replace("LHR to LAX", "[A-Z]{3}", action:= map{'LAX': 'Los Angeles', 'LHR': 'London'})</fos:expression>
                <fos:result>"London to Los Angeles"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("57°43′30″", "([0-9]+)°([0-9]+)′([0-9]+)″)", action: ->($s, $groups){string(number($groups[1]) + number($groups[2])÷60 + number($groups[3])÷3600)||'°'})</fos:expression>
+               <fos:expression>replace("57°43′30″", "([0-9]+)°([0-9]+)′([0-9]+)″)", action:= ($s, $groups)->{string(number($groups[1]) + number($groups[2])÷60 + number($groups[3])÷3600)||'°'})</fos:expression>
                <fos:result>"57.725°"</fos:result>
             </fos:test>
          </fos:example>
@@ -12145,109 +12145,7 @@ let $newi := $o/tool</eg>
       </fos:history>
    </fos:function>
    
-   <!--<fos:function name="range-from" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="range-from" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="transmission"/>
-            <fos:arg name="start" type="(function(item()) as xs:boolean)"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Returns a sequence containing items from an input sequence, starting with the first
-            item that matches a supplied predicate.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>If <code>$input</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>Let <code>$S</code> be <code>fn:index-where($input, $start)[1]</code>.</p>
-         <p>If <code>$S</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>Otherwise, the function returns <code>subsequence($input, $S)</code>.</p>
-      </fos:rules>
-      <fos:notes>
-         <p>If the requirement is to exclude the item that matches the predicate, and to start with
-         the following item, the <code>fn:tail</code> function can be applied to the result.</p>
-         <p>The function can be combined with <code>fn:range-to</code>, for example the following
-            might be used to select elements based on the value of an attribute:</p>
-         <eg>$input => range-from(->{@time=$startTime}) => range-to(->{@time=$endTime})</eg>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>range-from((), matches(?, "c"))</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>range-from(("a", "b", "c", "d", "e"), matches(?, "c"))</fos:expression>
-               <fos:result>("c", "d", "e")</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>range-from(("a", "b", "c", "d", "e"), matches(?, "c")) => tail()</fos:expression>
-               <fos:result>("d", "e")</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>range-from(("a", "b", "c", "d", "e"), matches(?, "z"))</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-      <fos:history>
-         <fos:version version="4.0">Proposed for 4.0; not yet reviewed. Alternative name <code>items-from</code>.</fos:version>
-      </fos:history>
-   </fos:function>
-   
-   <fos:function name="range-to" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="range-to" return-type="item()*">
-            <fos:arg name="input" type="item()*" usage="inspection"/>
-            <fos:arg name="end" type="(function(item()) as xs:boolean)"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Returns a sequence containing items from an input sequence, ending with the first
-            item that matches a supplied predicate.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>If <code>$input</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>Let <code>$E</code> be <code>fn:index-where($input, $end)[1]</code>.</p>
-         <p>The function returns <code>fn:slice($input, end:$E)</code>.</p>
-      </fos:rules>
-      <fos:notes>
-         <p>To exclude the item that matches the predicate, write 
-            <code>range-to($input, $condition) => slice(end: -2)</code>.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>range-to((), matches(?, "c"))</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>range-to(("a", "b", "c", "d", "e"), matches(?, "c"))</fos:expression>
-               <fos:result>("a", "b", "c")</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>range-to(("a", "b", "c", "d", "e"), matches(?, "c")) => trunk()</fos:expression>
-               <fos:result>("a", "b")</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>range-to(("a", "b", "c", "d", "e"), matches(?, "z"))</fos:expression>
-               <fos:result>("a", "b", "c", "d", "e")</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-      <fos:history>
-         <fos:version version="4.0">Proposed for 4.0; not yet reviewed. Alternative name <code>items-until</code>.</fos:version>
-      </fos:history>
-   </fos:function>-->
+  
    
    <fos:function name="starts-with-sequence" prefix="fn">
       <fos:signatures>
@@ -18468,7 +18366,7 @@ return fold-left($MAPS, map{},
          of the corresponding values, retaining their order in the input sequence.</p>
          
          <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:build($key-value-pairs, $kvp->{$kvp?key}, $kvp->{$kvp?value}, $combine)</eg>
+         <eg>map:build($key-value-pairs, $kvp -> {$kvp?key}, $kvp -> {$kvp?value}, $combine)</eg>
 
 
       </fos:rules>
@@ -19475,7 +19373,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                <fos:result>map{}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:build(1 to 10, ->{. mod 3})</fos:expression>
+               <fos:expression>map:build(1 to 10, function{. mod 3})</fos:expression>
                <fos:result>map{0: (3, 6, 9), 1: (1, 4, 7, 10), 2: (2, 5, 8)}</fos:result>
                <fos:postamble>Returns a map with one entry for each distinct value of <code>. mod 3</code>. The
                   function to compute the value is the identity function, and duplicates are combined by
@@ -19506,19 +19404,19 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@ssn</code> values, and whose
                corresponding values are the employee nodes:</p>
-            <eg>map:build(//employee, ->{@ssn})</eg>
+            <eg>map:build(//employee, function{@ssn})</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values represent the number of employees at each distinct location. Any employees that
                lack an <code>@location</code> attribute will be excluded from the result.</p>
-            <eg>map:build(//employee, ->{@location}, ->{1}, op("+"))</eg>
+            <eg>map:build(//employee, function{@location}, function{1}, op("+"))</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values contain the employee node for the highest-paid employee at each distinct location:</p>
-            <eg>map:build(//employee, ->{@location}, 
-               combine := ->($a, $b){highest(($a, $b), ->{xs:decimal(@salary)}))</eg>
+            <eg>map:build(//employee, function{@location}, 
+               combine := ($a, $b)->{highest(($a, $b), function{xs:decimal(@salary)}))</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map allowing efficient access to every element in a document by means
@@ -21339,7 +21237,7 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:replace([10, 11, 12], 2, ->{.+10})</fos:expression>
+               <fos:expression>array:replace([10, 11, 12], 2, function{.+10})</fos:expression>
                <fos:result>[10, 21, 12]</fos:result>
             </fos:test>
             <fos:test>
@@ -21575,7 +21473,7 @@ else $fallback($position)</eg>
                <fos:result>(3, 4)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:index-where(array{1 to 10}, ->{. mod 2 = 0}))</fos:expression>
+               <fos:expression>array:index-where(array{1 to 10}, function{. mod 2 = 0}))</fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
             <fos:test>
@@ -21584,7 +21482,7 @@ else $fallback($position)</eg>
                <fos:result>(1, 2, 3, 4, 9, 10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:index-where([(1, 2, 3), (4, 5, 6), (7, 8)], ->($m){count($m) = 3})</fos:expression>
+               <fos:expression>array:index-where([(1, 2, 3), (4, 5, 6), (7, 8)], ($m)->{count($m) = 3})</fos:expression>
                <fos:result>(1, 2)</fos:result>
             </fos:test>
          </fos:example>
@@ -22342,11 +22240,11 @@ else array:fold-left(array:tail($array),
                <fos:result>[1, 2, 3, 4, 5]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, ->{2*.})</fos:expression>
+               <fos:expression>array:build(1 to 5, function{2*.})</fos:expression>
                <fos:result>[2, 4, 6, 8, 10]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, ->{1 to .})</fos:expression>
+               <fos:expression>array:build(1 to 5, function{1 to .})</fos:expression>
                <fos:result>[1, (1,2), (1,2,3), (1,2,3,4), (1,2,3,4,5)]</fos:result>
             </fos:test>
             <fos:test>
@@ -22354,7 +22252,7 @@ else array:fold-left(array:tail($array),
                <fos:result>[("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e")]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, ->{array{1 to .}})</fos:expression>
+               <fos:expression>array:build(1 to 5, function{array{1 to .}})</fos:expression>
                <fos:result>[[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5]]</fos:result>
             </fos:test>
          </fos:example>
@@ -23841,11 +23739,11 @@ declare function fn:all(
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>all((1, 3, 7), ->{. mod 2 = 1})</fos:expression>
+               <fos:expression>all((1, 3, 7), function{. mod 2 = 1})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>all(-5 to +5, ->{. ge 0})</fos:expression>
+               <fos:expression>all(-5 to +5, function{. ge 0})</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
@@ -24130,14 +24028,14 @@ function($item){
                <fos:result>("orange", "yellow", "indigo", "violet")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>highest(1 to 25, (), ->{. idiv 10})</fos:expression>
+               <fos:expression>highest(1 to 25, (), function{. idiv 10})</fos:expression>
                <fos:result>(20, 21, 22, 23, 24, 25)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>To find employees having the highest salary:
             </p>
-            <eg>highest($employees, (), ->{xs:decimal(salary)})</eg>
+            <eg>highest($employees, (), function{xs:decimal(salary)})</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -24180,7 +24078,7 @@ function($item){
                <fos:result>(2, 3)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>index-where(1 to 10, ->{. mod 2 = 0})</fos:expression>
+               <fos:expression>index-where(1 to 10, function{. mod 2 = 0})</fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
             <fos:test>
@@ -24324,7 +24222,7 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-after(10 to 20, ->{. gt 12})</fos:expression>
+               <fos:expression>items-after(10 to 20, function{. gt 12})</fos:expression>
                <fos:result>(14, 15, 16, 17, 18, 19, 20)</fos:result>
             </fos:test>
             <fos:test>
@@ -24332,7 +24230,7 @@ function($item){
                <fos:result>("May")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-after(10 to 20, ->{. gt 100})</fos:expression>
+               <fos:expression>items-after(10 to 20, function{. gt 100})</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
@@ -24340,7 +24238,7 @@ function($item){
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-after(->{boolean(self::h2)})]]></fos:expression>
+               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-after(function{boolean(self::h2)})]]></fos:expression>
                <fos:result><![CDATA[<img/>]]></fos:result>
             </fos:test>
          </fos:example>
@@ -24379,7 +24277,7 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-before(10 to 20, ->{. gt 12})</fos:expression>
+               <fos:expression>items-before(10 to 20, function{. gt 12})</fos:expression>
                <fos:result>(10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
@@ -24387,7 +24285,7 @@ function($item){
                <fos:result>("January", "February", "March")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-before(10 to 20, ->{. gt 100})</fos:expression>
+               <fos:expression>items-before(10 to 20, function{. gt 100})</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
@@ -24395,7 +24293,7 @@ function($item){
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-before(->{boolean(self::img)})) ! name()]]></fos:expression>
+               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-before(function{boolean(self::img)})) ! name()]]></fos:expression>
                <fos:result>"p", "p", "h2"</fos:result>
             </fos:test>
             <fos:test>
@@ -24438,7 +24336,7 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-starting-where(10 to 20, ->{. gt 12})</fos:expression>
+               <fos:expression>items-starting-where(10 to 20, function{. gt 12})</fos:expression>
                <fos:result>(13, 14, 15, 16, 17, 18, 19, 20)</fos:result>
             </fos:test>
             <fos:test>
@@ -24446,7 +24344,7 @@ function($item){
                <fos:result>("April", "May")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-starting-where(10 to 20, ->{. gt 100})</fos:expression>
+               <fos:expression>items-starting-where(10 to 20, function{. gt 100})</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
@@ -24454,7 +24352,7 @@ function($item){
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-starting-where(->{boolean(self::h2)})) ! name()]]></fos:expression>
+               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-starting-where(function{boolean(self::h2)})) ! name()]]></fos:expression>
                <fos:result>"h2", "img"</fos:result>
             </fos:test>
          </fos:example>
@@ -24494,7 +24392,7 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-ending-where(10 to 20, ->{. gt 12})</fos:expression>
+               <fos:expression>items-ending-where(10 to 20, function{. gt 12})</fos:expression>
                <fos:result>(10, 11, 12, 13)</fos:result>
             </fos:test>
             <fos:test>
@@ -24502,7 +24400,7 @@ function($item){
                <fos:result>("January", "February", "March", "April")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-ending-where(10 to 20, ->{. gt 100})</fos:expression>
+               <fos:expression>items-ending-where(10 to 20, function{. gt 100})</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
@@ -24510,7 +24408,7 @@ function($item){
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-ending-where(->{boolean(self::h2)})) ! name()]]></fos:expression>
+               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-ending-where(function{boolean(self::h2)})) ! name()]]></fos:expression>
                <fos:result>"p", "p", "h2"</fos:result>
             </fos:test>
          </fos:example>
@@ -24631,14 +24529,14 @@ function($item){
                <fos:result>("June", "July")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>lowest(1 to 25, (), ->{. idiv 10})</fos:expression>
+               <fos:expression>lowest(1 to 25, (), function{. idiv 10})</fos:expression>
                <fos:result>(1, 2, 3, 4, 5, 6, 7, 8, 9)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>To find employees having the lowest salary:
             </p>
-            <eg>lowest($employees, (), ->{xs:decimal(salary)})</eg>
+            <eg>lowest($employees, (), function{xs:decimal(salary)})</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -24646,109 +24544,7 @@ function($item){
       </fos:history>
    </fos:function>
 
-  <!-- <fos:function name="replace-with">
-      <fos:signatures>
-         <fos:proto name="replace-with" return-type="xs:string">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="pattern" type="xs:string"/>
-            <fos:arg name="action" type="function(xs:string) as xs:string?"/>
-         </fos:proto>
-         <fos:proto name="replace-with" return-type="xs:string">
-            <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="pattern" type="xs:string"/>
-            <fos:arg name="action" type="function(xs:string) as xs:string?"/>
-            <fos:arg name="flags" type="xs:string"/>
-         </fos:proto>       
-      </fos:signatures>
-
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Replaces the parts of a string that match a regular expression with replacement
-            strings obtained by calling a user-supplied function.</p>
-      </fos:summary>
-
-      <fos:rules>
-         <p>The effect of calling the first version of this function (omitting the argument
-            <code>$flags</code>) is the same as the effect of calling the second version with the
-            <code>$flags</code> argument set to a zero-length string. Flags are defined in
-            <specref
-               ref="flags"/>.</p>
-         <p>The <code>$flags</code> argument is interpreted in the same manner as for the
-            <code>fn:matches</code> function. </p>
-         <p>If <code>$value</code> is the empty sequence, it is interpreted as the zero-length
-            string.</p>
-         <p>The function returns the <code>xs:string</code> that is obtained by replacing each
-            non-overlapping substring <var>S</var> of <code>$value</code> that matches the given
-            <code>$pattern</code> with a string obtained by calling the <code>$action</code>
-            function, supplying <var>S</var> as the argument.</p>
-
-         <p>If the <code>$action</code> function returns an empty sequence, it is treated
-            as if it returned a zero-length string.</p>
-
-         <p>If two overlapping substrings of <code>$value</code> both match the
-            <code>$pattern</code>, then only the first one (that is, the one whose first <termref
-               def="character"
-            >character</termref> comes first in the <code>$value</code> string) is
-            replaced.</p>
-
-         <p> If two alternatives within the pattern both match at the same position in the
-            <code>$input</code>, then the match that is chosen is the one matched by the first
-            alternative. For example:</p>
-         <eg xml:space="preserve"> replace-with("abcd", "(ab)|(a)", ->{'#' || . || '#'}) returns "#ab#cd"</eg>
-
-      </fos:rules>
-      <fos:errors>
-         <p>A dynamic error is raised <errorref class="RX" code="0002"
-               /> if the value of
-            <code>$pattern</code> is invalid according to the rules described in section <specref
-               ref="regex-syntax"/>. </p>
-         <p>A dynamic error is raised <errorref class="RX" code="0001"
-               /> if the value of
-            <code>$flags</code> is invalid according to the rules described in section <specref
-               ref="flags"/>. </p>
-         <p>A dynamic error is raised <errorref class="RX" code="0003"
-               /> if the pattern matches a
-            zero-length string, that is, if the expression <code>fn:matches("", $pattern,
-               $flags)</code> returns <code>true</code>. It is not an error, however, if a captured
-            substring is zero-length.</p>
-      </fos:errors>
-      <fos:notes>
-         <p>If the input string contains no substring that matches the regular
-            expression, the result of the function is a single string identical to the input
-            string.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:example>
-            <fos:test>
-               <fos:expression>replace-with("abracadabra", "bra", ->{"*"})</fos:expression>
-               <fos:result>"a*cada*"</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>replace-with("abracadabra", "bra", upper-case#1)</fos:expression>
-               <fos:result>aBRAcadaBRA</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>replace-with("Chapter 9", "[0-9]+", "->{string(number(.)+1)}")</fos:expression>
-               <fos:result>"Chapter 10"</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>replace-with("LHR to LAX", "[A-Z]{3}", map{'LAX': 'Los Angeles', 'LHR': 'London'})</fos:expression>
-               <fos:result>"London to Los Angeles"</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-   </fos:function>
--->
+  
 
 
 
@@ -24807,11 +24603,11 @@ declare function fn:some(
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some((1, 3, 7), ->{. mod 2 = 1})</fos:expression>
+               <fos:expression>some((1, 3, 7), function{. mod 2 = 1})</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some(-5 to +5, ->{. ge 0}))</fos:expression>
+               <fos:expression>some(-5 to +5, function{. ge 0}))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>


### PR DESCRIPTION
Fixes errors in the fn:replace examples, updates elsewhere to reflect changes to the syntax of lambda expressions and focus functions.