### PR TITLE
Action QT4CG-036-02: Further elaboration of the rules for function identity

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -961,7 +961,10 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   may have  the property of being <term>context-dependent</term>: the result of such a
                function depends on the values of properties in the static and dynamic
                evaluation context <phrase diff="add" at="2023-03-12">of the caller</phrase>
-                  as well as on the actual supplied arguments (if any).</termdef></p>
+                  as well as on the actual supplied arguments (if any). A function definition may
+               be context-dependent for some arities in its arity range, and context-independent
+               for others: for example <code>fn:name#0</code> is context-dependent
+                  while <code>fn:name#1</code> is context-independent.</termdef></p>
                
                <p><termdef id="dt-context-independent" term="context-independent">A 
                   <phrase diff="chg" at="2023-03-12"><xtermref spec="XP40" ref="dt-function-definition">function definition</xtermref></phrase> 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -693,7 +693,11 @@ inferred by static type inference as discussed in  <specref
                         </ulist>
                         <p diff="add" at="2023-03-11"><termdef id="dt-context-dependent" term="context dependent">A 
                            <termref def="dt-function-definition"/> is said to be <term>context dependent</term>
-                        if its result depends on the static or dynamic context of its caller.</termdef></p>
+                        if its result depends on the static or dynamic context of its caller.
+                        A function definition may
+                        be context-dependent for some arities in its arity range, and context-independent
+                        for others: for example <code>fn:name#0</code> is context-dependent
+                           while <code>fn:name#1</code> is context-independent.</termdef></p>
                         
                         <note diff="add" at="2023-03-11"><p>Some system functions, such as <code>fn:position</code>, <code>fn:last</code>,
                         and <code>fn:static-base-uri</code>, exist for the sole purpose of providing information
@@ -8270,8 +8274,8 @@ return $a("A")]]></eg>
                whose name matches <var>F</var>, and whose <termref def="dt-arity-range"/> includes <var>N</var></phrase>.
                Call this <termref def="dt-function-definition"/> <var>FD</var>.</p>
             
-            <p diff="chg" at="2023-03-11">If the function is
-          <termref def="dt-context-dependent"/>, then the returned function has
+            <p diff="chg" at="2023-03-11">If <var>FD</var> is
+          <termref def="dt-context-dependent"/> for the given arity, then the returned function item has
                a captured context comprising
           the static and dynamic context of the named function reference.</p>
             
@@ -8309,10 +8313,31 @@ return $a("A")]]></eg>
                   <item><p>The name of <var>FI</var> is the name of <var>FD</var>.</p></item>
                   <item><p diff="add" at="2023-05-25">The identity of <var>FI</var> is as follows:</p>
                      <ulist>
-                        <item><p>If <var>FD</var> is <termref def="dt-context-dependent"/>, then a new function
-                        identity distinct from the identity of any other function item.</p></item>
+                        <item><p>If <var>FD</var> is <termref def="dt-context-dependent"/> for the given arity, then a new function
+                        identity distinct from the identity of any other function item.</p>
+                           <note><p>In the general case, a function reference to a context-dependent function
+                           will produce different results every time it is evaluated, because the resulting function
+                           item has a <term>captured context</term> 
+                              (see <xspecref spec="DM40" ref="function-items"/>) that includes the dynamic context
+                           of the particular evaluation. Optimizers, however, are allowed to detect cases where
+                           the captured context happens to be the same, or where any variations are immaterial,
+                           and where it is therefore safe to return the same function item each time. This might be
+                           the case, for example, where the only context dependency of a function is on the default
+                           collation, and the default collation for both evaluations is known to be the same.</p></note></item>
                         <item><p>Otherwise, a function identity that is the same as that produced by the evaluation
-                           of any other named function reference with the same function name and arity.</p></item>
+                           of any other named function reference with the same function name and arity.</p>
+                             <p>This rule applies even across different 
+                                <xtermref spec="FO40" ref="execution-scope">execution scopes</xtermref>:
+                             for example if an parameter to a call to <function>fn:transform</function> is set to the
+                             result of the expression <code>fn:abs#1</code>, then the function item passed as the parameter
+                                value will be identical to that obtained by evaluating the expression <code>fn:abs#1</code>
+                             within the target XSLT stylesheet.</p>
+                           <p>This rule also applies when the target function definition is 
+                           <xtermref spec="FO40" ref="dt-nondeterministic">nondeterministic</xtermref>. 
+                           For example all evaluations of the named function reference <code>map:keys#2</code>
+                           return identical function items, even though two evaluations of <function>map:keys</function>
+                           with the same arguments may produce different results.</p>
+                        </item>
                      </ulist>
                      <note><p>See also <specref ref="id-function-identity"/>.</p></note>
                   </item>
@@ -8681,15 +8706,16 @@ return $incrementors[2](4)]]></eg>
                or to different functions. For this purpose, every function item has an identity. Functions with the
                same identity are indistinguishable in every way; in particular, any function call with identical
                arguments will produce an identical result.</p>
-               <p>In general, evaluation of an expression that returns a new function item (one that was
-               not present in its operands) delivers a function item whose identity is unique, and thus distinct
+               <p>In general, evaluation of an expression that returns a function item other than one that was
+               present in its operands delivers a function item whose identity is unique, and thus distinct
                from any other function item. There are two exceptions to this rule:</p>
                
                <ulist>
                   <item><p>Evaluating a function reference such as <code>count#1</code> returns the same function
                   every time. Specifically, if the function name identifies a <termref def="dt-function-definition"/>
                   that is not <termref def="dt-context-dependent"/> (which is the most usual case), then all 
-                     function references using this function name and arity return the same function.</p>
+                     function references using this function name and arity return the same function.
+                  For more details see <specref ref="id-named-function-ref"/>.</p>
                   </item>
                   <item><p>An optimizer is permitted to rewrite expressions in such a way that repeated
                   evaluation is avoided if it can be established that the result will be the same each time,


### PR DESCRIPTION
Following review and acceptance of the proposal introducing the concept of function identity (PR #525, Issue #520) this PR makes some refinements in response to comments raised during the review, especially in the following areas:

* clarification as regards named function references to context-dependent functions
* relationship to (in)determinacy of a function
* avoiding the phrase "new function item"
* stating that the identity of a function item such as fn:count#1 applies even across execution scopes, e.g. calls to fn:transform.
