### PR TITLE
[Editorial] Drop the unused symbol URILiteral from the XPath grammar appendix

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2925,7 +2925,7 @@ ErrorVal ::= "$" VarName
 
   <!-- ] end Types + Tests -->
 
-  <g:production name="URILiteral" if="fulltext xpath40 xquery40" inline="false">
+  <g:production name="URILiteral" if="fulltext xquery40" inline="false">
     <g:ref name="StringLiteral"/>
   </g:production>
 


### PR DESCRIPTION
Fix #39