### PR TITLE
123: fn:duplicate-values

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11311,11 +11311,19 @@ let $newi := $o/tool</eg>
          <p>Which value of a set of values that compare equal is returned is <termref
                def="implementation-dependent">implementation-dependent</termref>. </p>
       </fos:rules>
+      
       <fos:notes>
-         <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
+         <p>The effect of the function is equivalent to the following XSLT expression:</p>
+         <eg><![CDATA[
+<xsl:for-each-group select="$values" group-by="." collation="{$collation}">
+  <xsl:sequence select="current-group()[2]"/>
+</xsl:for-each>
+]]></eg>
+         <p>The following XQuery expression is equivalent if no collation is specified
+(<code>group by</code> requires collation URIs to be static):</p>
          <eg>
 for $group in $values
-group by $value := $group (: collation 'selected for $coll' :)
+group by $value := $group
 where count($group) > 1
 return $value
          </eg>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11279,6 +11279,80 @@ let $newi := $o/tool</eg>
          </fos:example>
       </fos:examples>
    </fos:function>
+
+   <fos:function name="duplicate-values" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="duplicate-values" return-type="xs:anyAtomicType*">
+            <fos:arg name="values" type="xs:anyAtomicType*"/>
+            <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties arity="1">
+         <fos:property>nondeterministic-wrt-ordering</fos:property>
+         <fos:property dependency="collations implicit-timezone">context-dependent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:properties arity="2">
+         <fos:property>deterministic</fos:property>
+         <fos:property dependency="collations static-base-uri implicit-timezone">context-dependent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns the values that appear in a sequence more than once.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The items of <code>$values</code> are compared against each other, according to the
+            rules of <code>fn:distinct-values</code> and with <code>$coll</code> as the collation
+            selected according to the rules in <specref ref="choosing-a-collation"/>.</p>
+         <p>From each resulting set of values that are considered equal, one value will be
+            returned if the set contains more than one value.</p>
+         <p>The order in which the sequence of values is returned is <termref
+               def="implementation-dependent">implementation-dependent</termref>.</p>
+         <p>Which value of a set of values that compare equal is returned is <termref
+               def="implementation-dependent">implementation-dependent</termref>. </p>
+      </fos:rules>
+      <fos:notes>
+         <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
+         <eg>
+for $group in $values
+group by $value := $group (: collation 'selected for $coll' :)
+where count($group) > 1
+return $value
+         </eg>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>duplicate-values((1, 2, 3, 1.0, 1e0))</fos:expression>
+               <fos:result>1</fos:result>
+               <fos:postamble>The result may be the <code>xs:integer</code>, <code>xs:decimal</code>
+                 or <code>xs:decimal</code> value of the input sequence.</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>duplicate-values(1 to 100)</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>duplicate-values(('1', <x>1</x>, '2', 2))</fos:expression>
+              <fos:result>"1"</fos:result>
+               <fos:postamble>The string <code>"1"</code> and the untyped value of the
+                  element node are considered equal, whereas the string <code>"2"</code>
+                  and the integer are considered unequal.</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Raise an error for duplicates in an ID sequence:</p>
+               <eg>let $ids := duplicate-values(//@id)
+where exists($ids)
+return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+
    <fos:function name="identity" prefix="fn">
       <fos:signatures>
          <fos:proto name="identity" return-type="item()*">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11345,7 +11345,7 @@ return $value
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>duplicate-values(('1', <x>1</x>, '2', 2))</fos:expression>
+               <fos:expression><![CDATA[duplicate-values(('1', <x>1</x>, '2', 2))]]></fos:expression>
               <fos:result>"1"</fos:result>
                <fos:postamble>The string <code>"1"</code> and the untyped value of the
                   element node are considered equal, whereas the string <code>"2"</code>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5398,6 +5398,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-distinct-values">
                <head><?function fn:distinct-values?></head>
             </div3>  
+            <div3 id="func-duplicate-values">
+               <head><?function fn:duplicate-values?></head>
+            </div3>  
             <div3 id="func-index-of">
                <head><?function fn:index-of?></head>
             </div3>
@@ -11349,6 +11352,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:char</code></p></item>
               <item><p><code>fn:characters</code></p></item>
               <item><p><code>fn:contains-sequence</code></p></item>
+              <item><p><code>fn:duplicate-values</code></p></item>
               <item><p><code>fn:ends-with-sequence</code></p></item>
               <item><p><code>fn:expanded-QName</code></p></item>
               <item><p><code>fn:foot</code></p></item>


### PR DESCRIPTION
I decided to create a PR for the initial proposal of this function, as I came across at least two other use cases for it since the issue was created.

I believe that the `group by` clause is the best choice for more complex operations, such as advanced comparisons or creating histograms.

