### PR TITLE
Editorial: improve generator for keyword tests

### DIFF
--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -120,6 +120,14 @@
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="example" use="optional" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            An example of a valid value for the argument: used for test data generation. If omitted,
+            a generic instance of the required data type is used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attributeGroup ref="fos:diff-markup"/>
       <xs:assert test="count((@return-type, @return-type-ref)) le 1"/>
     </xs:complexType>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -2138,7 +2138,7 @@
    <fos:function name="parse-integer" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-integer" return-type="xs:integer">
-            <fos:arg name="value" type="xs:string"/>
+            <fos:arg name="value" type="xs:string" example="'12345'"/>
             <fos:arg name="radix" type="xs:integer" default="10"/>
          </fos:proto>
       </fos:signatures>
@@ -5975,7 +5975,7 @@ Tak, tak, tak! - da kommen sie.
    <fos:function name="boolean" prefix="fn">
       <fos:signatures>
          <fos:proto name="boolean" return-type="xs:boolean">
-            <fos:arg name="input" type="item()*" usage="inspection"/>
+            <fos:arg name="input" type="item()*" usage="inspection" example="42"/>
          </fos:proto>
       </fos:signatures>
       <fos:summary>
@@ -6058,7 +6058,7 @@ Tak, tak, tak! - da kommen sie.
    <fos:function name="not" prefix="fn">
       <fos:signatures>
          <fos:proto name="not" return-type="xs:boolean">
-            <fos:arg name="input" type="item()*" usage="inspection"/>
+            <fos:arg name="input" type="item()*" usage="inspection" example="42"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -9201,7 +9201,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
    <fos:function name="parse-ietf-date" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-ietf-date" return-type="xs:dateTime?">
-            <fos:arg name="value" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?" example="'Wed, 06 Jun 1994 07:29:35 GMT'"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15306,7 +15306,7 @@ else
    <fos:function name="parse-xml" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-xml" return-type="document-node(element(*))?">
-            <fos:arg name="value" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?" example="'&lt;a/&gt;'"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -15476,7 +15476,7 @@ else
       <fos:signatures>
          <fos:proto name="serialize" return-type="xs:string">
             <fos:arg name="input" type="item()*" usage="absorption"/>
-            <fos:arg name="options" type="item()?" usage="absorption" default="()"/>
+            <fos:arg name="options" type="item()?" usage="absorption" default="()" example="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -16965,7 +16965,7 @@ declare function fold-right(
       <fos:signatures>
          <fos:proto name="iterate-while" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="function(item()*) as xs:boolean"/>
+            <fos:arg name="predicate" type="function(item()*) as xs:boolean" example="false#0"/>
             <fos:arg name="action" type="function(item()*) as item()*"/>
          </fos:proto>
       </fos:signatures>
@@ -18121,7 +18121,10 @@ return fold-left($MAPS, map{},
    <fos:function name="of" prefix="map">
       <fos:signatures>
          <fos:proto name="of" return-type="map(*)">
-            <fos:arg name="pairs" type="record(key as xs:anyAtomicType, value as item()*, *)*" usage="inspection"/>
+            <fos:arg name="pairs" 
+                     type="record(key as xs:anyAtomicType, value as item()*, *)*" 
+                     usage="inspection"
+                     example="map{'key':'n','value':false()},map{'key':'y','value':true()}"/>
             <fos:arg name="combine" type="function(item()*, item()*) as item()*" usage="inspection" default="fn:op(',')"/>
          </fos:proto>
       </fos:signatures>
@@ -19376,7 +19379,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
    <fos:function name="json-to-xml" prefix="fn">
       <fos:signatures>
          <fos:proto name="json-to-xml" return-type="document-node()?">
-            <fos:arg name="value" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?" example="'[22,23]'"/>
             <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -19720,7 +19723,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
    <fos:function name="xml-to-json" prefix="fn">
       <fos:signatures>
          <fos:proto name="xml-to-json" return-type="xs:string?">
-            <fos:arg name="node" type="node()?" usage="absorption"/>
+            <fos:arg name="node" type="node()?" usage="absorption" example="()"/>
             <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -20045,7 +20048,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
    <fos:function name="parse-json" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-json" return-type="item()?">
-            <fos:arg name="value" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?" example="'[22,23]'"/>
             <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -20357,7 +20360,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
    <fos:function name="json-doc" prefix="fn">
       <fos:signatures>
          <fos:proto name="json-doc" return-type="item()?">
-            <fos:arg name="href" type="xs:string?"/>
+            <fos:arg name="href" type="xs:string?" example="'JSONTestSuite/test_parsing/y_number.json'"/>
             <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -23434,7 +23437,8 @@ r:random-sequence(200);
       <fos:signatures>
          <fos:proto name="all" return-type="xs:boolean">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="function(item()) as xs:boolean" default="fn:identity#1"/>
+            <fos:arg name="predicate" type="function(item()) as xs:boolean" 
+               default="fn:identity#1" example="fn:boolean#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24309,7 +24313,8 @@ function($item){
       <fos:signatures>
          <fos:proto name="some" return-type="xs:boolean">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="function(item()) as xs:boolean" default="fn:identity#1"/>
+            <fos:arg name="predicate" type="function(item()) as xs:boolean" 
+               default="fn:identity#1" example="fn:boolean#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25311,7 +25316,13 @@ path with an explicit <code>file:</code> scheme.</p>
    <fos:function name="build-uri" prefix="fn" diff="add">
       <fos:signatures>
          <fos:proto name="build-uri" return-type="xs:string">
-            <fos:arg name="parts" type-ref="uri-structure-record"/>
+            <fos:arg name="parts" type-ref="uri-structure-record"
+               example='map {
+               "scheme": "https",
+               "host": "qt4cg.org",
+               "port": (),
+               "path": "/specifications/index.html"
+               }'/>
             <fos:arg name="options" type="map(*)" default="map{}"/>
          </fos:proto>
       </fos:signatures>

--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -42,9 +42,9 @@
    <xsl:template match="function[@prefix='op', 'xs']"/>
    
    <!-- Exclude functions that are either (a) difficult to test, or (b) not yet agreed / implemented -->
-   <xsl:template match="function[@name=('error', 'concat', 'truncate', 'transform', 'json', 'differences', 
-      'foot', 'load-xquery-module', 'parts', 'stack-trace', 'group-by', 'substitute', 'collection', 'uri-collection',
-      'items-ending-where', 'items-starting-where', 'slice', 'random-number-generator', 'replace')]" priority="5"/>
+   <xsl:template match="function[@name=('error', 'concat', 'transform',  
+      'load-xquery-module', 'parts', 'stack-trace', 'group-by', 'substitute', 'collection', 'uri-collection',
+      'items-starting-where', 'random-number-generator')]" priority="5"/>
    
    <xsl:template match="function[@prefix='array'][@name=('replace', 'slice', 'from-sequence', 'of', 'partition')]" priority="6"/>
    
@@ -69,7 +69,7 @@
             <xsl:for-each select="arg">
                <xsl:if test="position() != 1">, </xsl:if>
                <xsl:text>{@name} := </xsl:text>
-               <xsl:apply-templates select="@type"/>
+               <xsl:apply-templates select="(@example, @default, @type)[1]"/>
             </xsl:for-each>
             <xsl:text>)</xsl:text>
             <xsl:text>
@@ -83,17 +83,26 @@
                <xsl:text>{if (..//@default='.') then "/doc!" else ""}{$prefix}:{../../@name}(</xsl:text>
                <xsl:for-each select="arg">
                   <xsl:if test="position() != 1">, </xsl:if>
-                  <xsl:apply-templates select="@type"/>
+                  <xsl:apply-templates select="(@example, @default, @type)[1]"/>
                </xsl:for-each>
                <xsl:text>)) and </xsl:text>
             </xsl:if>
             <xsl:text>$x instance of </xsl:text>
-            <xsl:apply-templates select="@return-type"/>
+            <xsl:choose>
+               <xsl:when test="@return-type">
+                  <xsl:apply-templates select="@return-type"/>
+               </xsl:when>
+               <xsl:otherwise>item()*</xsl:otherwise>
+            </xsl:choose>           
          </test>
          <result>
             <assert-true/>
          </result>
       </test-case>
+   </xsl:template>
+   
+   <xsl:template match="@default | @example">
+      <xsl:value-of select="."/>
    </xsl:template>
    
    <xsl:template match="@type[starts-with(., 'item()') or starts-with(., 'xs:string') or starts-with(., 'xs:anyAtomicType')]" priority="5">
@@ -107,14 +116,16 @@
    <xsl:template match="@type[starts-with(., 'xs:numeric') 
       or starts-with(., 'xs:integer') 
       or starts-with(., 'xs:double')
-      or starts-with(., 'xs:nonNegativeInteger')]" priority="5">
+      or starts-with(., 'xs:nonNegativeInteger')
+      or starts-with(., 'xs:positiveInteger')]" priority="5">
       <xsl:text>1</xsl:text>
    </xsl:template>
    
    <xsl:template match="@type[starts-with(., 'xs:numeric*') 
       or starts-with(., 'xs:integer*') 
       or starts-with(., 'xs:double*')
-      or starts-with(., 'xs:nonNegativeInteger*')]" priority="7">
+      or starts-with(., 'xs:nonNegativeInteger*')
+      or starts-with(., 'xs:positiveInteger')]" priority="7">
       <xsl:text>(42, 43)</xsl:text>
    </xsl:template>
    
@@ -270,32 +281,8 @@
       <xsl:text>'BuiltInKeywords.xml'</xsl:text>
    </xsl:template>
    
-   <xsl:template match="@type[../@name = 'href'][../../@name='json-doc']" priority="13">
-      <xsl:text>'JSONTestSuite/test_parsing/y_number.json'</xsl:text>
-   </xsl:template>
-   
    <xsl:template match="*[@name = 'arguments']/@type" priority="80">
       <xsl:text>[22]</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[../@name = 'input'][../../@name=('boolean', 'not')]" priority="12">
-      <xsl:text>42</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[../@name = 'value'][../../@name='parse-ietf-date']" priority="12">
-      <xsl:text>'Wed, 06 Jun 1994 07:29:35 GMT'</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[../@name = 'value'][../../@name='parse-xml']" priority="12">
-      <xsl:text>'&lt;a/>'</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[../@name = 'node'][../../@name='xml-to-json']" priority="12">
-      <xsl:text>()</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[../@name = 'options'][../../@name='serialize']" priority="12">
-      <xsl:text>map{{}}</xsl:text>
    </xsl:template>
    
    <xsl:template match="@type[../../@name=('sum', 'zero-or-one', 'exactly-one', 'avg')]" priority="12">


### PR DESCRIPTION
Improves the stylesheet that generates the BuiltInKeywords.xml test set, using example values for arguments where appropriate, taking these from the function catalog.