### PR TITLE
Issue90 XSLT: simplified stylesheets with no xsl:version

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12482,33 +12482,33 @@ else if (fn:empty($input))
                   <fos:type>xs:string?</fos:type>
                   <fos:default>()</fos:default>
                </fos:option>              
-               <fos:option key="normalize-space">
+               <!--<fos:option key="normalize-space">
                   <fos:meaning>The value <code>false</code> indicates that text and attributes are compared <emph>as-is</emph>;
                      the value <code>true</code> indicates that they are compared after normalization using <code>fn:normalize-space</code>.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>true</fos:default>
-               </fos:option>
-               <fos:option key="preserve-space">
+               </fos:option>-->
+               <!--<fos:option key="preserve-space">
                   <fos:meaning>Determines whether text nodes consisting entirely of whitespace are significant.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>true</fos:default>
-               </fos:option>
+               </fos:option>-->
                <fos:option key="processing-instructions">
                   <fos:meaning>Determines whether processing instructions are significant.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
                </fos:option>
-               <fos:option key="text-boundaries">
+               <!--<fos:option key="text-boundaries">
                   <fos:meaning>Determines whether boundaries between text nodes are significant, even when two text
                      nodes are separated by an ignored comment or processing instruction. (This property
                      is provided, with the default <code>true</code>, for compatibility with previous versions.)
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>true</fos:default>
-               </fos:option>
+               </fos:option>-->
                <fos:option key="timezones">
                   <fos:meaning>Determines whether timezones in date/time values are significant.
                   </fos:meaning>
@@ -12535,6 +12535,16 @@ else if (fn:empty($input))
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>true</fos:default>
                </fos:option>
+               <fos:option key="whitespace">
+                  <fos:meaning><phrase diff="chg" at="2023-03-13">Determines the extent to which whitespace is treated as significant. The value
+                     <code>preserve</code> retains all whitespace; <code>strip</code> ignores text nodes
+                     consisting entirely of whitespace; <code>collapse</code> ignores text nodes consisting
+                     entirely of whitespace, and additionally normalizes whitespace within strings and nodes
+                     that contain whitespace alongside non-whitespace characters.</phrase>
+                  </fos:meaning>
+                  <fos:type>enum("preserve", "strip", "collapse")</fos:type>
+                  <fos:default>preserve</fos:default>
+               </fos:option>
                <fos:option key="unordered-elements">
                   <fos:meaning>A list of QNames of elements considered to be unordered: that is, their child
                      elements may appear in any order.
@@ -12553,8 +12563,8 @@ else if (fn:empty($input))
          <p>The rules reference a function <code>equal-strings</code> which compares two strings as follows:</p>
          
          <olist>
-            <item><p>If the <code>normalize-space</code> option is true, each string is processed
-               by calling the <code>fn:normalize-space</code> function.</p></item>
+            <item><p diff="chg" at="2022-03-13">If the <code>whitespace</code> option is set to <code>collapse</code> or <code>strip</code>, 
+               each string is processed by calling the <code>fn:normalize-space</code> function.</p></item>
             <item><p>If the <code>normalization-form</code> option is present, each string is then normalized
             by calling the <code>fn:normalize-unicode</code> function, supplying the specified normalization
             form.</p></item>           
@@ -12568,7 +12578,7 @@ else if (fn:empty($input))
     let $n1 := if (exists($options?normalization-form))
                then fn:normalize-unicode(?, $options?normalization-form) 
                else fn:identity#1,
-        $n2 := if ($options?normalize-space)
+        $n2 := if ($options?whitespace = ("collapse", "strip")
                then fn:normalize-space#1 
                else fn:identity#1               
     }
@@ -12689,10 +12699,13 @@ else if (fn:empty($input))
                      <olist>
                         <item><p>Comment nodes are discarded if the option <code>comments</code> is false.</p></item>
                         <item><p>Processing instruction nodes are discarded if the option <code>processing-instructions</code> is false.</p></item>
-                        <item><p>Adjacent text nodes are merged if the option <code>text-boundaries</code> is false.</p></item>
-                        <item><p>Whitespace-only text nodes are discarded if the option <code>preserve-space</code> is false,
+                        <item><p>Adjacent text nodes are merged.</p></item>
+                        <item><p>Whitespace-only text nodes are discarded <phrase diff="add" at="2023-03-13">if the 
+                           option <code>whitespace</code> is set to <code>strip</code> or <code>collapse</code></phrase>,
                            or if <code>$parent</code> is an element node whose type annotation is a complex type with an element-only
-                           or empty content model.</p></item>
+                           or empty content model. 
+                           <phrase diff="add" at="2023-03-13">However, whitespace-only text nodes are not discarded if they
+                           come within the scope of an element having the attribute <code>xml:space="preserve"</code></phrase>.</p></item>
                  
                      </olist>
                   
@@ -12879,33 +12892,6 @@ else if (fn:empty($input))
                         <item>
                            <p>Both nodes are text nodes, and the <code>equal-strings</code> function 
                               returns true when applied to their string values.</p>
-                           <note>
-                              <p>The handling of whitespace is controlled by a number of options:</p>
-                              <ulist>
-                                 <item><p>Firstly, text nodes consisting entirely of whitespace are considered
-                                 significant by default, unless the parent element has been schema-validated and
-                                 has an element-only content model. This can be overridden by setting the
-                                 <code>preserve-space</code> option to <code>false</code>. The process is not influenced
-                                 by any <code>xml:space</code> attributes that might be present.</p></item>
-                                 <item><p>The decision whether a text node is whitespace is made after
-                                 stripping comments and processing instructions. However, the text nodes
-                                 either side of a comment or processing instruction are merged only if the
-                                 <code>text-boundaries</code> option is true (it is false by default).
-                                 </p></item>
-                                 <item><p>If the <code>preserve-space</code> option and the
-                                 <code>normalize-space</code> option are both true, then a whitespace-only
-                                 text node will be reduced to zero length; this means that all whitespace-only
-                                 text nodes will compare equal regardless of their actual content, but the
-                                 presence of the node is still considered significant.</p></item>
-                                 <item><p>The <code>normalize-space</code> option affects the comparison
-                                 of text nodes, attribute nodes, comments and processing instructions (if not
-                                 stripped): it applies to all such nodes when their string values are
-                                 compared, and to nodes whose typed value is a string when comparing typed
-                                 values. It also affects strings within maps and arrays. It has no effect where
-                                 more specific rules apply, for example when comparing node names, namespace URIs,
-                                 or map keys.</p></item>
-                              </ulist>
-                           </note>
                         </item>
                   </olist>
                   </item>
@@ -13065,11 +13051,23 @@ else if (fn:empty($input))
                <fos:expression><eg><![CDATA[fn:deep-equal(
     parse-xml("<para style="bold"><span>x</span></para>"),
     parse-xml("<para style=" bold"> <span>x</span></para>"),
-    options := map{'normalize-space': true(), 'whitespace-text-nodes': false())]]></eg></fos:expression>
+    options := map{'whitespace':'strip')]]></eg></fos:expression>
                <fos:result>false()</fos:result>
-               <fos:postamble>The <code>normalize-space</code> option ensures that the leading whitespace
-                  in the attribute value is ignored; the <code>whitespace-text-nodes</code> option
-                  causes the whitespace preceding the <code>span</code> element to be ignored.</fos:postamble>
+               <fos:postamble>The <code>whitespace=strip</code> option ensures that 
+                  whitespace preceding the <code>span</code> element is ignored, but the leading whitespace
+                  in the attribute value is still significant.</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[fn:deep-equal(
+    parse-xml("<para style="bold"><span>x</span></para>"),
+    parse-xml("<para style=" bold"> <span>x</span></para>"),
+    options := map{'whitespace':'collapse')]]></eg></fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>The <code>whitespace=collapse</code> option ensures both that the leading whitespace
+                  in the attribute value is ignored, and that the whitespace text node preceding the <code>span</code> 
+                  element is ignored.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11411,6 +11411,12 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               and potentially (depending on the sort algorithm) with sorting. The problem has been fixed by requiring
               comparisons to be performed based on the exact mathematical value without any loss of precision.</p>
            </item>
+           <item diff="add" at="2023-03-13">
+              <p>In version 3.1, the <code>fn:deep-equal</code> function did not merge adjacent text nodes after stripping
+              comments and processing instructions, so the elements <code><![CDATA[<a>abc<!--note1-->def</code>]]></code>
+                 and <code><![CDATA[<a>abcde<!--note2-->f</code>]]></code> were considered non-equal. In version 4.0, 
+              the text nodes are now merged prior to comparison, so these two elements compare equal.</p>
+           </item>
            <item diff="add" at="2022-12-18">
               <p>In version 4.0, omitting the <code>$error-object</code> of <code>fn:error</code> has the same
                  effect as setting it to an empty sequence. In 3.1, the effects could be different (the effect of omitting

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -6682,55 +6682,75 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>A simplified syntax is allowed for a <termref def="dt-stylesheet-module">stylesheet
                   module</termref> that defines only a single template rule for the document node.
                The stylesheet module may consist of just a <termref def="dt-literal-result-element">literal result element</termref> (see <specref ref="literal-result-element"/>)
-               together with its contents. The literal result element must have an
+               together with its contents. <phrase diff="del" at="2023-07-08">The literal result element must have an
                   <code>xsl:version</code> attribute (and it must therefore also declare the XSLT
-               namespace). Such a stylesheet module is equivalent to a standard stylesheet module
-               whose <elcode>xsl:stylesheet</elcode> element contains a <termref def="dt-template-rule">template rule</termref> containing the literal result
-               element, minus its <code>xsl:version</code> attribute; the template rule has a match
-                  <termref def="dt-pattern">pattern</termref> of <code>/</code>.</p>
-            <example>
+               namespace).</phrase> Such a stylesheet module is equivalent to a standard stylesheet module
+               whose <elcode>xsl:stylesheet</elcode> element contains a 
+               <termref def="dt-template-rule">template rule</termref> containing the literal result
+               element; the template rule has a match <termref def="dt-pattern">pattern</termref> of <code>/</code>.</p>
+            <example diff="add" at="2023-07-08">
                <head>A Simplified Stylesheet</head>
-               <p>For example:</p>
-               <eg xml:space="preserve" role="xml">&lt;html xsl:version="3.0"
+               <p>The following example shows a stylesheet that simply evaluates one XPath expression:</p>
+               <eg><![CDATA[<out>{count(//*)}</out>]]></eg>
+               <p>The output of the stylesheet will be an XML document such as <code><![CDATA[<out>17</out>]]></code>
+               showing the number of elements found in the supplied source document.</p>
+               <p>This simplified stylesheet is defined to be equivalent to the following expanded stylesheet:</p>
+               <eg><![CDATA[<xsl:stylesheet xmlns="http://www.w3.org/1999/XSL/Transform"
+                  version="4.0" expand-text="yes">
+    <xsl:template match="/">
+        <out>{count(//*)}</out>
+    </xsl:template>
+</xsl:stylesheet>]]></eg>
+            </example>
+            <p>A simplified stylesheet can contain XSLT instructions, in which case the XSLT namespace needs
+            to be declared. This is illustrated in the next example.</p>
+            <example>
+               <head>A Simplified Stylesheet Containing XSLT Instructions</head>
+               <p>This stylesheet outputs an HTML document containing a table that summarizes the value
+                  of transactions according to their rate of tax:</p>
+               <eg xml:space="preserve" role="xml"><![CDATA[<html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-      xmlns="http://www.w3.org/1999/xhtml"&gt;
-  &lt;head&gt;
-    &lt;title&gt;Expense Report Summary&lt;/title&gt;
-  &lt;/head&gt;
-  &lt;body&gt;
-    &lt;p&gt;Total Amount: &lt;xsl:value-of select="expense-report/total"/&gt;&lt;/p&gt;
-  &lt;/body&gt;
-&lt;/html&gt;</eg>
-               <p>has the same meaning as</p>
-               <eg xml:space="preserve" role="xslt-document">&lt;xsl:stylesheet version="3.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns="http://www.w3.org/1999/xhtml"&gt;
-&lt;xsl:template match="/"&gt;
-&lt;html&gt;
-  &lt;head&gt;
-    &lt;title&gt;Expense Report Summary&lt;/title&gt;
-  &lt;/head&gt;
-  &lt;body&gt;
-    &lt;p&gt;Total Amount: &lt;xsl:value-of select="expense-report/total"/&gt;&lt;/p&gt;
-  &lt;/body&gt;
-&lt;/html&gt;
-&lt;/xsl:template&gt;
-&lt;/xsl:stylesheet&gt;</eg>
-               <p>Note that it is not possible, using a simplified stylesheet, to request that the
-                  serialized output contains a <code>DOCTYPE</code> declaration. This can only be
-                  done by using a standard stylesheet module, and using the
-                     <elcode>xsl:output</elcode> element.</p>
+      xsl:version="4.0">
+  <head>
+    <title>Expenditure by Tax Rate</title>
+  </head>
+  <body>
+    <table>
+      <thead>
+        <tr>
+           <th>Gross Amount</th>
+           <th>Tax Rate</th>
+        </tr>
+      </thead>
+      <tbody>
+        <xsl:for-each-group select="//transaction" group-by="vat-rate">
+          <tr>
+            <td>{sum(current-group()/value)}</td>
+            <td>{current-grouping-key()}</td>
+          </tr>
+        </xsl:for-each-group>
+      </tbody>
+    </table>
+  </body>
+</html>]]></eg>
+ 
+               <p>Note that it is not possible, in a simplified stylesheet, to define
+                  serialization properties (for example to request a <code>DOCTYPE</code>
+                  declaration). A processor <rfc2119>may</rfc2119> offer a way to do
+                  this using options in the transformation API.</p>
             </example>
             <p>More formally, a simplified stylesheet module is equivalent to the standard
                stylesheet module that would be generated by applying the following transformation to
                the simplified stylesheet module, invoking the transformation by calling the <termref def="dt-named-template">named template</termref>
                <code>expand</code>, with the containing literal result element as the <termref def="dt-context-node">context node</termref>: </p>
-            <eg xml:space="preserve" role="xslt-document">&lt;xsl:stylesheet version="3.0"
+            <eg xml:space="preserve" role="xslt-document">&lt;xsl:stylesheet version="4.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;
 
 &lt;xsl:template name="expand"&gt;
   &lt;xsl:element name="xsl:stylesheet"&gt;
-    &lt;xsl:attribute name="version" select="@xsl:version"/&gt;
+    &lt;xsl:attribute name="version" select="@xsl:version otherwise '4.0'"/&gt;
+    &lt;xsl:attribute name="expand-text" 
+                   select="not(number(@xsl:version) le 3.0)"/&gt;
     &lt;xsl:element name="xsl:template"&gt;
       &lt;xsl:attribute name="match" select="'/'"/&gt;
       &lt;xsl:copy-of select="."/&gt;
@@ -6739,7 +6759,7 @@ and <code>version="1.0"</code> otherwise.</p>
 &lt;/xsl:template&gt;  
 
 &lt;/xsl:stylesheet&gt;</eg>
-            <p>
+            <p diff="del" at="2023-07-08">
                <error spec="XT" type="static" class="SE" code="0150">
                   <p>A <termref def="dt-literal-result-element">literal result element</termref>
                      that is used as the outermost element of a simplified stylesheet module
@@ -6757,6 +6777,18 @@ and <code>version="1.0"</code> otherwise.</p>
                means that the only useful way to initiate the transformation is to supply a document
                node as the <termref def="dt-initial-match-selection"/>, to be matched by the implicit
                   <code>match="/"</code> template rule using the <termref def="dt-unnamed-mode">unnamed mode</termref>. </p>
+            <note diff="chg" at="2023-07-08">
+               <p>There are two significant changes to simplified stylesheets in XSLT 4.0.</p>
+               <olist>
+                  <item><p>It is no longer required to include an <code>xsl:version</code> attribute; this
+                  in turn means it is often no longer necessary to declare the <code>xsl</code> namespace.
+                  The <code>xsl:version</code> attribute defaults to the version of the XSLT processor,
+                  that is, "4.0" for an XSLT 4.0 processor.</p></item>
+                  <item><p>If the <code>xsl:version</code> attribute is omitted, or is set to "4.0" or a larger
+                  value, then the <code>expand-text</code> attribute defaults to <code>true</code>, meaning that 
+                  <termref def="dt-text-value-template">text value templates</termref> are recognized.</p></item>
+               </olist>
+            </note>
          </div2>
          <div2 id="backwards">
             <head>Backwards Compatible Processing</head>
@@ -38768,6 +38800,10 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                   and <elcode>xsl:transform</elcode>, enabling an XSLT editing tool to identify the top-level module
                   of a stylesheet, and hence the declarations of functions, templates, and global variables available
                   to a module that is being edited.</p></item>
+                  
+                  <item><p>Simplified stylesheet modules no longer need to specify the <code>xsl:version</code>
+                     attribute; and if the explicit or implicit <code>xsl:version</code> attribute is
+                  "4.0" or greater, then the <code>expand-text</code> attribute defaults to <code>true</code>.</p></item>
                </olist>
             </div3>
          </div2>


### PR DESCRIPTION
Fix #90. Allow simplified stylesheets with no xsl:version attribute (and therefore no XSL namespace declaration)