### PR TITLE
Fix typo in XPath §2.4.5 - E1 should be tagged as code not as var.

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -2801,7 +2801,7 @@ would raise an error because it has an <code>id</code> child whose value is not 
             error because the <code>else</code> branch of the conditional is <termref def="dt-guarded"/>.</p>
             
             <p>Similarly, in the mapping expression <code>E1!E2</code>, the subexpression <code>E2</code> is guarded
-            by the existence of an item from <var>E1</var>. This means, for example, that the expression <code>(1 to $n)!doc('bad.xml')</code>
+            by the existence of an item from <code>E1</code>. This means, for example, that the expression <code>(1 to $n)!doc('bad.xml')</code>
             must not raise a dynamic error if <code>$n</code> is zero. The rule governing evaluation of guarded expressions
                is phrased so as not to disallow “loop-lifting” or “constant-folding” optimizations 
                whose aim is to avoid repeated evaluation of a common subexpression;


### PR DESCRIPTION
A trivial markup error that leads to the meta-variable E1 being wrongly rendered.