### PR TITLE
528 fn:elements-to-maps

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22691,7 +22691,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:notes>
    </fos:function>
    
-   <fos:function name="items-to-json" prefix="fn">
+   <!--<fos:function name="items-to-json" prefix="fn">
       <fos:signatures>
          <fos:proto name="items-to-json" return-type="xs:string">
             <fos:arg name="input" type="item()*"/>
@@ -22886,10 +22886,12 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <p>Attribute nodes that are reached via an element node are output as described
                         under “element nodes”, above.</p>
 
-                     <p>Free-standing attribute nodes are output as JSON objects with properties:</p>
+                     <p>A top-level attribute node is output as as a JSON object comprising a single key-value pair.
+                     The key is the string <code>"#attribute"</code>, and the value is a JSON object with
+                     two properties:</p>
                      <ulist>
-                        <item><p><code>#attribute</code> set to the name of the attribute, as a local name
-                        in the case of an attribute in no namespace, or in <code>Q{uri}local</code> format
+                        <item><p><code>#name</code> set to the name of the attribute as a string, being the local name
+                        in the case of an attribute in no namespace, or a string in <code>Q{uri}local</code> format
                         otherwise.</p></item>
                         <item><p><code>#value</code> set to
                            the result of atomizing the attribute value and applying the
@@ -22900,7 +22902,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   <p>Namespace nodes that are reached via an element node result in no output.</p>
                      <p>A top-level namespace node is output as a JSON object comprising a single key-value pair.
                         The key is the string <code>"#namespace"</code>, and the value is a JSON object
-                        with two string-valued properties: <code>"#prefix"</code> holding the name of the namespace node,
+                        with two string-valued properties: <code>"#prefix"</code> holding the name of the namespace node
+                        (or an empty string for a namespace node whose name is absent),
                         and <code>"#uri"</code> holding the namespace URI (in XDM terms, the string value of the namespace node).</p>
                   </item>
                </ulist>            
@@ -22917,8 +22920,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <note><p>Conflicts between property names can arise because the XDM model allows keys of different types,
                   for example the <code>xs:date</code> value <code>2020-12-31</code> and the string value 
                   <code>"2020-12-31"</code> can co-exist. The map <code>map{xs:duration('PT1D'):20, "PT1D":30}</code>
-                  is converted to the JSON string <code>{"PT1D":20,"PT1D(1)":30}</code> or 
-                  <code>{"PT1D":30,"PT1D(1)":20}</code>, depending on the (unpredictable) order in which the
+                  is converted to the JSON string <code>{"PT1D":20,"PT1D[2]":30}</code> or 
+                  <code>{"PT1D":30,"PT1D[2]":20}</code>, depending on the (unpredictable) order in which the
                entries in the map are processed.</p></note>
                <note><p>Because the order of entries in a map is unpredictable, the order in which the
                properties are listed in the JSON output is also unpredictable.</p></note>
@@ -22940,24 +22943,19 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   <item><p><code>#arguments</code> whose value is an array
                   of strings, which identify the names and types of the function arguments,
                   in the format <code>$Q{uri}local as SequenceType</code>: for example 
-                     <code>["$x as double", "$y as string"]</code>. Namespace prefixes must not be used:
-                     unprefixed element names and variable names are taken to be in no namespace, and unprefixed
-                     type names are taken to be in the namespace <code>http://www.w3.org/2001/XMLSchema</code>.
+                     <code>["$x as xs:double", "$y as xs:string"]</code>. QNames in no namespace should be written
+                     as simple strings containing the local name only; QNames in a namespace should be written
+                     in the form <code>Q{uri}local</code>, except that the namespace 
+                     <code>http://www.w3.org/2001/XMLSchema</code> should be indicated
+                     using the conventional prefix <code>xs</code>, as in the above example.
                   </p></item>
-                  <item><p><code>#result</code> whose value is a string 
+                  <item><p><code>#result</code> whose value is a string. 
                      identifying the type of the function result, using the same conventions as for <code>#arguments</code>.</p></item>
-                  <item><p>Optionally at implementer discretion, <code>#implementation</code> whose value is a string 
+                  <item><p>Optionally at implementer discretion, <code>#body</code> whose value is a string.</p></item> 
                </ulist>
 
-               <p><emph>Function items</emph></p>
-               <p>An XDM function item, other than a map or array, is output as a JSON object comprising a single key-value pair.
-               The key is the string <code>"#function"</code>. The corresponding value is a JSON object. If the function has a name,
-               this object must contain a property giving the name in the format <code>"#name": "Q{uri}local"</code>. In all
-                  cases the object must contain a property giving the arity as a number, for example <code>"#arity": 3</code>.
-               Other properties <rfc2119>may</rfc2119> be included at the discretion of the implementation; their names 
-               <rfc2119>must</rfc2119> start with an underscore.</p>
-              
->>>>>>> 706257d7 (Substantial revision of element mappings in fn:xdm-to-json)
+               
+
                
             </item>
          </ulist>
@@ -23041,6 +23039,173 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:examples>
       <fos:history>
          <fos:version version="4.0">Proposed for 4.0; initial review on 2023-06-27.</fos:version>
+      </fos:history>
+   </fos:function>-->
+   
+ 
+   <fos:function name="elements-to-maps" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="elements-to-maps" return-type="map(xs:string, item()?)*">
+            <fos:arg name="elements" type="element(*)*"/>
+            <fos:arg name="options" type="map(*)" usage="inspection"  default="map{}"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Converts a sequence of element nodes to a sequence of maps, suitable for serialization as JSON.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function converts the supplied element nodes to maps. The conversion is one-to-one and retains order:
+         for each element node in the input, there will be a corresponding map in the output. The form of the
+         generated maps is designed to be suitable for serialization as JSON using the JSON output method.</p>
+         <p>The conversion can process any element nodes
+            whatsoever, but it is not lossless. For example, information about  base URIs and unused in-scope namespaces
+         is lost.</p>
+         
+         <p>The element nodes actually present in the <code>$elements</code> argument are refered to as top-level
+         elements; their descendant elements are refered to as descendant elements.</p>
+         
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         
+         <fos:options>
+            <fos:option key="uniform">
+               <fos:meaning>Indicates that all elements with the same name (except where schema type information is available)
+                  should use the same JSON layout. Setting this option requires the processor to analyze the entire input
+               before deciding what layout to use for each element; but by ensuring consistency across elements, it may
+               make the resulting JSON easier to process.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">
+                     The layout for each element node is decided independently, based on its individual content.
+                  </fos:value>
+                  <fos:value value="true">
+                     In the absence of schema type information, and of an explicit entry in the <code>layouts</code>
+                     property, the layout chosen for a given element node must be the same as that for all other
+                     elements of the same name.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="layouts">
+               <fos:meaning>A mapping from element names to layout names, used to override the default
+               formatting rules for a particular element name.</fos:meaning>
+               <fos:type>map{xs:QName, enum("empty", "empty-plus", "simple", "simple-plus", "list", "list-plus", 
+                  "record", "sequence", "mixed", "xml", "html", "xhtml")}</fos:type>
+               <fos:default>map{}</fos:default>
+            </fos:option>
+         </fos:options>
+         
+         
+         
+         
+ 
+         <p>A top-level element node is output as a map comprising a single key-value pair, where the
+            key is a string derived from the element name as described below, and the content
+            follows the rules of a specific layout appropriate to that element.</p>
+         
+         <p>The name of a top-level element is represented as follows:</p>
+         
+         <ulist>
+            <item><p>If the element name is in no namespace, as a string containing the
+               local part of the element name.</p></item>
+            <item><p>If the element name is in a namespace, as a string in the format
+               <code>Q{uri}local</code>, where <code>uri</code> is the namespace, and <code>local</code>
+               is the local part of the element name.</p></item>
+         </ulist>
+         
+         <p>For a descendant element, the name is represented as follows:</p>
+         
+         <ulist>
+            <item><p>If the element name is in the same namespace as its parent, or if both are
+               in no namespace, then as a string containing the
+               local part of the element name.</p></item>
+            <item><p>Otherwise, as a string in the format
+               <code>Q{uri}local</code>, where <code>uri</code> is the namespace (or the empty string
+               to represent no namespace), and <code>local</code> is the local part of the element name.</p></item>
+         </ulist>
+         
+         <p>Note that prefixes used in element names are not retained; neither are the prefix-to-uri mappings
+            represented by namespace nodes in the XDM tree.</p>
+         
+         <note><p>Where an element appears as a child of an element formatted using record layout
+            (see <specref ref="record-json-layout"/>), its name is when necessary suffixed by an index such as <code>"[1]"</code>
+            or <code>"[2]"</code> to make it unique.</p></note>
+         
+         <p>The available layouts 
+            are described in <specref ref="xml-to-json-mappings"/>. A layout is selected for each element node <var>E</var>
+            by applying the following rules in order:</p>
+            <olist>
+               <item><p>If the name of <var>E</var> is listed as the key of an entry in the <code>layouts</code> 
+                  option, then the corresponding named layout is used.</p></item>
+               <item><p>If <var>E</var> has a type annotation <var>T</var> other than <code>xs:untyped</code>
+               or <code>xs:anyType</code>, then the layout appropriate to its schema type
+               is used. Specifically, taking the layouts in the order presented in 
+                  <specref ref="json-element-layouts"/>, the first layout whose <term>XSD conditions</term>
+               are satisfied by <var>T</var> is chosen.</p></item>
+               <item><p>If the option <code>uniform</code> is set to false (which is its default value),
+                  then the chosen layout is the first layout, in the order they are listed in 
+                  <specref ref="json-element-layouts"/>, whose <term>match pattern</term>
+               matches <var>E</var>.</p></item>
+               <item><p>If the option <code>uniform</code> is set to true, then let <var>S</var>
+               be the set of all element nodes in the input having the same name as <var>E</var>,
+                  with type annotation <code>xs:untyped</code> or <code>xs:anyType</code>,
+               including both top-level element nodes and descendant element nodes.
+               The chosen layout is then the first layout, in the order they are listed in 
+                  <specref ref="json-element-layouts"/>, whose <term>match pattern</term> matches
+                  every element node in <var>S</var>.</p></item>
+            </olist>
+ 
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error is raised if the selected layout rules require atomization of an element that does not have a typed
+            value (typically because it has been validated against an element-only content model): <errorref
+               class="TY" code="0012"/>.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>The namespace URI and local name of all elements and attributes is available in the JSON output.
+            Prefixes are not retained, and namespaces that are declared but not used are not retained.</p>
+         <p>The distinction between different atomic types is lost, except for the boolean/number/string
+         distinction present in JSON.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[elements-to-maps(<a x="2">banana</a>)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[map{"a":
+   map{"@x":"2",
+       "#content":"banana"}
+}]]></eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[elements-to-maps(<a><b/><c>2</c></a>)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[map{"a":
+   map{"b":"",
+       "c":"2"}
+}]]></eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[elements-to-maps(<a>A <i>nice</i> one!</a>)]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[map{"a":
+   ["A ",
+    map{"i":"nice"},
+    " one!"]
+}]]></eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[elements-to-maps(<a>A <i>nice</i> one!</a>, 
+              map{'layouts':map{QName('', 'a'): 'xml'}})]]></eg></fos:expression>
+               <fos:result><eg><![CDATA[[map{"a":
+   "<a>A <i>nice</i> one!</a>"
+}]]></eg></fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0.</fos:version>
       </fos:history>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22708,10 +22708,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:summary>
       <fos:rules>
          <p>This function returns a string, in JSON format, containing a representation of the
-         supplied input <code>$input</code>. The function is error-free (it accepts any input sequence
-         whatsoever), but it is not lossless: there are cases when two different XDM values will
+         supplied input <code>$input</code>. The function can process any input sequence
+         whatsoever, but it is not lossless: there are cases when two different XDM values will
          have the same JSON representation. For example, the sequence <code>(1, 2)</code>
-            and the array <code>[1, 2]</code> are both output as <code>[1,2]</code>.</p>
+            and the array <code>[1, 2]</code> are both output as <code>"[1,2]"</code>.</p>
          
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
          
@@ -22730,51 +22730,15 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
-            <fos:option key="strip-space">
-               <fos:meaning>Determines whether whitespace-only text nodes are retained in the output, when
-                  outputting element nodes using array format.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false</fos:default>
-               <fos:values>
-                  <fos:value value="false">
-                     In the array format of element content, whitespace-only text nodes are included.
-                  </fos:value>
-                  <fos:value value="true">
-                     In the array format of element content, whitespace-only text nodes are omitted.
-                  </fos:value>
-               </fos:values>
+            <fos:option key="layouts">
+               <fos:meaning>A mapping from element names to layout names, used to override the default
+               formatting rules for a particular element name.</fos:meaning>
+               <fos:type>map{xs:QName, enum("empty", "empty-plus", "simple", "simple-plus", "list", "record", "sequence", "mixed")}</fos:type>
+               <fos:default>map{}</fos:default>
             </fos:option>
-            <fos:option key="use-value-format">
-               <fos:meaning>Identifies elements whose content should be output using value format.</fos:meaning>
-               <fos:type>xs:QName*</fos:type>
-               <fos:default>()</fos:default>
-            </fos:option>
-            <fos:option key="use-map-format">
-               <fos:meaning>Identifies elements whose content should be output using map format.</fos:meaning>
-               <fos:type>xs:QName*</fos:type>
-               <fos:default>()</fos:default>
-            </fos:option>
-            <fos:option key="use-array-format">
-               <fos:meaning>Identifies elements whose content should be output using array format.</fos:meaning>
-               <fos:type>xs:QName*</fos:type>
-               <fos:default>()</fos:default>
-            </fos:option>
-            <!--<fos:option key="element-map">
-               <fos:meaning>Determines whether elements whose children are element nodes with distinct
-                  names should be treated specially.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>true</fos:default>
-               <fos:values>
-                  <fos:value value="false">
-                     The processor treats such elements in the same way as any other element.
-                  </fos:value>
-                  <fos:value value="true">
-                     The processor generates a JSON object in which the child element names are used
-                     as JSON property names.
-                  </fos:value>
-               </fos:values>
-            </fos:option>-->
          </fos:options>
+         
+         
          
          
          <p>An input sequence is handled as follows:</p>
@@ -22785,7 +22749,12 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             from the items by applying the rules below.</p></item>
          </ulist>
          
-         <p>Items are processed as follows:</p>
+         <p>Much of the complexity is concerned with the representation of element nodes: the principles are described
+            in <specref ref="xml-to-json-mappings"/>.</p>
+         
+        
+         
+         <p>Items in a supplied sequence are processed as follows:</p>
          
          <ulist>
             <item>
@@ -22801,134 +22770,57 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </item>
             <item>
                <p><emph>Nodes</emph></p>
+               <p>A node is represented as a JSON object containing a single key-value pair. For elements, the key
+               is derived from the element name as described in <specref ref="element-names-in-json"/>; 
+               for all other node kinds it represents the node kind (for example,
+               <code>#text</code> or <code>#comment</code>).</p>
                <ulist>
                   <item>
                      <p><emph>Document nodes</emph></p>
-                     <p>A document node is output as a JSON object with the following properties, in order:</p>
-                     <ulist>
-                        <item><p>A property <code>#document</code> set to the value of the document URI of the document
-                           if available, or an empty string otherwise..</p></item>
-                        <item><p>A property <code>#base-uri</code> set to the value of the base URI of the document
-                           if available; the property is absent if this is not available.</p></item>
-                        <item><p>A property <code>#content</code>. If the document node has exactly one child node and this
-                           is an element node, then the value of the <code>#content</code> property is the
-                           representation of that element child. If the document node has no children, the 
-                           <code>#content</code> property is absent. In all other cases the value of the 
-                           <code>#content</code> property follows the rules for the content of element nodes
-                           using array representation.</p></item>                       
-                     </ulist>
+                     <p>A document node is output as a JSON object comprising a single key-value pair, where the
+                        key is the string <code>"#document"</code> and the value represents the content, using
+                        the <code>sequence</code> layout described (for element nodes) in 
+                        <specref ref="sequence-json-layout"/>.</p>
+                     <p>For example, an XML document containing a single empty element <code>&lt;doc/></code>
+                     would be represented as <code>#document: [{"doc":""}]</code></p>
+                     <p>A document node with no children is represented by an empty JSON array: <code>#document: []</code>.</p>
+                     <note><p>The XDM model allows a a document node to have an arbitrary sequence of children, including text nodes,
+                     comments, processing instructions, and multiple elements.</p></note>
                   </item>
                   <item>
                      <p><emph>Element nodes</emph></p>
-                     <p>An element node is output as a JSON object with the following properties, in order:</p>
-                     <ulist>
-                        <item>
-                           <p><code>#element</code> indicates the name of the element. For a top-level element
-                              (one that has no parent element within the content being converted) the local name
-                              is used unqualified if the element is in no namespace, and the form 
-                              <code>Q{uri}local</code> is used otherwise. In other cases (for child elements),
-                              if the element is in the same
-                           namespace as its parent, or if both are in no namespace, then the local name of the 
-                           element is used without qualification; otherwise the format <code>Q{uri}local</code> is used, where
-                           <code>uri</code> may be a zero-length string in the case of an element in no namespace.</p>
-                        </item>
-                        <item>
-                           <p>For each attribute of the element, in arbitrary order, a property whose
-                              name is derived from the attribute name as follows:</p>
-                                 <ulist>
-                                    <item><p>If the attribute name is in no namespace, then <code>"@"</code> followed
-                                    by the local name.</p></item>
-                                    <item><p>If the attribute name is in the XML namespace, then <code>"@xml:"</code> followed
-                                       by the local name.</p></item>
-                                    <item><p>Otherwise <code>"@Q{uri}local"</code> where <code>uri</code> is the namespace
-                                       URI and <code>local</code> is the local name.</p></item>
-                                 </ulist>
-                              
-                                 <p>The property value is the result of atomizing the attribute node and applying the
-                                 <code>fn:xdm-to-json</code> function to the result. (For untyped attributes, the result
-                                 will always be a single string.)</p>
-                              
-                           
-                        </item>
-                        <item>
-                           <p>The children of the element are processed using one of four formats:
-                           empty format, value format, map format, and array format.</p>
-                           <p>If the parent element name is listed in one of the option parameters
-                           <code>use-value-format</code>, <code>use-map-format</code>, or
-                           <code>use-array-format</code>, then this determines the format that
-                           is used.</p>
-                           <p>If the element name is not listed in any of these parameters:</p>
-                           <ulist>
-                              <item><p>Empty format is used if the element has no children.</p></item>
-                              <item><p>Value format is used if the element has a type annotation that is
-                              a simple type or a complex type with simple content, or if it is untyped and
-                              the content comprises a single text node.</p></item>
-                              <item><p>Array format is used in all other cases.</p></item>
-                           </ulist>
-                           <p>The four formats are as follows:</p>
-                           <ulist>
-                              <item>
-                                 <p>In <term>empty format</term>, nothing is output.</p>
-                              </item>
-                              <item>
-                                 <p>In <term>value format</term>, a property <code>#value</code> is output containing the result
-                                    of atomizing the element node and applying the <code>fn:xdm-to-json</code> function
-                                    to the result.</p>
-                                 <note><p>If value format is selected for elements that have children, the content of
-                                    the element is flattened to a string and information about child elements is lost.
-                                    Comments and processing instructions in the content are discarded</p></note>
-                              </item>
-                              <item>
-                                 <p>In <term>array format</term>, a property <code>#content</code> is output whose value is an array;
-                                 the array contains the JSON representation of each child node, in order. Whitespace-only text
-                                 nodes are omitted if the <code>strip-space</code> option is set to true.</p>
-                              </item>
-                              <item>
-                                 <p>In <term>map format</term>, one property is output for each child element node, in order.
-                                 </p>
-                                 <p>The key of the property is in two parts, concatenated together:</p>
-                                 <ulist>
-                                    <item><p>The first part is the name of the child element. If the child
-                                       element is in the same namespace as its parent (or if both are in no namespace)
-                                       then the local part of
-                                    the name is used without qualification. Otherwise, the format <code>Q{uri}local</code>
-                                    is used, where <code>uri</code> is a zero-length string if the element is in no namespace.</p>
-                                    </item>
-                                    <item><p>The second part is included only for element names that would otherwise
-                                    appear more than once: it takes the form <code>[index]</code> where <code>index</code>
-                                    is a positive integer allocated sequentially to elements having the same name, starting at 1 (one). 
-                                    For example
-                                    if there is one <code>author</code> element child then the key will be <code>"author"</code>;
-                                       if there are two, then the keys will be <code>"author[1]"</code> and <code>"author[2]"</code>.
-                                    </p></item>
-                                 </ulist>
-                                 <p>The value of the property is a map obtained by applying these rules recursively to the
-                                    child element, but omitting the <code>#element</code> property.</p>
-                                 <p>Note that when map format is used, information about the order of child elements is retained
-                                    in the generated JSON, but will typically be lost when the JSON is subsequently parsed (except in the
-                                 case of multiple children with the same name); in addition, text nodes, comments, and processing
-                                 instructions are discarded.</p>
-                              </item>
-                              
-                           </ulist>
-                        </item>
-                     </ulist>
+                     <p>A top-level element node is output as a JSON object comprising a single key-value pair, where the
+                        key is derived from the element name as described in <specref ref="element-names-in-json"/>, and the content
+                        follows the rules of a specific layout appropriate to that element. The rules for 
+                        selecting a layout, and the mapping rules for each layout, are described in 
+                        <specref ref="xml-to-json-mappings"/>.</p>    
                   </item>
                   <item>
                      <p><emph>Text nodes</emph></p>
-                     <p>A JSON object with a single property <code>#text</code> whose value is the
-                        string value of the text node.</p>
+                     <p>A top-level text node is output as a JSON object comprising a single key-value pair.
+                        The key is the string <code>"#text"</code>, and the value is the string value of the text node
+                        as a JSON string.</p>
+                     <p>Text nodes appearing as children of an element node are formatted according to the rules of
+                        a specific element layout.</p>
                   </item>
                   <item>
                      <p><emph>Comment nodes</emph></p>
-                     <p>A JSON object with a single property <code>#comment</code> whose value is the
-                        string value of the comment.</p>
+                     <p>A top-level comment node is output as a JSON object comprising a single key-value pair.
+                        The key is the string <code>"#comment"</code>, and the value is the string value of the comment node
+                        as a JSON string.</p>
+                     <p>Comment nodes appearing as children of an element node are formatted according to the rules of
+                        a specific element layout. If the layout is one that does not ignore comments, then
+                        comments follow the above conventions.</p>
                   </item>
                   <item>
                      <p><emph>Processing instruction nodes</emph></p>
-                     <p>A JSON object with two properties (in order): <code>#processing-instruction</code> set to the
-                        name of the processing instruction, and <code>#data</code> set to the
-                        string value of the processing instruction node.</p>
+                     <p>A top-level processing-instruction node is output as a JSON object comprising a single key-value pair.
+                        The key is the string <code>"#processing-instruction"</code>, and the value is a JSON object
+                        with two string-valued properties: <code>"#name"</code> holding the name of the processing instruction,
+                        and <code>"#data"</code> holding the data (in XDM terms, the string value of the node).</p>
+                     <p>Processing instruction nodes appearing as children of an element node are formatted according to the rules of
+                        a specific element layout. If the layout is one that does not ignore processing instructions, then
+                        they are output following the above conventions.</p>
                   </item>
                   <item>
                      <p><emph>Attribute nodes</emph></p>
@@ -22947,9 +22839,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </item>
                   <item><p><emph>Namespace nodes</emph></p>
                   <p>Namespace nodes that are reached via an element node result in no output.</p>
-                  <p>Free-standing namespace nodes are output as JSON objects with properties
-                  <code>#namespace</code> set to the namespace prefix (<code>""</code> for the default
-                  namespace) and <code>#uri</code> set to the namespace URI.</p>
+                     <p>A top-level namespace node is output as a JSON object comprising a single key-value pair.
+                        The key is the string <code>"#namespace"</code>, and the value is a JSON object
+                        with two string-valued properties: <code>"#prefix"</code> holding the name of the namespace node,
+                        and <code>"#uri"</code> holding the namespace URI (in XDM terms, the string value of the namespace node).</p>
                   </item>
                </ulist>            
             </item>
@@ -22977,6 +22870,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   JSON array, in order, obtained by applying the <code>fn:xdm-to-json</code> function to the XDM array member.</p>              
             </item>
             <item>
+
                <p><emph>Functions</emph></p>
                <p>An XDM function, other than a map or array, is output as a JSON object with the following properties:</p>
                <ulist>
@@ -22995,6 +22889,16 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      identifying the type of the function result, using the same conventions as for <code>#arguments</code>.</p></item>
                   <item><p>Optionally at implementer discretion, <code>#implementation</code> whose value is a string 
                </ulist>
+
+               <p><emph>Function items</emph></p>
+               <p>An XDM function item, other than a map or array, is output as a JSON object comprising a single key-value pair.
+               The key is the string <code>"#function"</code>. The corresponding value is a JSON object. If the function has a name,
+               this object must contain a property giving the name in the format <code>"#name": "Q{uri}local"</code>. In all
+                  cases the object must contain a property giving the arity as a number, for example <code>"#arity": 3</code>.
+               Other properties <rfc2119>may</rfc2119> be included at the discretion of the implementation; their names 
+               <rfc2119>must</rfc2119> start with an underscore.</p>
+              
+>>>>>>> 706257d7 (Substantial revision of element mappings in fn:xdm-to-json)
                
             </item>
          </ulist>
@@ -23019,7 +22923,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>A dynamic error is raised if any element name appears in more than one of the options
             <code>use-value-format</code>, <code>use-map-format</code>, and <code>use-array-format</code>: <errorref
                class="JS" code="0005"/>.</p>
-         <p>A dynamic error is raised if value format is selected for an element that does not have a typed
+         <p>A dynamic error is raised if the selected layout rules require atomization of an element that does not have a typed
             value (typically because it has been validated against an element-only content model): <errorref
                class="TY" code="0012"/>.</p>
       </fos:errors>
@@ -23055,19 +22959,15 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
             <fos:test>
                <fos:expression><![CDATA[xdm-to-json(<a x="2">banana</a>)]]></fos:expression>
-               <fos:result>'{"#element":"a","@x":"2","#value":"banana"}'</fos:result>
+               <fos:result>'{"a":{"@x":"2","#content":"banana"}}'</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><![CDATA[xdm-to-json(<a><b/><c>2</c></a>)]]></fos:expression>
-               <fos:result>'{"#element":"a","#content":{"b":null,"c":"2"}}'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><![CDATA[xdm-to-json(<a><b/><b/><c/></a>)]]></fos:expression>
-               <fos:result>'{"#name":"a","#content":[{"#name":"b"},{"#name":"b"},{"#name":"c}]}'</fos:result>
+               <fos:result>'{"a":{"#content":{"b":"","c":"2"}}'</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><![CDATA[xdm-to-json(<a>A <i>nice</i> one!</a>)]]></fos:expression>
-               <fos:result>'{"#name":"a","#content":["A ",{"#name":"i", "#value":"nice"}," one!"]}'</fos:result>
+               <fos:result>'{"a":{"#content":["A ",{"i":"nice"}," one!"]}}'</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22691,9 +22691,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:notes>
    </fos:function>
    
-   <fos:function name="json" prefix="fn">
+   <fos:function name="xdm-to-json" prefix="fn">
       <fos:signatures>
-         <fos:proto name="json" return-type="xs:string">
+         <fos:proto name="xdm-to-json" return-type="xs:string">
             <fos:arg name="input" type="xs:string?"/>
             <fos:arg name="options" type="map(*)" usage="inspection"  default="map{}"/>
          </fos:proto>
@@ -22730,7 +22730,36 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
-            <fos:option key="element-map">
+            <fos:option key="strip-space">
+               <fos:meaning>Determines whether whitespace-only text nodes are retained in the output, when
+                  outputting element nodes using array format.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">
+                     In the array format of element content, whitespace-only text nodes are included.
+                  </fos:value>
+                  <fos:value value="true">
+                     In the array format of element content, whitespace-only text nodes are omitted.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="use-value-format">
+               <fos:meaning>Identifies elements whose content should be output using value format.</fos:meaning>
+               <fos:type>xs:QName*</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="use-map-format">
+               <fos:meaning>Identifies elements whose content should be output using map format.</fos:meaning>
+               <fos:type>xs:QName*</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="use-array-format">
+               <fos:meaning>Identifies elements whose content should be output using array format.</fos:meaning>
+               <fos:type>xs:QName*</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <!--<fos:option key="element-map">
                <fos:meaning>Determines whether elements whose children are element nodes with distinct
                   names should be treated specially.</fos:meaning>
                <fos:type>xs:boolean</fos:type>
@@ -22744,7 +22773,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      as JSON property names.
                   </fos:value>
                </fos:values>
-            </fos:option>
+            </fos:option>-->
          </fos:options>
          
          
@@ -22764,7 +22793,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <ulist>
                   <item><p>An <code>xs:boolean</code> value is output as the JSON value <code>true</code> or <code>false</code>.</p></item>
                   <item><p>A numeric value, other than <code>INF</code>, <code>-INF</code>, or <code>NaN</code>,
-                  is output as a JSON number.</p></item>
+                  is output as a JSON number. The format of the number follows the rules for casting the number to
+                  a string.</p></item>
                   <item><p>Any other atomic value is cast to <code>xs:string</code>, and the result is output as a JSON string,
                   escaped as described below.</p></item>
                </ulist>
@@ -22774,12 +22804,18 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <ulist>
                   <item>
                      <p><emph>Document nodes</emph></p>
-                     <p>A document node is output as a JSON object with two properties, in order:</p>
+                     <p>A document node is output as a JSON object with the following properties, in order:</p>
                      <ulist>
-                        <item><p>A property <code>#document</code> set to the value of the base URI of the document
+                        <item><p>A property <code>#document</code> set to the value of the document URI of the document
                            if available, or an empty string otherwise..</p></item>
-                        <item><p>A property <code>#content</code> whose value follows the rules for
-                        outputting the content of an element node, given below.</p></item>                       
+                        <item><p>A property <code>#base-uri</code> set to the value of the base URI of the document
+                           if available; the property is absent if this is not available.</p></item>
+                        <item><p>A property <code>#content</code>. If the document node has exactly one child node and this
+                           is an element node, then the value of the <code>#content</code> property is the
+                           representation of that element child. If the document node has no children, the 
+                           <code>#content</code> property is absent. In all other cases the value of the 
+                           <code>#content</code> property follows the rules for the content of element nodes
+                           using array representation.</p></item>                       
                      </ulist>
                   </item>
                   <item>
@@ -22787,15 +22823,14 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <p>An element node is output as a JSON object with the following properties, in order:</p>
                      <ulist>
                         <item>
-                           <p><code>#element</code> set to the local name of the element.</p>
-                        </item>
-                        <item>
-                           <p>If the element name has a prefix, <code>#prefix</code>, set to the value of the prefix.</p>
-                        </item>
-                     
-                        <item>
-                           <p>If the element name is in a namespace, <code>#namespace</code>, set to the value of the 
-                           namespace URI.</p>
+                           <p><code>#element</code> indicates the name of the element. For a top-level element
+                              (one that has no parent element within the content being converted) the local name
+                              is used unqualified if the element is in no namespace, and the form 
+                              <code>Q{uri}local</code> is used otherwise. In other cases (for child elements),
+                              if the element is in the same
+                           namespace as its parent, or if both are in no namespace, then the local name of the 
+                           element is used without qualification; otherwise the format <code>Q{uri}local</code> is used, where
+                           <code>uri</code> may be a zero-length string in the case of an element in no namespace.</p>
                         </item>
                         <item>
                            <p>For each attribute of the element, in arbitrary order, a property whose
@@ -22810,38 +22845,69 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                                  </ulist>
                               
                                  <p>The property value is the result of atomizing the attribute node and applying the
-                                 <code>fn:json</code> function to the result. (For untyped attributes, the result
+                                 <code>fn:xdm-to-json</code> function to the result. (For untyped attributes, the result
                                  will always be a single string.)</p>
                               
                            
                         </item>
                         <item>
-                           <p>The children of the element are processed as follows:</p>
+                           <p>The children of the element are processed using one of four formats:
+                           empty format, value format, map format, and array format.</p>
+                           <p>If the parent element name is listed in one of the option parameters
+                           <code>use-value-format</code>, <code>use-map-format</code>, or
+                           <code>use-array-format</code>, then this determines the format that
+                           is used.</p>
+                           <p>If the element name is not listed in any of these parameters:</p>
+                           <ulist>
+                              <item><p>Empty format is used if the element has no children.</p></item>
+                              <item><p>Value format is used if the element has a type annotation that is
+                              a simple type or a complex type with simple content, or if it is untyped and
+                              the content comprises a single text node.</p></item>
+                              <item><p>Array format is used in all other cases.</p></item>
+                           </ulist>
+                           <p>The four formats are as follows:</p>
                            <ulist>
                               <item>
-                                 <p>If there are no children, nothing is output.</p>
+                                 <p>In <term>empty format</term>, nothing is output.</p>
                               </item>
                               <item>
-                                 <p>If the element has a type annotation that is a simple type, or if its content
-                                 comprises a single text node, then a property <code>#value</code> set to the result
-                                 of atomizing the element node and applying the <code>fn:json</code> function
-                                 to the result.</p>
+                                 <p>In <term>value format</term>, a property <code>#value</code> is output containing the result
+                                    of atomizing the element node and applying the <code>fn:xdm-to-json</code> function
+                                    to the result.</p>
+                                 <note><p>In value format, comments and processing instructions in the content are discarded.</p></note>
                               </item>
                               <item>
-                                 <p>If (a) the children consist exclusively of elements and whitespace-only
-                                 text nodes, and (b) the child element nodes are all in the same namespace, or all in no
-                                 namespace, and (c) each child element has a local name that is distinct from the local
-                                 name of any other child, and (d) the <code>element-map</code> option is not
-                                    present in <code>$options</code> with the value <code>false()</code>,
-                                    then a property <code>#content</code> whose value is a JSON
-                                 object having one property for each child element node. The name of this property
-                                 is the local name of the element, and the value of the property is obtained by applying
-                                 these rules recursively, except that for an empty element, the value is represented
-                                 as JSON <code>null</code>.</p>
+                                 <p>In <term>array format</term>, a property <code>#content</code> is output whose value is an array;
+                                 the array contains the JSON representation of each child node, in order. Whitespace-only text
+                                 nodes are omitted if the <code>strip-space</code> option is set to true.</p>
                               </item>
-                              <item><p>Otherwise, a property <code>#content</code> whose value is an array, with
-                              one member for each child node (including whitespace-only text nodes), obtained
-                              by applying the <code>fn:json</code> function to that child node.</p></item>
+                              <item>
+                                 <p>In <term>map format</term>, one property is output for each child element node, in order.
+                                 </p>
+                                 <p>The key of the property is in two parts, concatenated together:</p>
+                                 <ulist>
+                                    <item><p>The first part is the name of the child element. If the child
+                                       element is in the same namespace as its parent (or if both are in no namespace)
+                                       then the local part of
+                                    the name is used without qualification. Otherwise, the format <code>Q{uri}local</code>
+                                    is used, where <code>uri</code> is a zero-length string if the element is in no namespace.</p>
+                                    </item>
+                                    <item><p>The second part is included only for element names that would otherwise
+                                    appear more than once: it takes the form <code>[index]</code> where <code>index</code>
+                                    is a positive integer allocated sequentially to elements having the same name, starting at 1 (one). 
+                                    For example
+                                    if there is one <code>author</code> element child then the key will be <code>"author"</code>;
+                                       if there are two, then the keys will be <code>"author[1]"</code> and <code>"author[2]"</code>.
+                                    </p></item>
+                                 </ulist>
+                                 <p>The value of the property is a map obtained by applying these rules recursively to the
+                                    child element, but omitting the <code>#element</code> property.</p>
+                                 <p>Note that when map format is used, information about the order of child elements is retained
+                                    in the generated JSON, but will typically be lost when the JSON is subsequently parsed (except in the
+                                 case of multiple children with the same name); in addition, text nodes, comments, and processing
+                                 instructions are discarded.</p>
+                              </item>
+                              
                            </ulist>
                         </item>
                      </ulist>
@@ -22858,7 +22924,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </item>
                   <item>
                      <p><emph>Processing instruction nodes</emph></p>
-                     <p>A JSON object with a two properties (in order): <code>#processing-instruction</code> set to the
+                     <p>A JSON object with two properties (in order): <code>#processing-instruction</code> set to the
                         name of the processing instruction, and <code>#data</code> set to the
                         string value of the processing instruction node.</p>
                   </item>
@@ -22866,18 +22932,23 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <p><emph>Attribute nodes</emph></p>
                      <p>Attribute nodes that are reached via an element node are output as described
                         under “element nodes”, above.</p>
-                     <p>Free-standing attribute nodes are output as JSON objects with properties
-                     <code>#attribute</code> set to the local name of the attribute, <code>#prefix</code>
-                     (if non-empty) set to the prefix of the attribute’s name, <code>#namespace</code>
-                     (if non-empty) set to the namespace URI, and <code>#value</code> set to
-                        the result of atomizing the attribute value and applying the
-                        <code>fn:json</code> function to the result.</p>
+
+                     <p>Free-standing attribute nodes are output as JSON objects with properties:</p>
+                     <ulist>
+                        <item><p><code>#attribute</code> set to the name of the attribute, as a local name
+                        in the case of an attribute in no namespace, or in <code>Q{uri}local</code> format
+                        otherwise.</p></item>
+                        <item><p><code>#value</code> set to
+                           the result of atomizing the attribute value and applying the
+                           <code>fn:xdm-to-json</code> function to the result.</p></item>
+                     </ulist>
                   </item>
-                  <item><p><emph>Namespace nodes</emph></p></item>
-                  <item><p>Namespace nodes that are reached via an element node result in no output.</p></item>
-                  <item><p>Free-standing namespace nodes are output as JSON objects with properties
+                  <item><p><emph>Namespace nodes</emph></p>
+                  <p>Namespace nodes that are reached via an element node result in no output.</p>
+                  <p>Free-standing namespace nodes are output as JSON objects with properties
                   <code>#namespace</code> set to the namespace prefix (<code>""</code> for the default
-                  namespace) and <code>#uri</code> set to the namespace URI.</p></item>
+                  namespace) and <code>#uri</code> set to the namespace URI.</p>
+                  </item>
                </ulist>            
             </item>
             <item>
@@ -22885,9 +22956,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <p>An XDM map is output as a JSON object with one property for each entry in the map.</p>
                <p>The property name is derived from the key value by converting the value to a string
                and applying escaping rules. If the property name thus generated is the same as a previously output
-               property name, then it is made unique by appending <code>"(N)"</code> where <var>N</var> is the smallest
-               positive integer that makes the resulting value unique.</p>
-               <p>The property value is derived by applying the <code>fn:json</code> function to the value in the map entry.</p>
+               property name, then it is made unique by appending <code>"[N]"</code> where <var>N</var> is the smallest
+               positive integer, starting at 2, that makes the resulting value unique.</p>
+               <p>The property value is derived by applying the <code>fn:xdm-to-json</code> function to the value in the map entry.</p>
                
                <note><p>Conflicts between property names can arise because the XDM model allows keys of different types,
                   for example the <code>xs:date</code> value <code>2020-12-31</code> and the string value 
@@ -22901,17 +22972,15 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <item>
                <p><emph>Arrays</emph></p>
                <p>An XDM array is output as a JSON array. Each member of the XDM array generates one entry in the
-                  JSON array, in order, obtained by applying the <code>fn:json</code> function to the XDM array member.</p>              
+                  JSON array, in order, obtained by applying the <code>fn:xdm-to-json</code> function to the XDM array member.</p>              
             </item>
             <item>
                <p><emph>Functions</emph></p>
-               <p>An XDM function, other than a map or array, is output as a JSON object with the following
-               properties:</p>
+               <p>An XDM function, other than a map or array, is output as a JSON object with the following properties:</p>
                <ulist>
-                  <item><p><code>#function</code>, set to the local name of the function
+                  <item><p><code>#function</code>, set to the name of the function
+                     in the format <code>Q{uri}local</code>
                   if it has a name, or the empty string otherwise.</p></item>
-                  <item><p><code>#namespace</code>, set to the namespace URI of the function. The property
-                  is omitted for an anonymous function.</p></item>
                   <item><p><code>#arity</code>, set to the arity of the function as a JSON number.</p></item>
                   <item><p><code>#arguments</code> whose value is an array
                   of strings, which identify the names and types of the function arguments,
@@ -22923,75 +22992,76 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   <item><p><code>#result</code> whose value is a string 
                      identifying the type of the function result, using the same conventions as for <code>#arguments</code>.</p></item>
                   <item><p>Optionally at implementer discretion, <code>#implementation</code> whose value is a string 
-                     representing the function’s implementation in implementation-defined format.</p></item>
                </ulist>
-               <p>Strings are escaped as follows:</p>
-               <olist>
-                  <item>
-                     <p>Any occurrence of backslash is replaced by <code>\\</code></p>
-                  </item>
-                  
-                  <item>
-                     <p>Any occurrence of quotation mark, backspace, form-feed, newline, carriage return, or tab is 
-                        replaced by <code>\"</code>, <code>\b</code>, <code>\f</code>, <code>\n</code>, <code>\r</code>, or <code>\t</code> respectively; </p>
-                  </item>
-                  
-                  <item>
-                     <p>Any other codepoint in the range 1-31 or 127-159 is replaced by an escape in 
-                        the form <code>\uHHHH</code> where <code>HHHH</code> is the upper-case hexadecimal representation of the codepoint value.</p>
-                  </item>
-               </olist>
+               
             </item>
-         </ulist>        
+         </ulist>
+         <p>Strings are escaped as follows:</p>
+         <olist>
+            <item>
+               <p>Any occurrence of backslash is replaced by <code>\\</code></p>
+            </item>
+            
+            <item>
+               <p>Any occurrence of quotation mark, backspace, form-feed, newline, carriage return, or tab is 
+                  replaced by <code>\"</code>, <code>\b</code>, <code>\f</code>, <code>\n</code>, <code>\r</code>, or <code>\t</code> respectively; </p>
+            </item>
+            
+            <item>
+               <p>Any other codepoint in the range 1-31 or 127-159 is replaced by an escape in 
+                  the form <code>\uHHHH</code> where <code>HHHH</code> is the upper-case hexadecimal representation of the codepoint value.</p>
+            </item>
+         </olist>
       </fos:rules>
+      <fos:errors>
+         <p>A dynamic error is raised if any element name appears in more than one of the options
+            <code>use-value-format</code>, <code>use-map-format</code>, and <code>use-array-format</code>: <errorref
+               class="JS" code="0005"/>.</p>
+      </fos:errors>
       <fos:notes>
-         <p>In the JSON output, names of properties defined in this specification are prefixed with <code>#</code>;
-         names not so prefixed are derived from names appearing in the input.</p>
-         <p>Namespace information may be lost (specifically, namespaces that are declared but not used are
-         not retained in the output).</p>
+         <p>The namespace URI and local name of all elements and attributes is available in the JSON output.
+            Prefixes are not retained, and namespaces that are declared but not used are not retained.</p>
          <p>The distinction between sequences and arrays is lost.</p>
-         <p>The distinction between different atomic types is lost, except for the boolean / number / string
+         <p>The distinction between different atomic types is lost, except for the boolean/number/string
          distinction present in JSON.</p>
-         <p>In elements whose children are elements with distinct names, whitespace text nodes are lost,
-         and the namespace URIs and prefixes of the child elements are lost.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>json(())</fos:expression>
+               <fos:expression>xdm-to-json(())</fos:expression>
                <fos:result>'null'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json(12)</fos:expression>
+               <fos:expression>xdm-to-json(12)</fos:expression>
                <fos:result>'12'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json((12, "December"))</fos:expression>
+               <fos:expression>xdm-to-json((12, "December"))</fos:expression>
                <fos:result>'[12,"December"]'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json(true())</fos:expression>
+               <fos:expression>xdm-to-json(true())</fos:expression>
                <fos:result>'true'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json(map{"a":1,"b":number('NaN'),"c":(1,2,3)})</fos:expression>
+               <fos:expression>xdm-to-json(map{"a":1,"b":number('NaN'),"c":(1,2,3)})</fos:expression>
                <fos:result>'{"a":1,"b":"NaN","c":[1,2,3]}'</fos:result>
                <fos:postamble>(or some permutation thereof)</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[json(<a x="2">banana</a>)]]></fos:expression>
+               <fos:expression><![CDATA[xdm-to-json(<a x="2">banana</a>)]]></fos:expression>
                <fos:result>'{"#element":"a","@x":"2","#value":"banana"}'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[json(<a><b/><c>2</c></a>)]]></fos:expression>
+               <fos:expression><![CDATA[xdm-to-json(<a><b/><c>2</c></a>)]]></fos:expression>
                <fos:result>'{"#element":"a","#content":{"b":null,"c":"2"}}'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[json(<a><b/><b/><c/></a>)]]></fos:expression>
+               <fos:expression><![CDATA[xdm-to-json(<a><b/><b/><c/></a>)]]></fos:expression>
                <fos:result>'{"#name":"a","#content":[{"#name":"b"},{"#name":"b"},{"#name":"c}]}'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[json(<a>A <i>nice</i> one!</a>)]]></fos:expression>
+               <fos:expression><![CDATA[xdm-to-json(<a>A <i>nice</i> one!</a>)]]></fos:expression>
                <fos:result>'{"#name":"a","#content":["A ",{"#name":"i", "#value":"nice"}," one!"]}'</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22730,10 +22730,29 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
+            <fos:option key="uniform">
+               <fos:meaning>Indicates that all elements with the same name (except where schema type information is available)
+                  should use the same JSON layout. Setting this option requires the processor to analyze the entire input
+               before deciding what layout to use for each element; but by ensuring consistency across elements, it may
+               make the resulting JSON easier to process.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">
+                     The layout for each element node is decided independently, based on its individual content.
+                  </fos:value>
+                  <fos:value value="true">
+                     In the absence of schema type information, and of an explicit entry in the <code>layouts</code>
+                     property, the layout chosen for a given element node must be the same as that for all other
+                     elements of the same name.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
             <fos:option key="layouts">
                <fos:meaning>A mapping from element names to layout names, used to override the default
                formatting rules for a particular element name.</fos:meaning>
-               <fos:type>map{xs:QName, enum("empty", "empty-plus", "simple", "simple-plus", "list", "record", "sequence", "mixed")}</fos:type>
+               <fos:type>map{xs:QName, enum("empty", "empty-plus", "simple", "simple-plus", "list", "list-plus", 
+                  "record", "sequence", "mixed")}</fos:type>
                <fos:default>map{}</fos:default>
             </fos:option>
          </fos:options>
@@ -22779,8 +22798,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <p><emph>Document nodes</emph></p>
                      <p>A document node is output as a JSON object comprising a single key-value pair, where the
                         key is the string <code>"#document"</code> and the value represents the content, using
-                        the <code>sequence</code> layout described (for element nodes) in 
-                        <specref ref="sequence-json-layout"/>.</p>
+                        the <code>mixed</code> layout described (for element nodes) in 
+                        <specref ref="mixed-json-layout"/>.</p>
                      <p>For example, an XML document containing a single empty element <code>&lt;doc/></code>
                      would be represented as <code>#document: [{"doc":""}]</code></p>
                      <p>A document node with no children is represented by an empty JSON array: <code>#document: []</code>.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22691,10 +22691,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:notes>
    </fos:function>
    
-   <fos:function name="xdm-to-json" prefix="fn">
+   <fos:function name="items-to-json" prefix="fn">
       <fos:signatures>
-         <fos:proto name="xdm-to-json" return-type="xs:string">
-            <fos:arg name="input" type="xs:string?"/>
+         <fos:proto name="items-to-json" return-type="xs:string">
+            <fos:arg name="input" type="item()*"/>
             <fos:arg name="options" type="map(*)" usage="inspection"  default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -22708,7 +22708,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:summary>
       <fos:rules>
          <p>This function returns a string, in JSON format, containing a representation of the
-         supplied input <code>$input</code>. The function can process any input sequence
+         supplied input <code>$input</code>.</p>
+         <p>The function can process any input sequence
          whatsoever, but it is not lossless: there are cases when two different XDM values will
          have the same JSON representation. For example, the sequence <code>(1, 2)</code>
             and the array <code>[1, 2]</code> are both output as <code>"[1,2]"</code>.</p>
@@ -22716,6 +22717,20 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
          
          <fos:options>
+            <fos:option key="escape-solidus">
+               <fos:meaning>Determines whether, when escaping strings, the solidus (<code>/</code>)
+                  should be escaped.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>true</fos:default>
+               <fos:values>
+                  <fos:value value="false">
+                     The solidus character is output as is.
+                  </fos:value>
+                  <fos:value value="true">
+                     The solidus character is escaped with a backslash, that is, as <code>"\/"</code>.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
             <fos:option key="indent">
                <fos:meaning>Determines whether additional whitespace should be added to the output to improve readability.</fos:meaning>
                <fos:type>xs:boolean</fos:type>
@@ -22752,7 +22767,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:meaning>A mapping from element names to layout names, used to override the default
                formatting rules for a particular element name.</fos:meaning>
                <fos:type>map{xs:QName, enum("empty", "empty-plus", "simple", "simple-plus", "list", "list-plus", 
-                  "record", "sequence", "mixed")}</fos:type>
+                  "record", "sequence", "mixed", "xml", "html", "xhtml")}</fos:type>
                <fos:default>map{}</fos:default>
             </fos:option>
          </fos:options>
@@ -22789,10 +22804,15 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </item>
             <item>
                <p><emph>Nodes</emph></p>
-               <p>A node is represented as a JSON object containing a single key-value pair. For elements, the key
+               <p>A node is represented as a JSON object containing a single key-value pair. 
+                  For elements and attributes, the key
                is derived from the element name as described in <specref ref="element-names-in-json"/>; 
                for all other node kinds it represents the node kind (for example,
                <code>#text</code> or <code>#comment</code>).</p>
+               <p>In the following rules, a node is considered to be <term>top-level</term> if it
+               is parentless, or if its parent is not itself part of the input being converted.
+               For example, if <code>$input</code> is a sequence of attribute nodes, then these
+               are considered to be top-level nodes, whether or not they have a parent element.</p>
                <ulist>
                   <item>
                      <p><emph>Document nodes</emph></p>
@@ -22810,9 +22830,29 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <p><emph>Element nodes</emph></p>
                      <p>A top-level element node is output as a JSON object comprising a single key-value pair, where the
                         key is derived from the element name as described in <specref ref="element-names-in-json"/>, and the content
-                        follows the rules of a specific layout appropriate to that element. The rules for 
-                        selecting a layout, and the mapping rules for each layout, are described in 
-                        <specref ref="xml-to-json-mappings"/>.</p>    
+                        follows the rules of a specific layout appropriate to that element. The available layouts 
+                        are described in <specref ref="xml-to-json-mappings"/>. A layout is selected for each element node <var>E</var>
+                        by applying the following rules in order:</p>
+                        <olist>
+                           <item><p>If the name of <var>E</var> is listed as the key of an entry in the <code>layouts</code> 
+                              option, then the corresponding named layout is used.</p></item>
+                           <item><p>If <var>E</var> has a type annotation <var>T</var> other than <code>xs:untyped</code>
+                           or <code>xs:anyType</code>, then the layout appropriate to its schema type
+                           is used. Specifically, taking the layouts in the order presented in 
+                              <specref ref="json-element-layouts"/>, the first layout whose <term>XSD conditions</term>
+                           are satisfied by <var>T</var> is chosen.</p></item>
+                           <item><p>If the option <code>uniform</code> is set to false (which is its default value),
+                              then the chosen layout is the first layout, in the order they are listed in 
+                              <specref ref="json-element-layouts"/>, whose <term>match pattern</term>
+                           matches <var>E</var>.</p></item>
+                           <item><p>If the option <code>uniform</code> is set to true, then let <var>S</var>
+                           be the set of all element nodes in the input having the same name as <var>E</var>,
+                           including element nodes that are not immediate items in the input sequence, but
+                           are rather contained recursively within nodes, maps, or arrays in the input sequence.
+                           The chosen layout is then the first layout, in the order they are listed in 
+                              <specref ref="json-element-layouts"/>, whose <term>match pattern</term> matches
+                              every element node in <var>S</var>.</p></item>
+                        </olist>
                   </item>
                   <item>
                      <p><emph>Text nodes</emph></p>
@@ -22872,7 +22912,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                and applying escaping rules. If the property name thus generated is the same as a previously output
                property name, then it is made unique by appending <code>"[N]"</code> where <var>N</var> is the smallest
                positive integer, starting at 2, that makes the resulting value unique.</p>
-               <p>The property value is derived by applying the <code>fn:xdm-to-json</code> function to the value in the map entry.</p>
+               <p>The property value is derived by applying the <code>fn:items-to-json</code> function to the value in the map entry.</p>
                
                <note><p>Conflicts between property names can arise because the XDM model allows keys of different types,
                   for example the <code>xs:date</code> value <code>2020-12-31</code> and the string value 
@@ -22886,7 +22926,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <item>
                <p><emph>Arrays</emph></p>
                <p>An XDM array is output as a JSON array. Each member of the XDM array generates one entry in the
-                  JSON array, in order, obtained by applying the <code>fn:xdm-to-json</code> function to the XDM array member.</p>              
+                  JSON array, in order, obtained by applying the <code>fn:items-to-json</code> function to the XDM array member.</p>              
             </item>
             <item>
 
@@ -22933,15 +22973,19 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </item>
             
             <item>
+               <p>Any solidus (<code>"/"</code>) is 
+                  replaced by <code>\/</code> if the <code>escape-solidus</code> option is set to
+                  true (its default value) but is output as <code>"/"</code> if the option is set
+                  to false; </p>
+            </item>
+            
+            <item>
                <p>Any other codepoint in the range 1-31 or 127-159 is replaced by an escape in 
                   the form <code>\uHHHH</code> where <code>HHHH</code> is the upper-case hexadecimal representation of the codepoint value.</p>
             </item>
          </olist>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised if any element name appears in more than one of the options
-            <code>use-value-format</code>, <code>use-map-format</code>, and <code>use-array-format</code>: <errorref
-               class="JS" code="0005"/>.</p>
          <p>A dynamic error is raised if the selected layout rules require atomization of an element that does not have a typed
             value (typically because it has been validated against an element-only content model): <errorref
                class="TY" code="0012"/>.</p>
@@ -22956,42 +23000,47 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>xdm-to-json(())</fos:expression>
+               <fos:expression>items-to-json(())</fos:expression>
                <fos:result>'null'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>xdm-to-json(12)</fos:expression>
+               <fos:expression>items-to-json(12)</fos:expression>
                <fos:result>'12'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>xdm-to-json((12, "December"))</fos:expression>
+               <fos:expression>items-to-json((12, "December"))</fos:expression>
                <fos:result>'[12,"December"]'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>xdm-to-json(true())</fos:expression>
+               <fos:expression>items-to-json(true())</fos:expression>
                <fos:result>'true'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>xdm-to-json(map{"a":1,"b":number('NaN'),"c":(1,2,3)})</fos:expression>
+               <fos:expression>items-to-json(map{"a":1,"b":number('NaN'),"c":(1,2,3)})</fos:expression>
                <fos:result>'{"a":1,"b":"NaN","c":[1,2,3]}'</fos:result>
                <fos:postamble>(or some permutation thereof)</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[xdm-to-json(<a x="2">banana</a>)]]></fos:expression>
+               <fos:expression><eg><![CDATA[items-to-json(<a x="2">banana</a>)]]></eg></fos:expression>
                <fos:result>'{"a":{"@x":"2","#content":"banana"}}'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[xdm-to-json(<a><b/><c>2</c></a>)]]></fos:expression>
+               <fos:expression><eg><![CDATA[items-to-json(<a><b/><c>2</c></a>)]]></eg></fos:expression>
                <fos:result>'{"a":{"#content":{"b":"","c":"2"}}'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[xdm-to-json(<a>A <i>nice</i> one!</a>)]]></fos:expression>
+               <fos:expression><eg><![CDATA[items-to-json(<a>A <i>nice</i> one!</a>)]]></eg></fos:expression>
                <fos:result>'{"a":{"#content":["A ",{"i":"nice"}," one!"]}}'</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[items-to-json(<a>A <i>nice</i> one!</a>, 
+              map{'layouts':map{QName('', 'a'): 'xml'}, 'escape-solidus':false()})]]></eg></fos:expression>
+               <fos:result>'{"a":"<a>A <i>nice</i> one!</a>"}'</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
+         <fos:version version="4.0">Proposed for 4.0; initial review on 2023-06-27.</fos:version>
       </fos:history>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22874,7 +22874,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                                  <p>In <term>value format</term>, a property <code>#value</code> is output containing the result
                                     of atomizing the element node and applying the <code>fn:xdm-to-json</code> function
                                     to the result.</p>
-                                 <note><p>In value format, comments and processing instructions in the content are discarded.</p></note>
+                                 <note><p>If value format is selected for elements that have children, the content of
+                                    the element is flattened to a string and information about child elements is lost.
+                                    Comments and processing instructions in the content are discarded</p></note>
                               </item>
                               <item>
                                  <p>In <term>array format</term>, a property <code>#content</code> is output whose value is an array;
@@ -23017,6 +23019,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>A dynamic error is raised if any element name appears in more than one of the options
             <code>use-value-format</code>, <code>use-map-format</code>, and <code>use-array-format</code>: <errorref
                class="JS" code="0005"/>.</p>
+         <p>A dynamic error is raised if value format is selected for an element that does not have a typed
+            value (typically because it has been validated against an element-only content model): <errorref
+               class="TY" code="0012"/>.</p>
       </fos:errors>
       <fos:notes>
          <p>The namespace URI and local name of all elements and attributes is available in the JSON output.

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5620,6 +5620,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-items-to-json" diff="add" at="A">
                <head><?function fn:items-to-json?></head>
             </div3>
+            <div3 id="func-elements-to-maps" diff="add" at="A">
+               <head><?function fn:elements-to-maps?></head>
+            </div3>
          </div2>
          <div2 id="html-functions">
             <head>Functions on HTML Data</head>
@@ -6017,13 +6020,13 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
          </div2>
          <div2 id="xml-to-json-mappings" diff="add" at="2023-05-30">
-            <head>JSON Representation of XML</head>
-            <p>The section describes the JSON representations of XML element and attribute nodes supported by the 
-               <code>fn:items-to-json</code> function.</p>
+            <head>Converting Elements to Maps</head>
+            <p>The <code>elements-to-maps</code> function converts XML element nodes to maps, in a form
+               suitable for serialization as JSON. This section describes the mappings used by this function.</p>
             
             <p>This mapping is designed with three objectives:</p>
             <ulist>
-               <item><p>It should be possible to represent any XML content in JSON.</p></item>
+               <item><p>It should be possible to represent any XML element as a map suitable for JSON serialization.</p></item>
                <item><p>The resulting JSON should be intuitive and easy to use.</p></item>
                <item><p>The JSON should be consistent and stable: small changes in the input should not result
                in large changes in the output.</p></item>
@@ -6038,18 +6041,18 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </ulist>
             
             <p>The requirement for consistency and stability is particularly challenging. An element such as 
-            <code><![CDATA[<name>John</name>]]></code> maps naturally to the JSON object property <code>"name":"John"</code>;
+            <code><![CDATA[<name>John</name>]]></code> maps naturally to the map <code>map{"name":"John"}</code>;
                but adding an attribute (so it becomes <code><![CDATA[<name role="first">John</name>]]></code>)
             then requires an incompatible change in the JSON representation. The format can be made extensible
-            by converting <code><![CDATA[<name>John</name>]]></code> to <code>"name":{"#content":"John"}</code>
-               and <code><![CDATA[<name role="first">John</name>]]></code> to <code>"name":{"@role":"first", "#content":"John"}</code>,
+            by converting <code><![CDATA[<name>John</name>]]></code> to <code>map{"name":{"#content":"John"}}</code>
+               and <code><![CDATA[<name role="first">John</name>]]></code> to <code>map{"name":{"@role":"first", "#content":"John"}}</code>,
                but this imposes unwanted complexity on the simplest cases. The solution is to provide some user
             control over the mappings that are chosen.</p>
             
             
             
             <div3 id="json-element-layouts">
-               <head>JSON Element Layouts</head>
+               <head>Element Layouts</head>
            
             
                <p>The key challenge in mapping XML to JSON is in deciding how element content is to be represented. To 
@@ -6115,7 +6118,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                
                <ulist>
                   <item><p>The layout to be used for a specific element name can be explicitly selected in the options
-                  to the <code>fn:items-to-json</code> function.</p></item>
+                  to the <code>fn:elements-to-maps</code> function.</p></item>
                   <item><p>In the absence of an explicit selection, if the data has been schema-validated, the layout is 
                      inferred from the content model for the element type as defined in the schema.</p></item>
                   <item>
@@ -6146,13 +6149,15 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <item><p><term>XML example</term>: an example of a typical XML element for which this layout is appropriate.</p></item>
                   <item><p><term>JSON equivalent</term>: the JSON representation of this example. The JSON
                   equivalent is always shown as a key-value pair suitable for use within a JSON object; the way
-                  this is used depends on the context in which the element appears.</p></item>
+                  this is used depends on the context in which the element appears.</p>
+                  <note><p>The <code>elements-to-maps</code> function produces a map as its result, but it is convenient
+                  to demonstrate the form of the map by showing the effect of serializing the map as JSON.</p></note></item>
                   <item><p><term>XSD conditions</term>: the properties of the XSD type definition that cause this
                   layout to be selected. The first layout that meets these conditions will be chosen.</p></item>
                   <item><p><term>Match pattern</term>: an XSLT 4.0 pattern defining the elements for which
                   this layout will be selected. The first layout whose pattern matches will be chosen.</p>
                   </item>
-                  <item><p><term>Mapping rules</term>: The rules for mapping the XML element to a JSON
+                  <item><p><term>Mapping rules</term>: The rules for mapping the XML element to an XDM map
                   representation.</p></item>
                   <item><p><term>Mapping for nilled elements</term>: special rules that apply to an
                   element having the attribute <code>xsi:nil="true"</code>. These rules only apply if the
@@ -6188,7 +6193,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"hr":""</eg></td>
+                           <td><eg>{"hr":""}</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6203,12 +6208,13 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>The content is represented by the JSON string <code>""</code>.</p></td>
+                           <td><p>The content is represented by the string <code>""</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The content is represented by the JSON value <code>null</code>, for example
-                              <code>&lt;hr xsi:nil="true"/></code> becomes <code>"hr":null</code>.</p></td>
+                           <td><p>The content is represented by an empty sequence, which is serialized as the JSON value 
+                              <code>null</code>, for example
+                              <code>&lt;hr xsi:nil="true"/></code> becomes <code>{"hr":null</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6233,11 +6239,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>XML example</th>
-                           <td><eg><![CDATA[<hr id="zzz"/>]]></eg></td>
+                           <td><eg><![CDATA[<hr class="ccc" id="zzz"/>]]></eg></td>
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"hr":{"@id":"zzz"}</eg></td>
+                           <td><eg>{"hr":{"@class":"ccc", "@id":"zzz"}}</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6253,17 +6259,18 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>The content is represented by a JSON object containing one entry for each
+                           <td><p>The content is represented by a map containing one entry for each
                               attribute in the XML element; if there are no attributes, the content
-                              is represented as an empty JSON object: <code>{}</code>. 
+                              is represented as an empty map. 
                               The mapping rules for attributes are
                            defined in <specref ref="attributes-in-json"/>.</p></td>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>An additional property <code>"#content":null</code> is added, for example
+                           <td><p>An additional key-value pair <code>"#content":()</code> is added, which
+                              serializes in JSON as <code>"#content":null</code>. For example
                               <code>&lt;hr id="x" xsi:nil="true"/></code> becomes 
-                              <code>"hr":{"@id":"x", "#content":null}</code>.</p></td>
+                              <code>{"hr":{"@id":"x", "#content":null}}</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6293,7 +6300,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"date":"2023-05-30"</eg></td>
+                           <td><eg>{"date":"2023-05-30"}</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6305,19 +6312,24 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>The element is atomized and the JSON representation is obtained by applying
-                              the <code>fn:items-to-json</code> function to the atomized value.</p>
-                              <p>If the element is untyped, the result will always be a JSON string.</p>
-                           <p>If the element has been schema-validated, the result may instead be a number,
-                           a boolean, or an array. If the type annotation is a simple type with variety <code>list</code>,
-                              an empty sequence is output as <code>[]</code>.</p>
-                              </td>
+                           <td><p>The element is atomized and the resulting atomized value is adjusted
+                              as follows, to ensure that it can be successfully serialized as JSON:</p>
+                              <ulist>
+                                 <item><p>Any numeric value that cannot be serialized as JSON (specifically,
+                                    infinity or NaN) is converted to a string by applying the <code>string</code> function.</p></item>
+                                 <item><p>An empty sequence is converted to an empty array.</p></item>
+                                 <item><p>A sequence of two or more items is converted to an array of two or more members.</p></item>
+                              </ulist>
+                              <note>
+                                 <p>If the element is untyped, the result will always be a JSON string.</p>
+                              </note>
+                          </td>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The content is represented using the JSON value <code>null</code>, for example
-                              <code><![CDATA[<date xsi:nil="true"/>]]></code> becomes 
-                              <code>"date":null</code>.</p></td>
+                           <td><p>The content is represented by an empty sequence, which is serialized as the JSON value 
+                              <code>null</code>, for example
+                              <code>&lt;hr xsi:nil="true"/></code> becomes <code>{"hr":null}</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6362,20 +6374,25 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>The content is represented by a JSON object containing one entry for each
-                              attribute in the XML element, plus a property named <code>"#content"</code>
-                              containing the result of atomizing the element and obtaining its JSON representation by applying
-                              the <code>fn:items-to-json</code> function to the atomized value.</p>
+                           <td><p>The content is represented by a map containing one entry for each
+                              attribute in the XML element, plus an entry named <code>"#content"</code>
+                              representing the result of atomizing the element.</p>
+                              <p>The atomized value is adjusted as described in <specref ref="simple-json-layout"/>.</p>
                               <p>The mapping rules for attributes are
                                  defined in <specref ref="attributes-in-json"/>.</p>
-                              <p>If the element is untyped, the value of each attribute, and of <code>"#content"</code>,
-                                 will always be a JSON string.</p>
-                              <p>If the element has been schema-validated, the values of each property may instead be a number,
-                                 a boolean, or an array.</p></td>
+                              <note>
+                                 <p>If the element is untyped, the value of each attribute, and of <code>"#content"</code>,
+                                    will always be a string.</p>
+                                 <p>If the element has been schema-validated, the values of each property may instead be a number,
+                                    a boolean, or an array.</p>
+                              </note>
+                           </td>
+                           
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The <code>"#content"</code> property takes the JSON value <code>null</code>.</p></td>
+                           <td><p>The <code>"#content"</code> property converts to an empty sequence, which is serialized in
+                              JSON as <code>null</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6388,7 +6405,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   </table>
                </div4>
                <div4 id="list-json-layout">
-                  <head>List Layout</head>
+                  <head>Simple List Layout</head>
                   
                   <table role="data" >
                      <tbody>
@@ -6399,7 +6416,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <tr>
                            <th>Usage</th>
                            <td><p>Intended for XML elements that act as wrappers for a list of child elements,
-                              all having the same element name. The wrapper element should not have any attributes.
+                              all having the same element name. Any attributes on either the wrapper element or
+                              the wrapped elements will be discarded.
                               The name of the child elements is not retained in the JSON output.</p></td>
                         </tr>
                         <tr>
@@ -6418,14 +6436,15 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                            <th>XSD conditions</th>
                            <td><p>The element has a complex type with element-only content, containing a single
                               element particle, whose <code>maxOccurs</code> value is greater than one (including
-                              <code>maxOccurs="unbounded"</code>); the type does not allow any attributes.</p></td>
+                              <code>maxOccurs="unbounded"</code>); attributes are not allowed on 
+                              the wrapper element.</p></td>
                         </tr>
                         <tr>
                            <th>Match pattern</th>
-                           <td><p><code>*[*[2] and all-equal(*!node-name()) and not(text()[normalize-space()]) and not(@*) ]</code></p>
+                           <td><p><code>*[*[2] and all-equal(*!node-name()) and not(text()[normalize-space()]) and not(@*)]</code></p>
                            <p>That is, there are at least two child elements; all child elements have the same name; 
                            there are no text node children other than whitespace-only text nodes; and there
-                           are no attributes.</p></td>
+                           are no attributes on the wrapper element.</p></td>
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
@@ -6434,7 +6453,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                               as if <term>mixed</term> layout were chosen. This is fallback behavior for use
                               when this layout is chosen inappropriately.</p>
                               <p>In other cases,
-                              the content is represented by a JSON array
+                              the content is represented by a XDM array
                                  containing the results of formatting the content
                               of each child element according to the rules for that element.</p> 
                              
@@ -6444,7 +6463,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The array is replaced by the JSON value <code>null</code> (for example <code>"dates":null</code>).</p></td>
+                           <td><p>The array is replaced by an empty sequence, corresponding to the JSON value 
+                              <code>null</code> (for example <code>{"dates":null}</code>).</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6460,11 +6480,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
   <item nr="n1"><p>One</p></item>
   <item nr="n2"><p>Two</p></item>
 </items>]]></eg>
-                     <p>When this is converted using list layout, the result is:</p>
-                     <eg><![CDATA["items":[
+                     <p>When this is converted using list layout and serialized as JSON, the result is:</p>
+                     <eg><![CDATA[{"items":[
    {"@nr":"n1", "p":"One"},
    {"@nr":"n2", "p":"Two"}
-]   ]]></eg>
+]}   ]]></eg>
                   </example>
                </div4>
                <div4 id="list-plus-json-layout">
@@ -6513,7 +6533,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                               as if <term>mixed</term> layout were chosen. This is fallback behavior for use
                               when this layout is chosen inappropriately.</p>
                               <p>In other cases,
-                                 The content is represented by a JSON object containing one entry for each
+                                 The content is represented by a map containing one entry for each
                                  attribute in the XML element, plus a property named after the 
                                  child elements (the <term>content property</term>), whose value is an array 
                                  containing the results of formatting the content
@@ -6529,8 +6549,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The array is replaced by the JSON value <code>null</code>, for example
-                              <code>"dates": {"@id":"x", "date":null}</code>.</p></td>
+                           <td><p>The array is replaced by an empty sequence, corresponding to the JSON value <code>null</code>, 
+                              for example
+                              <code>{"dates": {"@id":"x", "date":null}}</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6578,7 +6599,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"employee": {"@id":"x", "date-of-birth":"1984-03-20", "location":"Germany", "position":"Janitor"}</eg></td>
+                           <td><eg>{"employee": {"@id":"x", "date-of-birth":"1984-03-20", "location":"Germany", "position":"Janitor"}}</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6605,26 +6626,26 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                               as if <term>mixed</term> layout were chosen. This is fallback behavior for use
                               when this layout is chosen inappropriately.</p>
                               <p>In other cases,
-                                 the content is represented by a JSON object containing one entry for each
-                                 attribute in the XML element, plus one property for each
+                                 the content is represented by a map containing one entry for each
+                                 attribute in the XML element, plus one entry for each
                                  child element, whose value is formatted according to the rules for that element.</p>
                               
-                              <p>The properties representing child elements are named after the child element name,
-                              as described in <specref ref="element-names-in-json"/>, except 
+                              <p>The properties representing child elements have names based on the child element name
+                                 in the normal way, except 
                                  that if the multiple child elements have the same name,
                               then each is made unique by adding a suffix in the form <code>[index]</code>, containing
                               a sequential number starting at 1. For example, if there are two children named <code>author</code>,
                               the properties are named <code>author[1]</code> and <code>author[2]</code>.</p>
                              
-                              <p>The order of child elements in the XML is retained in the JSON output, though it
-                              will typically be lost once the JSON is parsed by the recipient.</p>
+                              <p>Because the child elements are converted to a map, their order is
+                                 not retained.</p>
                               
                               </td>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>Alongside any attributes, the value includes the additional property
-                               <code>"#content":null</code>.</p></td>
+                           <td><p>Alongside any attributes, the value includes the additional entry
+                              <code>"#content":()</code>, which will be serialized in JSON as <code>"#content":null</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6664,12 +6685,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"section": [
+                           <td><eg>{"section": [
       {"@id":"x"},                        
       {"head":"Introduction"},
       {"p":"Lorem ipsum"},
       {"p":"Dolor sit amet"}
-   ]</eg></td>
+   ]}</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6690,8 +6711,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>A nilled element is indicated by a property value of <code>null</code> in place
-                              of the array, for example <code>"section": null</code>.</p></td>
+                           <td><p>A nilled element is indicated by a property value of <code>()</code> in place
+                              of the array. In JSON this is serialized as <code>null</code>.
+                              for example <code>"section": null</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6721,12 +6743,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"para": [
+                           <td><eg>{"para": [
             {"@id":"x"},
             "This is a ",
             {"i":"fine"},
             "mess!"
-   ]</eg></td>
+   ]}</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6739,23 +6761,23 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>The content is represented by a JSON array containing one entry for each
+                           <td><p>The content is represented by an XDM array containing one entry for each
                                  attribute in the XML element, and one entry for each child node, 
                               in order. </p>
-                              <p>Each attribute node is represented within this array by a JSON object
-                              containing a single property, with the key representing the attribute name
+                              <p>Each attribute node is represented within this array by a single-entry
+                              map, with the key representing the attribute name
                               and the value representing the attribute value, formatted as described
                               in <specref ref="attributes-in-json"/>.</p>
                               <p>Child nodes are represented within the array as follows:</p>
                               <ulist>
-                                 <item><p>A text node child is represented as a JSON string.</p></item>
-                                 <item><p>An element node child is represented as a JSON object containing a single
+                                 <item><p>A text node child is represented as a string.</p></item>
+                                 <item><p>An element node child is represented as a map containing a single
                                  entry, with the key representing the element name and the value representing the
                                  element's content, formatted according to the chosen layout for that element.</p></item>
-                                 <item><p>A comment node is represented as a JSON object containing a single
+                                 <item><p>A comment node is represented as a map containing a single
                                  entry whose key is the string <code>"#comment</code>, and whose corresponding
                                  value is a string containing the text of the comment.</p></item>
-                                 <item><p>A processing instruction node is represented as a JSON object containing two
+                                 <item><p>A processing instruction node is represented as a map containing two
                                     entries: the first has the key <code>"#processing-instruction"</code> and its value is the name
                                     of the processing instruction as a string; the second has the key <code>"#data"</code> and its
                                     value is a JSON string containing the string value of the processing instruction node.</p></item>
@@ -6768,8 +6790,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>A nilled element is indicated by a property value of <code>null</code> in place
-                              of the array, for example <code>"para": null</code>.</p></td>
+                           <td><p>A nilled element is indicated by a property value of <code>()</code> in place
+                              of the array, which in JSON is serialized as <code>null</code>:
+                              for example <code>{"para": null}</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6783,7 +6806,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <head>Serialized Layout</head>
                   
                   <p>Serialized layout allows an element node to be represented as lexical XML, HTML,
-                  or XHTML, contained within a JSON string.</p>
+                  or XHTML, contained within a map.</p>
                   
                   <table role="data" >
                      <tbody>
@@ -6819,8 +6842,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The element node is serialized as if by the <code>fn:serialize</code>
-                              function, and the resulting content is output as a JSON string (applying
-                              any JSON escaping needed in the normal way).</p>
+                              function, and the resulting content is output as a string.</p>
                               <p>The serialization parameter <code>method</code> is set to
                               <code>"xml"</code>, <code>"html"</code>, or <code>"xhtml"</code>
                               as appropriate.</p>
@@ -6829,7 +6851,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                               <p>The serialization parameter <code>omit-xml-declaration</code> is set
                                  to true.</p>
                               <p>Other serialization parameters take their default values.</p>
-                              <note><p>The element name will typically be repeated, for example
+                              <note><p>The outermost element name will typically be repeated, for example
                               <code>"p":"&lt;p>Lorem ipsum&lt;/p>"</code>.</p></note>
                            </td>
                         </tr>
@@ -6842,85 +6864,51 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   </table>
                </div4>
             </div3>
-            <div3 id="element-names-in-json">
-               <head>Representing Element Names in JSON</head>
-               <p>The following rules apply to the JSON representation of a top-level element: that is, an element that has
-               no parent element, or whose parent element is not included in the subtree being converted to JSON representation:</p>
-               
-               <ulist>
-                  <item><p>If the element name is in no namespace, it is represented as a JSON string containing the
-                  local part of the element name.</p></item>
-                  <item><p>If the element name is in a namespace, it is represented as a JSON string in the format
-                     <code>Q{uri}local</code>, where <code>uri</code> is the namespace, and <code>local</code>
-                  is the local part of the element name.</p></item>
-               </ulist>
-               
-               <p>For a non-top-level element, that is an element having a parent element that is itself represented
-               in the JSON output, the following rules apply:</p>
-               
-               <ulist>
-                  <item><p>If the element name is in the same namespace as its parent, or if both are
-                     in no namespace, then it is represented as a JSON string containing the
-                     local part of the element name.</p></item>
-                  <item><p>Otherwise, it is represented as a JSON string in the format
-                     <code>Q{uri}local</code>, where <code>uri</code> is the namespace (or the empty string
-                     to represent no namespace), and <code>local</code> is the local part of the element name.</p></item>
-               </ulist>
-               
-               <p>Note that prefixes used in element names are not retained; neither are the prefix-to-uri mappings
-               represented by namespace nodes in the XDM tree.</p>
-               
-               <p>Where an element appears as a child of an element formatted using record layout
-               (see <specref ref="record-json-layout"/>), its name is when necessary suffixed by an index such as <code>"[1]"</code>
-               or <code>"[2]"</code> to make it unique.</p>
-            </div3>
+            
             <div3 id="attributes-in-json">
-               <head>Representing Attributes in JSON</head>
-               <p>When attribute nodes are output in JSON as a result of formatting the containing element, they are generally
-               represented as key-value pairs within a JSON object.</p>
-               <p>For an attribute in no namespace, the key is represented as an <code>"@"</code> character followed by the local
-               name of the attribute.</p>
-               <p>For an attribute in the XML namespace, the key is represented as <code>"@xml:"</code> followed by the local
-                  name of the attribute.</p>
-               <p>For an attribute in any other namespace, the key is represented in the form <code>"@Q{uri}local"</code> where
-                  <code>uri</code> is the namespace and <code>local</code> is the local part of the attribute name.</p>
-               <p>The corresponding value is obtained by atomizing the attribute value and formatting the result by applying
-               the rules of the <code>fn:items-to-json</code> function recursively. For untyped data the result will always be
-               a JSON string. For typed data the result may be a JSON number or boolean. If the type has variety 
-                  <code>list</code>, it is output as an array: in this case an empty value is output as <code>[]</code>
-               rather than <code>null</code>.</p>
+               <head>Representing Attributes</head>
+               <p>Attributes are generally converted to key-value pairs within a map. The key is always a string:</p>
+               <ulist>
+               <item><p>For an attribute in no namespace, the key is <code>"@"</code> followed by the local
+               name of the attribute.</p></item>
+               <item><p>For an attribute in the XML namespace, the key is <code>"@xml:"</code> followed by the local
+                  name of the attribute.</p></item>
+               <item><p>For an attribute in any other namespace, the key takes the form <code>"@Q{uri}local"</code> where
+                  <code>uri</code> is the namespace and <code>local</code> is the local part of the attribute name.</p></item>
+               </ulist>
+               <p>The corresponding value is obtained by atomizing the atomized value of the attribute node
+                  as follows, to ensure that error-free JSON serialization is possible:</p>
+               <ulist>
+                  <item><p>Numeric values that have no JSON serialization (specifically, infinity and NaN) are
+                  converted to strings by applying the <code>string</code> function. For example, <code>NaN</code>
+                  becomes <code>"NaN"</code>.</p></item>
+                  <item><p>A sequence of two or more items is converted to an array of two or more singleton members.
+                  For example, <code>(1, 2, 3)</code> becomes <code>[1, 2, 3]</code>.</p></item>
+               </ulist>
+               <note><p>No adjustment is needed when the attribute is untyped; the typed value in that case is always
+               a simple string.</p>
+               <p>TODO: Issue 641 may make these adjustments unnecessary.</p></note>
+              
                <p>Attributes in the <code>xsi</code> namespace (<code>http://www.w3.org/2001/XMLSchema-instance</code>)
                   are discarded.</p>
                <note><p>This is because these attributes can appear even when the schema does not allow the element
-                  to have attributes, which means that a JSON layout might be chosen that does not accommodate attributes.</p>
+                  to have attributes, which means that a layout might be chosen that does not accommodate attributes.</p>
                </note>
             </div3>
             <div3 id="items-to-json-examples">
                <head>Examples</head>
                <p>The following examples show the effect of transforming some simple XML documents with default options,
-               except that <code>indent</code> is set to <code>true</code>. The actual indentation is implementation
-               dependent.</p>
+               and then serializing the result as JSON with <code>indent</code> is set to <code>true</code>. 
+                  The actual indentation is implementation dependent.</p>
                
                <table class="data">
                   <thead>
                      <tr>
-                        <th>XDM</th>
-                        <th>JSON</th>
+                        <th>XDM element</th>
+                        <th>JSON equivalent</th>
                      </tr>
                   </thead>
                   <tbody>
-                     <tr>
-                        <td><eg><![CDATA[1 to 5]]></eg></td>
-                        <td><eg><![CDATA[[1, 2, 3, 4, 5]]]></eg></td>
-                     </tr>
-                     <tr>
-                        <td><eg><![CDATA[map{'x':1,'y':2}]]></eg></td>
-                        <td><eg><![CDATA[{"x":1,"y":2}]]></eg></td>
-                     </tr>
-                     <tr>
-                        <td><eg><![CDATA[()]]></eg></td>
-                        <td><eg><![CDATA[null]]></eg></td>
-                     </tr>
                      <tr>
                         <td><eg><![CDATA[<a x='1' b='2'/>]]></eg></td>
                         <td><eg><![CDATA[{ "a":{
@@ -7003,8 +6991,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <table class="data">
                   <thead>
                      <tr>
-                        <th>XDM</th>
-                        <th>JSON</th>
+                        <th>XDM element</th>
+                        <th>JSON equivalent</th>
                      </tr>
                   </thead>
                   <tbody>
@@ -12822,6 +12810,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:contains-sequence</code></p></item>
               <item><p><code>fn:decode-from-uri</code></p></item>
               <item><p><code>fn:duplicate-values</code></p></item>
+              <item><p><code>fn:elements-to-maps</code></p></item>
               <item><p><code>fn:ends-with-sequence</code></p></item>
               <item><p><code>fn:every</code></p></item>
               <item><p><code>fn:expanded-QName</code></p></item>
@@ -12836,7 +12825,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:items-before</code></p></item>
               <item><p><code>fn:items-ending-where</code></p></item>
               <item><p><code>fn:items-starting-where</code></p></item>
-              <item><p><code>fn:items-to-json</code></p></item>
+              <!--<item><p><code>fn:items-to-json</code></p></item>-->
               <item><p><code>fn:iterate-while</code></p></item>
               <item><p><code>fn:log</code></p></item>
               <item><p><code>fn:lowest</code></p></item>
@@ -12852,7 +12841,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:transitive-closure</code></p></item>
               <item><p><code>fn:trunk</code></p></item>
               <item><p><code>fn:void</code></p></item>
-              <item><p><code>fn:xdm-to-json</code></p></item>
+              <!--<item><p><code>fn:xdm-to-json</code></p></item>-->
               <item><p><code>array:build</code></p></item>
               <item><p><code>array:foot</code></p></item>
               <item><p><code>array:members</code></p></item>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5617,8 +5617,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-xml-to-json">
                <head><?function fn:xml-to-json?></head>
             </div3>
-            <div3 id="func-json" diff="add" at="A">
-               <head><?function fn:json?></head>
+            <div3 id="func-xdm-to-json" diff="add" at="A">
+               <head><?function fn:xdm-to-json?></head>
             </div3>
          </div2>
          <div2 id="html-functions">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6445,8 +6445,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Usage</th>
-                           <td><p>Intended for XML elements that contain multiple child elements, with different
-                              names, where the order of the child elements is not significant. 
+                           <td><p>Intended primarily for XML elements that contain multiple child elements, with different
+                              names, where the order of the child elements is not significant. Also used for elements
+                              whose content is a single element node child.
                               The element may or may not have attributes.</p></td>
                         </tr>
                         <tr>
@@ -6463,14 +6464,21 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
-                           <td><p>The element has a complex type with element-only content, whose particle contains
-                              a single term, whose compositor is <term>all</term>.</p>
-                           <p>(That is, the element is validated against a complex type defined using <code>xs:all</code>.)</p></td>
+                           <td><p>The element has a complex type with element-only content, and either:</p>
+                              <olist>
+                                 <item><p>The content model contains
+                                 a single term, whose compositor is <term>all</term> 
+                                    (that is, the element is validated against a complex type 
+                                    defined using <code>xs:all</code>); or</p></item>
+                              <item><p>The content model allows at most one child element (it may allow a choice
+                                 of child elements but must not allow multiple children).</p></item>
+                              </olist>
+                           </td>
                         </tr>
                         <tr>
                            <th>Match pattern</th>
-                           <td><p><code>*[*[2] and all-different(*!node-name()) and not(text()[normalize-space()])]</code></p>
-                              <p>That is, there are at least two child elements; all child elements have different names; and
+                           <td><p><code>*[* and all-different(*!node-name()) and not(text()[normalize-space()])]</code></p>
+                              <p>That is, there is at least one child element; all child elements have different names; and
                                  there are no text node children other than whitespace-only text nodes.</p></td>
                         </tr>
                         <tr>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6016,6 +6016,692 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <code>fn:json-to-xml</code> function is <termref def="implementation-dependent">implementation-dependent</termref>.</p>
             </div3>
          </div2>
+         <div2 id="xml-to-json-mappings" diff="add" at="2023-05-30">
+            <head>JSON Representation of XML</head>
+            <p>The section describes the JSON representations of XML element and attribute nodes supported by the 
+               <code>fn:xdm-to-json</code> function.</p>
+            
+            <p>This mapping is designed with three objectives:</p>
+            <ulist>
+               <item><p>It should be possible to represent any XML content in JSON.</p></item>
+               <item><p>The resulting JSON should be intuitive and easy to use.</p></item>
+               <item><p>The JSON should be consistent and stable: small changes in the input should not result
+               in large changes in the output.</p></item>
+            </ulist>
+            
+            <p>Achieving all three objectives requires design compromises. It also requires sacrificing some other
+            desiderata. In consequence:</p>
+            <ulist>
+               <item><p>The conversion is not lossless.</p></item>
+               <item><p>The conversion is not streamable.</p></item>
+               <item><p>The results are not necessarily compatible with those produced by other popular libraries.</p></item>
+            </ulist>
+            
+            <div3 id="json-element-layouts">
+               <head>JSON Element Layouts</head>
+           
+            
+               <p>The key challenge in mapping XML to JSON is in deciding how element content is to be represented. To 
+                  illustrate the variety of mappings that are possible, the following table
+               lists some examples of typical XML elements and their potential JSON equivalents:</p>
+               
+               <table role="data" >
+                  <thead>
+                     <tr>
+                        <th>XML element</th>
+                        <th>Potential JSON equivalent</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><eg><![CDATA[<hr/>]]></eg></td>
+                        <td><eg><![CDATA["hr": null]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<age>23</age>]]></eg></td>
+                        <td><eg><![CDATA["age": 23]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<box width="5" height="10"/>]]></eg></td>
+                        <td><eg><![CDATA["box": {"width":5, "height":10}]]></eg></td>                    
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<label id="t41">Warning!</label>]]></eg></td>
+                        <td><eg><![CDATA["label": {"@id": "t41", "#content":"Warning!"}]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<box>
+    <width>5</width>
+    <height>10</height>
+</box>]]></eg></td>
+                        <td><eg><![CDATA["box": {
+    "@width":5, 
+    "@height":10
+}]]></eg></td>                    
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<polygon>
+    <point x="0" y="0"/>
+    <point x="1" y="0"/>
+    <point x="1" y="1"/>
+    <point x="0" y="1"/>
+</polygon>]]></eg></td>
+                        <td><eg><![CDATA["polygon": [
+    {"x":0, "y":0}, 
+    {"x":1, "y":0}, 
+    {"x":1, "y":1}, 
+    {"x":0, "y":1}
+]    ]]></eg></td>                    
+                     </tr>
+                  </tbody>
+               </table>
+             
+               <p>To accommodate the variety of possible mappings of XML elements to JSON, this specification defines a
+               number of named mappings, called <term>layouts</term>, and allows the layout to be selected in three different
+               ways:</p>
+               
+               <ulist>
+                  <item><p>The layout to be used for a specific element name can be explicitly selected in the options
+                  to the <code>fn:xdm-to-json</code> function.</p></item>
+                  <item><p>Otherwise, if the data has been schema-validated, the layout is inferred from the content model
+                  for the element type as defined in the schema.</p></item>
+                  <item><p>Otherwise (that is, when the data is untyped and no specific layout has been selected), 
+                     a default layout is chosen based on the properties of the individual element instance.</p></item>              
+               </ulist>
+               
+               <p>The advantage of using schema information is that it gives a consistent representation for all
+               elements of a particular type, even if they vary in content: for example if an element type allows optional
+               attributes, the JSON representation will be consistent between those elements that have attributes and those
+               without.</p>
+               
+               <p>The different layouts available are defined in the following sections. For each layout
+               there is a table showing:</p>
+               
+               <ulist>
+                  <item><p><term>Layout name</term>: the name to be used to select this layout in
+                  the options parameter of the <code>fn:xdm-to-json</code> function.</p></item>
+                  <item><p><term>Usage</term>: the situations for which this layout is designed.</p></item>
+                  <item><p><term>XML example</term>: an example of a typical XML element for which this layout is appropriate.</p></item>
+                  <item><p><term>JSON equivalent</term>: the JSON representation of this example. The JSON
+                  equivalent is always shown as a key-value pair suitable for use within a JSON object; the way
+                  this is used depends on the context in which the element appears.</p></item>
+                  <item><p><term>XSD conditions</term>: the properties of the XSD type definition that cause this
+                  layout to be selected. The first layout that meets these conditions will be chosen.</p></item>
+                  <item><p><term>Match pattern</term>: an XSLT 4.0 pattern defining the elements for which
+                  this layout will be selected. The first layout whose pattern matches will be chosen.</p>
+                  </item>
+                  <item><p><term>Mapping rules</term>: The rules for mapping the XML element to a JSON
+                  representation.</p></item>
+                  <item><p><term>Mapping for nilled elements</term>: special rules that apply to an
+                  element having the attribute <code>xsi:nil="true"</code>. These rules only apply if the
+                  element has been schema-validated.</p></item>
+                  <item><p><term>Notes</term>: General observations, especially concerning what information is retained
+                  by this mapping and what information is lost.</p></item>
+               </ulist>
+               
+               <p>Note that it is possible to use any layout for any element. Use of an inappropriate layout
+               may result in information being discarded; but in some cases, discarding information may be the 
+               desired outcome.</p>
+               
+               <note><p>Acknowledgements for this categorization: see <bibref ref="Goessner"/>. Although
+               Goessner's categories have been used, the actual mappings vary from his proposal.</p></note>
+               
+               
+               <div4 id="empty-json-layout">
+                  <head>Empty Layout</head>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>empty</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that have no content and no attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<hr/>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"hr":""</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a complex type with variety empty, or a simple type with
+                           variety list and <code>maxLength="0"</code>, or a type derived from <code>xs:string</code>
+                              with an <code>enumeration</code> or <code>length</code> or <code>maxLength</code>
+                              facet that restricts it to be zero-length; the type does not allow any attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*[not(*|text()|@*)]</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>The content is represented by the JSON string <code>""</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>The content is represented by the JSON value <code>null</code>, for example
+                              <code>&lt;hr xsi:nil="true"/></code> becomes <code>"hr":null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>If any child nodes or attributes are present, they are discarded. (This can happen
+                           when this layout is explicitly selected for elements that are not actually empty.)</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </div4>
+               <div4 id="empty-plus-json-layout">
+                  <head>Empty Layout with Attributes</head>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>empty-plus</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that have no content but may have attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<hr id="zzz"/>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"hr":{"@id":"zzz"}</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a complex type with variety empty, or a simple type with
+                              variety list and <code>maxLength="0"</code>, or a type derived from <code>xs:string</code>
+                              with an <code>enumeration</code> or <code>length</code> or <code>maxLength</code>
+                              facet that restricts it to be zero-length; 
+                              the type allows attributes to appear.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*[@* and not(*|text())]</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>The content is represented by a JSON object containing one entry for each
+                              attribute in the XML element; if there are no attributes, the content
+                              is represented as an empty JSON object: <code>{}</code>. 
+                              The mapping rules for attributes are
+                           defined in <specref ref="attributes-in-json"/>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>An additional property <code>"#content":null</code> is added, for example
+                              <code>&lt;hr id="x" xsi:nil="true"/></code> becomes 
+                              <code>"hr":{"@id":"x", "#content":null}</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>If any child nodes are present in the element, they are discarded.
+                              (This can happen
+                              when this layout is explicitly selected for elements that are not actually empty.)</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </div4>
+               <div4 id="simple-json-layout">
+                  <head>Simple Layout</head>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>simple</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that have simple content and no attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<date>2023-05-30</date>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"date":"2023-05-30"</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a simple type.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*[not(*|@*)]</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>The element is atomized and the JSON representation is obtained by applying
+                              the <code>fn:xdm-to-json</code> function to the atomized value.</p>
+                           <p>If the element is untyped, the result will always be a JSON string.</p>
+                           <p>If the element has been schema-validated, the result may instead be a number,
+                           a boolean, or an array. If the element is nilled, the result will be the JSON value
+                           <code>null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>The content is represented using the JSON value <code>null</code>, for example
+                              <code><![CDATA[<date xsi:nil="true"/>]]></code> becomes 
+                              <code>"date":null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>If any attributes are present, they are discarded. If the element has a type
+                           annotation that is a complex type with element-only content, atomization will fail and
+                           a dynamic error occurs. In the case of mixed content, if child elements are present, 
+                           atomization means that they will not appear in the result.</p>
+                           <p>Comments and processing instructions in the content are discarded. Whitespace is
+                           retained.</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </div4>
+               <div4 id="simple-plus-json-layout">
+                  <head>Simple Layout with Attributes</head>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>simple-plus</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that have simple content and (optionally) attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<price currency="USD">23.50</date>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"date":{"@currency":"USD", "#content":23.50}</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a complex type with simple content.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*[not(*)]</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>The content is represented by a JSON object containing one entry for each
+                              attribute in the XML element, plus a property named <code>"#content"</code>
+                              containing the resuult of atomizing the element and obtaining its JSON representation by applying
+                              the <code>fn:xdm-to-json</code> function to the atomized value.</p>
+                              <p>The mapping rules for attributes are
+                                 defined in <specref ref="attributes-in-json"/>.</p>
+                              <p>If the element is untyped, the value of each attribute, and of <code>"#content"</code>,
+                                 will always be a JSON string.</p>
+                              <p>If the element has been schema-validated, the values of each property may instead be a number,
+                                 a boolean, or an array.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>The <code>"#content"</code> property takes the JSON value <code>null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>In the case of mixed content, if child elements are present, 
+                              atomization means that they will not appear in the result.</p>
+                              <p>Comments and processing instructions in the content are discarded. Whitespace is
+                                 retained.</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </div4>
+               <div4 id="list-json-layout">
+                  <head>List Layout</head>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>list</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that act as wrappers for a list of child elements,
+                              all having the same element name. The wrapper element may or may not have attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<dates id="x">
+  <date>2023-03-20</date>
+  <date>2023-04-12</date>
+  <date>2023-05-30</date>
+</dates>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"dates": {"@id":"x", date": ["2023-03-20", "2023-04-12", "2023-05-30"]}</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a complex type with element-only content, containing a single
+                              element particle, whose <code>maxOccurs</code> value is greater than one (including
+                              <code>maxOccurs="unbounded"</code>).</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*[*[2] and all-equal(*!node-name()) and not(text()[normalize-space()])]</code></p>
+                           <p>That is, there are at least two child elements; all child elements have the same name; and
+                           there are no text node children other than whitespace-only text nodes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>If the element has element children with names that are not all equal, or
+                              if it has non-whitespace text node children, then it is output
+                              as if <term>mixed</term> layout were chosen. This is fallback behavior for use
+                              when this layout is chosen inappropriately.</p>
+                              <p>In other cases,
+                              The content is represented by a JSON object containing one entry for each
+                              attribute in the XML element, plus a property named after the 
+                              child elements (the <term>content property</term>), whose value is an array 
+                                 containing the results of formatting the content
+                              of each child element according to the rules for that element.</p> 
+                             
+                              <p>If there are no children and the element is untyped (which can occur when 
+                              this layout is chosen explicitly via the options to <code>fn:xdm-to-json</code>)
+                              then the content property is omitted (since the child element name is unknown).
+                              But if the element is typed, then the content property is included and set to
+                              an empty JSON array.</p>
+                              
+                              </td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>The content property is included and takes the JSON value <code>null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>Comments and processing instructions in the content are discarded.</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </div4>
+               <div4 id="record-json-layout">
+                  <head>Record Layout</head>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>record</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that contain multiple child elements, with different
+                              names, where the order of the child elements is not significant. 
+                              The element may or may not have attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<employee id="x">
+  <date-of-birth>1984-03-20</date>
+  <location>Germany</location>
+  <position>Janitor</position>
+</employee>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"employee": {"@id":"x", "date-of-birth":"1984-03-20", "location":"Germany", "position":"Janitor"}</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a complex type with element-only content, whose particle contains
+                              a single term, whose compositor is <term>all</term>.</p>
+                           <p>(That is, the element is validated against a complex type defined using <code>xs:all</code>.)</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*[*[2] and all-different(*!node-name()) and not(text()[normalize-space()])]</code></p>
+                              <p>That is, there are at least two child elements; all child elements have different names; and
+                                 there are no text node children other than whitespace-only text nodes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>If the element has non-whitespace text node children, then it is output
+                              as if <term>mixed</term> layout were chosen. This is fallback behavior for use
+                              when this layout is chosen inappropriately.</p>
+                              <p>In other cases,
+                                 the content is represented by a JSON object containing one entry for each
+                                 attribute in the XML element, plus one property for each
+                                 child element, whose value is formatted according to the rules for that element.</p>
+                              
+                              <p>The properties representing child elements are named after the child element name,
+                              as described in <specref ref="element-names-in-json"/>, except 
+                                 that if the multiple child elements have the same name,
+                              then each is made unique by adding a suffix in the form <code>[index]</code>, containing
+                              a sequential number starting at 1. For example, if there are two children named <code>author</code>,
+                              the properties are named <code>author[1]</code> and <code>author[2]</code>.</p>
+                             
+                              <p>The order of child elements in the XML is retained in the JSON output, though it
+                              will typically be lost once the JSON is parsed by the recipient.</p>
+                              
+                              <p>If the element is nilled, the JSON representation must include the
+                                 property <code>"#content":null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>Alongside any attributes, the value includes the additional property
+                               <code>"#content":null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>Although this layout is intended primarily for elements whose children are unordered
+                              and uniquely named, it is also viable to use it in cases where elements can repeat, so
+                              long as order relative to other elements is not significant. Indeed, 
+                              with XSD 1.1, a complex type defined using
+                              <code>xs:all</code> can allow elements to appear more than once, and this will cause
+                              this layout to be selected.</p>
+                              <p>Comments and processing instructions in the content are discarded.</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </div4>
+               <div4 id="sequence-json-layout">
+                  <head>Sequence Layout</head>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>sequence</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that contain a sequence of element node children,
+                              whose order is significant. 
+                              The element may or may not have attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<section id="x">
+   <head>Introduction</head>
+   <p>Lorem ipsum.</p>
+   <p>Dolor sit amet.</p>
+</section>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"section": {
+   "@id":"x", 
+   "#content": [
+      {"head":"Introduction"},
+      {"p":"Lorem ipsum"},
+      {"p":"Dolor sit amet"}]
+   }</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a complex type with element-only content that does not meet
+                              the criteria for list or record layout.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*[not(text()[normalize-space()])</code></p>
+                           <p>That is, the element has no text node children other than whitespace nodes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>The mapping rules are identical to the rules for mixed layout (see 
+                              <specref ref="mixed-json-layout"/>) except that whitespace-only text nodes
+                              are discarded.</p>
+                           </td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>The value of the <code>#content</code> property is present with the value <code>null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>Because whitespace text nodes are stripped, this layout should not normally be used
+                              with mixed content.</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </div4>
+               <div4 id="mixed-json-layout">
+                  <head>Mixed Layout</head>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>mixed</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that contain mixed content. 
+                              The element may or may not have attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<para id="x">This is a <i>fine</i> mess!</para>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"para": {
+         "@id":"x", 
+         "#content": [
+            "This is a ",
+            {"i":"fine"},
+            "mess!"]
+   }</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a complex type that does not satisfy the criteria for any other
+                              layout to be used.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>The content is represented by a JSON object containing one entry for each
+                                 attribute in the XML element, plus one property named <code>"#content</code>for the content. 
+                                 The value of
+                                 the <code>"#content"</code> property is an array containing one entry for each child node, 
+                              in order. But if the element is nilled, the <code>"#content"</code> property has the JSON value 
+                              <code>null</code>.</p>
+                              <p>Child nodes are represented within this array as follows:</p>
+                              <ulist>
+                                 <item><p>A text node child is represented as a JSON string.</p></item>
+                                 <item><p>An element node child is represented as a JSON object containing a single
+                                 entry, with the key representing the element name and the value representing the
+                                 element's content, formatted according to the chosen layout for that element.</p></item>
+                                 <item><p>A comment node is represented as a JSON object containing a single
+                                 entry whose key is the string <code>"#comment</code>, and whose corresponding
+                                 value is a string containing the text of the comment.</p></item>
+                                 <item><p>A processing instruction node is represented as a JSON object containing two
+                                    entries: the first has the key <code>"#processing-instruction"</code> and its value is the name
+                                    of the processing instruction as a string; the second has the key <code>"#data"</code> and its
+                                    value is a JSON string containing the string value of the processing instruction node.</p></item>
+                              </ulist>
+                              
+                              <p>Whitespace text nodes are retained.</p>
+                               
+                            
+                           </td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>The value of the <code>#content</code> property is present with the value <code>null</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>This is the only layout that retains information about all child nodes, including
+                           text nodes (both whitespace and non-whitespace), elements, comments, and processing instructions.</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </div4>
+            </div3>
+            <div3 id="element-names-in-json">
+               <head>Representing Element Names in JSON</head>
+               <p>The following rules apply to the JSON representation of a top-level element: that is, an element that has
+               no parent, or whose parent is not included in the subtree being converted to JSON representation:</p>
+               
+               <ulist>
+                  <item><p>If the element name is in no namespace, it is represented as a JSON string containing the
+                  local part of the element name.</p></item>
+                  <item><p>If the element name is in a namespace, it is represented as a JSON string in the format
+                     <code>Q{uri}local</code>, where <code>uri</code> is the namespace, and <code>local</code>
+                  is the local part of the element name.</p></item>
+               </ulist>
+               
+               <p>For a non-top-level element, that is an element having a parent element that is also represented
+               in the JSON output, the following rules apply:</p>
+               
+               <ulist>
+                  <item><p>If the element name is in the same namespace as its parent, or if both are
+                     in no namespace, then it is represented as a JSON string containing the
+                     local part of the element name.</p></item>
+                  <item><p>Otherwise, it is represented as a JSON string in the format
+                     <code>Q{uri}local</code>, where <code>uri</code> is the namespace (or the empty string
+                     to represent no namespace), and <code>local</code> is the local part of the element name.</p></item>
+               </ulist>
+               
+               <p>Note that prefixes used in element names are not retained; neither are the prefix-to-uri mappings
+               represented by namespace nodes in the XDM tree.</p>
+               
+               <p>Where an element appears as a child of an element formatted using record layout
+               (see <specref ref="record-json-layout"/>), its name is when necessary suffixed by an index such as <code>"[1]"</code>
+               or <code>"[2]"</code> to make it unique.</p>
+            </div3>
+            <div3 id="attributes-in-json">
+               <head>Representing Attributes in JSON</head>
+               <p>When attribute nodes are output in JSON as a result of formatting the containing element, they are generally
+               represented as key-value pairs within a JSON object.</p>
+               <p>For an attribute in no namespace, the key is represented as an <code>"@"</code> character followed by the local
+               name of the attribute.</p>
+               <p>For an attribute in the XML namespace, the key is represented as <code>"@xml:"</code> followed by the local
+                  name of the attribute.</p>
+               <p>For an attribute in any other namespace, the key is represented in the form <code>"@Q{uri}local"</code> where
+                  <code>uri</code> is the namespace and <code>local</code> is the local part of the attribute name.</p>
+               <p>The corresponding value is obtained by atomizing the attribute value and formatting the result by applying
+               the rules of the <code>fn:xdm-to-json</code> function recursively. For untyped data the result will always be
+               a JSON string. For typed data the result may be a JSON number or boolean, or (if the type has variety 
+                  <code>list</code>), an array.</p>
+            </div3>
+         </div2>
          <div2 id="html">
             <head>XDM Mapping from HTML DOM Nodes</head>
 
@@ -10738,6 +11424,9 @@ ISBN 0 521 77752 6.</bibl>
                <bibl  id="HTML40" key="HTML 4.0">HTML 4.01 Recommendation, 24 December
 1999. Available at:
 <loc href="http://www.w3.org/TR/REC-html40/">http://www.w3.org/TR/REC-html40/</loc>.
+               </bibl>
+               <bibl id="Goessner" key="Goessner">Converting Between XML and JSON. Stefan Goessner, 31 May 2006. 
+                  <loc href="https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html">https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html</loc>.
                </bibl>
                <bibl id="ICU" key="ICU">ICU - International Components for Unicode. Available at <loc href="http://site.icu-project.org">http://site.icu-project.org</loc>.
                </bibl>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5617,8 +5617,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-xml-to-json">
                <head><?function fn:xml-to-json?></head>
             </div3>
-            <div3 id="func-xdm-to-json" diff="add" at="A">
-               <head><?function fn:xdm-to-json?></head>
+            <div3 id="func-items-to-json" diff="add" at="A">
+               <head><?function fn:items-to-json?></head>
             </div3>
          </div2>
          <div2 id="html-functions">
@@ -6019,7 +6019,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <div2 id="xml-to-json-mappings" diff="add" at="2023-05-30">
             <head>JSON Representation of XML</head>
             <p>The section describes the JSON representations of XML element and attribute nodes supported by the 
-               <code>fn:xdm-to-json</code> function.</p>
+               <code>fn:items-to-json</code> function.</p>
             
             <p>This mapping is designed with three objectives:</p>
             <ulist>
@@ -6054,27 +6054,27 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
                <p>The key challenge in mapping XML to JSON is in deciding how element content is to be represented. To 
                   illustrate the variety of mappings that are possible, the following table
-               lists some examples of typical XML elements and their potential JSON equivalents:</p>
+               lists some examples of typical XML elements and their JSON equivalents:</p>
                
                <table role="data" >
                   <thead>
                      <tr>
                         <th>XML element</th>
-                        <th>Potential JSON equivalent</th>
+                        <th>JSON equivalent</th>
                      </tr>
                   </thead>
                   <tbody>
                      <tr>
                         <td><eg><![CDATA[<hr/>]]></eg></td>
-                        <td><eg><![CDATA["hr": null]]></eg></td>
+                        <td><eg><![CDATA["hr": ""]]></eg></td>
                      </tr>
                      <tr>
-                        <td><eg><![CDATA[<age>23</age>]]></eg></td>
-                        <td><eg><![CDATA["age": 23]]></eg></td>
+                        <td><eg><![CDATA[<date-of-birth>2023-05-18</age>]]></eg></td>
+                        <td><eg><![CDATA["date-of-birth": 2023-05-18]]></eg></td>
                      </tr>
                      <tr>
                         <td><eg><![CDATA[<box width="5" height="10"/>]]></eg></td>
-                        <td><eg><![CDATA["box": {"width":5, "height":10}]]></eg></td>                    
+                        <td><eg><![CDATA["box": {"@width":5, "@height":10}]]></eg></td>                    
                      </tr>
                      <tr>
                         <td><eg><![CDATA[<label id="t41">Warning!</label>]]></eg></td>
@@ -6086,8 +6086,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
     <height>10</height>
 </box>]]></eg></td>
                         <td><eg><![CDATA["box": {
-    "@width":5, 
-    "@height":10
+    "width":5, 
+    "height":10
 }]]></eg></td>                    
                      </tr>
                      <tr>
@@ -6115,12 +6115,13 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                
                <ulist>
                   <item><p>The layout to be used for a specific element name can be explicitly selected in the options
-                  to the <code>fn:xdm-to-json</code> function.</p></item>
+                  to the <code>fn:items-to-json</code> function.</p></item>
                   <item><p>In the absence of an explicit selection, if the data has been schema-validated, the layout is 
                      inferred from the content model for the element type as defined in the schema.</p></item>
                   <item>
                      <p>Otherwise (that is, when the data is untyped and no specific layout has been selected), 
                      a default layout is chosen based on the properties of the individual element instance.</p>
+                     
                      <p>If the <code>uniform</code> option is set to <code>true</code>, then the same layout
                      must be used for all elements with a given name. This means that all elements must be
                      examined before any element is processed. The layout chosen is the first one (in the order of
@@ -6140,7 +6141,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                
                <ulist>
                   <item><p><term>Layout name</term>: the name to be used to select this layout in
-                  the options parameter of the <code>fn:xdm-to-json</code> function.</p></item>
+                  the options parameter of the <code>fn:items-to-json</code> function.</p></item>
                   <item><p><term>Usage</term>: the situations for which this layout is designed.</p></item>
                   <item><p><term>XML example</term>: an example of a typical XML element for which this layout is appropriate.</p></item>
                   <item><p><term>JSON equivalent</term>: the JSON representation of this example. The JSON
@@ -6305,7 +6306,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The element is atomized and the JSON representation is obtained by applying
-                              the <code>fn:xdm-to-json</code> function to the atomized value.</p>
+                              the <code>fn:items-to-json</code> function to the atomized value.</p>
                               <p>If the element is untyped, the result will always be a JSON string.</p>
                            <p>If the element has been schema-validated, the result may instead be a number,
                            a boolean, or an array. If the type annotation is a simple type with variety <code>list</code>,
@@ -6363,8 +6364,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                            <th>Mapping rules</th>
                            <td><p>The content is represented by a JSON object containing one entry for each
                               attribute in the XML element, plus a property named <code>"#content"</code>
-                              containing the resuult of atomizing the element and obtaining its JSON representation by applying
-                              the <code>fn:xdm-to-json</code> function to the atomized value.</p>
+                              containing the result of atomizing the element and obtaining its JSON representation by applying
+                              the <code>fn:items-to-json</code> function to the atomized value.</p>
                               <p>The mapping rules for attributes are
                                  defined in <specref ref="attributes-in-json"/>.</p>
                               <p>If the element is untyped, the value of each attribute, and of <code>"#content"</code>,
@@ -6519,7 +6520,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                                  of each child element according to the rules for that element.</p> 
                               
                               <p>If there are no children and the element is untyped (which can occur when 
-                                 this layout is chosen explicitly via the options to <code>fn:xdm-to-json</code>)
+                                 this layout is chosen explicitly via the options to <code>fn:items-to-json</code>)
                                  then the content property is omitted (since the child element name is unknown).
                                  But if the element is typed, then the content property is included and set to
                                  an empty JSON array.</p>
@@ -6778,11 +6779,73 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      </tbody>
                   </table>
                </div4>
+               <div4 id="serialized-json-layout">
+                  <head>Serialized Layout</head>
+                  
+                  <p>Serialized layout allows an element node to be represented as lexical XML, HTML,
+                  or XHTML, contained within a JSON string.</p>
+                  
+                  <table role="data" >
+                     <tbody>
+                        <tr>
+                           <th>Layout names</th>
+                           <td><p><code>xml</code>, <code>html</code>, <code>xhtml</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>This layout is useful when the input contains a mix of
+                              structured data and marked-up textual content. It allows the
+                              textual content to be output as XML, HTML, or XHTML markup within
+                              a JSON framework.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<p>That was <i>awesome</i></p>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg><![CDATA["p":"<p>That was <i>awesome</i></p>"]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>Not applicable. Serialized layout will only be used if 
+                           explicitly selected in the <code>layouts</code> option.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p>Not applicable. Serialized layout will only be used if
+                              explicitly selected in the <code>layouts</code> option.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>The element node is serialized as if by the <code>fn:serialize</code>
+                              function, and the resulting content is output as a JSON string (applying
+                              any JSON escaping needed in the normal way).</p>
+                              <p>The serialization parameter <code>method</code> is set to
+                              <code>"xml"</code>, <code>"html"</code>, or <code>"xhtml"</code>
+                              as appropriate.</p>
+                              <p>The serialization parameter <code>indent</code> is taken from
+                              the supplied <code>$options</code> parameter.</p>
+                              <p>The serialization parameter <code>omit-xml-declaration</code> is set
+                                 to true.</p>
+                              <p>Other serialization parameters take their default values.</p>
+                              <note><p>The element name will typically be repeated, for example
+                              <code>"p":"&lt;p>Lorem ipsum&lt;/p>"</code>.</p></note>
+                           </td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>Nilled elements are handled according to the standard serialization rules.</p></td>
+                        </tr>
+       
+                     </tbody>
+                  </table>
+               </div4>
             </div3>
             <div3 id="element-names-in-json">
                <head>Representing Element Names in JSON</head>
                <p>The following rules apply to the JSON representation of a top-level element: that is, an element that has
-               no parent, or whose parent is not included in the subtree being converted to JSON representation:</p>
+               no parent element, or whose parent element is not included in the subtree being converted to JSON representation:</p>
                
                <ulist>
                   <item><p>If the element name is in no namespace, it is represented as a JSON string containing the
@@ -6792,7 +6855,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   is the local part of the element name.</p></item>
                </ulist>
                
-               <p>For a non-top-level element, that is an element having a parent element that is also represented
+               <p>For a non-top-level element, that is an element having a parent element that is itself represented
                in the JSON output, the following rules apply:</p>
                
                <ulist>
@@ -6822,9 +6885,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>For an attribute in any other namespace, the key is represented in the form <code>"@Q{uri}local"</code> where
                   <code>uri</code> is the namespace and <code>local</code> is the local part of the attribute name.</p>
                <p>The corresponding value is obtained by atomizing the attribute value and formatting the result by applying
-               the rules of the <code>fn:xdm-to-json</code> function recursively. For untyped data the result will always be
+               the rules of the <code>fn:items-to-json</code> function recursively. For untyped data the result will always be
                a JSON string. For typed data the result may be a JSON number or boolean. If the type has variety 
-                  <code>list</code>), it is output as an array: in this case an empty value is output as <code>[]</code>
+                  <code>list</code>, it is output as an array: in this case an empty value is output as <code>[]</code>
                rather than <code>null</code>.</p>
                <p>Attributes in the <code>xsi</code> namespace (<code>http://www.w3.org/2001/XMLSchema-instance</code>)
                   are discarded.</p>
@@ -6832,7 +6895,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   to have attributes, which means that a JSON layout might be chosen that does not accommodate attributes.</p>
                </note>
             </div3>
-            <div3 id="xdm-to-json-examples">
+            <div3 id="items-to-json-examples">
                <head>Examples</head>
                <p>The following examples show the effect of transforming some simple XML documents with default options,
                except that <code>indent</code> is set to <code>true</code>. The actual indentation is implementation
@@ -6999,7 +7062,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>Further improvements to the usability of the JSON output could be achieved by doing some
                simple transformation of the XML prior to conversion. For example, the <code>name</code>
                attribute of various productions could be converted to a child element, and 
-                  <code>&lt;ref name="x"/&gt;</code> could be transformed to <code>&lt;ref&gt;x"&lt;/ref&gt;</code>.</p></note>
+                  <code>&lt;ref name="x"/&gt;</code> could be transformed to <code>&lt;ref&gt;x&lt;/ref&gt;</code>.</p></note>
             </div3>
          </div2>
          <div2 id="html">
@@ -12773,6 +12836,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:items-before</code></p></item>
               <item><p><code>fn:items-ending-where</code></p></item>
               <item><p><code>fn:items-starting-where</code></p></item>
+              <item><p><code>fn:items-to-json</code></p></item>
               <item><p><code>fn:iterate-while</code></p></item>
               <item><p><code>fn:log</code></p></item>
               <item><p><code>fn:lowest</code></p></item>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6037,6 +6037,17 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <item><p>The results are not necessarily compatible with those produced by other popular libraries.</p></item>
             </ulist>
             
+            <p>The requirement for consistency and stability is particularly challenging. An element such as 
+            <code><![CDATA[<name>John</name>]]></code> maps naturally to the JSON object property <code>"name":"John"</code>;
+               but adding an attribute (so it becomes <code><![CDATA[<name role="first">John</name>]]></code>)
+            then requires an incompatible change in the JSON representation. The format can be made extensible
+            by converting <code><![CDATA[<name>John</name>]]></code> to <code>"name":{"#content":"John"}</code>
+               and <code><![CDATA[<name role="first">John</name>]]></code> to <code>"name":{"@role":"first", "#content":"John"}</code>,
+               but this imposes unwanted complexity on the simplest cases. The solution is to provide some user
+            control over the mappings that are chosen.</p>
+            
+            
+            
             <div3 id="json-element-layouts">
                <head>JSON Element Layouts</head>
            
@@ -6095,24 +6106,34 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      </tr>
                   </tbody>
                </table>
+
+               
              
-               <p>To accommodate the variety of possible mappings of XML elements to JSON, this specification defines a
+               <p>This specification defines a
                number of named mappings, called <term>layouts</term>, and allows the layout to be selected in three different
                ways:</p>
                
                <ulist>
                   <item><p>The layout to be used for a specific element name can be explicitly selected in the options
                   to the <code>fn:xdm-to-json</code> function.</p></item>
-                  <item><p>Otherwise, if the data has been schema-validated, the layout is inferred from the content model
-                  for the element type as defined in the schema.</p></item>
-                  <item><p>Otherwise (that is, when the data is untyped and no specific layout has been selected), 
-                     a default layout is chosen based on the properties of the individual element instance.</p></item>              
+                  <item><p>In the absence of an explicit selection, if the data has been schema-validated, the layout is 
+                     inferred from the content model for the element type as defined in the schema.</p></item>
+                  <item>
+                     <p>Otherwise (that is, when the data is untyped and no specific layout has been selected), 
+                     a default layout is chosen based on the properties of the individual element instance.</p>
+                     <p>If the <code>uniform</code> option is set to <code>true</code>, then the same layout
+                     must be used for all elements with a given name. This means that all elements must be
+                     examined before any element is processed. The layout chosen is the first one (in the order of
+                     presentation in the following sections) whose match pattern matches every element with
+                     the relevant name.</p>
+                  </item>              
                </ulist>
                
                <p>The advantage of using schema information is that it gives a consistent representation for all
                elements of a particular type, even if they vary in content: for example if an element type allows optional
                attributes, the JSON representation will be consistent between those elements that have attributes and those
-               without.</p>
+               without. In the absence of a schema, consistency can be achieved either by using the <code>uniform</code>
+               option, or by selecting a layout explicitly in the <code>layouts</code> option.</p>
                
                <p>The different layouts available are defined in the following sections. For each layout
                there is a table showing:</p>
@@ -6377,7 +6398,88 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <tr>
                            <th>Usage</th>
                            <td><p>Intended for XML elements that act as wrappers for a list of child elements,
-                              all having the same element name. The wrapper element may or may not have attributes.</p></td>
+                              all having the same element name. The wrapper element should not have any attributes.
+                              The name of the child elements is not retained in the JSON output.</p></td>
+                        </tr>
+                        <tr>
+                           <th>XML example</th>
+                           <td><eg><![CDATA[<dates>
+  <date>2023-03-20</date>
+  <date>2023-04-12</date>
+  <date>2023-05-30</date>
+</dates>]]></eg></td>
+                        </tr>
+                        <tr>
+                           <th>JSON equivalent</th>
+                           <td><eg>"dates": ["2023-03-20", "2023-04-12", "2023-05-30"]</eg></td>
+                        </tr>
+                        <tr>
+                           <th>XSD conditions</th>
+                           <td><p>The element has a complex type with element-only content, containing a single
+                              element particle, whose <code>maxOccurs</code> value is greater than one (including
+                              <code>maxOccurs="unbounded"</code>); the type does not allow any attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Match pattern</th>
+                           <td><p><code>*[*[2] and all-equal(*!node-name()) and not(text()[normalize-space()]) and not(@*) ]</code></p>
+                           <p>That is, there are at least two child elements; all child elements have the same name; 
+                           there are no text node children other than whitespace-only text nodes; and there
+                           are no attributes.</p></td>
+                        </tr>
+                        <tr>
+                           <th>Mapping rules</th>
+                           <td><p>If the element has element children with names that are not all equal, or
+                              if it has non-whitespace text node children, then it is output
+                              as if <term>mixed</term> layout were chosen. This is fallback behavior for use
+                              when this layout is chosen inappropriately.</p>
+                              <p>In other cases,
+                              the content is represented by a JSON array
+                                 containing the results of formatting the content
+                              of each child element according to the rules for that element.</p> 
+                             
+                              <p>If there are no children then the content is represented by an empty array.</p>
+                              
+                              </td>
+                        </tr>
+                        <tr>
+                           <th>Mapping for nilled elements</th>
+                           <td><p>The array is replaced by the JSON value <code>null</code> (for example <code>"dates":null</code>).</p></td>
+                        </tr>
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>Comments and processing instructions in the content are discarded.</p></td>
+                        </tr>
+                     </tbody>
+                  </table>
+                  
+                  <example>
+                     <head>Conversion of a list of elements with complex content</head>
+                     <p>Consider the following XML:</p>
+                     <eg><![CDATA[<items>
+  <item nr="n1"><p>One</p></item>
+  <item nr="n2"><p>Two</p></item>
+</items>]]></eg>
+                     <p>When this is converted using list layout, the result is:</p>
+                     <eg><![CDATA["items":[
+   {"@nr":"n1", "p":"One"},
+   {"@nr":"n2", "p":"Two"}
+]   ]]></eg>
+                  </example>
+               </div4>
+               <div4 id="list-plus-json-layout">
+                  <head>List Layout with Attributes</head>
+                  
+                  <table role="data">
+                     <tbody>
+                        <tr>
+                           <th>Layout name</th>
+                           <td><p><code>list-plus</code></p></td>
+                        </tr>
+                        <tr>
+                           <th>Usage</th>
+                           <td><p>Intended for XML elements that act as wrappers for a list of child elements,
+                              all having the same element name. The wrapper element may have attributes,
+                              and the name of the child elements is retained in the JSON output.</p></td>
                         </tr>
                         <tr>
                            <th>XML example</th>
@@ -6389,7 +6491,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"dates": {"@id":"x", date": ["2023-03-20", "2023-04-12", "2023-05-30"]}</eg></td>
+                           <td><eg>"dates": {"@id":"x", "date": ["2023-03-20", "2023-04-12", "2023-05-30"]}</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6400,8 +6502,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <tr>
                            <th>Match pattern</th>
                            <td><p><code>*[*[2] and all-equal(*!node-name()) and not(text()[normalize-space()])]</code></p>
-                           <p>That is, there are at least two child elements; all child elements have the same name; and
-                           there are no text node children other than whitespace-only text nodes.</p></td>
+                              <p>That is, there are at least two child elements; all child elements have the same name; and
+                                 there are no text node children other than whitespace-only text nodes.</p></td>
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
@@ -6410,23 +6512,24 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                               as if <term>mixed</term> layout were chosen. This is fallback behavior for use
                               when this layout is chosen inappropriately.</p>
                               <p>In other cases,
-                              The content is represented by a JSON object containing one entry for each
-                              attribute in the XML element, plus a property named after the 
-                              child elements (the <term>content property</term>), whose value is an array 
+                                 The content is represented by a JSON object containing one entry for each
+                                 attribute in the XML element, plus a property named after the 
+                                 child elements (the <term>content property</term>), whose value is an array 
                                  containing the results of formatting the content
-                              of each child element according to the rules for that element.</p> 
-                             
-                              <p>If there are no children and the element is untyped (which can occur when 
-                              this layout is chosen explicitly via the options to <code>fn:xdm-to-json</code>)
-                              then the content property is omitted (since the child element name is unknown).
-                              But if the element is typed, then the content property is included and set to
-                              an empty JSON array.</p>
+                                 of each child element according to the rules for that element.</p> 
                               
-                              </td>
+                              <p>If there are no children and the element is untyped (which can occur when 
+                                 this layout is chosen explicitly via the options to <code>fn:xdm-to-json</code>)
+                                 then the content property is omitted (since the child element name is unknown).
+                                 But if the element is typed, then the content property is included and set to
+                                 an empty JSON array.</p>
+                              
+                           </td>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The content property is included and takes the JSON value <code>null</code>.</p></td>
+                           <td><p>The array is replaced by the JSON value <code>null</code>, for example
+                              <code>"dates": {"@id":"x", "date":null}</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6434,6 +6537,19 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                      </tbody>
                   </table>
+                  <example>
+                     <head>Conversion of a list of elements with complex content</head>
+                     <p>Consider the following XML:</p>
+                     <eg><![CDATA[<items format="bullets">
+  <item nr="1"><p>One</p></item>
+  <item nr="2"><p>Two</p></item>
+</items>]]></eg>
+                     <p>When this is converted using list layout, the result is:</p>
+                     <eg><![CDATA["items": {"@format":"bullets", "item": [
+   {"@nr":"1, "p":"One"},
+   {"@nr":"2, "p":"Two"}
+]   ]]></eg>
+                  </example>
                </div4>
                <div4 id="record-json-layout">
                   <head>Record Layout</head>
@@ -6547,13 +6663,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"section": {
-   "@id":"x", 
-   "#content": [
+                           <td><eg>"section": [
+      {"@id":"x"},                        
       {"head":"Introduction"},
       {"p":"Lorem ipsum"},
-      {"p":"Dolor sit amet"}]
-   }</eg></td>
+      {"p":"Dolor sit amet"}
+   ]</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6574,7 +6689,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The value of the <code>#content</code> property is present with the value <code>null</code>.</p></td>
+                           <td><p>A nilled element is indicated by a property value of <code>null</code> in place
+                              of the array, for example <code>"section": null</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6604,13 +6720,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>JSON equivalent</th>
-                           <td><eg>"para": {
-         "@id":"x", 
-         "#content": [
+                           <td><eg>"para": [
+            {"@id":"x"},
             "This is a ",
             {"i":"fine"},
-            "mess!"]
-   }</eg></td>
+            "mess!"
+   ]</eg></td>
                         </tr>
                         <tr>
                            <th>XSD conditions</th>
@@ -6623,13 +6738,14 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>The content is represented by a JSON object containing one entry for each
-                                 attribute in the XML element, plus one property named <code>"#content</code>for the content. 
-                                 The value of
-                                 the <code>"#content"</code> property is an array containing one entry for each child node, 
-                              in order. But if the element is nilled, the <code>"#content"</code> property has the JSON value 
-                              <code>null</code>.</p>
-                              <p>Child nodes are represented within this array as follows:</p>
+                           <td><p>The content is represented by a JSON array containing one entry for each
+                                 attribute in the XML element, and one entry for each child node, 
+                              in order. </p>
+                              <p>Each attribute node is represented within this array by a JSON object
+                              containing a single property, with the key representing the attribute name
+                              and the value representing the attribute value, formatted as described
+                              in <specref ref="attributes-in-json"/>.</p>
+                              <p>Child nodes are represented within the array as follows:</p>
                               <ulist>
                                  <item><p>A text node child is represented as a JSON string.</p></item>
                                  <item><p>An element node child is represented as a JSON object containing a single
@@ -6651,7 +6767,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The value of the <code>#content</code> property is present with the value <code>null</code>.</p></td>
+                           <td><p>A nilled element is indicated by a property value of <code>null</code> in place
+                              of the array, for example <code>"para": null</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Notes</th>
@@ -6714,6 +6831,175 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <note><p>This is because these attributes can appear even when the schema does not allow the element
                   to have attributes, which means that a JSON layout might be chosen that does not accommodate attributes.</p>
                </note>
+            </div3>
+            <div3 id="xdm-to-json-examples">
+               <head>Examples</head>
+               <p>The following examples show the effect of transforming some simple XML documents with default options,
+               except that <code>indent</code> is set to <code>true</code>. The actual indentation is implementation
+               dependent.</p>
+               
+               <table class="data">
+                  <thead>
+                     <tr>
+                        <th>XDM</th>
+                        <th>JSON</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><eg><![CDATA[1 to 5]]></eg></td>
+                        <td><eg><![CDATA[[1, 2, 3, 4, 5]]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[map{'x':1,'y':2}]]></eg></td>
+                        <td><eg><![CDATA[{"x":1,"y":2}]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[()]]></eg></td>
+                        <td><eg><![CDATA[null]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<a x='1' b='2'/>]]></eg></td>
+                        <td><eg><![CDATA[{ "a":{
+    "@x": "1",
+    "@b": "2"
+  } }]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<a><x>1</x><y>2</y></a>]]></eg></td>
+                        <td><eg><![CDATA[{ "a":{
+    "x": "1",
+    "y": "2"
+  } }]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<polygon> 
+   <point x='0' y='0'/> 
+   <point x='0' y='1'/> 
+   <point x='1' y='1'/> 
+   <point x='1' y='0'/>
+</polygon>]]></eg></td>
+                        <td><eg><![CDATA[{ "polygon":[
+       {"@x": "0", "@y": "0"},
+       {"@x": "0", "@y": "1"},
+       {"@x": "1", "@y": "1"},
+       {"@x": "1", "@y": "0"}
+  ] ] }]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[<cities>
+   <city id="LDN">
+      <name>London</name>
+      <size>18.2</size>
+   </city>
+   <city id="PRS">
+      <name>Paris</name>
+      <size>19.1</size>
+   </city>
+   <city id="BLN">
+      <name>Berlin</name>
+      <size>14.6</size>
+   </city>
+</cities>]]></eg></td>
+                        <td><eg><![CDATA[{ "cities":[
+    {
+      "@id": "LDN",
+      "name": "London",
+      "size": "18.2"
+    },
+    {
+      "@id": "PRS",
+      "name": "Paris",
+      "size": "19.1"
+    },
+    {
+      "@id": "BLN",
+      "name": "Berlin",
+      "size": "14.6"
+    }
+  ] }]]></eg></td>
+                     </tr>
+                     <!--<tr>
+                        <td><eg><![CDATA[]]></eg></td>
+                        <td><eg><![CDATA[]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[]]></eg></td>
+                        <td><eg><![CDATA[]]></eg></td>
+                     </tr>
+                     <tr>
+                        <td><eg><![CDATA[]]></eg></td>
+                        <td><eg><![CDATA[]]></eg></td>
+                     </tr>-->
+                  </tbody>
+               </table>
+               <p>The following more complex example demonstrates a case where the default conversion is
+               inadequate (for example, it wrongly assumes that for the third production, the order of child
+               elements is immaterial). A better result, shown below, can be achieved by
+               using a schema-aware conversion.</p>
+               <table class="data">
+                  <thead>
+                     <tr>
+                        <th>XDM</th>
+                        <th>JSON</th>
+                     </tr>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td><eg><![CDATA[<g:grammar language="xquery"
+     xmlns:g="http://www.w3.org/XPath/grammar">
+   <g:production name="FunctionBody">
+      <g:ref name="EnclosedExpr"/>
+      <g:ref name="Block"/>
+   </g:production>
+   
+   <g:production name="EnclosedExpr">
+      <g:ref name="Lbrace"/>
+      <g:ref name="Expr"/>
+      <g:optional>
+         <g:ref name="Expr"/>
+      </g:optional>
+      <g:ref name="Rbrace"/>
+   </g:production>
+   
+   <g:production name="SimpleReturnClause">
+      <g:string>return</g:string>
+      <g:ref name="ExprSingle"/>
+   </g:production>
+</g:grammar>]]></eg></td>
+                        <td><eg><![CDATA[[{ "Q{http://www.w3.org/XPath/grammar}grammar":[
+    { "@language":"xquery" },
+    { "production":[
+        { "@name":"FunctionBody" },
+        { "ref":{"@name": "EnclosedExpr"} },
+        { "ref":{"@name": "Block"} }
+      ] },
+    { "production":[
+        { "@name":"EnclosedExpr" },
+        { "ref":{"@name": "Lbrace"} },
+        { "ref":{"@name": "Expr"} },
+        { "optional":[
+            { "ref":{"@name": "Expr"} }
+          ] },
+        { "ref":{"@name": "Rbrace"} }
+      ] },
+    { "production":[
+        { "@name":"SimpleReturnClause" },
+        { "string":"return" },
+        { "ref":{"@name": "ExprSingle"} }
+      ] }
+  ] }]]]></eg></td>
+                     </tr>
+                  </tbody>
+               </table>
+               <note><p>In the above example, the schema used to validate the source document was simplified to eliminate
+               options that do not actually arise in this input instance (such as the <code>g:string</code>
+               element having attributes). This is a legitimate technique that may be useful when trying to obtain 
+               the simplest possible JSON representation.</p>
+               <p>Further improvements to the usability of the JSON output could be achieved by doing some
+               simple transformation of the XML prior to conversion. For example, the <code>name</code>
+               attribute of various productions could be converted to a child element, and 
+                  <code>&lt;ref name="x"/&gt;</code> could be transformed to <code>&lt;ref&gt;x"&lt;/ref&gt;</code>.</p></note>
             </div3>
          </div2>
          <div2 id="html">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6285,10 +6285,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                            <th>Mapping rules</th>
                            <td><p>The element is atomized and the JSON representation is obtained by applying
                               the <code>fn:xdm-to-json</code> function to the atomized value.</p>
-                           <p>If the element is untyped, the result will always be a JSON string.</p>
+                              <p>If the element is untyped, the result will always be a JSON string.</p>
                            <p>If the element has been schema-validated, the result may instead be a number,
-                           a boolean, or an array. If the element is nilled, the result will be the JSON value
-                           <code>null</code>.</p></td>
+                           a boolean, or an array. If the type annotation is a simple type with variety <code>list</code>,
+                              an empty sequence is output as <code>[]</code>.</p>
+                              </td>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
@@ -6501,8 +6502,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                               <p>The order of child elements in the XML is retained in the JSON output, though it
                               will typically be lost once the JSON is parsed by the recipient.</p>
                               
-                              <p>If the element is nilled, the JSON representation must include the
-                                 property <code>"#content":null</code>.</p></td>
+                              </td>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
@@ -6706,8 +6706,14 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <code>uri</code> is the namespace and <code>local</code> is the local part of the attribute name.</p>
                <p>The corresponding value is obtained by atomizing the attribute value and formatting the result by applying
                the rules of the <code>fn:xdm-to-json</code> function recursively. For untyped data the result will always be
-               a JSON string. For typed data the result may be a JSON number or boolean, or (if the type has variety 
-                  <code>list</code>), an array.</p>
+               a JSON string. For typed data the result may be a JSON number or boolean. If the type has variety 
+                  <code>list</code>), it is output as an array: in this case an empty value is output as <code>[]</code>
+               rather than <code>null</code>.</p>
+               <p>Attributes in the <code>xsi</code> namespace (<code>http://www.w3.org/2001/XMLSchema-instance</code>)
+                  are discarded.</p>
+               <note><p>This is because these attributes can appear even when the schema does not allow the element
+                  to have attributes, which means that a JSON layout might be chosen that does not accommodate attributes.</p>
+               </note>
             </div3>
          </div2>
          <div2 id="html">
@@ -11428,13 +11434,13 @@ ISBN 0 521 77752 6.</bibl>
                <bibl id="exslt" key="EXSLT">EXSLT: A Community Initiative to Provide Extensions to XSLT.
                   <loc href="https://exslt.github.io">https://exslt.github.io</loc>.</bibl> 
                <bibl id="functx" key="FunctX">FunctX Functions. 
-                  <loc href="http://www.functx.com/">http://www.functx.com/</loc>.</bibl> 
+                  <loc href="http://www.functx.com/">http://www.functx.com/</loc>.</bibl>
+               <bibl id="Goessner" key="Goessner">Converting Between XML and JSON. Stefan Goessner, 31 May 2006. 
+                  <loc href="https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html">https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html</loc>.
+               </bibl>
                <bibl  id="HTML40" key="HTML 4.0">HTML 4.01 Recommendation, 24 December
 1999. Available at:
 <loc href="http://www.w3.org/TR/REC-html40/">http://www.w3.org/TR/REC-html40/</loc>.
-               </bibl>
-               <bibl id="Goessner" key="Goessner">Converting Between XML and JSON. Stefan Goessner, 31 May 2006. 
-                  <loc href="https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html">https://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html</loc>.
                </bibl>
                <bibl id="ICU" key="ICU">ICU - International Components for Unicode. Available at <loc href="http://site.icu-project.org">http://site.icu-project.org</loc>.
                </bibl>


### PR DESCRIPTION
Revises the detail of the proposed json() function, including a name change to xdm-to-json().

The proposed changes give us a starting point for implementation, but I would expect there might be further tweaks to the spec once we try applying the function to real examples.