### PR TITLE
588: (Editorial, XSLT) minor clarifications regarding xsl:sort

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -1698,7 +1698,7 @@ of problems processing the schema using various tools
       <xs:complexContent mixed="true">
         <xs:extension base="xsl:sequence-constructor-or-select">
           <xs:attribute name="lang" type="xsl:avt"/>
-          <xs:attribute name="data-type" type="xsl:avt" default="text"/>
+          <xs:attribute name="data-type" type="xsl:avt"/>
           <xs:attribute name="order" type="xsl:avt" default="ascending"/>
           <xs:attribute name="case-order" type="xsl:avt"/>
           <xs:attribute name="collation" type="xsl:avt"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -22173,7 +22173,9 @@ for $i in 1 to count($V) return
                      any other <termref def="dt-effective-value"/>, then
                      this value <rfc2119>must</rfc2119> be an <termref def="dt-eqname">EQName</termref> denoting an <termref def="dt-expanded-qname">expanded
                         QName</termref> with a non-absent namespace, and the effect of the
-                  attribute is <termref def="dt-implementation-defined"/>.</p>
+                  attribute is <termref def="dt-implementation-defined"/>. 
+               <phrase diff="add" at="2023-07-04">If the attribute is omitted, no conversion
+               takes place.</phrase></p>
                <imp-def-feature id="idf-ext-sortdatatype">If the <code>data-type</code> attribute of
                   the <elcode>xsl:sort</elcode> element has a value other than <code>text</code> or
                      <code>number</code>, the effect is implementation-defined.</imp-def-feature>


### PR DESCRIPTION
The main issue turned out to be spurious; there is in fact an explanation of the order attribute in the right place. But I made a couple of other minor editorial changes, including dropping the default for @data-type in the (non-normative) schema for XSLT 4.0 - the default of `data-type="text"` is inappropriate because it forces conversion, e.g. of dates to strings, and the default should be no conversion.

Fix #588.