### PR TITLE
567: schema for xslt40

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -21,7 +21,7 @@
   <xs:annotation>
     <xs:documentation>
       <p>
-         This is an XSD 1.1 schema for XSLT 3.0 stylesheets. It defines all the
+         This is an XSD 1.1 schema for XSLT 4.0 stylesheets. It defines all the
          elements that appear in the XSLT namespace; it also provides hooks that
          allow the inclusion of user-defined literal result elements, extension
          instructions, and top-level data elements.
@@ -72,7 +72,7 @@
         <li>
            The schema makes no attempt to check XPath expressions for syntactic or
            semantic correctness, nor to check that component references are
-           resolved (for example that a template named in xsl:call-template has a
+           resolved (for example that a template named in <code>xsl:call-template</code> has a
            declaration). Doing this in general requires cross-document validation,
            which is beyond the scope of XSD.
         </li>
@@ -147,16 +147,13 @@ of problems processing the schema using various tools
   <xs:complexType name="versioned-element-type" mixed="true">
     <xs:annotation>
       <xs:documentation>
-        <p>
-           This complex type provides a generic supertype for all XSLT elements
-           with the exception of xsl:output; it contains the definitions of the
-           version attribute that may appear on any element.
-        </p>
-        <p>
-           The xsl:output does not use this definition because, although it has a
-           version attribute, the syntax and semantics of this attribute are
-           unrelated to the standard version attribute allowed on other elements.
-        </p>
+        <p>This complex type provides a generic supertype for all XSLT elements with
+                the exception of <code>xsl:output</code>; it contains the
+                definitions of the <code>version</code> attribute that may appear on any element.
+                </p>
+        <p>The <code>xsl:output</code> element does not use this definition because, although it
+             has a <code>version</code> attribute, the syntax and semantics of this attribute are
+             unrelated to the standard <code>version</code> attribute allowed on other elements.</p>
       </xs:documentation>
     </xs:annotation>
     <xs:complexContent>
@@ -263,20 +260,18 @@ of problems processing the schema using various tools
   <xs:element name="accept">
     <xs:annotation>
       <xs:documentation>
-        <p>
-           This element appears as a child of xsl:use-package and defines any
-           variations that the containing package wishes to make to the visibility
-           of components made available from a library package. For example, it may
-           indicate that some of the public components in the library package are
-           not to be made available to the containing package.
-        </p>
+        <p>This element appears as a child of <code>xsl:use-package</code> and defines 
+            any variations that the containing package wishes to make to the visibility of
+            components made available from a library package. For example, it may indicate that
+            some of the public components in the library package are not to be made available
+            to the containing package.</p>
       </xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:complexContent>
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:attribute name="component" type="xsl:component-kind-type"/>
-          <xs:attribute name="names" type="xsl:EQNames"/>
+          <xs:attribute name="names" type="xsl:component-tests"/>
           <xs:attribute name="visibility" type="xsl:visibility-type"/>
           <xs:attribute name="_component" type="xs:string"/>
           <xs:attribute name="_names" type="xs:string"/>
@@ -374,16 +369,18 @@ of problems processing the schema using various tools
             <xs:element ref="xsl:with-param"/>
           </xs:choice>
           <xs:attribute name="select" type="xsl:expression" default="child::node()"/>
+          <xs:attribute name="separator" type="xsl:expression"/>
           <xs:attribute name="mode" type="xsl:mode"/>
           <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_separator" type="xs:string"/>
           <xs:attribute name="_mode" type="xs:string"/>
           <xs:assert test="every $e in subsequence(xsl:sort, 2) 
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if an xsl:sort element other than the first
-                   in a sequence of sibling xsl:sort elements has a stable
+                   It is a static error if an <code>xsl:sort</code> element other than the first
+                   in a sequence of sibling <code>xsl:sort</code> elements has a <code>stable</code>
                    attribute.
                 </p>
               </xs:documentation>
@@ -404,6 +401,7 @@ of problems processing the schema using various tools
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
+  
   
   <xs:element name="assert" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -438,10 +436,8 @@ of problems processing the schema using various tools
           <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
-                </p>
+                <p>The <code>type</code> and <code>validation</code> attributes are mutually exclusive
+                (if one is present, the other must be absent).</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -576,10 +572,8 @@ of problems processing the schema using various tools
           <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
-                </p>
+                <p>The <code>type</code> and <code>validation</code> attributes are mutually exclusive
+                  (if one is present, the other must be absent).</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -605,10 +599,8 @@ of problems processing the schema using various tools
           <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
-                </p>
+                <p>The <code>type</code> and <code>validation</code> attributes are mutually exclusive
+                  (if one is present, the other must be absent).</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -629,10 +621,8 @@ of problems processing the schema using various tools
           <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
-                </p>
+                <p>The <code>type</code> and <code>validation</code> attributes are mutually exclusive
+                  (if one is present, the other must be absent).</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -694,10 +684,8 @@ of problems processing the schema using various tools
           <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
-                </p>
+                <p>The <code>type</code> and <code>validation</code> attributes are mutually exclusive
+                  (if one is present, the other must be absent).</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -737,18 +725,16 @@ of problems processing the schema using various tools
   <xs:element name="expose">
     <xs:annotation>
       <xs:documentation>
-        <p>
-           This element appears as a child of xsl:use-package and defines the
-           visibility of components that are made available (or not) by this
-           package to other using packages.
-        </p>
+        <p>This element appears as a child of <code>xsl:use-package</code> and defines 
+            the visibility of components that are made available (or not) by this package
+            to other using packages.</p>
       </xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:complexContent>
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:attribute name="component" type="xsl:component-kind-type"/>
-          <xs:attribute name="names" type="xsl:EQNames"/>
+          <xs:attribute name="names" type="xsl:component-tests"/>
           <xs:attribute name="visibility" type="xsl:visibility-not-hidden-type"/>
           <xs:attribute name="_component" type="xs:string"/>
           <xs:attribute name="_names" type="xs:string"/>
@@ -773,14 +759,16 @@ of problems processing the schema using various tools
                       maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="separator" type="xsl:expression"/>
           <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_separator" type="xs:string"/>
           <xs:assert test="every $e in subsequence(xsl:sort, 2) 
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if an xsl:sort element other than the first
-                   in a sequence of sibling xsl:sort elements has a stable
+                   It is a static error if an <code>xsl:sort</code> element other than the first
+                   in a sequence of sibling <code>xsl:sort</code> elements has a <code>stable</code>
                    attribute.
                 </p>
               </xs:documentation>
@@ -822,8 +810,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if an xsl:sort element other than the first
-                   in a sequence of sibling xsl:sort elements has a stable
+                   It is a static error if an <code>xsl:sort</code> element other than the first
+                   in a sequence of sibling <code>xsl:sort</code> elements has a <code>stable</code>
                    attribute.
                 </p>
               </xs:documentation>
@@ -907,34 +895,13 @@ of problems processing the schema using various tools
           <xs:attribute name="_visibility" type="xs:string"/>
           <xs:attribute name="_streamability" type="xs:string"/>
           <xs:attribute name="_override-extension-function" type="xs:string"/>
-          <xs:attribute name="_identity-sensitive" type="xs:string"/>
+          <xs:attribute name="_new-each-time" type="xs:string"/>
           <xs:attribute name="_cache" type="xs:string"/>
           <xs:assert test="exists(@name | @_name)"/>
-          <xs:assert test="every $e in xsl:param 
-                           satisfies (empty($e/(@select | @_select)) and empty($e/child::node()))">
-            <xs:annotation>
-              <xs:documentation>
-                <p>
-                   A parameter for a function must have no default value.
-                </p>
-              </xs:documentation>
-            </xs:annotation>
-          </xs:assert>
           <xs:assert test="every $e in xsl:param satisfies empty($e/(@visibility | @_visibility))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   A parameter for a function must have no visibility attribute.
-                </p>
-              </xs:documentation>
-            </xs:annotation>
-          </xs:assert>
-          <xs:assert test="every $e in xsl:param satisfies empty($e/(@required | @_required))">
-            <xs:annotation>
-              <xs:documentation>
-                <p>
-                   A parameter for a function must have no required attribute.
-                </p>
+                <p>A parameter for a function must have no <code>visibility</code> attribute.</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -969,13 +936,15 @@ of problems processing the schema using various tools
     <xs:complexType>
       <xs:complexContent mixed="true">
         <xs:extension base="xsl:sequence-constructor">
-          <xs:attribute name="test" type="xsl:expression"/>         
-          <xs:attribute name="then" type="xsl:expression"/>         
+          <xs:attribute name="test" type="xsl:expression"/>
+          <xs:attribute name="then" type="xsl:expression"/>
           <xs:attribute name="else" type="xsl:expression"/>
           <xs:attribute name="_test" type="xs:string"/>
           <xs:attribute name="_then" type="xs:string"/>
           <xs:attribute name="_else" type="xs:string"/>
           <xs:assert test="exists(@test | @_test)"/>
+          <xs:assert test="not(exists(@then | @_then) and 
+            (exists(* except xsl:fallback) or exists(text()[normalize-space()])))"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -1008,8 +977,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   XTSE0215: It is a static error if an xsl:import-schema element
-                   that contains an xs:schema element has a schema-location
+                   XTSE0215: It is a static error if an <code>xsl:import-schema</code> element
+                   that contains an xs:schema element has a <code>schema-location</code>
                    attribute
                 </p>
               </xs:documentation>
@@ -1026,20 +995,6 @@ of problems processing the schema using various tools
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:attribute name="href" type="xs:anyURI"/>
           <xs:attribute name="_href" type="xs:string"/>
-          <xs:assert test="exists(@href | @_href)"/>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-  </xs:element>
-  
-  <xs:element name="item-type" substitutionGroup="xsl:declaration">
-    <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="xsl:element-only-versioned-element-type">
-          <xs:attribute name="name" type="xs:QName"/>         
-          <xs:attribute name="as" type="xsl:item-type"/>
-          <xs:attribute name="_name" type="xs:string"/>
-          <xs:attribute name="_as" type="xs:string"/>
           <xs:assert test="exists(@href | @_href)"/>
         </xs:extension>
       </xs:complexContent>
@@ -1086,7 +1041,8 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
   
-  <xs:element name="map" substitutionGroup="xsl:instruction">
+  <xs:element name="map"
+              substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent mixed="true">
         <xs:extension base="xsl:sequence-constructor">
@@ -1109,7 +1065,7 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="matching-substring" type="xsl:sequence-constructor-or-select"/>
+  <xs:element name="matching-substring" type="xsl:sequence-constructor"/>
 
   <xs:element name="merge" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1203,6 +1159,11 @@ of problems processing the schema using various tools
     <xs:complexType>
       <xs:complexContent mixed="false">
         <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="xsl:template"/> 
+            <xs:element ref="xsl:fallback"/> 
+          </xs:choice>
+          <xs:attribute name="as" type="xsl:sequence-type"/>
           <xs:attribute name="name" type="xsl:EQName"/>
           <xs:attribute name="streamable" type="xsl:yes-or-no" default="no"/>
           <xs:attribute name="use-accumulators" type="xsl:accumulator-names"/>
@@ -1222,8 +1183,10 @@ of problems processing the schema using various tools
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>
+          <xs:attribute name="_as" type="xs:string"/>
           <xs:attribute name="_name" type="xs:string"/>
           <xs:attribute name="_streamable" type="xs:string"/>
+          <xs:attribute name="_use-accumulators" type="xs:string"/>
           <xs:attribute name="_on-no-match" type="xs:string"/>
           <xs:attribute name="_on-multiple-match" type="xs:string"/>
           <xs:attribute name="_warning-on-no-match" type="xs:string"/>
@@ -1258,8 +1221,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_result-prefix" type="xs:string"/>
           <xs:assert test="exists(@stylesheet-prefix | @_stylesheet-prefix)"/>
           <xs:assert test="exists(@result-prefix | @_result-prefix)"/>
-          <xs:assert test="every $prefix in (@stylesheet-prefix, @result-prefix)
-                                                /normalize-space(.)[. ne '#default'] 
+          <xs:assert test="every $prefix in (@stylesheet-prefix, @result-prefix)/normalize-space(.)[. ne '#default']
                            satisfies $prefix = in-scope-prefixes(.)"/>
         </xs:extension>
       </xs:complexContent>
@@ -1293,11 +1255,7 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="non-matching-substring" type="xsl:sequence-constructor-or-select"/>
-  
-  <xs:element name="note" 
-              type="xsl:versioned-element-type" 
-              substitutionGroup="xsl:instruction xsl:declaration"/>
+  <xs:element name="non-matching-substring" type="xsl:sequence-constructor"/>
 
   <xs:element name="number" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1334,9 +1292,9 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if the value attribute of xsl:number is
-                   present unless the select, level, count, and from attributes are
-                   all absent.
+                   It is a static error if the value attribute of <code>xsl:number</code> is
+                   present unless the <code>select</code>, <code>level</code>, <code>count</code>, 
+                   and <code>from</code> attributes are all absent.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1356,7 +1314,8 @@ of problems processing the schema using various tools
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor-or-select"/>
 
-  <xs:element name="otherwise" type="xsl:sequence-constructor-or-select"/>
+  <xs:element name="otherwise" 
+              type="xsl:sequence-constructor-or-select"/>
 
   <xs:element name="output" substitutionGroup="xsl:declaration">
     <xs:complexType>
@@ -1432,11 +1391,9 @@ of problems processing the schema using various tools
   <xs:element name="override">
     <xs:annotation>
       <xs:documentation>
-        <p>
-           This element appears as a child of xsl:use-package and defines any
-           overriding definitions of components that the containing package wishes
-           to make to the components made available from a library package.
-        </p>
+        <p>This element appears as a child of <code>xsl:use-package</code> and defines 
+            any overriding definitions of components that the containing package wishes to make 
+            to the components made available from a library package.</p>
       </xs:documentation>
     </xs:annotation>
     <xs:complexType>
@@ -1483,11 +1440,9 @@ of problems processing the schema using various tools
   <xs:element name="param" substitutionGroup="xsl:declaration">
     <xs:annotation>
       <xs:documentation>
-        <p>
-           Declaration of the xsl:param element, used both defining function
-           parameters, template parameters, parameters to xsl:iterate, and global
-           stylesheet parameters.
-        </p>
+        <p>Declaration of the <code>xsl:param</code> element, used both defining function
+            parameters, template parameters, parameters to <code>xsl:iterate</code>,
+            and global stylesheet parameters.</p>
       </xs:documentation>
     </xs:annotation>
     <xs:complexType>
@@ -1510,7 +1465,7 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   When the attribute static="yes" is specified, the xsl:param
+                   When the attribute <code>static="yes"</code> is specified, the <code>xsl:param</code>
                    element must have empty content.
                 </p>
               </xs:documentation>
@@ -1539,8 +1494,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   It is a static error if an xsl:sort element other than the first
-                   in a sequence of sibling xsl:sort elements has a stable
+                   It is a static error if an <code>xsl:sort</code> element other than the first
+                   in a sequence of sibling <code>xsl:sort</code> elements has a <code>stable</code>
                    attribute.
                 </p>
               </xs:documentation>
@@ -1635,10 +1590,8 @@ of problems processing the schema using various tools
           <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
-                </p>
+                <p>The <code>type</code> and <code>validation</code> attributes are mutually exclusive
+                  (if one is present, the other must be absent).</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -1690,10 +1643,8 @@ of problems processing the schema using various tools
           <xs:assert test="not(exists(@type | @_type) and exists(@validation | @_validation))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   The type and validation attributes are mutually exclusive (if
-                   one is present, the other must be absent).
-                </p>
+                <p>The <code>type</code> and <code>validation</code> attributes are mutually exclusive
+                  (if one is present, the other must be absent).</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -1715,7 +1666,7 @@ of problems processing the schema using various tools
   </xs:element>
 
   <xs:element name="stylesheet" substitutionGroup="xsl:transform"/>
-  
+
   <xs:element name="switch" substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent>
@@ -1723,15 +1674,14 @@ of problems processing the schema using various tools
           <xs:sequence>
             <xs:element ref="xsl:when" maxOccurs="unbounded"/>
             <xs:element ref="xsl:otherwise" minOccurs="0"/>
-            <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
-          <xs:attribute name="_select" type="xs:string"/>
+          <xs:attribute name="_select" type="xsl:avt"/>
+          <xs:assert test="exists(@select | @_select)"/>
         </xs:extension>
-      </xs:complexContent>     
+      </xs:complexContent>
     </xs:complexType>
   </xs:element>
-
   
   <xs:element name="template" substitutionGroup="xsl:declaration">
     <xs:complexType>
@@ -1760,8 +1710,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   An xsl:template element must have either a match attribute or a
-                   name attribute, or both.
+                   An <code>xsl:template</code> element must have either a <code>match</code> attribute or a
+                   <code>name</code> attribute, or both.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1772,8 +1722,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   An xsl:template element that has no match attribute must have no
-                   mode attribute and no priority attribute.
+                   An <code>xsl:template</code> element that has no <code>match</code> attribute must have no
+                   <code>mode</code> attribute and no <code>priority</code> attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1782,8 +1732,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   An xsl:template element that has no name attribute must have no
-                   visibility attribute
+                   An <code>xsl:template</code> element that has no <code>name</code> attribute must have no
+                   <code>visibility</code> attribute
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1794,10 +1744,10 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   If the visibility attribute is present with the value abstract
+                   If the <code>visibility</code> attribute is present with the value <code>abstract</code>
                    then (a) the sequence constructor defining the template body
                    must be empty: that is, the only permitted children are
-                   xsl:context-item and xsl:param
+                   <code>xsl:context-item</code> and <code>xsl:param</code>
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1806,8 +1756,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   If the visibility attribute is present with the value abstract
-                   then there must be no match attribute.
+                   If the <code>visibility</code> attribute is present with the value <code>abstract</code>
+                   then there must be no <code>match</code> attribute.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1815,9 +1765,7 @@ of problems processing the schema using various tools
           <xs:assert test="every $e in xsl:param satisfies empty($e/(@visibility | @_visibility))">
             <xs:annotation>
               <xs:documentation>
-                <p>
-                   A parameter for a template must have no visibility attribute.
-                </p>
+                <p>A parameter for a template must have no <code>visibility</code> attribute.</p>
               </xs:documentation>
             </xs:annotation>
           </xs:assert>
@@ -1861,9 +1809,9 @@ of problems processing the schema using various tools
               <p>
                  The version attribute indicates the version of XSLT that the
                  stylesheet module requires. The attribute is required, unless the
-                 xsl:stylesheet element is a child of an xsl:package element, in
+                 <code>xsl:stylesheet</code> element is a child of an <code>xsl:package</code> element, in
                  which case it is optional: the default is then taken from the
-                 parent xsl:package element.
+                 parent <code>xsl:package</code> element.
               </p>
             </xs:documentation>
           </xs:annotation>
@@ -1897,8 +1845,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   The static attribute must not be present on an xsl:variable or
-                   xsl:param element unless it is a top-level element.
+                   The static attribute must not be present on an <code>xsl:variable</code> or
+                   <code>xsl:param</code> element unless it is a top-level element.
                 </p>
               </xs:documentation>
             </xs:annotation>
@@ -1910,13 +1858,13 @@ of problems processing the schema using various tools
               <xs:documentation>
                 <p>
                    XTSE0808: It is a static error if a namespace prefix is used
-                   within the [xsl:]exclude-result-prefixes attribute and there is
+                   within the <code>[xsl:]exclude-result-prefixes</code> attribute and there is
                    no namespace binding in scope for that prefix.
                 </p>
                 <p>
                    XTSE0809: It is a static error if the value #default is used
-                   within the [xsl:]exclude-result-prefixes attribute and the
-                   parent element of the [xsl:]exclude-result-prefixes attribute
+                   within the <code>[xsl:]exclude-result-prefixes</code> attribute and the
+                   parent element of the <code>[xsl:]exclude-result-prefixes</code> attribute
                    has no default namespace.
                 </p>
               </xs:documentation>
@@ -1953,12 +1901,10 @@ of problems processing the schema using various tools
   <xs:element name="use-package" substitutionGroup="xsl:declaration">
     <xs:annotation>
       <xs:documentation>
-        <p>
-           This element appears as a child of xsl:package and defines a dependency
-           of the containing package on another package, identified by URI in the
-           name attribute. The package-version attribute indicates which version of
-           the library package is required, or may indicate a range of versions.
-        </p>
+        <p>This element appears as a child of <code>xsl:package</code> and defines a dependency
+            of the containing package on another package, identified by URI in the <code>name</code>
+            attribute. The <code>package-version</code> attribute indicates which version of the
+            library package is required, or may indicate a range of versions.</p>
       </xs:documentation>
     </xs:annotation>
     <xs:complexType>
@@ -1993,10 +1939,8 @@ of problems processing the schema using various tools
   <xs:element name="variable" substitutionGroup="xsl:declaration xsl:instruction">
     <xs:annotation>
       <xs:documentation>
-        <p>
-           Declaration of the xsl:variable element, used both for local and global
-           variable bindings.
-        </p>
+        <p>Declaration of the <code>xsl:variable</code> element, used both for local
+            and global variable bindings.</p>
         <p>
            This definition takes advantage of the ability in XSD 1.1 for an element
            to belong to more than one substitution group. A global variable is a
@@ -2037,8 +1981,8 @@ of problems processing the schema using various tools
             <xs:annotation>
               <xs:documentation>
                 <p>
-                   When the attribute static="yes" is specified, the xsl:variable
-                   element must have empty content, and the select attribute must
+                   When the attribute <code>static="yes"</code> is specified, the <code>xsl:variable</code>
+                   element must have empty content, and the <code>select</code> attribute must
                    be present to define the value of the variable.
                 </p>
               </xs:documentation>
@@ -2052,10 +1996,14 @@ of problems processing the schema using various tools
   <xs:element name="when">
     <xs:complexType>
       <xs:complexContent mixed="true">
-        <xs:extension base="xsl:sequence-constructor-or-select">
+        <xs:extension base="xsl:sequence-constructor">
+          <xs:attribute name="select" type="xsl:expression"/>
           <xs:attribute name="test" type="xsl:expression"/>
+          <xs:attribute name="_select" type="xs:string"/>
           <xs:attribute name="_test" type="xs:string"/>
           <xs:assert test="exists(@test | @_test)"/>
+          <xs:assert test="not(exists(@select | @_select) and 
+            (exists(* except xsl:fallback) or exists(text()[normalize-space()])))"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -2083,20 +2031,15 @@ of problems processing the schema using various tools
 
   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
   <xs:annotation>
-    <xs:documentation>
-      <p>
-         PART C: definition of literal result elements There are three ways to
-         define the literal result elements permissible in a stylesheet. (a) do
-         nothing. This allows any element to be used as a literal result element,
-         provided it is not in the XSLT namespace (b) declare all permitted literal
-         result elements as members of the xsl:literal-result-element substitution
-         group (c) redefine the model group xsl:result-elements to accommodate all
-         permitted literal result elements. Literal result elements are allowed to
-         take certain attributes in the XSLT namespace. These are defined in the
-         attribute group literal-result-element-attributes, which can be included
-         in the definition of any literal result element.
-      </p>
-    </xs:documentation>
+    <xs:documentation> PART C: definition of literal result elements There are three ways to define
+      the literal result elements permissible in a stylesheet. (a) do nothing. This allows any
+      element to be used as a literal result element, provided it is not in the XSLT namespace (b)
+      declare all permitted literal result elements as members of the <code>xsl:literal-result-element</code>
+      substitution group (c) redefine the model group xsl:result-elements to accommodate all
+      permitted literal result elements. Literal result elements are allowed to take certain
+      attributes in the XSLT namespace. These are defined in the attribute group
+      <code>literal-result-element-attributes</code>, which can be included in the definition of any literal
+      result element. </xs:documentation>
   </xs:annotation>
   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
 
@@ -2149,9 +2092,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The use-accumulators attribute of xsl:source-document, xsl:merge-source,
-           or xsl:global-context-item: either a list, each member being a QName; or
-           the value #all
+           The <code>use-accumulators</code> attribute of <code>xsl:source-document</code>, 
+           <code>xsl:merge-source</code>, or <code>xsl:global-context-item</code>: 
+           either a list, each member being a QName; or the value <code>#all</code>
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2174,7 +2117,7 @@ of problems processing the schema using various tools
            This type is used for all attributes that allow an attribute value
            template. The general rules for the syntax of attribute value templates,
            and the specific rules for each such attribute, are described in the
-           XSLT 2.1 Recommendation.
+           XSLT 4.0 Recommendation.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2216,7 +2159,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The default-mode attribute of xsl:stylesheet, xsl:transform, xsl:package
+           The <code>default-mode</code> attribute of <code>xsl:stylesheet</code>, 
+           <code>xsl:transform</code>, <code>xsl:package</code>
            (or any other xsl:* element): either a QName or #unnamed.
         </p>
       </xs:documentation>
@@ -2229,12 +2173,30 @@ of problems processing the schema using various tools
       </xs:simpleType>
     </xs:union>
   </xs:simpleType>
+  
+  <xs:simpleType name="component-test">
+    <xs:annotation>
+      <xs:documentation>
+        <p> A NameTest or a named function reference. </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xsl:nametest xsl:named-function-reference"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="component-tests">
+    <xs:annotation>
+      <xs:documentation>
+        <p> A list of NameTests or named function references</p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:list itemType="xsl:component-test"/>
+  </xs:simpleType>
 
   <xs:simpleType name="expression">
     <xs:annotation>
       <xs:documentation>
         <p>
-           An XPath 2.0 expression.
+           An XPath 4.0 expression.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2247,7 +2209,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           An XPath ItemType
+           An XPath 4.0 ItemType
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2275,7 +2237,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The level attribute of xsl:number: one of single, multiple, or any.
+           The <code>level</code> attribute of <code>xsl:number</code>: 
+           one of <code>single</code>, <code>multiple</code>, or <code>any</code>.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2290,8 +2253,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The mode attribute of xsl:apply-templates: either a QName, or #current,
-           or #unnamed, or #default.
+           The <code>mode</code> attribute of <code>xsl:apply-templates</code>: 
+           either a QName, or <code>#current</code>,
+           or <code>#unnamed</code>, or <code>#default</code>.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2310,8 +2274,8 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The mode attribute of xsl:template: either a list, each member being
-           either a QName or #default or #unnamed; or the value #all
+           The <code>mode</code> attribute of <code>xsl:template</code>: either a list, each member being
+           either a QName or <code>#default</code> or <code>#unnamed</code>; or the value <code>#all</code>
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2352,32 +2316,51 @@ of problems processing the schema using various tools
     </xs:union>
   </xs:simpleType>
 
+   <xs:simpleType name="named-function-reference">
+    <xs:annotation>
+      <xs:documentation>
+        <p> In simple terms, this is an EQName followed by "#arity" where "arity" is a non-negative integer. However,
+          XSD doesn't allow us to reuse the definition of EQName in this way, so it has to be defined from scratch. The simplest
+          way to do this is with an assertion. However, the assertion cannot exploit types such as <code>xsl:EQName</code> defined in this
+        schema</p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:pattern value="((Q\{.*\})|([\i-[:]][\c-[:]]*:))?[\i-[:]][\c-[:]]*#[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="nametest">
+    <xs:annotation>
+      <xs:documentation>
+        <p> A list of NameTests, as defined in the XPath 31 Recommendation. Each NameTest is either
+          an EQName, or "*", or "prefix:*", or "*:localname", or the wildcard Q{uri}*. </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="xsl:EQName">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:enumeration value="*"/>
+        </xs:restriction>
+      </xs:simpleType>
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="[\i-[:]][\c-[:]]*:\*"/>
+          <xs:pattern value="\*:[\i-[:]][\c-[:]]*"/>
+          <xs:pattern value="Q\{[^}]*\}\*"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+
   <xs:simpleType name="nametests">
     <xs:annotation>
       <xs:documentation>
-        <p>
-           A list of NameTests, as defined in the XPath 2.0 Recommendation. Each
-           NameTest is either a QName, or "*", or "prefix:*", or "*:localname"
-        </p>
+        <p> A list of NameTests, as defined in the XPath 4.0 Recommendation. Each NameTest is either
+          a QName, or "*", or "prefix:*", or "*:localname" </p>
       </xs:documentation>
     </xs:annotation>
-    <xs:list>
-      <xs:simpleType>
-        <xs:union memberTypes="xsl:EQName">
-          <xs:simpleType>
-            <xs:restriction base="xs:token">
-              <xs:enumeration value="*"/>
-            </xs:restriction>
-          </xs:simpleType>
-          <xs:simpleType>
-            <xs:restriction base="xs:token">
-              <xs:pattern value="\i\c*:\*"/>
-              <xs:pattern value="\*:\i\c*"/>
-            </xs:restriction>
-          </xs:simpleType>
-        </xs:union>
-      </xs:simpleType>
-    </xs:list>
+    <xs:list itemType="xsl:nametest"/>
   </xs:simpleType>
   
   <xs:simpleType name="on-multiple-match-type">
@@ -2436,8 +2419,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           The method attribute of xsl:output: Either one of the recognized names
-           "xml", "xhtml", "html", "text", or a QName that must include a prefix.
+           The <code>method</code> attribute of <code>xsl:output</code>: Either one of the recognized names
+           "xml", "xhtml", "html", "text", "json", or "adaptive",
+            or a QName that must include a prefix.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2448,6 +2432,8 @@ of problems processing the schema using various tools
           <xs:enumeration value="xhtml"/>
           <xs:enumeration value="html"/>
           <xs:enumeration value="text"/>
+          <xs:enumeration value="json"/>
+          <xs:enumeration value="adaptive"/>
         </xs:restriction>
       </xs:simpleType>
       <xs:simpleType>
@@ -2462,10 +2448,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A match pattern as defined in the XSLT 2.1 Recommendation. The syntax
-           for patterns is a restricted form of the syntax for XPath 2.0
-           expressions. Change since XSLT 2.0: Patterns may now match any item (not
-           only nodes)
+           A match pattern as defined in the XSLT 4.0 Recommendation. The syntax
+           for patterns is a restricted form of the syntax for XPath 4.0
+           expressions. 
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2476,7 +2461,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           Either a namespace prefix, or #default. Used in the xsl:namespace-alias
+           Either a namespace prefix, or <code>#default</code>. Used in the <code>xsl:namespace-alias</code>
            element.
         </p>
       </xs:documentation>
@@ -2494,9 +2479,9 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           A list of QNames. Used in the [xsl:]use-attribute-sets attribute of
-           various elements, and in the cdata-section-elements attribute of
-           xsl:output
+           A list of QNames. Used in the <code>[xsl:]use-attribute-sets</code> attribute of
+           various elements, and in the <code>cdata-section-elements</code> attribute of
+           <code>xsl:output</code>.
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2507,16 +2492,16 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           An extended QName. This schema does not use the built-in type xs:QName,
+           An extended QName. This schema does not use the built-in type <code>xs:QName</code>,
            but rather defines its own QName type. This may be either a local name,
            or a prefixed QName, or a name written using the extended QName notation
-           Q{uri}local
+           <code>Q{uri}local</code>
         </p>
         <p>
-           Although xs:QName would define the correct validation on these
+           Although <code>xs:QName</code> would define the correct validation on these
            attributes, a schema processor would expand unprefixed QNames
            incorrectly when constructing the PSVI, because (as defined in XML
-           Schema errata) an unprefixed xs:QName is assumed to be in the default
+           Schema errata) an unprefixed <code>xs:QName</code> is assumed to be in the default
            namespace, which is not the correct assumption for XSLT. The datatype is
            therefore defined as a union of NCName and QName, so that an unprefixed
            name will be validated as an NCName and will therefore not be treated as
@@ -2551,7 +2536,7 @@ of problems processing the schema using various tools
       <xs:documentation>
         <p>
            The description of a datatype, conforming to the SequenceType production
-           defined in the XPath 2.0 Recommendation
+           defined in the XPath 4.0 Recommendation
         </p>
       </xs:documentation>
     </xs:annotation>
@@ -2695,7 +2680,7 @@ of problems processing the schema using various tools
     <xs:annotation>
       <xs:documentation>
         <p>
-           One of the values "yes" or "no" or "maybe". The values "true" or "false",
+           One of the values "yes" or "no" or "omit". The values "true" or "false",
            or "1" or "0" are accepted as synonyms of "yes" and "no" respectively.
         </p>
       </xs:documentation>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -9,7 +9,7 @@
 <!ENTITY % p "xs:">
 <!ENTITY % s ":xs">
 ]> *-->
-<?xml-stylesheet href="http://www.w3.org/2008/09/xsd.xsl" type="text/xsl"?>
+<!--<?xml-stylesheet href="http://www.w3.org/2008/09/xsd.xsl" type=" t e x t / x s l"?>-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
            xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"
@@ -112,7 +112,94 @@ of problems processing the schema using various tools
     </xs:documentation>
   </xs:annotation>
   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
-
+  
+  <xs:defaultOpenContent>
+    <!-- Allow xsl:note anywhere -->
+    <xs:any processContents="strict" 
+            namespace="##targetNamespace"
+            notQName="xsl:accept 
+                      xsl:accumulator 
+                      xsl:accumulator-rule 
+                      xsl:analyze-string 
+                      xsl:apply-imports 
+                      xsl:apply-templates 
+                      xsl:array 
+                      xsl:assert 
+                      xsl:attribute 
+                      xsl:attribute-set 
+                      xsl:break 
+                      xsl:call-template 
+                      xsl:catch 
+                      xsl:character-map 
+                      xsl:choose 
+                      xsl:comment 
+                      xsl:context-item 
+                      xsl:copy 
+                      xsl:copy-of 
+                      xsl:document 
+                      xsl:decimal-format 
+                      xsl:element 
+                      xsl:evaluate 
+                      xsl:expose 
+                      xsl:fallback 
+                      xsl:for-each 
+                      xsl:for-each-group 
+                      xsl:fork 
+                      xsl:function 
+                      xsl:global-context-item 
+                      xsl:if 
+                      xsl:import 
+                      xsl:import-schema 
+                      xsl:include 
+                      xsl:iterate 
+                      xsl:key 
+                      xsl:map 
+                      xsl:map-entry 
+                      xsl:matching-substring 
+                      xsl:merge 
+                      xsl:merge-action 
+                      xsl:merge-key 
+                      xsl:merge-source 
+                      xsl:message 
+                      xsl:mode 
+                      xsl:namespace 
+                      xsl:namespace-alias 
+                      xsl:next-iteration 
+                      xsl:next-match 
+                      xsl:non-matching-substring 
+                      xsl:number 
+                      xsl:on-completion 
+                      xsl:on-empty 
+                      xsl:on-non-empty 
+                      xsl:otherwise 
+                      xsl:output 
+                      xsl:output-character 
+                      xsl:override 
+                      xsl:package 
+                      xsl:param 
+                      xsl:perform-sort 
+                      xsl:preserve-space 
+                      xsl:processing-instruction 
+                      xsl:result-document 
+                      xsl:sequence 
+                      xsl:sort 
+                      xsl:source-document 
+                      xsl:strip-space 
+                      xsl:stylesheet 
+                      xsl:switch 
+                      xsl:template 
+                      xsl:text 
+                      xsl:transform 
+                      xsl:try 
+                      xsl:use-package 
+                      xsl:value-of 
+                      xsl:variable 
+                      xsl:when 
+                      xsl:where-populated 
+                      xsl:with-param
+            "/>
+  </xs:defaultOpenContent>
+  
   <xs:complexType name="generic-element-type" mixed="true">
     <xs:annotation>
       <xs:documentation>
@@ -1256,6 +1343,8 @@ of problems processing the schema using various tools
   </xs:element>
 
   <xs:element name="non-matching-substring" type="xsl:sequence-constructor"/>
+  
+  <xs:element name="note" type="xs:anyType"/>
 
   <xs:element name="number" substitutionGroup="xsl:instruction">
     <xs:complexType>


### PR DESCRIPTION
This PR applies the errata to the XSLT 3.0 version of the schema, and extends the schema to support new syntax that has been introduced in XSLT 4.0.

Fix #567.