### PR TITLE
XDM minor edits, back material

### DIFF
--- a/specifications/xpath-datamodel-40/src/dm-example.xsd
+++ b/specifications/xpath-datamodel-40/src/dm-example.xsd
@@ -9,7 +9,7 @@
            schemaLocation="http://www.w3.org/2001/xml.xsd" />
 
 <xs:import namespace="http://www.w3.org/1999/xlink"
-           schemaLocation="http://www.cs.rpi.edu/~puninj/XGMML/xlinks-2001.xsd" />
+           schemaLocation="https://www.w3.org/XML/2008/06/xlink.xsd" />
 
 <xs:element name="catalog">
   <xs:complexType>
@@ -32,7 +32,7 @@
   </xs:sequence>
   <xs:attribute name="label" type="xs:token" />
   <xs:attribute name="code" type="xs:ID" use="required" />
-  <xs:attributeGroup ref="xlink:simpleLink" />
+  <xs:attributeGroup ref="xlink:simpleAttrs" />
 </xs:complexType>
 
 <xs:element name="tshirt" type="cat:tshirtType" substitutionGroup="cat:_item" />

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -2694,15 +2694,15 @@ the values <emph>T1, T2, etc.</emph> represent &textNode;s.</p>
 <p>For brevity:</p>
 
 <ulist>
-<item><p>&textNode;s in the data model that contain only white space are not shown.</p>
+<item><p>Text nodes in the data model that contain only white space are not shown.</p>
 </item>
 <item><p>Literal strings are shown in quotes without the <code>xs:string()</code>
-constructor
+constructor.
 </p></item>
 <item><p>Literal decimals are shown without the <code>xs:decimal()</code>
-constructor
+constructor.
 </p></item>
-<item><p>Nodes are referred to using the syntax <code>[nodeID]</code>
+<item><p>Nodes are referred to using the syntax <code>[nodeID].</code>
 </p></item>
 <item><p>xs:QNames are used with the following prefixes bindings:</p>
 
@@ -2732,11 +2732,11 @@ anonymous type names</td>
 
 </item>
 <item><p>The abbreviation <quote><code>\n</code></quote> is used in string literals
-to represent a newline character; this isn't supported in XPath, but it makes
+to represent a newline character; this is not supported in XPath, but it makes
 this presentation clearer.</p></item>
 <item><p>Accessors that return the empty sequence have been omitted.</p>
 </item>
-<item><p>To simplify the presentation, we’re assuming an implementation
+<item><p>To simplify the presentation, we assume an implementation
 that does not expose the namespace axis. Therefore,
 &namespaceNode;s are shared across multiple elements.
 See <specref ref="NamespaceNode"/>.</p>


### PR DESCRIPTION
Note, the example was invalid because of a failure to access the included xsd file.