### PR TITLE
More typographic changes

### DIFF
--- a/specifications/css/qtspecs.css
+++ b/specifications/css/qtspecs.css
@@ -74,6 +74,23 @@ div.exampleInner {
     margin-bottom: 1em;
 }
 
+div.example table p {
+    margin: 0;
+}
+div.example code {
+    background-color: inherit;
+    border: none;
+}
+div.example tbody tr:nth-child(odd) {
+    background-color: var(--example-bg-odd);
+}
+div.example tbody tr:nth-child(even) {
+    background-color: var(--example-bg-even);
+}
+div.example table {
+    width: 100%;
+}
+
 div.issueBody    { margin-left: 0.25in;
                  }
 
@@ -106,7 +123,7 @@ p.element-syntax-chg { border: solid thick yellow; background-color: #ffccff
 
 div.example-chg  { border: solid thick yellow; background-color: #40e0d0; padding: 1em
                  }
-                 
+
 span.verb        { font: small-caps 100% sans-serif
                  }
 
@@ -137,7 +154,7 @@ background: repeating-linear-gradient(
   #ffdddd 80px
 );
 }
-                 
+
 table.scrap td {
 	 vertical-align: baseline;
 	 text-align: left;
@@ -155,25 +172,28 @@ table.data table.index {
 
 div.exampleInner pre { margin-left: 1em;
                        margin-top: 0em; margin-bottom: 0em}
-                       
-pre.small { font-size: small }                       
+
+pre.small {
+    /*font-size: small*/
+}
+
 div.exampleOuter {border: 4px double gray;
                   margin: 0em; padding: 0em}
 
 div.exampleInner table { border: 0;
                          border-spacing: 0;
                        }
-                   
+
 div.exampleInner td { vertical-align: baseline;
                       padding: 0;
                     }
-                   
+
 div.exampleWrapper { margin: 4px }
 div.exampleHeader { font-weight: bold;
                     margin: 4px}
-                    
+
 div.proto { border: 0;
-            border-spacing: 0; 
+            border-spacing: 0;
           }
 
 div.issue { border-bottom-color: black;

--- a/specifications/css/w3c-base.css
+++ b/specifications/css/w3c-base.css
@@ -66,6 +66,8 @@
 
 	--example-border: #e0cb52;
 	--example-bg: #fcfaee;
+	--example-bg-odd: #faf6e1;
+	--example-bg-even: #fcfaee;
 	--example-text: var(--text);
 	--exampleheading-text: #574b0f;
 

--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -32,9 +32,9 @@ table.casting    { font-size: x-small;
                  }
 table.hierarchy  { font-size: x-small;
                  }
-table.proto      {
-                  
-                 }
+table.proto {
+    line-height: 1.25;
+}
 
 td.castY         { background-color: #7FFF7F;
                    color: black;
@@ -93,7 +93,7 @@ table.record tr td, {
 }
 table.proto tr.arg td:first-child,
 table.record tr.arg td:first-child  {
-  padding-left: 2em;
+  padding-left: 0.5em;
 }
 table.proto tr.name span.name {
   font-weight: bold;

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -289,57 +289,57 @@
 	</xsl:template>
 	
 	<xsl:template match="fos:example/*" priority="4">
-		<tr>
-			<xsl:copy-of select="@diff, @at"/>
-			<td colspan="2">
-				<xsl:copy-of select="." copy-namespaces="no"/>
-			</td>
-		</tr>
+	  <tr>
+	    <xsl:copy-of select="@diff, @at"/>
+	    <td colspan="2">
+	      <xsl:copy-of select="." copy-namespaces="no"/>
+	    </td>
+	  </tr>
 	</xsl:template>
 
 	<xsl:template match="fos:test" priority="5">
-		<tr>
-			<xsl:copy-of select="@diff, @at"/>
-			<td>
-				<xsl:if test="fos:preamble">
-					<p><xsl:copy-of select="fos:preamble/node()" copy-namespaces="no"/></p>
-				</xsl:if>
-				<p>
-					<xsl:choose>
-						<xsl:when test="fos:expression/@xml:space = 'preserve'">
-							<code><xsl:value-of select="translate(fos:expression, ' ', '&#xa0;')"/></code>
-						</xsl:when>
-						<xsl:when test="fos:expression/eg">
-							<xsl:apply-templates select="fos:expression/node()"/>
-						</xsl:when>
-						<xsl:otherwise>
-							<code><xsl:value-of select="fos:expression"/></code>
-						</xsl:otherwise>
-					</xsl:choose>
-				</p>
-			</td>
-			<td>
-				<xsl:if test="fos:result[2]"><p>One of the following:</p></xsl:if>
-				<xsl:apply-templates select="fos:result|fos:error-result"/>
-				<xsl:if test="fos:result[@normalize-space = 'true']">
-					<p>(with whitespace added for legibility)</p>
-				</xsl:if>
-				<xsl:if test="fos:result[@allow-permutation = 'true']">
-					<p>(or some permutation thereof)</p>
-				</xsl:if>
-				<xsl:if test="fos:result[@approx = 'true']">
-					<p>(approximately)</p>
-				</xsl:if>
-				<xsl:if test="fos:postamble">
-					<p><emph>
-						<xsl:text>(</xsl:text>
-						<xsl:copy-of select="fos:postamble/node()" copy-namespaces="no"/>
-						<xsl:text>)</xsl:text>
-						<xsl:if test="not(ends-with(fos:postamble, '.'))">.</xsl:if>
-					</emph></p>
-				</xsl:if>
-			</td>
-		</tr>
+	  <tr>
+	    <xsl:copy-of select="@diff, @at"/>
+	    <td valign="top">
+	      <xsl:if test="fos:preamble">
+		<p><xsl:copy-of select="fos:preamble/node()" copy-namespaces="no"/></p>
+	      </xsl:if>
+	      <p>
+		<xsl:choose>
+		  <xsl:when test="fos:expression/@xml:space = 'preserve'">
+		    <code><xsl:value-of select="translate(fos:expression, ' ', '&#xa0;')"/></code>
+		  </xsl:when>
+		  <xsl:when test="fos:expression/eg">
+		    <xsl:apply-templates select="fos:expression/node()"/>
+		  </xsl:when>
+		  <xsl:otherwise>
+		    <code><xsl:value-of select="fos:expression"/></code>
+		  </xsl:otherwise>
+		</xsl:choose>
+	      </p>
+	    </td>
+	    <td valign="top">
+	      <xsl:if test="fos:result[2]"><p>One of the following:</p></xsl:if>
+	      <xsl:apply-templates select="fos:result|fos:error-result"/>
+	      <xsl:if test="fos:result[@normalize-space = 'true']">
+		<p>(with whitespace added for legibility)</p>
+	      </xsl:if>
+	      <xsl:if test="fos:result[@allow-permutation = 'true']">
+		<p>(or some permutation thereof)</p>
+	      </xsl:if>
+	      <xsl:if test="fos:result[@approx = 'true']">
+		<p>(approximately)</p>
+	      </xsl:if>
+	      <xsl:if test="fos:postamble">
+		<p><emph>
+		  <xsl:text>(</xsl:text>
+		  <xsl:copy-of select="fos:postamble/node()" copy-namespaces="no"/>
+		  <xsl:text>)</xsl:text>
+		  <xsl:if test="not(ends-with(fos:postamble, '.'))">.</xsl:if>
+		</emph></p>
+	      </xsl:if>
+	    </td>
+	  </tr>
 	</xsl:template>
 	
 	<xsl:template match="fos:result">


### PR DESCRIPTION
Further to #560, I'll just merge this if it passes.

1. Make the `<pre>` font the same size as the other monospaced environments
2. Tighten up the spacing in function signatures
3. Make table-formatted examples use valign=top
4. Add subtle shading to table-formatted examples so the rows are easier to distinguish.