### PR TITLE
Added fn:items-X cross-references

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24422,7 +24422,9 @@ function($item){
             or -1 if no item matches the predicate.</p>
          <p>The function then returns <code>if ($P lt 0) then () else fn:subsequence($input, $P + 1)</code>.</p>
       </fos:rules>
-
+      <fos:notes>
+         <p>To retain the first matching item, use <code>fn:items-starting-where</code>.</p>
+      </fos:notes>
 
       <fos:examples>
 
@@ -24477,7 +24479,10 @@ function($item){
             or -1 if no item matches the predicate.</p>
          <p>The function then returns <code>if ($P lt 0) then $seq else fn:subsequence($input, 1, $P - 1)</code>.</p>
       </fos:rules>
-
+      <fos:notes>
+         <p>To retain the first matching item, use <code>fn:items-ending-where</code>.</p>
+      </fos:notes>
+      
 
       <fos:examples>
 
@@ -24536,7 +24541,10 @@ function($item){
             or -1 if no item matches the predicate.</p>
          <p>The function then returns <code>if ($P lt 0) then () else fn:subsequence($input, $P)</code>.</p>
       </fos:rules>
-
+      <fos:notes>
+         <p>To exclude the first item, use <code>fn:items-after</code>.</p>
+      </fos:notes>
+      
 
       <fos:examples>
 
@@ -24592,7 +24600,10 @@ function($item){
             or -1 if no item matches the predicate.</p>
          <p>The function then returns <code>if ($P lt 0) then $seq else fn:subsequence($input, 1, $P)</code>.</p>
       </fos:rules>
-
+      <fos:notes>
+         <p>To exclude the last item, use <code>fn:items-before</code>.</p>
+      </fos:notes>
+      
 
       <fos:examples>
 


### PR DESCRIPTION
This PR provides cross-references in the form of notes between members of the pairs `items-before()` & `items-ending-where()` and `items-after()` & `items-starting-where()`. The goal is a light editorial intervention to enhance function discovery. (Anticipating a user who, at any one of these spec descriptions, wonders how they might exclude/include the first matching item.)