### PR TITLE
464: Revised narrative of normalization steps for serialization

### DIFF
--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -457,52 +457,54 @@ content expression as described in Step 1e of
 of <bibref ref="xquery-31"/>, where the construction mode is
 <code>preserve</code>.
 
+Let <emph>S<sub>0</sub></emph> be the sequence that is input to serialization. 
 The steps in computing the normalized sequence are:
 </p>
       <!--End of text replaced by erratum E6-->
 <olist>
-<item><p>If the sequence that is input to serialization is
-empty, create a sequence <emph>S<sub>1</sub></emph> that consists of a
-zero-length string.  Otherwise, copy each item in the sequence that is
-input to serialization to create the new sequence <emph>S<sub>1</sub></emph>.
-Each item in the sequence that is an array is flattened by calling the function
-<code>array:flatten()</code> before being copied.
-</p></item>
-<item><p>For each item in <emph>S<sub>1</sub></emph>, if the item is atomic, obtain the 
-lexical representation of the item by casting it to an <code role="SCHEMATYPE">xs:string</code>
-and copy the string representation to the new sequence; otherwise, copy the
-item to the new sequence.
-The new sequence is <emph>S<sub>2</sub></emph>.</p></item>
+<item><p>Create a new sequence <emph>S<sub>1</sub></emph> from <emph>S<sub>0</sub></emph> as follows. For
+each item in <emph>S<sub>0</sub></emph>, if the item is an array, copy the results of
+passing the item into the function <code>array:flatten()</code>; otherwise, copy the item
+itself. If <emph>S<sub>0</sub></emph> is empty, let <emph>S<sub>1</sub></emph> consist
+of a zero-length string. </p></item>
+<item><p>Create a new sequence <emph>S<sub>2</sub></emph> from <emph>S<sub>1</sub></emph> as follows. For
+each item in <emph>S<sub>1</sub></emph>, if the item is atomic, copy to <emph>S<sub>2</sub></emph> only the lexical
+representation resulting from casting the item to an <code role="SCHEMATYPE">xs:string</code>, otherwise, 
+copy the item to <emph>S<sub>2</sub></emph>.</p></item>
 <item>
-<p>If the <code>item-separator</code> serialization
-parameter is absent, then for each subsequence of adjacent strings in
-<emph>S<sub>2</sub></emph>,
-copy a single string to the new sequence equal to the values of the
-strings in the subsequence concatenated in order, each separated by a
-single space.  Copy all other items to the new sequence.
-Otherwise, copy each item in
-<emph>S<sub>2</sub></emph> to the
-new sequence, inserting between each pair of items a string whose
-value is equal to the value of the <code>item-separator</code>
-parameter.
-The new sequence is <emph>S<sub>3</sub></emph>.</p></item>
-<item><p>For each item in <emph>S<sub>3</sub></emph>, if the item is a string,
-create a text node in the new sequence whose <termref def="dt-string-value">string value</termref> is equal to
-the string; otherwise, copy the item to the new sequence.  The new
-sequence is <emph>S<sub>4</sub></emph>.</p></item>
-<item><p>For each item in <emph>S<sub>4</sub></emph>, if the item is a document node,
-copy its children to the new sequence; otherwise, copy the item to the new 
-sequence.  The new sequence is <emph>S<sub>5</sub></emph>.</p></item>
-<item><p>For each subsequence of adjacent text nodes in <emph>S<sub>5</sub></emph>, copy a single text node to the new sequence equal to the values of the text nodes in the subsequence concatenated in order.  Any text nodes with values of zero length are dropped.  Copy all other items to the new sequence. The new sequence is <emph>S<sub>6</sub></emph>.</p></item>
-<item><p>It is a <termref def="serial-err">serialization error</termref> <errorref code="0001" class="NR"/> if an item in <emph>S<sub>6</sub></emph> is an
-attribute node,
-a namespace node
-or a
-<termref def="dt-function-item">function</termref>.
-Otherwise, construct a new sequence,
-<emph>S<sub>7</sub></emph>, that consists of a single document node and
-copy all the items in the sequence, which are all nodes, as children of
-that document node.</p></item></olist><p><emph>S<sub>7</sub></emph> is the normalized sequence.</p>
+<p>Create a new sequence <emph>S<sub>3</sub></emph> from <emph>S<sub>2</sub></emph> as follows. If the
+<code>item-separator</code> serialization parameter is present, then copy each item in
+<emph>S<sub>2</sub></emph> to <emph>S<sub>3</sub></emph>, inserting between each pair of items
+a string whose value is equal to the value of the item-separator parameter. If the
+<code>item-separator</code> serialization parameter is not present, then first maximally 
+group the items in <emph>S<sub>2</sub></emph> into subsequences of <code role="SCHEMATYPE">xs:string</code> items 
+and non-<code role="SCHEMATYPE">xs:string</code> items. For each group of items, if the group is a subsequence of
+non-<code role="SCHEMATYPE">xs:string</code> items, copy the subsequence to
+<emph>S<sub>3</sub></emph>; if the group is a subsequence of <code role="SCHEMATYPE">xs:string</code> 
+items, copy to <emph>S<sub>3</sub></emph> the results of passing to
+<code>fn:string-join()</code> the subsequence and the value of
+<code>item-separator</code> as the function's two parameters. </p></item>
+<item><p>Create a new sequence <emph>S<sub>4</sub></emph> from <emph>S<sub>3</sub></emph> as follows.
+For each item in <emph>S<sub>3</sub></emph>, if the item is a string,
+copy to <emph>S<sub>4</sub></emph> a text node whose <termref def="dt-string-value">string value</termref> is equal to
+the string; otherwise, copy the item to <emph>S<sub>4</sub></emph>.</p></item>
+<item><p>
+Create a new sequence <emph>S<sub>5</sub></emph> from <emph>S<sub>4</sub></emph> as follows.
+For each item in <emph>S<sub>4</sub></emph>, if the item is a document node,
+copy its children to <emph>S<sub>5</sub></emph>; otherwise, copy the item to <emph>S<sub>5</sub></emph>.</p></item>
+<item><p>Create a new sequence <emph>S<sub>6</sub></emph> from <emph>S<sub>5</sub></emph> as follows. First,
+remove any text nodes with values of zero length from <emph>S<sub>5</sub></emph>, then
+maximally group the results into groups of text nodes and non-text nodes. For each group
+of items, if the group is a subsequence of text nodes, copy to
+<emph>S<sub>6</sub></emph> a single text node whose value is equal to the concatenated
+values of the subsequence; if the group is a subsequence of non-text nodes, copy the
+subsequence of items to <emph>S<sub>6</sub></emph>. It is a <termref def="serial-err">serialization error</termref>
+<errorref code="0001" class="NR"/> if any item in <emph>S<sub>6</sub></emph> is an
+attribute node, a namespace node, or a <termref def="dt-function-item">function</termref>. </p></item>
+<item><p>Create a new sequence <emph>S<sub>7</sub></emph> from <emph>S<sub>6</sub></emph> as follows.
+Let <emph>S<sub>7</sub></emph> be a single document node. 
+Copy sequence <emph>S<sub>6</sub></emph> to the document node as its children.
+</p></item></olist><p><emph>S<sub>7</sub></emph> is the normalized sequence.</p>
 <p>The <termref def="result-tree">result tree</termref> rooted at the document node that is
 created by the final step of this sequence
 normalization process is the


### PR DESCRIPTION
This PR acts on #464 by revising the description of steps involved in normalizing a sequence that is input to serialization. I normally would wield a light editorial hand, but the issues raised in #464 as well as closer reading of the prose convinced me that a wholesale revision would be beneficial. For example, new sequences were described as if the reader already knew about them, but they are really only introduced as the last sentence in many steps.

I have capitalized on the original version of step 1's appeal to `array:flatten` to abbreviate the description for two of the steps.