### PR TITLE
585: [Editorial] Rearrange text (and grammar) for dynamic function calls

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1869,12 +1869,17 @@ ErrorVal ::= "$" VarName
     </g:choice>
   </g:production>
 
-  <g:production name="FilterExpr" if=" xslt40-patterns">
+  <!--<g:production name="FilterExprP" if=" xslt40-patterns">
     <g:ref name="PrimaryExpr"/>
     <g:ref name="PredicateList"/>
+  </g:production>-->
+  
+  <g:production name="FilterExpr" if="xpath40 xquery40">
+    <g:ref name="PostfixExpr"/>
+    <g:ref name="Predicate"/>
   </g:production>
 
-  <g:production name="PostfixExpr" if="xpath40 xquery40  xslt40-patterns">
+  <!--<g:production name="PostfixExpr" if="xpath40 xquery40  xslt40-patterns">
     <g:ref name="PrimaryExpr"/>
     <g:zeroOrMore>
       <g:choice>
@@ -1883,7 +1888,22 @@ ErrorVal ::= "$" VarName
         <g:ref name="Lookup"/>
       </g:choice>
     </g:zeroOrMore>
+  </g:production>-->
+  
+  <g:production name="PostfixExpr" if="xpath40 xquery40 xslt40-patterns">
+    <g:choice>
+      <g:ref name="PrimaryExpr"/>
+      <g:ref name="FilterExpr"/>
+      <g:ref name="DynamicFunctionCall"/>     
+      <g:ref name="LookupExpr"/>
+    </g:choice> 
   </g:production>
+  
+  <g:production name="DynamicFunctionCall" if="xpath40 xquery40  xslt40-patterns">
+    <g:ref name="PostfixExpr"/>
+    <g:ref name="PositionalArgumentList"/>
+  </g:production>
+
 
   <g:production name="ArgumentList" if="xpath40 xquery40  xslt40-patterns">
     <g:string>(</g:string>
@@ -1942,6 +1962,11 @@ ErrorVal ::= "$" VarName
     <g:string>[</g:string>
     <g:ref name="Expr" if="xpath40 xquery40  xslt40-patterns"/>
     <g:string>]</g:string>
+  </g:production>
+  
+  <g:production name="LookupExpr" if="xpath40 xquery40">
+    <g:ref name="PostfixExpr"/>
+    <g:ref name="Lookup"/>
   </g:production>
 
   <g:production name="Lookup" if="xpath40 xquery40">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7071,6 +7071,196 @@ At evaluation time, the value of a variable reference is the value to which the 
 
       </div2>
       
+      <div2 id="id-postfix-expression">
+         <head>Postfix Expressions</head>
+         
+         <scrap>
+            <head/>
+            <prodrecap id="PostfixExpr" ref="PostfixExpr"/>
+            <prodrecap ref="FilterExpr"/>
+            <prodrecap ref="DynamicFunctionCall"/>
+            <prodrecap ref="LookupExpr"/>
+         </scrap>
+         
+         <p>A postfix expression takes one of the following forms:</p>
+         
+         <ulist>
+            <item><p><termdef term="filter expression" id="dt-filter-expression">
+               A <term>filter expression</term> is an expression in the form <code>E1[E2]</code>: 
+               its effect is
+               to return those items from the value of <code>E1</code> that
+               satisfy the predicate in E2.</termdef></p>
+            <p>Filter expressions are described in <specref ref="id-filter-expression"/>.</p>
+            <p>An example of a filter expression is <code>(1 to 100)[. mod 2 = 0]</code>
+            which returns all even numbers in the range 1 to 100.</p>
+            <p>The base expression <code>E1</code> can itself be a postfix expression,
+            so multiple predicates are allowed, in the form <code>E1[E2][E3][E4]</code>.</p></item>
+            <item><p>An expression (other than a raw EQName) followed by an argument
+               list in parentheses (that is, <code>E1(E2, E3, ...)</code>) is
+               referred to as a <termref
+                  def="dt-dynamic-function-invocation"
+                  >dynamic function call</termref>. Its
+               effect is to evaluate <code>E1</code> to obtain a function,
+               and then call that function, with
+               <code>E2</code>, <code>E3</code>, <code>...</code> as
+               arguments. Dynamic function calls are described in <specref
+                  ref="id-dynamic-function-invocation"/>.</p>
+            <p>An example of a dynamic function call is <code>$f("a", 2)</code> where
+            the value of variable <code>$f</code> must be a function item.</p></item>
+            <item><p>A <code>lookup-expression</code> takes the form
+            <code>E1?K</code>, where <code>E1</code> is an expression returning a sequence
+            of maps or arrays, and <code>K</code> is a key specifier, which indicates which
+            entries in a map, or members in an array, should be selected.</p>
+               <p>Lookup expressions are described in <specref ref="id-postfix-lookup"/>.</p>
+            <p>An example of a lookup expression is <code>$emp?name</code>, where
+            the value of variable <code>$emp</code> is a map, and the string <code>"name"</code>
+            is the key of one of the entries in the map.</p></item>
+         </ulist>
+         
+         <p>Postfix expressions are evaluated from left-to-right. For example, the 
+         expression <code>$E1[E2]?(E3)(E4)</code> is evaluated by first evaluating
+            the filter expression <code>$E1[E2]</code> to produce a sequence of maps and arrays 
+            (say <code>$S</code>), then evaluating the lookup expression <code>$S?(E3)</code>
+            to produce a function item (say <code>$F</code>), then evaluating the dynamic
+            function call <code>$F(E4)</code> to produce the final result.</p>
+         
+         <note><p>The grammar for postfix expressions is defined here in a way designed
+         to link clearly to the semantics of the different kinds of expression. For parsing
+         purposes, the equivalent production rule:</p>
+         <eg>PostfixExpr := PrimaryExpr (Predicate | PositionalArgumentList | Lookup)*</eg>
+         <p>(as used in XPath 3.1) is probably more convenient.</p></note>
+         
+      </div2>
+         
+         <div2 id="id-filter-expression">
+            <head>Filter Expressions</head>
+            
+            <scrap>
+               <head/>
+               <prodrecap ref="FilterExpr"/>
+               <prodrecap id="Predicate" ref="Predicate"/>
+            </scrap>
+            
+            <p>A filter expression consists of a base expression followed by
+               a predicate, which is an expression written in square
+               brackets. The result of the filter expression consists of the
+               items returned by the base expression, filtered by applying the
+               predicate to each item in turn. The ordering of the items
+               returned by a filter expression is the same as their order in
+               the result of the primary expression.</p>
+            
+            <note>
+               <p>Where the expression before the square brackets is a
+                  <nt def="ReverseStep"
+                     >ReverseStep</nt> or <nt def="ForwardStep"
+                        >ForwardStep</nt>, the expression is technically not a
+                  filter expression but an <nt
+                     def="AxisStep"
+                     >AxisStep</nt>. There are minor differences
+                  in the semantics: see <specref
+                     ref="id-predicate"/>
+               </p>
+            </note>
+            
+            
+            
+            <p>Here are some examples of filter expressions:</p>
+            
+            <ulist>
+               
+               <item>
+                  <p>Given a sequence of products in a variable, return only those products whose price is greater than 100.</p>
+                  <eg role="parse-test"><![CDATA[$products[price gt 100]]]></eg>
+               </item>
+               
+               <item>
+                  <p>List all the integers from 1 to 100 that are divisible by 5. (See <specref
+                     ref="construct_seq"
+                  /> for an explanation of the <code>to</code> operator.)</p>
+                  <eg role="parse-test"><![CDATA[(1 to 100)[. mod 5 eq 0]]]></eg>
+               </item>
+               
+               <item>
+                  <p>The result of the following expression is the integer 25:</p>
+                  <eg role="parse-test"><![CDATA[(21 to 29)[5]]]></eg>
+               </item>
+               
+               <item>
+                  <p>The following example returns the fifth through ninth items in the sequence bound to variable <code>$orders</code>.</p>
+                  <eg role="parse-test"><![CDATA[$orders[position() = (5 to 9)]]]></eg>
+               </item>
+               
+               <item>
+                  <p>The following example illustrates the use of a filter expression as a <termref
+                     def="dt-step">step</termref> in a <termref def="dt-path-expression"
+                        >path expression</termref>. It returns the last chapter or appendix within the book bound to variable <code>$book</code>:</p>
+                  <eg role="parse-test"><![CDATA[$book/(chapter | appendix)[last()]]]></eg>
+               </item>
+               
+            </ulist>
+            
+            <p>For each item in the input sequence, the predicate expression
+               is evaluated using an <term>inner focus</term>, defined as
+               follows: The context item is the item currently being tested
+               against the predicate. The context size is the number of items
+               in the input sequence. The context position is the position of
+               the context item within the input sequence. </p>
+            
+            <p>For each item in the input sequence, the result of the
+               predicate expression is coerced to an <code>xs:boolean</code>
+               value, called the <term>predicate truth value</term>, as
+               described below. Those items for which the predicate truth value
+               is <code>true</code> are retained, and those for which the
+               predicate truth value is <code>false</code> are discarded.</p>
+            
+            
+            <p>The predicate truth value is derived by applying the following rules,
+               in order:</p>
+            
+            <olist>
+               
+               <item>
+                  <p>If the value of the predicate expression is a <termref def="dt-singleton"
+                     >singleton</termref> atomic value of a
+                     <termref def="dt-numeric"
+                        >numeric</termref> type or derived
+                     from a <termref def="dt-numeric"
+                        >numeric</termref> type,
+                     the predicate truth value is <code>true</code> if the value
+                     of the predicate expression is equal (by the
+                     <code>eq</code> operator) to the <term>context
+                        position</term>, and is <code>false</code>
+                     otherwise. <termdef
+                        term="numeric predicate" role="xquery" id="dt-numeric-predicate"
+                        >A predicate whose predicate
+                        expression returns a numeric type is called a <term>numeric
+                           predicate</term>.</termdef>
+                  </p>
+                  
+                  <note role="xquery">
+                     <p>In a region of a query where <termref def="dt-ordering-mode"
+                        >ordering mode</termref> is
+                        <code>unordered</code>, the result of a numeric predicate is
+                        <termref
+                           def="dt-implementation-dependent"
+                           >implementation-dependent</termref> , as explained in <specref
+                              ref="id-unordered-expressions"/>.</p>
+                  </note>
+               </item>
+               
+               
+               <item>
+                  <p>Otherwise, the predicate truth value is the <termref def="dt-ebv"
+                     >effective boolean value</termref> of the
+                     predicate expression.</p>
+               </item>
+               
+            </olist>
+         </div2>
+         
+      
+      
+      
       <div2 id="id-functions">
          <head>Functions</head>
          
@@ -7090,17 +7280,19 @@ At evaluation time, the value of a variable reference is the value to which the 
          </ulist>
          
          <p diff="chg" at="B">The functions defined by a statically known <termref def="dt-function-definition"/> can be invoked using a
-         <termref def="dt-static-function-call"/>. <termref def="dt-function-item">Function items</termref> corresponding
-         to these definitions can also be obtained, as dynamic values, by evaluating a <termref def="dt-named-function-ref"/>. 
+            <termref def="dt-static-function-call"/>. <termref def="dt-function-item">Function items</termref> corresponding
+            to these definitions can also be obtained, as dynamic values, by evaluating a <termref def="dt-named-function-ref"/>. 
             <termref def="dt-function-item">Function items</termref> can also be obtained using the <code>fn:function-lookup</code>
-         function: in this case the function name and arity do not need to be known statically, and the function definition
-         need not be present in the <termref def="dt-static-context"/>, so long as it is in the <termref def="dt-dynamic-context"/>.</p>
+            function: in this case the function name and arity do not need to be known statically, and the function definition
+            need not be present in the <termref def="dt-static-context"/>, so long as it is in the <termref def="dt-dynamic-context"/>.</p>
          
-         <p diff="chg" at="B">The mechanisms for making function calls by reference to function definitions and function items 
-            are described in the following sections.</p>
          
-            <div3 id="id-static-functions" diff="add" at="A">
-               <head>Function Definitions</head>
+         <p>Static and dynamic function calls are described in the following sections.</p>
+         
+         <div3 id="id-static-functions" diff="add" at="A">
+         
+               <head>Static Function Calls</head>
+
                <p>The <termref def="dt-static-context"/> for an expression includes a set 
                   of <termref def="dt-statically-known-function-definitions"/>. Every <termref def="dt-function-definition"/>
                in the static context has a name (which is an <termref def="dt-expanded-qname"/>) and 
@@ -7110,212 +7302,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                This means that for a given static function call, it is possible to identify the target function definition
                in the static context unambiguously from knowledge of the function name and the number of supplied arguments.</p>
                
-               <!--<p>Declared functions in the static context may include any or all of the following:</p>
-               <ulist>
-                  <item><p>Built-in functions defined in these specifications or in a host language
-                  referencing these specifications.</p></item>
-                  <item role="xpath"><p>User-defined functions declared using the syntax of a host language such
-                  as XQuery or XSLT.</p></item>
-                  <item role="xquery"><p>User-defined functions declared in the <termref def="dt-prolog">prolog</termref>.</p></item>
-                  <item><p>External functions made available in some implementation-defined way.</p></item>
-               </ulist>
                
-               <p>
-                  <termdef term="built-in function" id="dt-built-in-function">The 
-                     <term>built-in functions</term>  are 
-                     the functions defined in <bibref ref="xpath-functions-40"/>in the 
-                     <code>http://www.w3.org/2005/xpath-functions</code>,
-                     <code>http://www.w3.org/2001/XMLSchema</code>,
-                     <code>http://www.w3.org/2005/xpath-functions/math</code>,
-                     <code>http://www.w3.org/2005/xpath-functions/map</code>,
-                     and <code>http://www.w3.org/2005/xpath-functions/array</code> namespaces.
-                     
-                  </termdef> 
-                  <phrase role="xquery">The set of built-in functions is specified in <specref
-                     ref="id-minimal-conformance"/> and <specref ref="id-conform-optional-features"
-                     />.</phrase>
-                  <phrase role="xpath">The set of built-in functions is specified by the host language.</phrase>
-                  
-                  <phrase role="xpath">Additional functions may be provided in
-                     the <termref def="dt-static-context">static
-                        context</termref>. XPath per se does not provide a way
-                     to declare named functions, but a host language may provide
-                     such a mechanism.</phrase>
-                  <phrase role="xquery">Additional functions may be declared in a
-                     <termref  def="dt-library-module">library module</termref>, or provided by
-                     the external environment as part of the <termref
-                        def="dt-static-context">static
-                        context</termref>.</phrase>
-               </p>-->
-               
-               <!--<p>Static functions may be variadic. If a function is variadic, the number of arguments appearing
-               in a function call may differ from the number of parameters declared in the function signature.
-               Different kinds of variadic functions are defined, distinguished by the value of the annotation
-               <code>%variadic</code>, which is present on all static functions, and takes one of four values:</p>
-               <ulist>
-                  <item><p><code>%variadic("no")</code> indicates that the function is not variadic.
-                  In a function call, an argument must be supplied for every parameter in the function signature.
-                  It can be supplied either positionally or by keyword, but there must be a one-to-one mapping
-                  between arguments and parameter declarations.</p></item>
-                  <item><p><code>%variadic("bounded")</code> indicates that the function is bounded-variadic.
-                  A bounded-variadic function declares zero or more required parameters and one or more
-                  optional parameters. In a function call, an argument must be supplied for every required
-                  parameter, and arguments may be supplied for optional parameters: in both cases, the
-                  argument may be supplied either positionally or by keyword.</p></item>
-                  <item><p><code>%variadic("sequence")</code> indicates that the function is sequence-variadic.
-                   A sequence-variadic function declares one or more parameters, of which the last typically
-                  has an occurrence indicator of <code>*</code> or <code>+</code> to indicate that a sequence 
-                  may be supplied. If the declaration includes <var>N</var> parameters, then a call on the 
-                  function may supply <var>N-1</var> or more arguments; the values of the <var>N</var>th
-                  and subsequent arguments are concatenated to form a single sequence, which is supplied
-                  as the value of the last parameter in the declaration.
-                  In a sequence-variadic function, the last parameter is implicitly optional (it defaults
-                  to an empty sequence), and all other parameters are required. In a call of a 
-                  sequence-variadic function, all arguments must be supplied positionally.</p></item>
-                  
-                  <item><p><code>%variadic("map")</code> indicates that the function is map-variadic.
-                     A map-variadic function declares one or more parameters, of which the last must
-                     be a type that accepts a map. It may restrict what kind of map is accepted (for example,
-                     by using a <code>RecordTest</code>), and it may
-                     accept things other than maps, but it must accept a single map as the supplied value.
-                     The last parameter is implicitly optional (it defaults to an empty map). All
-                     other parameters are required, and must be supplied positionally.
-                     All keyword arguments in the
-                     function call are assembled into a map, and this map is supplied as the value of
-                     the last parameter. Alternatively, the last parameter can be supplied positionally
-                     (typically, as an already-assembled map).</p>
-                     <p>The names and types of the keyword arguments supplied to a map-variadic
-                     function may be constrained by declaring the required type in the function signature
-                     as a <term>Record Test</term>, which then allows static type checking. However, there
-                     is no requirement to use such a type.</p>
-                  </item>
-               </ulist>-->
-               
-               <!--<p>A function has a <term>declared arity</term> which is the number of parameters
-               defined in the function declaration. This value, together with the value of the
-               <code>variadic</code> annotation, determine the number of positional arguments
-               and keyword arguments that may appear in a function call. Specifically, for each function
-               there are six properties that can be computed:</p>
-               
-               <ulist>
-                  <item><p>The minimum number of arguments in total <var>MinA</var>.</p></item>
-                  <item><p>The maximum number of arguments in total <var>MaxA</var>.</p></item>
-                  <item><p>The minimum number of positional arguments <var>MinP</var>.</p></item>
-                  <item><p>The maximum number of positional arguments <var>MaxP</var>.</p></item>
-                  <item><p>The minimum number of keyword arguments <var>MinK</var>.</p></item>
-                  <item><p>The maximum number of keyword arguments <var>MaxK</var>.</p></item>
-               </ulist>
-               
-               <p>The values of these properties are given by the following table, where <var>A</var>
-                  is the declared arity and <var>R</var> is the number of parameters that do not have
-                  a default value. The last parameter in a map-variadic or sequence-variadic value
-                  has an implicit default value, so it is not included in this count.
-               </p>
-              
-               <table role="medium" width="100%">
-                  <caption>Number of Arguments allowed in a Function Call</caption>
-                  <thead>
-                     <tr>
-                        <th>%variadic</th>
-                        <th>MinA</th>
-                        <th>MaxA</th>
-                        <th>MinP</th>
-                        <th>MaxP</th>
-                        <th>MinK</th>
-                        <th>MaxK</th>
-                     </tr>
-                  </thead>
-                  <tbody>
-                     <tr>
-                        <td>no</td>
-                        <td>A</td>
-                        <td>A</td>
-                        <td>0</td>
-                        <td>A</td>
-                        <td>0</td>
-                        <td>A</td>
-                     </tr>
-                     <tr>
-                        <td>bounded</td>
-                        <td>R</td>
-                        <td>A</td>
-                        <td>0</td>
-                        <td>A</td>
-                        <td>0</td>
-                        <td>A</td>
-                     </tr>
-                     <tr>
-                        <td>map</td>
-                        <td>R</td>
-                        <td>unbounded</td>
-                        <td>R</td>
-                        <td>R</td>
-                        <td>0</td>
-                        <td>unbounded</td>
-                     </tr>
-                     <tr>
-                        <td>sequence</td>
-                        <td>R</td>
-                        <td>unbounded</td>
-                        <td>R</td>
-                        <td>unbounded</td>
-                        <td>0</td>
-                        <td>0</td>
-                     </tr>
-                  </tbody>
-               </table>
-               
-               <p>If two functions <var>F</var> and <var>G</var> in the static context have the same name, 
-               then both of the following conditions must be true:</p>
-               
-               <ulist>
-                  <item><p>MinP(F) > MaxP(G) or MinP(G) > MaxP(F)</p></item>
-                  <item><p>MinK(F) > MaxK(G) or MinK(G) > MaxK(F)</p></item>
-               </ulist>
-               
-               <p>In consequence, a function call with a known number of positional arguments and a known
-               number of keyword arguments can never match more than one function in the static context.</p>
-               -->
-               <!--<p>Similarly, a named function reference such as <code>fn#3</code> is a reference to a
-               function in the static context with name <code>fn</code> and arity 3,
-               and there can be at most one such function.</p>-->
-               
-               <!--<p>Taking examples from the standard function library:</p>
-               <ulist>
-                  <item><p>The function <code>fn:position</code> takes no arguments. It has
-                     <var>MinA</var>=0, <var>MaxA</var>=0, <var>MinP</var>=0, <var>MaxP</var>=0, 
-                     <var>MinK</var>=0, <var>MaxK</var>=0.</p></item>
-                  <item><p>The function <code>fn:node-name</code>  is bounded-variadic.
-                     It has one optional argument, which
-                     can be supplied either by position or by keyword. It has
-                     <var>MinA</var>=0, <var>MaxA</var>=1, <var>MinP</var>=0, <var>MaxP</var>=1, 
-                     <var>MinK</var>=0, <var>MaxK</var>=1.</p></item>
-                  
-                  <item><p>The function <code>fn:format-date</code> is bounded-variadic. It defines
-                  two required parameters (<code>value</code> and <code>picture</code>), followed by
-                  three optional parameters (<code>language</code>, <code>calendar</code>, and
-                  <code>place</code>). For all three optional parameters, the default value is an empty
-                  sequence. The function can be called with any number of positional arguments from 2 to 5.
-                  Alternatively the optional parameters can be supplied by keyword: for example
-                  <code>format-date(current-date(), "[D1] [MNn] [Y0001]", place: "America/New_York")</code>.
-                  It is also possible to supply the required parameters by keyword.</p>
-                  <p>The function thus has <var>MinA</var>=2, <var>MaxA</var>=5, <var>MinP</var>=0, 
-                     <var>MaxP</var>=5, <var>MinK</var>=0, <var>MaxK</var>=5.</p></item>
-                  <item><p>The <code>fn:concat</code> function is sequence-variadic. This means
-                  that the function calls <code>fn:concat("a", "b", "c")</code>, 
-                     <code>fn:concat(("a", "b", "c"))</code>, and <code>fn:concat(("a", "b"), "c")</code>
-                  all have the same effect (delivering the result <code>"abc"</code>). Keyword
-                  arguments cannot be used with this function.</p>
-                     <p>The function thus has <var>MinA</var>=0, <var>MaxA</var>=unbounded, <var>MinP</var>=0, 
-                        <var>MaxP</var>=unbounded, <var>MinK</var>=0, <var>MaxK</var>=0.</p></item>
-                  <item><p>The <code>fn:serialize</code> function is map-variadic. This means
-                     that the function call <code>fn:serialize($doc, method: "xml", indent: true())</code>
-                  has the same effect as the function call 
-                     <code>fn:serialize($doc, map{"method":"xml", "indent":true()})</code></p>
-                     <p>The function thus has <var>MinA</var>=1, <var>MaxA</var>=unbounded, <var>MinP</var>=1, 
-                        <var>MaxP</var>=2, <var>MinK</var>=0, <var>MaxK</var>=unbounded.</p>
-                     </item>
-               </ulist>-->
                
                <p>A <termref def="dt-static-function-call"/> is bound to a <termref def="dt-function-definition"/> 
                   in the static context by matching the name
@@ -7352,12 +7339,12 @@ At evaluation time, the value of a variable reference is the value to which the 
             <scrap>
                <head/>
                <prodrecap id="FunctionCall" ref="FunctionCall"/>
-               <prodrecap ref="ArgumentList"/>
+               <prodrecap id="ArgumentList" ref="ArgumentList"/>
                <prodrecap ref="PositionalArguments"/>               
                <prodrecap id="Argument" ref="Argument"/>
                <prodrecap id="ArgumentPlaceholder" ref="ArgumentPlaceholder"/>
                <prodrecap ref="KeywordArguments"/>
-               <prodrecap ref="KeywordArgument"/>
+               <prodrecap id="KeywordArgument" ref="KeywordArgument"/>
             </scrap>
             <p><termdef term="static function call" id="dt-static-function-call">A <term>static function call</term> 
                consists of an EQName followed by a parenthesized list of zero or more arguments.</termdef></p>
@@ -7471,25 +7458,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                      <code>fn:sort(//employee, fn:default-collation(), ($e)->{xs:decimal($e/salary)})</code>.
                   </p>
                </item>
-               <!--<item diff="add" at="A">
-                  <p>
-                     <code role="parse-test"
-                        >fn:serialize($value, method: 'json', indent: true())</code> is a static function call
-                     with three arguments. This function is declared as map-variadic, so it is effectively
-                     called supplying <code>$value</code> for the first parameter, and 
-                     <code>map{'method':'json', 'indent':true()}</code> for the second.</p>
-               </item>-->
-               <!--<item diff="add" at="A">
-                  <p>
-                     <code role="parse-test"
-                        >fn:codepoints-to-string(66, 65, 67, 72)</code> is a static function call with
-                     four arguments. This function is declared as sequence-variadic, so the four arguments
-                     are effectively combined into a sequence <code>(66, 65, 67, 72)</code> which is supplied
-                     as the value of the first (and only) parameter. The call is thus equivalent to
-                     the single-argument call <code>fn:codepoints-to-string((66, 65, 67, 72))</code>: it returns <code>"BACH"</code>.
-                     The call could also be written with two arguments: 
-                     <code>fn:codepoints-to-string((66, 65), (67, 72)))</code>.</p>
-               </item>-->
+               
             </ulist>
             
             <p>An <code>EQName</code> in a <code>KeywordArgument</code> is expanded to a QName value; if there
@@ -7745,8 +7714,66 @@ At evaluation time, the value of a variable reference is the value to which the 
             <p>These constructs are described in detail in the following sections, or in
                <bibref ref="xpath-functions-40"/>.</p>
          
+            <div4 id="id-dynamic-function-invocation">
+               <head>Dynamic Function Calls</head>
+               
+               <scrap>
+                  <head/>
+                  <prodrecap id="DynamicFunctionCall" ref="DynamicFunctionCall"/>
+                  <prodrecap id="PositionalArgumentList" ref="PositionalArgumentList"/>              
+                  <prodrecap id="PositionalArguments" ref="PositionalArguments"/>  
+                  <prodrecap ref="Argument"/>
+                  <prodrecap ref="ArgumentPlaceholder"/>
+               </scrap>
+               
+               <p>
+                  <termdef term="dynamic function call" id="dt-dynamic-function-invocation"
+                     >A <term>dynamic function call</term>
+                     consists of a base expression that returns the function and a
+                     parenthesized list of zero or more arguments (<termref
+                        def="dt-arg-expr">argument expressions</termref> or
+                     ArgumentPlaceholders).</termdef>
+               </p>
+               
+               <p>
+                  A dynamic function call is evaluated as described in
+                  <specref
+                     ref="id-eval-dynamic-function-call"/>.
+               </p>
+               
+               <p>The following are examples of some dynamic function calls:</p>
+               
+               <ulist>
+                  <item>
+                     <p>This example calls the function contained in <code>$f</code>, passing the arguments 2 and 3:
+                        <eg
+                           role="parse-test"><![CDATA[$f(2, 3)]]></eg>
+                     </p>
+                  </item>
+                  <item>
+                     <p>This example fetches the second item from sequence <code>$f</code>, treats it as a function and calls it, passing an <code>xs:string</code> argument:
+                        <eg
+                           role="parse-test"><![CDATA[$f[2]("Hi there")]]></eg>
+                     </p>
+                  </item>
+                  <item>
+                     <p>This example calls the function <code>$f</code> passing no arguments, and filters the result with a positional predicate:
+                        <eg
+                           role="parse-test"><![CDATA[$f()[2]]]></eg>
+                     </p>
+                  </item>
+                  
+               </ulist>
+               
+               <note diff="add" at="A">
+                  <p>Arguments in a dynamic function call are always supplied positionally.</p>
+               </note>
+               
+            </div4>
+         
          <div4 id="id-eval-dynamic-function-call">
                <head>Evaluating Dynamic Function Calls</head>
+           
             
             <p>This section applies to dynamic function calls whose arguments do not include
             an <code>ArgumentPlaceholder</code>. For function calls that include a placeholder,
@@ -7764,13 +7791,6 @@ At evaluation time, the value of a variable reference is the value to which the 
 
                <olist>
 
-                  <!--<item diff="chg" at="A">
-                     <p>The <term>arity</term> of a <code>PositionalArgumentList</code>
-                        is the number of positional arguments in the <code>PositionalArgumentList</code>.
-                        Keyword arguments are not allowed in a dynamic function call.
-                     </p>
-                  </item>
--->
                   <item>
                      <p>
                           The <termref def="dt-function-item"/> <var>F</var> to be called
@@ -7801,10 +7821,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                           Each argument value is converted
                           to the corresponding parameter type in <var>F</var>'s signature
                           by applying the <termref def="dt-coercion-rules">coercion rules</termref>, resulting in a
-                        <term>converted argument value</term><!--<termref
-                           def="dt-arg-value"
-                        >converted argument value</termref>-->. <!--The correspondence of arguments to parameters
-                        is by matching position.-->
+                        <term>converted argument value</term>
                      </p>
 
                   </item>
@@ -7979,15 +7996,7 @@ return $vat()
                                     <phrase role="xquery">or an <termref def="dt-external-function"
                                           >external function</termref>,
                                     </phrase>
-                                    <!--<phrase role="xpath">or a <termref
-                                          def="dt-host-language-function"
-                                          >host language function</termref>
-                                    </phrase>
-                                  or a
-                                  <termref
-                                       def="dt-partially-applied-function"
-                                       >partial application</termref>
-                                       of such a function)--> the <phrase diff="chg" at="2023-03-11">body</phrase> of the function is
+                                    the <phrase diff="chg" at="2023-03-11">body</phrase> of the function is
                                        evaluated, and the result is converted
                                        to the declared return type, in the same way as for a 
                                        static function call (see <specref ref="id-function-calls"/>).</p>
@@ -9258,229 +9267,7 @@ return filter($days,$m)
             </div3>
       </div2>
       
-      <div2 id="id-postfix-expression">
-         <head>Postfix Expressions</head>
 
-         <scrap>
-            <head/>
-            <prodrecap id="PostfixExpr" ref="PostfixExpr"/>
-            <prodrecap ref="Predicate"/>
-            <prodrecap ref="PositionalArgumentList"/>
-            <prodrecap ref="PositionalArguments"/>               
-            <prodrecap ref="Argument"/>
-         </scrap>
-
-         <p>
-            <termdef term="filter expression" id="dt-filter-expression"
-                  >An
-    expression followed by a predicate (that is, <code>E1[E2]</code>)
-    is referred to as a <term>filter expression</term>: its effect is
-    to return those items from the value of <code>E1</code> that
-    satisfy the predicate in E2.</termdef> Filter expressions are
-    described in <specref
-               ref="id-filter-expression"/>
-         </p>
-
-         <p>An expression (other than a raw EQName) followed by an argument
-    list in parentheses (that is, <code>E1(E2, E3, ...)</code>) is
-    referred to as a <termref
-               def="dt-dynamic-function-invocation"
-               >dynamic function call</termref>. Its
-    effect is to evaluate <code>E1</code> to obtain a function,
-    and then call that function, with
-    <code>E2</code>, <code>E3</code>, <code>...</code> as
-    arguments. Dynamic function calls are described in <specref
-               ref="id-dynamic-function-invocation"/>.</p>
-
-         <div3 id="id-filter-expression">
-            <head>Filter Expressions</head>
-
-            <scrap>
-               <head/>
-               <prodrecap ref="PostfixExpr"/>
-               <prodrecap id="Predicate" ref="Predicate"/>
-            </scrap>
-
-            <p>A filter expression consists of a base expression followed by
-      a predicate, which is an expression written in square
-      brackets. The result of the filter expression consists of the
-      items returned by the base expression, filtered by applying the
-      predicate to each item in turn. The ordering of the items
-      returned by a filter expression is the same as their order in
-      the result of the primary expression.</p>
-
-            <note>
-               <p>Where the expression before the square brackets is a
-      <nt def="ReverseStep"
-                     >ReverseStep</nt> or <nt def="ForwardStep"
-                     >ForwardStep</nt>, the expression is technically not a
-      filter expression but an <nt
-                     def="AxisStep"
-                     >AxisStep</nt>. There are minor differences
-      in the semantics: see <specref
-                     ref="id-predicate"/>
-               </p>
-            </note>
-
-
-
-            <p>Here are some examples of filter expressions:</p>
-
-            <ulist>
-
-               <item>
-                  <p>Given a sequence of products in a variable, return only those products whose price is greater than 100.</p>
-                  <eg role="parse-test"><![CDATA[$products[price gt 100]]]></eg>
-               </item>
-
-               <item>
-                  <p>List all the integers from 1 to 100 that are divisible by 5. (See <specref
-                        ref="construct_seq"
-                     /> for an explanation of the <code>to</code> operator.)</p>
-                  <eg role="parse-test"><![CDATA[(1 to 100)[. mod 5 eq 0]]]></eg>
-               </item>
-
-               <item>
-                  <p>The result of the following expression is the integer 25:</p>
-                  <eg role="parse-test"><![CDATA[(21 to 29)[5]]]></eg>
-               </item>
-
-               <item>
-                  <p>The following example returns the fifth through ninth items in the sequence bound to variable <code>$orders</code>.</p>
-                  <eg role="parse-test"><![CDATA[$orders[position() = (5 to 9)]]]></eg>
-               </item>
-
-               <item>
-                  <p>The following example illustrates the use of a filter expression as a <termref
-                        def="dt-step">step</termref> in a <termref def="dt-path-expression"
-                        >path expression</termref>. It returns the last chapter or appendix within the book bound to variable <code>$book</code>:</p>
-                  <eg role="parse-test"><![CDATA[$book/(chapter | appendix)[last()]]]></eg>
-               </item>
-
-            </ulist>
-
-            <p>For each item in the input sequence, the predicate expression
-      is evaluated using an <term>inner focus</term>, defined as
-      follows: The context item is the item currently being tested
-      against the predicate. The context size is the number of items
-      in the input sequence. The context position is the position of
-      the context item within the input sequence. </p>
-
-            <p>For each item in the input sequence, the result of the
-      predicate expression is coerced to an <code>xs:boolean</code>
-      value, called the <term>predicate truth value</term>, as
-      described below. Those items for which the predicate truth value
-      is <code>true</code> are retained, and those for which the
-      predicate truth value is <code>false</code> are discarded.</p>
-
-
-            <p>The predicate truth value is derived by applying the following rules,
-       in order:</p>
-
-            <olist>
-
-               <item>
-                  <p>If the value of the predicate expression is a <termref def="dt-singleton"
-                        >singleton</termref> atomic value of a
-	   <termref def="dt-numeric"
-                        >numeric</termref> type or derived
-	   from a <termref def="dt-numeric"
-                        >numeric</termref> type,
-	   the predicate truth value is <code>true</code> if the value
-	   of the predicate expression is equal (by the
-	   <code>eq</code> operator) to the <term>context
-	   position</term>, and is <code>false</code>
-	   otherwise. <termdef
-                        term="numeric predicate" role="xquery" id="dt-numeric-predicate"
-                           >A predicate whose predicate
-	   expression returns a numeric type is called a <term>numeric
-	   predicate</term>.</termdef>
-                  </p>
-
-                  <note role="xquery">
-                     <p>In a region of a query where <termref def="dt-ordering-mode"
-                           >ordering mode</termref> is
-	 <code>unordered</code>, the result of a numeric predicate is
-	 <termref
-                           def="dt-implementation-dependent"
-                           >implementation-dependent</termref> , as explained in <specref
-                           ref="id-unordered-expressions"/>.</p>
-                  </note>
-               </item>
-
-
-               <item>
-                  <p>Otherwise, the predicate truth value is the <termref def="dt-ebv"
-                        >effective boolean value</termref> of the
-	   predicate expression.</p>
-               </item>
-
-            </olist>
-         </div3>
-
-         <div3 id="id-dynamic-function-invocation">
-            <head>Dynamic Function Calls</head>
-
-            <scrap>
-               <head/>
-               <prodrecap ref="PostfixExpr"/>
-               <prodrecap id="ArgumentList" ref="ArgumentList"/>              
-               <prodrecap id="PositionalArguments" ref="PositionalArguments"/>  
-               <prodrecap ref="Argument"/>
-               <prodrecap ref="ArgumentPlaceholder"/>
-               <prodrecap id="KeywordArguments" ref="KeywordArguments"/>
-               <prodrecap id="KeywordArgument" ref="KeywordArgument"/>
-            </scrap>
-
-            <p>
-               <termdef term="dynamic function call" id="dt-dynamic-function-invocation"
-                     >A <term>dynamic function call</term>
-            consists of a
-            base expression
-            that returns the function and a
-            parenthesized list of zero or more arguments (<termref
-                     def="dt-arg-expr"
-                  >argument expressions</termref> or
-            ArgumentPlaceholders).</termdef>
-            </p>
-
-            <p>
-            A dynamic function call
-            is evaluated as described in
-            <specref
-                  ref="id-eval-dynamic-function-call"/>.
-          </p>
-
-            <p>The following are examples of some dynamic function calls:</p>
-
-            <ulist>
-               <item>
-                  <p>This example calls the function contained in $f, passing the arguments 2 and 3:
-                <eg
-                        role="parse-test"><![CDATA[$f(2, 3)]]></eg>
-                  </p>
-               </item>
-               <item>
-                  <p>This example fetches the second item from sequence $f, treats it as a function and calls it, passing an <code>xs:string</code> argument:
-                <eg
-                        role="parse-test"><![CDATA[$f[2]("Hi there")]]></eg>
-                  </p>
-               </item>
-               <item>
-                  <p>This example calls the function <code>$f</code> passing no arguments, and filters the result with a positional predicate:
-                <eg
-                        role="parse-test"><![CDATA[$f()[2]]]></eg>
-                  </p>
-               </item>
-
-            </ulist>
-            
-            <note diff="add" at="A">
-               <p>Arguments in a dynamic function call are always supplied positionally.</p>
-            </note>
-
-         </div3>
-      </div2>
 
       <div2 id="id-path-expressions">
          <head>Path Expressions</head>
@@ -10405,7 +10192,7 @@ return filter($days,$m)
             <p id="dt-predicate"
                   >A predicate within a Step has similar syntax and semantics
 	 to a predicate within a <termref
-                  def="id-filter-expression"
+                  def="dt-filter-expression"
                >filter expression</termref>.  The
 	 only difference is in the way the context position is set for
 	 evaluation of the predicate.</p>
@@ -15721,11 +15508,13 @@ return .($k)
 
             </div4>
             <div4 id="id-postfix-lookup">
-               <head>Postfix Lookup</head>
+               <head>Postfix Lookup Expressions</head>
 
                <scrap>
                   <head/>
+                  <prodrecap id="LookupExpr" ref="LookupExpr"/>
                   <prodrecap id="Lookup" ref="Lookup"/>
+                  <prodrecap ref="KeySpecifier"/>
                </scrap>
 
                <p>
@@ -19463,7 +19252,7 @@ raised <errorref
             <prodrecap id="ArrowDynamicFunction" ref="ArrowDynamicFunction"/>
             <prodrecap ref="InlineFunctionExpr"/>
             <prodrecap ref="ArgumentList"/>
-            <prodrecap id="PositionalArgumentList" ref="PositionalArgumentList"/>
+            <prodrecap ref="PositionalArgumentList"/>
          </scrap>
 
          <p>


### PR DESCRIPTION
This PR is purely editorial. It addresses the problems described in issue #585, in particular, the syntax of dynamic function calls is now described before the semantics.