### PR TITLE
413: Spec for CSV parsing with fn:parse-csv()

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -49,7 +49,45 @@
          <fos:field name="include-template-content" type="xs:boolean?" required="false"/>
       </fos:record>
    </fos:type>
-   
+
+   <fos:type id="common-csv-options">
+      <fos:record extensible="false">
+         <fos:field name="row-delimiter" type="xs:string" required="false"/>
+         <fos:field name="column-delimiter" type="xs:string" required="false"/>
+         <fos:field name="quote-character" type="xs:string" required="false"/>
+      </fos:record>
+   </fos:type>
+
+   <fos:type id="parse-csv-options">
+      <fos:record extensible="false">
+         <fos:field name="row-delimiter" type="xs:string" required="false"/>
+         <fos:field name="column-delimiter" type="xs:string" required="false"/>
+         <fos:field name="quote-character" type="xs:string" required="false"/>
+         <fos:field name="trim-whitespace" type="xs:boolean" required="false"/>
+      </fos:record>
+   </fos:type>
+
+   <fos:type id="parsed-csv-structure-record">
+      <fos:record extensible="false">
+         <fos:field name="columns" type="csv-columns-record" required="true"/>
+         <fos:field name="rows" type="csv-row-record*" required="true"/>
+      </fos:record>
+   </fos:type>
+
+   <fos:type id="csv-columns-record">
+      <fos:record extensible="false">
+         <fos:field name="names" type="map(xs:string, xs:integer)" required="true"/>
+         <fos:field name="fields" required="true" type="xs:string*"/>
+      </fos:record>
+   </fos:type>
+
+   <fos:type id="csv-row-record">
+      <fos:record extensible="false">
+         <fos:field name="fields" type="xs:string*" required="true"/>
+         <fos:field name="field" required="true" type="function(union(xs:integer, xs:string)) as xs:string?"/>
+      </fos:record>
+   </fos:type>
+
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="node-name" return-type="xs:QName?">
@@ -20787,6 +20825,1059 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:examples>
    </fos:function>
 
+   <fos:function name="parse-csv" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="parse-csv" return-type="array(xs:string)*">
+            <fos:arg name="csv" type="xs:string?"/>
+            <fos:arg name="options" type-ref="parse-csv-options" usage="inspection" default="map{}"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Parses CSV data supplied as a string, returning the results in the form of a sequence of arrays of strings.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The effect of the one-argument form of this function is the same as calling the
+            two-argument form with an empty map as the value of the <code>$options</code>
+            argument.</p>
+
+         <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
+            sequence of <code>xs:string</code> values. The function parses this sequence to return
+            an XDM value.</p>
+
+         <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
+            return the empty sequence as the value of the <code>body</code> field of the returned
+            map.</p>
+
+         <p>The <code>$options</code> argument can be used to control the way in which the parsing
+            takes place. The <termref
+               def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
+
+         <p>Implementations <rfc2119>must</rfc2119> treat any of CRLF, CR, or LF as a single line
+            separator, as with <code>fn:unparsed-text-lines</code>.</p>
+
+         <p>Fields are regarded as simple <code>xs:string</code> values. Implementations
+            <rfc2119>must</rfc2119> leave whitespace within a field untouched, without
+            normalizing or otherwise altering it, unless whitespace trimming is explicitly requested
+            by the user using the <code>trim-whitespace</code> option.</p>
+
+         <p>When whitespace trimming is requested, implementations <rfc2119>must</rfc2119> only
+            strip leading and trailing whitespace, this is not equivalent to calling
+            <code>fn:normalize-space()</code>.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+
+         <fos:options>
+            <fos:option key="field-delimiter">
+               <fos:meaning>The character used to delimit fields within a record. An instance of
+                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>","</fos:default>
+            </fos:option>
+            <fos:option key="record-delimiter">
+               <fos:meaning>The characters used to delimit records within the CSV string, if the
+                  default use of line separator as record separator is to be overridden.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="quote-character">
+               <fos:meaning>The character used to quote fields within the CSV string. An instance of
+                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>'"'</fos:default>
+            </fos:option>
+            <fos:option key="trim-whitespace">
+               <fos:meaning>Determines whether fields should have leading and trailing whitespace
+                  removed before being returned.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">Fields will be returned with any leading or trailing
+                     whitespace intact. Implementations <rfc2119>must</rfc2119> preserve whitespace
+                     as it occurred in the CSV string.
+                  </fos:value>
+                  <fos:value value="true">Fields will be returned with leading or trailing
+                     whitespace removed, and all non-leading or -trailing whitespace preserved.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+         </fos:options>
+
+         <p>The result of the function is a sequence of arrays-of-strings
+            <code>array(xs:string)*</code>.</p>
+         <p>A blank row is represented as an empty array.</p>
+         <p>An empty field is represented by the empty string.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
+            <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
+            fields.</p>
+         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
+            for <code>field-separator</code>, <code>record-separator</code>,
+            <code>quote-character</code> are specified and are not a single character.</p>
+         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
+            <code>field-separator</code>, <code>record-separator</code>,
+            <code>quote-character</code> are equal.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>All fields are returned as <code>xs:string</code> values.</p>
+         <p>Quoted fields in the input are returned without the quotes.</p>
+         <p>For more discussion of the returned data, see <specref ref="csv"/>.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:variable name="lf" id="escaped-lf"><![CDATA[char('x0A')]]></fos:variable>
+         <fos:variable name="cr" id="escaped-cr"><![CDATA[char('x0D')]]></fos:variable>
+         <fos:variable name="crlf" id="escaped-crlf"><![CDATA[char('x0D')||char('x0A')]]></fos:variable>
+         <fos:example>
+            <p>Handling any of the default record separators:</p>
+            <fos:test use="escaped-crlf">
+               <fos:expression>parse-csv(`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"]
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+            <fos:test use="escaped-cr">
+               <fos:expression>parse-csv(`name,city{$cr}Bob,Berlin{$cr}Alice,Aachen{$cr}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"]
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+            <fos:test use="escaped-lf">
+               <fos:expression>parse-csv(`name,city{$lf}Bob,Berlin{$lf}Alice,Aachen{$lf}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"]
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Quote handling:</p>
+            <fos:test use="escaped-crlf">
+               <fos:expression>parse-csv(`"name","city"${crlf}"Bob","Berlin"${crlf}"Alice","Aachen"${crlf}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"]
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf">
+               <fos:expression>parse-csv(`"name","city"${crlf}"Bob ""The Exemplar"" Mustermann","Berlin"${crlf}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"]
+   ['Bob "The Exemplar" Mustermann', "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Non-default record- and field-separators:</p>
+            <fos:test>
+               <fos:expression>parse-csv("name;city§Bob;Berlin§Alice;Aachen", map{"record-separator": "§", "field-separator": ";"})</fos:expression>
+               <fos:result>(
+   ["name", "city"]
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Non-default quote character:</p>
+            <fos:test use="escaped-crlf">
+               <fos:expression>parse-csv(`|name|,|city|${crlf}|Bob|,|Berlin|${crlf}`, map{"quote-character": "|"})</fos:expression>
+               <fos:result>(
+   ["name", "city"]
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Trimming whitespace in fields:</p>
+            <fos:test use="escaped-crlf">
+               <fos:expression xml:space="preserve">parse-csv(`name  ,city  ${crlf}Bob   ,Berlin${crlf}Alice ,Aachen${crlf}`, map{"trim-whitespace: true()})</fos:expression>
+               <fos:result>(
+   ["name", "city"]
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+
+   <fos:function name="csv-to-xdm" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="csv-to-xdm" return-type-ref="parsed-csv-structure-record">
+            <fos:arg name="csv" type="xs:string?"/>
+            <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Parses CSV data supplied as a string, returning the results in the form of a
+            <code>parsed-csv-structure-record</code> record containing information about the
+            column structure of the data, as well as the data itself as a sequence of
+            <code>csv-row-record</code> records.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The effect of the one-argument form of this function is the same as calling the
+            two-argument form with an empty map as the value of the <code>$options</code>
+            argument.</p>
+
+         <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
+            sequence of <code>xs:string</code> values. The function parses this sequence using
+            <code>fn:parse-csv</code>, and then processes its result to return an XDM value.</p>
+
+         <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
+            return a <code>parsed-csv-structure-record</code> whose <code>rows</code> entry is the empty sequence.</p>
+
+         <p>If <code>$csv</code> is the empty sequence, but column name extraction has been
+            requested, or explicit column names have been supplied, then the
+            <code>parsed-csv-structure-record</code> returned by implementations
+            <rfc2119>must</rfc2119> have a <code>rows</code> entry whose value is the empty
+            sequence.</p>
+
+         <p>The <code>$options</code> argument can be used to control the way in which the parsing
+            takes place. The <termref
+               def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
+
+         <p>Handling of delimiters, and whitespace trimming, are handled using
+            <code>fn:parse-csv</code>, and the options controlling their use are defined
+            there.</p>
+
+         <p>If the <code>headers</code> option is true, implementations <rfc2119>must</rfc2119>
+            exclude the first record from the returned map’s <code>body</code> key, and return it as
+            the value of the returned map’s <code>headers-record</code> key.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         <fos:options>
+            <fos:option key="field-delimiter">
+               <fos:meaning>The character used to delimit fields within a record. An instance of
+                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>","</fos:default>
+            </fos:option>
+            <fos:option key="record-delimiter">
+               <fos:meaning>The characters used to delimit records within the CSV string, if the
+                  default use of line separator as record separator is to be overridden.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="quote-character">
+               <fos:meaning>The character used to quote fields within the CSV string. An instance of
+                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>'"'</fos:default>
+            </fos:option>
+            <fos:option key="trim-whitespace">
+               <fos:meaning>Determines whether fields should have leading and trailing whitespace
+                  removed before being returned.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">Fields will be returned with any leading or trailing
+                     whitespace intact. Implementations <rfc2119>must</rfc2119> preserve whitespace
+                     as it occurred in the CSV string.
+                  </fos:value>
+                  <fos:value value="true">Fields will be returned with leading or trailing
+                     whitespace removed, and all non-leading or -trailing whitespace preserved.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="column-names">
+               <fos:meaning>Determines whether the first row of the CSV should be treated as a list
+                  of column names and returned as a <code>csv-columns-record</code> in the
+                  <code>columns</code> entry of the returned map.</fos:meaning>
+               <fos:type>union(xs:boolean, map(xs:string, xs:integer))</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="true">A <code>csv-columns-record</code> is constructed using the
+                     first row of the CSV data and returned as the <code>header</code> entry of the
+                     <code>parsed-csv-structure-record</code>. The row’s fields are transformed
+                     into a map of the form <code>{ "Column name": column-number }</code> for the
+                     <code>names</code> entry of the <code>csv-columns-record</code>, and the
+                     fields of the row are returned as a sequence of strings
+                     (<code>xs:string*</code>) for the <code>fields</code> entry. Implmentations
+                     <rfc2119>must</rfc2119> exclude the first row from the <code>rows</code>
+                     entry of the returned <code>parsed-csv-structure-record</code>.</fos:value>
+                  <fos:value value="false">Implementations <rfc2119>must</rfc2119> return an empty
+                     <code>csv-columns-record</code>, equivalent to the literal map <code>map {
+                     names: map {}, fields: () }</code>, in the <code>columns</code> entry of
+                     the returned <code>parsed-csv-structure-record</code>. Implementations
+                     <rfc2119>must not</rfc2119> exclude the first row from the <code>rows</code>
+                     entry of the <code>parsed-csv-structure-record</code>.</fos:value>
+                  <fos:value value="map(xs:integer, xs:string)">A <code>csv-columns-record</code> is
+                     constructed using the supplied map and returned as the <code>header</code>
+                     entry of the <code>parsed-csv-structure-record</code>. The supplied map is used
+                     as the <code>names</code> entry, and a sequence of strings for the
+                     <code>fields</code> is constructed, filling in blank columns with the empty
+                     string. and the fields of the row are returned as the <code>fields</code>
+                     entry. Implementations <rfc2119>must not</rfc2119> exclude the first row from
+                     the <code>rows</code> entry of the <code>parsed-csv-structure-record</code>.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="number-of-columns">
+               <fos:meaning>Specifies how many columns to return.</fos:meaning>
+               <fos:type>union(enum("all", "first-row"), xs:integer)</fos:type>
+               <fos:default>"all"</fos:default>
+               <fos:values>
+                  <fos:value value="'all'">All fields from all rows
+                     <rfc2119>must</rfc2119> be returned, without being padded or truncated,
+                     regardless of whether rows have varying numbers of fields, or of how many
+                     fields they have.</fos:value>
+                  <fos:value value="'first-row'">The number of fields in the first row is counted,
+                     and processing proceeds as if that integer had been supplied as the value for
+                     this option.</fos:value>
+                  <fos:value value="xs:integer">The number of columns is set to this value. Rows
+                     with more fields than the supplied value are truncated by discarding the extra
+                     fields. as if calling <code>fn:subsequence(R, 1, I)</code>, given the row’s
+                     sequence of fields in <var>R</var>, and the supplied value in <var>I</var>. If
+                     a row has fewer fields than the supplied value it is padded by appending empty
+                     string values until it contains the specified number of fields.</fos:value>
+               </fos:values>
+            </fos:option>
+         </fos:options>
+
+         <p>If column names were extracted from the first row of the CSV, when there are duplicate
+            column names, implementations <rfc2119>must</rfc2119> include only the first occurrence
+            in the <code>names</code> entry of the <code>csv-columns-record</code>, ignoring
+            subsequent entries. Any fields in the first record whose value is the empty string
+            <rfc2119>must</rfc2119> also be omitted.</p>
+
+         <p>The result of the function is a <code>parsed-csv-structure-record</code>, a map with
+            string keys containing two entries, <code>columns</code>, and <code>rows</code>.</p>
+         <olist>
+            <item>
+               <p>The entry with key <code>"columns"</code> holds a <code>csv-columns-record</code>
+                  record. If column names have been extracted, or supplied, then the record will
+                  have a <code>names</code> entry whose value is a map of column-name to
+                  column-number, <code>map(xs:integer, xs:string)</code>. The record’s
+                  <code>fields</code> entry will contains the column names as a sequence of
+                  strings, <code>xs:string*</code>, replicating the row they were taken from.</p>
+
+               <p>If column names were not extracted or supplied, then the
+                  <code>csv-columns-record</code> will contain a <code>names</code> entry whose
+                  value is an empty map, and a <code>fields</code> entry whose value is the empty
+                  sequence.</p>
+            </item>
+            <item>
+               <p>The entry with key <code>"rows"</code> holds the records of the CSV as a sequence
+                  of row records, <code>csv-row-record*</code>. If there is no data in the CSV, this
+                  will be the empty sequence.</p>
+
+               <p>Each record in the <code>rows</code> sequence contains a <code>fields</code>
+                  entry, containing the row’s fields as a sequence of strings,
+                  <code>xs:string*</code>, and a <code>field</code> entry containing an arity-one
+                  function. The function takes a string or integer key <var>K</var> as input, and
+                  returns the field in <var>fields</var> that corresponds to the position
+                  <var>K</var>, if <var>K</var> is an <code>xs:integer</code>, or the position
+                  obtained by looking up <var>K</var> in the <code>names</code> map if <var>K</var>
+                  is an <code>xs:string</code>.</p>
+
+               <p>The properties of this function are as follows:</p>
+               <ulist>
+                  <item>
+                     <p>name: absent</p>
+                  </item>
+                  <item>
+                     <p>parameter names: (<var>$key</var>)</p>
+                  </item>
+                  <item>
+                     <p>signature: <code>(union(xs:integer, xs:string)) => xs:string?</code></p>
+                  </item>
+                  <item>
+                     <p>non-local variable bindings: none</p>
+                  </item>
+                  <item>
+                     <p>implementation: implementation-dependent</p>
+                  </item>
+                  <item>
+                     <p>errors: A dynamic error <errorref class="CV" code="0004"/> occurs if the
+                        supplied <var>$key</var> is a string and does not occur in the map of column
+                        names.</p>
+                  </item>
+               </ulist>
+
+               <p>This function behaves identically to <code>fn:csv-fetch-field-by-column</code>
+                  would had the <code>header</code> entry of the containing
+                  <code>parsed-csv-structure-record</code> and the <code>fields</code> entry of
+                  this <code>csv-row-record</code> been supplied as its first two arguments, and
+                  <var>$key</var> as its last. See the definition of
+                  <code>fn:csv-fetch-field-by-column</code> for more details</p>
+            </item>
+         </olist>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
+            <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
+            fields.</p>
+         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
+            for <code>field-separator</code>, <code>record-separator</code>,
+            <code>quote-character</code> are specified and are not a single character.</p>
+         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
+            <code>field-separator</code>, <code>record-separator</code>,
+            <code>quote-character</code> are equal.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>All fields are returned as <code>xs:string</code> values.</p>
+         <p>Quoted fields in the input are returned without the quotes.</p>
+         <p>For more discussion of the returned data, see <specref ref="csv"/>.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('x0D')||char('x0A')]]></fos:variable>
+         <fos:variable name="csv-string" id="csv-string">`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`</fos:variable>
+         <fos:variable name="options" id="non-default-delims">map { "record-separator": "§", "field-separator": ";", "quote-character": "|" }</fos:variable>
+         <fos:variable name="non-std-csv" id="non-standard-csv-string">`|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|`</fos:variable>
+         <fos:variable name="trim-opts" id="trim-whitespace-options">map { "trim-whitespace": true() }</fos:variable>
+         <fos:example>
+            <p>With defaults for delimiters and quotes, and default column extraction (false):</p>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>map:keys(csv-to-xdm($csv-string))</fos:expression>
+               <fos:result>("header", "rows")</fos:result>
+            </fos:test>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>csv-to-xdm($csv-string)?columns</fos:expression>
+               <fos:result>map {
+  "names": map {},
+  "fields": (),
+}</fos:result>
+            </fos:test>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>count(csv-to-xdm($csv-string)?rows)</fos:expression>
+               <fos:result>3</fos:result>
+            </fos:test>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>csv-to-xdm($csv-string)?rows[1]?field("name")</fos:expression>
+               <fos:error-result error-code="CV"/>
+            </fos:test>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>csv-to-xdm($csv-string)?rows[1]?field(2)</fos:expression>
+               <fos:result>"city"</fos:result>
+            </fos:test>
+            <p>With defaults for delimiters and quotes, and <code>columns: true()</code> set:</p>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>csv-to-xdm($csv-string, map {"columns": true()})?columns</fos:expression>
+               <fos:result>map {
+  "names": map { "name": 1, "city": 2 },
+  "fields": ("name", "city"),
+}</fos:result>
+            </fos:test>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>count(csv-to-xdm($csv-string, map {"columns": true()})?rows)</fos:expression>
+               <fos:result>2</fos:result>
+            </fos:test>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>csv-to-xdm($csv-string), map {"columns": true()}?rows[1]?fields</fos:expression>
+               <fos:result>("Bob", "Berlin")</fos:result>
+            </fos:test>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>csv-to-xdm($csv-string, map {"columns": true()})?rows[1]?field("name")</fos:expression>
+               <fos:result>"Bob"</fos:result>
+            </fos:test>
+            <fos:test use="csv-string escaped-crlf-2">
+               <fos:expression>csv-to-xdm($csv-string, map {"columns": true()})?rows[1]?field(2)</fos:expression>
+               <fos:result>"Berlin"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Non-default record- and field-delimiters, non-default quotes:</p>
+            <fos:test use="non-default-delims non-standard-csv-string">
+               <fos:expression>map:keys(csv-to-xdm($non-std-csv, $options))</fos:expression>
+               <fos:result>("header", "rows")</fos:result>
+            </fos:test>
+            <fos:test use="non-default-delims non-standard-csv-string">
+               <fos:expression>csv-to-xdm($non-std-csv, $options)?columns</fos:expression>
+               <fos:result>map {
+                  "names": map {},
+                  "fields": (),
+                  }</fos:result>
+            </fos:test>
+            <fos:test use="non-default-delims non-standard-csv-string">
+               <fos:expression>count(csv-to-xdm($non-std-csv, $options)?rows)</fos:expression>
+               <fos:result>3</fos:result>
+            </fos:test>
+            <fos:test use="non-default-delims non-standard-csv-string">
+               <fos:expression>csv-to-xdm($non-std-csv, $options)?rows[3]?field(1)</fos:expression>
+               <fos:result>"Alice"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Trimming whitespace in fields:</p>
+            <fos:test use="escaped-crlf-2 trim-whitespace-options">
+               <fos:expression xml:space="preserve">csv-to-xdm(`name  ,city  ${crlf}Bob   ,Berlin${crlf}Alice ,Aachen${crlf}`, $trim-opts)?rows?fields</fos:expression>
+               <fos:result>("name", "city", "Bob", "Berlin", "Alice", "Aachen")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string">`date,name,city,amount,currency,original amount,note{$crlf}2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}2023-07-20,Alice,Aachen,15.00{$crlf}2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`</fos:variable>
+         <fos:example>
+            <p>Filtering columns</p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "columns": true(), "filter-columns": (2,1,4) })?columns?fields</fos:expression>
+               <fos:result>("name","date","amount")</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "columns": true(), "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["Bob","2023-07-19","10.00"],
+   ["Alice","2023-07-20","15.00"],
+   ["Charlie","2023-07-20","15.00"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns, using <code>"all"</code> (the default)</p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": "all" })?columns?fields</fos:expression>
+               <fos:result>("date","name","city","amount","currency","original amount","note")</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": "all" })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
+   ["2023-07-20","Alice","Aachen","15.00"],
+   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake","not a lie"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns using <code>"first-row"</code></p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": "first-row" })?columns?fields</fos:expression>
+               <fos:result>("date","name","city","amount","currency","original amount","note")</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": "first-row" })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
+   ["2023-07-20","Alice","Aachen","15.00","","",""],
+   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns with a number</p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": 6 })?columns?fields</fos:expression>
+               <fos:result>("date","name","city","amount","currency","original amount")</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
+   ["2023-07-20","Alice","Aachen","15.00","",""],
+   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+
+   <fos:function name="csv-to-xml" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="csv-to-xml" return-type="element(fn:csv)">
+            <fos:arg name="csv" type="xs:string?"/>
+            <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Parses CSV data supplied as a string, returning the results as an XML document, as described by
+            <specref ref="csv-represent-as-xml"/>.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The effect of the one-argument form of this function is the same as calling the
+            two-argument form with an empty map as the value of the <code>$options</code>
+            argument.</p>
+
+         <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
+            sequence of <code>xs:string</code> values. The function parses this sequence using
+            <code>fn:parse-csv</code>, and then processes its result to return an XML document.</p>
+
+         <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
+            return a <code><![CDATA[<fn:csv>]]></code> whose <code><![CDATA[<fn:rows>]]></code> element
+            is empty.</p>
+
+         <p>If <code>$csv</code> is the empty sequence, but column name extraction has been
+            requested, but explicit column names have not been supplied, then the implementation
+            <rfc2119>must</rfc2119> return a <code><![CDATA[<fn:csv>]]></code> element whose
+            <code><![CDATA[<fn:header>]]></code> element is empty.</p>
+
+         <p>If <code>$csv</code> is the empty sequence, but explicit column names have been
+            supplied, then the implementation <rfc2119>must</rfc2119> return a
+            <code><![CDATA[<fn:csv>]]></code> element whose <code><![CDATA[<fn:header>]]></code>
+            element contains the appropriate <code><![CDATA[<fn:column>]]></code> elements.</p>
+
+         <p>The <code>$options</code> argument can be used to control the way in which the parsing
+            takes place. The <termref
+               def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
+
+         <p>Handling of delimiters, and whitespace trimming, are handled using
+            <code>fn:parse-csv</code>, and the options controlling their use are defined
+            there.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+
+         <fos:options>
+            <fos:option key="field-delimiter">
+               <fos:meaning>The character used to delimit fields within a record. An instance of
+                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>","</fos:default>
+            </fos:option>
+            <fos:option key="record-delimiter">
+               <fos:meaning>The characters used to delimit records within the CSV string, if the
+                  default use of line separator as record separator is to be overridden.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="quote-character">
+               <fos:meaning>The character used to quote fields within the CSV string. An instance of
+                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>'"'</fos:default>
+            </fos:option>
+            <fos:option key="trim-whitespace">
+               <fos:meaning>Determines whether fields should have leading and trailing whitespace
+                  removed before being returned.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">Fields will be returned with any leading or trailing
+                     whitespace intact. Implementations <rfc2119>must</rfc2119> preserve whitespace
+                     as it occurred in the CSV string.
+                  </fos:value>
+                  <fos:value value="true">Fields will be returned with leading or trailing
+                     whitespace removed, and all non-leading or -trailing whitespace preserved.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="column-names">
+               <fos:meaning>Determines whether the first row of the CSV should be treated as a list
+                  of column headers and returned as a <code>csv-columns-record</code> in the
+                  <code>header</code> entry of the returned map.</fos:meaning>
+               <fos:type>union(xs:boolean, map(xs:integer, xs:string))</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="true">The <code><![CDATA[<header>]]></code> element is populated
+                     with <code><![CDATA[<column>]]></code> elements constructed using the values
+                     from the first row of the CSV data. Implmentations <rfc2119>must</rfc2119>
+                     exclude the first row from the <code><![CDATA[<rows>]]></code>
+                     element.</fos:value>
+                  <fos:value value="false">Implementations <rfc2119>must not</rfc2119> include a
+                     <code><![CDATA[<header>]]></code> element in the output.</fos:value>
+                  <fos:value value="map(xs:integer, xs:string)">The supplied map is used to
+                     construct a sequence of <code><![CDATA[<column>]]></code> elements to populate
+                     the <code><![CDATA[<header>]]></code> element. The <code>xs:integer</code>
+                     denotes the column number, and the <code>xs:string</code> the column name. Gaps
+                     in the integer sequence of column numbers are filled with empty
+                     <code><![CDATA[<column>]]></code> elements. Implementations <rfc2119>must
+                     not</rfc2119> exclude the first row from the <code><![CDATA[<rows>]]></code>
+                     element.</fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="filter-columns">
+               <fos:meaning>A sequence indicating which fields to return and in which order. If this
+                  option is missing or the empty sequence, all fields are returned in their natural
+                  order. Items in the sequence are treated as the index of the column to return. In
+                  the returned data, only fields from the specified columnms are returned, and in
+                  the order specified.</fos:meaning>
+               <fos:type>xs:integer*</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="number-of-columns">
+               <fos:meaning>Specifies how many columns to return.</fos:meaning>
+               <fos:type>union(enum("all", "first-row"), xs:integer)</fos:type>
+               <fos:default>"all"</fos:default>
+               <fos:values>
+                  <fos:value value="'all'">All fields from all rows
+                     <rfc2119>must</rfc2119> be returned, without being padded or truncated,
+                     regardless of whether rows have varying numbers of fields, or of how many
+                     fields they have.</fos:value>
+                  <fos:value value="'first-row'">The number of fields in the first row is counted,
+                     and processing proceeds as if that integer had been supplied as the value for
+                     this option.</fos:value>
+                  <fos:value value="xs:integer">The number of columns is set to this value. Rows
+                     with more fields than the supplied value are truncated by discarding the extra
+                     fields. as if calling <code>fn:subsequence(R, 1, I)</code>, given the row’s
+                     sequence of fields in <var>R</var>, and the supplied value in <var>I</var>. If
+                     a row has fewer fields than the supplied value it is padded by appending empty
+                     string values until it contains the specified number of fields.</fos:value>
+               </fos:values>
+            </fos:option>
+         </fos:options>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
+            <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
+            fields.</p>
+         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
+            for <code>field-separator</code>, <code>record-separator</code>,
+            <code>quote-character</code> are specified and are not a single character.</p>
+         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
+            <code>field-separator</code>, <code>record-separator</code>,
+            <code>quote-character</code> are equal.</p>
+      </fos:errors>
+      <fos:examples>
+         <fos:variable name="crlf" id="escaped-crlf-3"><![CDATA[char('x0D')||char('x0A')]]></fos:variable>
+         <fos:variable name="csv-string" id="csv-string-2">`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`</fos:variable>
+         <fos:example>
+            <p>An empty CSV with default column extraction (false):</p>
+            <fos:test>
+               <fos:expression>csv-to-xml("")</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:rows/>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>An empty CSV with column extraction:</p>
+            <fos:test>
+               <fos:expression>csv-to-xml("", map { "columns": true() })</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:header/>
+   <fn:rows/>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>An empty CSV with explicit column names:</p>
+            <fos:test>
+               <fos:expression>csv-to-xml("", map { "columns": map { "name": 1, "city": 3 })</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:header>
+      <fn:column>name</fn:field>
+      <fn:column/>
+      <fn:column>city</fn:field>
+   </fn:header>
+   <fn:rows/>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>With defaults for delimiters and quotes, and column extraction:</p>
+            <fos:test use="escaped-crlf-3 csv-string-2">
+               <fos:expression>csv-to-xml($csv-string, map { "columns": true() })</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:header>
+      <fn:column>name</fn:field>
+      <fn:column>city</fn:field>
+   </fn:header>
+   <fn:rows>
+      <fn:row>
+         <fn:field column="name">Bob</fn:field>
+         <fn:field column="city">Berlin</fn:field>
+      </fn:row>
+      <fn:row>
+         <fn:field column="name">Alice</fn:field>
+         <fn:field column="city">Aachen</fn:field>
+      </fn:row>
+   </fn:rows>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>With defaults for delimiters and quotes, and column extraction:</p>
+            <fos:test use="escaped-crlf-3 csv-string-2">
+               <fos:expression>csv-to-xml($csv-string, map { "columns": true() })</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:header>
+      <fn:field>name</fn:field>
+      <fn:field>city</fn:field>
+   </fn:header>
+   <fn:rows>
+      <fn:row>
+         <fn:field column="name">Bob</fn:field>
+         <fn:field column="city">Berlin</fn:field>
+      </fn:row>
+      <fn:row>
+         <fn:field column="name">Alice</fn:field>
+         <fn:field column="city">Aachen</fn:field>
+      </fn:row>
+   </fn:rows>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string-2">`date,name,city,amount,currency,original amount,note{$crlf}2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}2023-07-20,Alice,Aachen,15.00{$crlf}2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`</fos:variable>
+         <fos:example>
+            <p>Filtering columns</p>
+            <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
+               <fos:expression>csv-to-xml($csv-string, map { "columns": true(), "filter-columns": (2,1,4) })</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:header>
+      <fn:field>name</fn:field>
+      <fn:field>date</fn:field>
+      <fn:field>amount</fn:field>
+   </fn:header>
+   <fn:rows>
+      <fn:row>
+         <fn:field column="name">Bob</fn:field>
+         <fn:field column="date">2023-07-19</fn:field>
+         <fn:field column="amount">10.00</fn:field>
+      </fn:row>
+      <fn:row>
+         <fn:field column="name">Alice</fn:field>
+         <fn:field column="date">2023-07-20</fn:field>
+         <fn:field column="amount">15.00</fn:field>
+      </fn:row>
+      <fn:row>
+         <fn:field column="name">Charlie</fn:field>
+         <fn:field column="date">2023-07-20</fn:field>
+         <fn:field column="amount">15.00</fn:field>
+      </fn:row>
+   </fn:rows>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns, using "all" (the default)</p>
+            <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
+               <fos:expression>csv-to-xml($csv-uneven-cols, map { "columns": true(), "number-of-columns": "all" })</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:header>
+      <fn:field>date</fn:field>
+      <fn:field>name</fn:field>
+      <fn:field>city</fn:field>
+      <fn:field>amount</fn:field>
+      <fn:field>currency</fn:field>
+      <fn:field>original amount</fn:field>
+      <fn:field>note</fn:field>
+   </fn:header>
+   <fn:rows>
+      <fn:row>
+         <fn:field column="date">2023-07-19</fn:field>
+         <fn:field column="name">Bob</fn:field>
+         <fn:field column="city">Berlin</fn:field>
+         <fn:field column="amount">10.00</fn:field>
+         <fn:field column="currency">USD</fn:field>
+         <fn:field column="original amount">13.99</fn:field>
+      </fn:row>
+      <fn:row>
+         <fn:field column="date">2023-07-20</fn:field>
+         <fn:field column="name">Alice</fn:field>
+         <fn:field column="city">Aachen</fn:field>
+         <fn:field column="amount">15.00</fn:field>
+      </fn:row>
+      <fn:row>
+         <fn:field column="date">2023-07-20</fn:field>
+         <fn:field column="name">Charlie</fn:field>
+         <fn:field column="city">Celle</fn:field>
+         <fn:field column="amount">15.00</fn:field>
+         <fn:field column="currency">GBP</fn:field>
+         <fn:field column="original amount">11.99</fn:field>
+         <fn:field column="note">cake</fn:field>
+         <fn:field>not a lie</fn:field>
+      </fn:row>
+   </fn:rows>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns using <code>"first-row"</code></p>
+            <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
+               <fos:expression>csv-to-xml($csv-uneven-cols, map { "columns": true(), "number-of-columns": "first-row" })</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:header>
+      <fn:field>date</fn:field>
+      <fn:field>name</fn:field>
+      <fn:field>city</fn:field>
+      <fn:field>amount</fn:field>
+      <fn:field>currency</fn:field>
+      <fn:field>original amount</fn:field>
+      <fn:field>note</fn:field>
+   </fn:header>
+   <fn:rows>
+      <fn:row>
+         <fn:field column="date">2023-07-19</fn:field>
+         <fn:field column="name">Bob</fn:field>
+         <fn:field column="city">Berlin</fn:field>
+         <fn:field column="amount">10.00</fn:field>
+         <fn:field column="currency">USD</fn:field>
+         <fn:field column="original amount">13.99</fn:field>
+         <fn:field column="note"/>
+      </fn:row>
+      <fn:row>
+         <fn:field column="date">2023-07-20</fn:field>
+         <fn:field column="name">Alice</fn:field>
+         <fn:field column="city">Aachen</fn:field>
+         <fn:field column="amount">15.00</fn:field>
+         <fn:field column="currency"/>
+         <fn:field column="original amount"/>
+         <fn:field column="note"/>
+      </fn:row>
+      <fn:row>
+         <fn:field column="date">2023-07-20</fn:field>
+         <fn:field column="name">Charlie</fn:field>
+         <fn:field column="city">Celle</fn:field>
+         <fn:field column="amount">15.00</fn:field>
+         <fn:field column="currency">GBP</fn:field>
+         <fn:field column="original amount">11.99</fn:field>
+         <fn:field column="note">cake</fn:field>
+      </fn:row>
+   </fn:rows>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns with a number</p>
+            <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
+               <fos:expression>csv-to-xml($csv-uneven-cols, map { "columns": true(), "number-of-columns": 6 })</fos:expression>
+               <fos:result><![CDATA[
+<fn:csv>
+   <fn:header>
+      <fn:field>date</fn:field>
+      <fn:field>name</fn:field>
+      <fn:field>city</fn:field>
+      <fn:field>amount</fn:field>
+      <fn:field>currency</fn:field>
+      <fn:field>original amount</fn:field>
+   </fn:header>
+   <fn:rows>
+      <fn:row>
+         <fn:field column="date">2023-07-19</fn:field>
+         <fn:field column="name">Bob</fn:field>
+         <fn:field column="city">Berlin</fn:field>
+         <fn:field column="amount">10.00</fn:field>
+         <fn:field column="currency">USD</fn:field>
+         <fn:field column="original amount">13.99</fn:field>
+      </fn:row>
+      <fn:row>
+         <fn:field column="date">2023-07-20</fn:field>
+         <fn:field column="name">Alice</fn:field>
+         <fn:field column="city">Aachen</fn:field>
+         <fn:field column="amount">15.00</fn:field>
+         <fn:field column="currency"/>
+         <fn:field column="original amount"/>
+      </fn:row>
+      <fn:row>
+         <fn:field column="date">2023-07-20</fn:field>
+         <fn:field column="name">Charlie</fn:field>
+         <fn:field column="city">Celle</fn:field>
+         <fn:field column="amount">15.00</fn:field>
+         <fn:field column="currency">GBP</fn:field>
+         <fn:field column="original amount">11.99</fn:field>
+      </fn:row>
+   </fn:rows>
+</fn:csv>
+]]></fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+
+   <fos:function name="csv-fetch-field-by-column" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="csv-fetch-field-by-column" return-type="xs:string">
+            <fos:arg name="columns" type-ref="csv-columns-record"/>
+            <fos:arg name="fields" type="xs:string*" usage="inspection"/>
+            <fos:arg name="key" type="union(xs:integer, xs:string)" usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Fetches a field from a parsed CSV row by name or position.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The first argument is a <code>csv-columns-record</code>, as provided in the
+            <code>header</code> entry of the <code>parsed-csv-structure-record</code> returned by
+            <code>fn:csv-to-xdm</code>.</p>
+
+         <p>The second argument is the row whose fields are being fetched, represented as a sequence
+            of strings as would be provided by the <code>fields</code> entry of a
+            <code>csv-row-record</code> returned by <code>fn:csv-to-xdm</code>.</p>
+
+         <p>The final argument is the key to use for the lookup, supplied as either an
+            <code>xs:string</code> (the column name) or <code>xs:integer</code> (the column
+            position).</p>
+
+         <p>When the argument is a string, if the string is missing from the keys of the map
+            contained in the <code>names</code> entry of the <code>$columns</code> argument’s
+            <code>csv-columns-record</code>, then implementations <rfc2119>must</rfc2119> raise
+            an <errorref class="CV" code="0004"/>.</p>
+
+         <p>When the argument is an integer, if the integer position is outside the bounds of the
+            <code>$fields</code> sequence (i.e. is greater than the size of the sequence), then
+            implementations <rfc2119>must</rfc2119> return the empty string.</p>
+
+         <p>The function returns the field in the sequence <code>$fields</code> at the position in
+            the sequence either explicitly provided (when <code>$key</code> is an
+            <code>xs:integer</code>), or looked up from the map of name to position in the
+            <code>csv-columns-record</code> provided in <code>$columns</code>.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error <errorref class="CV" code="0004"/> occurs if the value of
+            <code>$key</code> is an <code>xs:string</code> but is not a member of the keys of the
+            map contained in the <code>names</code> entry of the <code>csv-columns-record</code> in
+            <code>$header</code>. fields.</p>
+      </fos:errors>
+      <fos:examples>
+         <fos:variable name="columns" id="csv-column-fetch-columns">map {
+   "names": map { "name": 1, "city": 2 },
+   "fields: ("name", "city")
+}</fos:variable>
+         <fos:variable name="fields" id="csv-column-fetch-fields">("Bob", "Berlin")</fos:variable>
+         <fos:example>
+            <p>With a string key:</p>
+            <fos:test use="csv-column-fetch-columns csv-column-fetch-fields">
+               <fos:expression>csv-fetch-field-by-column($columns, $fields, "name")</fos:expression>
+               <fos:result>"Bob"</fos:result>
+            </fos:test>
+            <fos:test use="csv-column-fetch-columns csv-column-fetch-fields">
+               <fos:expression>csv-fetch-field-by-column($columns, $fields, "amount")</fos:expression>
+               <fos:error-result error-code="FOCV0004"/>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>With an integer key</p>
+            <fos:test use="csv-column-fetch-columns csv-column-fetch-fields">
+               <fos:expression>csv-fetch-field-by-column($columns, $fields, 2)</fos:expression>
+               <fos:result>"Berlin"</fos:result>
+            </fos:test>
+            <fos:test use="csv-column-fetch-columns csv-column-fetch-fields">
+               <fos:expression>csv-fetch-field-by-column($columns, $fields, 3)</fos:expression>
+               <fos:result>""</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+
    <fos:function name="parse-json" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-json" return-type="item()?">
@@ -21351,7 +22442,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                         under “element nodes”, above.</p>
                      <p>Free-standing attribute nodes are output as JSON objects with properties
                      <code>#attribute</code> set to the local name of the attribute, <code>#prefix</code>
-                     (if non-empty) set to the prefix of the attribute's name, <code>#namespace</code>
+                     (if non-empty) set to the prefix of the attribute’s name, <code>#namespace</code>
                      (if non-empty) set to the namespace URI, and <code>#value</code> set to
                         the result of atomizing the attribute value and applying the
                         <code>fn:json</code> function to the result.</p>
@@ -21406,7 +22497,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   <item><p><code>#result</code> whose value is a string 
                      identifying the type of the function result, using the same conventions as for <code>#arguments</code>.</p></item>
                   <item><p>Optionally at implementer discretion, <code>#implementation</code> whose value is a string 
-                     representing the function's implementation in implementation-defined format.</p></item>
+                     representing the function’s implementation in implementation-defined format.</p></item>
                </ulist>
                <p>Strings are escaped as follows:</p>
                <olist>
@@ -23226,8 +24317,8 @@ return array:sort($in, $SWEDISH)
                <fos:meaning>Values for external variables defined in the library module. Values <rfc2119>must</rfc2119> be supplied
                   for external variables that have no default value, and <rfc2119>may</rfc2119> be supplied for external variables
                   that do have a default value. The supplied value <rfc2119>must</rfc2119> conform to the required type of the variable, without conversion.
-                  The map contains one entry for each external variable: the key is the variable's name, and the associated value is
-                  the variable's value. The <termref
+                  The map contains one entry for each external variable: the key is the variable’s name, and the associated value is
+                  the variable’s value. The <termref
                      def="option-parameter-conventions"
                   >option parameter conventions</termref> do not apply
                   to this contained map.</fos:meaning>

--- a/specifications/xpath-functions-40/src/schema-for-csv.xsd
+++ b/specifications/xpath-functions-40/src/schema-for-csv.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    targetNamespace="http://www.w3.org/2005/xpath-functions"
+    xmlns:csv="http://www.w3.org/2005/xpath-functions">
+
+    <!--
+     * This is a schema for the XML representation of CSV used as the target for the
+     * function fn:csv-to-xml()
+     *
+     * The schema is made available under the terms of the W3C software notice and license
+     * at http://www.w3.org/Consortium/Legal/copyright-software-19980720
+     *
+    -->
+
+    <xs:element name="csv" type="csv:csvType"/>
+
+    <xs:element name="columns" type="csv:columnsType"/>
+
+    <xs:element name="rows" type="csv:rowsType"/>
+
+    <xs:element name="column" type="csv:columnFieldType"/>
+
+    <xs:element name="row" type="csv:rowType"/>
+
+    <xs:element name="field" type="csv:fieldType"/>
+
+    <xs:complexType name="csvType">
+        <xs:sequence>
+            <xs:element ref="csv:columns" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="csv:rows" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="columnsType">
+        <xs:sequence>
+            <xs:element ref="csv:column" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="rowsType">
+        <xs:sequence>
+            <xs:element ref="csv:row" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="rowType">
+        <xs:sequence>
+            <xs:element ref="csv:field"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="columnFieldType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:anyAttribute processContents="skip" namespace="##other"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="fieldType">
+        <xs:simpleContent>
+            <xs:extension base="csv:columnFieldType">
+                  <xs:attribute name="column" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+</xs:schema>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5705,6 +5705,26 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <head><?function fn:parse-html?></head>
             </div3>
          </div2>
+         <div2 id="csv-functions">
+            <head>Functions on CSV Data</head>
+            <p>The functions listed parse CSV data.</p>
+            <?local-function-index?>
+            <p>The structured representation of a parsed CSV is described by the
+               <code>parsed-csv-structure-record</code>, see <specref ref="csv-to-xdm-mapping"/>.</p>
+
+            <div3 id="func-parse-csv">
+               <head><?function fn:parse-csv?></head>
+            </div3>
+            <div3 id="func-csv-to-xdm">
+               <head><?function fn:csv-to-xdm?></head>
+            </div3>
+            <div3 id="func-csv-to-xml">
+               <head><?function fn:csv-to-xml?></head>
+            </div3>
+            <div3 id="func-csv-fetch-field-by-column">
+               <head><?function fn:csv-fetch-field-by-column?></head>
+            </div3>
+         </div2>
          <div2 id="json">
             <head>Conversion to and from JSON</head>
 
@@ -6878,6 +6898,484 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>The result of the <xspecref spec="DM40" ref="dm-unparsed-entity-system-id"/>
                   <code>dm:unparsed-entity-system-id($node)</code> for an HTML DOM <code>Node</code>
                   is an empty sequence.</p>
+            </div3>
+         </div2>
+         <div2 id="csv">
+            <head>Conversion from CSV</head>
+
+            <p>Comma separated values (CSV) refers to a wide variety of plain-text tabular data with
+               fields and records separated by standard character delimiters. CSV has developed
+               informally for decades, and this implementation refers to <bibref ref="rfc4180"/>,
+               which provides a standardized grammar. This section defines a mapping from RFC 4180
+               to constructs in the XDM model, and provides illustrative examples of how these
+               constructs can be used in conjunction with existing language features to provide rich
+               processing of CSV data.</p>
+
+            <p>A CSV is a 2-dimensional tabular data structure consisting of multiple rows. Each
+               <term>row</term> contains multiple fields. Each <term>field</term>’s position in
+               the row is organised by <term>column</term> located in a <term>column</term> Fields
+               across records are members of a <term>column</term>, identified by position and
+               possibly name. Each field contains a single string value. Column names can be
+               assigned within a CSV using an optional <term>header row</term>.</p>
+
+            <p>The rows and fields from this specification map directly to the <term>record</term>
+               and field structures defined in RFC 4180, which has no explicit structure to
+               represent columns.</p>
+
+            <p>A row can be thought of as analogous to both a sequence of fields and a map of fields
+               (when columns are named). Fields are ordered left-to-right and thus have a position,
+               as with an array. Named columns allow fields to be retrieved by name, as with a
+               map.</p>
+
+            <p>Fields are simple strings. A field that contains reserved characters (one of the
+               delimiters) must be quoted, and the quote character must be escaped if it occurs
+               within a field. (See <specref ref="csv-field-quoting"/>.)</p>
+
+            <p>The functions for processing CSV-formatted data are built on
+               <code>fn:parse-csv</code>, which provides a simple representation of a parsed CSV
+               as a sequence of arrays-of-strings, <code>array(xs:string)*</code>, handling row and
+               column delimiters, and quoting.</p>
+
+            <p>The <code>fn:csv-to-xml</code> and <code>fn:csv-to-xdm</code> functions provide more
+               sophisticated processing.</p>
+
+
+            <div3 id="common-parsing-options">
+               <head>Common parsing options</head>
+
+               <p>All three functions: <code>fn:parse-csv</code>, <code>fn:csv-to-xml</code>, and
+                  <code>fn:csv-to-xdm</code>, take options to control basic parsing, consisting
+                  of specifying the various delimiters. These core delimiter options are used by the
+                  functions that generate CSV data:</p>
+
+               <?type common-csv-options ?>
+
+               <p>Additionally, the parsing functions share an additional option to control whether
+                  leading and trailing whitespace should be stripped or not.</p>
+
+               <?type parse-csv-options ?>
+            </div3>
+
+            <div3 id="csv-delimiters">
+               <head>CSV delimiters</head>
+
+
+               <div4 id="row-delimiters">
+                  <head>Row delimiters</head>
+
+                  <p>Rows in CSV are typically delimited with CRLF, LF, or CR line endings, although
+                     field quoting means that there is not always a one-to-one mapping between line
+                     and row in a file.</p>
+
+                  <p>The row delimiter defaults to matching any of CRLF (<code><![CDATA[&#x0D;&#x0A;]]></code>),
+                     LF (<code><![CDATA[&#x0A;]]></code>), or CR (<code><![CDATA[&#x0D;]]></code>). Valid values for the row
+                     delimiter are a single unicode character, or one of CRLF, LF, or CR, that has
+                     not been marked for use as the column delimiter. Implementations
+                     <rfc2119>must</rfc2119> raise <errorref class="CV" code="0002"/> if the
+                     <code>row-delimiter</code> option is set to a mutli-character string other
+                     than CRLF (<code><![CDATA[&#x0D;&#x0A;]]></code>), and <errorref class="CV" code="0003"/>
+                     if the same string has been set for row or column delimiter, or quote
+                     character.</p>
+              </div4>
+
+               <div4 id="column-delimiters">
+                  <head>Column/Field delimiters</head>
+
+                  <p>Fields in CSV are typically delimited with a comma. Files with other field
+                     delimiters are common, especially when the comma has data significance, for
+                     example with the use of the decimal comma in much of the world (there the
+                     delimiter is usually the semicolon).</p>
+
+                  <p>The column delimiter defaults to the comma <code>","</code>. Valid values for
+                     the column delimiter are a single unicode character, that has not been marked
+                     for use as the row delimiter. Implementations <rfc2119>must</rfc2119> raise
+                     <errorref class="CV" code="0002"/> if the <code>column-delimiter</code>
+                     option is set to a mutli-character string, and <errorref class="CV" code="0003"
+                     /> if the same string has been set for row or column delimiter, or quote
+                     character.</p>
+               </div4>
+            </div3>
+
+            <div3 id="csv-field-quoting">
+               <head>Field quoting</head>
+
+               <p>CSVs, per RFC 4180, require that fields be wrapped with a quote character if they
+                  contain either the row or column delimiter. This is achieved by wrapping the field
+                  with the quote character:</p>
+
+               <eg>"A single field, with a comma","another field containing CRLF
+                  within it"</eg>
+
+               <p>If a field is to contain the quote character, it must be escaped by preceding it
+                  with itself, as with escaping double quotes in XPath (see <xspecref
+                     ref="id-literals" spec="XP40"/>). Implementations <rfc2119>must</rfc2119> raise
+                  <errorref class="CV" code="0001"/> if a quote character appears within a field
+                  incorrectly escaped.</p>
+
+               <eg>incorrectly escaped " quote character</eg>
+
+               <p>The quotes surrounding quoted fields are not included in their content. The
+                  following input string, when parsed, would produce a sequence of strings, as shown
+                  below:</p>
+
+               <eg>'"Field 1","Field 2","Field ""with quotes"" 3"'</eg>
+
+               <eg>('Field 1', 'Field 2', 'Field "with quotes" 3')</eg>
+
+               <p>The quote character defaults to the double quote <code>"</code>.</p>
+
+               <div4 id="csv-field-quoting-column-delimiters">
+                  <head>Field quoting and column delimiters</head>
+
+                  <p>No space is allowed between the column delimiter and a quote. Implementations
+                     <rfc2119>must</rfc2119> raise <errorref class="CV" code="0001"/> if
+                     whitespace or other characters occur between a quote character and the nearest
+                     column delimiter.</p>
+
+                  <p>The following example is illegal and parsing it should raise an error.</p>
+
+                  <eg>'"Field 1", "Field 2", "Field 3"'</eg>
+
+               </div4>
+            </div3>
+
+            <div3 id="basic-csv-to-xdm-mapping">
+               <head>Basic mapping of CSV to XDM</head>
+
+               <p>The basic output from <code>fn:parse-csv</code> returns a sequence of rows, where
+                  each row is simply mapped to an array of <code>xs:string</code> values.</p>
+
+               <p>The first row of the CSV is returned as with all the other rows.
+                  <code>fn:parse-csv</code> does not distinguish between a header row and data
+                  rows, and returns all of them.</p>
+
+               <eg>
+'Column 1,Column 2,Column 3
+Field 1A,Field 1B,Field 1C
+Field 2A,Field 2B,Field 2C'
+               </eg>
+
+               <p>Produces</p>
+
+               <eg>
+(
+   ["Column 1", "Column 2", "Column 3"],
+   ["Field 1A", "Field 1B", "Field 1C"],
+   ["Field 2A", "Field 2B", "Field 2C"]
+)
+               </eg>
+
+               <p>There is an expectation that, in the general case, all rows in a given CSV will
+                  have the same number of columns, but there is no guarantee of this.</p>
+
+               <eg>
+'Column 1,Column 2,Column 3
+Field 1A,Field 1B,Field 1C
+Field 2A,Field 2B,Field 2C,Field 2D'
+               </eg>
+
+               <p>Produces</p>
+
+               <eg>
+(
+   ["Column 1", "Column 2", "Column 3"],
+   ["Field 1A", "Field 1B", "Field 1C"],
+   ["Field 2A", "Field 2B", "Field 2C", "Field 2D]
+)
+               </eg>
+
+               <p><bibref ref="rfc4180"/> states that CSVs <rfc2119>should</rfc2119> contain the
+                  same number of fields in each row, so that there are a uniform number of columns.
+                  However, the reality is that CSVs can, and sometimes do, contain a variable number
+                  of fields in a row. As a result, implementations of this function <rfc2119>must
+                  not</rfc2119> truncate or pad the number of fields in each row for any reason.
+                  The <code>fn:csv-to-xml</code> and <code>fn:csv-to-xdm</code> functions provide
+                  facilities to deal with enforcing uniformity and an expected number of
+                  columns.</p>
+            </div3>
+
+            <div3 id="csv-to-xdm-mapping">
+               <head>Mapping CSV data to XDM in <code>fn:csv-to-xdm</code></head>
+
+
+               <p>The <code>fn:csv-to-xdm</code> function returns a
+                  <code>parsed-csv-structure-record</code>:</p>
+
+               <?type parsed-csv-structure-record ?>
+
+               <div4 id="csv-xdm-header">
+                  <head>The <code>header</code> entry</head>
+
+                  <p>The <code>columns</code> entry describes how columns map to names, as well as
+                     providing all the fields in the header row that was used to generate the column
+                     names.</p>
+
+                  <?type csv-columns-record ?>
+
+                  <p>It’s required. If column names were not extracted, then implementations
+                     <rfc2119>must</rfc2119> return a <code>csv-columns-record</code> whose
+                     <code>names</code> entry is an empty map, and whose <code>fields</code>
+                     entry is the empty sequence.</p>
+               </div4>
+
+               <div4 id="csv-xdm-rows">
+                  <head>The <code>rows</code> entry</head>
+
+                  <p>The <code>rows</code> entry returns the rows themselves. It is a sequence of
+                     <code>csv-row</code> records. If the CSV was empty of rows, implementations
+                     <rfc2119>must</rfc2119> return a <code>rows</code> entry consisting of the
+                     empty sequence.</p>
+               </div4>
+
+               <div4 id="csv-xdm-row">
+                  <head>The <code>csv-row</code> record</head>
+
+                  <?type csv-row-record ?>
+
+                  <p>The <code>csv-row</code> record represents a single row. The
+                     <code>fields</code> entry is a sequence containing the fields as
+                     <code>xs:string</code>.</p>
+
+                  <p>The <code>field</code> entry contains a function, as described below:</p>
+               </div4>
+
+               <div4 id="csv-xdm-field-function">
+                  <head>The <code>field</code> function</head>
+
+                  <p>The function returned in the <code>field</code> entry is an arity 1 (one)
+                     function which takes either a string or an integer as its argument
+                     <code>$key</code>, and returns a field from the <code>csv-row</code>’s
+                     <code>fields</code> sequence by either column position (when passed an
+                     <code>xs:integer</code>) or column name (when passed an
+                     <code>xs:string</code>).</p>
+
+                  <p>This function is, effectively, a partial application of
+                     <code>fn:csv-fetch-field-by-column</code> where its <code>$columns</code>
+                     argument is bound to the <code>columns</code> entry of the
+                     <code>parsed-csv-structure-record</code>, and its <code>$row</code> argument
+                     is bound to <code>array{csv-row?fields}</code>. This is described in more
+                     detail below:</p>
+
+                  <p>Given a string, <code>$csv-string</code> containing CSV data, implementations
+                     <rfc2119>must</rfc2119> return a function that will return identical results
+                     to <code>fn:csv-fetch-field-by-column</code> called with the same
+                     <code>csv-columns</code> and an <code>array()</code> containing the same
+                     items as the <code>fields</code> sequence:</p>
+
+                  <eg>let $csv-record := fn:csv-to-xdm($csv-string),
+   $csv-columns := $csv-record?columns,
+   $csv-row := head($csv-record?rows)
+   return if (empty($csv-row?field(1)))
+   then empty(fn:csv-fetch-field-by-column($csv-columns, array{$csv-row}, 1))
+   else $csv-row?field(1) = fn:csv-fetch-field-by-column($csv-columns, array{$csv-row}, 1)
+   (: must return true :)
+                  </eg>
+               </div4>
+            </div3>
+            <div3 id="csv-represent-as-xml">
+               <head>Representing CSV data as XML</head>
+
+               <p>The <code>fn:csv-to-xml</code> function returns XML representing the CSV data.
+                  Following is a CSV text and its XML representation.</p>
+
+               <eg>Name,Date,Amount
+Alice,2023-07-14,1.23
+Bob,2023-07-14,2.34
+               </eg>
+
+               <eg><![CDATA[
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns>
+      <column>Name</column>
+      <column>Date</column>
+      <column>Amount</column>
+   </columns>
+   <rows>
+      <row>
+         <field column="Name">Alice</field>
+         <field column="Date">2023-07-14</field>
+         <field column="Amount">1.23</field>
+      </row>
+      <row>
+         <field column="Name">Bob</field>
+         <field column="Date">2023-07-14</field>
+         <field column="Amount">2.34</field>
+      </row>
+   </rows>
+</csv>
+]]></eg>
+
+               <p>If column names were not extracted, then implementations <rfc2119>should
+                  not</rfc2119> include the <code><![CDATA[<header>]]></code> element, and
+                  <code><![CDATA[<field>]]></code> elements <rfc2119>should not</rfc2119> have
+                  the <code>column</code> attribute:</p>
+
+               <eg><![CDATA[
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <rows>
+      <row>
+         <field>Name</field>
+         <field>Date</field>
+         <field>Amount</field>
+      </row>
+      <row>
+         <field>Alice</field>
+         <field>2023-07-14</field>
+         <field>1.23</field>
+      </row>
+      <row>
+         <field>Bob</field>
+         <field>2023-07-14</field>
+         <field>2.34</field>
+      </row>
+   </rows>
+</csv>
+]]></eg>
+
+               <p>An XSD 1.0 schema for the XML representation is provided in <specref ref="schema-for-csv"/>.</p>
+            </div3>
+            <div3 id="illustrative-csv-examples">
+               <head>Illustrative examples of processing CSV data</head>
+
+
+               <p>The following examples illustrate how an application can build more complex processing of the output of <code>fn:parse-csv</code>.</p>
+
+               <p>A variable, <code>$crlf</code> is assumed to be in scope containing the CR and LF characters</p>
+
+               <eg>let $crlf := fn:char('x0D')||fn:char('x0A')</eg>
+
+               <div4 id="csv-to-html-table">
+                  <head>Converting a CSV into an HTML-style table using <code>fn:csv-to-xdm</code></head>
+
+                  <p>Direct conversion is a matter of iterating across the records and fields to
+                     generate <code>&lt;tr&gt;</code> and <code>&lt;td&gt;</code> elements.</p>
+
+                  <p>Using XQuery:</p>
+                  <eg><![CDATA[
+let $csv := fn:csv-to-xdm(`name,city{$crlf}Bob,Berlin`),
+    $headers := $parsed-csv?headers-record
+return <table>
+   <thead>{
+      for $column in $csv?columns?fields
+         return <th>{ $column }</th>
+   }</thead>
+   <tbody>{
+      for $row in $csv?rows return <tr>
+         { for $field in $row?fields return <td>{ $field }</td> }
+      </tr>
+   }</tbody>
+</table>
+                  ]]></eg>
+
+                  <p>Using XSLT:</p>
+                  <eg><![CDATA[
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:eg="http://example.org/eg"
+  xmlns:array="http://www.w3.org/2005/xpath-functions/array"
+  exclude-result-prefixes="eg array"
+  version="4.0">
+  <xsl:output method="xml" indent="true"/>
+
+  <xsl:template match="." mode="csv-th" expand-text="true">
+    <th>{.}</th>
+  </xsl:template>
+
+  <xsl:template match="." mode="csv-td" expand-text="true">
+    <td>{.}</td>
+  </xsl:template>
+
+  <xsl:template match="." mode="csv-tr">
+    <tr>
+      <xsl:apply-templates select=".?fields" mode="csv-td"/>
+    </tr>
+  </xsl:function>
+
+  <xsl:template name="xsl:initial-template">
+    <xsl:variable name="csv" select="csv-to-xdm(`name,city{$crlf}Bob,Berlin`)"/>
+    <table>
+      <thead>
+        <tr>
+          <xsl:apply-templates select="$csv?columns?fields" mode="csv-th"/>
+        </tr>
+      </thead>
+      <tbody>
+        <xsl:apply-templates select="$csv?rows" mode="csv-tr"/>
+      </tbody>
+    </table>
+  </xsl:template>
+</xsl:stylesheet>
+                  ]]></eg>
+               </div4>
+               <div4 id="csv-to-html-table-csv-to-xml">
+                  <head>Converting a CSV into an HTML-style table using <code>fn:csv-to-xml</code></head>
+
+                  <p>The <code>fn:csv-to-xml</code> function makes these kinds of
+                     conversion-to-XML-table tasks simpler by providing a simple XML represenation of the data. Here, in XQuery:</p>
+
+                  <eg><![CDATA[
+let $csv := fn:csv-to-xml(`name,city{$crlf}Bob,Berlin`)
+return <table>
+   <thead>{
+      for $column in $csv/csv/columns/column
+         return <th>{ $column }</th>
+   }</thead>
+   <tbody>{
+      for $row in $csv/csv/rows/row
+         return <tr>{ for $field in $row/field return <td>{ $field }</td> }</tr>
+      }
+   }</tbody>
+</table>
+                  ]]></eg>
+
+                  <p>And in XSLT:</p>
+
+                  <eg><![CDATA[
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
+  exclude-result-prefixes="fn"
+  version="4.0">
+  <xsl:output method="xml" indent="true"/>
+
+  <xsl:template match="fn:column" expand-text="true">
+    <th>{.}</th>
+  </xsl:template>
+
+  <xsl:template match="fn:field" expand-text="true">
+    <td>{.}</td>
+  </xsl:template>
+
+  <xsl:template match="fn:row">
+    <tr>
+      <xsl:apply-templates/>
+    </tr>
+  </xsl:function>
+
+  <xsl:template match="fn:columns">
+    <thead>
+      <tr>
+        <xsl:apply-templates/>
+      </tr>
+    </thead>
+  </xsl:function>
+
+  <xsl:template match="fn:rows">
+    <tbody>
+      <xsl:apply-templates/>
+    </tbody>
+  </xsl:function>
+
+  <xsl:template match="fn:csv">
+    <table>
+      <xsl:apply-templates/>
+    </table>
+  </xsl:template>
+
+  <xsl:template name="xsl:initial-template">
+    <xsl:apply-templates select="fn:csv-to-xml(`name,city{$crlf}Bob,Berlin`)"/>
+  </xsl:template>
+</xsl:stylesheet>
+                  ]]></eg>
+               </div4>
             </div3>
          </div2>
       </div1>
@@ -10230,6 +10728,10 @@ Organization for Standardization, 2012. Available from: <loc href="http://www.is
                   Internationalized Resource Identifiers (IRIs).</emph> Available at:
                   <loc href="http://www.ietf.org/rfc/rfc3987.txt">http://www.ietf.org/rfc/rfc3987.txt</loc>.
                </bibl>
+               <bibl id="rfc4180" key="RFC 4180">IETF. <emph>RFC 4180:
+                  Common Format and MIME Type for Comma-Separated Values (CSV) Files.</emph> Available at:
+                  <loc href="http://www.ietf.org/rfc/rfc4180.txt">http://www.ietf.org/rfc/rfc4180.txt</loc>.
+               </bibl>
                <bibl id="rfc7159" key="RFC 7159">IETF. <emph>RFC 7159: The Javascript Object Notation (JSON) Data Interchange Format</emph> Available at:
                   <loc href="http://www.rfc-editor.org/rfc/rfc7159.txt">http://www.rfc-editor.org/rfc/rfc7159.txt</loc>.
                </bibl>
@@ -10463,6 +10965,29 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <code>fn:char</code> if the supplied character name is not recognized, or
                   if it represents a codepoint that is not valid in the version of XML supported by the
                   processor.</p>
+            </error>
+            <error class="CV" code="0001" label="CSV field quoting error."
+               type="dynamic">
+               <p>Raised by <code>fn:parse-csv</code> if a syntax error in the quoting of one of the
+                  fields in the input CSV is found.</p>
+            </error>
+            <error class="CV" code="0002" label="Illegal CSV delimiter error."
+               type="dynamic">
+               <p>Raised by <code>fn:parse-csv</code> if the <code>field-separator</code>,
+                  <code>record-separator</code>, or <code>quote-character</code> option is set to
+                  an illegal value.</p>
+            </error>
+            <error class="CV" code="0003" label="duplicate CSV delimiter error."
+               type="dynamic">
+               <p>Raised by <code>fn:parse-csv</code> if any of the delimiter characters have been
+                  set to the same value.</p>
+            </error>
+            <error class="CV" code="0004" label="Argument supplied is not a known column name."
+               type="dynamic">
+               <p>Raised by <code>fn:csv-fetch-field-by-column</code>, and the function from the
+                  <code>field</code> entry of <code>csv-columns-record</code>, if its
+                  <code>$key</code> argument is an <code>xs:string</code> and is not one of the
+                  known column names.</p>
             </error>
             <error class="DC" code="0001" label="No context document." type="dynamic">
                <p>Raised by <code>fn:id</code>, <code>fn:idref</code>, and <code>fn:element-with-id</code>
@@ -10804,8 +11329,14 @@ ISBN 0 521 77752 6.</bibl>
             <p>The schema is reproduced below, and can also be found in <loc href="schema-for-json.xsd">schema-for-json.xsd</loc>:</p>
             <?doc schema-for-json.xsd?>
          </div2>
-      </div1> 
-      
+         <div2 id="schema-for-csv">
+            <head>Schema for the result of <code>fn:csv-to-xml</code></head>
+            <p>This schema describes the output of the function <code>fn:csv-to-xml</code>.</p>
+            <p>The schema is reproduced below, and can also be found in <loc href="schema-for-json.xsd">schema-for-json.xsd</loc>:</p>
+            <?doc schema-for-csv.xsd?>
+         </div2>
+      </div1>
+
       <inform-div1 id="other-functions">
          <head>Other Functions</head>
          <p>This Appendix describes some sources of functions that fall outside the scope of the function library defined
@@ -11402,6 +11933,10 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>map:filter</code></p></item>
               <item><p><code>map:replace</code></p></item>
               <item><p><code>map:substitute</code></p></item>
+              <item><p><code>fn:parse-csv</code></p></item>
+              <item><p><code>fn:csv-to-xdm</code></p></item>
+              <item><p><code>fn:csv-to-xml</code></p></item>
+              <item><p><code>fn:csv-fetch-field-by-column</code></p></item>
               <!--<item><p><code>array:partition</code></p></item>-->
               <item><p><code>array:replace</code></p></item>
               <item><p><code>array:slice</code></p></item>


### PR DESCRIPTION
This is a spec proposal for `fn:parse-csv()` from #413.

I've tried to cover off most of what was discussed in that issue, but I have avoided dealing with backlash escapes (per @ChristianGruen's early comment), sticking with the RFC 4180 quoting approach.

There are some issues with the structure where I tried to follow the existing structure of chapter 15, but that leaves the function definition in 15.4 separated by a lot of text before the wider format discussion in 15.7. The split between function def and context affects the JSON and HTML parsing functions too, so I have avoided trying to fix that as well in this PR.

If this meets with approval, I'll squash commits and rebase before merging.