### PR TITLE
fix error in LambdaParams rule

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2391,8 +2391,8 @@ ErrorVal ::= "$" VarName
   <g:production name="LambdaParams" if="xpath40 xquery40  xslt40-patterns">
     <g:choice>
       <g:ref name="LambdaParam"/>
-      <g:string>(</g:string>
       <g:sequence>
+         <g:string>(</g:string>
          <g:optional>
            <g:ref name="LambdaParam"/>
            <g:zeroOrMore>
@@ -2400,9 +2400,9 @@ ErrorVal ::= "$" VarName
              <g:ref name="LambdaParam"/>
            </g:zeroOrMore>
          </g:optional>
+         <g:string>)</g:string>
       </g:sequence>
-      <g:string>)</g:string>
-    </g:choice>
+   </g:choice>
   </g:production>
   
   <g:production name="LambdaParam" if="xpath40 xquery40  xslt40-patterns">


### PR DESCRIPTION
fixes https://github.com/qt4cg/qtspecs/issues/531#issue-1733539612

LambdaParam | "(" | (LambdaParam ("," LambdaParam)*)? | ")" should be:
LambdaParam | ( "(" (LambdaParam ("," LambdaParam)*)? ")" )