### PR TITLE
561: abbreviation fn=function, drop lambda syntax

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2357,7 +2357,7 @@ ErrorVal ::= "$" VarName
     <g:choice lookahead="2">
       <g:ref name="NamedFunctionRef"/>
       <g:ref name="InlineFunctionExpr"/>
-      <g:ref name="LambdaExpr"/>
+      <!--<g:ref name="LambdaExpr"/>-->
     </g:choice>
   </g:production>
 
@@ -2371,14 +2371,17 @@ ErrorVal ::= "$" VarName
     <g:zeroOrMore if="xquery40">
       <g:ref name="Annotation"/>
     </g:zeroOrMore>
-    <g:string>function</g:string>
+    <g:choice>
+      <g:string>function</g:string>
+      <g:string>fn</g:string>
+    </g:choice>
     <g:optional>
       <g:ref name="FunctionSignature"/>
     </g:optional>
     <g:ref name="FunctionBody"/>
   </g:production>
   
-  <g:production name="LambdaExpr" if="xpath40 xquery40  xslt40-patterns">
+  <!--<g:production name="LambdaExpr" if="xpath40 xquery40  xslt40-patterns">
     <g:ref name="LambdaParams"/>
     <g:string>-></g:string>
     <g:ref name="EnclosedExpr"/>
@@ -2401,7 +2404,7 @@ ErrorVal ::= "$" VarName
     <g:ref name="VarName"/>
   </g:production>
   
-
+-->
   <!-- ] end Function Items -->
 
   <g:production name="MapConstructor" if="xpath40 xquery40">

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1404,9 +1404,11 @@ specification since the publication of XPath 3.1 Recommendation.</p>
         <code>ancestor::(section|appendix)</code>.</p></item>
       <item><p>String templates provide a new way of constructing strings: for example <code>`{$greeting}, {$planet}!`</code>
       is equivalent to <code>$greeting || ', ' || $planet || '!'</code></p></item>
+      <item><p>In inline function expressions, the keyword <code>function</code> may be abbreviated
+      as <code>fn</code>.</p></item>
       <item><p>New abbreviated syntax is introduced (<termref def="dt-focus-function"/>) 
         for simple inline functions taking a single argument. 
-        An example is <code>function{../@code}</code></p></item>
+        An example is <code>fn{../@code}</code></p></item>
       <item><p>The arrow operator <code>=></code> is now complemented by a “mapping arrow” operator <code>=!></code>
         which applies a the supplied function to each item in the input sequence independently.</p></item>
       <item><p>The “function conversion rules” are now renamed “coercion rules”.</p></item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7723,7 +7723,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                   in the static context: for example <code>fn:node-name#1</code>
                returns a function item whose effect is to call the static <code>fn:node-name</code> function
                with one argument.</p></item>
-               <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/> and <specref ref="id-lambda-expressions"/>)
+               <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/><!-- and <specref ref="id-lambda-expressions"/>-->)
                   constructs a function item whose <phrase diff="chg" at="2023-03-11">body</phrase> is defined locally. For example the
                construct <code>($x)->{$x+1}</code> returns a function item whose effect is to increment
                the value of the supplied argument.</p></item>
@@ -8455,19 +8455,10 @@ return $a("A")]]></eg>
              Anonymous functions may be created, for example, by evaluating an inline function 
              expression or by partial function application.</termdef>
             </p>
+            
+            <p diff="add" at="2023-07-04">The keywords <code>function</code> and <code>fn</code> 
+               are synonymous.</p>
 
- 
-
-            <!--<note diff="add" at="A">
-               <p>A more concise notation is introduced for simple functions in &language; because it 
-                  can improve the readability of code
-           by reducing visual clutter. For example, a sort operation previously written as <code>sort(//employee, (), 
-              function($emp as element(employee)) as xs:string { $emp/@dateOfBirth })</code> can now be written
-           <code>sort(//employee, (), ->{@dateOfBirth})</code>.</p>
-               <p>The use of the notation <code>->{expr}</code> mirrors the use of <code>-></code>
-                  as an <termref def="dt-arrow-operator"/>.</p>
-      
-            </note>-->
 
    
 
@@ -8476,14 +8467,14 @@ return $a("A")]]></eg>
 
                <eg>function($x as xs:integer, $y as xs:integer) as xs:integer {$x + $y}</eg>
 
-               <p>The types can be omitted:</p>
+               <p>The types can be omitted<phrase diff="add" at="2023-07-04">, and the keyword can be abbreviated</phrase>:</p>
 
-               <eg>function($x, $y) {$x + $y}</eg>
+               <eg>fn($x, $y) {$x + $y}</eg>
                
                
             
  
-            <p diff="add" at="A">A zero-arity function can be written as, for example, <code>function(){current-date()}</code>.</p>
+            <p diff="add" at="A">A zero-arity function can be written as, for example, <code>fn(){current-date()}</code>.</p>
 
 
          
@@ -8605,7 +8596,7 @@ return $a("A")]]></eg>
                      <p>This example creates a function that takes two <code>xs:double</code> arguments and returns their product:
                 <eg
                            role="parse-test"
-                           ><![CDATA[function($a as xs:double, $b as xs:double) as xs:double { $a * $b }]]></eg>
+                           ><![CDATA[fn($a as xs:double, $b as xs:double) as xs:double { $a * $b }]]></eg>
                      </p>
                   </item>
                   <item>
@@ -8632,26 +8623,27 @@ return $incrementors[2](4)]]></eg>
                the function body, which returns a result of type <code>item()*</code>.</termdef></p>
                <p>Here are some examples of focus functions:</p>
                <ulist>
-                  <item><p><code>function{@age}</code> - a function that expects a node as its argument, and returns
+                  <item><p><code>fn{@age}</code> - a function that expects a node as its argument, and returns
                   the <code>@age</code> attribute of that node.</p></item>
-                  <item><p><code>function{.+1}</code> - a function that expects a number as its argument, and returns
+                  <item><p><code>fn{.+1}</code> - a function that expects a number as its argument, and returns
                   that number plus one.</p></item>
                   <item><p><code>function{`${.}`}</code> - a function that expects a string as its argument, and prepends
                      a <code>"$"</code> character.</p></item>
                </ulist>
                <p>Focus functions are often useful as arguments to simple higher-order functions such as <code>fn:sort</code>.
-               For example, to sort employees by salary, write <code>sort(//employee, (), function{+@salary})</code>.
+               For example, to sort employees by salary, write <code>sort(//employee, (), fn{+@salary})</code>.
                (The unary plus has the effect of converting the attribute's value to a number, for numeric sorting).</p>
-               <p>Focus functions can also be useful on the right-hand side of the <termref def="dt-arrow-operator"/>.
-               For example, <code>$s => tokenize() => function{`"{.}"`}()</code> first tokenizes the string <code>$s</code>,
+               <p>Focus functions can also be useful on the right-hand side of the <termref def="dt-arrow-operator"/>
+                  and <termref def="dt-mapping-arrow-operator"/>.
+               For example, <code>$s => tokenize() =!> fn{`"{.}"`}()</code> first tokenizes the string <code>$s</code>,
                then wraps each token in double quotation marks.</p>
-               <p>The expression <code>function{EXPR}</code> is a syntactic shorthand for the expression
+               <p>The expression <code>function{EXPR}</code> (or <code>fn{EXPR}</code>) is a syntactic shorthand for the expression
                <code>function($Z as item()) as item()* {$Z!(EXPR)}</code>, where <code>$Z</code> is a variable name that is
                otherwise unused. Note that the function body (<code>EXPR</code>) is evaluated with a singleton focus: 
                   the context position and context size will always be 1 (one).</p>
             </div4>
             
-         <div4 id="id-lambda-expressions" diff="add" at="2023-04-18">
+         <!--<div4 id="id-lambda-expressions" diff="add" at="2023-04-18">
             <head>Lambda Expressions</head>
             
             <scrap>
@@ -8716,7 +8708,7 @@ return $incrementors[2](4)]]></eg>
             <code>($a, $b, $c, ...)</code> it is not possible to establish unambiguously that this introduces a lambda
             expression until the arrow symbol (<code>-></code>) is encountered. Various strategies can be used
             to address this difficulty.</p></note>
-         </div4>
+         </div4>-->
             
             <div4 id="id-function-identity" diff="add" at="2023-05-25">
                <head>Function Identity</head>
@@ -19468,7 +19460,7 @@ raised <errorref
 
          <p>
             <termdef term="arrow operator" id="dt-arrow-operator"
-               >An <term>arrow operator</term>  applies a function to the value of an expression, using the value as the first argument to the function.</termdef>  
+               >The <term>arrow operator</term>  applies a function to the value of an expression, using the value as the first argument to the function.</termdef>  
          </p>
          <p diff="chg" at="2023-04-18">The <term>sequence arrow</term> operator <code>=></code> is defined as follows:
             <ulist>
@@ -19488,7 +19480,9 @@ raised <errorref
          
         
          
-         <p diff="add" at="A">The <term>mapping arrow</term> operator <code>=!></code> is defined as follows:</p>
+         <p diff="add" at="A"><termdef term="dt-mapping-arrow operator" id="dt-mapping-arrow-operator">
+            The <term>mapping arrow operator</term> <code>=!></code> applies a function to each
+            item in a sequence.</termdef> It is defined as follows:</p>
             
          <ulist diff="add" at="A">
             <item>
@@ -19558,17 +19552,16 @@ raised <errorref
             introduced by <code>=!></code> are mapping operations; the function introduced by <code>=></code>
             is a reduce operation.</p></note>
          
-         <p diff="add" at="A">The following example introduces an inline function to the pipeline, in the form of
-            a lambda expression:</p>
+         <p diff="add" at="A">The following example introduces an inline function to the pipeline:</p>
          <eg role="parse-test" diff="add" at="A"
-            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> (($a)->{$a+1})() => sum()]]></eg>
+            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn($a){$a+1}() => sum()]]></eg>
          
          <p diff="add" at="A">This is equivalent to <code>sum((1 to 5) ! (math:sqrt(xs:double(.))+1))</code>.</p>
          
          <p diff="add" at="A">The same effect can be achieved using a <termref def="dt-focus-function"/>:</p>
          
          <eg role="parse-test" diff="add" at="A"
-            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> function{.+1}() => sum()]]></eg>
+            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn{.+1}() => sum()]]></eg>
          
             <note diff="add" at="A"><p>The <code>ArgumentList</code> may include <code>PlaceHolders</code>,
             though this is not especially useful. For example, the expression <code>"$" => concat(?)</code> is equivalent


### PR DESCRIPTION
Allows "fn" as an abbreviation for "function", and drops the "thin-arrow" lambda function syntax. Fix #561.