### PR TITLE
548: require parens around lambda arguments

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2389,20 +2389,15 @@ ErrorVal ::= "$" VarName
   </g:production>
   
   <g:production name="LambdaParams" if="xpath40 xquery40  xslt40-patterns">
-    <g:choice>
-      <g:ref name="LambdaParam"/>
-      <g:sequence>
-         <g:string>(</g:string>
-         <g:optional>
-           <g:ref name="LambdaParam"/>
-           <g:zeroOrMore>
-             <g:string>,</g:string>
-             <g:ref name="LambdaParam"/>
-           </g:zeroOrMore>
-         </g:optional>
-         <g:string>)</g:string>
-      </g:sequence>
-   </g:choice>
+     <g:string>(</g:string>
+     <g:optional>
+       <g:ref name="LambdaParam"/>
+       <g:zeroOrMore>
+         <g:string>,</g:string>
+         <g:ref name="LambdaParam"/>
+       </g:zeroOrMore>
+     </g:optional>
+     <g:string>)</g:string>
   </g:production>
   
   <g:production name="LambdaParam" if="xpath40 xquery40  xslt40-patterns">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7416,7 +7416,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                </item>
                <item diff="add" at="A">
                   <p>
-                     <code role="parse-test">sort(//employee, key := $e->{xs:decimal($e/salary)})</code> is a static function 
+                     <code role="parse-test">sort(//employee, key := ($e)->{xs:decimal($e/salary)})</code> is a static function 
                      call with one positional argument and one keyword argument. 
                      The corresponding function declaration defines three parameters,
                      a required parameter <code>$input</code>, an optional parameter <code>$collation</code>,
@@ -7425,7 +7425,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                      to take its default value. The default value of the <code>$collation</code> parameter
                      is given as <code>fn:default-collation()</code>, so the value supplied to the function is the
                      default collation from the dynamic context of the caller. It is equivalent to the call 
-                     <code>fn:sort(//employee, fn:default-collation(), $e->{xs:decimal($e/salary)})</code>.
+                     <code>fn:sort(//employee, fn:default-collation(), ($e)->{xs:decimal($e/salary)})</code>.
                   </p>
                </item>
                <!--<item diff="add" at="A">
@@ -7682,7 +7682,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                with one argument.</p></item>
                <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/> and <specref ref="id-lambda-expressions"/>)
                   constructs a function item whose <phrase diff="chg" at="2023-03-11">body</phrase> is defined locally. For example the
-               construct <code>$x->{$x+1}</code> returns a function item whose effect is to increment
+               construct <code>($x)->{$x+1}</code> returns a function item whose effect is to increment
                the value of the supplied argument.</p></item>
                <item><p>A <term>partial function application</term> (see 
                   <specref ref="id-partial-function-application"/>) derives one function item from another by supplying
@@ -8600,7 +8600,7 @@ return $incrementors[2](4)]]></eg>
                For example, to sort employees by salary, write <code>sort(//employee, (), function{+@salary})</code>.
                (The unary plus has the effect of converting the attribute's value to a number, for numeric sorting).</p>
                <p>Focus functions can also be useful on the right-hand side of the <termref def="dt-arrow-operator"/>.
-               For example, <code>$s => tokenize() => (function{`"{.}"`})()</code> first tokenizes the string <code>$s</code>,
+               For example, <code>$s => tokenize() => function{`"{.}"`}()</code> first tokenizes the string <code>$s</code>,
                then wraps each token in double quotation marks.</p>
                <p>The expression <code>function{EXPR}</code> is a syntactic shorthand for the expression
                <code>function($Z as item()) as item()* {$Z!(EXPR)}</code>, where <code>$Z</code> is a variable name that is
@@ -8621,20 +8621,20 @@ return $incrementors[2](4)]]></eg>
             
             <p>Lambda expressions provide an abbreviated syntax for inline functions.</p>
             
-            <p>For example, the expression <code>$a -> {$a+1}</code> is equivalent to 
+            <p>For example, the expression <code>($a) -> {$a+1}</code> is equivalent to 
             <code>function($a){$a + 1}</code></p>
             
             <p>A lambda expression of the form <code>($x, $y, $z, ...) -> {EXPR}</code> has precisely the same effect, and is subject
                to the same rules, as the expanded form <code>function($x, $y, $z, ...){EXPR}</code></p>
             
-            <p>The parentheses around the parameter list may be omitted if the function takes exactly one argument.</p>
+            <p>The parentheses around the parameter list are required even if the function takes only one argument.</p>
             
             <p>For example:</p>
             
             <ulist>
                <item>
                   <p>This example creates a function that prepends the string <code>"£"</code> to a supplied value:
-                     <eg role="parse-test"><![CDATA[$x -> {`£{$x}`}]]></eg>
+                     <eg role="parse-test"><![CDATA[($x) -> {`£{$x}`}]]></eg>
                   </p>
                   <p>It is equivalent to the function <code>concat("£", ?)</code>.</p>
                </item>
@@ -8643,7 +8643,7 @@ return $incrementors[2](4)]]></eg>
                      attribute of a supplied element node:
                      <eg
                         role="parse-test"
-                        ><![CDATA[$e -> {$e!@name}]]></eg>
+                        ><![CDATA[($e) -> {$e!@name}]]></eg>
                   </p>
                   <p>It is equivalent to the function <code>function($x as item()) as item()* {$x ! @name}</code>.</p>
                </item>
@@ -8666,7 +8666,7 @@ return $incrementors[2](4)]]></eg>
             </ulist>
             
             <note><p>The concise syntax is introduced in 4.0 because a compact notation aids readability
-            in simple higher-order function calls such as <code>fn:sort(//emp, (), $e -> {$e/@salary})</code>,
+            in simple higher-order function calls such as <code>fn:sort(//emp, (), ($e) -> {$e/@salary})</code>,
             and also because it is familiar to users of other popular languages such as Java, C#, and Javascript.</p></note>
             
             <note><p>The grammar for lambda expressions involves unbounded lookahead: given an expression that starts
@@ -19563,12 +19563,12 @@ raised <errorref
          <p diff="add" at="A">The following example introduces an inline function to the pipeline, in the form of
             a lambda expression:</p>
          <eg role="parse-test" diff="add" at="A"
-            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> ($a->{$a+1})() => sum()]]></eg>
+            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> (($a)->{$a+1})() => sum()]]></eg>
          
          <p diff="add" at="A">This is equivalent to <code>sum((1 to 5) ! (math:sqrt(xs:double(.))+1))</code>.</p>
          
             <note diff="add" at="A"><p>The <code>ArgumentList</code> may include <code>PlaceHolders</code>,
-            though this is not especially useful. For example, the expression <code>"$" -> concat(?)</code> is equivalent
+            though this is not especially useful. For example, the expression <code>"$" => concat(?)</code> is equivalent
             to <code>concat("$", ?)</code>: its value is a function that prepends a supplied string with
             a <code>$</code> symbol.</p></note>
          


### PR DESCRIPTION
Require parentheses around the parameter list in a lambda expression, even when there is only one parameter, to avoid the problem of needing whitespace before the arrow. Resolves issue #548.