### PR TITLE
Minor editorial corrections, XDM chh. 1, 2

### DIFF
--- a/etc/status-entities.dtd
+++ b/etc/status-entities.dtd
@@ -327,7 +327,7 @@ implementability of this specification has been tested in the context
 of its normative inclusion in host languages defined by the
 <loc href="https://www.w3.org/TR/xquery-31/">XQuery 3.1</loc>
 and
-XSLT 3.0 (expected in 2017) specifications;
+<loc href="https://www.w3.org/TR/xslt-30/">XSLT 3.0</loc> specifications;
 see the
 <loc href="&xquery-impl-report;">XQuery 3.1 implementation report</loc>
 (and, in the future, the WGs expect that there will also be an

--- a/specifications/xpath-datamodel-40/src/xdt-datatypes.xml
+++ b/specifications/xpath-datamodel-40/src/xdt-datatypes.xml
@@ -32,7 +32,7 @@ predefined types are derived from <code>xs:untypedAtomic</code>
 <def>
 <p>The datatype <term>xs:anyAtomicType</term> is an atomic type that
 includes all atomic values (and no values that are not atomic). Its
-base type is <code>xs:anySimpleType</code> from which all simple
+base type is <code>xs:anySimpleType</code>, from which all simple
 types, including atomic, list, and union types are derived. All
 primitive atomic types, such as <code>xs:decimal</code> and
 <code>xs:string</code>, have <code>xs:anyAtomicType</code>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -274,7 +274,7 @@ not specify the programming-language interfaces or bindings used to
 represent or access the data.</p>
 
 <p>The data model can represent various
-values including not only the input and the output of a stylesheet or query, but all
+values, including not only the input and the output of a stylesheet or query but all
 values of expressions used during the intermediate calculations.
 Examples include the input document or document repository (represented
 as a &documentNode; or a sequence of &documentNode;s), the result of a
@@ -346,7 +346,7 @@ examples as <termref def="dt-instance">instances of the data model</termref>.
   <p>Within this specification, the term URI refers to a
     Uniform Resource Identifier as defined in
     <bibref ref="RFC3986"/> and extended in <bibref ref="RFC3987"/>
-    with the new name IRI. The term URI has been retained in preference to
+    with the new name Internationalized Reference Identifier, IRI. The term URI has been retained in preference to
     IRI to avoid introducing new names for concepts such as “Base URI”
     that are defined or referenced across the whole family of XML
     specifications.</p>
@@ -387,7 +387,7 @@ membership of different item types is overlapping.</p>
 
 <p>Every node is one of the seven kinds of nodes defined in Section <specref
 ref="Node"/>. Nodes form a tree. Each node has at most one parent
-(reachable via the <function>parent</function> accessor) and descendant
+(reachable via the <function>parent</function> accessor) and zero or more descendant
 nodes that are reachable directly or indirectly
 via the <function>children</function>,
 <function>attributes</function>, and
@@ -429,7 +429,7 @@ referred to as a <term>fragment</term>.</termdef></p>
       in XSD, plus <code>xs:untypedAtomic</code>), and these have non-overlapping value spaces, so each
       datum belongs to exactly one primitive atomic type.</p>
     
-    <note diff="chg" at="2022-11-05"><p>The term <term>value space</term> is defined in <bibref ref="xmlschema11-2"/>,
+    <note diff="chg" at="2022-11-05"><p>The term <term>value space</term> is defined in <bibref ref="xmlschema11-2"/>
       as a set of <emph>values</emph>. The term <term>datum</term> is used here in preference to <emph>value</emph>,
       because <termref def="dt-value"/> has a different meaning in this data model.</p></note>
 
@@ -461,15 +461,15 @@ in <specref ref="xs-types"/>.</termdef></p>
       for unvalidated element nodes.</termdef></p>  
 
     <p><phrase diff="chg" at="2022-11-05">Named types are identified</phrase> in the data model by an
-    <termref def="dt-expanded-qname">expanded-QName</termref>. <phrase diff="add" at="2022-11-05">A schema 
+    <termref def="dt-expanded-qname">expanded QName</termref>. <phrase diff="add" at="2022-11-05">A schema 
       may also contain anonymous types, and these may be used as <termref def="dt-type-annotation">type annotations</termref> 
       on nodes and atomic values; anonymous types, however, cannot be referenced explicitly in programs.</phrase>
     </p>
     
    
 
-    <p diff="chg" at="2022-11-05"><termdef id="dt-expanded-qname" term="expanded-QName">An
-<term>expanded-QName</term> is a <phrase diff="del" at="2022-11-05">set of three values</phrase> 
+    <p diff="chg" at="2022-11-05"><termdef id="dt-expanded-qname" term="expanded QName">An
+<term>expanded QName</term> is a <phrase diff="del" at="2022-11-05">set of three values</phrase> 
   <phrase diff="add" at="2022-11-05">triple</phrase> consisting of a
   possibly <phrase diff="chg" at="2022-11-05">absent</phrase> prefix, a possibly 
   <phrase diff="chg" at="2022-11-05">absent</phrase> namespace URI, and a local
@@ -498,7 +498,9 @@ of <bibref ref="xmlschema-2"/>.</p>
 <p>Three built-in list types:
 <code>xs:NMTOKENS</code>, <code>xs:IDREFS</code>, and <code>xs:ENTITIES</code>.
 </p>
-<p>The following types which were originally defined in
+</item>
+<item>
+<p>The following types, which were originally defined in
 <bibref ref="xpath-datamodel"/> and were subsequently adopted by
 <bibref ref="xmlschema11-2"/>:
 <code>xs:anyAtomicType</code>, <code>xs:dayTimeDuration</code>,
@@ -507,13 +509,13 @@ of <bibref ref="xmlschema-2"/>.</p>
 </item>
 <item>
 <p>In the case of a processor that supports
-<bibref ref="xmlschema11-2"/>, the data model also includes:
+<bibref ref="xmlschema11-2"/>, 
 the new union type <code>xs:error</code> (a type with no instances)
 and the new derived type <code>xs:dateTimeStamp</code>.</p>
 </item>
 <item>
-<p>The following types, although they use the <code>xs:</code> namespace,
-are defined here in the data model and not in XML Schema:
+<p>The following types, which use the <code>xs:</code> namespace
+and are defined here in the data model but not in XML Schema:
 <code>xs:untypedAtomic</code>, and
 <code>xs:numeric</code>,
 a union type whose members are <code>xs:double</code>, <code>xs:float</code>
@@ -522,7 +524,7 @@ and <code>xs:decimal</code>.
 </item>
 </ulist>
   
-  <p diff="add" at="2022-11-05">Schema types fulfil a different role from <termref def="dt-item-type">item types</termref>.
+  <p diff="add" at="2022-11-05">Schema types fulfill a role different from <termref def="dt-item-type">item types</termref>.
   Schema types other than atomic types arise in the data model only as <termref def="dt-type-annotation">type annotations</termref>
   on element and attribute nodes. Nodes are not instances of schema types in the sense of the XPath <code>instance of</code>
   operator; but an element or attribute node may be an instance of the item type <code>element(*, S)</code> or <code>attribute(*, S)</code>
@@ -542,8 +544,8 @@ and <code>xs:decimal</code>.
 <div2 id="notation">
 <head>Notation</head>
 
-<p>In addition to prose, this specification defines a set of accessor
-functions to explain the data model. The accessors are shown with the
+<p>To explain the data model, this specification uses both prose and a defined set of accessor
+functions. The accessors are shown with the
 prefix <emph>dm:</emph>. This prefix is always shown in italics to
 emphasize that these functions are abstract; they exist to explain the
 interface between the data model and specifications that rely on the
@@ -578,7 +580,7 @@ and properties are indicated by the styles <emph role="info-item">information
 item</emph> and <emph role="infoset-property">infoset property</emph>, respectively.</p>
 
 <p>Some aspects of type assignment rely on the ability to access properties of
-the schema components. Such properties are indicated by the style
+the schema components. Such properties are indicated by curly brackets, e.g.,
 {component property}. Note that this does not mean a lightweight schema processor
 cannot be used, it only means that the application must have some mechanism to
 access the necessary properties.</p>
@@ -591,7 +593,7 @@ access the necessary properties.</p>
 <p>Each node has a unique identity.
 
 The identity of
-a node is distinct from its value or other visible properties; nodes may be
+a node is distinct from its value or other intrinsic properties; nodes may be
 distinct even when they have the same values for all intrinsic
 properties other than their identity.
 (The
@@ -645,10 +647,8 @@ stable but implementation-dependent.</imp-dep-feature>
 
 <item>
 <p>&attributeNode;s immediately follow the &namespaceNode;s of the
-element with which they are associated. If there are no
-&namespaceNode;s associated with a given element, then the
-&attributeNode;s associated with that element immediately
-follow the element. The relative order of &attributeNode;s is
+&elementNode; with which they are associated, if any; otherwise they immediately
+follow the &elementNode;; with which they are associated. The relative order of &attributeNode;s is
 stable but implementation-dependent.</p>
 <imp-dep-feature>The relative order of &attributeNode;s nodes is
 stable but implementation-dependent.</imp-dep-feature>
@@ -689,7 +689,7 @@ one sequence and a sequence may contain duplicate items.</p>
 <p>Sequences never contain other sequences; if sequences are combined,
 the result is always a “flattened” sequence. In other words, appending
 “(d e)” to “(a b c)” produces a sequence of length 5: “(a b c d e)”.
-It <emph>does not</emph> produce a sequence of length 4: “(a b c (d e))”,
+It <emph>does not</emph> produce a sequence of length 4: “(a b c (d e))”;
 such a nested sequence never occurs.</p>
 
 <note>
@@ -795,7 +795,7 @@ a reference to a type definition in the Schema Component Model.
   <ulist diff="chg" at="2022-11-05">
     <item><p>All items are instances of the type <code>item()</code>.</p></item>
     <item><p>Every <termref def="dt-node"/> is an instance of the type <code>node()</code>, and more
-    specifically it is an instance of one of seven node kinds <code>document()</code>,
+    specifically it is an instance of one of seven node kinds: <code>document()</code>,
     <code>element(*)</code>, <code>attribute(*)</code>, <code>text()</code>,
     <code>comment()</code>, <code>processing-instruction()</code>, or
     <code>namespace()</code>. Nodes may also be instances of more specific
@@ -853,24 +853,24 @@ the specifications do not speculate on what happens if they are not.</p>
 <head>Representation of Types</head>
 
 <p>The data model uses
-<termref def="dt-expanded-qname">expanded-QNames</termref> to
+<termref def="dt-expanded-qname">expanded QNames</termref> to
 represent the names of schema types, which include the built-in
-types defined by <bibref ref="xmlschema-2"/>, five additional types
+types defined by <bibref ref="xmlschema-2"/> and the five additional types
 defined by this specification, and may include other user- or
 implementation-defined types.</p>
 
 <imp-def-feature>Support for additional user-defined or
 implementation-defined types is implementation-defined.</imp-def-feature>
 
-<p>For XML Schema types, the namespace name of the expanded-QName is
+<p>For XML Schema types, the namespace name of the expanded QName is
 the {target namespace} property of the type definition, and its local
 name is the {name} property of the type definition.</p>
 
-<p>The data model relies on the fact that an expanded-QName uniquely
+<p>The data model relies on the fact that an expanded QName uniquely
 identifies every named type. Although it is possible for different
-schemas to define different types with the same expanded-QName, at
+schemas to define different types with the same expanded QName, at
 most one of them can be used in any given validation episode. The data model
-cannot support environments where different types with the same expanded-QName
+cannot support environments where different types with the same expanded QName
 are available.
 </p>
 
@@ -920,7 +920,7 @@ ref="xdtschema"/>.</p>
 
 <p>Some of the types defined in XML Schema have differing definitions
 in XSD 1.0 and XSD 1.1; furthermore, some types are defined by
-reference to other specifications including XML and XML Namespaces,
+reference to other specifications, including XML and XML Namespaces,
 and these too may vary from one version of the specification to the
 next.</p>
 
@@ -935,7 +935,7 @@ production in XML 1.1 Second Edition. Similarly, the xs:anyURI data
 type <rfc2119>should</rfc2119> support the definition used in XSD 1.1 (which allows any
 sequence of characters), and the xs:NCName data type <rfc2119>should</rfc2119> support
 the definition based on the syntax of a name as defined in both XML
-1.1 Second Edition and XML 1.0 Fifth Edition (which are the same).</p>
+1.1 Second Edition and XML 1.0 Fifth Edition (which provide the same definition).</p>
 
 <p>In practice interoperability problems can arise both because
 specifications are not always in synchronization with each other (for
@@ -980,21 +980,17 @@ This type system comprises two distinct subsystems that both include
 the primitive simple types. 
 In the diagrams, connecting lines represent relationships between derived types
 and the types from which they are derived;
-the arrowheads point toward the type from which they are derived. 
-The dashed line represents relationships not present in this diagram,
-but that appear in one of the other diagrams. 
-Dotted lines represent additional relationships that follow an evident pattern.
-The information that appears in each diagram is recapitulated in tabular form.
+the latter are always higher and to the left of the latter. 
 </p>
 
 <p>The <code>xs:IDREFS</code>, <code>xs:NMTOKENS</code>,
-<code>xs:ENTITIES</code> types, and <code>xs:numeric</code> and both the
+<code>xs:ENTITIES</code> types, and <code>xs:numeric</code>, and both the
 <code>user-defined list types</code> and
 <code>user-defined union types</code>
 are special types in that these types are lists or unions
 rather than types derived by extension or restriction.</p>
 
-<p>The first diagram and its corresponding table illustrate the
+<p>The first diagram illustrates the
 relationship of various <termref def="dt-item-type">item
 types</termref>. Item types in the data model form a directed graph,
 rather than a hierarchy or lattice: in the relationship defined by the
@@ -1004,7 +1000,7 @@ more than one other type. Examples include functions
 <code>function(xs:NCName) as xs:int</code> and also for
 <code>function(xs:string) as xs:decimal</code>), and union types
 (<code>A</code> is substitutable for <code>union(A, B)</code> and also
-for <code>union(A, C)</code>. In XDM, item types include node types,
+for <code>union(A, C)</code>). In XDM, item types include node types,
 function types, and built-in atomic types. The list, which shows only
 hierarchic relationships, is therefore a simplification of the full
 model.</p>
@@ -1013,7 +1009,7 @@ model.</p>
 
 <p>This list illustrates the 
 <phrase diff="chg" at="2022-11-05"><termref def="dt-schema-type"/></phrase>
-subsystem, in which all types are derived from distinguished type
+subsystem, in which all types are derived from 
 <code>xs:anyType</code>. </p>
 
 &common-anyType.xml;
@@ -1206,7 +1202,7 @@ will create functions in the data model with zero annotations.
       <p>Where the function body is implemented in XPath, XQuery, or XSLT, the captured
       context includes the static context for the user-written code (for example, its in-scope namespaces)
       as well as any nonlocal variable bindings.</p>
-      <p>Functions implemented internally to the processor may capture specific parts of the static or dynamic context,
+      <p>Functions implemented internally by the processor may capture specific parts of the static or dynamic context,
       for example <code>fn:position#0</code> captures the value of the context position.</p>
     </note>
   </item>
@@ -1546,7 +1542,7 @@ the PSVI. If:</p>
 and have the values <quote><emph>valid</emph></quote> and
 <quote><emph>full</emph></quote>, respectively, the
 schema type of an element or attribute information item is
-represented by an <termref def="dt-expanded-qname">expanded-QName</termref>
+represented by an <termref def="dt-expanded-qname">expanded QName</termref>
 whose namespace and local name correspond
 to the first applicable items in the following list:
 </p>


### PR DESCRIPTION
Minor corrections to XDM chapters 1, 2. 
* `expanded-QName` versus `expanded QName`. The latter outnumbered the former ca. 3:2, and is better, so I with with it.
* some language pointing to tables & lines, language rendered obsolete by @ndw 's nice new graphs, excised
* other minor edits for clarity, consistency