### PR TITLE
Removed chapter 4 from XDM

### DIFF
--- a/specifications/css/xpath-datamodel-40.css
+++ b/specifications/css/xpath-datamodel-40.css
@@ -17,14 +17,6 @@
                                   border-bottom: 1px solid gray;
                                 }
 
-      .infoset-mapping table    { margin-left: 1em;
-                                }
-      .infoset-mapping thead td { font-weight: bold;
-                                }
-      .infoset-mapping td       { padding-left: 1em;
-                                  padding-right: 1em;
-                                }
-
       .issue-closed             { color: green;
                                 }
 

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -2035,17 +2035,6 @@ an attribute node that has no parent.</p>
 </div2>
 </div1>
 
-<div1 id="infoset-mapping">
-<head>Infoset Mapping</head>
-
-<p>This specification describes how to map each kind of node to the
-corresponding information item. This mapping produces an Infoset; it
-does not and cannot produce a PSVI. Validation must be used to obtain
-a PSVI for a (portion of a) data model instance.
-</p>
-
-</div1>
-
 <div1 id="accessors">
 <head>Accessors</head>
 
@@ -2407,7 +2396,13 @@ is returned.</p>
 <loc href="#CommentNode">comment</loc>.</termdef> Each kind of
 node is described in the following sections.</p>
 
-
+<p>Each section consists of an overview of the node, followed by 
+  information on accessors and methods construction from an Infoset or a PSVI.
+  The final section provides a mapping to Infosets. No mapping 
+  is provided, nor can it be provided, for producing a PSVI. 
+  Validation must be used to obtain a PSVI for a (portion of a) data 
+  model instance.
+</p>
 
 <p id="constraints-general">All nodes <rfc2119>must</rfc2119> satisfy
 the following general constraints:</p>

--- a/specifications/xpath-datamodel-40/style/data-model.xsl
+++ b/specifications/xpath-datamodel-40/style/data-model.xsl
@@ -427,8 +427,7 @@ General notes <a href="#const-infoset">occur elsewhere</a>.</p>
       </h2>
 
       <p>This section summarizes the infoset mapping for each kind of
-      node. General notes <a href="#infoset-mapping">occur
-      elsewhere</a>.</p>
+      node.</p>
 
       <xsl:for-each select="//div3[head = 'Infoset Mapping']">
 	<div>


### PR DESCRIPTION
As noted in Slack, chapter 4 of the XDM specs is out of place. In this PR I have moved the very general material in chapter 4 to the preamble of chapter 6 (now 5), which provided the opportunity to orient the reader to the structure of that chapter.

Cross-references to chapter 4 have been search for and dealt with. The CSS deletion comes from my observation that there is no such class `infoset-mapping` in the resultant HTML file; section 4's `infoset-mapping` is an id.