### PR TITLE
600: fn:decode-from-uri

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4353,6 +4353,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
       </fos:examples>
    </fos:function>
+
    <fos:function name="encode-for-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="encode-for-uri" return-type="xs:string">
@@ -4399,9 +4400,9 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:example>
             <fos:test>
                <fos:expression><eg>encode-for-uri(
-  "http://www.example.com/00/Weather/CA/Los%20Angeles#ocean"
+  "http://example.com/00/Weather/CA/Los%20Angeles#ocean"
 )</eg></fos:expression>
-               <fos:result>"http%3A%2F%2Fwww.example.com%2F00%2FWeather%2FCA%2FLos%2520Angeles%23ocean"</fos:result>
+               <fos:result>"http%3A%2F%2Fexample.com%2F00%2FWeather%2FCA%2FLos%2520Angeles%23ocean"</fos:result>
                <fos:postamble>This is probably not what the user intended because all of the
                   delimiters have been encoded.</fos:postamble>
             </fos:test>
@@ -4409,23 +4410,89 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:example>
             <fos:test>
                <fos:expression><eg>concat(
-  "http://www.example.com/",
+  "http://example.com/",
   encode-for-uri("~bébé")
 )</eg></fos:expression>
-               <fos:result>"http://www.example.com/~b%C3%A9b%C3%A9"</fos:result>
+               <fos:result>"http://example.com/~b%C3%A9b%C3%A9"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression><eg>concat(
-  "http://www.example.com/",
+  "http://example.com/",
   encode-for-uri("100% organic")
 )</eg></fos:expression>
-               <fos:result>"http://www.example.com/100%25%20organic"</fos:result>
+               <fos:result>"http://example.com/100%25%20organic"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
    </fos:function>
+
+   <fos:function name="decode-from-uri" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="decode-from-uri" return-type="xs:string">
+            <fos:arg name="value" type="xs:string?"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Decodes URI-encoded characters in a string.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>This function returns the original representation of a URI-encoded string.</p>
+         <p>If <code>$value</code> is the empty sequence, the function returns the zero-length
+            string.</p>
+         <p>Otherwise, the value is first converted to an sequence of octets. Each plus sign
+            (<code>+</code>) is replaced with the octet representing a space character
+            (<code>x20</code>), and occurrences of <code>%[a-fA-F0-9][a-fA-F0-9]</code>
+            are replaced with octets for the two-digit hexadecimal numbers that follow the
+            percent sign. All other characters are added as a UTF-8 octet sequences.
+            For example, <code>"A%42+C"</code> becomes <code>x41x42x20x43</code>, and
+            <code>"💡"</code> becomes <code>xF0x9Fx92xA1</code>.</p>
+         <p>If <code>%</code> is followed by up to two characters that are no hexadecimal digits,
+            these characters are replaced by octets representing the Unicode replacement character
+            (<code>0xFFFD</code>): <code>xEF</code>, <code>xBF</code>, and <code>xBD</code>.
+            The following incomplete or invalid percent-encoded strings <code>"%"</code>,
+            <code>"%X"</code>, and <code>"%AX"</code> are all replaced with these octets.
+            For the string <code>"%1X!"</code>, the octets <code>xEFxBFxBDx21</code>
+            are returned.</p>
+         <p>Next, the resulting octets are interpreted as UTF-8: <code>x41x42x20x43</code>
+            becomes <code>"AB C"</code>, and <code>xF0x9Fx92xA1</code> becomes <code>"💡"</code>.</p>
+         <p>If an invalid UTF-8 character subsequence is encountered, the corresponding octets
+            that have been parsed so far are replaced with a Unicode replacement character.
+            For example, the octets <code>xF0x9Fx92x41</code> are converted to <code>"�A"</code>,
+            as the fourth octet is invalid. Next, the sequence <code>xF0xF0x9Fx92xA1</code> is
+            converted to <code>"�💡"</code>, as the second octet is invalid. However, this octet
+            becomes valid when being parsed as the first octet of the remaining UTF-8 sequence.</p>
+         <p>Similarly, a character that is no valid XML character is replaced with a
+            Unicode replacement character: <code>x00</code> becomes <code>"�"</code>.</p>
+      </fos:rules>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>decode-from-uri("http://example.com/")</fos:expression>
+               <fos:result>"http://example.com/"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>decode-from-uri("~b%C3%A9b%C3%A9?a=b+c")</fos:expression>
+               <fos:result>"~bébé?a=b c"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>decode-from-uri("%00-%XX-%F0%9F%92%41-%F0%F0%9F%92%A1")</fos:expression>
+               <fos:result>"�-�-�A-�💡"</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+
    <fos:function name="iri-to-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="iri-to-uri" return-type="xs:string">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4479,9 +4479,9 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <code>"�💡"</code>: The second octet is invalid, but it becomes valid when being
                parsed as the first octet of the remaining UTF-8 sequence.</p></item>
          </ulist>
-         <p>Similarly, a character that is no valid XML character is replaced with a
-            Unicode replacement character. For example,
-            <code>x00</code> becomes <code>"�"</code>.</p>
+         <p>Similarly, a UTF-8 octet sequence that represents a codepoint that is not a
+            valid XML character is replaced with a Unicode replacement character.
+            For example, <code>x00</code> becomes <code>"�"</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4440,29 +4440,34 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Decodes URI-encoded characters in a string.</p>
+         <p>Decodes URI-escaped characters in a string.</p>
       </fos:summary>
       <fos:rules>
-         <p>This function returns the original representation of a URI-encoded string.</p>
+         <p>This function returns the original representation of a URI-escaped string.</p>
          <p>If <code>$value</code> is the empty sequence, the function returns the zero-length
             string.</p>
          <p>Otherwise, the value is first converted to an sequence of octets. Each plus sign
             (<code>+</code>) is replaced with the octet representing a space character
-            (<code>x20</code>), and occurrences of <code>%[a-fA-F0-9][a-fA-F0-9]</code>
-            are replaced with octets for the two-digit hexadecimal numbers that follow the
-            percent sign. All other characters are added as UTF-8 octet sequences.
-            For example, <code>"A%42+C"</code> becomes <code>x41x42x20x43</code>, and
-            <code>"💡"</code> becomes <code>xF0x9Fx92xA1</code>.</p>
+            (<code>x20</code>), and any substring that matches the regular expression
+            <code>%[a-fA-F0-9][a-fA-F0-9]</code> is replaced with an octet for the two-digit
+            hexadecimal number that follows the percent sign. Characters that are not part of
+            such a substring are replaced with the octets of their UTF-8 encoding.
+            For example, <code>"A%42+C"</code> results in the octets <code>x41</code>,
+            <code>x42</code>, <code>x20</code>, <code>x43</code>, and <code>"💡"</code> yields
+            <code>xF0</code>, <code>x9F</code>, <code>x92</code>, and <code>xA1</code>.</p>
          <p>If <code>%</code> is followed by up to two characters that are no hexadecimal digits,
-            these characters are replaced by octets representing the Unicode replacement character
-            (<code>0xFFFD</code>): <code>xEF</code>, <code>xBF</code>, and <code>xBD</code>.
-            The incomplete or invalid percent-encoded strings <code>"%"</code>, <code>"%X"</code>,
-            and <code>"%AX"</code> are all replaced with these octets. For the string
-            <code>"%1X!"</code>, the octets <code>xEFxBFxBDx21</code> are returned.</p>
-         <p>Next, the resulting octets are interpreted as UTF-8: <code>x41x42x20x43</code>
-            becomes <code>"AB C"</code>, and <code>xF0x9Fx92xA1</code> becomes <code>"💡"</code>.</p>
-         <p>If an invalid UTF-8 character subsequence is encountered, the octets that have
-            successfully been parsed are replaced with a Unicode replacement character:</p>
+            these characters are replaced by octets <code>xEF</code>, <code>xBF</code>,
+            and <code>xBD</code>, that is, the UTF-8 encoding of the Unicode replacement character
+            (<code>0xFFFD</code>). For example, the incomplete or invalid percent-encoded strings
+            <code>"%"</code>, <code>"%X"</code>, and <code>"%AX"</code> are all replaced with
+            these octets. For the string <code>"%1X!"</code>, the octets <code>xEF</code>,
+            <code>xBF</code>, <code>xBD</code>, and <code>x21</code> are returned.</p>
+         <p>Next, the resulting octets are interpreted as UTF-8. For example,
+            <code>x41x42x20x43</code> becomes <code>"AB C"</code>, and <code>xF0x9Fx92xA1</code>
+            becomes <code>"💡"</code>.</p>
+         <p>If an invalid UTF-8 octet sequence is encountered, the octets that have
+            successfully been parsed are replaced with a Unicode replacement character.
+            Examples:</p>
          <ulist>
             <item><p>The octet <code>xF0</code> is converted to <code>"�"</code>.</p></item>
             <item><p>The octets <code>xF0x9Fx92x41</code> are converted to <code>"�A"</code>:
@@ -4475,7 +4480,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
                parsed as the first octet of the remaining UTF-8 sequence.</p></item>
          </ulist>
          <p>Similarly, a character that is no valid XML character is replaced with a
-            Unicode replacement character: <code>x00</code> becomes <code>"�"</code>.</p>
+            Unicode replacement character. For example,
+            <code>x00</code> becomes <code>"�"</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4450,24 +4450,30 @@ return normalize-unicode(concat($v1, $v2))</eg>
             (<code>+</code>) is replaced with the octet representing a space character
             (<code>x20</code>), and occurrences of <code>%[a-fA-F0-9][a-fA-F0-9]</code>
             are replaced with octets for the two-digit hexadecimal numbers that follow the
-            percent sign. All other characters are added as a UTF-8 octet sequences.
+            percent sign. All other characters are added as UTF-8 octet sequences.
             For example, <code>"A%42+C"</code> becomes <code>x41x42x20x43</code>, and
             <code>"💡"</code> becomes <code>xF0x9Fx92xA1</code>.</p>
          <p>If <code>%</code> is followed by up to two characters that are no hexadecimal digits,
             these characters are replaced by octets representing the Unicode replacement character
             (<code>0xFFFD</code>): <code>xEF</code>, <code>xBF</code>, and <code>xBD</code>.
-            The following incomplete or invalid percent-encoded strings <code>"%"</code>,
-            <code>"%X"</code>, and <code>"%AX"</code> are all replaced with these octets.
-            For the string <code>"%1X!"</code>, the octets <code>xEFxBFxBDx21</code>
-            are returned.</p>
+            The incomplete or invalid percent-encoded strings <code>"%"</code>, <code>"%X"</code>,
+            and <code>"%AX"</code> are all replaced with these octets. For the string
+            <code>"%1X!"</code>, the octets <code>xEFxBFxBDx21</code> are returned.</p>
          <p>Next, the resulting octets are interpreted as UTF-8: <code>x41x42x20x43</code>
             becomes <code>"AB C"</code>, and <code>xF0x9Fx92xA1</code> becomes <code>"💡"</code>.</p>
-         <p>If an invalid UTF-8 character subsequence is encountered, the corresponding octets
-            that have been parsed so far are replaced with a Unicode replacement character.
-            For example, the octets <code>xF0x9Fx92x41</code> are converted to <code>"�A"</code>,
-            as the fourth octet is invalid. Next, the sequence <code>xF0xF0x9Fx92xA1</code> is
-            converted to <code>"�💡"</code>, as the second octet is invalid. However, this octet
-            becomes valid when being parsed as the first octet of the remaining UTF-8 sequence.</p>
+         <p>If an invalid UTF-8 character subsequence is encountered, the octets that have
+            successfully been parsed are replaced with a Unicode replacement character:</p>
+         <ulist>
+            <item><p>The octet <code>xF0</code> is converted to <code>"�"</code>.</p></item>
+            <item><p>The octets <code>xF0x9Fx92x41</code> are converted to <code>"�A"</code>:
+               The bit pattern of the first octet indicates that the UTF-8 character comprises
+               four octets. As the fourth octet is invalid, a Unicode replacement character is
+               added for the first three octets, and the fourth (invalid) octet is parsed as a
+               new character.</p></item>
+            <item><p>Similarly, the sequence <code>xF0xF0x9Fx92xA1</code> is converted to
+               <code>"�💡"</code>: The second octet is invalid, but it becomes valid when being
+               parsed as the first octet of the remaining UTF-8 sequence.</p></item>
+         </ulist>
          <p>Similarly, a character that is no valid XML character is replaced with a
             Unicode replacement character: <code>x00</code> becomes <code>"�"</code>.</p>
       </fos:rules>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4469,15 +4469,17 @@ return normalize-unicode(concat($v1, $v2))</eg>
             successfully been parsed are replaced with a Unicode replacement character.
             Examples:</p>
          <ulist>
-            <item><p>The octet <code>xF0</code> is converted to <code>"�"</code>.</p></item>
-            <item><p>The octets <code>xF0x9Fx92x41</code> are converted to <code>"�A"</code>:
+            <item><p>The single octet <code>xF0</code> is converted to <code>"�"</code>.</p></item>
+            <item><p>The octets <code>xF0</code>, <code>x9F</code>, <code>x92</code>, and
+               <code>x41</code> are converted to <code>"�A"</code>:
                The bit pattern of the first octet indicates that the UTF-8 character comprises
                four octets. As the fourth octet is invalid, a Unicode replacement character is
                added for the first three octets, and the fourth (invalid) octet is parsed as a
                new character.</p></item>
-            <item><p>Similarly, the sequence <code>xF0xF0x9Fx92xA1</code> is converted to
-               <code>"�💡"</code>: The second octet is invalid, but it becomes valid when being
-               parsed as the first octet of the remaining UTF-8 sequence.</p></item>
+            <item><p>Similarly, the octets <code>xF0</code>, <code>xF0</code>, <code>x9F</code>,
+               <code>x92</code>, and <code>xA1</code> are converted to <code>"�💡"</code>:
+               The second octet is invalid, but it becomes valid when being parsed as the
+               first octet of the remaining UTF-8 sequence.</p></item>
          </ulist>
          <p>Similarly, a UTF-8 octet sequence that represents a codepoint that is not a
             valid XML character is replaced with a Unicode replacement character.

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4463,8 +4463,9 @@ return normalize-unicode(concat($v1, $v2))</eg>
             these octets. For the string <code>"%1X!"</code>, the octets <code>xEF</code>,
             <code>xBF</code>, <code>xBD</code>, and <code>x21</code> are returned.</p>
          <p>Next, the resulting octets are interpreted as UTF-8. For example,
-            <code>x41x42x20x43</code> becomes <code>"AB C"</code>, and <code>xF0x9Fx92xA1</code>
-            becomes <code>"💡"</code>.</p>
+            <code>x41</code>, <code>x42</code>, <code>x20</code>, and <code>x43</code>
+            becomes <code>"AB C"</code>, and <code>xF0</code>, <code>x9F</code>,
+            <code>x92</code>, and <code>xA1</code> becomes <code>"💡"</code>.</p>
          <p>If an invalid UTF-8 octet sequence is encountered, the octets that have
             successfully been parsed are replaced with a Unicode replacement character.
             Examples:</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3248,10 +3248,13 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
             of <code>xs:anyURI</code> or as strings.</p>
          <?local-function-index?>
          <div2 id="func-resolve-uri">
-		   <head><?function fn:resolve-uri?></head>
+            <head><?function fn:resolve-uri?></head>
          </div2>
          <div2 id="func-encode-for-uri">
             <head><?function fn:encode-for-uri?></head>
+         </div2>
+         <div2 id="func-decode-from-uri">
+            <head><?function fn:decode-from-uri?></head>
          </div2>
          <div2 id="func-iri-to-uri">
             <head><?function fn:iri-to-uri?></head>
@@ -11352,6 +11355,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:char</code></p></item>
               <item><p><code>fn:characters</code></p></item>
               <item><p><code>fn:contains-sequence</code></p></item>
+              <item><p><code>fn:decode-from-uri</code></p></item>
               <item><p><code>fn:duplicate-values</code></p></item>
               <item><p><code>fn:ends-with-sequence</code></p></item>
               <item><p><code>fn:expanded-QName</code></p></item>


### PR DESCRIPTION
I did my best to define rules for a counterpart of the `fn:encode-for-uri` function, including various edge cases.

I’m convinced that the function has been requested often enough to justify its inclusion in the spec. I’m also aware that users may have different expectations regarding the details of the conversion rules. On the other hand, this discussion can be observed for other languages as well, and that’s mostly due to the… heterogeneous history of URIs, not the actual implementations. For example, `URLDecode.decode` in Java converts the plus character to a space, and JavaScript’s `decodeURI` adopts it unchanged. I decided to convert it as well, as `fn:encode-for-uri` encodes the plus sign to `%2B`.

@ndw My rules have largely been inspired by your decoding rules for `fn:parse-uri`. I hope these rules can be dropped and replaced with a reference to this new function (analogous to `fn:build-uri`, which references `fn:encode-for-uri`).
