### PR TITLE
513: after arrow operator, inline function no longer needs parens

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1569,20 +1569,15 @@ ErrorVal ::= "$" VarName
   
   <g:production name="SequenceArrowTarget" if="xpath40 xquery40">
     <g:string>=></g:string>
-    <g:choice>
-      <g:sequence>
-        <g:ref name="ArrowStaticFunction"/>
-        <g:ref name="ArgumentList"/>
-      </g:sequence>
-      <g:sequence>
-        <g:ref name="ArrowDynamicFunction"/>
-        <g:ref name="PositionalArgumentList"/>
-      </g:sequence>
-    </g:choice>
+    <g:ref name="ArrowTarget"/>
   </g:production>
   
   <g:production name="MappingArrowTarget" if="xpath40 xquery40">
     <g:string>=!></g:string>
+    <g:ref name="ArrowTarget"/>
+  </g:production>
+  
+  <g:production name="ArrowTarget" if="xpath40 xquery40">
     <g:choice>
       <g:sequence>
         <g:ref name="ArrowStaticFunction"/>
@@ -1972,6 +1967,7 @@ ErrorVal ::= "$" VarName
   <g:production name="ArrowDynamicFunction">
     <g:choice>
       <g:ref name="VarRef"/>
+      <g:ref name="InlineFunctionExpr"/>
       <g:ref name="ParenthesizedExpr"/>
     </g:choice>
   </g:production>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19420,8 +19420,10 @@ raised <errorref
             <prodrecap id="ArrowExpr" ref="ArrowExpr"/>
             <prodrecap id="SequenceArrowTarget" ref="SequenceArrowTarget"/>
             <prodrecap id="MappingArrowTarget" ref="MappingArrowTarget"/>
+            <prodrecap id="ArrowTarget" ref="ArrowTarget"/>
             <prodrecap id="ArrowStaticFunction" ref="ArrowStaticFunction"/>
             <prodrecap id="ArrowDynamicFunction" ref="ArrowDynamicFunction"/>
+            <prodrecap ref="InlineFunctionExpr"/>
             <prodrecap ref="ArgumentList"/>
             <prodrecap id="PositionalArgumentList" ref="PositionalArgumentList"/>
          </scrap>
@@ -19445,32 +19447,7 @@ raised <errorref
             </ulist>
             </p>
          
-         <!--<ulist>
-            <item>
-               <p>If the arrow is followed by an <nt def="ArrowFunctionSpecifier"/>:</p>
-               <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
-                  <code>U</code>, an <nt def="ArrowFunctionSpecifier">ArrowFunctionSpecifier</nt>
-                  <code>F</code>, and an <nt def="ArgumentList">ArgumentList</nt>
-                  <code>(A, B, C...)</code>, the expression <code>U =&gt; F(A, B, C...)</code> is equivalent to the
-                  expression <code>F(U, A, B, C...)</code>.</p>
-            </item>
-            <item>
-               <p>If the arrow is followed by an <nt def="EnclosedExpr"/>:</p>
-               <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
-                  <code>U</code>, and an <nt def="EnclosedExpr"/> 
-                  <code>E</code>, the expression <code>U => E</code> is equivalent to the expression
-                  <code>U => (function ($V) E1) ()</code> where:
-                  <ulist>
-                     <item><p><var>V</var> is a system-allocated and otherwise unused variable name, and</p></item>
-                     <item><p><var>E1</var> is formed from <var>E</var> by replacing any <nt def="TildeExpr"/>
-                        that is contained in <var>E</var>, and is not contained in any nested <nt def="ArrowExpr"/>,
-                     by the variable reference <code>$V</code>.</p></item>
-                  </ulist>
-                  
-            </item>
-         </ulist>-->
-           
-
+         
         
          
          <p diff="add" at="A">The <term>mapping arrow</term> operator <code>=!></code> is defined as follows:</p>
@@ -19494,23 +19471,7 @@ raised <errorref
                   expression <code>(for $u in U return F($u, A, B, C...))</code>.</p>
                
             </item>
-            <!--<item>
-               <p>If the arrow is followed by an <nt def="EnclosedExpr">EnclosedExpr</nt>:</p>
-               <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
-                  <code>U</code>, and an <nt def="EnclosedExpr">EnclosedExpr</nt> 
-                  <code>{E}</code>, the expression <code>U -> {E}</code> is equivalent to the expression
-                  <code>(U) ! (E)</code>.</p>
-                  
-                  <p>For example, the expression <code>$x -> {.+1}</code> is equivalent to
-                  <code>($x)!(.+1)</code>.</p>
-                  <note><p>The precedence of the <code>!</code> operator is higher than that
-                  of <code>-></code>, so <code>$x -> f() -> {.+1}</code> is equivalent to
-                  <code>($x -> f()) ! (.+1)</code>. Using the <code>-></code> operator in such a pipeline expression,
-                     in preference to <code>!</code>, can therefore reduce the need for parentheses.</p></note>
-               <note><p>The expression <code>$x -> {.+1}</code> can be considered as an abbreviation
-                  for <code>$x -> (->{.+1})()</code>: that is, it calls the anonymous function
-                  <code>->{.+1}</code> once for each item in <code>$x</code>.</p></note>
-            </item>-->
+            
          </ulist>
          
             
@@ -19519,8 +19480,7 @@ raised <errorref
             <p diff="add" at="A">The sequence arrow operator thus applies the supplied function to the result
                of the left-hand operand as a whole, while the mapping arrow operator applies the function to
                each item in the value of the left-hand operand individually. In the case where the result
-               of the left-hand operand is a single item, the two operators have almost the same effect;
-               the only difference is that the thin arrow binds the <termref def="dt-focus"/>.</p>
+               of the left-hand operand is a single item, the two operators have the same effect.</p>
          
          <note><p>The mapping arrow symbol <code>=!></code> is intended to suggest a combination of
          function application (<code>=></code>) and sequence mapping (<code>!</code>) combined in a single operation.</p></note>
@@ -19566,6 +19526,11 @@ raised <errorref
             ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> ($a->{$a+1})() => sum()]]></eg>
          
          <p diff="add" at="A">This is equivalent to <code>sum((1 to 5) ! (math:sqrt(xs:double(.))+1))</code>.</p>
+         
+         <p diff="add" at="A">The same effect can be achieved using a <termref def="dt-focus-function"/>:</p>
+         
+         <eg role="parse-test" diff="add" at="A"
+            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> function{.+1}() => sum()]]></eg>
          
             <note diff="add" at="A"><p>The <code>ArgumentList</code> may include <code>PlaceHolders</code>,
             though this is not especially useful. For example, the expression <code>"$" -> concat(?)</code> is equivalent


### PR DESCRIPTION
Resolves issue #513 by removing the requirement for an inline function expression on the RHS of an arrow operator to be enclosed in parentheses.