### PR TITLE
XQFO Examples: Fixes, Formatting

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -10223,13 +10223,14 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>QName("http://www.example.com/example", "person")
+               <fos:expression><eg>QName("http:/example.com", "person")
 => expanded-QName()</eg></fos:expression>
-               <fos:result>Q{http://www.example.com/example}person</fos:result>
+               <fos:result>"Q{http://example.com}person"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>QName("", "person") => expanded-QName()</fos:expression>
-               <fos:result>Q{}person</fos:result>
+               <fos:expression><eg>QName("", "person")
+=> expanded-QName()</eg></fos:expression>
+               <fos:result>"Q{}person"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -11743,7 +11744,7 @@ return exists($break)
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>parse-xml('<a/>') ! (identity(/) is /)</fos:expression>
+               <fos:expression><![CDATA[parse-xml('<a/>') ! (identity(/) is /)]]></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>If the argument is a node, the function returns the identical node, not a copy</fos:postamble>
             </fos:test>
@@ -12486,95 +12487,92 @@ return exists($break)
       <fos:examples>
          <fos:variable name="in" id="v-slice" as="xs:string*" select="('a', 'b', 'c', 'd', 'e')"/>
          <fos:example>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 2, end := 4)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 2)</fos:expression>
                <fos:result>("b", "c", "d", "e")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, end := 2)</fos:expression>
                <fos:result>("a", "b")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 3, end := 3)</fos:expression>
                <fos:result>("c")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 4, end := 3)</fos:expression>
                <fos:result>("d", "c")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 2, end := 5, step := 2)</fos:expression>
                <fos:result>("b", "d")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 5, end := 2, step := -2)</fos:expression>
                <fos:result>("e", "c")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 2, end := 5, step := -2)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 5, end := 2, step := 2)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in)</fos:expression>
                <fos:result>("a", "b", "c", "d", "e")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := -1)</fos:expression>
                <fos:result>("e")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := -3)</fos:expression>
                <fos:result>("c", "d", "e")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, end := -2)</fos:expression>
                <fos:result>("a", "b", "c", "d")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := 2, end := -2)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := -2, end := 2)</fos:expression>
                <fos:result>("d", "c", "b")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := -4, end := -2)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := -2, end := -4)</fos:expression>
                <fos:result>("d", "c", "b")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := -4, end := -2, step := 2)</fos:expression>
                <fos:result>("b", "d")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice($in, start := -2, end := -4, step := -2)</fos:expression>
                <fos:result>("d", "b")</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="v-slice">
                <fos:expression>slice(("a", "b", "c", "d"), 0)</fos:expression>
                <fos:result>("a", "b", "c", "d")</fos:result>
             </fos:test>
-            
          </fos:example>
       </fos:examples>
       <fos:history>
          <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
       </fos:history>
    </fos:function>
-   
-  
    
    <fos:function name="starts-with-sequence" prefix="fn">
       <fos:signatures>
@@ -20318,7 +20316,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <fos:test>
                <fos:expression><eg>json-to-xml(
-  '{"x": 1, "y": [3,4,5]}'
+  '{"x": 1, "y": [3,4,5]}',
+  map { "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
@@ -20340,7 +20339,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
             <fos:test>
                <fos:expression><eg>json-to-xml(
-  '{"x": "\\", "y": "\u0025"}'
+  '{"x": "\\", "y": "\u0025"}',
+  map { "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
@@ -20351,7 +20351,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test>
                <fos:expression><eg>json-to-xml(
   '{"x": "\\", "y": "\u0025"}',
-  map { 'escape': true() }
+  map { 'escape': true(), "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
@@ -21721,8 +21721,7 @@ else $fallback($position)</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="3.1">First introduced in 3.1.</fos:version>
-         <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized.</fos:version>
+         <fos:version version="4.0">First introduced in 4.0.</fos:version>
       </fos:history>
    </fos:function>
    
@@ -22003,87 +22002,86 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:variable name="in" id="a-slice" as="xs:string*" select="['a', 'b', 'c', 'd', 'e']"/>
          <fos:example>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := 4)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2)</fos:expression>
                <fos:result>["b", "c", "d", "e"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, end := 2)</fos:expression>
                <fos:result>["a", "b"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 3, end := 3)</fos:expression>
                <fos:result>["c"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 4, end := 3)</fos:expression>
                <fos:result>["d", "c"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := 5, step := 2)</fos:expression>
                <fos:result>["b", "d"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 5, end := 2, step := -2)</fos:expression>
                <fos:result>["e", "c"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := 5, step := -2)</fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 5, end := 2, step := 2)</fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in)</fos:expression>
                <fos:result>["a", "b", "c", "d", "e"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -1)</fos:expression>
                <fos:result>["e"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -3)</fos:expression>
                <fos:result>["c", "d", "e"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, end := -2)</fos:expression>
                <fos:result>]"a", "b", "c", "d"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := -2)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -2, end := 2)</fos:expression>
                <fos:result>["d", "c", "b"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -4, end := -2)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -2, end := -4)</fos:expression>
                <fos:result>["d", "c", "b"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -4, end := -2, step := 2)</fos:expression>
                <fos:result>["b", "d"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -2, end := -4, step := -2)</fos:expression>
                <fos:result>["d", "b"]</fos:result>
             </fos:test>
-            <fos:test>
+            <fos:test use="a-slice">
                <fos:expression>array:slice(["a", "b", "c", "d"], 0)</fos:expression>
                <fos:result>["a", "b", "c", "d"]</fos:result>
             </fos:test>
-            
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -24536,14 +24534,14 @@ function($item) {
          <fos:variable name="e" id="v-highest-e"><![CDATA[<a x="10" y="5" z="2"/>]]></fos:variable>
          <fos:example>
             <fos:test use="v-highest-e">
-               <fos:expression>highest($e/@*, (), string#1) ! name()</fos:expression>
-               <fos:result>("y")</fos:result>
-               <fos:postamble>The attribute values are compared as strings.</fos:postamble>
+               <fos:expression>highest($e/@*) ! name()</fos:expression>
+               <fos:result>("x")</fos:result>
+               <fos:postamble>By default, untyped values are compared as numbers.</fos:postamble>
             </fos:test>
             <fos:test use="v-highest-e">
-               <fos:expression>highest($e/@*, (), number#1) ! name()</fos:expression>
-               <fos:result>("x")</fos:result>
-               <fos:postamble>Here, the attribute values are compared as numbers.</fos:postamble>
+               <fos:expression>highest($e/@*, (), string#1) ! name()</fos:expression>
+               <fos:result>("y")</fos:result>
+               <fos:postamble>Here, the attribute values are compared as strings.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>highest(("red", "green", "blue"), (), string-length#1)</fos:expression>
@@ -25084,14 +25082,14 @@ function($item) {
          <fos:variable name="e" id="v-lowest-e"><![CDATA[<a x="10" y="5" z="2"/>]]></fos:variable>
          <fos:example>
             <fos:test use="v-lowest-e">
-               <fos:expression>lowest($e/@*, (), string#1) ! name()</fos:expression>
-               <fos:result>("x")</fos:result>
-               <fos:postamble>The attribute values are compared as strings</fos:postamble>
+               <fos:expression>lowest($e/@*) ! name()</fos:expression>
+               <fos:result>("z")</fos:result>
+               <fos:postamble>By default, untyped values are compared as numbers.</fos:postamble>
             </fos:test>
             <fos:test use="v-lowest-e">
-               <fos:expression>lowest($e/@*, (), number#1) ! name()</fos:expression>
-               <fos:result>("z")</fos:result>
-               <fos:postamble>Here, the attribute values are compared as numbers</fos:postamble>
+               <fos:expression>lowest($e/@*, (), string#1) ! name()</fos:expression>
+               <fos:result>("x")</fos:result>
+               <fos:postamble>Here, the attribute values are compared as strings.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>lowest(("red", "green", "blue"), (), string-length#1)</fos:expression>
@@ -25731,7 +25729,9 @@ declare function fn:some(
 <fos:examples role="wide">
   <fos:example>
     <p>In the examples that follow, keys with values that are null, or an empty array,
-are elided for editorial clarity.</p>
+    are elided for editorial clarity. String literals that include an ampersand character
+    are written as string templates (for example <code>`Barnes&amp;Noble`</code>) to ensure
+    that the examples work in both XPath and XQuery.</p>
     <fos:test>
       <fos:expression><eg>parse-uri(
   "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri"
@@ -25779,19 +25779,19 @@ are elided for editorial clarity.</p>
   <fos:example>
     <fos:test>
       <fos:expression><eg>parse-uri(
-  "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance"
+  `https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`
 )</eg></fos:expression>
       <fos:result><eg>map {
-  "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance",
+  "uri": `https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`,
   "scheme": "https",
   "hierarchical": true(),
   "authority": "example.com:8080",
   "host": "example.com",
   "port": "8080",
   "path": "/path",
-  "query": "s=%22hello world%22&amp;sort=relevance",
+  "query": `s=%22hello world%22&amp;sort=relevance`,
   "query-segments": array {
-    map { "key": "s", "value": "&quot;hello world&quot;" },
+    map { "key": "s", "value": '"hello world"' },
     map { "key": "sort", "value": "relevance" }
   },
   "path-segments": array { "", "path" }
@@ -26326,7 +26326,7 @@ path with an explicit <code>file:</code> scheme.</p>
     "port": (),
     "path": "/specifications/index.html"
   })</eg></fos:expression>
-               <fos:result>https://qt4cg.org/specifications/index.html</fos:result>
+               <fos:result>"https://qt4cg.org/specifications/index.html"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -587,13 +587,16 @@
          <fos:example>
             <fos:test>
                <fos:expression><eg>error(
-  QName('http://www.example.com/HR', 'myerr:toohighsal'),
-  'Does not apply because salary is too high'
+  QName(
+    'http://www.example.com/HR',
+    'myerr:toohighsal'
+  ),
+  'Salary is too high'
 )</eg></fos:expression>
                <fos:error-result error-code="myerr:toohighsal"/>
                <fos:postamble>This returns <code>http://www.example.com/HR#toohighsal</code> and the
                      <code>xs:string</code>
-                  <code>"Does not apply because salary is too high"</code> (or the corresponding
+                  <code>"Salary is too high"</code> (or the corresponding
                      <code>xs:QName</code>) to the external processing environment, unless the error
                   is caught using a try/catch construct in the host language.</fos:postamble>
             </fos:test>
@@ -6157,10 +6160,6 @@ Tak, tak, tak! - da kommen sie.
          <fos:variable name="abc" id="v-boolean-abc"
             select="(&quot;a&quot;, &quot;b&quot;, &quot;&quot;)"/>
          <fos:example>
-            <p><code>fn:boolean($abc)</code> raises a type error <errorref class="RG" code="0006"
-               />.</p>
-         </fos:example>
-         <fos:example>
             <fos:test use="v-boolean-abc">
                <fos:expression>boolean($abc[1])</fos:expression>
                <fos:result>true()</fos:result>
@@ -6177,6 +6176,10 @@ Tak, tak, tak! - da kommen sie.
                <fos:expression>boolean($abc[3])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
+            <p><code>fn:boolean($abc)</code> raises a type error <errorref class="RG" code="0006"
+               />.</p>
          </fos:example>
          <fos:example>
             <p><code>fn:boolean([])</code> raises a type error <errorref class="RG" code="0006"
@@ -8200,19 +8203,25 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>year-from-date(xs:date("1999-05-31"))</fos:expression>
+               <fos:expression><eg>year-from-date(
+  xs:date("1999-05-31")
+)</eg></fos:expression>
                <fos:result>1999</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>year-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
+               <fos:expression><eg>year-from-date(
+  xs:date("2000-01-01+05:00")
+)</eg></fos:expression>
                <fos:result>2000</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>year-from-date(xs:date("-0002-06-01"))</fos:expression>
+               <fos:expression><eg>year-from-date(
+  xs:date("-0002-06-01")
+)</eg></fos:expression>
                <fos:result>-2</fos:result>
                <fos:postamble>The result is the same whether XSD 1.0 or 1.1 is in use, despite
                the absence of a year 0 in the XSD 1.0 value space.</fos:postamble>
@@ -8244,13 +8253,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>month-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
+               <fos:expression><eg>month-from-date(
+  xs:date("1999-05-31-05:00")
+)</eg></fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>month-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
+               <fos:expression><eg>month-from-date(
+  xs:date("2000-01-01+05:00")
+)</eg></fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -8280,13 +8293,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>day-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
+               <fos:expression><eg>day-from-date(
+  xs:date("1999-05-31-05:00")
+)</eg></fos:expression>
                <fos:result>31</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>day-from-date(xs:date("2000-01-01+05:00"))</fos:expression>
+               <fos:expression><eg>day-from-date(
+  xs:date("2000-01-01+05:00")
+)</eg></fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -8317,13 +8334,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>timezone-from-date(xs:date("1999-05-31-05:00"))</fos:expression>
+               <fos:expression><eg>timezone-from-date(
+  xs:date("1999-05-31-05:00")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("-PT5H")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>timezone-from-date(xs:date("2000-06-12Z"))</fos:expression>
+               <fos:expression><eg>timezone-from-date(
+  xs:date("2000-06-12Z")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("PT0S")</fos:result>
             </fos:test>
          </fos:example>
@@ -11521,8 +11542,8 @@ let $newi := $o/tool</eg>
          <fos:example>
             <p>Assuming <code>$in</code> is an element with no children:</p>
             <eg>
-               let $break := &lt;br/&gt;
-               return empty($break)
+let $break := &lt;br/&gt;
+return empty($break)
             </eg>
             <p>The result is <code>false()</code>.</p>
          </fos:example>
@@ -11580,8 +11601,8 @@ let $newi := $o/tool</eg>
          <fos:example>
             <p>Assuming <code>$in</code> is an element with no children:</p>
             <eg>
-               let $break := &lt;br/>
-               return exists($break)
+let $break := &lt;br/>
+return exists($break)
             </eg>
             <p>The result is <code>true()</code>.</p>
          </fos:example>
@@ -12860,14 +12881,22 @@ else if (empty($input))
   ("A", "B", "C", "D"),
   ("b", "c"),
   function($x, $y) {
-    compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0
+    compare(
+      $x,
+      $y,
+      "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"
+    ) eq 0
   }
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[let $chap := parse-xml("<doc><chap><h1/><p/><p/><footnote/></chap></doc>")//chap
-return contains-sequence($chap ! child::*, $chap ! child::p, op("is"))]]></eg></fos:expression>
+return contains-sequence(
+  $chap ! child::*,
+  $chap ! child::p,
+  op("is")
+)]]></eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the <code>p</code> children of the <code>chap</code> element form a contiguous subsequence.</fos:postamble>
             </fos:test>       
@@ -13865,10 +13894,6 @@ return contains-sequence($chap ! child::*, $chap ! child::p, op("is"))]]></eg></
             </fos:test>
          </fos:example>
          <fos:example>
-            <p><code>fn:avg(($d1, $seq3))</code> raises a type error <errorref class="RG"
-                  code="0006"/>. </p>
-         </fos:example>
-         <fos:example>
             <fos:test>
                <fos:expression>avg(())</fos:expression>
                <fos:result>()</fos:result>
@@ -13885,6 +13910,10 @@ return contains-sequence($chap ! child::*, $chap ! child::p, op("is"))]]></eg></
                <fos:expression>avg(($seq3, xs:float('NaN')))</fos:expression>
                <fos:result>xs:float('NaN')</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
+            <p><code>fn:avg(($d1, $seq3))</code> raises a type error <errorref class="RG"
+                  code="0006"/>. </p>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -14017,10 +14046,6 @@ return contains-sequence($chap ! child::*, $chap ! child::p, op("is"))]]></eg></
             </fos:test>
          </fos:example>
          <fos:example>
-            <p><code>fn:max((3,4,"Zero"))</code> raises a type error <errorref class="RG"
-                  code="0006"/>. </p>
-         </fos:example>
-         <fos:example>
             <fos:test>
                <fos:expression>max((current-date(), xs:date("2100-01-01")))</fos:expression>
                <fos:result>xs:date("2100-01-01")</fos:result>
@@ -14034,6 +14059,10 @@ return contains-sequence($chap ! child::*, $chap ! child::p, op("is"))]]></eg></
                <fos:result>"c"</fos:result>
                <fos:postamble>Assuming a typical default collation.</fos:postamble>
             </fos:test>
+         </fos:example>
+         <fos:example>
+            <p><code>fn:max((3,4,"Zero"))</code> raises a type error <errorref class="RG"
+                  code="0006"/>. </p>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -14166,10 +14195,6 @@ return contains-sequence($chap ! child::*, $chap ! child::p, op("is"))]]></eg></
             </fos:test>
          </fos:example>
          <fos:example>
-            <p><code>fn:min((3,4,"Zero"))</code> raises a type error <errorref class="RG"
-                  code="0006"/>. </p>
-         </fos:example>
-         <fos:example>
             <p><code>fn:min((xs:float(0.0E0), xs:float(-0.0E0)))</code> can return either positive
                or negative zero. The two items are equal, so it is <termref
                   def="implementation-dependent"
@@ -14189,6 +14214,10 @@ return contains-sequence($chap ! child::*, $chap ! child::p, op("is"))]]></eg></
                <fos:result>"a"</fos:result>
                <fos:postamble>Assuming a typical default collation.</fos:postamble>
             </fos:test>
+         </fos:example>
+         <fos:example>
+            <p><code>fn:min((3,4,"Zero"))</code> raises a type error <errorref class="RG"
+                  code="0006"/>. </p>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -14304,10 +14333,6 @@ else
             </fos:test>
          </fos:example>
          <fos:example>
-            <p><code>fn:sum(($d1, 9E1))</code> raises a type error <errorref class="RG" code="0006"
-               />. </p>
-         </fos:example>
-         <fos:example>
             <fos:test use="v-sum-d1 v-sum-d2">
                <fos:expression>sum(($d1, $d2), "ein Augenblick")</fos:expression>
                <fos:result>xs:yearMonthDuration("P20Y10M")</fos:result>
@@ -14329,6 +14354,10 @@ else
                <fos:result>10</fos:result>
                <fos:postamble>Atomizing an array returns the sequence obtained by atomizing its members.</fos:postamble>
             </fos:test>
+         </fos:example>
+         <fos:example>
+            <p><code>fn:sum(($d1, 9E1))</code> raises a type error <errorref class="RG" code="0006"
+               />. </p>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -14865,7 +14894,9 @@ else
          </fos:variable>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-idref-emp">
-               <fos:expression><eg>$emp/(element-with-id('ID21256')/@xml:id => idref())/ancestor::employee/last
+               <fos:expression><eg>$emp/(
+  element-with-id('ID21256')/@xml:id => idref()
+)/ancestor::employee/last
 => string()</eg></fos:expression>
                <fos:result>"Brown"</fos:result>
                <fos:postamble>Assuming that <code>manager</code> has the is-idref property, the call on <code>fn:idref</code> selects
@@ -14875,7 +14906,9 @@ else
          </fos:example>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-idref-emp">
-               <fos:expression><eg>$emp/(element-with-id('E30561')/empnr => idref())/ancestor::employee/last
+               <fos:expression><eg>$emp/(
+  element-with-id('E30561')/empnr => idref()
+)/ancestor::employee/last
 => string()</eg></fos:expression>
                <fos:result>"Singh"</fos:result>
                <fos:postamble>Assuming that <code>employee/deputy</code> has the is-idref property, the call on <code>fn:idref</code> selects
@@ -18763,7 +18796,8 @@ return fold-left($MAPS, map{},
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of(
-  (map:pairs($week), map { "key": 6, "value": "Sonnabend" }),
+  (map:pairs($week),
+   map { "key": 6, "value": "Sonnabend" }),
   function($old, $new)  { $new }
 )</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
@@ -18776,7 +18810,8 @@ return fold-left($MAPS, map{},
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of(
-  (map:pairs($week), map { "key": 6, "value": "Sonnabend" }),
+  (map:pairs($week),
+   map { "key": 6, "value": "Sonnabend" }),
   function($old, $new) { `{$old}|{$new}` }
 )</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
@@ -18840,8 +18875,13 @@ map:for-each(
          <fos:example>
             <fos:test>
                <fos:expression><eg>
-let $numbers := map { 0: 'zero', 1: 'one', 2: 'two', 3: 'three' }
-return map:keys($numbers, function($string) { $string = ('two', 'three') })
+let $numbers := map {
+  0: 'zero',
+  1: 'one',
+  2: 'two',
+  3: 'three'
+}
+return map:keys($numbers, function { . = ('two', 'three') })
                </eg></fos:expression>
                <fos:result>(2, 3)</fos:result>
             </fos:test>
@@ -18849,8 +18889,10 @@ return map:keys($numbers, function($string) { $string = ('two', 'three') })
          <fos:example>
             <fos:test>
                <fos:expression><eg>
-let $square := map:merge((1 to 5) ! map:entry(., . * .))
-return map:keys($square, function($n) { $n &gt; 5 and $n &lt; 20 })
+let $square := map:merge(
+  (1 to 5) ! map:entry(., . * .)
+)
+return map:keys($square, function { . &gt; 5 and . &lt; 20 })
                </eg></fos:expression>
                <fos:result>(3, 4)</fos:result>
             </fos:test>
@@ -18863,7 +18905,9 @@ let $birthdays := map {
   'joel': xs:date('1969-11-10'),
   'john': xs:date('2001-05-05')
 }
-return map:keys($birthdays, function($date) { year-from-date($date) = 1969 })
+return map:keys($birthdays, function($date) {
+  year-from-date($date) = 1969
+})
                </eg></fos:expression>
                <fos:result>"joel"</fos:result>
             </fos:test>
@@ -18901,16 +18945,20 @@ return map:keys($birthdays, function($date) { year-from-date($date) = 1969 })
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:values(
+               <fos:expression><eg>map:values(
   map{ 1: "yes", 2: "no" }
-)</fos:expression>
+)</eg></fos:expression>
                <fos:result allow-permutation="true">("yes", "no")</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:values(
-  map { 1: ("red", "green"), 2: ("blue", "yellow"), 3:() }
+  map {
+    1: ("red", "green"),
+    2: ("blue", "yellow"),
+    3:()
+  }
 )</eg></fos:expression>
                <fos:result allow-permutation="true">("red", "green", "blue", "yellow")</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
@@ -18953,7 +19001,9 @@ return map:keys($birthdays, function($date) { year-from-date($date) = 1969 })
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:entries(map{1:"yes", 2:"no"})</fos:expression>
+               <fos:expression><eg>map:entries(
+  map { 1: "yes", 2: "no" }
+)</eg></fos:expression>
                <fos:result allow-permutation="true">(map{1:"yes"}, map{2:"no"})</fos:result>
                <fos:postamble>The result sequence is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
@@ -18997,7 +19047,9 @@ return map:keys($birthdays, function($date) { year-from-date($date) = 1969 })
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:pairs(map{1:"yes", 2:"no"})</fos:expression>
+               <fos:expression><eg>map:pairs(
+  map { 1: "yes", 2: "no" }
+)</eg></fos:expression>
                <fos:result allow-permutation="true">(map{"key":1, "value":"yes"}, map{"key":2, "value":"no"})</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
@@ -19025,11 +19077,7 @@ return map:keys($birthdays, function($date) { year-from-date($date) = 1969 })
          <p>The function <code>map:contains</code> returns <code>true</code> if the <termref def="dt-map"
                >map</termref> supplied as <code>$map</code> contains an entry with the <termref
                   def="dt-same-key">same key</termref> as <code>$key</code>; otherwise it returns <code>false</code>.</p>
-
-
-
       </fos:rules>
-
 
       <fos:examples>
          <fos:variable name="week" id="v-map-contains-week"
@@ -19544,19 +19592,23 @@ return
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>map:filter(map{1: "Sunday", 2: "Monday", 
-               3: "Tuesday", 4:"Wednesday",
-               5: "Thursday", 6: "Friday", 
-               7: "Saturday"},
-          ($k, $v)->{$k = (1, 7)})</eg></fos:expression>
+               <fos:expression><eg>map:filter(
+  map { 1: "Sunday", 2: "Monday", 
+        3: "Tuesday", 4:"Wednesday",
+        5: "Thursday", 6: "Friday", 
+        7: "Saturday" },
+  function($k, $v) { $k = (1, 7) }
+)</eg></fos:expression>
                <fos:result><eg>map{1:"Sunday", 7:"Saturday"}</eg></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>map:filter(map{1: "Sunday", 2: "Monday", 
-               3: "Tuesday", 4: "Wednesday",
-               5: "Thursday", 6:"Friday", 
-               7:"Saturday"},
-          ($k, $v)->{$v = ("Saturday", "Sunday")})</eg></fos:expression>
+               <fos:expression><eg>map:filter(
+  map { 1: "Sunday", 2: "Monday", 
+        3: "Tuesday", 4: "Wednesday",
+        5: "Thursday", 6:"Friday", 
+        7:"Saturday" },
+  function($k, $v) { $v = ("Saturday", "Sunday") }
+)</eg></fos:expression>
                <fos:result><eg>map{1:"Sunday", 7:"Saturday"}</eg></fos:result>
             </fos:test>
 
@@ -19713,18 +19765,18 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <p>More formally, the result of the function is the result of the following expression:</p>
          
          <eg>
-            fold-left($input, map{}, ->($map, $next) {
-               let $nextKey := $key($next)
-               let $nextValue := $value($next)
-               return
-                  if (fn:exists($nextKey))
-                  then
-                     if (map:contains($map, $nextKey))
-                     then map:put($map, $nextKey, $combine($map($nextKey), $nextValue))
-                     else map:put($map, $nextKey, $nextValue)
-                  else
-                     $map
-            })
+fold-left($input, map{}, ->($map, $next) {
+   let $nextKey := $key($next)
+   let $nextValue := $value($next)
+   return
+      if (fn:exists($nextKey))
+      then
+         if (map:contains($map, $nextKey))
+         then map:put($map, $nextKey, $combine($map($nextKey), $nextValue))
+         else map:put($map, $nextKey, $nextValue)
+      else
+         $map
+})
          </eg>
       </fos:rules>
       
@@ -19758,15 +19810,19 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                   sequence concatenation.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:build(1 to 5, value := format-integer(?, "w"))</fos:expression>
+               <fos:expression><eg>map:build(
+  1 to 5,
+  value := format-integer(?, "w")
+)</eg></fos:expression>
                <fos:result>map{1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}</fos:result>
                <fos:postamble>Returns a map with five entries. The function to compute the key is an identity function, the
                   function to compute the value invokes <code>fn:format-integer</code>.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:build(
-  ("January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December"),
+  ("January", "February", "March", "April",
+   "May", "June", "July", "August", "September",
+   "October", "November", "December"),
   substring(?, 1, 1)
 )</eg></fos:expression>
                <fos:result>map{"A": ("April", "August"), "D": ("December"), "F": ("February"), "J": ("January", "June", "July"), 
@@ -19774,7 +19830,8 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:build(
-  ("apple", "apricot", "banana", "blueberry", "cherry"), 
+  ("apple", "apricot", "banana",
+   "blueberry", "cherry"), 
   substring(?, 1, 1),
   string-length#1,
   op("+")
@@ -19951,7 +20008,8 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <fos:example>
             <fos:test use="v-collation-key-C">
                <fos:expression><eg>map:merge(
-  (map { collation-key("A", $C): 1 }, map { collation-key("a", $C): 2 }),
+  (map { collation-key("A", $C): 1 },
+   map { collation-key("a", $C): 2 }),
   map { "duplicates": "use-last" }
 )(collation-key("A", $C))</eg></fos:expression>
                <fos:result>2</fos:result>
@@ -19962,7 +20020,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </fos:example>
          <fos:example>
             <fos:test use="v-collation-key-C">
-               <fos:expression><eg>let $M := map { collation-key("A", $C): 1, collation-key("B", $C): 2 }
+               <fos:expression><eg>let $M := map {
+  collation-key("A", $C): 1,
+  collation-key("B", $C): 2
+}
 return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>The strings <code>"A"</code> and <code>"a"</code> have the same collation key under this
@@ -21890,8 +21951,9 @@ else $fallback($position)</eg>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:index-where(
-  [ "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December" ],
+  [ "January", "February", "March", "April",
+    "May", "June", "July", "August", "September",
+    "October", "November", "December" ],
   contains(?, "r")
 )</eg></fos:expression>
                <fos:result>(1, 2, 3, 4, 9, 10, 11, 12)</fos:result>
@@ -22467,7 +22529,7 @@ else $fallback($position)</eg>
             <fos:test>
                <fos:expression><eg>array:filter(
   ["the cat", "sat", "on the mat"],
-  function($s) { count(tokenize($s)) gt 1 }
+  function { count(tokenize(.)) > 1 }
 )</eg></fos:expression>
                <fos:result>["the cat", "on the mat"]</fos:result>
             </fos:test>
@@ -22663,8 +22725,12 @@ else array:fold-left(array:tail($array),
                <fos:result>[["A", 1], ["B", 2], ["C", 3]]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $A := ["A", "B", "C", "D"]
-return array:for-each-pair($A, array:tail($A), concat#2)</eg></fos:expression>
+               <fos:expression><eg>let $array := ["A", "B", "C", "D"]
+return array:for-each-pair(
+  $array,
+  array:tail($array),
+  concat#2
+)</eg></fos:expression>
                <fos:result>["AB", "BC", "CD"]</fos:result>
             </fos:test>
          </fos:example>
@@ -22714,19 +22780,31 @@ return array:for-each-pair($A, array:tail($A), concat#2)</eg></fos:expression>
                <fos:result>[1, 2, 3, 4, 5]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, function { 2 * . })</fos:expression>
+               <fos:expression><eg>array:build(
+  1 to 5,
+  function { 2 * . }
+)</eg></fos:expression>
                <fos:result>[2, 4, 6, 8, 10]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, function { 1 to . })</fos:expression>
+               <fos:expression><eg>array:build(
+  1 to 5,
+  function { 1 to . }
+)</eg></fos:expression>
                <fos:result>[1, (1,2), (1,2,3), (1,2,3,4), (1,2,3,4,5)]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(("red", "green", "blue"), characters#1)</fos:expression>
+               <fos:expression><eg>array:build(
+  ("red", "green", "blue"),
+  characters#1
+)</eg></fos:expression>
                <fos:result>[("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e")]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, function { array { 1 to . } })</fos:expression>
+               <fos:expression><eg>array:build(
+  1 to 5,
+  function { array { 1 to . } }
+)</eg></fos:expression>
                <fos:result>[[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5]]</fos:result>
             </fos:test>
          </fos:example>
@@ -24192,14 +24270,16 @@ declare function fn:all(
             </fos:test>
             <fos:test>
                <fos:expression><eg>all(
-  ("January", "February", "March", "April",  "September", "October", "November", "December"),
+  ("January", "February", "March", "April",
+   "September", "October", "November", "December"),
   contains(?, "r")
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>all(
-  ("January", "February", "March", "April", "September", "October", "November", "December")
+  ("January", "February", "March", "April",
+   "September", "October", "November", "December")
   =!> contains("r")
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
@@ -24359,7 +24439,10 @@ declare function fn:all(
                <fos:result>"s-t-r-e-t-c-h"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>"Banana" => characters() => reverse() => string-join()</fos:expression>
+               <fos:expression><eg>"Banana"
+=> characters()
+=> reverse()
+=> string-join()</eg></fos:expression>
                <fos:result>"ananaB"</fos:result>
             </fos:test>
          </fos:example>
@@ -24470,13 +24553,18 @@ function($item) {
                <fos:expression><eg>highest(
   ("red", "green", "blue"),
   (),
-  map { "red": xs:hexBinary('FF0000'), "green": xs:hexBinary('008000'), "blue": xs:hexBinary('0000FF') }
+  map {
+    "red"  : xs:hexBinary('FF0000'),
+    "green": xs:hexBinary('008000'),
+    "blue" : xs:hexBinary('0000FF')
+  }
 )</eg></fos:expression>
                <fos:result>("red")</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>highest(
-  ("red", "orange", "yellow", "green", "blue", "indigo", "violet"),
+  ("red", "orange", "yellow", "green",
+   "blue", "indigo", "violet"),
   (),
   string-length#1
 )</eg></fos:expression>
@@ -24538,8 +24626,9 @@ function($item) {
             </fos:test>
             <fos:test>
                <fos:expression><eg>index-where(
-  ("January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December"),
+  ("January", "February", "March", "April",
+   "May", "June", "July", "August", "September",
+   "October", "November", "December"),
   contains(?, "r")
 )</eg></fos:expression>
                <fos:result>(1, 2, 3, 4, 9, 10, 11, 12)</fos:result>
@@ -24769,7 +24858,8 @@ function($item) {
                <fos:result>"p", "p", "h2"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>("Aardvark", "Antelope", "Bison", "Buffalo", "Camel", "Dingo")
+               <fos:expression><eg>("Aardvark", "Antelope", "Bison",
+ "Buffalo", "Camel", "Dingo")
 => items-starting-where(starts-with(?, "B"))
 => items-before(starts-with(?, "D"))</eg></fos:expression>
                <fos:result>"Bison", "Buffalo", "Camel"</fos:result>
@@ -25011,7 +25101,11 @@ function($item) {
                <fos:expression><eg>lowest(
   ("red", "green", "blue"),
   (),
-  map { "red": xs:hexBinary('FF0000'), "green": xs:hexBinary('008000'), "blue": xs:hexBinary('0000FF') }
+  map {
+    "red"  : xs:hexBinary('FF0000'),
+    "green": xs:hexBinary('008000'),
+    "blue" : xs:hexBinary('0000FF')
+  }
 )</eg></fos:expression>
                <fos:result>("blue")</fos:result>
             </fos:test>
@@ -25103,14 +25197,16 @@ declare function fn:some(
             </fos:test>
             <fos:test>
                <fos:expression><eg>some(
-  ("January", "February", "March", "April", "September", "October", "November", "December"),
+  ("January", "February", "March", "April",
+   "September", "October", "November", "December"),
   contains(?, "z")
 )</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>some(
-  ("January", "February", "March", "April", "September", "October", "November", "December")
+  ("January", "February", "March", "April",
+   "September", "October", "November", "December")
   =!> contains("r")
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
@@ -26300,35 +26396,45 @@ path with an explicit <code>file:</code> scheme.</p>
             <fos:test>
                <fos:expression><eg>partition(
   ("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
-  function($partition, $next) { substring($partition[1],1,1) ne substring($next,1,1) }
+  function($partition, $next) {
+    substring(head($partition),1,1) ne substring($next,1,1)
+  }
 )</eg></fos:expression>
                <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
   (1, 2, 3, 4, 5, 6, 7),
-  function($partition, $next) { count($partition) eq 2 }
+  function($partition, $next) {
+    count($partition) eq 2
+  }
 )</eg></fos:expression>
                <fos:result>([1, 2], [3, 4], [5, 6], [7])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
   (1, 4, 6, 3, 1, 1),
-  function($partition, $next) { sum($partition) ge 5 }
+  function($partition, $next) {
+    sum($partition) ge 5
+  }
 )</eg></fos:expression>
                <fos:result>([1, 4], [6], [3, 1, 1])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
   tokenize("In the beginning was the word"), 
-  function($partition, $next) { sum(($partition, $next) ! string-length()) gt 10 }
+  function($partition, $next) {
+    sum(($partition, $next) ! string-length()) gt 10
+  }
 )</eg></fos:expression>
                <fos:result>(["In", "the"], ["beginning"], ["was", "the", "word"])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
   (1, 2, 3, 6, 7, 9, 10),
-  function($partition, $next) { $next != foot($partition) + 1 }
+  function($partition, $next) {
+    $next != foot($partition) + 1
+  }
 )</eg></fos:expression>
                <fos:result>([1, 2, 3], [6, 7], [9, 10])</fos:result>
             </fos:test>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -586,8 +586,10 @@
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>error(QName('http://www.example.com/HR', 'myerr:toohighsal'),
-                  'Does not apply because salary is too high')</fos:expression>
+               <fos:expression><eg>error(
+  QName('http://www.example.com/HR', 'myerr:toohighsal'),
+  'Does not apply because salary is too high'
+)</eg></fos:expression>
                <fos:error-result error-code="myerr:toohighsal"/>
                <fos:postamble>This returns <code>http://www.example.com/HR#toohighsal</code> and the
                      <code>xs:string</code>
@@ -2106,8 +2108,11 @@
                the grouping separator is <code>&#x2b9;</code> and the decimal separator is
                   <code>&#xb7;</code>:</p>
             <fos:test>
-               <fos:expression>format-number(1234.5678, '#&#x2b9;##0&#xb7;00',
-                  'ch')</fos:expression>
+               <fos:expression><eg>format-number(
+  1234.5678,
+  '#&#x2b9;##0&#xb7;00',
+  'ch'
+)</eg></fos:expression>
                <fos:result>"1&#x2b9;234&#xb7;57"</fos:result>
             </fos:test>
             <p>The following examples assume that the exponent separator is
@@ -2243,13 +2248,16 @@ return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
                Note, enumerating systems that do not assign a symbol to zero (e.g., spreadsheet
                columns) must be preprocessed in a different fashion.</p>
             <fos:test>
-               <fos:expression>lower-case("AAB") => translate("abcdefghijklmnopqrstuvwxyz", "0123456789abcdefghijklmnop") => parse-integer(26)</fos:expression>
+               <fos:expression><eg>lower-case("AAB")
+=> translate("abcdefghijklmnopqrstuvwxyz", "0123456789abcdefghijklmnop")
+=> parse-integer(26)</eg></fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
             <p>Digit-based numeration systems comparable to the Arabic numbers 0 through 9 can be
                parsed via translation.</p>
             <fos:test>
-               <fos:expression>translate('٢٠٢٣', '٠١٢٣٤٥٦٧٨٩', '0123456789') => parse-integer()</fos:expression>
+               <fos:expression><eg>translate('٢٠٢٣', '٠١٢٣٤٥٦٧٨٩', '0123456789')
+=> parse-integer()</eg></fos:expression>
                <fos:result>2023</fos:result>
             </fos:test>
          </fos:example>
@@ -3488,8 +3496,11 @@ return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>compare('Strasse', 'Straße',
-                  'http://www.w3.org/2013/collation/UCA?lang=de;strength=primary')</fos:expression>
+               <fos:expression><eg>compare(
+  'Strasse',
+  'Straße',
+  'http://www.w3.org/2013/collation/UCA?lang=de;strength=primary'
+)</eg></fos:expression>
                <fos:result>0</fos:result>
                <fos:postamble>The specified collation equates
                      <quote>ss</quote> and the (German) character <quote>ß</quote>
@@ -3625,8 +3636,10 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>concat('Thy ', (), 'old ', "groans", "", ' ring',
-                  ' yet', ' in', ' my', ' ancient',' ears.')</fos:expression>
+               <fos:expression><eg>concat(
+  'Thy ', (), 'old ', "groans", "", ' ring',
+  ' yet', ' in', ' my', ' ancient',' ears.'
+)</eg></fos:expression>
                <fos:result>"Thy old groans ring yet in my ancient ears."</fos:result>
             </fos:test>
          </fos:example>
@@ -3638,7 +3651,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>concat('Ingratitude, ', 'thou ', 'marble-hearted', ' fiend!')</fos:expression>
+               <fos:expression><eg>concat('Ingratitude, ', 'thou ',
+  'marble-hearted', ' fiend!')</eg></fos:expression>
                <fos:result>"Ingratitude, thou marble-hearted fiend!"</fos:result>
             </fos:test>
          </fos:example>
@@ -3697,15 +3711,16 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>string-join(('Now', 'is', 'the', 'time', '...'),
-                  ' ')</fos:expression>
+               <fos:expression>string-join(('Now', 'is', 'the', 'time', '...'), ' ')</fos:expression>
                <fos:result>"Now is the time ..."</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>string-join(('Blow, ', 'blow, ', 'thou ', 'winter ', 'wind!'),
-                  '')</fos:expression>
+               <fos:expression><eg>string-join(
+  ('Blow, ', 'blow, ', 'thou ', 'winter ', 'wind!'),
+  ''
+)</eg></fos:expression>
                <fos:result>"Blow, blow, thou winter wind!"</fos:result>
             </fos:test>
          </fos:example>
@@ -3730,13 +3745,15 @@ return normalize-unicode(concat($v1, $v2))</eg>
 &lt;/doc&gt;</fos:variable>
          <fos:example>
             <fos:test use="v-string-join-doc">
-               <fos:expression>$doc//@xml:id ! string-join((node-name(), '="', ., '"'))</fos:expression>
+               <fos:expression><eg>$doc//@xml:id
+! string-join((node-name(), '="', ., '"'))</eg></fos:expression>
                <fos:result>'xml:id="xyz"'</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-string-join-doc">
-               <fos:expression>$doc//section ! string-join(ancestor-or-self::*/name(), '/')</fos:expression>
+               <fos:expression><eg>$doc//section
+! string-join(ancestor-or-self::*/name(), '/')</eg></fos:expression>
                <fos:result>"doc/chap/section"</fos:result>
             </fos:test>
          </fos:example>
@@ -3940,7 +3957,9 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>string-length("Harp not on that string, madam; that is past.")</fos:expression>
+               <fos:expression><eg>string-length(
+  "Harp not on that string, madam; that is past."
+)</eg></fos:expression>
                <fos:result>45</fos:result>
             </fos:test>
          </fos:example>
@@ -4000,8 +4019,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression xml:space="preserve">normalize-space(" The    wealthy curled darlings
-                                        of    our    nation. ")</fos:expression>
+               <fos:expression><eg>normalize-space(" The    wealthy curled darlings
+           of    our    nation. ")</eg></fos:expression>
                <fos:result>"The wealthy curled darlings of our nation."</fos:result>
             </fos:test>
          </fos:example>
@@ -4376,7 +4395,9 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>encode-for-uri("http://www.example.com/00/Weather/CA/Los%20Angeles#ocean")</fos:expression>
+               <fos:expression><eg>encode-for-uri(
+  "http://www.example.com/00/Weather/CA/Los%20Angeles#ocean"
+)</eg></fos:expression>
                <fos:result>"http%3A%2F%2Fwww.example.com%2F00%2FWeather%2FCA%2FLos%2520Angeles%23ocean"</fos:result>
                <fos:postamble>This is probably not what the user intended because all of the
                   delimiters have been encoded.</fos:postamble>
@@ -4384,14 +4405,19 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>concat("http://www.example.com/",
-                  encode-for-uri("~bébé"))</fos:expression>
+               <fos:expression><eg>concat(
+  "http://www.example.com/",
+  encode-for-uri("~bébé")
+)</eg></fos:expression>
                <fos:result>"http://www.example.com/~b%C3%A9b%C3%A9"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>concat("http://www.example.com/", encode-for-uri("100% organic"))</fos:expression>
+               <fos:expression><eg>concat(
+  "http://www.example.com/",
+  encode-for-uri("100% organic")
+)</eg></fos:expression>
                <fos:result>"http://www.example.com/100%25%20organic"</fos:result>
             </fos:test>
          </fos:example>
@@ -4453,8 +4479,9 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>iri-to-uri
-                  ("http://www.example.com/00/Weather/CA/Los%20Angeles#ocean")</fos:expression>
+               <fos:expression><eg>iri-to-uri(
+  "http://www.example.com/00/Weather/CA/Los%20Angeles#ocean"
+)</eg></fos:expression>
                <fos:result>"http://www.example.com/00/Weather/CA/Los%20Angeles#ocean"</fos:result>
             </fos:test>
          </fos:example>
@@ -4504,13 +4531,17 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>escape-html-uri("http://www.example.com/00/Weather/CA/Los Angeles#ocean")</fos:expression>
+               <fos:expression><eg>escape-html-uri(
+  "http://www.example.com/00/Weather/CA/Los Angeles#ocean"
+)</eg></fos:expression>
                <fos:result>"http://www.example.com/00/Weather/CA/Los Angeles#ocean"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>escape-html-uri("javascript:if (navigator.browserLanguage == 'fr') window.open('http://www.example.com/~bébé');")</fos:expression>
+               <fos:expression><eg>escape-html-uri(
+  "javascript:if (navigator.browserLanguage == 'fr') window.open('http://www.example.com/~bébé');"
+)</eg></fos:expression>
                <fos:result>"javascript:if (navigator.browserLanguage == 'fr') window.open('http://www.example.com/~b%C3%A9b%C3%A9');"</fos:result>
             </fos:test>
          </fos:example>
@@ -4591,29 +4622,41 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>contains("abcdefghi", "-d-e-f-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>contains(
+  "abcdefghi",
+  "-d-e-f-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>contains("a*b*c*d*e*f*g*h*i*", "d-ef-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>contains(
+  "a*b*c*d*e*f*g*h*i*",
+  "d-ef-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>contains("abcd***e---f*--*ghi", "def",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>contains(
+  "abcd***e---f*--*ghi",
+  "def",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>contains((), "--***-*---",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>contains(
+  (),
+  "--***-*---",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
                   equivalent to the zero-length string.</fos:postamble>
@@ -4693,29 +4736,41 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>starts-with("abcdefghi", "-a-b-c-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>starts-with(
+  "abcdefghi",
+  "-a-b-c-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>starts-with("a*b*c*d*e*f*g*h*i*", "a-bc-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>starts-with(
+  "a*b*c*d*e*f*g*h*i*",
+  "a-bc-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>starts-with("abcd***e---f*--*ghi", "abcdef",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>starts-with(
+  "abcd***e---f*--*ghi",
+  "abcdef",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>starts-with((), "--***-*---",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>starts-with(
+  (),
+  "--***-*---",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
                   equivalent to the zero-length string.</fos:postamble>
@@ -4723,8 +4778,11 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>starts-with("-abcdefghi", "-abc",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>starts-with(
+  "-abcdefghi",
+  "-abc",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -4803,29 +4861,41 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>ends-with("abcdefghi", "-g-h-i-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>ends-with(
+  "abcdefghi",
+  "-g-h-i-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>ends-with("abcd***e---f*--*ghi", "defghi",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>ends-with(
+  "abcd***e---f*--*ghi",
+  "defghi",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>ends-with("abcd***e---f*--*ghi", "defghi",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>ends-with(
+  "abcd***e---f*--*ghi",
+  "defghi",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>ends-with((), "--***-*---",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>ends-with(
+  (),
+  "--***-*---",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
                   equivalent to the zero-length string.</fos:postamble>
@@ -4833,8 +4903,11 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>ends-with("abcdefghi", "ghi-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>ends-with(
+  "abcdefghi",
+  "ghi-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -4912,29 +4985,41 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>substring-before("abcdefghi", "--d-e-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>substring-before(
+  "abcdefghi",
+  "--d-e-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>"abc"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>substring-before("abc--d-e-fghi", "--d-e-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>substring-before(
+  "abc--d-e-fghi",
+  "--d-e-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>"abc--"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>substring-before("a*b*c*d*e*f*g*h*i*", "***cde",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>substring-before(
+  "a*b*c*d*e*f*g*h*i*",
+  "***cde",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>"a*b*"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>substring-before("Eureka!", "--***-*---",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>substring-before(
+  "Eureka!",
+  "--***-*---",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>""</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
                   equivalent to the zero-length string.</fos:postamble>
@@ -5015,29 +5100,41 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression> substring-after("abcdefghi", "--d-e-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>substring-after(
+  "abcdefghi",
+  "--d-e-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>"fghi"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>substring-after("abc--d-e-fghi", "--d-e-",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>substring-after(
+  "abc--d-e-fghi",
+  "--d-e-",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>"-fghi"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>substring-after("a*b*c*d*e*f*g*h*i*", "***cde***",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>substring-after(
+  "a*b*c*d*e*f*g*h*i*",
+  "***cde***",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>"*f*g*h*i*"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>substring-after("Eureka!", "--***-*---",
-                  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary")</fos:expression>
+               <fos:expression><eg>substring-after(
+  "Eureka!",
+  "--***-*---",
+  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+)</eg></fos:expression>
                <fos:result>"Eureka!"</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
                   equivalent to the zero-length string.</fos:postamble>
@@ -5347,23 +5444,45 @@ Tak, tak, tak! - da kommen sie.
                <fos:postamble>The first <code>d</code> is replaced.</fos:postamble>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("abracadabra", "bra", action:= function{"*"})</fos:expression>
+               <fos:expression><eg>replace(
+  "abracadabra",
+  "bra",
+  action := function { "*" }
+)</eg></fos:expression>
                <fos:result>"a*cada*"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("abracadabra", "bra", action:= upper-case#1)</fos:expression>
+               <fos:expression><eg>replace(
+  "abracadabra",
+  "bra",
+  action := upper-case#1
+)</eg></fos:expression>
                <fos:result>aBRAcadaBRA</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("Chapter 9", "[0-9]+", action:= function{string(number(.)+1)})</fos:expression>
+               <fos:expression><eg>replace(
+  "Chapter 9",
+  "[0-9]+",
+  action := function { string(number(.) + 1) }
+)</eg></fos:expression>
                <fos:result>"Chapter 10"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("LHR to LAX", "[A-Z]{3}", action:= map{'LAX': 'Los Angeles', 'LHR': 'London'})</fos:expression>
+               <fos:expression><eg>replace(
+  "LHR to LAX",
+  "[A-Z]{3}",
+  action := map {'LAX': 'Los Angeles', 'LHR': 'London' }
+)</eg></fos:expression>
                <fos:result>"London to Los Angeles"</fos:result>
             </fos:test>
             <fos:test diff="add" at="A">
-               <fos:expression>replace("57°43′30″", "([0-9]+)°([0-9]+)′([0-9]+)″)", action:= ($s, $groups)->{string(number($groups[1]) + number($groups[2])÷60 + number($groups[3])÷3600)||'°'})</fos:expression>
+               <fos:expression><eg>replace(
+  "57°43′30″",
+  "([0-9]+)°([0-9]+)′([0-9]+)″",
+  action := function ($s, $groups) {
+    string(number($groups[1]) + number($groups[2]) ÷ 60 + number($groups[3]) ÷ 3600) || '°'
+  }
+)</eg></fos:expression>
                <fos:result>"57.725°"</fos:result>
             </fos:test>
          </fos:example>
@@ -5505,8 +5624,10 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>tokenize("Some unparsed &lt;br&gt; HTML &lt;BR&gt; text",
-                  "\s*&lt;br&gt;\s*", "i")</fos:expression>
+               <fos:expression><eg>tokenize(
+  "Some unparsed &lt;br&gt; HTML &lt;BR&gt; text",
+  "\s*&lt;br&gt;\s*", "i"
+)</eg></fos:expression>
                <fos:result>("Some unparsed", "HTML", "text")</fos:result>
             </fos:test>
          </fos:example>
@@ -5666,8 +5787,10 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>analyze-string("2008-12-03",
-                  "^(\d+)\-(\d+)\-(\d+)$")</fos:expression>
+               <fos:expression><eg>analyze-string(
+  "2008-12-03",
+  "^(\d+)\-(\d+)\-(\d+)$"
+)</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true" as="element()"><![CDATA[
 <analyze-string-result xmlns="http://www.w3.org/2005/xpath-functions">
   <match><group nr="1">2008</group>-<group nr="2"
@@ -5677,8 +5800,10 @@ Tak, tak, tak! - da kommen sie.
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>analyze-string("A1,C15,,D24, X50,",
-                  "([A-Z])([0-9]+)")</fos:expression>
+               <fos:expression><eg>analyze-string(
+  "A1,C15,,D24, X50,",
+  "([A-Z])([0-9]+)"
+)</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true" as="element()"><![CDATA[
 <analyze-string-result xmlns="http://www.w3.org/2005/xpath-functions">                  
   <match><group nr="1">A</group><group nr="2">1</group></match>
@@ -5761,7 +5886,11 @@ Tak, tak, tak! - da kommen sie.
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-token("red green blue", "RED", "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
+               <fos:expression><eg>contains-token(
+  "red green blue",
+  "RED",
+  "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -6192,64 +6321,82 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:duration("P1Y"),
-                  xs:duration("P12M"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:duration("P1Y"),
+  xs:duration("P12M")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:duration("PT24H"),
-                  xs:duration("P1D"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:duration("PT24H"),
+  xs:duration("P1D")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:duration("P1Y"),
-                  xs:duration("P365D"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:duration("P1Y"),
+  xs:duration("P365D")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:yearMonthDuration("P0Y"),
-                  xs:dayTimeDuration("P0D"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:yearMonthDuration("P0Y"),
+  xs:dayTimeDuration("P0D")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:yearMonthDuration("P1Y"),
-                  xs:dayTimeDuration("P365D"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:yearMonthDuration("P1Y"),
+  xs:dayTimeDuration("P365D")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:yearMonthDuration("P2Y"),
-                  xs:yearMonthDuration("P24M"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:yearMonthDuration("P2Y"),
+  xs:yearMonthDuration("P24M")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:dayTimeDuration("P10D"),
-                  xs:dayTimeDuration("PT240H"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:dayTimeDuration("P10D"),
+  xs:dayTimeDuration("PT240H")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:duration("P2Y0M0DT0H0M0S"),
-                  xs:yearMonthDuration("P24M"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:duration("P2Y0M0DT0H0M0S"),
+  xs:yearMonthDuration("P24M")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:duration-equal(xs:duration("P0Y0M10D"),
-                  xs:dayTimeDuration("PT240H"))</fos:expression>
+               <fos:expression><eg>op:duration-equal(
+  xs:duration("P0Y0M10D"),
+  xs:dayTimeDuration("PT240H")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -6281,19 +6428,25 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>years-from-duration(xs:yearMonthDuration("P20Y15M"))</fos:expression>
+               <fos:expression><eg>years-from-duration(
+  xs:yearMonthDuration("P20Y15M")
+)</eg></fos:expression>
                <fos:result>21</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>years-from-duration(xs:yearMonthDuration("-P15M"))</fos:expression>
+               <fos:expression><eg>years-from-duration(
+  xs:yearMonthDuration("-P15M")
+)</eg></fos:expression>
                <fos:result>-1</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>years-from-duration(xs:dayTimeDuration("-P2DT15H"))</fos:expression>
+               <fos:expression><eg>years-from-duration(
+  xs:dayTimeDuration("-P2DT15H")
+)</eg></fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -6325,19 +6478,25 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>months-from-duration(xs:yearMonthDuration("P20Y15M"))</fos:expression>
+               <fos:expression><eg>months-from-duration(
+  xs:yearMonthDuration("P20Y15M")
+)</eg></fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>months-from-duration(xs:yearMonthDuration("-P20Y18M"))</fos:expression>
+               <fos:expression><eg>months-from-duration(
+  xs:yearMonthDuration("-P20Y18M")
+)</eg></fos:expression>
                <fos:result>-6</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>months-from-duration(xs:dayTimeDuration("-P2DT15H0M0S"))</fos:expression>
+               <fos:expression><eg>months-from-duration(
+  xs:dayTimeDuration("-P2DT15H0M0S")
+)</eg></fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -6368,19 +6527,25 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>days-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
+               <fos:expression><eg>days-from-duration(
+  xs:dayTimeDuration("P3DT10H")
+)</eg></fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>days-from-duration(xs:dayTimeDuration("P3DT55H"))</fos:expression>
+               <fos:expression><eg>days-from-duration(
+  xs:dayTimeDuration("P3DT55H")
+)</eg></fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>days-from-duration(xs:yearMonthDuration("P3Y5M"))</fos:expression>
+               <fos:expression><eg>days-from-duration(
+  xs:yearMonthDuration("P3Y5M")
+)</eg></fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -6411,25 +6576,33 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
+               <fos:expression><eg>hours-from-duration(
+  xs:dayTimeDuration("P3DT10H")
+)</eg></fos:expression>
                <fos:result>10</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-duration(xs:dayTimeDuration("P3DT12H32M12S"))</fos:expression>
+               <fos:expression><eg>hours-from-duration(
+  xs:dayTimeDuration("P3DT12H32M12S")
+)</eg></fos:expression>
                <fos:result>12</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-duration(xs:dayTimeDuration("PT123H"))</fos:expression>
+               <fos:expression><eg>hours-from-duration(
+  xs:dayTimeDuration("PT123H")
+)</eg></fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-duration(xs:dayTimeDuration("-P3DT10H"))</fos:expression>
+               <fos:expression><eg>hours-from-duration(
+  xs:dayTimeDuration("-P3DT10H")
+)</eg></fos:expression>
                <fos:result>-10</fos:result>
             </fos:test>
          </fos:example>
@@ -6460,13 +6633,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>minutes-from-duration(xs:dayTimeDuration("P3DT10H"))</fos:expression>
+               <fos:expression><eg>minutes-from-duration(
+  xs:dayTimeDuration("P3DT10H")
+)</eg></fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>minutes-from-duration(xs:dayTimeDuration("-P5DT12H30M"))</fos:expression>
+               <fos:expression><eg>minutes-from-duration(
+  xs:dayTimeDuration("-P5DT12H30M")
+)</eg></fos:expression>
                <fos:result>-30</fos:result>
             </fos:test>
          </fos:example>
@@ -6498,13 +6675,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>seconds-from-duration(xs:dayTimeDuration("P3DT10H12.5S"))</fos:expression>
+               <fos:expression><eg>seconds-from-duration(
+  xs:dayTimeDuration("P3DT10H12.5S")
+)</eg></fos:expression>
                <fos:result>12.5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>seconds-from-duration(xs:dayTimeDuration("-PT256S"))</fos:expression>
+               <fos:expression><eg>seconds-from-duration(
+  xs:dayTimeDuration("-PT256S")
+)</eg></fos:expression>
                <fos:result>-16.0</fos:result>
             </fos:test>
          </fos:example>
@@ -6536,8 +6717,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:add-yearMonthDurations(xs:yearMonthDuration("P2Y11M"),
-                  xs:yearMonthDuration("P3Y3M"))</fos:expression>
+               <fos:expression><eg>op:add-yearMonthDurations(
+  xs:yearMonthDuration("P2Y11M"),
+  xs:yearMonthDuration("P3Y3M")
+)</eg></fos:expression>
                <fos:result>xs:yearMonthDuration("P6Y2M")</fos:result>
             </fos:test>
          </fos:example>
@@ -6570,8 +6753,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-yearMonthDurations(xs:yearMonthDuration("P2Y11M"),
-                  xs:yearMonthDuration("P3Y3M"))</fos:expression>
+               <fos:expression><eg>op:subtract-yearMonthDurations(
+  xs:yearMonthDuration("P2Y11M"),
+  xs:yearMonthDuration("P3Y3M")
+)</eg></fos:expression>
                <fos:result>xs:yearMonthDuration("-P4M")</fos:result>
             </fos:test>
          </fos:example>
@@ -6614,8 +6799,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:multiply-yearMonthDuration(xs:yearMonthDuration("P2Y11M"),
-                  2.3)</fos:expression>
+               <fos:expression><eg>op:multiply-yearMonthDuration(
+  xs:yearMonthDuration("P2Y11M"),
+  2.3
+)</eg></fos:expression>
                <fos:result>xs:yearMonthDuration("P6Y9M")</fos:result>
             </fos:test>
          </fos:example>
@@ -6658,8 +6845,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:divide-yearMonthDuration(xs:yearMonthDuration("P2Y11M"),
-                  1.5)</fos:expression>
+               <fos:expression><eg>op:divide-yearMonthDuration(
+  xs:yearMonthDuration("P2Y11M"),
+  1.5
+)</eg></fos:expression>
                <fos:result>xs:yearMonthDuration("P1Y11M")</fos:result>
             </fos:test>
          </fos:example>
@@ -6690,8 +6879,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:divide-yearMonthDuration-by-yearMonthDuration(xs:yearMonthDuration("P3Y4M"),
-                  xs:yearMonthDuration("-P1Y4M"))</fos:expression>
+               <fos:expression><eg>op:divide-yearMonthDuration-by-yearMonthDuration(
+  xs:yearMonthDuration("P3Y4M"),
+  xs:yearMonthDuration("-P1Y4M")
+)</eg></fos:expression>
                <fos:result>-2.5</fos:result>
             </fos:test>
          </fos:example>
@@ -6699,8 +6890,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <p>The following example demonstrates how to calculate the length of an
                   <code>xs:yearMonthDuration</code> value in months:</p>
             <fos:test>
-               <fos:expression>op:divide-yearMonthDuration-by-yearMonthDuration(xs:yearMonthDuration("P3Y4M"),
-                  xs:yearMonthDuration("P1M"))</fos:expression>
+               <fos:expression><eg>op:divide-yearMonthDuration-by-yearMonthDuration(
+  xs:yearMonthDuration("P3Y4M"),
+  xs:yearMonthDuration("P1M")
+)</eg></fos:expression>
                <fos:result>40</fos:result>
             </fos:test>
          </fos:example>
@@ -6731,8 +6924,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:add-dayTimeDurations(xs:dayTimeDuration("P2DT12H5M"),
-                  xs:dayTimeDuration("P5DT12H"))</fos:expression>
+               <fos:expression><eg>op:add-dayTimeDurations(
+  xs:dayTimeDuration("P2DT12H5M"),
+  xs:dayTimeDuration("P5DT12H")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration('P8DT5M')</fos:result>
             </fos:test>
          </fos:example>
@@ -6764,8 +6959,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-dayTimeDurations(xs:dayTimeDuration("P2DT12H"),
-                  xs:dayTimeDuration("P1DT10H30M"))</fos:expression>
+               <fos:expression><eg>op:subtract-dayTimeDurations(
+  xs:dayTimeDuration("P2DT12H"),
+  xs:dayTimeDuration("P1DT10H30M")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration('P1DT1H30M')</fos:result>
             </fos:test>
          </fos:example>
@@ -6811,8 +7008,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:multiply-dayTimeDuration(xs:dayTimeDuration("PT2H10M"),
-                  2.1)</fos:expression>
+               <fos:expression><eg>op:multiply-dayTimeDuration(
+  xs:dayTimeDuration("PT2H10M"),
+  2.1
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration('PT4H33M')</fos:result>
             </fos:test>
          </fos:example>
@@ -6857,8 +7056,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:divide-dayTimeDuration(xs:dayTimeDuration("P1DT2H30M10.5S"),
-                  1.5)</fos:expression>
+               <fos:expression><eg>op:divide-dayTimeDuration(
+  xs:dayTimeDuration("P1DT2H30M10.5S"),
+  1.5
+)</eg></fos:expression>
                <fos:result>xs:duration("PT17H40M7S")</fos:result>
             </fos:test>
          </fos:example>
@@ -6892,17 +7093,22 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>round-half-to-even(op:divide-dayTimeDuration-by-dayTimeDuration(
-                  xs:dayTimeDuration("P2DT53M11S"), xs:dayTimeDuration("P1DT10H")),
-                  4)</fos:expression>
+               <fos:expression><eg>round-half-to-even(
+  op:divide-dayTimeDuration-by-dayTimeDuration(
+    xs:dayTimeDuration("P2DT53M11S"), xs:dayTimeDuration("P1DT10H")
+  ),
+  4
+)</eg></fos:expression>
                <fos:result>1.4378</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>This examples shows how to determine the number of seconds in a duration.</p>
             <fos:test>
-               <fos:expression>op:divide-dayTimeDuration-by-dayTimeDuration(xs:dayTimeDuration("P2DT53M11S"),
-                  xs:dayTimeDuration("PT1S"))</fos:expression>
+               <fos:expression><eg>op:divide-dayTimeDuration-by-dayTimeDuration(
+  xs:dayTimeDuration("P2DT53M11S"),
+  xs:dayTimeDuration("PT1S")
+)</eg></fos:expression>
                <fos:result>175991.0</fos:result>
             </fos:test>
          </fos:example>
@@ -6948,15 +7154,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>dateTime(xs:date("1999-12-31"),
-                  xs:time("12:00:00"))</fos:expression>
+               <fos:expression><eg>dateTime(
+  xs:date("1999-12-31"),
+  xs:time("12:00:00")
+)</eg></fos:expression>
                <fos:result>xs:dateTime("1999-12-31T12:00:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>dateTime(xs:date("1999-12-31"),
-                  xs:time("24:00:00"))</fos:expression>
+               <fos:expression><eg>dateTime(
+  xs:date("1999-12-31"),
+  xs:time("24:00:00")
+)</eg></fos:expression>
                <fos:result>xs:dateTime("1999-12-31T00:00:00")</fos:result>
                <fos:postamble>This is because <code>"24:00:00"</code> is an alternate lexical form
                   for <code>"00:00:00"</code></fos:postamble>
@@ -7002,50 +7212,64 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:dateTime-equal(xs:dateTime("2002-04-02T12:00:00-01:00"),
-                  xs:dateTime("2002-04-02T17:00:00+04:00"))</fos:expression>
+               <fos:expression><eg>op:dateTime-equal(
+  xs:dateTime("2002-04-02T12:00:00-01:00"),
+  xs:dateTime("2002-04-02T17:00:00+04:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>op:dateTime-equal(xs:dateTime("2002-04-02T12:00:00"),
-                  xs:dateTime("2002-04-02T23:00:00+06:00"))</fos:expression>
+               <fos:expression><eg>op:dateTime-equal(
+  xs:dateTime("2002-04-02T12:00:00"),
+  xs:dateTime("2002-04-02T23:00:00+06:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:dateTime-equal(xs:dateTime("2002-04-02T12:00:00"),
-                  xs:dateTime("2002-04-02T17:00:00"))</fos:expression>
+               <fos:expression><eg>op:dateTime-equal(
+  xs:dateTime("2002-04-02T12:00:00"),
+  xs:dateTime("2002-04-02T17:00:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:dateTime-equal(xs:dateTime("2002-04-02T12:00:00"),
-                  xs:dateTime("2002-04-02T12:00:00"))</fos:expression>
+               <fos:expression><eg>op:dateTime-equal(
+  xs:dateTime("2002-04-02T12:00:00"),
+  xs:dateTime("2002-04-02T12:00:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:dateTime-equal(xs:dateTime("2002-04-02T23:00:00-04:00"),
-                  xs:dateTime("2002-04-03T02:00:00-01:00"))</fos:expression>
+               <fos:expression><eg>op:dateTime-equal(
+  xs:dateTime("2002-04-02T23:00:00-04:00"),
+  xs:dateTime("2002-04-03T02:00:00-01:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:dateTime-equal(xs:dateTime("1999-12-31T24:00:00"),
-                  xs:dateTime("2000-01-01T00:00:00"))</fos:expression>
+               <fos:expression><eg>op:dateTime-equal(
+  xs:dateTime("1999-12-31T24:00:00"),
+  xs:dateTime("2000-01-01T00:00:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:dateTime-equal(xs:dateTime("2005-04-04T24:00:00"),
-                  xs:dateTime("2005-04-04T00:00:00"))</fos:expression>
+               <fos:expression><eg>op:dateTime-equal(
+  xs:dateTime("2005-04-04T24:00:00"),
+  xs:dateTime("2005-04-04T00:00:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -7115,8 +7339,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:date-equal(xs:date("2004-12-25Z"),
-                  xs:date("2004-12-25+07:00"))</fos:expression>
+               <fos:expression><eg>op:date-equal(
+  xs:date("2004-12-25Z"),
+  xs:date("2004-12-25+07:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>The starting instants are
                      <code>xs:dateTime("2004-12-25T00:00:00Z")</code> and
@@ -7127,8 +7353,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:date-equal(xs:date("2004-12-25-12:00"),
-                  xs:date("2004-12-26+12:00"))</fos:expression>
+               <fos:expression><eg>op:date-equal(
+  xs:date("2004-12-25-12:00"),
+  xs:date("2004-12-26+12:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -7159,15 +7387,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:date-less-than(xs:date("2004-12-25Z"),
-                  xs:date("2004-12-25-05:00"))</fos:expression>
+               <fos:expression><eg>op:date-less-than(
+  xs:date("2004-12-25Z"),
+  xs:date("2004-12-25-05:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:date-less-than(xs:date("2004-12-25-12:00"),
-                  xs:date("2004-12-26+12:00"))</fos:expression>
+               <fos:expression><eg>op:date-less-than(
+  xs:date("2004-12-25-12:00"),
+  xs:date("2004-12-26+12:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -7212,8 +7444,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:time-equal(xs:time("08:00:00+09:00"),
-                  xs:time("17:00:00-06:00"))</fos:expression>
+               <fos:expression><eg>op:time-equal(
+  xs:time("08:00:00+09:00"),
+  xs:time("17:00:00-06:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>The <code>xs:dateTime</code>s calculated using the reference date
                   components are <code>1972-12-31T08:00:00+09:00</code> and
@@ -7224,15 +7458,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:time-equal(xs:time("21:30:00+10:30"),
-                  xs:time("06:00:00-05:00"))</fos:expression>
+               <fos:expression><eg>op:time-equal(
+  xs:time("21:30:00+10:30"),
+  xs:time("06:00:00-05:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:time-equal(xs:time("24:00:00+01:00"),
-                  xs:time("00:00:00+01:00"))</fos:expression>
+               <fos:expression><eg>op:time-equal(
+  xs:time("24:00:00+01:00"),
+  xs:time("00:00:00+01:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>This not the result one might expect. For <code>xs:dateTime</code>
                   values, a time of <code>24:00:00</code> is equivalent to <code>00:00:00</code> on
@@ -7285,22 +7523,28 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>op:time-less-than(xs:time("12:00:00"),
-                  xs:time("23:00:00+06:00"))</fos:expression>
+               <fos:expression><eg>op:time-less-than(
+  xs:time("12:00:00"),
+  xs:time("23:00:00+06:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:time-less-than(xs:time("11:00:00"),
-                  xs:time("17:00:00Z"))</fos:expression>
+               <fos:expression><eg>op:time-less-than(
+  xs:time("11:00:00"),
+  xs:time("17:00:00Z")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:time-less-than(xs:time("23:59:59"),
-                  xs:time("24:00:00"))</fos:expression>
+               <fos:expression><eg>op:time-less-than(
+  xs:time("23:59:59"),
+  xs:time("24:00:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -7395,8 +7639,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>op:gYear-equal(xs:gYear("1976-05:00"),
-                  xs:gYear("1976"))</fos:expression>
+               <fos:expression><eg>op:gYear-equal(
+  xs:gYear("1976-05:00"),
+  xs:gYear("1976")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -7439,8 +7685,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:gMonthDay-equal(xs:gMonthDay("--12-25-14:00"),
-                  xs:gMonthDay("--12-26+10:00"))</fos:expression>
+               <fos:expression><eg>op:gMonthDay-equal(
+  xs:gMonthDay("--12-25-14:00"),
+  xs:gMonthDay("--12-26+10:00")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble> The starting instants are <code>1972-12-25T00:00:00-14:00</code> and
                      <code>1972-12-26T00:00:00+10:00</code>, respectively, and normalize to
@@ -7450,8 +7698,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:gMonthDay-equal(xs:gMonthDay("--12-25"),
-                  xs:gMonthDay("--12-26Z"))</fos:expression>
+               <fos:expression><eg>op:gMonthDay-equal(
+  xs:gMonthDay("--12-25"),
+  xs:gMonthDay("--12-26Z")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -7492,8 +7742,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>op:gMonth-equal(xs:gMonth("--12-14:00"),
-                  xs:gMonth("--12+10:00"))</fos:expression>
+               <fos:expression><eg>op:gMonth-equal(
+  xs:gMonth("--12-14:00"),
+  xs:gMonth("--12+10:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble> The starting instants are <code>1972-12-01T00:00:00-14:00</code> and
                      <code>1972-12-01T00:00:00+10:00</code>, respectively, and normalize to
@@ -7503,8 +7755,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>op:gMonth-equal(xs:gMonth("--12"),
-                  xs:gMonth("--12Z"))</fos:expression>
+               <fos:expression><eg>op:gMonth-equal(
+  xs:gMonth("--12"),
+  xs:gMonth("--12Z")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -7545,8 +7799,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:gDay-equal(xs:gDay("---25-14:00"),
-                  xs:gDay("---25+10:00"))</fos:expression>
+               <fos:expression><eg>op:gDay-equal(
+  xs:gDay("---25-14:00"),
+  xs:gDay("---25+10:00")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble> The starting instants are <code>1972-12-25T00:00:00-14:00</code> and
                      <code>1972-12-25T00:00:00+10:00</code>, respectively, and normalize to
@@ -7590,31 +7846,41 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>year-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>year-from-dateTime(
+  xs:dateTime("1999-05-31T13:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>1999</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>year-from-dateTime(xs:dateTime("1999-05-31T21:30:00-05:00"))</fos:expression>
+               <fos:expression><eg>year-from-dateTime(
+  xs:dateTime("1999-05-31T21:30:00-05:00")
+)</eg></fos:expression>
                <fos:result>1999</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>year-from-dateTime(xs:dateTime("1999-12-31T19:20:00"))</fos:expression>
+               <fos:expression><eg>year-from-dateTime(
+  xs:dateTime("1999-12-31T19:20:00")
+)</eg></fos:expression>
                <fos:result>1999</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>year-from-dateTime(xs:dateTime("1999-12-31T24:00:00"))</fos:expression>
+               <fos:expression><eg>year-from-dateTime(
+  xs:dateTime("1999-12-31T24:00:00")
+)</eg></fos:expression>
                <fos:result>2000</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>year-from-dateTime(xs:dateTime("-0002-06-06T00:00:00"))</fos:expression>
+               <fos:expression><eg>year-from-dateTime(
+  xs:dateTime("-0002-06-06T00:00:00")
+)</eg></fos:expression>
                <fos:result>-2</fos:result>
                <fos:postamble>The result is the same whether XSD 1.0 or 1.1 is in use, despite
                   the absence of a year 0 in the XSD 1.0 value space.</fos:postamble>
@@ -7645,20 +7911,28 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>month-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>month-from-dateTime(
+  xs:dateTime("1999-05-31T13:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>month-from-dateTime(xs:dateTime("1999-12-31T19:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>month-from-dateTime(
+  xs:dateTime("1999-12-31T19:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>12</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>month-from-dateTime(adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T19:20:00-05:00"),
-                  xs:dayTimeDuration("PT0S")))</fos:expression>
+               <fos:expression><eg>month-from-dateTime(
+  adjust-dateTime-to-timezone(
+    xs:dateTime("1999-12-31T19:20:00-05:00"),
+    xs:dayTimeDuration("PT0S")
+  )
+)</eg></fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -7687,20 +7961,28 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>day-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>day-from-dateTime(
+  xs:dateTime("1999-05-31T13:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>31</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>day-from-dateTime(xs:dateTime("1999-12-31T20:00:00-05:00"))</fos:expression>
+               <fos:expression><eg>day-from-dateTime(
+  xs:dateTime("1999-12-31T20:00:00-05:00")
+)</eg></fos:expression>
                <fos:result>31</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>day-from-dateTime(adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T19:20:00-05:00"),
-                  xs:dayTimeDuration("PT0S")))</fos:expression>
+               <fos:expression><eg>day-from-dateTime(
+  adjust-dateTime-to-timezone(
+    xs:dateTime("1999-12-31T19:20:00-05:00"),
+    xs:dayTimeDuration("PT0S")
+  )
+)</eg></fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -7729,32 +8011,44 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-dateTime(xs:dateTime("1999-05-31T08:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>hours-from-dateTime(
+  xs:dateTime("1999-05-31T08:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>8</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-dateTime(xs:dateTime("1999-12-31T21:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>hours-from-dateTime(
+  xs:dateTime("1999-12-31T21:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>21</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-dateTime(adjust-dateTime-to-timezone(xs:dateTime("1999-12-31T21:20:00-05:00"),
-                  xs:dayTimeDuration("PT0S")))</fos:expression>
+               <fos:expression><eg>hours-from-dateTime(
+  adjust-dateTime-to-timezone(
+    xs:dateTime("1999-12-31T21:20:00-05:00"),
+    xs:dayTimeDuration("PT0S")
+  )
+)</eg></fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-dateTime(xs:dateTime("1999-12-31T12:00:00"))</fos:expression>
+               <fos:expression><eg>hours-from-dateTime(
+  xs:dateTime("1999-12-31T12:00:00")
+)</eg></fos:expression>
                <fos:result>12</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-dateTime(xs:dateTime("1999-12-31T24:00:00"))</fos:expression>
+               <fos:expression><eg>hours-from-dateTime(
+  xs:dateTime("1999-12-31T24:00:00")
+)</eg></fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -7783,13 +8077,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>minutes-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>minutes-from-dateTime(
+  xs:dateTime("1999-05-31T13:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>20</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>minutes-from-dateTime(xs:dateTime("1999-05-31T13:30:00+05:30"))</fos:expression>
+               <fos:expression><eg>minutes-from-dateTime(
+  xs:dateTime("1999-05-31T13:30:00+05:30")
+)</eg></fos:expression>
                <fos:result>30</fos:result>
             </fos:test>
          </fos:example>
@@ -7818,7 +8116,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>seconds-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>seconds-from-dateTime(
+  xs:dateTime("1999-05-31T13:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
@@ -7849,19 +8149,25 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>timezone-from-dateTime(xs:dateTime("1999-05-31T13:20:00-05:00"))</fos:expression>
+               <fos:expression><eg>timezone-from-dateTime(
+  xs:dateTime("1999-05-31T13:20:00-05:00")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("-PT5H")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>timezone-from-dateTime(xs:dateTime("2000-06-12T13:20:00Z"))</fos:expression>
+               <fos:expression><eg>timezone-from-dateTime(
+  xs:dateTime("2000-06-12T13:20:00Z")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("PT0S")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>timezone-from-dateTime(xs:dateTime("2004-08-27T00:00:00"))</fos:expression>
+               <fos:expression><eg>timezone-from-dateTime(
+  xs:dateTime("2004-08-27T00:00:00")
+)</eg></fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -8069,8 +8375,12 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hours-from-time(adjust-time-to-timezone(xs:time("01:23:00+05:00"),
-                  xs:dayTimeDuration("PT0S")))</fos:expression>
+               <fos:expression><eg>hours-from-time(
+  adjust-time-to-timezone(
+    xs:time("01:23:00+05:00"),
+    xs:dayTimeDuration("PT0S")
+  )
+)</eg></fos:expression>
                <fos:result>20</fos:result>
             </fos:test>
          </fos:example>
@@ -8232,55 +8542,71 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             select="xs:dayTimeDuration(&quot;-PT10H&quot;)"/>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'))</fos:expression>
+               <fos:expression><eg>adjust-dateTime-to-timezone(
+  xs:dateTime('2002-03-07T10:00:00')
+)</eg></fos:expression>
                <fos:result>xs:dateTime('2002-03-07T10:00:00-05:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-dateTime-to-timezone-tz10">
-               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'))</fos:expression>
+               <fos:expression><eg>adjust-dateTime-to-timezone(
+  xs:dateTime('2002-03-07T10:00:00-07:00')
+)</eg></fos:expression>
                <fos:result>xs:dateTime('2002-03-07T12:00:00-05:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-dateTime-to-timezone-tz10">
-               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'),
-                  $tz-10)</fos:expression>
+               <fos:expression><eg>adjust-dateTime-to-timezone(
+  xs:dateTime('2002-03-07T10:00:00'),
+  $tz-10
+)</eg></fos:expression>
                <fos:result>xs:dateTime('2002-03-07T10:00:00-10:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-dateTime-to-timezone-tz10">
-               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
-                  $tz-10)</fos:expression>
+               <fos:expression><eg>adjust-dateTime-to-timezone(
+  xs:dateTime('2002-03-07T10:00:00-07:00'),
+  $tz-10
+)</eg></fos:expression>
                <fos:result>xs:dateTime('2002-03-07T07:00:00-10:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
-                  xs:dayTimeDuration("PT10H"))</fos:expression>
+               <fos:expression><eg>adjust-dateTime-to-timezone(
+  xs:dateTime('2002-03-07T10:00:00-07:00'),
+  xs:dayTimeDuration("PT10H")
+)</eg></fos:expression>
                <fos:result>xs:dateTime('2002-03-08T03:00:00+10:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T00:00:00+01:00'),
-                  xs:dayTimeDuration("-PT8H"))</fos:expression>
+               <fos:expression><eg>adjust-dateTime-to-timezone(
+  xs:dateTime('2002-03-07T00:00:00+01:00'),
+  xs:dayTimeDuration("-PT8H")
+)</eg></fos:expression>
                <fos:result>xs:dateTime('2002-03-06T15:00:00-08:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00'),
-                  ())</fos:expression>
+               <fos:expression><eg>adjust-dateTime-to-timezone(
+  xs:dateTime('2002-03-07T10:00:00'),
+  ()
+)</eg></fos:expression>
                <fos:result>xs:dateTime('2002-03-07T10:00:00')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-dateTime-to-timezone(xs:dateTime('2002-03-07T10:00:00-07:00'),
-                  ())</fos:expression>
+               <fos:expression><eg>adjust-dateTime-to-timezone(
+  xs:dateTime('2002-03-07T10:00:00-07:00'),
+  ()
+)</eg></fos:expression>
                <fos:result>xs:dateTime('2002-03-07T10:00:00')</fos:result>
             </fos:test>
          </fos:example>
@@ -8353,13 +8679,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             select="xs:dayTimeDuration(&quot;-PT10H&quot;)"/>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07"))</fos:expression>
+               <fos:expression><eg>adjust-date-to-timezone(
+  xs:date("2002-03-07")
+)</eg></fos:expression>
                <fos:result>xs:date("2002-03-07-05:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07-07:00"))</fos:expression>
+               <fos:expression><eg>adjust-date-to-timezone(
+  xs:date("2002-03-07-07:00")
+)</eg></fos:expression>
                <fos:result>xs:date("2002-03-07-05:00")</fos:result>
                <fos:postamble><code>$value</code> is converted to
                      <code>xs:dateTime("2002-03-07T00:00:00-07:00")</code>. This is adjusted to the
@@ -8369,15 +8699,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-date-to-timezone-tz10">
-               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07"),
-                  $tz-10)</fos:expression>
+               <fos:expression><eg>adjust-date-to-timezone(
+  xs:date("2002-03-07"),
+  $tz-10
+)</eg></fos:expression>
                <fos:result>xs:date("2002-03-07-10:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-date-to-timezone-tz10">
-               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07-07:00"),
-                  $tz-10)</fos:expression>
+               <fos:expression><eg>adjust-date-to-timezone(
+  xs:date("2002-03-07-07:00"),
+  $tz-10
+)</eg></fos:expression>
                <fos:result>xs:date("2002-03-06-10:00")</fos:result>
                <fos:postamble><code>$value</code> is converted to
                   <code>xs:dateTime("2002-03-07T00:00:00-07:00")</code>.
@@ -8387,15 +8721,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07"),
-                  ())</fos:expression>
+               <fos:expression><eg>adjust-date-to-timezone(
+  xs:date("2002-03-07"),
+  ()
+)</eg></fos:expression>
                <fos:result>xs:date("2002-03-07")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-date-to-timezone(xs:date("2002-03-07-07:00"),
-                  ())</fos:expression>
+               <fos:expression><eg>adjust-date-to-timezone(
+  xs:date("2002-03-07-07:00"),
+  ()
+)</eg></fos:expression>
                <fos:result>xs:date("2002-03-07")</fos:result>
             </fos:test>
          </fos:example>
@@ -8469,47 +8807,62 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             select="xs:dayTimeDuration(&quot;-PT10H&quot;)"/>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00"))</fos:expression>
+               <fos:expression><eg>adjust-time-to-timezone(
+  xs:time("10:00:00")
+)</eg></fos:expression>
                <fos:result>xs:time("10:00:00-05:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00-07:00"))</fos:expression>
+               <fos:expression><eg>adjust-time-to-timezone(
+  xs:time("10:00:00-07:00")
+)</eg></fos:expression>
                <fos:result>xs:time("12:00:00-05:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-time-to-timezone-tz10">
-               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00"),
-                  $tz-10)</fos:expression>
+               <fos:expression><eg>adjust-time-to-timezone(
+  xs:time("10:00:00"),
+  $tz-10
+)</eg></fos:expression>
                <fos:result>xs:time("10:00:00-10:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-adjust-time-to-timezone-tz10">
-               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00-07:00"),
-                  $tz-10)</fos:expression>
+               <fos:expression><eg>adjust-time-to-timezone(
+  xs:time("10:00:00-07:00"),
+  $tz-10
+)</eg></fos:expression>
                <fos:result>xs:time("07:00:00-10:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00"), ())</fos:expression>
+               <fos:expression><eg>adjust-time-to-timezone(
+  xs:time("10:00:00"),
+  ()
+)</eg></fos:expression>
                <fos:result>xs:time("10:00:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00-07:00"),
-                  ())</fos:expression>
+               <fos:expression><eg>adjust-time-to-timezone(
+  xs:time("10:00:00-07:00"),
+  ()
+)</eg></fos:expression>
                <fos:result>xs:time("10:00:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>adjust-time-to-timezone(xs:time("10:00:00-07:00"),
-                  xs:dayTimeDuration("PT10H"))</fos:expression>
+               <fos:expression><eg>adjust-time-to-timezone(
+  xs:time("10:00:00-07:00"),
+  xs:dayTimeDuration("PT10H")
+)</eg></fos:expression>
                <fos:result>xs:time("03:00:00+10:00")</fos:result>
             </fos:test>
          </fos:example>
@@ -8558,8 +8911,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>op:subtract-dateTimes(xs:dateTime("2000-10-30T06:12:00"),
-                  xs:dateTime("1999-11-28T09:00:00Z"))</fos:expression>
+               <fos:expression><eg>op:subtract-dateTimes(
+  xs:dateTime("2000-10-30T06:12:00"),
+  xs:dateTime("1999-11-28T09:00:00Z")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("P337DT2H12M")</fos:result>
             </fos:test>
          </fos:example>
@@ -8606,8 +8961,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="PT0S">
-               <fos:expression>op:subtract-dates(xs:date("2000-10-30"),
-                  xs:date("1999-11-28"))</fos:expression>
+               <fos:expression><eg>op:subtract-dates(
+  xs:date("2000-10-30"),
+  xs:date("1999-11-28")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("P337D")</fos:result>
                <fos:postamble>The normalized values of the two starting instants are <code>{2000,
                      10, 30, 0, 0, 0, PT0S}</code> and <code>{1999, 11, 28, 0, 0, 0,
@@ -8620,8 +8977,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="PT5H">
-               <fos:expression>op:subtract-dates(xs:date("2000-10-30"),
-                  xs:date("1999-11-28Z"))</fos:expression>
+               <fos:expression><eg>op:subtract-dates(
+  xs:date("2000-10-30"),
+  xs:date("1999-11-28Z")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("P336DT19H")</fos:result>
                <fos:postamble> The normalized values of the two starting instants are <code>{2000,
                      10, 29, 19, 0, 0, PT0S}</code> and <code>{1999, 11, 28, 0, 0, 0,
@@ -8630,8 +8989,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-dates(xs:date("2000-10-15-05:00"),
-                  xs:date("2000-10-10+02:00"))</fos:expression>
+               <fos:expression><eg>op:subtract-dates(
+  xs:date("2000-10-15-05:00"),
+  xs:date("2000-10-10+02:00")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("P5DT7H")</fos:result>
             </fos:test>
          </fos:example>
@@ -8674,8 +9035,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test implicit-timezone="-PT5H">
-               <fos:expression>op:subtract-times(xs:time("11:12:00Z"),
-                  xs:time("04:00:00"))</fos:expression>
+               <fos:expression><eg>op:subtract-times(
+  xs:time("11:12:00Z"),
+  xs:time("04:00:00")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("PT2H12M")</fos:result>
                <fos:postamble>This is obtained by subtracting from the <code>xs:dateTime</code>
                   value <code>{1972, 12, 31, 11, 12, 0, PT0S}</code> the <code>xs:dateTime</code>
@@ -8684,8 +9047,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-times(xs:time("11:00:00-05:00"),
-                  xs:time("21:30:00+05:30"))</fos:expression>
+               <fos:expression><eg>op:subtract-times(
+  xs:time("11:00:00-05:00"),
+  xs:time("21:30:00+05:30")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("PT0S")</fos:result>
                <fos:postamble>The two <code>xs:dateTime</code> values are <code>{1972, 12, 31, 11,
                      0, 0, -PT5H}</code> and <code>{1972, 12, 31, 21, 30, 0, PT5H30M}</code>. These
@@ -8695,8 +9060,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-times(xs:time("17:00:00-06:00"),
-                  xs:time("08:00:00+09:00"))</fos:expression>
+               <fos:expression><eg>op:subtract-times(
+  xs:time("17:00:00-06:00"),
+  xs:time("08:00:00+09:00")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("P1D")</fos:result>
                <fos:postamble>The two normalized <code>xs:dateTime</code> values are <code>{1972,
                      12, 31, 23, 0, 0, PT0S}</code> and <code>{1972, 12, 30, 23, 0, 0,
@@ -8705,8 +9072,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-times(xs:time("24:00:00"),
-                  xs:time("23:59:59"))</fos:expression>
+               <fos:expression><eg>op:subtract-times(
+  xs:time("24:00:00"),
+  xs:time("23:59:59")
+)</eg></fos:expression>
                <fos:result>xs:dayTimeDuration("-PT23H59M59S")</fos:result>
                <fos:postamble>The two normalized <code>xs:dateTime</code> values are <code>{1972,
                      12, 31, 0, 0, 0, ()}</code> and <code>{1972, 12, 31, 23, 59, 59.0,
@@ -8747,8 +9116,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:add-yearMonthDuration-to-dateTime(xs:dateTime("2000-10-30T11:12:00"),
-                  xs:yearMonthDuration("P1Y2M"))</fos:expression>
+               <fos:expression><eg>op:add-yearMonthDuration-to-dateTime(
+  xs:dateTime("2000-10-30T11:12:00"),
+  xs:yearMonthDuration("P1Y2M")
+)</eg></fos:expression>
                <fos:result>xs:dateTime("2001-12-30T11:12:00")</fos:result>
             </fos:test>
          </fos:example>
@@ -8786,8 +9157,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:add-dayTimeDuration-to-dateTime(xs:dateTime("2000-10-30T11:12:00"),
-                  xs:dayTimeDuration("P3DT1H15M"))</fos:expression>
+               <fos:expression><eg>op:add-dayTimeDuration-to-dateTime(
+  xs:dateTime("2000-10-30T11:12:00"),
+  xs:dayTimeDuration("P3DT1H15M")
+)</eg></fos:expression>
                <fos:result>xs:dateTime("2000-11-02T12:27:00")</fos:result>
             </fos:test>
          </fos:example>
@@ -8821,8 +9194,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-yearMonthDuration-from-dateTime(xs:dateTime("2000-10-30T11:12:00"),
-                  xs:yearMonthDuration("P1Y2M"))</fos:expression>
+               <fos:expression><eg>op:subtract-yearMonthDuration-from-dateTime(
+  xs:dateTime("2000-10-30T11:12:00"),
+  xs:yearMonthDuration("P1Y2M")
+)</eg></fos:expression>
                <fos:result>xs:dateTime("1999-08-30T11:12:00")</fos:result>
             </fos:test>
          </fos:example>
@@ -8851,8 +9226,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-dayTimeDuration-from-dateTime(xs:dateTime("2000-10-30T11:12:00"),
-                  xs:dayTimeDuration("P3DT1H15M"))</fos:expression>
+               <fos:expression><eg>op:subtract-dayTimeDuration-from-dateTime(
+  xs:dateTime("2000-10-30T11:12:00"),
+  xs:dayTimeDuration("P3DT1H15M")
+)</eg></fos:expression>
                <fos:result>xs:dateTime("2000-10-27T09:57:00")</fos:result>
             </fos:test>
          </fos:example>
@@ -8887,8 +9264,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:add-yearMonthDuration-to-date(xs:date("2000-10-30"),
-                  xs:yearMonthDuration("P1Y2M"))</fos:expression>
+               <fos:expression><eg>op:add-yearMonthDuration-to-date(
+  xs:date("2000-10-30"),
+  xs:yearMonthDuration("P1Y2M")
+)</eg></fos:expression>
                <fos:result>xs:date("2001-12-30")</fos:result>
             </fos:test>
          </fos:example>
@@ -8923,8 +9302,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:add-dayTimeDuration-to-date(xs:date("2004-10-30Z"),
-                  xs:dayTimeDuration("P2DT2H30M0S"))</fos:expression>
+               <fos:expression><eg>op:add-dayTimeDuration-to-date(
+  xs:date("2004-10-30Z"),
+  xs:dayTimeDuration("P2DT2H30M0S")
+)</eg></fos:expression>
                <fos:result>xs:date("2004-11-01Z")</fos:result>
                <fos:postamble> The starting instant of the first argument is the
                      <code>xs:dateTime</code> value <code>{2004, 10, 30, 0, 0, 0, PT0S}</code>.
@@ -8963,22 +9344,28 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-yearMonthDuration-from-date(xs:date("2000-10-30"),
-                  xs:yearMonthDuration("P1Y2M"))</fos:expression>
+               <fos:expression><eg>op:subtract-yearMonthDuration-from-date(
+  xs:date("2000-10-30"),
+  xs:yearMonthDuration("P1Y2M")
+)</eg></fos:expression>
                <fos:result>xs:date("1999-08-30")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-yearMonthDuration-from-date(xs:date("2000-02-29Z"),
-                  xs:yearMonthDuration("P1Y"))</fos:expression>
+               <fos:expression><eg>op:subtract-yearMonthDuration-from-date(
+  xs:date("2000-02-29Z"),
+  xs:yearMonthDuration("P1Y")
+)</eg></fos:expression>
                <fos:result>xs:date("1999-02-28Z")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-yearMonthDuration-from-date(xs:date("2000-10-31-05:00"),
-                  xs:yearMonthDuration("P1Y1M"))</fos:expression>
+               <fos:expression><eg>op:subtract-yearMonthDuration-from-date(
+  xs:date("2000-10-31-05:00"),
+  xs:yearMonthDuration("P1Y1M")
+)</eg></fos:expression>
                <fos:result>xs:date("1999-09-30-05:00")</fos:result>
             </fos:test>
          </fos:example>
@@ -9012,8 +9399,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-dayTimeDuration-from-date(xs:date("2000-10-30"),
-                  xs:dayTimeDuration("P3DT1H15M"))</fos:expression>
+               <fos:expression><eg>op:subtract-dayTimeDuration-from-date(
+  xs:date("2000-10-30"),
+  xs:dayTimeDuration("P3DT1H15M")
+)</eg></fos:expression>
                <fos:result>xs:date("2000-10-26")</fos:result>
             </fos:test>
          </fos:example>
@@ -9050,15 +9439,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:add-dayTimeDuration-to-time(xs:time("11:12:00"),
-                  xs:dayTimeDuration("P3DT1H15M"))</fos:expression>
+               <fos:expression><eg>op:add-dayTimeDuration-to-time(
+  xs:time("11:12:00"),
+  xs:dayTimeDuration("P3DT1H15M")
+)</eg></fos:expression>
                <fos:result>xs:time("12:27:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:add-dayTimeDuration-to-time(xs:time("23:12:00+03:00"),
-                  xs:dayTimeDuration("P1DT3H15M"))</fos:expression>
+               <fos:expression><eg>op:add-dayTimeDuration-to-time(
+  xs:time("23:12:00+03:00"),
+  xs:dayTimeDuration("P1DT3H15M")
+)</eg></fos:expression>
                <fos:result>xs:time("02:27:00+03:00")</fos:result>
                <fos:postamble>That is, <code>{0, 0, 0, 2, 27, 0, PT3H}</code></fos:postamble>
             </fos:test>
@@ -9093,15 +9486,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-dayTimeDuration-from-time(xs:time("11:12:00"),
-                  xs:dayTimeDuration("P3DT1H15M"))</fos:expression>
+               <fos:expression><eg>op:subtract-dayTimeDuration-from-time(
+  xs:time("11:12:00"),
+  xs:dayTimeDuration("P3DT1H15M")
+)</eg></fos:expression>
                <fos:result>xs:time("09:57:00")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>op:subtract-dayTimeDuration-from-time(xs:time("08:20:00-05:00"),
-                  xs:dayTimeDuration("P23DT10H10M"))</fos:expression>
+               <fos:expression><eg>op:subtract-dayTimeDuration-from-time(
+  xs:time("08:20:00-05:00"),
+  xs:dayTimeDuration("P23DT10H10M")
+)</eg></fos:expression>
                <fos:result>xs:time("22:10:00-05:00")</fos:result>
             </fos:test>
          </fos:example>
@@ -9805,7 +10202,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>QName("http://www.example.com/example", "person") => expanded-QName()</fos:expression>
+               <fos:expression><eg>QName("http://www.example.com/example", "person")
+=> expanded-QName()</eg></fos:expression>
                <fos:result>Q{http://www.example.com/example}person</fos:result>
             </fos:test>
             <fos:test>
@@ -9897,8 +10295,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>local-name-from-QName(QName("http://www.example.com/example",
-                  "person"))</fos:expression>
+               <fos:expression><eg>local-name-from-QName(
+  QName("http://www.example.com/example", "person")
+)</eg></fos:expression>
                <fos:result>"person"</fos:result>
             </fos:test>
          </fos:example>
@@ -9928,8 +10327,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>namespace-uri-from-QName(QName("http://www.example.com/example",
-                  "person"))</fos:expression>
+               <fos:expression><eg>namespace-uri-from-QName(
+  QName("http://www.example.com/example", "person")
+)</eg></fos:expression>
                <fos:result>xs:anyURI("http://www.example.com/example")</fos:result>
             </fos:test>
          </fos:example>
@@ -10700,17 +11100,20 @@ Himmlische, dein Heiligtum.</p>}]]>
                <fos:result>'/Q{http://example.com/one}p[1]/Q{http://example.com/one}br[2]'</fos:result>
             </fos:test>
             <fos:test use="v-path-e">
-               <fos:expression>path($e//text()[starts-with(normalize-space(),
-                  'Tochter')])</fos:expression>
+               <fos:expression><eg>path(
+  $e//text()[
+    starts-with(normalize-space(), 'Tochter')
+  ]
+)</eg></fos:expression>
                <fos:result>'/Q{http://example.com/one}p[1]/text()[2]'</fos:result>
             </fos:test>
          </fos:example>
          <fos:variable name="emp" id="v-path-emp" as="element()"><![CDATA[
-            <employee xml:id="ID21256">
-               <empnr>E21256</empnr>
-               <first>John</first>
-               <last>Brown</last>
-            </employee>]]>
+  <employee xml:id="ID21256">
+     <empnr>E21256</empnr>
+     <first>John</first>
+     <last>Brown</last>
+  </employee>]]>
          </fos:variable>
          <fos:example>
             <fos:test use="v-path-emp">
@@ -11037,8 +11440,10 @@ let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>index-of(("a", "sport", "and", "a", "pastime"),
-                  "a")</fos:expression>
+               <fos:expression><eg>index-of(
+  ("a", "sport", "and", "a", "pastime"),
+  "a"
+)</eg></fos:expression>
                <fos:result>(1, 4)</fos:result>
             </fos:test>
          </fos:example>
@@ -11270,8 +11675,11 @@ let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>distinct-values((xs:untypedAtomic("cherry"),
-                  xs:untypedAtomic("plum"), xs:untypedAtomic("plum")))</fos:expression>
+               <fos:expression><eg>distinct-values((
+  xs:untypedAtomic("cherry"),
+  xs:untypedAtomic("plum"),
+  xs:untypedAtomic("plum")
+))</eg></fos:expression>
                <fos:result allow-permutation="true"
                   >(xs:untypedAtomic("cherry"),
                   xs:untypedAtomic("plum"))</fos:result>
@@ -12058,39 +12466,39 @@ let $newi := $o/tool</eg>
          <fos:variable name="in" id="v-slice" as="xs:string*" select="('a', 'b', 'c', 'd', 'e')"/>
          <fos:example>
             <fos:test>
-               <fos:expression>slice($in, start:2, end:4)</fos:expression>
+               <fos:expression>slice($in, start := 2, end := 4)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:2)</fos:expression>
+               <fos:expression>slice($in, start := 2)</fos:expression>
                <fos:result>("b", "c", "d", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, end:2)</fos:expression>
+               <fos:expression>slice($in, end := 2)</fos:expression>
                <fos:result>("a", "b")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:3, end:3)</fos:expression>
+               <fos:expression>slice($in, start := 3, end := 3)</fos:expression>
                <fos:result>("c")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:4, end:3)</fos:expression>
+               <fos:expression>slice($in, start := 4, end := 3)</fos:expression>
                <fos:result>("d", "c")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:2, end:5, step:2)</fos:expression>
+               <fos:expression>slice($in, start := 2, end := 5, step := 2)</fos:expression>
                <fos:result>("b", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:5, end:2, step:-2)</fos:expression>
+               <fos:expression>slice($in, start := 5, end := 2, step := -2)</fos:expression>
                <fos:result>("e", "c")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:2, end:5, step:-2)</fos:expression>
+               <fos:expression>slice($in, start := 2, end := 5, step := -2)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:5, end:2, step:2)</fos:expression>
+               <fos:expression>slice($in, start := 5, end := 2, step := 2)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
@@ -12098,39 +12506,39 @@ let $newi := $o/tool</eg>
                <fos:result>("a", "b", "c", "d", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:-1)</fos:expression>
+               <fos:expression>slice($in, start := -1)</fos:expression>
                <fos:result>("e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:-3)</fos:expression>
+               <fos:expression>slice($in, start := -3)</fos:expression>
                <fos:result>("c", "d", "e")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, end:-2)</fos:expression>
+               <fos:expression>slice($in, end := -2)</fos:expression>
                <fos:result>("a", "b", "c", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:2, end:-2)</fos:expression>
+               <fos:expression>slice($in, start := 2, end := -2)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:-2, end:2)</fos:expression>
+               <fos:expression>slice($in, start := -2, end := 2)</fos:expression>
                <fos:result>("d", "c", "b")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:-4, end:-2)</fos:expression>
+               <fos:expression>slice($in, start := -4, end := -2)</fos:expression>
                <fos:result>("b", "c", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:-2, end:-4)</fos:expression>
+               <fos:expression>slice($in, start := -2, end := -4)</fos:expression>
                <fos:result>("d", "c", "b")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:-4, end:-2, step:2)</fos:expression>
+               <fos:expression>slice($in, start := -4, end := -2, step := 2)</fos:expression>
                <fos:result>("b", "d")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>slice($in, start:-2, end:-4, step:-2)</fos:expression>
+               <fos:expression>slice($in, start := -2, end := -4, step := -2)</fos:expression>
                <fos:result>("d", "b")</fos:result>
             </fos:test>
             <fos:test>
@@ -12204,15 +12612,34 @@ and all(for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>starts-with-sequence(1 to 10, 101 to 105, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
+               <fos:expression><eg>starts-with-sequence(
+  1 to 10,
+  101 to 105,
+  function($x, $y) { $x mod 100 = $y mod 100 }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>starts-with-sequence(("A", "B", "C"), ("a", "b"), ->($x, $y){compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
+               <fos:expression><eg>starts-with-sequence(
+  ("A", "B", "C"),
+  ("a", "b"),
+  function($x, $y) {
+    compare(
+      $x,
+      $y,
+      "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"
+    ) eq 0
+  }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return starts-with-sequence($p!ancestor::*, $p!parent::*, op("is"))]]></fos:expression>
+               <fos:expression><eg><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2]
+return starts-with-sequence(
+  $p/ancestor::*[1],
+  $p/parent::*,
+  op("is")
+)]]></eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>       
             <fos:test>
@@ -12220,11 +12647,19 @@ and all(for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>starts-with-sequence(("Alpha", "Beta", "Gamma"), ("A", "B"), starts-with#2)</fos:expression>
+               <fos:expression><eg>starts-with-sequence(
+  ("Alpha", "Beta", "Gamma"),
+  ("A", "B"),
+  starts-with#2
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>starts-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 3, ->($x, $y){ends-with($x, 'a')}</fos:expression>
+               <fos:expression><eg>starts-with-sequence(
+  ("Alpha", "Beta", "Gamma", "Delta"),
+  1 to 3,
+  function($x, $y) { ends-with($x, 'a' ) }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the first three items in the input sequence end with <code>"a"</code>.</fos:postamble>
             </fos:test>
@@ -12291,16 +12726,34 @@ and all(for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>ends-with-sequence(1 to 10, 108 to 110, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
+               <fos:expression><eg>ends-with-sequence(
+  1 to 10,
+  108 to 110,
+  function($x, $y) { $x mod 100 = $y mod 100 }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>ends-with-sequence(("A", "B", "C"), ("b", "c"), ->($x, $y){compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
+               <fos:expression><eg>ends-with-sequence(
+  ("A", "B", "C"),
+  ("b", "c"),
+  function($x, $y) {
+    compare(
+      $x,
+      $y,
+      "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"
+    ) eq 0
+  }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2] return ends-with-sequence($p!ancestor::node(), $p!root(), op("is"))</fos:expression>
-               <fos:result>true()]]></fos:expression>
+               <fos:expression><eg><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2]
+return ends-with-sequence(
+  $p/ancestor::node()[last()],
+  $p/root(),
+  op("is")
+)]]></eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>       
             <fos:test>
@@ -12308,11 +12761,19 @@ and all(for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>ends-with-sequence(("Alpha", "Beta", "Gamma"), ("B", "G"), starts-with#2)</fos:expression>
+               <fos:expression><eg>ends-with-sequence(
+  ("Alpha", "Beta", "Gamma"),
+  ("B", "G"),
+  starts-with#2
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>ends-with-sequence(("Alpha", "Beta", "Gamma", "Delta"), 1 to 2, ->($x, $y){string-length($x) eq 5}</fos:expression>
+               <fos:expression><eg>ends-with-sequence(
+  ("Alpha", "Beta", "Gamma", "Delta"),
+  1 to 2,
+  function($x, $y) { string-length($x) eq 5 }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the last two items in the input sequence have a string length of 5.</fos:postamble>
             </fos:test>
@@ -12387,15 +12848,26 @@ else if (empty($input))
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(1 to 10, 103 to 105, ->($x, $y){$x mod 100 = $y mod 100})</fos:expression>
+               <fos:expression><eg>contains-sequence(
+  1 to 10,
+  103 to 105,
+  function($x, $y) { $x mod 100 = $y mod 100 }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(("A", "B", "C", "D"), ("b", "c"), ->($x, $y){compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0})</fos:expression>
+               <fos:expression><eg>contains-sequence(
+  ("A", "B", "C", "D"),
+  ("b", "c"),
+  function($x, $y) {
+    compare($x, $y, "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive") eq 0
+  }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[let $chap := parse-xml("<doc><chap><h1/><p/><p/><footnote/></chap></doc>")//chap return contains-sequence($chap!child::*, $chap!child::p, op("is"))]]></fos:expression>
+               <fos:expression><eg><![CDATA[let $chap := parse-xml("<doc><chap><h1/><p/><p/><footnote/></chap></doc>")//chap
+return contains-sequence($chap ! child::*, $chap ! child::p, op("is"))]]></eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because the <code>p</code> children of the <code>chap</code> element form a contiguous subsequence.</fos:postamble>
             </fos:test>       
@@ -12404,11 +12876,18 @@ else if (empty($input))
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(("Alpha", "Beta", "Gamma", "Delta"), ("B", "G"), starts-with#2)</fos:expression>
+               <fos:expression><eg>contains-sequence(
+  ("Alpha", "Beta", "Gamma", "Delta"), ("B", "G"),
+  starts-with#2
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(("Zero", "Alpha", "Beta", "Gamma", "Delta", "Epsilon"), 1 to 4, ->($x, $y){ends-with($x, 'a')}</fos:expression>
+               <fos:expression><eg>contains-sequence(
+  ("Zero", "Alpha", "Beta", "Gamma", "Delta", "Epsilon"),
+  1 to 4,
+  function($x, $y) { ends-with($x, 'a') }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because there is a run of 4 consecutive items ending in <code>"a"</code>.</fos:postamble>
             </fos:test>
@@ -13793,8 +14272,10 @@ else
          </fos:example>
          <fos:example>
             <fos:test use="v-sum-d1 v-sum-d2 v-sum-seq1">
-               <fos:expression>sum($seq1[. lt xs:yearMonthDuration('P3M')],
-                  xs:yearMonthDuration('P0M'))</fos:expression>
+               <fos:expression><eg>sum(
+  $seq1[. lt xs:yearMonthDuration('P3M')],
+  xs:yearMonthDuration('P0M')
+)</eg></fos:expression>
                <fos:result>xs:yearMonthDuration("P0M")</fos:result>
             </fos:test>
          </fos:example>
@@ -14384,7 +14865,8 @@ else
          </fos:variable>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-idref-emp">
-               <fos:expression>$emp/(element-with-id('ID21256')/@xml:id => idref())/ancestor::employee/last => string()</fos:expression>
+               <fos:expression><eg>$emp/(element-with-id('ID21256')/@xml:id => idref())/ancestor::employee/last
+=> string()</eg></fos:expression>
                <fos:result>"Brown"</fos:result>
                <fos:postamble>Assuming that <code>manager</code> has the is-idref property, the call on <code>fn:idref</code> selects
                   the <code>manager</code> element. If, instead, the <code>manager</code> had a <code>ref</code>
@@ -14393,7 +14875,8 @@ else
          </fos:example>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-idref-emp">
-               <fos:expression>$emp/(element-with-id('E30561')/empnr => idref())/ancestor::employee/last => string()</fos:expression>
+               <fos:expression><eg>$emp/(element-with-id('E30561')/empnr => idref())/ancestor::employee/last
+=> string()</eg></fos:expression>
                <fos:result>"Singh"</fos:result>
                <fos:postamble>Assuming that <code>employee/deputy</code> has the is-idref property, the call on <code>fn:idref</code> selects
                   the <code>deputy</code> element.</fos:postamble>
@@ -15950,7 +16433,10 @@ else
          </fos:example>
          <fos:example>
             <fos:test use="v-serialize-data">
-               <fos:expression><![CDATA[serialize($data, map{"method":"xml", "omit-xml-declaration":true()})]]></fos:expression>
+               <fos:expression><eg><![CDATA[serialize(
+  $data,
+  map { "method": "xml", "omit-xml-declaration": true() }
+)]]></eg></fos:expression>
                <fos:result><![CDATA['<a b="3"/>']]></fos:result>
             </fos:test>
          </fos:example>
@@ -16490,13 +16976,11 @@ else
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>function-lookup(xs:QName('substring'), 2)('abcd',
-                  2)</fos:expression>
+               <fos:expression>function-lookup(xs:QName('fn:substring'), 2)('abcd', 2)</fos:expression>
                <fos:result>'bcd'</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-
             <p>The expression <code>(fn:function-lookup(xs:QName('xs:dateTimeStamp'), 1),
                   xs:dateTime#1)[1] ('2011-11-11T11:11:11Z')</code> returns an
                   <code>xs:dateTime</code> value set to the specified date, time, and timezone; if
@@ -16504,8 +16988,6 @@ else
                derived type <code>xs:dateTimeStamp</code>. The query is written to ensure that no
                failure occurs when the implementation does not recognize the type
                   <code>xs:dateTimeStamp</code>.</p>
-
-
          </fos:example>
          <fos:example>
             <p>The expression
@@ -16515,8 +16997,6 @@ returns the result of
                calling <code>zip:binary-entry($href, $entry)</code> if the function is available, or
                an empty sequence otherwise.</p>
          </fos:example>
-
-
       </fos:examples>
    </fos:function>
    <fos:function name="function-name" prefix="fn">
@@ -16552,7 +17032,7 @@ returns the result of
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>function-name(function($node){count($node/*)})</fos:expression>
+               <fos:expression>function-name(function($node) { count($node/*) })</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -16587,14 +17067,14 @@ returns the result of
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>function-arity(function($node){name($node)})</fos:expression>
+               <fos:expression>function-arity(function($node) { name($node) })</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>let $initial := substring(?, 1, 1) return
-                  function-arity($initial)</fos:expression>
+               <fos:expression><eg>let $initial := substring(?, 1, 1)
+return function-arity($initial)</eg></fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -16652,8 +17132,10 @@ declare function for-each($input, $action) {
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>for-each(("john", "jane"),
-                  string-to-codepoints#1)</fos:expression>
+               <fos:expression><eg>for-each(
+  ("john", "jane"),
+  string-to-codepoints#1
+)</eg></fos:expression>
                <fos:result>(106, 111, 104, 110, 106, 97, 110, 101)</fos:result>
             </fos:test>
          </fos:example>
@@ -16808,24 +17290,33 @@ declare function fold-left(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-left(1 to 5, 0, function($a, $b) { $a + $b
-                  })</fos:expression>
+               <fos:expression><eg>fold-left(
+  1 to 5,
+  0,
+  function($a, $b) { $a + $b }
+)</eg></fos:expression>
                <fos:result>15</fos:result>
                <fos:postamble>This returns the sum of the items in the sequence</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-left((2,3,5,7), 1, function($a, $b) { $a * $b
-                  })</fos:expression>
+               <fos:expression><eg>fold-left(
+  (2,3,5,7),
+  1,
+  function($a, $b) { $a * $b }
+)</eg></fos:expression>
                <fos:result>210</fos:result>
                <fos:postamble>This returns the product of the items in the sequence</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-left((true(), false(), false()), false(), function($a, $b) {
-                  $a or $b })</fos:expression>
+               <fos:expression><eg>fold-left(
+  (true(), false(), false()),
+  false(),
+  function($a, $b) { $a or $b }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>This returns <code>true</code> if any item in the sequence has an effective boolean
                   value of <code>true</code></fos:postamble>
@@ -16833,8 +17324,11 @@ declare function fold-left(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-left((true(), false(), false()), false(), function($a, $b) {
-                  $a and $b })</fos:expression>
+               <fos:expression><eg>fold-left(
+  (true(), false(), false()),
+  false(),
+  function($a, $b) { $a and $b }
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>This returns <code>true</code> only if every item in the sequence has an effective
                   boolean value of <code>true</code></fos:postamble>
@@ -16842,27 +17336,42 @@ declare function fold-left(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-left(1 to 5, (), function($a, $b) {($b,
-                  $a)})</fos:expression>
+               <fos:expression><eg>fold-left(
+  1 to 5,
+  (),
+  function($a, $b) { $b, $a }
+)</eg></fos:expression>
                <fos:result>(5,4,3,2,1)</fos:result>
                <fos:postamble>This reverses the order of the items in a sequence</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-left(1 to 5, "", concat(?, ".", ?))</fos:expression>
+               <fos:expression><eg>fold-left(
+  1 to 5,
+  "",
+  concat(?, ".", ?)
+)</eg></fos:expression>
                <fos:result>".1.2.3.4.5"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-left(1 to 5, "$zero", concat("$f(", ?, ", ", ?, ")"))</fos:expression>
+               <fos:expression><eg>fold-left(
+  1 to 5,
+  "$zero",
+  concat("$f(", ?, ", ", ?, ")")
+)</eg></fos:expression>
                <fos:result>"$f($f($f($f($f($zero, 1), 2), 3), 4), 5)"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-left(1 to 5, map{}, function($map, $n) {map:put($map, $n, $n*2)})</fos:expression>
+               <fos:expression><eg>fold-left(
+  1 to 5,
+  map { },
+  function($map, $n) { map:put($map, $n, $n * 2) }
+)</eg></fos:expression>
                <fos:result>map{1:2, 2:4, 3:6, 4:8, 5:10}</fos:result>
             </fos:test>
          </fos:example>
@@ -16940,22 +17449,32 @@ declare function fold-right(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-right(1 to 5, 0, function($a, $b) { $a + $b
-                  })</fos:expression>
+               <fos:expression><eg>fold-right(
+  1 to 5,
+  0,
+  function($a, $b) { $a + $b }
+)</eg></fos:expression>
                <fos:result>15</fos:result>
                <fos:postamble>This returns the sum of the items in the sequence</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-right(1 to 5, "", concat(?, ".", ?))</fos:expression>
+               <fos:expression><eg>fold-right(
+  1 to 5,
+  "",
+  concat(?, ".", ?)
+)</eg></fos:expression>
                <fos:result>"1.2.3.4.5."</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>fold-right(1 to 5, "$zero", concat("$f(", ?, ", ", ?,
-                  ")"))</fos:expression>
+               <fos:expression><eg>fold-right(
+  1 to 5,
+  "$zero",
+  concat("$f(", ?, ", ", ?, ")")
+)</eg></fos:expression>
                <fos:result>"$f(1, $f(2, $f(3, $f(4, $f(5, $zero)))))"</fos:result>
             </fos:test>
          </fos:example>
@@ -17022,14 +17541,22 @@ declare function fn:iterate-while(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><![CDATA[iterate-while(2, -> { . < 100 }, -> { . * . })]]></fos:expression>
+               <fos:expression><eg><![CDATA[iterate-while(
+  2,
+  function { . < 100 },
+  function { . * . }
+)]]></eg></fos:expression>
                <fos:result>256</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><![CDATA[let $input := (0 to 4, 6 to 10)
-return iterate-while(0, function($n) { $n = $input }, function($n) { $n + 1 })]]></fos:expression>
+               <fos:expression><eg><![CDATA[let $input := (0 to 4, 6 to 10)
+return iterate-while(
+  0, 
+  function($n) { $n = $input }, 
+  function($n) { $n + 1 }
+)]]></eg></fos:expression>
                <fos:result>5</fos:result>
                <fos:postamble>This returns the first positive number missing in a sequence.</fos:postamble>
             </fos:test>
@@ -17129,27 +17656,35 @@ declare function fn:for-each-pair($input1, $input2, $action)
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>for-each-pair(("a", "b", "c"), ("x", "y", "z"),
-                  concat#2)</fos:expression>
+               <fos:expression><eg>for-each-pair(
+  ("a", "b", "c"),
+  ("x", "y", "z"),
+  concat#2
+)</eg></fos:expression>
                <fos:result>("ax", "by", "cz")</fos:result>
             </fos:test>
          </fos:example>
          <!--<fos:example>
             <fos:test>
-               <fos:expression><![CDATA[for-each-pair(function($a, $b){<e a="{$a}" b="{$b}"/>}, (1 to 3), ("x", "y", "z"))]]></fos:expression>
+               <fos:expression><![CDATA[for-each-pair(function($a, $b) { <e a="{$a}" b="{$b}"/> }, (1 to 3), ("x", "y", "z"))]]></fos:expression>
                <fos:result as="element()*"><![CDATA[(<e a="1" b="x"/>, <e a="2" b="y"/>, <e a="3" b="z"/>)]]></fos:result>
                <fos:postamble>This example uses XQuery syntax</fos:postamble>
             </fos:test>
          </fos:example>-->
          <fos:example>
             <fos:test>
-               <fos:expression>for-each-pair(1 to 5, 1 to 5, function($a, $b){10*$a + $b})</fos:expression>
+               <fos:expression><eg>for-each-pair(
+  1 to 5,
+  1 to 5,
+  function($a, $b) { 10 * $a + $b }
+)</eg></fos:expression>
                <fos:result>(11, 22, 33, 44, 55)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>let $s := 1 to 8 return for-each-pair($s, tail($s), function($a, $b){$a*$b})</fos:expression>
+               <fos:expression><eg>let $s := 1 to 8
+return for-each-pair($s, tail($s), function($a, $b) { $a * $b })</eg></fos:expression>
                <fos:result>(2, 6, 12, 20, 30, 42, 56)</fos:result>
             </fos:test>
          </fos:example>
@@ -17363,24 +17898,21 @@ return sort($in, $SWEDISH)
          <fos:example>
             <fos:test use="transitive-closure-data">
                <fos:expression><eg>let $tc := transitive-closure($direct-reports)
-return $tc($data//person[@id="2"])/string(@id)</eg>                   
-               </fos:expression>
+return $tc($data//person[@id="2"])/string(@id)</eg></fos:expression>
                <fos:result>("3", "4", "6", "7", "8")</fos:result>
             </fos:test>
             <fos:test use="transitive-closure-data">
                <fos:expression><eg>let $tc := transitive-closure($direct-reports, min:=0)
-return $tc($data//person[@id="2"])/string(@id)</eg>                   
-               </fos:expression>
+return $tc($data//person[@id="2"])/string(@id)</eg></fos:expression>
                <fos:result>("2", "3", "4", "6", "7", "8")</fos:result>
             </fos:test>   
             <fos:test use="transitive-closure-data">
                <fos:expression><eg>let $tc := transitive-closure($direct-reports, max:=2)
-return $tc($data//person[@id="2"])/string(@id)</eg>                   
-               </fos:expression>
+return $tc($data//person[@id="2"])/string(@id)</eg></fos:expression>
                <fos:result>("3", "4", "6")</fos:result>
             </fos:test>               
             <fos:test use="transitive-closure-data">
-               <fos:expression><eg>let $tc := transitive-closure(function{child::*})
+               <fos:expression><eg>let $tc := transitive-closure(function { child::* })
 return $tc($data)/@id/string()</eg></fos:expression>
                <fos:result>("0", "1", "2", "3", "4", "5", "6", "7","8")</fos:result>
                <fos:postamble>The transitive closure of the child axis is the ancestor axis
@@ -17390,14 +17922,14 @@ return $tc($data)/@id/string()</eg></fos:expression>
          <fos:example>
             <p>The following example, given <code>$root</code> as the root of an XSLT stylesheet module, returns the URIs
             of all stylesheet modules reachable using <code>xsl:import</code> and <code>xsl:include</code> declarations:</p>
-            <eg>let $tc := transitive-closure(function{document(//(xsl:import|xsl:include)/@href)}) 
+            <eg>let $tc := transitive-closure(function { document(//(xsl:import|xsl:include)/@href) }) 
 return $tc($root) =!> document-uri()</eg>
             <p>This example uses the XSLT-defined <code>document()</code> function.</p>
          </fos:example>
          <fos:example>
             <p>The following example, given <code>$doc</code> as the root of a document consisting of nested sections with paths
                such as <code>article/section/section/section</code>, returns the headings of all level-2 and level-3 sections:</p>
-            <eg>let $tc := transitive-closure(function{child::section}, min:=2, max:=3) 
+            <eg>let $tc := transitive-closure(function { child::section }, min:=2, max:=3) 
 return $tc($doc/article)/head</eg>
          </fos:example>
       </fos:examples>
@@ -17799,7 +18331,10 @@ return $tc($doc/article)/head</eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>atomic-equal("https://www.w3.org/", xs:anyURI("https://www.w3.org/"))</fos:expression>
+               <fos:expression><eg>atomic-equal(
+  "https://www.w3.org/",
+  xs:anyURI("https://www.w3.org/")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
@@ -18009,7 +18544,7 @@ $duplicates-handler := map {
 },
 
 $combine-maps := function($A as map(*), $B as map(*), $deduplicator as function(*)) {
-    fold-left(map:keys($B), $A, function($z, $k){ 
+    fold-left(map:keys($B), $A, function($z, $k) { 
         if (map:contains($z, $k))
         then map:put($z, $k, $deduplicator($z($k), $B($k)))
         else map:put($z, $k, $B($k))
@@ -18071,12 +18606,17 @@ return fold-left($MAPS, map{},
                <fos:postamble>Returns an empty map</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:merge((map:entry(0, "no"), map:entry(1, "yes")))</fos:expression>
+               <fos:expression><eg>map:merge((
+  map:entry(0, "no"),
+  map:entry(1, "yes")
+))</eg></fos:expression>
                <fos:result>map{0:"no", 1:"yes"}</fos:result>
                <fos:postamble>Returns a map with two entries</fos:postamble>
             </fos:test>
             <fos:test use="v-map-merge-week">
-               <fos:expression>map:merge(($week, map{7:"Unbekannt"}))</fos:expression>
+               <fos:expression><eg>map:merge((
+  ($week, map { 7: "Unbekannt" })
+)</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
                   5:"Freitag", 6:"Samstag", 7:"Unbekannt"}</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the <phrase>returned map 
@@ -18084,7 +18624,10 @@ return fold-left($MAPS, map{},
                   entry.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-merge-week">
-               <fos:expression>map:merge(($week, map{6:"Sonnabend"}), map{"duplicates":"use-last"})</fos:expression>
+               <fos:expression><eg>map:merge(
+  ($week, map { 6: "Sonnabend" }),
+  map { "duplicates": "use-last" }
+)</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
                   5:"Freitag", 6:"Sonnabend"}</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
@@ -18094,7 +18637,10 @@ return fold-left($MAPS, map{},
                   sequence.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-merge-week">
-               <fos:expression>map:merge(($week, map{6:"Sonnabend"}), map{"duplicates":"use-first"})</fos:expression>
+               <fos:expression><eg>map:merge(
+  ($week, map { 6: "Sonnabend" }),
+  map { "duplicates": "use-first" }
+)</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
                   5:"Freitag", 6:"Samstag"}</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
@@ -18104,7 +18650,10 @@ return fold-left($MAPS, map{},
                   sequence.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-merge-week">
-               <fos:expression>map:merge(($week, map{6:"Sonnabend"}), map{"duplicates":"combine"})</fos:expression>
+               <fos:expression><eg>map:merge(
+  ($week, map { 6: "Sonnabend" }),
+  map { "duplicates": "combine" }
+)</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
                   5:"Freitag", 6:("Samstag", "Sonnabend")}</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
@@ -18169,7 +18718,7 @@ return fold-left($MAPS, map{},
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-of-week"
-            select="map{0:&quot;Sonntag&quot;, 1:&quot;Montag&quot;, 2:&quot;Dienstag&quot;,&#xa;     3:&quot;Mittwoch&quot;, 4:&quot;Donnerstag&quot;, 5:&quot;Freitag&quot;, 6:&quot;Samstag&quot;}"/>
+            select="map { 0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;,&#xa;     3: &quot;Mittwoch&quot;, 4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6 :&quot;Samstag&quot; }"/>
          <fos:example>
             <fos:test>
                <fos:expression>map:of(())</fos:expression>
@@ -18182,12 +18731,18 @@ return fold-left($MAPS, map{},
                <fos:postamble>The function <code>map:of</code> is the inverse of <code>map:pairs</code>.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:of((map:entry(0, "no"), map:entry(1, "yes")))</fos:expression>
+               <fos:expression><eg><![CDATA[map:of((
+  map { "key": 0, "value": "no" },
+  map { "key": 1, "value": "yes" }
+))]]></eg></fos:expression>
                <fos:result>map{0:"no", 1:"yes"}</fos:result>
                <fos:postamble>Returns a map with two entries</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression>map:of((map:pairs($week), map{"key":7, "value":"Unbekannt"}))</fos:expression>
+               <fos:expression><eg>map:of((
+  map:pairs($week),
+  map { "key": 7, "value": "Unbekannt" }
+))</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
                   5:"Freitag", 6:"Samstag", 7:"Unbekannt"}</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map 
@@ -18195,7 +18750,10 @@ return fold-left($MAPS, map{},
                   entry.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression>map:of((map:pairs($week), map{"key":6, "value":"Sonnabend"}))</fos:expression>
+               <fos:expression><eg>map:of((
+  map:pairs($week),
+  map { "key": 6, "value": "Sonnabend" }
+))</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
                   5:"Freitag", 6:("Samstag", "Sonnabend")}</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
@@ -18204,7 +18762,10 @@ return fold-left($MAPS, map{},
                   one used in the result combines the two supplied values into a single sequence.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression>map:of((map:pairs($week), map{"key":6, "value":"Sonnabend"}), ($old, $new)->{$new})</fos:expression>
+               <fos:expression><eg>map:of(
+  (map:pairs($week), map { "key": 6, "value": "Sonnabend" }),
+  function($old, $new)  { $new }
+)</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
                   5:"Freitag", 6:"Sonnabend"}</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
@@ -18214,7 +18775,10 @@ return fold-left($MAPS, map{},
                   is the one that comes last in the input sequence.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression>map:of((map:pairs($week), map{"key":6, "value":"Sonnabend"}), ($old, $new)->{`{$old}|{$new}`})</fos:expression>
+               <fos:expression><eg>map:of(
+  (map:pairs($week), map { "key": 6, "value": "Sonnabend" }),
+  function($old, $new) { `{$old}|{$new}` }
+)</eg></fos:expression>
                <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
                   5:"Freitag", 6:"Samstag|Sonnabend"}</fos:result>
                <fos:postamble>In the result map, the value for key <code>6</code> is obtained by concatenating the values
@@ -18337,13 +18901,17 @@ return map:keys($birthdays, function($date) { year-from-date($date) = 1969 })
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:values(map{1:"yes", 2:"no"})</fos:expression>
+               <fos:expression>map:values(
+  map{ 1: "yes", 2: "no" }
+)</fos:expression>
                <fos:result allow-permutation="true">("yes", "no")</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:values(map{1:("red", "green"), 2:"blue", "yellow", 3:()})</fos:expression>
+               <fos:expression><eg>map:values(
+  map { 1: ("red", "green"), 2: ("blue", "yellow"), 3:() }
+)</eg></fos:expression>
                <fos:result allow-permutation="true">("red", "green", "blue", "yellow")</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
@@ -18567,7 +19135,8 @@ return map:keys($birthdays, function($date) { year-from-date($date) = 1969 })
                   present and the associated value is an empty sequence.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map{1:"single", 2:"double", 3:"triple"} => map:get(10, ->($k){$k || "-fold"})</fos:expression>
+               <fos:expression><eg>map { 1: "single", 2: "double", 3: "triple" }
+=> map:get(10, function { . || "-fold" })</eg></fos:expression>
                <fos:result>"10-fold"</fos:result>
                <fos:postamble>The map holds special cases; the fallback function handles other cases.</fos:postamble>
             </fos:test>
@@ -18897,22 +19466,32 @@ map:merge (
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:for-each(map{1:"yes", 2:"no"}, function($k,
-                  $v){$k})</fos:expression>
+               <fos:expression><eg>map:for-each(
+  map { 1: "yes", 2: "no" },
+  function($k, $v) { $k }
+)</eg></fos:expression>
                <fos:result allow-permutation="true">(1,2)</fos:result>
                <fos:postamble>This function call is equivalent to calling <code>map:keys</code>. The
                   result is in implementation-dependent order.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>distinct-values(map:for-each(map{1:"yes", 2:"no"}, function($k,
-                  $v){$v}))</fos:expression>
+               <fos:expression><eg>distinct-values(
+  map:for-each(
+    map { 1: "yes", 2: "no" },
+    function($k, $v) { $v }
+  )
+)</eg></fos:expression>
                <fos:result allow-permutation="true">("yes", "no")</fos:result>
                <fos:postamble>This function call returns the distinct values present in the map, in
                   implementation-dependent order.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:merge(map:for-each(map{"a":1, "b":2}, function($k,
-                  $v){map:entry($k, $v+1)}))</fos:expression>
+               <fos:expression><eg>map:merge(
+  map:for-each(
+    map { "a": 1, "b": 2 },
+    function($k, $v) { map:entry($k, $v + 1) }
+  )
+)</eg></fos:expression>
                <fos:result>map{"a":2, "b":3}</fos:result>
                <fos:postamble>This function call returns a map with the same keys as the input map,
                   with the value of each entry increased by one.</fos:postamble>
@@ -19028,14 +19607,22 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <fos:example>
             <fos:test>
                <fos:expression>map:replace(map{1:"alpha", 2:"beta"}, 1, upper-case#1)</fos:expression>
-               <fos:result>map{1:"ALPHA", 2:"beta"}</fos:result>
+               <fos:result>map { 1: "ALPHA", 2: "beta" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>map:replace(map{1:"alpha", 2:"beta"}, 3, upper-case#1)</fos:expression>
-               <fos:result>map{1:"alpha", 2:"beta" 3:""}</fos:result>
+               <fos:result>map { 1: "alpha", 2: "beta" 3: "" }</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>fold-left(("a", "b", "c", "a"), map{}, function($map, $key) {map:replace($map, $key, function($val){($val otherwise 0) + 1}}) </fos:expression>
+               <fos:expression><eg>fold-left(
+  ("a", "b", "c", "a"),
+  map { },
+  function($map, $key) {
+    map:replace($map, $key, function($val) {
+      ($val otherwise 0) + 1
+    })
+  }
+)</eg></fos:expression>
                <fos:result>map{"a":2, "b":1, "c":1}</fos:result>
             </fos:test>
          </fos:example>
@@ -19076,13 +19663,17 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:substitute(map{1:true(), 2:false()}, function($k,
-                  $v){not($v)})</fos:expression>
+               <fos:expression><eg>map:substitute(
+  map { 1: true(), 2: false() },
+  function($k, $v) { not($v) }
+)</eg></fos:expression>
                <fos:result>map{1:false(), 2:true()}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:substitute(map{1:"yes", 2:"no"}, function($k,
-                  $v){$v || ' (' || $k || ')'}))</fos:expression>
+               <fos:expression><eg>map:substitute(
+  map { 1: "yes", 2: "no" },
+  function($k, $v) { $v || ' (' || $k || ')' }
+)</eg></fos:expression>
                <fos:result>map{1:"yes (1)", 2:"no (2)"}</fos:result>
             </fos:test>
          </fos:example>
@@ -19147,8 +19738,8 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             equivalent to the <code>duplicates: combine</code> option on <code>map:merge</code>. Other potentially useful
             functions for combining duplicates include:</p>
          <ulist>
-            <item><p><code>->($a, $b){$a}</code> Use the first value and discard the remainder</p></item>
-            <item><p><code>->($a, $b){$b}</code> Use the last value and discard the remainder</p></item>
+            <item><p><code>->($a, $b) { $a }</code> Use the first value and discard the remainder</p></item>
+            <item><p><code>->($a, $b) { $b }</code> Use the last value and discard the remainder</p></item>
             <item><p><code>fn:concat(?, ",", ?)</code> Form the string-concatenation of the values, comma-separated</p></item>
             <item><p><code>fn:op('+')</code> Compute the sum of the values</p></item>
          </ulist>
@@ -19160,27 +19751,34 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                <fos:result>map{}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:build(1 to 10, function{. mod 3})</fos:expression>
+               <fos:expression>map:build(1 to 10, function { . mod 3 })</fos:expression>
                <fos:result>map{0: (3, 6, 9), 1: (1, 4, 7, 10), 2: (2, 5, 8)}</fos:result>
                <fos:postamble>Returns a map with one entry for each distinct value of <code>. mod 3</code>. The
                   function to compute the value is the identity function, and duplicates are combined by
                   sequence concatenation.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:build(1 to 5, value := format-integer(?, "w")})</fos:expression>
+               <fos:expression>map:build(1 to 5, value := format-integer(?, "w"))</fos:expression>
                <fos:result>map{1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}</fos:result>
                <fos:postamble>Returns a map with five entries. The function to compute the key is an identity function, the
                   function to compute the value invokes <code>fn:format-integer</code>.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:build(("January", "February", "March", "April", "May",
-                  "June", "July", "August", "September", "October", "November", "December"), substring(?, 1, 1)})</fos:expression>
+               <fos:expression><eg>map:build(
+  ("January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"),
+  substring(?, 1, 1)
+)</eg></fos:expression>
                <fos:result>map{"A": ("April", "August"), "D": ("December"), "F": ("February"), "J": ("January", "June", "July"), 
                   "M": ("March", "May"), "N": ("November"), "O": ("October"), "S": ("September")}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:build(("apple", "apricot", "banana", "blueberry", "cherry"), 
-                  substring(?, 1, 1), string-length#1, op("+"))</fos:expression>
+               <fos:expression><eg>map:build(
+  ("apple", "apricot", "banana", "blueberry", "cherry"), 
+  substring(?, 1, 1),
+  string-length#1,
+  op("+")
+)</eg></fos:expression>
                <fos:result>map{"a": 12, "b": 15, "c": 6}</fos:result>
                <fos:postamble>Constructs a map where the key is the first character of an input item, and where the corresponding value
                   is the total string-length of the items starting with that character.</fos:postamble>
@@ -19191,19 +19789,19 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@ssn</code> values, and whose
                corresponding values are the employee nodes:</p>
-            <eg>map:build(//employee, function{@ssn})</eg>
+            <eg>map:build(//employee, function { @ssn })</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values represent the number of employees at each distinct location. Any employees that
                lack an <code>@location</code> attribute will be excluded from the result.</p>
-            <eg>map:build(//employee, function{@location}, function{1}, op("+"))</eg>
+            <eg>map:build(//employee, function { @location }, function { 1 }, op("+"))</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values contain the employee node for the highest-paid employee at each distinct location:</p>
-            <eg>map:build(//employee, function{@location}, 
-               combine := ($a, $b)->{highest(($a, $b), function{xs:decimal(@salary)}))</eg>
+            <eg>map:build(//employee, function { @location }, 
+               combine := ($a, $b)->{highest(($a, $b), function { xs:decimal(@salary) }))</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map allowing efficient access to every element in a document by means
@@ -19352,8 +19950,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             select="'http://www.w3.org/2013/collation/UCA?strength=primary'"/>
          <fos:example>
             <fos:test use="v-collation-key-C">
-               <fos:expression>map:merge((map{collation-key("A", $C):1}, map{collation-key("a",
-                  $C):2}), map{"duplicates":"use-last"})(collation-key("A", $C))</fos:expression>
+               <fos:expression><eg>map:merge(
+  (map { collation-key("A", $C): 1 }, map { collation-key("a", $C): 2 }),
+  map { "duplicates": "use-last" }
+)(collation-key("A", $C))</eg></fos:expression>
                <fos:result>2</fos:result>
                <fos:postamble>Given that the keys of the two entries are equal under the rules of
                   the chosen collation, only one of the entries can appear in the result; the one
@@ -19362,8 +19962,8 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </fos:example>
          <fos:example>
             <fos:test use="v-collation-key-C">
-               <fos:expression>let $M := map{collation-key("A", $C):1, collation-key("B", $C):2}
-                  return $M(collation-key("a", $C))</fos:expression>
+               <fos:expression><eg>let $M := map { collation-key("A", $C): 1, collation-key("B", $C): 2 }
+return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>The strings <code>"A"</code> and <code>"a"</code> have the same collation key under this
                   collation.</fos:postamble>
@@ -19551,7 +20151,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                   with the value <code>true</code>.
                </fos:meaning>
                <fos:type>function(xs:string) as xs:string</fos:type>
-               <fos:default>The default is effectively the function <code>function($s){"&amp;#xFFFD;"}</code>: that is,
+               <fos:default>The default is effectively the function <code>function($s) { "&amp;#xFFFD;" }</code>: that is,
                   a function that replaces the escape sequence with the Unicode <code>REPLACEMENT CHARACTER</code>.</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function"
@@ -19656,7 +20256,9 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>json-to-xml('{"x": 1, "y": [3,4,5]}')</fos:expression>
+               <fos:expression><eg>json-to-xml(
+  '{"x": 1, "y": [3,4,5]}'
+)</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
   <number key="x">1</number>
@@ -19668,12 +20270,17 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
 </map>]]></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json-to-xml('"abcd"', map{'liberal': false()})</fos:expression>
+               <fos:expression><eg>json-to-xml(
+  '"abcd"',
+  map { 'liberal': false() }
+)</eg></fos:expression>
                <fos:result ignore-prefixes="true"
                   ><![CDATA[<string xmlns="http://www.w3.org/2005/xpath-functions">abcd</string>]]></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json-to-xml('{"x": "\\", "y": "\u0025"}')</fos:expression>
+               <fos:expression><eg>json-to-xml(
+  '{"x": "\\", "y": "\u0025"}'
+)</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
   <string key="x">\</string>
@@ -19681,8 +20288,10 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
 </map>]]></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json-to-xml('{"x": "\\", "y": "\u0025"}', map{'escape':
-                  true()})</fos:expression>
+               <fos:expression><eg>json-to-xml(
+  '{"x": "\\", "y": "\u0025"}',
+  map { 'escape': true() }
+)</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
   <string escaped="true" key="x">\\</string>
@@ -20187,7 +20796,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                   with the value <code>true</code>.
                </fos:meaning>
                <fos:type>function(xs:string) as xs:string</fos:type>
-               <fos:default>The default is effectively the function <code>function($s){"&amp;#xFFFD;"}</code>: that is,
+               <fos:default>The default is effectively the function <code>function($s) { "&amp;#xFFFD;" }</code>: that is,
                   a function that replaces the escape sequence with the Unicode <code>REPLACEMENT CHARACTER</code>.</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function"
@@ -20341,19 +20950,32 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                <fos:result>map{"x":"\","y":"%"}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>parse-json('{"x":"\\", "y":"\u0025"}', map{'escape':true()})</fos:expression>
+               <fos:expression><eg>parse-json(
+  '{"x":"\\", "y":"\u0025"}',
+  map { 'escape': true() }
+)</eg></fos:expression>
                <fos:result>map{"x":"\\","y":"%"}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>parse-json('{"x":"\\", "y":"\u0000"}')</fos:expression>
+               <fos:expression><eg>parse-json(
+  '{"x":"\\", "y":"\u0000"}'
+)</eg></fos:expression>
                <fos:result>map{"x":"\","y":codepoints-to-string(65533)}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>parse-json('{"x":"\\", "y":"\u0000"}', map{'escape':true()})</fos:expression>
+               <fos:expression><eg>parse-json(
+  '{"x":"\\", "y":"\u0000"}',
+  map { 'escape': true() }
+)</eg></fos:expression>
                <fos:result>map{"x":"\\","y":"\u0000"}</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>parse-json('{"x":"\\", "y":"\u0000"}', map{'fallback':function($s){'['||$s||']'}})</fos:expression>
+               <fos:expression><eg>parse-json(
+  '{"x":"\\", "y":"\u0000"}',
+  map {
+    'fallback': function($s) { '['||$s||']' }
+  }
+)</eg></fos:expression>
                <fos:result>map{"x":"\","y":"[\u0000]"}</fos:result>
             </fos:test>
          </fos:example>
@@ -20926,11 +21548,11 @@ else $fallback($position)</eg>
                <fos:result>["b", "c"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>["a"] => array:get(1, ->($i){})</fos:expression>
+               <fos:expression>["a"] => array:get(1, ->($i) { })</fos:expression>
                <fos:result>"a"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>[] => array:get(1, ->($i){})</fos:expression>
+               <fos:expression>[] => array:get(1, ->($i) { })</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -21024,7 +21646,7 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:replace([10, 11, 12], 2, function{.+10})</fos:expression>
+               <fos:expression>array:replace([10, 11, 12], 2, function { . + 10 })</fos:expression>
                <fos:result>[10, 21, 12]</fos:result>
             </fos:test>
             <fos:test>
@@ -21260,16 +21882,25 @@ else $fallback($position)</eg>
                <fos:result>(3, 4)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:index-where(array{1 to 10}, function{. mod 2 = 0}))</fos:expression>
+               <fos:expression><eg>array:index-where(
+  array { 1 to 10 },
+  function {. mod 2 = 0 }
+)</eg></fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:index-where(["January", "February", "March", "April", "May",
-                  "June", "July", "August", "September", "October", "November", "December"], contains(?, "r"))</fos:expression>
+               <fos:expression><eg>array:index-where(
+  [ "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December" ],
+  contains(?, "r")
+)</eg></fos:expression>
                <fos:result>(1, 2, 3, 4, 9, 10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:index-where([(1, 2, 3), (4, 5, 6), (7, 8)], ($m)->{count($m) = 3})</fos:expression>
+               <fos:expression><eg>array:index-where(
+  [(1, 2, 3), (4, 5, 6), (7, 8)],
+  function($m) { count($m) = 3 }
+)</eg></fos:expression>
                <fos:result>(1, 2)</fos:result>
             </fos:test>
          </fos:example>
@@ -21311,39 +21942,39 @@ else $fallback($position)</eg>
          <fos:variable name="in" id="a-slice" as="xs:string*" select="['a', 'b', 'c', 'd', 'e']"/>
          <fos:example>
             <fos:test>
-               <fos:expression>array:slice($in, start:2, end:4)</fos:expression>
+               <fos:expression>array:slice($in, start := 2, end := 4)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:2)</fos:expression>
+               <fos:expression>array:slice($in, start := 2)</fos:expression>
                <fos:result>["b", "c", "d", "e"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, end:2)</fos:expression>
+               <fos:expression>array:slice($in, end := 2)</fos:expression>
                <fos:result>["a", "b"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:3, end:3)</fos:expression>
+               <fos:expression>array:slice($in, start := 3, end := 3)</fos:expression>
                <fos:result>["c"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:4, end:3)</fos:expression>
+               <fos:expression>array:slice($in, start := 4, end := 3)</fos:expression>
                <fos:result>["d", "c"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:2, end:5, step:2)</fos:expression>
+               <fos:expression>array:slice($in, start := 2, end := 5, step := 2)</fos:expression>
                <fos:result>["b", "d"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:5, end:2, step:-2)</fos:expression>
+               <fos:expression>array:slice($in, start := 5, end := 2, step := -2)</fos:expression>
                <fos:result>["e", "c"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:2, end:5, step:-2)</fos:expression>
+               <fos:expression>array:slice($in, start := 2, end := 5, step := -2)</fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:5, end:2, step:2)</fos:expression>
+               <fos:expression>array:slice($in, start := 5, end := 2, step := 2)</fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
@@ -21351,39 +21982,39 @@ else $fallback($position)</eg>
                <fos:result>["a", "b", "c", "d", "e"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:-1)</fos:expression>
+               <fos:expression>array:slice($in, start := -1)</fos:expression>
                <fos:result>["e"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:-3)</fos:expression>
+               <fos:expression>array:slice($in, start := -3)</fos:expression>
                <fos:result>["c", "d", "e"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, end:-2)</fos:expression>
+               <fos:expression>array:slice($in, end := -2)</fos:expression>
                <fos:result>]"a", "b", "c", "d"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:2, end:-2)</fos:expression>
+               <fos:expression>array:slice($in, start := 2, end := -2)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:-2, end:2)</fos:expression>
+               <fos:expression>array:slice($in, start := -2, end := 2)</fos:expression>
                <fos:result>["d", "c", "b"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:-4, end:-2)</fos:expression>
+               <fos:expression>array:slice($in, start := -4, end := -2)</fos:expression>
                <fos:result>["b", "c", "d"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:-2, end:-4)</fos:expression>
+               <fos:expression>array:slice($in, start := -2, end := -4)</fos:expression>
                <fos:result>["d", "c", "b"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:-4, end:-2, step:2)</fos:expression>
+               <fos:expression>array:slice($in, start := -4, end := -2, step := 2)</fos:expression>
                <fos:result>["b", "d"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:slice($in, start:-2, end:-4, step:-2)</fos:expression>
+               <fos:expression>array:slice($in, start := -2, end := -4, step := -2)</fos:expression>
                <fos:result>["d", "b"]</fos:result>
             </fos:test>
             <fos:test>
@@ -21496,15 +22127,27 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:insert-before(["a", "b", "c", "d"], 3, ("x", "y"))</fos:expression>
+               <fos:expression><eg>array:insert-before(
+  ["a", "b", "c", "d"],
+  3,
+  ("x", "y")
+)</eg></fos:expression>
                <fos:result>["a", "b", ("x", "y"), "c", "d"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:insert-before(["a", "b", "c", "d"], 5, ("x", "y"))</fos:expression>
+               <fos:expression><eg>array:insert-before(
+  ["a", "b", "c", "d"],
+  5,
+  ("x", "y")
+)</eg></fos:expression>
                <fos:result>["a", "b", "c", "d", ("x", "y")]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:insert-before(["a", "b", "c", "d"], 3, ["x", "y"])</fos:expression>
+               <fos:expression><eg>array:insert-before(
+  ["a", "b", "c", "d"],
+  3,
+  ["x", "y"]
+)</eg></fos:expression>
                <fos:result>["a", "b", ["x", "y"], "c", "d"]</fos:result>
             </fos:test>
          </fos:example>
@@ -21754,20 +22397,29 @@ else $fallback($position)</eg>
          <p>Informally, the function returns an array whose members are obtained by applying 
          the supplied <code>$function</code> to each member of the input array in turn.</p>
          <p>More formally, the function returns the result of the expression
-            <code>array:of(array:members($array) ! map{'value':$action(?value)}</code>.</p>
+            <code>array:of(array:members($array) ! map { 'value': $action(?value) }</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:for-each(["A", "B", 1, 2], function($z) {$z instance of xs:integer})</fos:expression>
+               <fos:expression><eg>array:for-each(
+  [ "A", "B", 1, 2 ],
+  function($z) { $z instance of xs:integer }
+)</eg></fos:expression>
                <fos:result>[false(), false(), true(), true()]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:for-each(["the cat", "sat", "on the mat"], tokenize#1)</fos:expression>
+               <fos:expression><eg>array:for-each(
+  [ "the cat", "sat", "on the mat" ],
+  tokenize#1
+)</eg></fos:expression>
                <fos:result>[("the", "cat"), "sat", ("on", "the", "mat")]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:for-each([["the", "cat"], ["sat"], ["on", "the", "mat"]], array:flatten#1)</fos:expression>
+               <fos:expression><eg>array:for-each(
+  [ [ "the", "cat" ], [ "sat" ], [ "on", "the", "mat" ] ],
+  array:flatten#1
+)</eg></fos:expression>
                <fos:result>[("the", "cat"), "sat", ("on", "the", "mat")]</fos:result>
             </fos:test>
          </fos:example>
@@ -21795,7 +22447,7 @@ else $fallback($position)</eg>
          <p>Informally, the function returns an array containing those members of the input
          array that satisfy the supplied predicate.</p>
          <p>More formally, the function returns the result of the expression
-            <code role="example">array:of(array:members($array) => fn:filter(function($m){$predicate($m?value)})</code>.</p>
+            <code role="example">array:of(array:members($array) => fn:filter(function($m) { $predicate($m?value) })</code>.</p>
 
       </fos:rules>
       <fos:errors>
@@ -21806,11 +22458,17 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:filter(["A", "B", 1, 2], function($x) {$x instance of xs:integer})</fos:expression>
+               <fos:expression><eg>array:filter(
+  ["A", "B", 1, 2],
+  function($x) { $x instance of xs:integer }
+)</eg></fos:expression>
                <fos:result>[1, 2]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:filter(["the cat", "sat", "on the mat"], function($s){count(tokenize($s)) gt 1})</fos:expression>
+               <fos:expression><eg>array:filter(
+  ["the cat", "sat", "on the mat"],
+  function($s) { count(tokenize($s)) gt 1 }
+)</eg></fos:expression>
                <fos:result>["the cat", "on the mat"]</fos:result>
             </fos:test>
             <fos:test>
@@ -21846,7 +22504,7 @@ else $fallback($position)</eg>
       </fos:summary>
       <fos:rules>
          <p>The result of the function is the value of the expression 
-            <code role="example">array:members($array) => fn:fold-left($zero, function($a, $b){$action($a, $b?value})</code></p>
+            <code role="example">array:members($array) => fn:fold-left($zero, function($a, $b) { $action($a, $b?value })</code></p>
 <!--         <eg>
 if (array:size($array) eq 0)
 then $zero
@@ -21864,17 +22522,29 @@ else array:fold-left(array:tail($array),
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:fold-left([true(), true(), false()], true(), function($x, $y){$x and $y})</fos:expression>
+               <fos:expression><eg>array:fold-left(
+  [true(), true(), false()],
+  true(),
+  function($x, $y) { $x and $y }
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>Returns true if every member of the input array has an effective boolean value of <code>true()</code>.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>array:fold-left([true(), true(), false()], false(), function($x, $y){$x or $y})</fos:expression>
+               <fos:expression><eg>array:fold-left(
+  [true(), true(), false()],
+  false(), 
+  function($x, $y) { $x or $y }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>Returns true if at least one member of the input array has an effective boolean value of <code>true()</code>.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>array:fold-left([1,2,3], [], function($x, $y){[$x, $y]})</fos:expression>
+               <fos:expression><eg>array:fold-left(
+  [ 1, 2, 3 ],
+  [],
+  function($x, $y) { [ $x, $y ] }
+)</eg></fos:expression>
                <fos:result>[[[[], 1], 2], 3]</fos:result>
             </fos:test>
          </fos:example>
@@ -21906,7 +22576,7 @@ else array:fold-left(array:tail($array),
       </fos:summary>
       <fos:rules>
          <p>The result of the function is the value of the expression 
-            <code role="example">array:members($array) => fn:fold-right($zero, function($a, $b){$action($a, $b?value})</code></p>
+            <code role="example">array:members($array) => fn:fold-right($zero, function($a, $b) { $action($a, $b?value })</code></p>
  
       </fos:rules>
       <fos:notes>
@@ -21918,17 +22588,29 @@ else array:fold-left(array:tail($array),
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:fold-right([true(), true(), false()], true(), function($x, $y){$x and $y})</fos:expression>
+               <fos:expression><eg>array:fold-right(
+  [true(), true(), false()],
+  true(),
+  function($x, $y) { $x and $y }
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>Returns true if every member of the input array has an effective boolean value of <code>true()</code>.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>array:fold-right([true(), true(), false()], false(), function($x, $y){$x or $y})</fos:expression>
+               <fos:expression><eg>array:fold-right(
+  [true(), true(), false()],
+  false(),
+  function($x, $y) { $x or $y }
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>Returns true if at least one member of the input array has an effective boolean value of <code>true()</code>.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>array:fold-right([1,2,3], [], function($x, $y){[$x, $y]})</fos:expression>
+               <fos:expression><eg>array:fold-right(
+  [ 1, 2, 3 ],
+  [],
+  function($x, $y) { [ $x, $y ] }
+)</eg></fos:expression>
                <fos:result>[1, [2, [3, []]]]</fos:result>
             </fos:test>
          </fos:example>
@@ -21973,11 +22655,16 @@ else array:fold-left(array:tail($array),
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:for-each-pair(["A", "B", "C"], [1, 2, 3], function($x, $y) { array {$x, $y}})</fos:expression>
+               <fos:expression><eg>array:for-each-pair(
+  ["A", "B", "C"],
+  [1, 2, 3],
+  function($x, $y) { array { $x, $y }}
+)</eg></fos:expression>
                <fos:result>[["A", 1], ["B", 2], ["C", 3]]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>let $A := ["A", "B", "C", "D"] return array:for-each-pair($A, array:tail($A), concat#2)</fos:expression>
+               <fos:expression><eg>let $A := ["A", "B", "C", "D"]
+return array:for-each-pair($A, array:tail($A), concat#2)</eg></fos:expression>
                <fos:result>["AB", "BC", "CD"]</fos:result>
             </fos:test>
          </fos:example>
@@ -22027,11 +22714,11 @@ else array:fold-left(array:tail($array),
                <fos:result>[1, 2, 3, 4, 5]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, function{2*.})</fos:expression>
+               <fos:expression>array:build(1 to 5, function { 2 * . })</fos:expression>
                <fos:result>[2, 4, 6, 8, 10]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, function{1 to .})</fos:expression>
+               <fos:expression>array:build(1 to 5, function { 1 to . })</fos:expression>
                <fos:result>[1, (1,2), (1,2,3), (1,2,3,4), (1,2,3,4,5)]</fos:result>
             </fos:test>
             <fos:test>
@@ -22039,7 +22726,7 @@ else array:fold-left(array:tail($array),
                <fos:result>[("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e")]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:build(1 to 5, function{array{1 to .}})</fos:expression>
+               <fos:expression>array:build(1 to 5, function { array { 1 to . } })</fos:expression>
                <fos:result>[[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5]]</fos:result>
             </fos:test>
          </fos:example>
@@ -22087,11 +22774,16 @@ else array:fold-left(array:tail($array),
                <fos:result>(1, 2, 3, 4, 5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:members([(1,1) (2,4), (3,9), (4,16), (5,25)])!sum(?value)</fos:expression>
+               <fos:expression><eg>array:members([(1,1), (2,4), (3,9), (4,16), (5,25)])
+! sum(?value)</eg></fos:expression>
                <fos:result>(2, 6, 12, 20, 30)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>let $array := ["any array"] return deep-equal($array, array:of(array:members($array)))</fos:expression>
+               <fos:expression><eg>let $array := [ "any array" ]
+return deep-equal(
+  $array,
+  array:of(array:members($array))
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -22136,16 +22828,16 @@ else array:fold-left(array:tail($array),
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of(map{'value',(1 to 5)})</fos:expression>
+               <fos:expression>array:of(map { 'value': (1 to 5) })</fos:expression>
                <fos:result>[(1, 2, 3, 4, 5)]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of((1 to 5)!map{'value':.})</fos:expression>
+               <fos:expression>array:of((1 to 5) ! map { 'value': . })</fos:expression>
                <fos:result>[1, 2, 3, 4, 5]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of((1 to 5)!map{'value':(., .*.)})</fos:expression>
-               <fos:result>[(1,1) (2,4), (3,9), (4,16), (5,25)]</fos:result>
+               <fos:expression>array:of((1 to 5) ! map { 'value': (., .*.) })</fos:expression>
+               <fos:result>[(1,1), (2,4), (3,9), (4,16), (5,25)]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -22197,7 +22889,7 @@ else array:fold-left(array:tail($array),
                ref="choosing-a-collation"/>.</p>
          
          <p diff="chg" at="A">The result of <code>array:sort#3</code> is the value of the expression
-            <code role="example">array:of(array:members($array) => sort($collation, function($x){$key($x?value)}))</code></p>
+            <code role="example">array:of(array:members($array) => sort($collation, function($x) { $key($x?value) }))</code></p>
 
         
       </fos:rules>
@@ -23491,21 +24183,25 @@ declare function fn:all(
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>all((1, 3, 7), function{. mod 2 = 1})</fos:expression>
+               <fos:expression>all((1, 3, 7), function { . mod 2 = 1 })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>all(-5 to +5, function{. ge 0})</fos:expression>
+               <fos:expression>all(-5 to +5, function { . ge 0 })</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>all(("January", "February", "March", "April", 
-                  "September", "October", "November", "December"), contains(?, "r"))</fos:expression>
+               <fos:expression><eg>all(
+  ("January", "February", "March", "April",  "September", "October", "November", "December"),
+  contains(?, "r")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>all(("January", "February", "March", "April", 
-                  "September", "October", "November", "December")!contains(., "r"))</fos:expression>
+               <fos:expression><eg>all(
+  ("January", "February", "March", "April", "September", "October", "November", "December")
+  =!> contains("r")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -23603,7 +24299,7 @@ declare function fn:all(
             </fos:test>
             <fos:test>
                <fos:expression>char("eth")</fos:expression>
-               <fos:result>"&#xD0;"</fos:result>
+               <fos:result>"&#xF0;"</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>char("NotEqualTilde")</fos:expression>
@@ -23706,7 +24402,7 @@ declare function fn:all(
          
          <p>Let <code>$modified-key</code> be the function:</p>
          <eg>
-function($item){
+function($item) {
    $key($item) => data() ! (
       if (. instance of xs:untypedAtomic)
       then xs:double(.)
@@ -23757,37 +24453,44 @@ function($item){
          <fos:variable name="e" id="v-highest-e"><![CDATA[<a x="10" y="5" z="2"/>]]></fos:variable>
          <fos:example>
             <fos:test use="v-highest-e">
-               <fos:expression>highest($e/@*) ! name()</fos:expression>
+               <fos:expression>highest($e/@*, (), string#1) ! name()</fos:expression>
                <fos:result>("y")</fos:result>
                <fos:postamble>The attribute values are compared as strings.</fos:postamble>
             </fos:test>
             <fos:test use="v-highest-e">
                <fos:expression>highest($e/@*, (), number#1) ! name()</fos:expression>
                <fos:result>("x")</fos:result>
-               <fos:postamble>Here the attribute values are compared as numbers.</fos:postamble>
+               <fos:postamble>Here, the attribute values are compared as numbers.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>highest(("red", "green", "blue"), (), string-length#1)</fos:expression>
                <fos:result>("green")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>highest(("red", "green", "blue"), (),
-                  map{"red": xs:hexBinary('FF0000'), "green": xs:hexBinary('008000'), "blue": xs:hexBinary('0000FF')})</fos:expression>
+               <fos:expression><eg>highest(
+  ("red", "green", "blue"),
+  (),
+  map { "red": xs:hexBinary('FF0000'), "green": xs:hexBinary('008000'), "blue": xs:hexBinary('0000FF') }
+)</eg></fos:expression>
                <fos:result>("red")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>highest(("red", "orange", "yellow", "green", "blue", "indigo", "violet"), (), string-length#1)</fos:expression>
+               <fos:expression><eg>highest(
+  ("red", "orange", "yellow", "green", "blue", "indigo", "violet"),
+  (),
+  string-length#1
+)</eg></fos:expression>
                <fos:result>("orange", "yellow", "indigo", "violet")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>highest(1 to 25, (), function{. idiv 10})</fos:expression>
+               <fos:expression>highest(1 to 25, (), function { . idiv 10 })</fos:expression>
                <fos:result>(20, 21, 22, 23, 24, 25)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>To find employees having the highest salary:
             </p>
-            <eg>highest($employees, (), function{xs:decimal(salary)})</eg>
+            <eg>highest($employees, (), function { xs:decimal(salary) })</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -23830,12 +24533,15 @@ function($item){
                <fos:result>(2, 3)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>index-where(1 to 10, function{. mod 2 = 0})</fos:expression>
+               <fos:expression>index-where(1 to 10, function { . mod 2 = 0 })</fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>index-where(("January", "February", "March", "April", "May",
-                  "June", "July", "August", "September", "October", "November", "December"), contains(?, "r"))</fos:expression>
+               <fos:expression><eg>index-where(
+  ("January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"),
+  contains(?, "r")
+)</eg></fos:expression>
                <fos:result>(1, 2, 3, 4, 9, 10, 11, 12)</fos:result>
             </fos:test>
          </fos:example>
@@ -23976,15 +24682,18 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-after(10 to 20, function{. gt 12})</fos:expression>
+               <fos:expression>items-after(10 to 20, function { . gt 12 })</fos:expression>
                <fos:result>(14, 15, 16, 17, 18, 19, 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-after(("January", "February", "March", "April", "May"), starts-with(?, "A"))</fos:expression>
+               <fos:expression><eg>items-after(
+  ("January", "February", "March", "April", "May"),
+  starts-with(?, "A")
+)</eg></fos:expression>
                <fos:result>("May")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-after(10 to 20, function{. gt 100})</fos:expression>
+               <fos:expression>items-after(10 to 20, function { . gt 100 })</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
@@ -23992,7 +24701,8 @@ function($item){
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-after(function{boolean(self::h2)})]]></fos:expression>
+               <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
+=> items-after(function { boolean(self::h2) })]]></eg></fos:expression>
                <fos:result><![CDATA[<img/>]]></fos:result>
             </fos:test>
          </fos:example>
@@ -24034,15 +24744,18 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-before(10 to 20, function{. gt 12})</fos:expression>
+               <fos:expression>items-before(10 to 20, function { . gt 12 })</fos:expression>
                <fos:result>(10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-before(("January", "February", "March", "April", "May"), starts-with(?, "A"))</fos:expression>
+               <fos:expression><eg>items-before(
+  ("January", "February", "March", "April", "May"),
+  starts-with(?, "A")
+)</eg></fos:expression>
                <fos:result>("January", "February", "March")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-before(10 to 20, function{. gt 100})</fos:expression>
+               <fos:expression>items-before(10 to 20, function { . gt 100 })</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
@@ -24050,11 +24763,15 @@ function($item){
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-before(function{boolean(self::img)})) ! name()]]></fos:expression>
+               <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
+=> items-before(function { boolean(self::img) })
+=!> name()]]></eg></fos:expression>
                <fos:result>"p", "p", "h2"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>("Aardvark", "Antelope", "Bison", "Buffalo", "Camel", "Dingo") => items-starting-where(starts-with(?, "B")) => items-before(starts-with(?, "D"))</fos:expression>
+               <fos:expression><eg>("Aardvark", "Antelope", "Bison", "Buffalo", "Camel", "Dingo")
+=> items-starting-where(starts-with(?, "B"))
+=> items-before(starts-with(?, "D"))</eg></fos:expression>
                <fos:result>"Bison", "Buffalo", "Camel"</fos:result>
             </fos:test>
          </fos:example>
@@ -24096,15 +24813,18 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-starting-where(10 to 20, function{. gt 12})</fos:expression>
+               <fos:expression>items-starting-where(10 to 20, function { . gt 12 })</fos:expression>
                <fos:result>(13, 14, 15, 16, 17, 18, 19, 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-starting-where(("January", "February", "March", "April", "May"), starts-with(?, "A"))</fos:expression>
+               <fos:expression><eg>items-starting-where(
+  ("January", "February", "March", "April", "May"),
+  starts-with(?, "A")
+)</eg></fos:expression>
                <fos:result>("April", "May")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-starting-where(10 to 20, function{. gt 100})</fos:expression>
+               <fos:expression>items-starting-where(10 to 20, function { . gt 100 })</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
@@ -24112,7 +24832,9 @@ function($item){
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-starting-where(function{boolean(self::h2)})) ! name()]]></fos:expression>
+               <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
+=> items-starting-where(function { boolean(self::h2) })
+=!> name()]]></eg></fos:expression>
                <fos:result>"h2", "img"</fos:result>
             </fos:test>
          </fos:example>
@@ -24155,15 +24877,18 @@ function($item){
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-ending-where(10 to 20, function{. gt 12})</fos:expression>
+               <fos:expression>items-ending-where(10 to 20, function { . gt 12 })</fos:expression>
                <fos:result>(10, 11, 12, 13)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-ending-where(("January", "February", "March", "April", "May"), starts-with(?, "A"))</fos:expression>
+               <fos:expression><eg>items-ending-where(
+  ("January", "February", "March", "April", "May"),
+  starts-with(?, "A")
+)</eg></fos:expression>
                <fos:result>("January", "February", "March", "April")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-ending-where(10 to 20, function{. gt 100})</fos:expression>
+               <fos:expression>items-ending-where(10 to 20, function { . gt 100 })</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
@@ -24171,7 +24896,9 @@ function($item){
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><![CDATA[(parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/* => items-ending-where(function{boolean(self::h2)})) ! name()]]></fos:expression>
+               <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
+=> items-ending-where(function { boolean(self::h2) })
+=!> name()]]></eg></fos:expression>
                <fos:result>"p", "p", "h2"</fos:result>
             </fos:test>
          </fos:example>
@@ -24215,13 +24942,11 @@ function($item){
          <p>The third argument defaults to the function <code>data#1</code>.</p>
          
          <p>Let <code>$modified-key</code> be the function:</p>
-         <eg>
-            function($item){
-            $key($item) => data() ! (
-            if (. instance of xs:untypedAtomic)
-            then xs:double(.)
-            else .)
-            }</eg>
+         <eg>function($item) {
+  $key($item) => data() ! (
+    if (. instance of xs:untypedAtomic) then xs:double(.) else .
+  )
+}</eg>
          
          <p>That is, the supplied function for computing key values is wrapped in a function that
             converts any <code>xs:untypedAtomic</code> values in its result to <code>xs:double</code>. This makes
@@ -24269,48 +24994,50 @@ function($item){
          <fos:variable name="e" id="v-lowest-e"><![CDATA[<a x="10" y="5" z="2"/>]]></fos:variable>
          <fos:example>
             <fos:test use="v-lowest-e">
-               <fos:expression>lowest($e/@*) ! name()</fos:expression>
+               <fos:expression>lowest($e/@*, (), string#1) ! name()</fos:expression>
                <fos:result>("x")</fos:result>
                <fos:postamble>The attribute values are compared as strings</fos:postamble>
             </fos:test>
             <fos:test use="v-lowest-e">
                <fos:expression>lowest($e/@*, (), number#1) ! name()</fos:expression>
                <fos:result>("z")</fos:result>
-               <fos:postamble>Here the attribute values are compared as numbers</fos:postamble>
+               <fos:postamble>Here, the attribute values are compared as numbers</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>lowest(("red", "green", "blue"), (), string-length#1)</fos:expression>
                <fos:result>("red")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>lowest(("red", "green", "blue"), (),
-                  map{"red": xs:hexBinary('FF0000'), "green": xs:hexBinary('008000'), "blue": xs:hexBinary('0000FF')})</fos:expression>
+               <fos:expression><eg>lowest(
+  ("red", "green", "blue"),
+  (),
+  map { "red": xs:hexBinary('FF0000'), "green": xs:hexBinary('008000'), "blue": xs:hexBinary('0000FF') }
+)</eg></fos:expression>
                <fos:result>("blue")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>lowest(("April", "June", "July", "August"), (), string-length#1)</fos:expression>
+               <fos:expression><eg>lowest(
+  ("April", "June", "July", "August"),
+  (),
+  string-length#1
+)</eg></fos:expression>
                <fos:result>("June", "July")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>lowest(1 to 25, (), function{. idiv 10})</fos:expression>
+               <fos:expression>lowest(1 to 25, (), function { . idiv 10 })</fos:expression>
                <fos:result>(1, 2, 3, 4, 5, 6, 7, 8, 9)</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>To find employees having the lowest salary:
             </p>
-            <eg>lowest($employees, (), function{xs:decimal(salary)})</eg>
+            <eg>lowest($employees, (), function { xs:decimal(salary) })</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
          <fos:version version="4.0">New in 4.0. Accepted 2022-09-20.</fos:version>
       </fos:history>
    </fos:function>
-
-  
-
-
-
 
    <fos:function name="some" prefix="fn">
       <fos:signatures>
@@ -24367,21 +25094,25 @@ declare function fn:some(
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some((1, 3, 7), function{. mod 2 = 1})</fos:expression>
+               <fos:expression>some((1, 3, 7), function {. mod 2 = 1 })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some(-5 to +5, function{. ge 0}))</fos:expression>
+               <fos:expression>some(-5 to +5, function {. ge 0 })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some(("January", "February", "March", "April", 
-                  "September", "October", "November", "December"), contains(?, "z"))</fos:expression>
+               <fos:expression><eg>some(
+  ("January", "February", "March", "April", "September", "October", "November", "December"),
+  contains(?, "z")
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some(("January", "February", "March", "April", 
-                  "September", "October", "November", "December")!contains(., "r"))</fos:expression>
+               <fos:expression><eg>some(
+  ("January", "February", "March", "April", "September", "October", "November", "December")
+  =!> contains("r")
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -24478,7 +25209,10 @@ declare function fn:some(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>all-equal(("ABC", "abc"), "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
+               <fos:expression><eg>all-equal(
+  ("ABC", "abc"),
+  "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"
+)</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -24559,7 +25293,10 @@ declare function fn:some(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>all-different(("ABC", "abc"), "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive")</fos:expression>
+               <fos:expression><eg>all-different(
+  ("ABC", "abc"),
+  "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"
+)</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -24900,7 +25637,9 @@ declare function fn:some(
     <p>In the examples that follow, keys with values that are null, or an empty array,
 are elided for editorial clarity.</p>
     <fos:test>
-      <fos:expression>parse-uri("http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri")</fos:expression>
+      <fos:expression><eg>parse-uri(
+  "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri"
+)</eg></fos:expression>
       <fos:result><eg>map {
   "uri": "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri",
   "scheme": "http",
@@ -24943,7 +25682,9 @@ are elided for editorial clarity.</p>
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>parse-uri("https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance")</fos:expression>
+      <fos:expression><eg>parse-uri(
+  "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance"
+)</eg></fos:expression>
       <fos:result><eg>map {
   "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance",
   "scheme": "https",
@@ -25182,7 +25923,9 @@ are elided for editorial clarity.</p>
   </fos:example>
   <fos:example>
     <fos:test>
-      <fos:expression>parse-uri("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")</fos:expression>
+      <fos:expression><eg>parse-uri(
+  "urn:oasis:names:specification:docbook:dtd:xml:4.1.2"
+)</eg></fos:expression>
       <fos:result>
 <eg>map {
   "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
@@ -25225,7 +25968,9 @@ are elided for editorial clarity.</p>
 <p>This example uses the algorithm described above, not an algorithm that is
 specifically aware of the <code>jar:</code> scheme.</p>
     <fos:test>
-      <fos:expression>parse-uri("jar:file:/C:/Program%20Files/test.jar!/foo/bar")</fos:expression>
+      <fos:expression><eg>parse-uri(
+  "jar:file:/C:/Program%20Files/test.jar!/foo/bar"
+)</eg></fos:expression>
       <fos:result>
 <eg>map {
   "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
@@ -25259,8 +26004,10 @@ description of <code>fn:resolve-uri</code>.</p>
   <fos:example>
 <p>This example demonstrates a non-standard query separator.</p>
     <fos:test>
-      <fos:expression>parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance",
-             map { "query-separator": ";" })</fos:expression>
+      <fos:expression><eg>parse-uri(
+  "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
+  map { "query-separator": ";" }
+)</eg></fos:expression>
       <fos:result>
 <eg>map {
   "uri": "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
@@ -25282,8 +26029,10 @@ description of <code>fn:resolve-uri</code>.</p>
   <fos:example>
 <p>This example uses an invalid query separator so raises an error.</p>
     <fos:test>
-      <fos:expression>parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance",
-             map { "query-separator": ";;" })</fos:expression>
+      <fos:expression><eg>parse-uri(
+  "https://example.com:8080/path?s=%22hello world%22;;sort=relevance",
+  map { "query-separator": ";;" }
+)</eg></fos:expression>
       <fos:error-result error-code="FOXX0000"/>
     </fos:test>
   </fos:example>
@@ -25534,11 +26283,11 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:notes>
          <p>The function enables a variety of positional grouping problems to be solved. For example:</p>
          <ulist>
-            <item><p><code>partition($input, function($a, $b){count($a) eq 3}</code>
+            <item><p><code>partition($input, function($a, $b) { count($a) eq 3 }</code>
                partitions a sequence into fixed size groups of length 3.</p></item>
-            <item><p><code>partition($input, function($a, $b){boolean($b/self::h1)}</code>
+            <item><p><code>partition($input, function($a, $b) { boolean($b/self::h1) }</code>
                starts a new group whenever an <code>h1</code> element is encountered.</p></item>
-            <item><p><code>partition($input, function($a, $b){$b lt foot($a)}</code>
+            <item><p><code>partition($input, function($a, $b) { $b lt foot($a) }</code>
                starts a new group whenever an item is encountered whose value is less than
                the value of the previous item.</p></item>
          </ulist>
@@ -25549,25 +26298,38 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>partition(("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
-                  function($partition, $next){substring($partitions[1],1,1) ne substring($next,1,1)})</fos:expression>
+               <fos:expression><eg>partition(
+  ("Anita", "Anne", "Barbara", "Catherine", "Christine"), 
+  function($partition, $next) { substring($partition[1],1,1) ne substring($next,1,1) }
+)</eg></fos:expression>
                <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>partition((1, 2, 3, 4, 5, 6, 7), function($partition, $next){count($partition) eq 2})</fos:expression>
+               <fos:expression><eg>partition(
+  (1, 2, 3, 4, 5, 6, 7),
+  function($partition, $next) { count($partition) eq 2 }
+)</eg></fos:expression>
                <fos:result>([1, 2], [3, 4], [5, 6], [7])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>partition((1, 4, 6, 3, 1, 1), function($partition, $next){sum($partition) ge 5})</fos:expression>
+               <fos:expression><eg>partition(
+  (1, 4, 6, 3, 1, 1),
+  function($partition, $next) { sum($partition) ge 5 }
+)</eg></fos:expression>
                <fos:result>([1, 4], [6], [3, 1, 1])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>partition(tokenize("In the beginning was the word"), 
-                  function($partition, $next){sum(($partition, $next)!string-length()) gt 10}</fos:expression>
+               <fos:expression><eg>partition(
+  tokenize("In the beginning was the word"), 
+  function($partition, $next) { sum(($partition, $next) ! string-length()) gt 10 }
+)</eg></fos:expression>
                <fos:result>(["In", "the"], ["beginning"], ["was", "the", "word"])</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>partition((1, 2, 3, 6, 7, 9, 10), function($partition, $next){$next ne foot($partition)+1})</fos:expression>
+               <fos:expression><eg>partition(
+  (1, 2, 3, 6, 7, 9, 10),
+  function($partition, $next) { $next != foot($partition) + 1 }
+)</eg></fos:expression>
                <fos:result>([1, 2, 3], [6, 7], [9, 10])</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
@@ -139,6 +139,8 @@
 
   
   <xsl:mode name="strip-space" on-no-match="shallow-copy"/>
+  <xsl:template match="@escaped-key[. = false()]" mode="strip-space"/>
+  <xsl:template match="@escaped[. = false()]" mode="strip-space"/>
   <xsl:template match="text()[not(normalize-space())][not(parent::fn:match)][not(parent::fn:non-match)]" mode="strip-space"/>
 
 


### PR DESCRIPTION
This PR contains lots of fixes in the XQFO examples and improves the formatting of examples with nested arguments and multiline expressions.

It’s probably helpful to merge it as soon as possible to avoid conflicts with other PRs.