### PR TITLE
591: [XSLT, editorial] Add defaults to XSLT element syntax summaries

### DIFF
--- a/schema/elements.dtd
+++ b/schema/elements.dtd
@@ -19,6 +19,7 @@
   name NMTOKEN #REQUIRED
   deprecated (yes|no) #IMPLIED
   required (yes|no) #IMPLIED
+  default CDATA #IMPLIED
   xmlns:e CDATA #FIXED "http://www.w3.org/1999/XSL/Spec/ElementSyntax"
 >
 <!ELEMENT e:attribute-value-template (e:constant|e:data-type)+>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -13,26 +13,26 @@
       <e:attribute name="name" required="no">
          <e:data-type name="uri"/>
       </e:attribute>
-      <e:attribute name="package-version" required="no">
+      <e:attribute name="package-version" required="no" default="'1'">
          <e:data-type name="string"/>
       </e:attribute>
       <e:attribute name="version" required="yes">
          <e:data-type name="decimal"/>
       </e:attribute>
 
-      <e:attribute name="input-type-annotations">
+      <e:attribute name="input-type-annotations" default="'unspecified'">
          <e:constant value="preserve"/>
          <e:constant value="strip"/>
          <e:constant value="unspecified"/>
       </e:attribute>
-      <e:attribute name="declared-modes" required="no">
+      <e:attribute name="declared-modes" required="no" default="'yes'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="default-mode">
+      <e:attribute name="default-mode" default="'#unnamed'">
          <e:data-type name="eqname"/>
          <e:constant value="#unnamed"/>
       </e:attribute>
-      <e:attribute name="default-validation">
+      <e:attribute name="default-validation" default="'strip'">
          <e:constant value="preserve"/>
          <e:constant value="strip"/>
       </e:attribute>
@@ -52,10 +52,10 @@
       <e:attribute name="exclude-result-prefixes" required="no">
          <e:data-type name="prefixes"/>
       </e:attribute>
-      <e:attribute name="expand-text" required="no">
+      <e:attribute name="expand-text" required="no" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="use-when" required="no">
+      <e:attribute name="use-when" required="no" default="true()">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:attribute name="xpath-default-namespace" required="no">
@@ -76,7 +76,7 @@
       <e:attribute name="name" required="yes">
          <e:data-type name="uri"/>
       </e:attribute>
-      <e:attribute name="package-version" required="no">
+      <e:attribute name="package-version" required="no" default="'*'">
          <e:data-type name="string"/>
       </e:attribute>
       <e:choice repeat="zero-or-more">
@@ -163,15 +163,15 @@
       <e:attribute name="version" required="yes">
          <e:data-type name="decimal"/>
       </e:attribute>
-      <e:attribute name="default-mode">
+      <e:attribute name="default-mode" default="'#unnamed'">
          <e:data-type name="eqname"/>
          <e:constant value="#unnamed"/>
       </e:attribute>
-      <e:attribute name="default-validation">
+      <e:attribute name="default-validation" default="'strip'">
          <e:constant value="preserve"/>
          <e:constant value="strip"/>
       </e:attribute>
-      <e:attribute name="input-type-annotations">
+      <e:attribute name="input-type-annotations" default="'unspecified'">
          <e:constant value="preserve"/>
          <e:constant value="strip"/>
          <e:constant value="unspecified"/>
@@ -197,7 +197,7 @@
       <e:attribute name="main-module">
          <e:data-type name="uri"/>
       </e:attribute>
-      <e:attribute name="use-when">
+      <e:attribute name="use-when" default="true()">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:attribute name="xpath-default-namespace">
@@ -215,15 +215,15 @@
       <e:attribute name="version" required="yes">
          <e:data-type name="decimal"/>
       </e:attribute>
-      <e:attribute name="default-mode">
+      <e:attribute name="default-mode" default="'#unnamed'">
          <e:data-type name="eqname"/>
          <e:constant value="#unnamed"/>
       </e:attribute>
-      <e:attribute name="default-validation">
+      <e:attribute name="default-validation" default="'strip'">
          <e:constant value="preserve"/>
          <e:constant value="strip"/>
       </e:attribute>
-      <e:attribute name="input-type-annotations">
+      <e:attribute name="input-type-annotations" default="'unspecified'">
          <e:constant value="preserve"/>
          <e:constant value="strip"/>
          <e:constant value="unspecified"/>
@@ -243,13 +243,13 @@
       <e:attribute name="exclude-result-prefixes">
          <e:data-type name="prefixes"/>
       </e:attribute>
-      <e:attribute name="expand-text">
+      <e:attribute name="expand-text" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:attribute name="main-module">
          <e:data-type name="uri"/>
       </e:attribute>
-      <e:attribute name="use-when">
+      <e:attribute name="use-when" default="true()">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:attribute name="xpath-default-namespace">
@@ -369,37 +369,37 @@
       <e:attribute name="name">
          <e:data-type name="eqname"/>
       </e:attribute>
-      <e:attribute name="decimal-separator">
+      <e:attribute name="decimal-separator" default="'.'">
          <e:data-type name="char"/>
       </e:attribute>
-      <e:attribute name="grouping-separator">
+      <e:attribute name="grouping-separator" default="','">
          <e:data-type name="char"/>
       </e:attribute>
-      <e:attribute name="infinity">
+      <e:attribute name="infinity" default="'Infinity'">
          <e:data-type name="string"/>
       </e:attribute>
-      <e:attribute name="minus-sign">
+      <e:attribute name="minus-sign" default="'-'">
          <e:data-type name="char"/>
       </e:attribute>
-      <e:attribute name="exponent-separator">
+      <e:attribute name="exponent-separator" default="'e'">
          <e:data-type name="char"/>
       </e:attribute>
-      <e:attribute name="NaN">
+      <e:attribute name="NaN" default="'NaN'">
          <e:data-type name="string"/>
       </e:attribute>
-      <e:attribute name="percent">
+      <e:attribute name="percent" default="'%'">
          <e:data-type name="char"/>
       </e:attribute>
-      <e:attribute name="per-mille">
+      <e:attribute name="per-mille" default="'&#x2030;'">
          <e:data-type name="char"/>
       </e:attribute>
-      <e:attribute name="zero-digit">
+      <e:attribute name="zero-digit" default="'0'">
          <e:data-type name="char"/>
       </e:attribute>
-      <e:attribute name="digit">
+      <e:attribute name="digit" default="'#'">
          <e:data-type name="char"/>
       </e:attribute>
-      <e:attribute name="pattern-separator">
+      <e:attribute name="pattern-separator" default="';'">
          <e:data-type name="char"/>
       </e:attribute>
       <e:empty/>
@@ -426,7 +426,7 @@
       <e:attribute name="mode">
          <e:data-type name="tokens"/>
       </e:attribute>
-      <e:attribute name="as">
+      <e:attribute name="as" default="'item()*'">
          <e:data-type name="sequence-type"/>
       </e:attribute>
       <e:attribute name="visibility">
@@ -475,16 +475,16 @@
       <e:attribute name="name">
          <e:data-type name="eqname"/>
       </e:attribute>
-      <e:attribute name="as" required="no">
+      <e:attribute name="as" required="no" default="'item()*'">
          <e:data-type name="sequence-type"/>
       </e:attribute>
-      <e:attribute name="streamable">
+      <e:attribute name="streamable" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="use-accumulators">
+      <e:attribute name="use-accumulators" default="''">
          <e:data-type name="tokens"/>
       </e:attribute>
-      <e:attribute name="on-no-match">
+      <e:attribute name="on-no-match" default="'text-only-copy'">
          <e:constant value="deep-copy"/>
          <e:constant value="shallow-copy"/>
          <e:constant value="deep-skip"/>
@@ -492,7 +492,7 @@
          <e:constant value="text-only-copy"/>
          <e:constant value="fail"/>
       </e:attribute>
-      <e:attribute name="on-multiple-match">
+      <e:attribute name="on-multiple-match" default="'use-last'">
          <e:constant value="use-last"/>
          <e:constant value="fail"/>
       </e:attribute>
@@ -502,13 +502,13 @@
       <e:attribute name="warning-on-multiple-match">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="typed">
+      <e:attribute name="typed" default="'unspecified'">
          <e:data-type name="boolean"/>
          <e:constant value="strict"/>
          <e:constant value="lax"/>
          <e:constant value="unspecified"/>
       </e:attribute>
-      <e:attribute name="visibility">
+      <e:attribute name="visibility" default="'private'">
          <e:constant value="public"/>
          <e:constant value="private"/>
          <e:constant value="final"/>
@@ -525,9 +525,9 @@
 
    <e:element-syntax name="context-item">
       <e:attribute name="as">
-         <e:data-type name="item-type"/>
+         <e:data-type name="item-type" default="'item()'"/>
       </e:attribute>
-      <e:attribute name="use">
+      <e:attribute name="use" default="'optional'">
          <e:constant value="required"/>
          <e:constant value="optional"/>
          <e:constant value="absent"/>
@@ -541,9 +541,9 @@
    <e:element-syntax name="global-context-item">
       <e:in-category name="declaration"/>
       <e:attribute name="as">
-         <e:data-type name="item-type"/>
+         <e:data-type name="item-type" default="'item()'"/>
       </e:attribute>
-      <e:attribute name="use">
+      <e:attribute name="use" default="'optional'">
          <e:constant value="required"/>
          <e:constant value="optional"/>
          <e:constant value="absent"/>
@@ -652,7 +652,7 @@
       <e:attribute name="then" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="else" required="no">
+      <e:attribute name="else" required="no" default="()">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:model name="sequence-constructor"/>
@@ -715,7 +715,7 @@
       <e:attribute name="select" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="rollback-output">
+      <e:attribute name="rollback-output" default="'yes'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:sequence>
@@ -732,7 +732,7 @@
    </e:element-syntax>
 
    <e:element-syntax name="catch">
-      <e:attribute name="errors" required="no">
+      <e:attribute name="errors" required="no" default="'*'">
          <e:data-type name="tokens"/>
       </e:attribute>
       <e:attribute name="select" required="no">
@@ -758,7 +758,7 @@
       <e:attribute name="as">
          <e:data-type name="sequence-type"/>
       </e:attribute>
-      <e:attribute name="static">
+      <e:attribute name="static" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:attribute name="visibility">
@@ -792,10 +792,10 @@
       <e:attribute name="required">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="tunnel">
+      <e:attribute name="tunnel" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="static">
+      <e:attribute name="static" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:model name="sequence-constructor"/>
@@ -820,7 +820,7 @@
       <e:attribute name="as">
          <e:data-type name="sequence-type"/>
       </e:attribute>
-      <e:attribute name="tunnel">
+      <e:attribute name="tunnel" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:model name="sequence-constructor"/>
@@ -852,16 +852,16 @@
       <e:attribute name="name" required="yes">
          <e:data-type name="eqname"/>
       </e:attribute>
-      <e:attribute name="use-attribute-sets">
+      <e:attribute name="use-attribute-sets" default="''">
          <e:data-type name="eqnames"/>
       </e:attribute>
-      <e:attribute name="visibility">
+      <e:attribute name="visibility" default="'private'">
          <e:constant value="public"/>
          <e:constant value="private"/>
          <e:constant value="final"/>
          <e:constant value="abstract"/>
       </e:attribute>
-      <e:attribute name="streamable">
+      <e:attribute name="streamable" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:element repeat="zero-or-more" name="attribute"/>
@@ -898,16 +898,16 @@
       <e:attribute name="name" required="yes">
          <e:data-type name="eqname"/>
       </e:attribute>
-      <e:attribute name="as" required="no">
+      <e:attribute name="as" required="no" default="'item()*'">
          <e:data-type name="sequence-type"/>
       </e:attribute>
-      <e:attribute name="visibility" required="no">
+      <e:attribute name="visibility" required="no" default="'private'">
          <e:constant value="public"/>
          <e:constant value="private"/>
          <e:constant value="final"/>
          <e:constant value="abstract"/>
       </e:attribute>
-      <e:attribute name="streamability" required="no">
+      <e:attribute name="streamability" required="no" default="'unclassified'">
          <e:constant value="unclassified"/>
          <e:constant value="absorbing"/>
          <e:constant value="inspection"/>
@@ -917,10 +917,10 @@
          <e:constant value="ascent"/>
          <e:data-type name="eqname"/>
       </e:attribute>
-      <e:attribute name="override-extension-function" required="no">
+      <e:attribute name="override-extension-function" required="no" default="'yes'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="override" required="no" deprecated="yes">
+      <e:attribute name="override" required="no" deprecated="yes" default="'yes'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:attribute name="new-each-time" required="no">
@@ -932,7 +932,7 @@
          <e:constant value="0"/>
          <e:constant value="maybe"/>
       </e:attribute>
-      <e:attribute name="cache" required="no">
+      <e:attribute name="cache" required="no" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:sequence>
@@ -952,7 +952,7 @@
       <e:attribute name="xpath" required="yes">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="as" required="no">
+      <e:attribute name="as" required="no" default="'item()*'">
          <e:data-type name="sequence-type"/>
       </e:attribute>
       <e:attribute name="base-uri" required="no">
@@ -969,7 +969,7 @@
       <e:attribute name="namespace-context" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="schema-aware" required="no">
+      <e:attribute name="schema-aware" required="no" default="'no'">
          <e:attribute-value-template>
             <e:data-type name="boolean"/>
          </e:attribute-value-template>
@@ -1015,10 +1015,10 @@
             <e:data-type name="uri"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="inherit-namespaces">
+      <e:attribute name="inherit-namespaces" default="'yes'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="use-attribute-sets">
+      <e:attribute name="use-attribute-sets" default="''">
          <e:data-type name="eqnames"/>
       </e:attribute>
       <e:attribute name="type">
@@ -1074,7 +1074,7 @@
 
    <e:element-syntax name="text">
       <e:in-category name="instruction"/>
-      <e:attribute name="disable-output-escaping" deprecated="yes">
+      <e:attribute name="disable-output-escaping" deprecated="yes" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:text/>
@@ -1093,7 +1093,7 @@
             <e:data-type name="string"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="disable-output-escaping" deprecated="yes">
+      <e:attribute name="disable-output-escaping" deprecated="yes" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:model name="sequence-constructor"/>
@@ -1167,13 +1167,13 @@
       <e:attribute name="select">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="copy-namespaces">
+      <e:attribute name="copy-namespaces" default="'yes'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="inherit-namespaces">
+      <e:attribute name="inherit-namespaces" default="'yes'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="use-attribute-sets">
+      <e:attribute name="use-attribute-sets" default="''">
          <e:data-type name="eqnames"/>
       </e:attribute>
       <e:attribute name="type">
@@ -1196,10 +1196,10 @@
       <e:attribute name="select" required="yes">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="copy-accumulators">
+      <e:attribute name="copy-accumulators" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="copy-namespaces">
+      <e:attribute name="copy-namespaces" default="'yes'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:attribute name="type">
@@ -1268,7 +1268,7 @@
       <e:attribute name="select">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="level">
+      <e:attribute name="level" default="'single'">
          <e:constant value="single"/>
          <e:constant value="multiple"/>
          <e:constant value="any"/>
@@ -1279,7 +1279,7 @@
       <e:attribute name="from">
          <e:data-type name="pattern"/>
       </e:attribute>
-      <e:attribute name="format">
+      <e:attribute name="format" default="'1'">
          <e:attribute-value-template>
             <e:data-type name="string"/>
          </e:attribute-value-template>
@@ -1295,7 +1295,7 @@
             <e:constant value="traditional"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="ordinal">
+      <e:attribute name="ordinal" default="'no'">
          <e:attribute-value-template>
             <e:data-type name="string"/>
          </e:attribute-value-template>
@@ -1332,7 +1332,7 @@
             <e:data-type name="language"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="order">
+      <e:attribute name="order" default="'ascending'">
          <e:attribute-value-template>
             <e:constant value="ascending"/>
             <e:constant value="descending"/>
@@ -1343,7 +1343,7 @@
             <e:data-type name="uri"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="stable">
+      <e:attribute name="stable" default="'yes'">
          <e:attribute-value-template>
             <e:data-type name="boolean"/>
          </e:attribute-value-template>
@@ -1406,7 +1406,7 @@
       <e:attribute name="break-when" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="composite">
+      <e:attribute name="composite" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:attribute name="collation">
@@ -1453,10 +1453,10 @@
       <e:attribute name="streamable" required="no">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="use-accumulators">
+      <e:attribute name="use-accumulators" default="''">
          <e:data-type name="tokens"/>
       </e:attribute>
-      <e:attribute name="sort-before-merge" required="no">
+      <e:attribute name="sort-before-merge" required="no" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:attribute name="validation">
@@ -1483,7 +1483,7 @@
             <e:data-type name="language"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="order">
+      <e:attribute name="order" default="'ascending'">
          <e:attribute-value-template>
             <e:constant value="ascending"/>
             <e:constant value="descending"/>
@@ -1555,7 +1555,7 @@
             <e:data-type name="string"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="flags" required="no">
+      <e:attribute name="flags" required="no" default="''">
          <e:attribute-value-template>
             <e:data-type name="string"/>
          </e:attribute-value-template>
@@ -1599,10 +1599,10 @@
             <e:data-type name="uri"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="streamable">
+      <e:attribute name="streamable" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
-      <e:attribute name="use-accumulators">
+      <e:attribute name="use-accumulators" default="''">
          <e:data-type name="tokens"/>
       </e:attribute>
       <e:attribute name="validation">
@@ -1628,10 +1628,10 @@
       <e:attribute name="initial-value" required="yes">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="as">
+      <e:attribute name="as" default="'item()*'">
          <e:data-type name="sequence-type"/>
       </e:attribute>
-      <e:attribute name="streamable">
+      <e:attribute name="streamable" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:element name="accumulator-rule" repeat="one-or-more"/>
@@ -1646,7 +1646,7 @@
       <e:attribute name="match" required="yes">
          <e:data-type name="pattern"/>
       </e:attribute>
-      <e:attribute name="phase" required="no">
+      <e:attribute name="phase" required="no" default="'start'">
          <e:constant value="start"/>
          <e:constant value="end"/>
       </e:attribute>
@@ -1672,7 +1672,7 @@
       <e:attribute name="use">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="composite">
+      <e:attribute name="composite" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:attribute name="collation" required="no">
@@ -1686,11 +1686,9 @@
       </e:allowed-parents>
    </e:element-syntax>
 
-   <!-- XPath Extensions -->
-
    <e:element-syntax name="map">
       <e:in-category name="instruction"/>
-      <e:attribute name="on-duplicates" required="no">
+      <e:attribute name="on-duplicates" required="no" default="error(xs:QName(err:XTDE3365))">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:model name="sequence-constructor"/>
@@ -1718,7 +1716,7 @@
       <e:attribute name="select" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="use" required="no">
+      <e:attribute name="use" required="no" default=".">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:model name="sequence-constructor"/>
@@ -1727,18 +1725,6 @@
       </e:allowed-parents>
    </e:element-syntax>
    
-   <!--<e:element-syntax name="array-member">
-      <e:in-category name="instruction"/>
-      <e:attribute name="select">
-         <e:data-type name="expression"/>
-      </e:attribute>
-      <e:model name="sequence-constructor"/>
-      <e:allowed-parents>
-         <e:parent-category name="sequence-constructor"/>
-      </e:allowed-parents>
-   </e:element-syntax>-->
-   
-
 
    <!-- Diagnostics -->
 
@@ -1747,12 +1733,12 @@
       <e:attribute name="select">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="terminate">
+      <e:attribute name="terminate" default="'no'">
          <e:attribute-value-template>
             <e:data-type name="boolean"/>
          </e:attribute-value-template>
       </e:attribute>
-      <e:attribute name="error-code">
+      <e:attribute name="error-code" default="'Q{http://www.w3.org/2005/xqt-errors}XTMM9000'">
          <e:attribute-value-template>
             <e:data-type name="eqname"/>
          </e:attribute-value-template>
@@ -1771,7 +1757,7 @@
       <e:attribute name="select">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="error-code">
+      <e:attribute name="error-code" default="'Q{http://www.w3.org/2005/xqt-errors}XTMM9001'">
          <e:attribute-value-template>
             <e:data-type name="eqname"/>
          </e:attribute-value-template>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -740,6 +740,18 @@
                      or <emph>sequence-type</emph>, and are not permitted in attributes of other types
                      (other than within expressions enclosed by curly braces within an <termref def="dt-attribute-value-template"/>).</p>
                </item>
+               <item diff="add" at="2023-07-04">
+                  <p>If an attribute has a simple default value, this is shown between tortoise-shell
+                  brackets (for example <code>&#x3014;'no'&#x3015;</code>). Where no default is shown,
+                  the consequence of omitting the attribute is explained in the prose narrative. 
+                  Default values shown in the summary apply only where the attribute itself
+                  is applicable; if an attribute is not permitted to appear in the particular context,
+                  then its default value should be ignored. (For example, the <code>stable</code>
+                     attribute of <elcode>xsl:sort</elcode> is shown as having a default value
+                     of <code>'yes'</code>, but the attribute is only allowed to appear on the
+                     first of a sequence of adjacent <elcode>xsl:sort</elcode> elements.) 
+                     The quotation marks around a default value are not part of the value.</p>
+               </item>
                <item>
                   <p>Unless the element is <rfc2119>required</rfc2119> to be empty, the model
                      element contains a comment specifying the allowed content. The allowed content
@@ -769,7 +781,7 @@
                   <e:attribute name="debug">
                      <e:data-type name="boolean"/>
                   </e:attribute>
-                  <e:attribute name="validation">
+                  <e:attribute name="validation" default="strict">
                      <e:attribute-value-template>
                         <e:constant value="strict"/>
                         <e:constant value="lax"/>

--- a/specifications/xslt-40/style/xslt.xsl
+++ b/specifications/xslt-40/style/xslt.xsl
@@ -314,7 +314,7 @@ constructor. These elements are:</p>
   <xsl:choose>
     <xsl:when test="contains(@name, ':')">
       <xsl:value-of select="@name"/>
-    </xsl:when>
+    </xsl:when> 
     <xsl:otherwise>
       <a href="#element-{@name}">
         <xsl:text>xsl:</xsl:text>
@@ -369,6 +369,11 @@ constructor. These elements are:</p>
   </xsl:choose>
   <xsl:text> = </xsl:text> 
   <xsl:apply-templates select="*"/>
+  <xsl:if test="@default">
+    <xsl:text>&#x3014;</xsl:text>
+    <xsl:value-of select="@default"/>
+    <xsl:text>&#x3015;</xsl:text>
+  </xsl:if>
 </xsl:template>
 
 <xsl:template match="e:data-type">


### PR DESCRIPTION
Fix #591. Add default values to e:attribute entries in the XSLT syntax summaries; change the DTD to allow these; change the stylesheet to render them; add a paragraph to the Notation section to explain the conventions.