### PR TITLE
[616] Converted X Node to x node

### DIFF
--- a/specifications/xpath-datamodel-40/src/attribute.xml
+++ b/specifications/xpath-datamodel-40/src/attribute.xml
@@ -1,10 +1,10 @@
 <div2 id="AttributeNode">
-  <head>&attributeNode;s</head>
+  <head>Attribute nodes</head>
 
 <div3 id="AttributeNodeOverview">
   <head>Overview</head>
 
-  <p>&attributeNode;s represent XML attributes. Attributes have the
+  <p>Attribute nodes represent XML attributes. Attributes have the
 following properties:</p>
 
 <ulist>
@@ -24,7 +24,7 @@ following properties:</p>
 </p></item>
 </ulist>
 
-<p>&attributeNode;s <rfc2119>must</rfc2119> satisfy the following constraints.</p>
+<p>Attribute nodes <rfc2119>must</rfc2119> satisfy the following constraints.</p>
 
 <olist>
 <item><p>If an &attributeNode; <emph>A</emph> is among the &dm.prop.attributes;
@@ -204,7 +204,7 @@ required. An &attributeNode; is constructed for each
 <emph role="infoset-property">attribute type</emph>, and
 <emph role="infoset-property">owner element</emph>.</p>
 
-<p>&attributeNode; properties are derived from the infoset as
+<p>Attribute node properties are derived from the infoset as
 follows:</p>
 
 <glist>

--- a/specifications/xpath-datamodel-40/src/comment.xml
+++ b/specifications/xpath-datamodel-40/src/comment.xml
@@ -1,10 +1,10 @@
 <div2 id="CommentNode">
-  <head>&commentNode;s</head>
+  <head>Comment nodes</head>
 
 <div3 id="CommentNodeOverview">
 <head>Overview</head>
 
-<p>&commentNode;s encapsulate XML comments. Comments have the following properties:
+<p>Comment nodes encapsulate XML comments. Comments have the following properties:
 </p>
 
 <ulist>
@@ -14,7 +14,7 @@
 </p></item>
 </ulist>
 
-<p>&commentNode;s <rfc2119>must</rfc2119> satisfy the following constraints.</p>
+<p>Comment nodes <rfc2119>must</rfc2119> satisfy the following constraints.</p>
 
 <olist>
 <item><p>The string <quote>--</quote> <rfc2119>must not</rfc2119> occur within the
@@ -175,7 +175,7 @@ optional.</p>
 <emph role="infoset-property">content</emph> and
 <emph role="infoset-property">parent</emph>.</p>
 
-<p>&commentNode; properties are derived from the infoset as
+<p>Comment node properties are derived from the infoset as
 follows:</p>
 
 <glist>

--- a/specifications/xpath-datamodel-40/src/document.xml
+++ b/specifications/xpath-datamodel-40/src/document.xml
@@ -1,10 +1,10 @@
 <div2 id="DocumentNode">
-<head>&documentNode;s</head>
+<head>Document nodes</head>
 
 <div3 id="DocumentNodeOverview">
 <head>Overview</head>
 
-<p>&documentNode;s encapsulate XML documents. Documents have the following
+<p>Document nodes encapsulate XML documents. Documents have the following
 properties:</p>
 
 <ulist>
@@ -22,12 +22,12 @@ properties:</p>
 </p></item>
 </ulist>
 
-<p id="constraints-document">&documentNode;s <rfc2119>must</rfc2119> satisfy the following constraints.</p>
+<p id="constraints-document">Document nodes <rfc2119>must</rfc2119> satisfy the following constraints.</p>
 
 <olist>
 <item><p>The &dm.prop.children; <rfc2119>must</rfc2119> consist exclusively
-of Element, Processing Instruction, Comment, and Text Nodes if it is not empty.
-Attribute, Namespace, and &documentNode;s can never appear as children
+of element, processing instruction, comment, and text nodes if it is not empty.
+Attribute, namespace, and &documentNode;s can never appear as children
 </p></item>
 <item><p>If a node <emph>N</emph> is among the &dm.prop.children; of a &documentNode;
 <emph>D</emph>, then the &dm.prop.parent; of <emph>N</emph>
@@ -221,7 +221,7 @@ required. A &documentNode; is constructed for each
 <p>The following infoset properties are optional:
 <emph role="infoset-property">unparsed entities</emph>.</p>
 
-<p>&documentNode; properties are derived from the infoset as
+<p>Document node properties are derived from the infoset as
 follows:</p>
 
 <glist>
@@ -265,7 +265,7 @@ items found in the <emph role="infoset-property">children</emph>
 property.</p>
 <p>For each element, processing instruction, and comment found in the
 <emph role="infoset-property">children</emph> property, a corresponding
-Element, Processing Instruction, or &commentNode; is constructed
+element, processing instruction, or &commentNode; is constructed
 and that sequence of nodes is used as the value of the &dm.prop.children;
 property.</p>
 <p>If present among the

--- a/specifications/xpath-datamodel-40/src/element.xml
+++ b/specifications/xpath-datamodel-40/src/element.xml
@@ -1,10 +1,10 @@
 <div2 id="ElementNode">
-<head>&elementNode;s</head>
+<head>Element nodes</head>
 
 <div3 id="ElementNodeOverview">
 <head>Overview</head>
 
-<p>&elementNode;s encapsulate XML elements. Elements have the following properties:</p>
+<p>Element nodes encapsulate XML elements. Elements have the following properties:</p>
 
 <ulist>
 <item><p>&dm.prop.base-uri;, possibly empty.
@@ -33,13 +33,13 @@
 </p></item>
 </ulist>
 
-<p>&elementNode;s <rfc2119>must</rfc2119> satisfy the following constraints.</p>
+<p>Element nodes <rfc2119>must</rfc2119> satisfy the following constraints.</p>
 
 <olist>
 <item id="elem-children">
 <p>The &dm.prop.children; <rfc2119>must</rfc2119> consist exclusively
-of Element, Processing Instruction, Comment, and &textNode;s if it is not empty.
-Attribute, Namespace, and &documentNode;s can never appear as children
+of element, processing instruction, comment, and &textNode;s if it is not empty.
+attribute, namespace, and &documentNode;s can never appear as children
 </p></item>
 <item><p>The &attributeNode;s of an element <rfc2119>must</rfc2119> have distinct
 <code>xs:QName</code>s.
@@ -48,7 +48,7 @@ Attribute, Namespace, and &documentNode;s can never appear as children
 <emph>E</emph>, then the &dm.prop.parent; of <emph>N</emph>
 <rfc2119>must</rfc2119> be <emph>E</emph>.
 </p></item>
-<item><p>Exclusive of Attribute and &namespaceNode;s, if a node
+<item><p>Exclusive of attribute and &namespaceNode;s, if a node
 <emph>N</emph> has a &dm.prop.parent; element <emph>E</emph>, then
 <emph>N</emph> <rfc2119>must</rfc2119> be among the &dm.prop.children; of
 <emph>E</emph>. (Attribute and &namespaceNode;s have a parent, but
@@ -285,7 +285,7 @@ required. An &elementNode; is constructed for each
 <emph role="infoset-property">base URI</emph>, and
 <emph role="infoset-property">parent</emph>.</p>
 
-<p>&elementNode; properties are derived from the infoset as
+<p>Element node properties are derived from the infoset as
 follows:</p>
 
 <glist>
@@ -358,7 +358,7 @@ property.</p>
 each element, processing instruction, comment, and maximal sequence of
 adjacent <emph role="info-item">character information items</emph> found in the
 <emph role="infoset-property">children</emph> property, a corresponding
-Element, Processing Instruction, Comment, or &textNode; is constructed
+element, processing instruction, comment, or &textNode; is constructed
 and that sequence of nodes is used as the value of the &dm.prop.children;
 property.</p>
 
@@ -498,7 +498,7 @@ property.</p>
 <p>For each element, processing instruction, comment, and maximal
 sequence of adjacent <emph role="info-item">character information items</emph> found in the
 <emph role="infoset-property">children</emph> property, a corresponding
-Element, Processing Instruction, Comment, or &textNode; is constructed
+element, processing instruction, comment, or &textNode; is constructed
 and that sequence of nodes is used as the value of the &dm.prop.children;
 property.</p>
 
@@ -506,7 +506,7 @@ property.</p>
 if the <emph role="infoset-property">schema normalized value</emph>
 PSVI property exists, the processor
 <rfc2119>may</rfc2119> use a sequence of nodes
-containing the Processing Instruction and &commentNode;s corresponding
+containing the processing instruction and &commentNode;s corresponding
 to the
 <emph role="info-item">processing instruction</emph> and
 <emph role="info-item">comment information items</emph> found in the
@@ -518,7 +518,7 @@ If the <emph role="infoset-property">schema normalized value</emph> is
 the empty string, the &textNode; <rfc2119>must not</rfc2119> be
 present, otherwise it <rfc2119>must</rfc2119> be present.</p>
 
-<p>The relative order of Processing Instruction and &commentNode;s must
+<p>The relative order of processing instruction and &commentNode;s must
 be preserved, but the position of the &textNode;, if it is present, among
 them is implementation defined.</p>
 

--- a/specifications/xpath-datamodel-40/src/namespace.xml
+++ b/specifications/xpath-datamodel-40/src/namespace.xml
@@ -1,5 +1,5 @@
 <div2 id="NamespaceNode">
-  <head>&namespaceNode;s</head>
+  <head>Namespace nodes</head>
 
 <div3 id="NamespaceNodeOverview">
   <head>Overview</head>
@@ -21,7 +21,7 @@ following properties:</p>
 </p></item>
 </ulist>
 
-<p>&namespaceNode;s <rfc2119>must</rfc2119> satisfy the following constraints.</p>
+<p>Namespace nodes <rfc2119>must</rfc2119> satisfy the following constraints.</p>
 
 <olist>
 <item><p>If a &namespaceNode; <emph>N</emph> is among the namespaces
@@ -224,7 +224,7 @@ required.</p>
 <emph role="infoset-property">prefix</emph>,
 <emph role="infoset-property">namespace name</emph>.</p>
 
-<p>&namespaceNode; properties are derived from the infoset as
+<p>Namespace node properties are derived from the infoset as
 follows:</p>
 
 <glist>

--- a/specifications/xpath-datamodel-40/src/processing-instruction.xml
+++ b/specifications/xpath-datamodel-40/src/processing-instruction.xml
@@ -1,10 +1,10 @@
 <div2 id="ProcessingInstructionNode">
-  <head>&processingInstructionNode;s</head>
+  <head>Processing instruction nodes</head>
 
 <div3 id="ProcessingInstructionNodeOverview">
 <head>Overview</head>
 
-<p>&processingInstructionNode;s encapsulate XML processing instructions.
+<p>Processing instruction nodes encapsulate XML processing instructions.
 Processing instructions have the following properties:</p>
 
 <ulist>
@@ -18,7 +18,7 @@ Processing instructions have the following properties:</p>
 </p></item>
 </ulist>
 
-<p>&processingInstructionNode;s <rfc2119>must</rfc2119> satisfy the following constraints.</p>
+<p>Processing instruction nodes <rfc2119>must</rfc2119> satisfy the following constraints.</p>
 
 <olist>
 <item><p>The string <quote>?&gt;</quote> <rfc2119>must not</rfc2119> occur within the
@@ -177,7 +177,7 @@ is not ignored.</p>
 <emph role="infoset-property">base URI</emph>, and
 <emph role="infoset-property">parent</emph>.</p>
 
-<p>&processingInstructionNode; properties are derived from the infoset as
+<p>Processing instruction node properties are derived from the infoset as
 follows:</p>
 
 <glist>

--- a/specifications/xpath-datamodel-40/src/text.xml
+++ b/specifications/xpath-datamodel-40/src/text.xml
@@ -1,10 +1,10 @@
 <div2 id="TextNode">
-  <head>&textNode;s</head>
+  <head>Text nodes</head>
 
 <div3 id="TextNodeOverview">
   <head>Overview</head>
 
-<p>&textNode;s encapsulate XML character content. Text has the following properties:
+<p>Text nodes encapsulate XML character content. Text has the following properties:
 </p>
 
   <ulist>
@@ -14,7 +14,7 @@
   </p></item>
   </ulist>
 
-<p>&textNode;s <rfc2119>must</rfc2119> satisfy the following constraint:</p>
+<p>Text nodes <rfc2119>must</rfc2119> satisfy the following constraint:</p>
 
 <olist>
 <item><p>If the &dm.prop.parent; of a text node is not empty,
@@ -200,7 +200,7 @@ uninterrupted by other types of information item.</p>
 </item>
 </olist>
 
-<p>&textNode; properties are derived from the infoset as
+<p>Text node properties are derived from the infoset as
 follows:</p>
 
 <glist>
@@ -216,7 +216,7 @@ the <emph role="infoset-property">element content whitespace</emph> property
 of the <emph role="info-item">character information items</emph> used to
 construct this node are <code>true</code>,
 the &dm.prop.content; of the &textNode;
-is the zero-length string. &textNode;s are only allowed to be empty if they
+is the zero-length string. Text nodes are only allowed to be empty if they
 have no parents; an empty &textNode; will be discarded when its parent
 is constructed, if it has a parent.</p>
 
@@ -259,7 +259,7 @@ construct this node have a parent and that parent is an element and its
 the &dm.prop.content; of the &textNode;
 is the zero-length string.</p>
 
-<p>&textNode;s are only allowed to be empty if they
+<p>Text nodes are only allowed to be empty if they
 have no parents; an empty &textNode; will be discarded when its parent
 is constructed, if it has a parent.</p>
 

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -56,13 +56,13 @@
 <!ENTITY Text  SYSTEM "text.xml">
 <!ENTITY ChangeLog  SYSTEM "changelog.xml">
 
-<!ENTITY documentNode "Document Node">
-<!ENTITY elementNode "Element Node">
-<!ENTITY attributeNode "Attribute Node">
-<!ENTITY namespaceNode "Namespace Node">
-<!ENTITY processingInstructionNode "Processing Instruction Node">
-<!ENTITY commentNode "Comment Node">
-<!ENTITY textNode "Text Node">
+<!ENTITY documentNode "document node">
+<!ENTITY elementNode "element node">
+<!ENTITY attributeNode "attribute node">
+<!ENTITY namespaceNode "namespace node">
+<!ENTITY processingInstructionNode "processing instruction node">
+<!ENTITY commentNode "comment node">
+<!ENTITY textNode "text node">
 
 <!ENTITY dm-example.xml SYSTEM "dm-example.xml.cdata">
 <!ENTITY dm-example.xsd SYSTEM "dm-example.xsd.cdata">
@@ -1495,7 +1495,7 @@ The <emph role="infoset-property">validity</emph> property may be
 <quote><emph>valid</emph></quote>, <quote><emph>invalid</emph></quote>,
 or <quote><emph>notKnown</emph></quote>
 and reflects the outcome of schema-validity assessment. In the data
-model, precise schema type information is exposed for Element and
+model, precise schema type information is exposed for element and
 &attributeNode;s that are <quote><emph>valid</emph></quote>. Nodes
 that are not <quote><emph>valid</emph></quote> are treated as if they
 were simply well-formed XML and only very general schema type
@@ -1639,7 +1639,7 @@ implementation-dependent.
 <div4 id="TypedValueDetermination">
 <head>Typed Value Determination</head>
 
-<p>This section describes how the typed value of an Element or
+<p>This section describes how the typed value of an element or
 &attributeNode; is computed from an element or attribute PSVI
 information item, where the information item has either a simple type
 or a complex type with simple content. For other kinds of

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -2396,8 +2396,8 @@ is returned.</p>
 <div1 id="Node">
 <head>Nodes</head>
 
-<p><termdef id="dt-node" term="Node">There are seven kinds of
-<term>Nodes</term> in the data model:
+<p><termdef id="dt-node" term="node">There are seven kinds of
+<term>nodes</term> in the data model:
 <loc href="#DocumentNode">document</loc>,
 <loc href="#ElementNode">element</loc>,
 <loc href="#AttributeNode">attribute</loc>,


### PR DESCRIPTION
Per #616 names of nodes have been set lowercase. This PR does not address the good suggestion that xrefs and styling be selectively applied. That is reserved for a future pass.