### PR TITLE
561: Editorial (abbreviation fn=function, drop lambda syntax)

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -5555,7 +5555,7 @@ Tak, tak, tak! - da kommen sie.
                <fos:expression><eg>replace(
   "57°43′30″",
   "([0-9]+)°([0-9]+)′([0-9]+)″",
-  action := function ($s, $groups) {
+  action := function($s, $groups) {
     string(number($groups[1]) + number($groups[2]) ÷ 60 + number($groups[3]) ÷ 3600) || '°'
   }
 )</eg></fos:expression>
@@ -13431,16 +13431,17 @@ return contains-sequence(
          
          <p>More formally, the <code>equal-strings</code> function can be expressed as follows:</p>
          
-         <eg><![CDATA[function ($s1 as xs:string, $s2 as xs:string, 
-                   $collation as xs:string, $options as map(*)) as xs:boolean {
-    let $n1 := if ($options?whitespace = "normalize"))
-               then normalize-unicode(?, $options?normalization-form) 
-               else identity#1,
-        $n2 := if ($options?normalize-space)
-               then normalize-space#1 
-               else identity#1               
-    }
-    return compare($n1($n2($s1)), $n1($n2($s2)), $collation) eq 0    
+         <eg><![CDATA[function($s1 as xs:string, $s2 as xs:string, 
+  $collation as xs:string, $options as map(*)
+) as xs:boolean {
+  let $n1 := if ($options?whitespace = "normalize"))
+             then normalize-unicode(?, $options?normalization-form) 
+             else identity#1,
+  $n2 := if ($options?normalize-space)
+             then normalize-space#1 
+             else identity#1               
+}
+return compare($n1($n2($s1)), $n1($n2($s2)), $collation) eq 0    
 }]]></eg>
          
          <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
@@ -18928,7 +18929,7 @@ return fold-left($MAPS, map{},
          of the corresponding values, retaining their order in the input sequence.</p>
          
          <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:build($key-value-pairs, $kvp -> {$kvp?key}, $kvp -> {$kvp?value}, $combine)</eg>
+         <eg>map:build($key-value-pairs, fn($kvp) { $kvp?key }, fn($kvp) { $kvp?value }, $combine)</eg>
 
 
       </fos:rules>
@@ -19137,7 +19138,7 @@ return map:keys($birthdays, function($date) {
                ref="properties-of-functions"
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
-         <p>The effect of the function is equivalent to <code>map:for-each($map, ($k, $v) -> {$v})</code>.</p>
+         <p>The effect of the function is equivalent to <code>map:for-each($map, fn($k, $v) { $v })</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -19193,7 +19194,7 @@ return map:keys($birthdays, function($date) {
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
          <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:for-each($map, ($k, $v) -> {map{$k :$v}})</eg>
+         <eg>map:for-each($map, fn($k, $v) { map { $k: $v } })</eg>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -19239,7 +19240,7 @@ return map:keys($birthdays, function($date) {
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
          <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:for-each($map, ($k, $v) -> {map{"key":$k, "value":$v}})</eg>
+         <eg>map:for-each($map, fn($k, $v) { map { "key": $k, "value": $v } })</eg>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -19692,13 +19693,13 @@ map:of-pairs((
          <p>The effect of the function call <code>map:remove($MAP, $KEY)</code> can be described more formally as the result of the expression below:</p>
 
          <eg diff="chg" at="2023-01-25"><![CDATA[
-map:merge (
-    map:for-each (
-       $MAP, -> $k, $v { 
-               if (some $key in $KEY satisfies (fn:atomic-equal($k, $key)) 
-               then () 
-               else map:entry($k, $v)
-             } ) ) ]]></eg>
+map:merge(
+  map:for-each($MAP, fn($k, $v) { 
+    if (some $key in $KEY satisfies fn:atomic-equal($k, $key))
+    then () 
+    else map:entry($k, $v)
+  })
+)]]></eg>
       </fos:rules>
 
       <fos:examples>
@@ -19802,10 +19803,9 @@ map:merge (
 
             <eg><![CDATA[
 let $dimensions := map{'height': 3, 'width': 4, 'depth': 5};
-return
-  <box>{
-     map:for-each($dimensions, function ($k, $v) { attribute {$k} {$v} })
-  }</box>]]></eg>
+return <box>{
+  map:for-each($dimensions, function($k, $v) { attribute { $k } { $v } })
+}</box>]]></eg>
 
             <p>The result is the element <code>&lt;box height="3" width="4"
                   depth="5"/></code>.</p>
@@ -19960,7 +19960,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       </fos:rules>
       <fos:notes>
          <p>The function call <code>map:substitute($m, $f)</code> returns the same result as
-         <code>map:merge(map:for-each($m, -> ($k, $v) { map:entry($k, $f($k, $v)) }))</code>.</p>
+         <code>map:merge(map:for-each($m, fn($k, $v) { map:entry($k, $f($k, $v)) }))</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -20015,7 +20015,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <p>More formally, the result of the function is the result of the following expression:</p>
          
          <eg>
-fold-left($input, map{}, ->($map, $next) {
+fold-left($input, map{}, fn($map, $next) {
    let $nextKey := $key($next)
    let $nextValue := $value($next)
    return
@@ -20040,8 +20040,8 @@ fold-left($input, map{}, ->($map, $next) {
             equivalent to the <code>duplicates: combine</code> option on <code>map:merge</code>. Other potentially useful
             functions for combining duplicates include:</p>
          <ulist>
-            <item><p><code>->($a, $b) { $a }</code> Use the first value and discard the remainder</p></item>
-            <item><p><code>->($a, $b) { $b }</code> Use the last value and discard the remainder</p></item>
+            <item><p><code>fn($a, $b) { $a }</code> Use the first value and discard the remainder</p></item>
+            <item><p><code>fn($a, $b) { $b }</code> Use the last value and discard the remainder</p></item>
             <item><p><code>fn:concat(?, ",", ?)</code> Form the string-concatenation of the values, comma-separated</p></item>
             <item><p><code>fn:op('+')</code> Compute the sum of the values</p></item>
          </ulist>
@@ -20096,19 +20096,19 @@ fold-left($input, map{}, ->($map, $next) {
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@ssn</code> values, and whose
                corresponding values are the employee nodes:</p>
-            <eg>map:build(//employee, function { @ssn })</eg>
+            <eg>map:build(//employee, fn { @ssn })</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values represent the number of employees at each distinct location. Any employees that
                lack an <code>@location</code> attribute will be excluded from the result.</p>
-            <eg>map:build(//employee, function { @location }, function { 1 }, op("+"))</eg>
+            <eg>map:build(//employee, fn { @location }, fn { 1 }, op("+"))</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values contain the employee node for the highest-paid employee at each distinct location:</p>
             <eg>map:build(//employee, function { @location }, 
-               combine := ($a, $b)->{highest(($a, $b), function { xs:decimal(@salary) }))</eg>
+               combine := fn($a, $b) { highest(($a, $b), fn { xs:decimal(@salary) }) })</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map allowing efficient access to every element in a document by means
@@ -22871,7 +22871,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:arg name="array" type="array(*)" usage="inspection"/>
             <fos:arg name="position" type="xs:integer"/>
             <fos:arg name="fallback" type="function(xs:integer) as item()*" 
-               default="->($i){fn:error(fn:QName('', 'FOAY0001'))}"/>
+               default="fn($i) { fn:error(fn:QName('', 'FOAY0001')) }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4209,7 +4209,7 @@ the schema type named <code>us:address</code>.</p>
                            def="ItemType">ItemType</nt> that is in parentheses.</p>
                       <note><p>Parenthesized item types are used primarily when defining nested item types in a function
                       signature. For example, a sequence of functions that each return a single boolean might be denoted
-                      <code>(function () as xs:boolean)*</code>. In this example the parentheses
+                      <code>(function() as xs:boolean)*</code>. In this example the parentheses
                       are needed to indicate where the occurrence indicator belongs.</p></note>
                   
                </item>
@@ -7465,7 +7465,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                </item>
                <item diff="add" at="A">
                   <p>
-                     <code role="parse-test">lang(node:=$n, language:='de')</code> is a static function 
+                     <code role="parse-test">lang(node := $n, language := 'de')</code> is a static function 
                      call with two keyword arguments. The corresponding function declaration defines two parameters,
                      a required parameter <code>language</code> and an optional parameter <code>node</code>.
                      This call supplies values for both parameters. It is equivalent to the call 
@@ -7475,7 +7475,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                </item>
                <item diff="add" at="A">
                   <p>
-                     <code role="parse-test">sort(//employee, key := ($e)->{xs:decimal($e/salary)})</code> is a static function 
+                     <code role="parse-test">sort(//employee, key := fn($e) { xs:decimal($e/salary) })</code> is a static function 
                      call with one positional argument and one keyword argument. 
                      The corresponding function declaration defines three parameters,
                      a required parameter <code>$input</code>, an optional parameter <code>$collation</code>,
@@ -7484,7 +7484,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                      to take its default value. The default value of the <code>$collation</code> parameter
                      is given as <code>fn:default-collation()</code>, so the value supplied to the function is the
                      default collation from the dynamic context of the caller. It is equivalent to the call 
-                     <code>fn:sort(//employee, fn:default-collation(), ($e)->{xs:decimal($e/salary)})</code>.
+                     <code>fn:sort(//employee, fn:default-collation(), fn($e) { xs:decimal($e/salary) })</code>.
                   </p>
                </item>
                
@@ -7722,8 +7722,8 @@ At evaluation time, the value of a variable reference is the value to which the 
                returns a function item whose effect is to call the static <code>fn:node-name</code> function
                with one argument.</p></item>
                <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/><!-- and <specref ref="id-lambda-expressions"/>-->)
-                  constructs a function item whose <phrase diff="chg" at="2023-03-11">body</phrase> is defined locally. For example the
-               construct <code>($x)->{$x+1}</code> returns a function item whose effect is to increment
+                  constructs a function item whose <phrase diff="chg" at="2023-03-11">body</phrase> is defined locally. For example, the
+               construct <code>fn($x) { $x + 1 }</code> returns a function item whose effect is to increment
                the value of the supplied argument.</p></item>
                <item><p>A <term>partial function application</term> (see 
                   <specref ref="id-partial-function-application"/>) derives one function item from another by supplying
@@ -7989,9 +7989,9 @@ At evaluation time, the value of a variable reference is the value to which the 
                                        <code>$incr</code> is a nonlocal variable that is available within the function because its variable binding has been added to the variable values of the function..  Even though the parameter and return type of this function are both <code>xs:decimal</code>,
                                   the more specific type <code>xs:integer</code> is preserved in both cases.</p>
                                     <eg role="parse-test"><![CDATA[
-let $incr := 1,
-    $f := function ($i as xs:decimal) as xs:decimal { $i + $incr }
-return $f(5)                      ]]></eg>
+let $incr := 1
+let $f := function($i as xs:decimal) as xs:decimal { $i + $incr }
+return $f(5)]]></eg>
                                  </example>
                                  <example>
                                     <head>Using the Context Item in an Anonymous Function</head>
@@ -8287,8 +8287,8 @@ return $sum-of-squares(1 to 3)]]></eg>
                               <head>Partial Application of an Anonymous Function</head>
                               <p>In the following example, <code>$f</code> is an anonymous function, and <code>$paf</code> is a partially applied function created from <code>$f</code>.</p>
                               <eg role="parse-test"><![CDATA[
-let $f := function ($seq, $delim) { fold-left($seq, "", concat(?, $delim, ?)) },
-    $paf := $f(?, ".")
+let $f := function($seq, $delim) { fold-left($seq, "", concat(?, $delim, ?)) }
+let $paf := $f(?, ".")
 return $paf(1 to 5)
 ]]></eg>
                               <p>
@@ -9104,8 +9104,8 @@ return $incrementors[2](4)]]></eg>
                         <p>This mechanism makes it easier to design versatile and extensible higher-order functions. 
                      For example, in previous versions of this specification, the second argument of
                      the <code>fn:filter</code> function expected an argument of type 
-                     <code>function (item()) as xs:boolean</code>. This has now been extended to
-                     <code>function (item(), xs:integer) as xs:boolean</code>, but existing code continues
+                     <code>function(item()) as xs:boolean</code>. This has now been extended to
+                     <code>function(item(), xs:integer) as xs:boolean</code>, but existing code continues
                      to work, because callback functions that are not interested in the value of the second
                      argument simply ignore it.                    
                   </p>
@@ -9299,7 +9299,7 @@ return filter($days,$m)
 
 <olist>
                      <item>
-                        <p>The map <code>$m</code> is treated as <code>function ($f)</code>,  equivalent to <code>map:get($m,?)</code>.</p>
+                        <p>The map <code>$m</code> is treated as <code>function($f)</code>,  equivalent to <code>map:get($m,?)</code>.</p>
                      </item>
                      <item>
                         <p>The <termref def="dt-coercion-rules"

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -39057,7 +39057,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                <item>
                   <p>XPath 4.0 introduces abbreviated syntax for <phrase diff="del" at="2023-01-17">conditional expressions
                   (<code>condition ?? action1 !! action2</code>) and for</phrase> inline functions
-                  (for example <code>-> ($x, $y) {$x + $y}</code>).</p>
+                  (for example <code>fn($x, $y) { $x + $y }</code>).</p>
                </item>
 
  


### PR DESCRIPTION
Old `->` lambda syntax removed from various examples; minor unifications.

I believe it’s ready to merge; please jump in otherwise.