### PR TITLE
317: fn:format-integer: $lang → $language

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1406,7 +1406,7 @@
          <fos:proto name="format-integer" return-type="xs:string">
             <fos:arg name="value" type="xs:integer?"/>
             <fos:arg name="picture" type="xs:string"/>
-            <fos:arg name="lang" type="xs:string?" default="()"/>
+            <fos:arg name="language" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -1731,7 +1731,7 @@
             selected by the tokens <code>w</code>, <code>W</code> and <code>Ww</code>. It also
             applies to other sequences, for example different languages using the Cyrillic alphabet
             use different sequences of characters, each starting with the letter #x410 (Cyrillic
-            capital letter A). In such cases, the <code>$lang</code> argument specifies which
+            capital letter A). In such cases, the <code>$language</code> argument specifies which
             language's conventions are to be used. If the argument is specified, the value
                <rfc2119>should</rfc2119> be either an empty sequence or a value that would be valid
             for the <code>xml:lang</code> attribute (see <bibref
@@ -1741,7 +1741,7 @@
             well as identification of dialects and regions within a country.</p>
          <p>The set of languages for which numbering is supported is <termref
                def="implementation-defined"
-               >implementation-defined</termref>. If the <code>$lang</code> argument is absent, or is
+               >implementation-defined</termref>. If the <code>$language</code> argument is absent, or is
             set to an empty sequence, or is invalid, or is not a language supported by the
             implementation, then the number is formatted using the default language from the dynamic
             context. </p>
@@ -1889,10 +1889,10 @@
                   twenty-three"</code></p>
          </fos:example>
          <fos:example>
-            <p>Ordinal numbering in Italian: The specification <code>"1;o(-º)"</code> with <code>$lang</code> equal to
+            <p>Ordinal numbering in Italian: The specification <code>"1;o(-º)"</code> with <code>$language</code> equal to
                   <code>it</code>, if supported, should produce the sequence:</p>
             <eg xml:space="preserve">1º 2º 3º 4º ...</eg>
-            <p>The specification <code>"Ww;o"</code> with <code>$lang</code> equal to
+            <p>The specification <code>"Ww;o"</code> with <code>$language</code> equal to
                   <code>it</code>, if supported, should produce the sequence:</p>
             <eg xml:space="preserve">Primo Secondo Terzo Quarto Quinto ...</eg>
          </fos:example>


### PR DESCRIPTION
Parameter name aligned with other functions (`fn:format-dateTime`, `fn:lang`, others).
Closes #317.