### PR TITLE
536: disallow mixing of symbols in operator tokens

### DIFF
--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -528,10 +528,14 @@
     <div3 id="id-lt-and-gt-characters" diff="add" at="2023-05-02">
       <head>Less-Than and Greater-Than Characters</head>
       
-      <p>In the operator symbols <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code>, <code>&gt;=</code>, 
-        <code>&lt;&lt;</code>, <code>&gt;&gt;</code>, <code>=&gt;</code>, and <code>-&gt;</code>, the <code>&lt;</code> character
-        may be written interchangeably using the codepoint x3C (less-than sign, &lt;) or xFF1C (full-width less-than sign, &#xFF1C;), while the <code>&gt;</code> character 
-        may be written interchangeably using the codepoint x3E (greater-than sign, &gt;) or xFF1E (full-width greater-than sign, &#xFF1E;). 
+      <p>The operator symbols <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code>, <code>&gt;=</code>, 
+        <code>&lt;&lt;</code>, <code>&gt;&gt;</code>, <code>=&gt;</code>, <code>=!&gt;</code>, and <code>-&gt;</code>
+        have alternative representations using the characters <code>"&#xFF1C;"</code> (xFF1C, full-width less-than sign) and
+        <code>"&#xFF1E;"</code> (xFF1E, full-width greater-than sign) in place of <code>"&lt;"</code> (x3C, less-than sign)
+        and <code>"&gt;"</code> (x3E, greater-than sign). The alternative tokens are respectively
+        <code>&#xff1c;</code>, <code>&#xff1c;=</code>, <code>&#xff1e;</code>, <code>&#xff1e;=</code>, 
+        <code>&#xff1c;&#xff1c;</code>, <code>&#xff1e;&#xff1e;</code>, <code>=&#xff1e;</code>, 
+        <code>=!&#xff1e;</code>, and <code>-&#xff1e;</code>.
         In order to avoid visual confusion these alternatives are not shown explicitly in the grammar.</p>
       
       <p>This option is provided to improve the readability of XPath expressions embedded in XML-based host languages such as XSLT; it


### PR DESCRIPTION
As proposed in issue #536, this change disallows mixing of ordinary and full-width angle brackets in the same token.