### PR TITLE
Support role=wide on fos:examples

### DIFF
--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -98,9 +98,13 @@ table.record tr.arg td:first-child  {
 table.proto tr.name span.name {
   font-weight: bold;
 }
-span.dagger {
-  font-family: serif;
-  font-weight: bold;
-  font-size: 150%;
-  font-style: italic;
+
+table.medium {
+    border-collapse: collapse;
+}
+
+tr + tr.testdiv th, tr + tr.testdiv td {
+    border-top: 2px solid var(--example-border);
+    margin-top: 0.5rem;
+    padding-top: 0.6rem;
 }

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24875,7 +24875,7 @@ declare function fn:some(
          see <code>fn:build-uri</code>.</p>
       </fos:notes>
       
-<fos:examples>
+<fos:examples role="wide">
   <fos:example>
     <p>In the examples that follow, keys with values that are null, or an empty array,
 are elided for editorial clarity.</p>
@@ -25444,7 +25444,7 @@ path with an explicit <code>file:</code> scheme.</p>
         <p>The resulting URI is returned.</p>
       </fos:rules>
       
-      <fos:examples>
+      <fos:examples role="wide">
          <fos:example>
             <fos:test>
                <fos:expression><eg>build-uri(map {

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -149,27 +149,29 @@
 					</def>
 				</gitem>
 			</xsl:if>
-			<xsl:if test="$fspec/fos:examples">
-				<gitem>
-					<label>Examples</label>
-					<def role="example">
-						<xsl:copy-of select="$fspec/fos:examples/(@diff, @at)"/>
-						<table role="medium">
-							<xsl:if test="$fspec/fos:examples//fos:result">
-								<thead>
-									<tr>
-										<th>Expression</th>
-										<th>Result</th>
-									</tr>
-								</thead>
-							</xsl:if>
-							<tbody>
-								<xsl:apply-templates select="$fspec/fos:examples/node()"/>
-							</tbody>
-						</table>						
-					</def>
-				</gitem>
-			</xsl:if>
+
+  <xsl:if test="$fspec/fos:examples">
+    <gitem>
+      <label>Examples</label>
+      <def role="example">
+	<xsl:copy-of select="$fspec/fos:examples/(@diff, @at)"/>
+	<table role="medium">
+	  <xsl:if test="not(contains-token($fspec/fos:examples/@role, 'wide'))
+                        and $fspec/fos:examples//fos:result">
+	    <thead>
+	      <tr>
+		<th>Expression</th>
+		<th>Result</th>
+	      </tr>
+	    </thead>
+	  </xsl:if>
+	  <tbody>
+	    <xsl:apply-templates select="$fspec/fos:examples/node()"/>
+	  </tbody>
+	</table>						
+      </def>
+    </gitem>
+  </xsl:if>
 			<xsl:if test="$fspec/fos:history">
 				<gitem>
 					<label>History</label>
@@ -296,6 +298,56 @@
 	    </td>
 	  </tr>
 	</xsl:template>
+
+	<xsl:template match="fos:test[ancestor::fos:examples[@role='wide']]" priority="6">
+	  <tr class="testdiv">
+	    <xsl:copy-of select="@diff, @at"/>
+            <th valign="top">Expression:</th>
+	    <td valign="top">
+	      <xsl:if test="fos:preamble">
+		<p><xsl:copy-of select="fos:preamble/node()" copy-namespaces="no"/></p>
+	      </xsl:if>
+	      <p>
+		<xsl:choose>
+		  <xsl:when test="fos:expression/@xml:space = 'preserve'">
+		    <code><xsl:value-of select="translate(fos:expression, ' ', '&#xa0;')"/></code>
+		  </xsl:when>
+		  <xsl:when test="fos:expression/eg">
+		    <xsl:apply-templates select="fos:expression/node()"/>
+		  </xsl:when>
+		  <xsl:otherwise>
+		    <code><xsl:value-of select="fos:expression"/></code>
+		  </xsl:otherwise>
+		</xsl:choose>
+	      </p>
+	    </td>
+          </tr>
+	  <tr>
+	    <xsl:copy-of select="@diff, @at"/>
+            <th valign="top">Result:</th>
+	    <td valign="top">
+	      <xsl:if test="fos:result[2]"><p>One of the following:</p></xsl:if>
+	      <xsl:apply-templates select="fos:result|fos:error-result"/>
+	      <xsl:if test="fos:result[@normalize-space = 'true']">
+		<p>(with whitespace added for legibility)</p>
+	      </xsl:if>
+	      <xsl:if test="fos:result[@allow-permutation = 'true']">
+		<p>(or some permutation thereof)</p>
+	      </xsl:if>
+	      <xsl:if test="fos:result[@approx = 'true']">
+		<p>(approximately)</p>
+	      </xsl:if>
+	      <xsl:if test="fos:postamble">
+		<p><emph>
+		  <xsl:text>(</xsl:text>
+		  <xsl:copy-of select="fos:postamble/node()" copy-namespaces="no"/>
+		  <xsl:text>)</xsl:text>
+		  <xsl:if test="not(ends-with(fos:postamble, '.'))">.</xsl:if>
+		</emph></p>
+	      </xsl:if>
+	    </td>
+	  </tr>
+        </xsl:template>
 
 	<xsl:template match="fos:test" priority="5">
 	  <tr>


### PR DESCRIPTION
This is a purely style related change. It supports role=wide on fos:example elements. If an example is identified as "wide" then the presentaiton is in sequential rows of the table rather than adjacent columns. See, for example, `parse-uri()`.