### PR TITLE
XPath minor edits, chh. 1-2

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -678,11 +678,11 @@ inferred by static type inference as discussed in  <specref
                               <term>System functions</term> include the functions defined in <bibref
                               ref="xpath-functions-40"/> and may also include additional functions provided
                               by the implementation.</termdef></p>
-                              <p>The behavior of system functions follows the rules given for the individual
+                              <p>The behavior of each system function follows the rules given for the individual
                            function in this family of specifications, or in the specification of the
-                           particular processor implementation. System functions in some cases have behavior that depends on the
-                           static or dynamic context of the caller (for example, they may compare strings
-                           using the default collation from the <phrase diff="chg" at="2023-05-19">dynamic</phrase> context of the caller): such
+                           particular processor implementation. A system function may have behavior that depends on the
+                           static or dynamic context of the caller (for example, comparing strings
+                           using the default collation from the <phrase diff="chg" at="2023-05-19">dynamic</phrase> context of the caller). Such
                            functions are said to be <termref def="dt-context-dependent"/>.</p></item>
                            <item><p><term>External functions</term> can be characterized as functions that are neither
                            part of the processor implementation, nor written in a language whose semantics
@@ -703,7 +703,7 @@ inferred by static type inference as discussed in  <specref
                         and <code>fn:static-base-uri</code>, exist for the sole purpose of providing information
                         about the static or dynamic context of their caller.</p></note>
                         <note><p diff="add" at="2023-03-11"><termref def="dt-application-function">Application functions</termref> 
-                           are only ever context dependent to the extent that they define optional parameters with default
+                           are context dependent only to the extent that they define optional parameters with default
                            values that are context dependent.</p></note>
                      </item>
                      <item><p>The function name, which is an <termref def="dt-expanded-qname"/>.</p></item>
@@ -1007,7 +1007,7 @@ items that would result from calling the <code>fn:collection</code> function wit
                               <term>exponent-separator</term> is
 		          the character used to separate the mantissa from the exponent in
 		          scientific notation both in the picture string and in the
-		          formatted number; the default value is the character (e).</termdef>
+		          formatted number; the default value is the Unicode Latin small letter e character (#x65).</termdef>
                         </p>
                      </item>
 
@@ -1035,7 +1035,7 @@ items that would result from calling the <code>fn:collection</code> function wit
                            <termdef id="id-static-decimal-format-per-mille" term="per-mille">
                               <term>per-mille</term>
 		          is the character used both in the picture string and in the formatted number to indicate that the number is written as a per-thousand fraction; the default
-		          value is the Unicode per-mille character
+		          value is the Unicode per mille sign character
 		          (#x2030)</termdef>
                         </p>
                      </item>
@@ -1045,7 +1045,7 @@ items that would result from calling the <code>fn:collection</code> function wit
                            <termdef id="id-static-decimal-format-zero-digit" term="zero-digit">
                               <term>zero-digit</term>
 		          is the character used to represent the digit zero; the default
-		          value is the Western digit zero (#x30). This character must be a digit
+		          value is the Unicode digit zero (#x30). This character must be a digit
 		          (category Nd in the Unicode property database), and it must have
 		          the numeric value zero. This property implicitly defines the
 		          ten Unicode characters that are used to represent the values 0
@@ -1080,7 +1080,7 @@ items that would result from calling the <code>fn:collection</code> function wit
                               term="pattern-separator">
                               <term>pattern-separator</term> is a character used
 		          to separate positive and negative sub-pictures
-		          in a picture string; the default value is the semi-colon character (;)</termdef>
+		          in a picture string; the default value is the semicolon character (;)</termdef>
                         </p>
                      </item>
                   </ulist>
@@ -1101,7 +1101,7 @@ items that would result from calling the <code>fn:collection</code> function wit
                         <p>
                            <termdef id="id-static-decimal-format-NaN" term="NaN">
                               <term>NaN</term> is the string used to
-		          represent the double value <code>NaN</code> (not-a-number); the default value is the string <code>"NaN"</code></termdef>
+		          represent the double value <code>NaN</code> (not a number); the default value is the string <code>"NaN"</code></termdef>
                         </p>
                      </item>
 
@@ -1171,7 +1171,7 @@ expression.
 the context size cannot be determined without lookahead, so it may be undefined.  If so, expressions like <code>last()</code> will raise a dynamic error because the context size is undefined.</p>
                </note>
                <termdef id="dt-singleton-focus" term="singleton focus"
-                     >A <term>singleton focus</term> is a focus that refers to a single item; in a singleton focus, context item is set to the item, context position = 1 and context size = 1.</termdef>
+                     >A <term>singleton focus</term> is a focus that refers to a single item; in a singleton focus, context item is set to the item, context position = 1, and context size = 1.</termdef>
             </p>
 
             <p>Certain language constructs, notably the <termref def="dt-path-expression"
@@ -2428,9 +2428,9 @@ An error that can be detected during the static analysis phase, and is not a typ
                      >A <term>dynamic
 error</term> is an error that
 must be detected during the dynamic evaluation phase and may be detected
-during the static analysis phase.
+during the static analysis phase.</termdef>
 Numeric overflow is an example of a <termref
-                     def="dt-dynamic-error">dynamic error</termref>.</termdef>
+                     def="dt-dynamic-error">dynamic error</termref>.
             </p>
             <p>
                <termdef id="dt-type-error" term="type error"
@@ -3347,7 +3347,7 @@ defined in <xspecref
       expression.</p>
 
             <p>Any process that attempts to <termref def="dt-resolve-relative-uri"
-                  >resolve URI</termref> against a
+                  >resolve a URI</termref> against a
       base URI, or to dereference the URI, may apply percent-encoding
       or decoding as defined in the relevant RFCs.</p>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -69,7 +69,7 @@ Each node has a unique <term>node identity</term>, a <term>typed value</term>, a
          
          
          <p>Maps (see <specref ref="id-maps"/>) and arrays (see <specref ref="id-arrays"/>) are
-         specific kinds of <termref def="dt-function-item"/>.</p>
+         specific kinds of <termref def="dt-function-item"/>s.</p>
 
       <p>
          <termdef id="dt-singleton" term="singleton"
@@ -135,10 +135,11 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
       namespace URI and prefix are both absent. In the case of a name
       in the default namespace, the prefix is absent.</termdef> When
       comparing two expanded QNames, the prefixes are ignored: the
-      local name parts must be equal under the Unicode Codepoint
-      Collation, and the namespace URI parts must either both be
-      absent, or must be equal under the Unicode Codepoint
-      Collation.</p>
+      local name parts must be equal under the Unicode codepoint
+      collation (<xspecref spec="FO31" ref="collations"/>), 
+      and the namespace URI parts must either both be
+      absent, or must be equal under the Unicode codepoint
+      collation.</p>
 
       <p>In the &language;
       grammar, QNames representing the names of
@@ -151,10 +152,10 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
          <head/>
          <prodrecap id="EQName" ref="EQName"/>
          <prodrecap id="QName" ref="QNameToken"/>
-         <prodrecap ref="NCNameTok"/>
          <prodrecap ref="URILiteral" id="URILiteral" role="xquery"/>
          <prodrecap id="URIQualifiedName" ref="URIQualifiedName"/>
          <prodrecap id="BracedURILiteral" ref="BracedURILiteral"/>
+         <prodrecap ref="NCNameTok"/>
       </scrap>
 
 
@@ -180,7 +181,7 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
             </item>
             <item>
                <p>URI plus local-name (for example,
-        <code>Q{http://example.com/ns}invoice)</code>.</p>
+        <code>Q{http://example.com/ns}invoice</code>).</p>
                <p>In this case the local name and namespace URI are as
         written, and the prefix is absent. This way of writing a QName
         is context-free, which makes it particularly suitable for use
@@ -413,8 +414,8 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
                      <code>xs:anyURI</code> type in <xspecref spec="XS1-2" ref="anyURI"/> or 
                      <xspecref spec="XS11-2" ref="anyURI"/>.</p>
                   <p diff="add" at="A">The statically known namespaces may include a binding for the zero-length prefix;
-                  however, this is only used in limited circumstances because the rules for resolving
-                  unprefixed QNames depend on the how such a name is used.</p>
+                  however, this is used only in limited circumstances because the rules for resolving
+                  unprefixed QNames depend on how such a name is used.</p>
                   <p>Note the difference between <termref def="dt-in-scope-namespaces"
                         >in-scope namespaces</termref>, which is a dynamic property of an element node, and <termref
                         def="dt-static-namespaces"
@@ -441,7 +442,7 @@ and by <termref def="dt-namespace-decl-attr"
                            spec="DM31" ref="dt-absent"
                         />. The namespace URI, if present, is used for any unprefixed QName appearing in a
 				position where an element name is expected.</termdef> The URI value is
-whitespace normalized according to the rules for the <code>xs:anyURI</code> type in <xspecref
+whitespace-normalized according to the rules for the <code>xs:anyURI</code> type in <xspecref
                         spec="XS1-2" ref="anyURI"/> or <xspecref spec="XS11-2" ref="anyURI"/>.</p>
                </item>
 
@@ -452,7 +453,7 @@ whitespace normalized according to the rules for the <code>xs:anyURI</code> type
                            spec="DM31" ref="dt-absent"
                         />. The namespace URI, if present, is used for any unprefixed QName appearing in a
 		                      position where a type name is expected.</termdef> The URI value is
-		                   whitespace normalized according to the rules for the <code>xs:anyURI</code> type in <xspecref
+		                   whitespace-normalized according to the rules for the <code>xs:anyURI</code> type in <xspecref
                         spec="XS1-2" ref="anyURI"/> or <xspecref spec="XS11-2" ref="anyURI"/>.</p>
                </item>
 
@@ -462,7 +463,7 @@ whitespace normalized according to the rules for the <code>xs:anyURI</code> type
                      <termdef id="dt-default-function-namespace" term="default function namespace">
                         <term>Default function namespace.</term> This is either a namespace URI, or <xtermref spec="DM31"
                            ref="dt-absent"/>. The namespace URI, if present, is used for any unprefixed QName appearing
-                     in a position where a function name is expected.</termdef> The URI value is whitespace normalized according
+                     in a position where a function name is expected.</termdef> The URI value is whitespace-normalized according
                      to the rules for the <code>xs:anyURI</code> type in <xspecref
                         spec="XS1-2" ref="anyURI"/> or <xspecref spec="XS11-2" ref="anyURI"/>
                   </p>
@@ -485,7 +486,7 @@ whitespace normalized according to the rules for the <code>xs:anyURI</code> type
                   <p>
                      <termdef id="dt-issd" term="in-scope schema definitions">
                         <term>In-scope schema
-			 definitions.</term> This is a generic term
+			 definitions</term> is a generic term
 			 for all the element declarations, attribute declarations, and schema type
 			 definitions that are in scope during
 			 static analysis of an expression.</termdef> It includes the
@@ -605,8 +606,7 @@ An expression that binds a variable extends the <termref
                         >in-scope variables</termref>, within the scope of the variable, with the variable and its type. 
 Within the body of an
 <termref
-                        def="dt-inline-func">inline function expression</termref>
-                     <phrase role="xquery"> or <termref def="dt-udf">user-defined function</termref>
+                        def="dt-inline-func">inline function expression</termref><phrase role="xquery"> or <termref def="dt-udf">user-defined function</termref>
                      </phrase>, the
 <termref def="dt-in-scope-variables"
                         >in-scope variables</termref> are extended
@@ -639,12 +639,12 @@ inferred by static type inference as discussed in  <specref
                      the <termref def="dt-static-context"/>.</termdef>
                   </p>
                   <p>Item type aliases allow frequently used item types, especially complex item types such as
-                  record types, to be given simple names, so that the definition of the type is not repeated
+                  record types, to be given simple names, to avoid repeating the definition 
                   every time it is used.</p>
                   <note>
                      <p role="xquery">In XQuery, named item types can be declared in the Query Prolog.</p>
-                     <p role="xpath">Item type aliases can be defined in XQuery 4.0 and in XSLT 4.0, but not
-                     in XPath 4.0 itself.</p>
+                     <p role="xpath">Item type aliases can be defined in a <termref def="dt-host-language">host language</termref> 
+                        such as XQuery 4.0 and in XSLT 4.0, but not in XPath 4.0 itself.</p>
                   </note>
                </item>
 

--- a/specifications/xquery-40/src/introduction.xml
+++ b/specifications/xquery-40/src/introduction.xml
@@ -25,11 +25,11 @@
 	<p role="xpath">The primary purpose of XPath is to address the nodes of XML trees and JSON trees. 
 		XPath gets its name from its use of a path notation for
 		navigating through the hierarchical structure of an XML document. XPath uses a compact,
-		non-XML syntax to facilitate use of XPath within URIs and XML attribute values. &language; adds a similar syntax for navigating JSON trees. </p>
+		non-XML syntax, allowing XPath expressions to be embedded within URIs and to be used as XML attribute values. &language; adds a similar syntax for navigating JSON trees. </p>
 
 	<p>
 		<termdef id="dt-datamodel" term="data model">&language; operates on the abstract, logical
-			structure of an XML document or JSON object, rather than its surface syntax. This logical structure,
+			structure of an XML document or JSON object rather than its surface syntax. This logical structure,
 			known as the <term>data model</term>, is defined in <bibref ref="xpath-datamodel-31"
 			/>.</termdef>
 	</p>
@@ -62,8 +62,7 @@
 					</phrase> and XPath does not, expressions containing these produce different
 					results in the two languages. For instance, the value of the string literal
 						<code role="parse-test">"&amp;amp;"</code> is <code>&amp;</code> in XQuery,
-					and <code>&amp;amp;</code> in XPath. (XPath is often embedded in other
-					languages, which may expand predefined entity references or character references
+					and <code>&amp;amp;</code> in XPath. (A host language may expand predefined entity references or character references
 					before the XPath expression is evaluated.)</p></item>
 			<item><p>If XPath 1.0 compatibility mode is enabled, XPath behaves differently from
 					XQuery in a number of ways, <phrase role="xpath">which are noted throughout this
@@ -73,8 +72,8 @@
 		</ulist></p>
 
 	<p>Because these languages are so closely related, their grammars and language descriptions are
-		generated from a common source to ensure consistency, and the editors of these
-		specifications work together closely.</p>
+		generated from a common source to ensure consistency, and their editors 
+		jointly work together.</p>
 
 	<p>&language; also depends on and is closely related to the following specifications:</p>
 

--- a/specifications/xquery-40/src/xquery-header.xml
+++ b/specifications/xquery-40/src/xquery-header.xml
@@ -113,23 +113,15 @@ values conforming to the data model defined in
 from its most distinctive feature, the path expression, which provides
 a means of hierarchic addressing of the nodes in an XML tree.  As well
 as modeling the tree structure of XML, the data model also includes
-atomic values, function items, and sequences.  This version of XPath
-supports JSON as well as XML, adding maps and arrays to the data model
-and supporting them with new expressions in the
-language and new functions in <bibref ref="xpath-functions-40"/>.  
-These are the most important new features in &language;:
-
-<olist>
-<item><p><specref ref="id-maps"/>.</p></item>
-<item><p><specref ref="id-arrays"/>.</p></item>
-</olist>
-
-&language; is a superset of <bibref ref="xpath-30"/>. A detailed list of changes
+atomic values, function items, maps, arrays, and sequences.  This version of XPath
+supports JSON as well as XML, and adds many new functions in <bibref ref="xpath-functions-40"/>.</p>
+  
+<p role="xpath" diff="chg">&language; is a superset of <bibref ref="xpath-30"/>. A detailed list of changes
 made since XPath 3.0 can be found in <specref ref="id-revision-log"/>. 
 </p>
 
 <p role="xquery">XML is a versatile markup language, capable of labeling the
-information content of diverse data sources including structured and
+information content of diverse data sources, including structured and
 semi-structured documents, relational databases, and object
 repositories. A query language that uses the structure of XML
 intelligently can express queries across all these kinds of data,


### PR DESCRIPTION
All minor edits. Some edits are motivated by an attempt to address broken parallelism or some other form of localized inconsistency. Does not include questions about function descriptions, raised at #624.