### PR TITLE
382 simplify rules for whitespace in fn:deep-equal

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12648,32 +12648,11 @@ else if (empty($input))
                   <fos:type>xs:string?</fos:type>
                   <fos:default>()</fos:default>
                </fos:option>              
-               <fos:option key="normalize-space">
-                  <fos:meaning>The value <code>false</code> indicates that text and attributes are compared <emph>as-is</emph>;
-                     the value <code>true</code> indicates that they are compared after normalization using <code>fn:normalize-space</code>.
-                  </fos:meaning>
-                  <fos:type>xs:boolean</fos:type>
-                  <fos:default>true</fos:default>
-               </fos:option>
-               <fos:option key="preserve-space">
-                  <fos:meaning>Determines whether text nodes consisting entirely of whitespace are significant.
-                  </fos:meaning>
-                  <fos:type>xs:boolean</fos:type>
-                  <fos:default>true</fos:default>
-               </fos:option>
                <fos:option key="processing-instructions">
                   <fos:meaning>Determines whether processing instructions are significant.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
-               </fos:option>
-               <fos:option key="text-boundaries">
-                  <fos:meaning>Determines whether boundaries between text nodes are significant, even when two text
-                     nodes are separated by an ignored comment or processing instruction. (This property
-                     is provided, with the default <code>true</code>, for compatibility with previous versions.)
-                  </fos:meaning>
-                  <fos:type>xs:boolean</fos:type>
-                  <fos:default>true</fos:default>
                </fos:option>
                <fos:option key="timezones">
                   <fos:meaning>Determines whether timezones in date/time values are significant.
@@ -12708,6 +12687,21 @@ else if (empty($input))
                   <fos:type>xs:QName*</fos:type>
                   <fos:default>()</fos:default>
                </fos:option>
+               <fos:option key="whitespace">
+                  <fos:meaning><phrase diff="chg" at="2023-03-13">Determines the extent to which whitespace 
+                     is treated as significant. The value
+                     <code>preserve</code> retains all whitespace. The value <code>strip</code> ignores text nodes
+                     consisting entirely of whitespace.
+                     The value <code>normalize</code> ignores whitespace text nodes in the same way as
+                     the <code>strip</code> option, and additionally compares text and attribute nodes after 
+                     normalizing whitespace in accordance with the rules of the <code>fn:normalize-space</code> 
+                     function. The detailed rules, given below, also take into account type annotations and 
+                     <code>xml:space</code> attributes.
+                  </phrase>
+                  </fos:meaning>
+                  <fos:type>enum("preserve", "strip", "normalize")</fos:type>
+                  <fos:default>preserve</fos:default>
+               </fos:option>
             </fos:options>
          
          <note><p>As a general rule for boolean options (but not invariably), the value <code>true</code> indicates 
@@ -12719,7 +12713,7 @@ else if (empty($input))
          <p>The rules reference a function <code>equal-strings</code> which compares two strings as follows:</p>
          
          <olist>
-            <item><p>If the <code>normalize-space</code> option is <code>true</code>, each string is processed
+            <item><p>If the <code>whitespace</code> option is set to <code>normalize</code>, then each string is processed
                by calling the <code>fn:normalize-space</code> function.</p></item>
             <item><p>If the <code>normalization-form</code> option is present, each string is then normalized
             by calling the <code>fn:normalize-unicode</code> function, supplying the specified normalization
@@ -12731,7 +12725,7 @@ else if (empty($input))
          
          <eg><![CDATA[function ($s1 as xs:string, $s2 as xs:string, 
                    $collation as xs:string, $options as map(*)) as xs:boolean {
-    let $n1 := if (exists($options?normalization-form))
+    let $n1 := if ($options?whitespace = "normalize"))
                then normalize-unicode(?, $options?normalization-form) 
                else identity#1,
         $n2 := if ($options?normalize-space)
@@ -12863,16 +12857,31 @@ else if (empty($input))
                   <item><p>Both nodes have the same node kind.</p></item>
                   <item><p>Either the <code>base-uri</code> option is <code>false</code>, or both nodes have the same value
                      for their base URI property, or both nodes have an absent base URI.</p></item>
-                  <item><p>Let <code>significant-children($parent)</code> be the sequence of nodes applying the following
+                  <item><p>Let <code>significant-children($parent)</code> be the sequence of nodes obtained by applying the following
                   steps to the children of <code>$parent</code>, in turn:</p>
                      <olist>
                         <item><p>Comment nodes are discarded if the option <code>comments</code> is <code>false</code>.</p></item>
                         <item><p>Processing instruction nodes are discarded if the option <code>processing-instructions</code> is <code>false</code>.</p></item>
-                        <item><p>Adjacent text nodes are merged if the option <code>text-boundaries</code> is <code>false</code>.</p></item>
-                        <item><p>Whitespace-only text nodes are discarded if the option <code>preserve-space</code> is <code>false</code>,
-                           or if <code>$parent</code> is an element node whose type annotation is a complex type with an element-only
-                           or empty content model.</p></item>
-                 
+                        <item><p>Adjacent text nodes are merged.</p></item>
+                        <item><p>Whitespace-only text nodes are discarded if both the following conditions are true:</p>
+                           <olist>
+                              <item>
+                                 <p>Either:</p>
+                                 <olist>
+                                    <item>
+                                       <p>The option <code>whitespace</code> is set to <code>strip</code>
+                                          or <code>normalize</code>; or</p>
+                                    </item>
+                                    <item>
+                                       <p><code>$parent</code> is a schema-validated element node whose type annotation 
+                                          is a complex type with an element-only or empty content model.</p>
+                                    </item>
+                                 </olist>
+                              </item>
+                              <item><p>The text node is not within the scope
+                              of an element that has the attribute <code>xml:space="preserve"</code>.</p></item>
+                           </olist>
+                        </item>
                      </olist>
                   
                   </item>
@@ -13015,7 +13024,8 @@ else if (empty($input))
                               </item>
                               <item>
                                  <p>Either the option <code>typed-value</code> is <code>true</code>, or 
-                                    the <code>equal-strings</code> function returns <code>true</code> when applied to the string value of <code>$i1</code> 
+                                    the <code>equal-strings</code> function returns <code>true</code> 
+                                    when applied to the string value of <code>$i1</code> 
                                     and the string value of <code>$i2</code>.</p>
                               </item>
                               
@@ -13058,33 +13068,7 @@ else if (empty($input))
                         <item>
                            <p>Both nodes are text nodes, and the <code>equal-strings</code> function 
                               returns <code>true</code> when applied to their string values.</p>
-                           <note>
-                              <p>The handling of whitespace is controlled by a number of options:</p>
-                              <ulist>
-                                 <item><p>Firstly, text nodes consisting entirely of whitespace are considered
-                                 significant by default, unless the parent element has been schema-validated and
-                                 has an element-only content model. This can be overridden by setting the
-                                 <code>preserve-space</code> option to <code>false</code>. The process is not influenced
-                                 by any <code>xml:space</code> attributes that might be present.</p></item>
-                                 <item><p>The decision whether a text node is whitespace is made after
-                                 stripping comments and processing instructions. However, the text nodes
-                                 either side of a comment or processing instruction are merged only if the
-                                 <code>text-boundaries</code> option is <code>true</code> (it is <code>false</code> by default).
-                                 </p></item>
-                                 <item><p>If the <code>preserve-space</code> option and the
-                                 <code>normalize-space</code> option are both <code>true</code>, then a whitespace-only
-                                 text node will be reduced to zero length; this means that all whitespace-only
-                                 text nodes will compare equal regardless of their actual content, but the
-                                 presence of the node is still considered significant.</p></item>
-                                 <item><p>The <code>normalize-space</code> option affects the comparison
-                                 of text nodes, attribute nodes, comments and processing instructions (if not
-                                 stripped): it applies to all such nodes when their string values are
-                                 compared, and to nodes whose typed value is a string when comparing typed
-                                 values. It also affects strings within maps and arrays. It has no effect where
-                                 more specific rules apply, for example when comparing node names, namespace URIs,
-                                 or map keys.</p></item>
-                              </ulist>
-                           </note>
+                          
                         </item>
                   </olist>
                   </item>
@@ -13111,6 +13095,17 @@ else if (empty($input))
             in this specification, and whose value is not a permitted value for that key.</p>
       </fos:errors>
       <fos:notes>
+         <p>By default, whitespace in text nodes and attribute is considered significant. There are various ways
+         whitespace differences can be ignored:</p>
+         <ulist>
+            <item><p>If nodes have been schema-validated, setting the <code>typed-values</code> 
+               option to true causes the typed values rather
+               than the string values to be compared. This will typically cause whitespace to be ignored
+               except where the type of the value is <code>xs:string</code>.</p></item>
+            <item><p>Setting the <code>whitespace</code> option to <code>normalize</code> causes all
+            text and attribute nodes to have leading and trailing whitespace removed, and intermediate
+            whitespace reduced to a single character.</p></item>
+         </ulist>
          <p>By default, two nodes are not required to have the same type annotation, and they are not
             required to have the same in-scope namespaces. They may also differ in their parent,
             their base URI, and the values returned by the <code>is-id</code> and
@@ -13134,10 +13129,11 @@ else if (empty($input))
          unless the error is suppressed using the <code>false-on-error</code> option.</p>
       </fos:notes>
       <fos:examples>
-         <fos:variable name="at" id="v-deep-equal-at" as="element()"
-            >&lt;attendees&gt; &lt;name last='Parker'
-            first='Peter'/&gt; &lt;name last='Barker' first='Bob'/&gt; &lt;name last='Parker'
-            first='Peter'/&gt; &lt;/attendees&gt;</fos:variable>
+         <fos:variable name="at" id="v-deep-equal-at" as="element()"><![CDATA[<attendees>
+  <name last="Parker" first="Peter"/>
+  <name last="Barker" first="Bob"/>
+  <name last="Parker" first="Peter"/>
+</attendees>]]></fos:variable>
          <fos:example>
             <fos:test use="v-deep-equal-at">
                <fos:expression>deep-equal($at, $at/*)</fos:expression>
@@ -13244,7 +13240,8 @@ else if (empty($input))
                <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<para style='bold'><span>x</span></para>"),
     parse-xml("<para style=' bold'> <span>x</span></para>"),
-    options := map{'normalize-space': true(), 'whitespace-text-nodes': false())]]></eg></fos:expression>
+    options := map{'normalize-space': true(), 
+                   'whitespace-text-nodes': false())]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>The <code>normalize-space</code> option ensures that the leading whitespace
                   in the attribute value is ignored; the <code>whitespace-text-nodes</code> option

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13228,8 +13228,10 @@ else if (empty($input))
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml("<para style='bold'><span>x</span></para>"),
-    parse-xml("<para style=' bold'> <span>x</span></para>"))]]></eg></fos:expression>
+    parse-xml(
+      "<para style='bold'><span>x</span></para>"),
+    parse-xml(
+      "<para style=' bold'> <span>x</span></para>"))]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>By default, both the leading whitespace in the <code>style</code> attribute
                   and the whitespace text node preceding the <code>span</code> element are significant.</fos:postamble>
@@ -13238,14 +13240,15 @@ else if (empty($input))
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml("<para style='bold'><span>x</span></para>"),
-    parse-xml("<para style=' bold'> <span>x</span></para>"),
-    options := map{'normalize-space': true(), 
-                   'whitespace-text-nodes': false())]]></eg></fos:expression>
+    parse-xml(
+      "<para style='bold'><span>x</span></para>"),
+    parse-xml(
+      "<para style=' bold'> <span>x</span></para>"),
+    options := map{'whitespace': 'normalize'})]]></eg></fos:expression>
                <fos:result>false()</fos:result>
-               <fos:postamble>The <code>normalize-space</code> option ensures that the leading whitespace
-                  in the attribute value is ignored; the <code>whitespace-text-nodes</code> option
-                  causes the whitespace preceding the <code>span</code> element to be ignored.</fos:postamble>
+               <fos:postamble>The <code>whitespace</code> option causes both the leading space
+                  in the attribute value and the whitespace preceding the 
+                  <code>span</code> element to be ignored.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11524,6 +11524,12 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
                  effect as setting it to an empty sequence. In 3.1, the effects could be different (the effect of omitting
                  the argument was implementation-defined).</p>
            </item>
+           <item diff="add" at="2023-03-13">
+              <p>In version 3.1, the <code>fn:deep-equal</code> function did not merge adjacent text nodes after stripping
+                 comments and processing instructions, so the elements <code><![CDATA[<a>abc<!--note1-->def</code>]]></code>
+                 and <code><![CDATA[<a>abcde<!--note2-->f</code>]]></code> were considered non-equal. In version 4.0, 
+                 the text nodes are now merged prior to comparison, so these two elements compare equal.</p>
+           </item>
            <item diff="add" at="2023-03-06">
               <p>In version 4.0, the function signature of <code>fn:namespace-uri-for-prefix</code> constrains the
                  first argument to be either an <code>xs:NCName</code> or a zero-length string (the new coercion rules


### PR DESCRIPTION
My previous attempt to make a pull request for this change got lost somewhere in the process; here is a renewed attempt. The changes are in response to comments made during the review of the orginal deep-equal() proposal, recorded in issue #382 