### PR TITLE
XPath spec ch. 3 minor edits

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1709,7 +1709,9 @@ typed-value property of the node in the data model.</p>
 <head>Relationship Between Typed-Value and String-Value</head>
 
 <p>Element and attribute nodes have both typed-value and string-value
-properties. However, implementations are allowed some flexibility in
+properties (the terms <term>typed value</term> and <term>string value</term> are 
+defined at <xspecref spec="XP40" ref="id-typed-value"/> of <bibref ref="xpath-40"/>). 
+However, implementations are allowed some flexibility in
 how these properties are stored. An implementation may choose to store
 the string-value property only and derive the typed-value property from it, or to store
 the typed-value property only and derive the string-value property from it, or to store

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3836,7 +3836,7 @@ items in the sequence. Apart from the item type <code>item()</code>,
 which permits any kind of item, item types divide into <term>node
 types</term> (such as <code>element()</code>), <term>generalized atomic
 types</term> (such as <code>xs:integer</code>) and function types
-(such as function() as item()*).</p>
+(such as <code>function() as item()*</code>).</p>
 
             <p>
                <termref def="dt-qname">Lexical QNames</termref> appearing in a <termref
@@ -3856,7 +3856,7 @@ types</term> (such as <code>xs:integer</code>) and function types
             <p>Item types representing element
 and attribute nodes may specify the required <termref
                   def="dt-type-annotation"
-                  >type annotations</termref> of those nodes, in
+                  >type annotations</termref> of those nodes in
 the form of a <termref
                   def="dt-schema-type"
                   >schema
@@ -3952,7 +3952,7 @@ the schema type named <code>us:address</code>.</p>
                   >sequence type</termref>. </termdef> For example, an <code>instance of</code> expression 
                returns <code>true</code> if a given value matches a given <termref
                   def="dt-sequence-type"
-               >sequence type</termref>, or <code>false</code> if it does not.</p>
+               >sequence type</termref>, and <code>false</code> if it does not.</p>
 
 
             <p>An &language; implementation must be able to determine relationships among the types in type annotations in an <termref
@@ -4184,7 +4184,7 @@ the schema type named <code>us:address</code>.</p>
                         item matches the <nt
                            def="ItemType">ItemType</nt> that is in parentheses.</p>
                       <note><p>Parenthesized item types are used primarily when defining nested item types in a function
-                      signature: for example a sequence of functions that return booleans might be denoted
+                      signature. For example, a sequence of functions that each return a single boolean might be denoted
                       <code>(function () as xs:boolean)*</code>. In this example the parentheses
                       are needed to indicate where the occurrence indicator belongs.</p></note>
                   
@@ -4302,7 +4302,7 @@ the schema type named <code>us:address</code>.</p>
                         the expression <code>"green" instance of color</code> returns <code>false</code>, because the type annotation
                         does not match. By contrast, <code>"green" instance of enum("red", "green", "blue")</code>
                         returns <code>true</code>.</p>
-                        <p>An <term>EnumerationType</term> only matches <code>xs:string</code> values, not
+                        <p>An <term>EnumerationType</term> matches only <code>xs:string</code> values, not
                         <code>xs:untypedAtomic</code> or <code>xs:anyURI</code> values, even though these might compare
                            equal. However, the <termref def="dt-coercion-rules">coercion rules</termref> allow <code>xs:untypedAtomic</code> or 
                            <code>xs:anyURI</code> values to be supplied where the required type is an enumeration type.</p>
@@ -4360,7 +4360,7 @@ the schema type named <code>us:address</code>.</p>
                         <code>)</code>
     matches any processing-instruction node whose PITarget is equal to <code
                            role="parse-test"
-                           >fn:normalize-space(N)</code>. If <code>fn:normalize-space(N)</code> is not in the lexical space of NCName, a type error is raised <errorref
+                           >fn:normalize-space(N)</code>. If the result of <code>fn:normalize-space(N)</code> is not in the lexical space of NCName, a type error is raised <errorref
                            class="TY" code="0004"/>
                      </p>
 
@@ -5172,8 +5172,8 @@ name.</p>
                      >function coercion</termref> mean that any map can be supplied as a value in a
   context where the required type has a more specific return type,
   such as <code>function(xs:anyAtomicType) as xs:integer</code>, even when the map
-  does not match in the sense required to satisfy the instance of
-  operator. In such cases, a type error will only occur if an actual
+  does not match in the sense required to satisfy the <code>instance of</code>
+  operator. In such cases, a type error will occur only if an actual
   call on the map (treated as a function) returns a value that is not
   an instance of the required return type.
 </p>
@@ -5216,7 +5216,7 @@ name.</p>
                   <p>The last case might seem surprising; 
                      however, <termref
                         def="dt-function-coercion"
-                        >function coercion</termref>n ensures that <code>$M</code> can be used successfully 
+                        >function coercion</termref> ensures that <code>$M</code> can be used successfully 
   anywhere that the required type is <code>function(xs:integer) as xs:string</code>.</p>
                </note>
                
@@ -5254,7 +5254,7 @@ name.</p>
 		             matches a map if it has an entry with key <code>"e"</code> whose value matches <code>element(Employee)</code>,
 		             regardless what other entries the map might contain.</p>
                
-               <p>A record test can only constrain entries whose keys are strings, but when the record
+               <p>A record test can constrain only those entries whose keys are strings, but when the record
 		             test is marked as extensible, then other entries may be present in the map with non-string keys.
 		             Entries whose key is a string can be expressed using an (unquoted) NCName if the key conforms to
 		             NCName syntax, or using a (quoted) string literal otherwise.</p>
@@ -5364,11 +5364,11 @@ declare function flatten($tree as tree) as item()* {
 		                In principle the <code>xs:string</code> type used to describe the <code>duplicates</code>
 		                   option could also be replaced by a schema-defined subtype
 		                of <code>xs:string</code> that enumerates the permitted values (<code>"reject"</code>,
-		                   "<code>use-first"</code>, "<code>use-last"</code>). 
+		                   <code>"use-first"</code>, <code>"use-last"</code>). 
 		                </p>
                   <p>The use of a record test in the signature of such a function causes the 
 		                   <termref def="dt-coercion-rules">coercion rules</termref>
-		                to be invoked: so, for example, if the function expects an entry in the map to be an <code>xs:double</code>
+		                to be invoked. So, for example, if the function expects an entry in the map to be an <code>xs:double</code>
 		                value, it becomes possible to supply a map in which the corresponding entry has type <code>xs:integer</code>.</p>
                   <p>Greater precision in defining the types of such arguments also enables better type checking,
 		                better diagnostics, better optimization, better documentation, and better syntax-directed
@@ -5478,8 +5478,8 @@ declare function flatten($tree as tree) as item()* {
                      >function coercion</termref> mean that any array can be supplied as a value in
   a context where the required type has a more specific return type,
   such as <code>function(xs:integer) as xs:integer</code>, even when the array does
-  not match in the sense required to satisfy the instance of
-  operator. In such cases, a type error will only occur if an actual
+  not match in the sense required to satisfy the <code>instance of</code>
+  operator. In such cases, a type error will occur only if an actual
   call on the array (treated as a function) returns a value that is
   not an instance of the required return type.</p>
                
@@ -5498,10 +5498,10 @@ declare function flatten($tree as tree) as item()* {
                
                <note>
                   <p>Even though it cannot occur in an instance, <code>xs:error</code> is a valid type name in a sequence type. The
-                     practical uses of <code>xs:error</code> as a sequence type are limited, but they do exist. For instance, an error handling function that always raises a dynamic error 
+                     practical uses of <code>xs:error</code> as a sequence type are limited, but they do exist. For instance, an error-handling function that always raises a dynamic error 
                      never returns a value, so <code>xs:error</code> is a good choice for the return type of the function.</p>
                   
-                  <p>The semantics of <code>xs:error</code> are well-defined as a consequence of the fact that <code>xs:error</code> is defined as a union type with
+                  <p>The semantics of <code>xs:error</code> are well defined as a consequence of the fact that <code>xs:error</code> is defined as a union type with
                      no member types. For example:</p>
                   
                   <ulist>
@@ -5522,7 +5522,7 @@ declare function flatten($tree as tree) as item()* {
                            <code role="parse-test">$x cast as xs:error?</code> raises a <termref
                               def="dt-dynamic-error">dynamic error</termref>
                            <xerrorref spec="FO31" class="RG" code="0001"
-                           /> if <code>exists($x)</code>, evaluates to the empty sequence if <code>empty($x)</code>.</p>
+                           /> if <code>exists($x)</code> returns <code>true</code>, and evaluates to the empty sequence if <code>empty($x)</code> returns <code>true</code>.</p>
                      </item>
                      <item>
                         <p>
@@ -5557,9 +5557,9 @@ declare function flatten($tree as tree) as item()* {
                      </item>
                   </ulist>
                   
-                  <p>All of the above examples assume that <code>$x</code> is actually evaluated. If the result of the query does not depend on the value of <code>$x</code>. the rules specified in <specref
+                  <p>All of the above examples assume that <code>$x</code> is actually evaluated. The rules specified in <specref
                      ref="id-errors-and-opt"
-                  /> permit an implementation to avoid evaluating <code>$x</code> and thus to avoid raising an error.</p>
+                  /> permit an implementation to avoid evaluating <code>$x</code> if the result of the query does not depend upon the value of <code>$x</code> and thus to avoid raising an error.</p>
                </note>
                
             </div3>
@@ -5783,7 +5783,7 @@ declare function flatten($tree as tree) as item()* {
                   form of the two <termref def="dt-item-type">item types</termref>, but it is 
                   assumed that trivial variations are first 
                eliminated: comments and unnecessary whitespace are removed, lexical QNames are
-               replaced by URI-qualified names applying appropriate defaults in the case of unprefixed
+               replaced by URI-qualified names with appropriate defaults applied in the case of unprefixed
                names, equivalent forms such as <code>element()</code> and <code>element(*)</code>
                are normalized.</p>
                
@@ -5793,7 +5793,7 @@ declare function flatten($tree as tree) as item()* {
                <div4 id="id-item-subtype-general">
                   <head>General Rules</head>
                   <p>Given <termref def="dt-item-type">item types</termref> <var>A</var> and <var>B</var>, 
-                     <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                     <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
  
  
                      <olist>
@@ -5820,7 +5820,7 @@ declare function flatten($tree as tree) as item()* {
                </div4>
                <div4 id="id-item-subtype-atomic">
                   <head>Atomic and Union Types</head>
-                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
   
                      <olist>
                         <item>
@@ -5869,7 +5869,7 @@ declare function flatten($tree as tree) as item()* {
                </div4>
                <div4 id="id-item-subtype-nodes">
                   <head>Node Types: General Rules</head>
-                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                   
                      <olist>
                         <item>
@@ -5924,7 +5924,7 @@ declare function flatten($tree as tree) as item()* {
                      <item><p><var>N</var> is the <nt def="Wildcard">Wildcard</nt> <code>*</code>.</p></item>
                   </olist>
                   
-                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply.</p>
+                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply.</p>
                   
                   <olist>
                      <item>
@@ -6033,7 +6033,7 @@ declare function flatten($tree as tree) as item()* {
                </div4>
                <div4 id="id-item-subtype-attributes">
                   <head>Node Types: Attribute Tests</head>
-                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                     <olist>
                         <item>
                            <p><var>A</var> is an <nt
@@ -6117,7 +6117,7 @@ declare function flatten($tree as tree) as item()* {
                </div4>
                <div4 id="id-item-subtype-functions">
                   <head>Functions</head>
-                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                   
 
                      <olist>
@@ -6174,7 +6174,7 @@ declare function flatten($tree as tree) as item()* {
                </div4>
                <div4 id="id-item-subtype-maps">
                   <head>Maps</head>
-                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                   
                      <olist>
                         <item>
@@ -6257,7 +6257,7 @@ declare function flatten($tree as tree) as item()* {
                </div4>
                <div4 id="id-item-subtype-arrays">
                   <head>Arrays</head>
-                  <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
+                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                   
                      <olist>   
                         


### PR DESCRIPTION
Minor edits to ch. 3 of XPath spec. Note, this PR includes an adjustment to the XDM spec, in the form of a cross-reference, because the terms "string value" and "typed value" are heavily used in XDM but defined only in XPath.