### PR TITLE
Adjusted CSS to target classes, not element + classes

### DIFF
--- a/specifications/css/showdiff.css
+++ b/specifications/css/showdiff.css
@@ -1,9 +1,9 @@
 /* Show diffs */
 
-div.diff-add { background-color: #99ff99 }
-div.diff-del { background-color: #ff9999; text-decoration: line-through }
-div.diff-chg { background-color: #ffff99 }
-div.diff-off {  }
+.diff-add { background-color: #99ff99 }
+.diff-del { background-color: #ff9999; text-decoration: line-through }
+.diff-chg { background-color: #ffff99 }
+.diff-off {  }
 
 span.diff-chg:before,
 span.diff-chg:after {
@@ -14,16 +14,6 @@ div.diff-chg:before,
 div.diff-chg:after {
 content: "";
 }
-
-span.diff-add { background-color: #99ff99 }
-span.diff-del { background-color: #ff9999; text-decoration: line-through }
-span.diff-chg { background-color: #ffff99 }
-span.diff-off {  }
-
-td.diff-add   { background-color: #99ff99 }
-td.diff-del   { background-color: #ff9999; text-decoration: line-through }
-td.diff-chg   { background-color: #ffff99 }
-td.diff-off   {  }
 
 p.element-syntax-chg { border: solid thick yellow; background-color: #ff99ff }
 


### PR DESCRIPTION
See comments #636 . The following targets all additions, deletions, changes, and off, regardless of what HTML element (as written didn't catch <li>, and who knows what other constructs might be in the wings). Checked in the browser developer tools to make sure the new rules wouldn't be overshadowed.