### PR TITLE
508: New Map & Array Functions: Inconsistencies

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -15845,7 +15845,7 @@ else
          
          <p>The result of the function is a <i>parcel</i>. A parcel is a single item,
          but its exact form is implementation-dependent. The only guaranteed operations
-         that apply to parcels are the <code>fn:unparcel</code> and <code>array:of</code>
+         that apply to parcels are the <code>fn:unparcel</code> and <code>array:of-members</code>
          functions.</p>
          
          
@@ -15853,9 +15853,9 @@ else
       
       <fos:notes>
          <p>The main use case for this function is for temporary values used while constructing
-         or deconstructing arrays using the <code>array:of</code> and <code>array:members</code>
+         or deconstructing arrays using the <code>array:of-members</code> and <code>array:members</code>
          functions, and higher-level constructs that may be defined in terms of these primitives
-         in XSLT or XQuery. The <code>array:of</code> function constructs an array from a sequence
+         in XSLT or XQuery. The <code>array:of-members</code> function constructs an array from a sequence
          of parcels, and the <code>array:members</code> function does the reverse.</p>
          <p>Applications may also choose to use parcels to represent nested sequences directly,
          without converting these to arrays. However, there are few operations available on parcels
@@ -15875,11 +15875,11 @@ else
                <fos:result>(1, 2, 3 ,4, 5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of((parcel(1 to 3), parcel(10 to 13))</fos:expression>
+               <fos:expression>array:of-members((parcel(1 to 3), parcel(10 to 13))</fos:expression>
                <fos:result>[(1, 2, 3), (10, 11, 12, 13)]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of(tokenize("A long hot summer") ! parcel((position(), .)))</fos:expression>
+               <fos:expression>array:of-members(tokenize("A long hot summer") ! parcel((position(), .)))</fos:expression>
                <fos:result>[(1,"A"), (2,"long"), (3,"hot"), (4,"summer")]</fos:result>
             </fos:test>
          </fos:example>
@@ -18767,9 +18767,9 @@ return fold-left($MAPS, map{},
       </fos:examples>
    </fos:function>
 
-   <fos:function name="of" prefix="map">
+   <fos:function name="of-pairs" prefix="map">
       <fos:signatures>
-         <fos:proto name="of" return-type="map(*)">
+         <fos:proto name="of-pairs" return-type="map(*)">
             <fos:arg name="pairs" 
                      type="record(key as xs:anyAtomicType, value as item()*, *)*" 
                      usage="inspection"
@@ -18788,7 +18788,7 @@ return fold-left($MAPS, map{},
       </fos:summary>
       <fos:rules>
          
-         <p>The function <code>map:of</code>
+         <p>The function <code>map:of-pairs</code>
             <phrase>returns a map</phrase> that
             is formed by combining <termref def="dt-key-value-pair-map">key-value pair maps</termref> supplied in the 
             <code>$key-value-pairs</code>
@@ -18821,17 +18821,18 @@ return fold-left($MAPS, map{},
             select="map { 0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;,&#xa;     3: &quot;Mittwoch&quot;, 4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6 :&quot;Samstag&quot; }"/>
          <fos:example>
             <fos:test>
-               <fos:expression>map:of(())</fos:expression>
+               <fos:expression>map:of-pairs(())</fos:expression>
                <fos:result>map{}</fos:result>
                <fos:postamble>Returns an empty map</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression>map:of(map:pairs($week))</fos:expression>
+               <fos:expression>map:of-pairs(map:pairs($week))</fos:expression>
                <fos:result>$week</fos:result>
-               <fos:postamble>The function <code>map:of</code> is the inverse of <code>map:pairs</code>.</fos:postamble>
+               <fos:postamble>The function <code>map:of-pairs</code> is the inverse of
+                  <code>map:pairs</code>.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[map:of((
+               <fos:expression><eg><![CDATA[map:of-pairs((
   map { "key": 0, "value": "no" },
   map { "key": 1, "value": "yes" }
 ))]]></eg></fos:expression>
@@ -18839,7 +18840,7 @@ return fold-left($MAPS, map{},
                <fos:postamble>Returns a map with two entries</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression><eg>map:of((
+               <fos:expression><eg>map:of-pairs((
   map:pairs($week),
   map { "key": 7, "value": "Unbekannt" }
 ))</eg></fos:expression>
@@ -18850,7 +18851,7 @@ return fold-left($MAPS, map{},
                   entry.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression><eg>map:of((
+               <fos:expression><eg>map:of-pairs((
   map:pairs($week),
   map { "key": 6, "value": "Sonnabend" }
 ))</eg></fos:expression>
@@ -18862,7 +18863,7 @@ return fold-left($MAPS, map{},
                   one used in the result combines the two supplied values into a single sequence.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression><eg>map:of(
+               <fos:expression><eg>map:of-pairs(
   (map:pairs($week),
    map { "key": 6, "value": "Sonnabend" }),
   function($old, $new)  { $new }
@@ -18876,7 +18877,7 @@ return fold-left($MAPS, map{},
                   is the one that comes last in the input sequence.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
-               <fos:expression><eg>map:of(
+               <fos:expression><eg>map:of-pairs(
   (map:pairs($week),
    map { "key": 6, "value": "Sonnabend" }),
   function($old, $new) { `{$old}|{$new}` }
@@ -19483,6 +19484,59 @@ map:merge(for $b in //book return map:entry($b/isbn, $b))]]></eg>
          </fos:example>
       </fos:examples>
    </fos:function>
+
+   <fos:function name="pair" prefix="map">
+      <fos:signatures>
+         <fos:proto name="pair" return-type="map(*)">
+            <fos:arg name="key" type="xs:anyAtomicType"/>
+            <fos:arg name="value" type="item()*" usage="navigation"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p><phrase>Returns</phrase> a <termref def="dt-key-value-pair-map"/> that 
+            represents a single key-value pair.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function <code>map:pair</code> returns a <termref def="dt-map"
+            >map</termref> which contains two entries, one (with the key <code>"key"</code>)
+            containing <code>$key</code> and the other (with the key <code>"value"</code>)
+            containing <code>$value</code>.</p>
+      </fos:rules>
+      <fos:notes>
+         <p>The function call <code>map:pair(K, V)</code> produces the same result as the
+         expression <code>map { "key": K, "value": V }</code>.</p>
+         <p>The function <code>map:pair</code> is intended primarily for use in conjunction with
+            the function <code>map:of-pairs</code>. A map may be constructed like this:</p>
+
+         <eg><![CDATA[
+map:of-pairs((
+   map:pair("Su", "Sunday"),
+   map:pair("Mo", "Monday"),
+   map:pair("Tu", "Tuesday"),
+   map:pair("We", "Wednesday"),
+   map:pair("Th", "Thursday"),
+   map:pair("Fr", "Friday"),
+   map:pair("Sa", "Saturday")
+   ))]]></eg>
+         <p>The <code>map:of-pairs</code> function can be used to construct
+            a map with a variable number of entries, for example:</p>
+         <eg><![CDATA[map:of-pairs(//book ! map:pair(./isbn, .))]]></eg>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>map:pair("M", "Monday")</fos:expression>
+               <fos:result>map { "key": "M", "value": "Monday" }</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+
    <fos:function name="remove" prefix="map">
       <fos:signatures>
          <fos:proto name="remove" return-type="map(*)">
@@ -21815,7 +21869,7 @@ else $fallback($position)</eg>
             members in positions 1 to <code>array:size($array)</code> are the same as the members in the corresponding position
             of <code>$array</code>, and the member in position <code>array:size($array) + 1</code> is <code>$member</code>.</p>
          <p diff="chg" at="A">More formally, the result is the value of the expression
-            <code>array:of((array:members($array), map{'value':$member}))</code>.</p>
+            <code>array:of-members((array:members($array), map{'value':$member}))</code>.</p>
 
       </fos:rules>
       <fos:examples>
@@ -21857,7 +21911,7 @@ else $fallback($position)</eg>
       <fos:rules>
          <p>Informally, the function concatenates the members of several arrays into a single array.</p>
          <p diff="chg" at="A">More formally, the function returns the result of 
-            <code>array:of($arrays ! array:members(.))</code>.</p>
+            <code>array:of-members($arrays ! array:members(.))</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -21914,7 +21968,7 @@ else $fallback($position)</eg>
          <p diff="add" at="2022-12-19">Setting the third argument to the empty sequence has the same effect as omitting the argument.</p>
          <p>Except in error cases, the result of the three-argument version of the function is the 
             value of the expression
-            <code role="example">array:of(array:members($array) => fn:subsequence($start, $length))</code>.</p>
+            <code role="example">array:of-members(array:members($array) => fn:subsequence($start, $length))</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="AY" code="0001"
@@ -22058,7 +22112,7 @@ else $fallback($position)</eg>
          <p>Returns an array containing selected members of a supplied input array based on their position.</p>
       </fos:summary>
       <fos:rules>
-         <p>Returns the value of <code role="example">array:of(array:members($array) => fn:slice($start, $end, $step))</code></p>
+         <p>Returns the value of <code role="example">array:of-members(array:members($array) => fn:slice($start, $end, $step))</code></p>
       </fos:rules>
       <fos:notes>
          <p>The function is formally defined by converting the array to a sequence, applying 
@@ -22180,7 +22234,7 @@ else $fallback($position)</eg>
             except the members whose position (counting from 1) is present in the sequence <code>$positions</code>.
          The order of the remaining members is preserved.</p>
          <p diff="chg" at="A">More formally, the result of the function, except in error cases, is given by the expression
-            <code role="example">array:of(array:members($array) => fn:remove($positions))</code>.
+            <code role="example">array:of-members(array:members($array) => fn:remove($positions))</code>.
          </p>
       </fos:rules>
       <fos:errors>
@@ -22242,7 +22296,7 @@ else $fallback($position)</eg>
             then all members from <code>$array</code> whose position is greater than or equal to <code>$position</code>. 
             Positions are counted from 1.</p>
          <p>More formally, except in error cases, the result is the value of the expression
-            <code role="example">array:of(array:members($array) => fn:insert-before($position, map{'value':$member}))</code>.</p>
+            <code role="example">array:of-members(array:members($array) => fn:insert-before($position, map{'value':$member}))</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
@@ -22476,7 +22530,7 @@ else $fallback($position)</eg>
       </fos:summary>
       <fos:rules>
          <p diff="chg" at="A">The function returns the result of the expression:
-            <code role="example">array:of(array:members($array) => fn:reverse())</code></p>
+            <code role="example">array:of-members(array:members($array) => fn:reverse())</code></p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -22526,7 +22580,7 @@ else $fallback($position)</eg>
          <p>Informally, the function returns an array whose members are obtained by applying 
          the supplied <code>$function</code> to each member of the input array in turn.</p>
          <p>More formally, the function returns the result of the expression
-            <code>array:of(array:members($array) ! map { 'value': $action(?value) }</code>.</p>
+            <code>array:of-members(array:members($array) ! map { 'value': $action(?value) }</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -22576,7 +22630,7 @@ else $fallback($position)</eg>
          <p>Informally, the function returns an array containing those members of the input
          array that satisfy the supplied predicate.</p>
          <p>More formally, the function returns the result of the expression
-            <code role="example">array:of(array:members($array) => fn:filter(function($m) { $predicate($m?value) })</code>.</p>
+            <code role="example">array:of-members(array:members($array) => fn:filter(function($m) { $predicate($m?value) })</code>.</p>
 
       </fos:rules>
       <fos:errors>
@@ -22771,7 +22825,7 @@ else array:fold-left(array:tail($array),
       </fos:summary>
       <fos:rules>
          <p>The function returns the result of the expression:</p>
-         <eg><code>array:of(
+         <eg><code>array:of-members(
     for-each-pair(array:members($array1), 
                      array:members($array2), 
                      function($m, $n) {map{'value': $action($m?value, $n?value)}}))</code>
@@ -22830,7 +22884,7 @@ return array:for-each-pair(
          <p>Informally, <code>array:build#2</code> applies the supplied function to each item 
             in the input sequence, and the resulting sequence becomes one member of the returned array.</p>
          <p>More formally, <code>array:build#2</code> returns the result of the expression:</p>
-         <eg>array:of($input ! map{'value':$action(.)})</eg>
+         <eg>array:of-members($input ! map{'value':$action(.)})</eg>
       </fos:rules>
       <fos:notes>
          <p>The single-argument function <code>array:build($input)</code> is equivalent to the XPath
@@ -22905,7 +22959,7 @@ return array:for-each-pair(
          
       </fos:rules>
       <fos:notes>
-         <p>This function is the inverse of <code>array:of</code>.</p>   
+         <p>This function is the inverse of <code>array:of-members</code>.</p>   
       </fos:notes>
  
       <fos:examples>
@@ -22927,7 +22981,7 @@ return array:for-each-pair(
                <fos:expression><eg>let $array := [ "any array" ]
 return deep-equal(
   $array,
-  array:of(array:members($array))
+  array:of-members(array:members($array))
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -22938,9 +22992,67 @@ return deep-equal(
       </fos:history>
    </fos:function>
    
-   <fos:function name="of" prefix="array">
+   <fos:function name="split" prefix="array">
       <fos:signatures>
-         <fos:proto name="of" return-type="array(*)">
+         <fos:proto name="split" return-type="array(*)*">
+            <fos:arg name="array" type="array(*)" usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Delivers the contents of an array as a sequence of singleton arrays.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The members of the array are delivered as a sequence of arrays. 
+            Each returned array encapsulates the value of a single array member.</p>
+      </fos:rules>
+      <fos:notes>
+         <p>The function call <code>array:split($array)</code> produces the same result as the
+            expression <code>for member $m in $array return [ $m ]</code>.</p>
+         <p>This function is the inverse of <code>array:join</code>.</p>   
+      </fos:notes>
+ 
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>array:split([])</fos:expression>
+               <fos:result>[]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>array:split([1 to 5])</fos:expression>
+               <fos:result>[(1, 2, 3, 4, 5)]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>array:split(
+  array { 1 to 5 }
+)</eg></fos:expression>
+               <fos:result>[1], [2], [3], [4], [5]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>array:split(
+  [(1,1), (2,4), (3,9), (4,16), (5,25)]
+) ! sum(.)</eg></fos:expression>
+               <fos:result>2, 6, 12, 20, 30</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $array := [ "any array" ]
+return deep-equal(
+  $array,
+  array:join(array:split($array))
+)</eg></fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+   
+   <fos:function name="of-members" prefix="array">
+      <fos:signatures>
+         <fos:proto name="of-members" return-type="array(*)">
             <fos:arg name="input" type="record(value as item()*)*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -22969,19 +23081,19 @@ return deep-equal(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:of(())</fos:expression>
+               <fos:expression>array:of-members(())</fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of(map { 'value': (1 to 5) })</fos:expression>
+               <fos:expression>array:of-members(map { 'value': (1 to 5) })</fos:expression>
                <fos:result>[(1, 2, 3, 4, 5)]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of((1 to 5) ! map { 'value': . })</fos:expression>
+               <fos:expression>array:of-members((1 to 5) ! map { 'value': . })</fos:expression>
                <fos:result>[1, 2, 3, 4, 5]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of((1 to 5) ! map { 'value': (., .*.) })</fos:expression>
+               <fos:expression>array:of-members((1 to 5) ! map { 'value': (., .*.) })</fos:expression>
                <fos:result>[(1,1), (2,4), (3,9), (4,16), (5,25)]</fos:result>
             </fos:test>
          </fos:example>
@@ -23034,9 +23146,7 @@ return deep-equal(
                ref="choosing-a-collation"/>.</p>
          
          <p diff="chg" at="A">The result of <code>array:sort#3</code> is the value of the expression
-            <code role="example">array:of(array:members($array) => sort($collation, function($x) { $key($x?value) }))</code></p>
-
-        
+            <code role="example">array:of-members(array:members($array) => sort($collation, function($x) { $key($x?value) }))</code></p>
       </fos:rules>
       <fos:errors>
          <p>If the set of computed sort keys contains values that are not comparable using the <code>le</code> operator then the sort 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7118,12 +7118,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <tr>
                   <td><p>Compose a map</p></td>
                   <td><p><code>map:merge($entries)</code></p></td>
-                  <td><p><code>map:of($key-value-pairs)</code></p></td>
+                  <td><p><code>map:of-pairs($key-value-pairs)</code></p></td>
                </tr>
                <tr>
                   <td><p>Create a single entry</p></td>
                   <td><p><code>map:entry($key, $value)</code></p></td>
-                  <td><p><code>map{"key":$key, "value":$value}</code></p></td>
+                  <td><p><code>map:pair($key, $value)</code></p></td>
                </tr>
                <tr>
                   <td><p>Extract the key part of a single entry</p></td>
@@ -7187,17 +7187,20 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-map-get">
                <head><?function map:get?></head>
             </div3>
-            <div3 id="func-map-pairs" diff="add" at="2023-04-03">
-               <head><?function map:pairs?></head>
-            </div3>
             <div3 id="func-map-keys">
                <head><?function map:keys?></head>
             </div3>
             <div3 id="func-map-merge">
                <head><?function map:merge?></head>
             </div3>
-            <div3 id="func-map-of" diff="add" at="2023-04-03">
-               <head><?function map:of?></head>
+            <div3 id="func-map-of-pairs" diff="add" at="2023-04-03">
+               <head><?function map:of-pairs?></head>
+            </div3>
+            <div3 id="func-map-pair">
+               <head><?function map:pair?></head>
+            </div3>
+            <div3 id="func-map-pairs" diff="add" at="2023-04-03">
+               <head><?function map:pairs?></head>
             </div3>
             <div3 id="func-map-put">
                <head><?function map:put?></head>
@@ -7217,13 +7220,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-map-values" diff="add" at="2023-04-19">
                <head><?function map:values?></head>
             </div3>
- 
-
-            
          </div2>
-         
-         
- 
  
          <div2 id="map-operations">
             <head>Other Operations on Maps </head>
@@ -7277,7 +7274,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <ulist diff="chg" at="2023-02-20">
                <item><p>The function <code>array:members</code> decomposes an array to a sequence of 
                   <term>value records</term>.</p></item>
-               <item><p>The function <code>array:of</code> composes an array from a sequence of 
+               <item><p>The function <code>array:of-members</code> composes an array from a sequence of 
                <term>value records</term>.</p></item>
             </ulist>
             
@@ -7317,21 +7314,17 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-array-foot" diff="add" at="2022-11-16">
                <head><?function array:foot?></head>
             </div3>
-            <div3 id="func-array-for-each-pair">
-               <head><?function array:for-each-pair?></head>
-            </div3>
-            
             <div3 id="func-array-for-each">
                <head><?function array:for-each?></head>
+            </div3>
+            <div3 id="func-array-for-each-pair">
+               <head><?function array:for-each-pair?></head>
             </div3>
             <div3 id="func-array-get">
                <head><?function array:get?></head>
             </div3>
             <div3 id="func-array-head">
                <head><?function array:head?></head>
-            </div3>
-            <div3 id="func-array-of" diff="add" at="2023-02-20">
-               <head><?function array:of?></head>
             </div3>
             <div3 id="func-array-index-where" diff="add" at="2022-11-17">
                <head><?function array:index-where?></head>
@@ -7344,6 +7337,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
             <div3 id="func-array-members" diff="add" at="2023-02-20">
                <head><?function array:members?></head>
+            </div3>
+            <div3 id="func-array-of-members" diff="add" at="2023-02-20">
+               <head><?function array:of-members?></head>
             </div3>
             <div3 id="func-array-put">
                <head><?function array:put?></head>
@@ -7366,13 +7362,12 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-array-sort">
                <head><?function array:sort?></head>
             </div3>
+            <div3 id="func-array-split">
+               <head><?function array:split?></head>
+            </div3>
             <div3 id="func-array-subarray">
                <head><?function array:subarray?></head>
             </div3> 
-            
-            
-            
-            
             <div3 id="func-array-tail">
                <head><?function array:tail?></head>
             </div3>
@@ -7382,43 +7377,56 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-array-values" diff="add" at="2023-05-07">
                <head><?function array:values?></head>
             </div3>
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
          </div2> 
          <div2 id="additional-array-operations" diff="add" at="2023-02-20">
             <head>Additional Operations on Arrays</head>
             <p><emph>This section is non-normative.</emph></p>
-            <p>The XPath language provides explicit syntax for certain operations on arrays. These constructs can
-            all be specified in terms of the primitives <code>array:of</code> and <code>array:members</code>:</p>
+            <p>The XPath language provides explicit syntax for certain operations on arrays.
+               These constructs can also be specified in terms of functions primitives:</p>
             
-             <ulist>
-               <item><p><code>array{$sequence}</code> constructs an array whose members are the items in <code>$sequence</code>.
-                  Every member of this array will be a singleton item.
-                  This can be defined as <code>array:of($sequence ! map{'value': .})</code>.</p></item>
-               <item><p><code>[E1, E2, E3, ..., En]</code> constructs an array in which <code>E1</code> is the first member,
-                  <code>E2</code> is the second member, and so on. The result is equivalent to the expression
-                  <code>array:of((map{'value':E1}, map{'value':E2}, map{'value':E3}, ... map{'value':En})). </code></p></item>
-               <item><p>The lookup expression <code>$array?*</code> is equivalent to 
-                  <code>array:members($array)!?value</code>.</p></item>
-                <item><p>The lookup expression <code>$array?$N</code>, where <code>$N</code> is an integer within the bounds
-                   of the array, is equivalent to 
-                   <code>array:members($array)[$N]?value</code>.</p></item>
-                <item><p>Similarly, applying the array as a function, <code>$array($N)</code>, is also equivalent to 
-                   <code>array:members($array)[$N]?value</code></p></item>
-            </ulist>
-            
-            
-         </div2>
+            <div3 id="singleton-arrays">
+               <head>Singleton Arrays</head>
+                 <item><p><code>array { $sequence }</code> constructs an array whose members
+                    are the items in <code>$sequence</code>. Every member of this array will
+                    be a singleton item. This can be defined as
+                    <code>array:join($sequence ! array { . })</code>.</p></item>
+                 <item><p><code>[E1, E2, E3, ..., En]</code> constructs an array in which
+                    <code>E1</code> is the first member, <code>E2</code> is the second member,
+                    and so on. The result is equivalent to the expression
+                    <code>array:join(([ E1 ], [ E2 ], ... [ En ])). </code></p></item>
+                 <item><p>The lookup expression <code>$array?*</code> is equivalent to 
+                    <code>array:split($array)?*</code>.</p></item>
+                 <item><p>The lookup expression <code>$array?$N</code>, where <code>$N</code>
+                    is an integer within the bounds of the array, is equivalent to 
+                    <code>array:split($array)[$N]?*</code>.</p></item>
+                 <item><p>Similarly, applying the array as a function, <code>$array($N)</code>,
+                    is also equivalent to 
+                    <code>array:split($array)[$N]?*</code></p></item>
+            </div3>
 
+            <div3 id="value-maps">
+               <head>Value Maps</head>
+               <ulist>
+                 <item><p><code>array { $sequence }</code> constructs an array whose members
+                    are the items in <code>$sequence</code>. Every member of this array will
+                    be a singleton item. This can be defined as
+                    <code>array:of-members($sequence ! map { 'value': . })</code>.</p></item>
+                 <item><p><code>[E1, E2, E3, ..., En]</code> constructs an array in which
+                    <code>E1</code> is the first member, <code>E2</code> is the second member,
+                    and so on. The result is equivalent to the expression
+                    <code>array:of-members((map { 'value': E1 }, map { 'value': E2 },
+                      map { 'value': E3 }, ... map { 'value': En })). </code></p></item>
+                 <item><p>The lookup expression <code>$array?*</code> is equivalent to 
+                    <code>array:members($array) ! ?value</code>.</p></item>
+                 <item><p>The lookup expression <code>$array?$N</code>, where <code>$N</code>
+                    is an integer within the bounds of the array, is equivalent to 
+                    <code>array:members($array)[$N]?value</code>.</p></item>
+                 <item><p>Similarly, applying the array as a function, <code>$array($N)</code>,
+                    is also equivalent to 
+                    <code>array:members($array)[$N]?value</code></p></item>
+              </ulist>
+            </div3>
+         </div2>
          
       </div1>
 
@@ -11383,12 +11391,14 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>array:build</code></p></item>
               <item><p><code>array:foot</code></p></item>
               <item><p><code>array:members</code></p></item>
-              <item><p><code>array:of</code></p></item>
+              <item><p><code>array:of-members</code></p></item>
               <item><p><code>array:slice</code></p></item>
+              <item><p><code>array:split</code></p></item>
               <item><p><code>array:trunk</code></p></item>
               <item><p><code>map:build</code></p></item>
               <item><p><code>map:filter</code></p></item>
-              <item><p><code>map:of</code></p></item>
+              <item><p><code>map:of-pairs</code></p></item>
+              <item><p><code>map:pair</code></p></item>
                
            </ulist>
 
@@ -11465,7 +11475,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
 	           for arguments that may be omitted, rather than multiple signatures.</p></item>
 	           <item><p>The formal specifications of array functions have been rewritten to use two new
 	              primitives: <code role="example">array:members</code> which converts an array to a sequence of value records, 
-	              and <code role="example">array:of</code> which does the inverse. This has enabled many of the
+	              and <code role="example">array:of-members</code> which does the inverse. This has enabled many of the
 	           functions to be specified more concisely, and with less duplication between similar functions
 	           for sequences and arrays.</p></item>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7386,6 +7386,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
             <div3 id="singleton-arrays">
                <head>Singleton Arrays</head>
+               <ulist>
                  <item><p><code>array { $sequence }</code> constructs an array whose members
                     are the items in <code>$sequence</code>. Every member of this array will
                     be a singleton item. This can be defined as
@@ -7402,6 +7403,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                  <item><p>Similarly, applying the array as a function, <code>$array($N)</code>,
                     is also equivalent to 
                     <code>array:split($array)[$N]?*</code></p></item>
+              </ulist>
             </div3>
 
             <div3 id="value-maps">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35285,7 +35285,7 @@ return ($m?price - $m?discount)</eg>
                (a singleton map whose single entry has the key <code>"value"</code>): 
                <code>&lt;xsl:array select="map:entry('value', 1 to 3), map:entry('value': 8 to 10)" use="?value"/></code>
             returns an array with two members: <code>[(1,2,3), (8,9,10)]</code>. This is essentially equivalent to
-            the effect of the <function>array:of</function> function.</p>
+            the effect of the <function>array:of-members</function> function.</p>
             <p>The <code>select</code> attribute and the contained sequence constructor are mutually
             exclusive: if the <code>select</code> attribute is present, then the only permitted child
             element is <elcode>xsl:fallback</elcode>.</p>


### PR DESCRIPTION
1. `map:of` renamed to `map:of-pairs` (as a hint that the input must match a specific format)
2. `array:of` renamed to `array:of-members` (as a hint…)
3. add `map:pair` for creating a single pair
4. add `array:split` for decomposing arrays to singleton arrays
