### PR TITLE
480: Attempt to allow xs:string to be 'promoted to' xs:anyURI

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -23,8 +23,31 @@ of the types <code>xs:float</code> or <code>xs:double</code>.  The
 result of this promotion is created by casting the original value to
 the required type. This kind of promotion may cause loss of
 precision.</p></item></olist></item>
-<item><p>URI type promotion: A value of type <code>xs:anyURI</code> (or any type derived by restriction from <code>xs:anyURI</code>) can be promoted to the type <code>xs:string</code>. The result of this promotion is created by casting the original value to the type <code>xs:string</code>.</p><note><p>Since <code>xs:anyURI</code> values can be promoted to <code>xs:string</code>, functions and operators that compare strings using the <termref def="dt-def-collation">default collation</termref> also compare <code>xs:anyURI</code> values using the <termref def="dt-def-collation">default collation</termref>. This ensures that orderings that include strings, <code>xs:anyURI</code> values, or any combination of the two types are consistent and well-defined.</p></note></item>
 
+<item><p>URI and string type promotion: A value of type <code>xs:anyURI</code>
+(or any type derived by restriction from <code>xs:anyURI</code>) can
+be promoted to the type <code>xs:string</code>. The converse is also allowed,
+a value of type <code>xs:string</code> can be promoted to any
+<code>xs:anyURI</code> type. In either case, the result of this
+promotion is created by casting the original value to the desired type.
+</p>
+
+<note><p>Since <code>xs:anyURI</code>
+values can be promoted to <code>xs:string</code>, functions and
+operators that compare strings using the <termref
+def="dt-def-collation">default collation</termref> also compare
+<code>xs:anyURI</code> values using the <termref
+def="dt-def-collation">default collation</termref>. This ensures that
+orderings that include strings, <code>xs:anyURI</code> values, or any
+combination of the two types are consistent and
+well-defined.</p></note>
+
+<note><p>Implementations are not required to impose any syntactic constraints
+on values of type <code>xs:anyURI</code>. An implementation that does may raise
+a dynamic error if an attempt is made to cast a <code>xs:string</code> to an
+<code>xs:anyURI</code> when the string is not a syntactically correct URI.</p>
+</note>
+</item>
 
 </olist>
 <p>Note that <termref def="dt-type-promotion">type promotion</termref> is different from <termref def="dt-subtype-substitution">subtype substitution</termref>. For example:</p><ulist>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -27,8 +27,9 @@ precision.</p></item></olist></item>
 <item><p>URI and string type promotion: A value of type <code>xs:anyURI</code>
 (or any type derived by restriction from <code>xs:anyURI</code>) can
 be promoted to the type <code>xs:string</code>. The converse is also allowed,
-a value of type <code>xs:string</code> can be promoted to any
-<code>xs:anyURI</code> type. In either case, the result of this
+a value of type <code>xs:string</code> (or any type derived by restriction
+from <code>xs:string</code>) can promoted to the type
+<code>xs:anyURI</code>. In either case, the result of this
 promotion is created by casting the original value to the desired type.
 </p>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8988,11 +8988,22 @@ return $incrementors[2](4)]]></eg>
                         <item>
                            <p>For each item of type <code>xs:anyURI</code>
                               in the atomic sequence that can be <termref def="dt-type-promotion">promoted</termref> to the 
-		                         expected atomic type using URI promotion as described in <specref
+		                         expected atomic type using URI and string promotion as described in <specref
                                  ref="promotion"/>, the promotion is done.</p>
                            <note diff="add" at="2022-11-17"><p>Promotion of <code>xs:anyURI</code> values is performed 
                               only when the required type is <code>xs:string</code> (perhaps with an occurrence indicator). It is not performed
                               when the required type is derived from <code>xs:string</code>.</p></note>
+                        </item>
+
+                        <item diff="add" at="2023-10-30">
+                           <p>For each item of type <code>xs:xstring</code>
+                           in the atomic sequence, if the <code>ItemType</code> is
+                           <code>xs:anyURI</code>, it is promoted using URI and string promotion
+                           as described in <specref
+                                 ref="promotion"/>.</p>
+                           <note><p>Promotion of <code>xs:string</code> values is performed 
+                              only when the required type is <code>xs:anyURI</code> (perhaps with an occurrence indicator). It is not performed
+                              when the required type is derived from <code>xs:anyURI</code>.</p></note>
                         </item>
                         
                         <item diff="add" at="A">


### PR DESCRIPTION
I think it might be a little cheeky to call it "promotion" in both directions, but this really has more to do with a kind of conversion, so I'm willing to let it slide.

If accepted, this PR resolves ACTION QT4CG-035-03.