### PR TITLE
Editorial: Updates to back matter and status section of F+O spec

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -212,7 +212,8 @@ for transition to Proposed Recommendation. </p>'>
        <status>
           <p>This version of the specification is work in progress. It is produced by the QT4 Working Group, officially
              the W3C XSLT 4.0 Extensions Community Group. Individual functions specified in the document may be at
-             different stages of review, reflected in their <term>History</term> notes. Comments are invited.</p>
+             different stages of review, reflected in their <term>History</term> notes. Comments are invited,
+             in the form of GitHub issues at <loc href="https://github.com/qt4cg/qtspecs">https://github.com/qt4cg/qtspecs</loc>.</p>
        </status>
 
         <langusage>
@@ -227,9 +228,8 @@ for transition to Proposed Recommendation. </p>'>
          <head>Introduction</head>
           
                 
-         <p>The purpose of this document is to propose functions and operators to be included in
-                XPath 4.0, XQuery 4.0, and XSLT 4.0. Note that this proposal has no official standing
-                at the time of publication.
+         <p>The purpose of this document is to define functions and operators for inclusion in
+                XPath 4.0, XQuery 4.0, and XSLT 4.0. 
                 The exact syntax used to call these
                 functions and operators is specified in <bibref ref="xpath-40"/>, <bibref ref="xquery-40"/> and 
             <bibref ref="xslt-40"/>. </p>
@@ -10407,7 +10407,7 @@ ISBN 0 521 77752 6.</bibl>
                <bibl id="exquery" key="EXQuery">EXQuery: Collaboratively Defining Open Standards for Portable XQuery Extensions.
                   <loc href="http://exquery.org/">http://exquery.org/</loc>.</bibl> 
                <bibl id="exslt" key="EXSLT">EXSLT: A Community Initiative to Provide Extensions to XSLT.
-                  <loc href="http://exslt.org/">http://exslt.org/</loc>.</bibl> 
+                  <loc href="https://exslt.github.io">https://exslt.github.io</loc>.</bibl> 
                <bibl id="functx" key="FunctX">FunctX Functions. 
                   <loc href="http://www.functx.com/">http://www.functx.com/</loc>.</bibl> 
                <bibl  id="HTML40" key="HTML 4.0">HTML 4.01 Recommendation, 24 December
@@ -11409,11 +11409,14 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:all</code></p></item>
               <item><p><code>fn:all-different</code></p></item>
               <item><p><code>fn:all-equal</code></p></item>
+              <item><p><code>fn:atomic-equal</code></p></item>
               <item><p><code>fn:build-uri</code></p></item>
+              <item><p><code>fn:char</code></p></item>
               <item><p><code>fn:characters</code></p></item>
               <item><p><code>fn:contains-sequence</code></p></item>
               <item><p><code>fn:ends-with-sequence</code></p></item>
               <item><p><code>fn:expanded-QName</code></p></item>
+              <item><p><code>fn:foot</code></p></item>
               <item><p><code>fn:highest</code></p></item>
               <item><p><code>fn:identity</code></p></item>
               <item><p><code>fn:in-scope-namespaces</code></p></item>
@@ -11427,26 +11430,40 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:iterate-while</code></p></item>
               <item><p><code>fn:lowest</code></p></item>
               <item><p><code>fn:op</code></p></item>
+              <item><p><code>fn:parse-integer</code></p></item>
               <item><p><code>fn:parse-QName</code></p></item>
               <item><p><code>fn:parse-uri</code></p></item>
               <item><p><code>fn:partition</code></p></item>
               <item><p><code>fn:replicate</code></p></item>
+              <item><p><code>fn:slice</code></p></item>
               <item><p><code>fn:some</code></p></item>
               <item><p><code>fn:starts-with-sequence</code></p></item>
+              <item><p><code>fn:transitive-closure</code></p></item>
+              <item><p><code>fn:trunk</code></p></item>
+              <item><p><code>fn:xdm-to-json</code></p></item>
+              <item><p><code>array:build</code></p></item>
+              <item><p><code>array:foot</code></p></item>
+              <item><p><code>array:members</code></p></item>
+              <item><p><code>array:of</code></p></item>
+              <item><p><code>array:slice</code></p></item>
+              <item><p><code>array:trunk</code></p></item>
+              <item><p><code>map:build</code></p></item>
+              <item><p><code>map:filter</code></p></item>
+              <item><p><code>map:of</code></p></item>
                
            </ulist>
 
            <p>A number of functions are included in the draft specification but have not yet been reviewed or accepted:</p>
            
            <ulist>
-              <item><p><code>fn:differences</code></p></item>
+              <!--<item><p><code>fn:differences</code></p></item>
               <item><p><code>fn:json</code></p></item>
-              <item><p><code>fn:slice</code></p></item>
+              <item><p><code>fn:slice</code></p></item>-->
               <item><p><code>fn:stack-trace</code></p></item>
               <item><p><code>map:filter</code></p></item>
               <item><p><code>map:replace</code></p></item>
               <item><p><code>map:substitute</code></p></item>
-              <item><p><code>array:partition</code></p></item>
+              <!--<item><p><code>array:partition</code></p></item>-->
               <item><p><code>array:replace</code></p></item>
               <item><p><code>array:slice</code></p></item>
               
@@ -11460,9 +11477,19 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
 	           <item><p>The keywords used for parameter names have been changed. Previously these names were
 	              of no significance, but in 4.0 they can be used with <code>keyword := value</code>
 	              argument syntax in function calls.</p></item>
+	           <item><p>The <code>fn:deep-equal</code> function has an <code>options</code> argument
+	           giving detailed control over how two values are compared.</p></item>
+	           <item><p>The <code>fn:format-integer</code> function can produce output in non-decimal
+	           radices, for example binary and hexadecimal.</p></item>
+	           <item><p>The <code>fn:json-doc</code> function accepts additional options.</p></item>
+	           <item><p>The <code>fn:remove</code> function allows several items to be removed from
+	              a sequence in a single call.</p></item>
+	           <item><p>The <code>fn:replace</code> function has an additional optional argument
+	              allowing the replacement string to be computed from the matched input string.</p></item>
 	        </olist>
 	        <p>The following changes are present in this draft, but have not been agreed by the community group:</p>
 	        <olist>
+	           
 	           <item><p>The third argument of <code>fn:format-number</code> can now be supplied
 	              as an <code>xs:QName</code> instead of as a string that can be converted to a QName.
 	              Using a <code>xs:QName</code>, especially in the (rare) cases when the value is


### PR DESCRIPTION
Mainly updates to the changes appendix. Also improve the status section, and correct the bibref to the EXSLT specs.