### PR TITLE
Better return type for map pair

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19616,7 +19616,7 @@ map:merge(for $b in //book return map:entry($b/isbn, $b))]]></eg>
 
    <fos:function name="pair" prefix="map">
       <fos:signatures>
-         <fos:proto name="pair" return-type="map(*)">
+         <fos:proto name="pair" return-type="record(key as xs:anyAtomicType, value as item()*)">
             <fos:arg name="key" type="xs:anyAtomicType"/>
             <fos:arg name="value" type="item()*" usage="navigation"/>
          </fos:proto>

--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -26,7 +26,7 @@
      <xsl:comment> ************************************************** </xsl:comment>
      <xsl:text>&#10;</xsl:text>
 
-      <test-set name="misc-BuiltInKeywords">
+      <test-set name="misc-BuiltInKeywords" covers-40="keywords">
          <description>Tests for keyword argument names to built-in functions: 4.0 proposal</description>        
          <dependency type="spec" value="XP40+ XQ40+"/>
          <xsl:comment>Generated using generate-keyword-test-set.xsl from function-catalog.xml on {current-date()}</xsl:comment>


### PR DESCRIPTION
Uses a record type (record(key, value)) for the return type of map:pair, to give more precision and to align with map:pairs() and map:of-pairs()