### PR TITLE
592: (XSLT, Editorial) Add missing description of exponent-separator

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10971,7 +10971,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <head>Defining a Decimal Format</head>
             
             <p>The definition of the <xfunction>format-number</xfunction> function
-               is now in <bibref ref="xpath-functions-40"/>. What remains here is the definition of
+               is now in <bibref ref="xpath-functions-40"/>. This section is a specification of
                the <elcode>xsl:decimal-format</elcode> declaration, which provides the context for
                this function when used in an XSLT stylesheet.</p>
             
@@ -10984,10 +10984,7 @@ and <code>version="1.0"</code> otherwise.</p>
                is the string supplied as the second argument of the
                <xfunction>format-number</xfunction> function.</termdef>
             </p>
-            <note>
-               <p>The <xfunction>format-number</xfunction> function, previously defined in this
-                  specification, is now defined in <bibref ref="xpath-functions-40"/>. </p>
-            </note>
+            
             <p>A <termref def="dt-package">package</termref> may
                contain multiple <elcode>xsl:decimal-format</elcode> declarations and may include or
                import <termref def="dt-stylesheet-module">stylesheet modules</termref> that also
@@ -11050,7 +11047,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      another definition of the same attribute with higher import precedence.</p>
                </error>
             </p>
-            <p>The following attributes control the interpretation of characters in the <termref def="dt-picture-string">picture string</termref> supplied to the
+            <p>The following attributes control the interpretation of characters in the 
+               <termref def="dt-picture-string">picture string</termref> supplied to the
                <xfunction>format-number</xfunction> function, and also specify characters that
                may appear in the result of formatting the number. In each case the value
                <rfc2119>must</rfc2119> be a single character <errorref class="SE" code="0020"/>.</p>
@@ -11061,6 +11059,12 @@ and <code>version="1.0"</code> otherwise.</p>
                      integer part from the fractional part of the formatted number; the default
                      value is the period character (<code>.</code>)</p>
                </item>
+               <item>
+                  <p diff="add" at="2023-07-04">
+                     <code>exponent-separator</code> specifies the character used to separate the
+                     mantissa from the exponent in scientific notation; the default value is the 
+                     character <code>"e"</code>.</p>
+               </item>   
                <item>
                   <p>
                      <code>grouping-separator</code> specifies the character typically used as a


### PR DESCRIPTION
Fix #592