### PR TITLE
Editorial: Correction to map:filter examples

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13191,7 +13191,7 @@ else if (empty($input))
                <fos:expression><eg><![CDATA[deep-equal(
     parse-xml("<a xmlns='AA'/>"),
     parse-xml("<p:a xmlns:p='AA'/>"),
-    options := map{'prefixes':true()})]]></eg></fos:expression>
+    options := map{'namespace-prefixes':true()})]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>False because the namespace prefixes differ</fos:postamble>
             </fos:test>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18962,17 +18962,20 @@ return
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>map:filter(map{1: "Sunday", 2: "Monday", 3: "Tuesday", 4:"Wednesday",
-               5: "Thursday", 6: "Friday", 7: "Saturday"},
-           ->($k, $v){$k = (1, 7)})</eg></fos:expression>
-               <fos:result>map{1:"Sunday", 7:"Saturday"}</fos:result>
+               <fos:expression><eg>map:filter(map{1: "Sunday", 2: "Monday", 
+               3: "Tuesday", 4:"Wednesday",
+               5: "Thursday", 6: "Friday", 
+               7: "Saturday"},
+          ($k, $v)->{$k = (1, 7)})</eg></fos:expression>
+               <fos:result><eg>map{1:"Sunday", 7:"Saturday"}</eg></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>
-map:filter(map{1: "Sunday", 2: "Monday", 3: "Tuesday", 4: "Wednesday",
-               5: "Thursday", 6:"Friday", 7:"Saturday"},
-           ->($k, $v){$v = ("Saturday", "Sunday")})</eg></fos:expression>
-               <fos:result>map{1:"Sunday", 7:"Saturday"}</fos:result>
+               <fos:expression><eg>map:filter(map{1: "Sunday", 2: "Monday", 
+               3: "Tuesday", 4: "Wednesday",
+               5: "Thursday", 6:"Friday", 
+               7:"Saturday"},
+          ($k, $v)->{$v = ("Saturday", "Sunday")})</eg></fos:expression>
+               <fos:result><eg>map{1:"Sunday", 7:"Saturday"}</eg></fos:result>
             </fos:test>
 
          </fos:example>


### PR DESCRIPTION
Corrects the syntax of the lambda functions in these two examples. Also improves the formatting.