### PR TITLE
647: schema location hints

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1456,6 +1456,10 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       <item role="xquery"><p>All implementations must now predeclare the namespace prefixes
       <code>math</code>, <code>map</code>, <code>array</code>, and <code>err</code>. In XQuery 3.1 it was permitted
         but not required to predeclare these namespaces.</p></item>
+      <item role="xquery"><p>In previous versions the interpretation of location hints in 
+        <code>import schema</code> declarations was entirely at the discretion of the processor. To
+        improve interoperability, XQuery 4.0 recommends (but does not mandate)
+        a specific strategy for interpreting these hints.</p></item>
     </olist>
     
     <p>The following changes are present in this draft, but are awaiting review and agreement:</p>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1511,6 +1511,8 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       <item><p>The operator mapping table has been simplified by removing entries for the operators <code>ne</code>,
       <code>le</code>, <code>gt</code>, and <code>ge</code>; these are now defined by reference to the
       rules for the operators <code>eq</code> and <code>lt</code>.</p></item>
+      <item><p>Recommended rules for processing an <code>import schema</code> declaration with multiple
+      location hints are now provided, though they are not binding on implementors.</p></item>
 
     </olist>
   </div3>

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -241,8 +241,7 @@
             </p>
 
             <p>An implementation that does not provide the Higher-Order Function Feature <termref
-                    def="must">MUST</termref> raise a static error <errorref class="ST" code="0129"
-                /> if it encounters a  
+                    def="must">MUST</termref> raise a static error [...] if it encounters a  
                     <nt def="TypedFunctionTest">TypedFunctionTest</nt>, <termref
                     def="dt-named-function-ref">named function reference</termref>, <termref
                     def="dt-inline-func">inline function expression</termref>, or <termref

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -76,8 +76,7 @@
          <p> It is a <termref def="dt-static-error">static error</termref> if the set of definitions
             contained in all schemas imported by a Prolog do not satisfy the conditions for schema
             validity specified in Sections 3 and 5 of Part 1 of <bibref ref="XMLSchema10"/> or
-               <bibref ref="XMLSchema11"/> --i.e., each definition must be valid, complete, and
-            unique.</p>
+               <bibref ref="XMLSchema11"/>.</p>
       </error>
 
       <error spec="XQ" role="xquery" code="0013" class="ST" type="static">
@@ -218,11 +217,11 @@
             optional parameters).</p>
       </error>
 
-      <error spec="XQ" role="xquery" code="0035" class="ST" type="static">
+      <!--<error spec="XQ" role="xquery" code="0035" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> to import two schema
             components that both define the same name in the same symbol space and in the same
             scope. </p>
-      </error>
+      </error>-->
 
       <!--
 <error spec="XQ" role="xquery" code="0036" class="ST" type="type">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -10191,11 +10191,11 @@ return filter($days,$m)
 		  to which the prefix is bound, regardless of the
 		  local part of the name.</p>
 
-               <p>A node test can contain an <nt def="BracedURILiteral">BracedURILiteral</nt>, for example
+               <p>A node test can contain a <nt def="BracedURILiteral">BracedURILiteral</nt>, for example
 		  <code role="parse-test"
                      >Q{http://example.com/msg}*</code>. Such a node test is true for any node of the principal 
                   node kind of the step axis whose expanded QName has the namespace URI specified in 
-                  the <nt def="BracedURILiteral">BracedURILiteral</nt>, regardless of the local part of the name.</p>.
+                  the <nt def="BracedURILiteral">BracedURILiteral</nt>, regardless of the local part of the name.</p>
 
                <p>A node test can also
 		  have the form <code role="parse-test"

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4244,9 +4244,9 @@ the schema type named <code>us:address</code>.</p>
 
                      <p>Example: Suppose <nt def="ItemType">ItemType</nt>
                         <code>dress-size</code> is a union type that allows
-    either <code>xs:decimal</code> values for numeric sizes (e.g. 4, 6, 10, 12),
+    either <code>xs:decimal</code> values for numeric sizes (for example: 4, 6, 10, 12),
     or one of an enumerated set of <code>xs:strings</code>
-    (e.g. <code>small</code>, <code>medium</code>, <code>large</code>). The <nt
+    (for example: <code>small</code>, <code>medium</code>, <code>large</code>). The <nt
                            def="ItemType">ItemType</nt>
                         <code>dress-size</code> matches any of these values.</p>
 
@@ -5101,7 +5101,7 @@ name.</p>
 
                <p role="xquery"
                      >An implementation may raise implementation-defined
-    errors or warnings for function assertions, e.g. if the parameters
+    errors or warnings for function assertions, for example if the parameters
     are not correct for a given assertion. If the namespace URI of a function 
     assertion’s <termref
                      def="dt-expanded-qname"
@@ -8071,7 +8071,7 @@ return $vat(shop/article)
                                   If <var>F</var>’s implementation is
                                   
                                   not an &language; expression
-                                  (e.g., <var>F</var> is
+                                  (for example, <var>F</var> is
                                   a <termref
                                        def="dt-system-function">system function</termref>
                                     <phrase role="xquery">or an <termref def="dt-external-function"
@@ -10193,9 +10193,9 @@ return filter($days,$m)
 
                <p>A node test can contain an <nt def="BracedURILiteral">BracedURILiteral</nt>, for example
 		  <code role="parse-test"
-                     >Q{http://example.com/msg}*</code> Such a node test is true for any node of the principal 
+                     >Q{http://example.com/msg}*</code>. Such a node test is true for any node of the principal 
                   node kind of the step axis whose expanded QName has the namespace URI specified in 
-                  the <nt def="BracedURILiteral">BracedURILiteral</nt>, regardless of the local part of the name.</p>
+                  the <nt def="BracedURILiteral">BracedURILiteral</nt>, regardless of the local part of the name.</p>.
 
                <p>A node test can also
 		  have the form <code role="parse-test"
@@ -15450,7 +15450,8 @@ map {
                </ulist>
 
                <note>
-                  <p>&language; does not provide explicit support for sparse arrays. Use integer-valued maps to represent sparse arrays, e.g. <code>map { 27 : -1, 153 : 17 } </code>.</p>
+                  <p>&language; does not provide explicit support for sparse arrays. Use integer-valued maps to represent sparse arrays, 
+                     for example: <code>map { 27 : -1, 153 : 17 } </code>.</p>
                </note>
 
             </div4>
@@ -15543,8 +15544,10 @@ map {
                   <prodrecap id="KeySpecifier" ref="KeySpecifier"/>
                </scrap>
 
-               
-               <p>Unary lookup is used in predicates (e.g. <code>$map[?name='Mike']</code> or with the simple map operator (e.g. <code>$maps ! ?name='Mike'</code>). See <specref
+
+
+               <p>Unary lookup is used in predicates (for example, <code>$map[?name='Mike']</code> 
+                  or with the simple map operator (for example, <code>$maps ! ?name='Mike'</code>). See <specref
                      ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
                
                

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -510,7 +510,7 @@ return (
       optional location hints, intended to allow a processor to locate schema documents containing 
       definitions of the required schema components in the target namespace. Processors <rfc2119>may</rfc2119> 
       interpret or disregard these hints in an <termref def="dt-implementation-defined"
-        >implementation-defined</termref> way. The prefered strategy,
+        >implementation-defined</termref> way. The preferred strategy,
       which <rfc2119>should</rfc2119> be used by default unless the user indicates otherwise, 
       is as follows:</p>
     
@@ -518,23 +518,21 @@ return (
       <item><p>If the target namespace is one for which the processor has built-in knowledge,
       for example the schema for a <termref def="dt-reserved-namespaces">reserved namespace</termref>, the location hints
       <rfc2119>should</rfc2119> be ignored, and the built-in schema used in preference.</p></item>
-      <item><p>In other cases, 
-       all the location hints are dereferenced, treating them as relative URIs relative
+      <item><p>In other cases, the location hints are taken in order, treating them as URI references relative
         to the static base URI of the query module.</p></item>
-      <item><p>If any location hint cannot be dereferenced, then that location hint is disregarded 
-        (optionally with a warning); but if none of the location hints can be dereferenced, then 
-        a static error is reported.</p></item>
-      <item><p>If dereferencing any location hint yields a resource that cannot be parsed as a valid
+      <item><p>If the first location hint cannot be successfully dereferenced, then that location hint is disregarded 
+        (optionally with a warning), and the process continues with the next location hint, until
+        one is found that can be successfully dereferenced; if none of the location hints can be dereferenced, 
+        then a static error is reported.</p></item>
+      <item><p>The dereferencing of a location hint <rfc2119>may</rfc2119> make use of implementation-defined
+        indirection mechanisms such as resolver callbacks and catalog files.</p></item>
+      <item><p>If a location hint is successfully dereferenced, but yields a resource that cannot be parsed as a valid
         XSD schema document with the correct target namespace, then a static error is reported.</p></item>
-      <item><p>If multiple location hints are dereferenced, yielding multiple schema documents
-        <var>A</var>, <var>B</var>, and <var>C</var>, then they should be treated as if there were a 
-        single schema document (in the requested target namespace) containing <code>xs:include</code> 
-        declarations referencing <var>A</var>, <var>B</var>, and <var>C</var>. This implies that the 
+      <item><p>If a valid schema document is located, then it is combined with the schema documents obtained
+        from other import schema declarations, in the same way as a schema is assembled from multiple
+        schema documents referenced using <code>xs:import</code> declarations. This implies that the 
         several schema documents must together comprise a valid schema, for example there cannot be two 
         different type definitions with the same name.</p></item>
-      <item><p>Notwithstanding the previous rule, if a processor is able to establish that two or more 
-        location hints refer to identical or equivalent schema documents, then the duplicates <rfc2119>should</rfc2119> 
-        be ignored.</p></item>
     </olist>
     
     <note><p>Processors that adopted a different strategy in earlier releases <rfc2119>may</rfc2119>
@@ -552,7 +550,8 @@ return (
         def="dt-prolog">Prolog</termref> specifies the same target namespace. It is a <termref
         def="dt-static-error">static error</termref>
       <errorref class="ST" code="0059"/> if the implementation is not able to process a schema
-      import by finding a valid schema with the specified target namespace. It is a <termref
+      import by finding a valid schema with the specified target namespace. 
+      <phrase diff="del" at="issue647">It is a <termref
         def="dt-static-error">static error</termref>
       <errorref class="ST" code="0035"/> if multiple imported schemas, or multiple physical
       resources within one schema, contain definitions for the same name in the same symbol space
@@ -560,7 +559,7 @@ return (
       consistent). However, it is not an error to import the schema with target namespace
         <code>http://www.w3.org/2001/XMLSchema </code>(predeclared prefix <code>xs</code>), even
       though the built-in types defined in this schema are implicitly included in the <termref
-        def="dt-is-types">in-scope schema types.</termref>
+        def="dt-is-types">in-scope schema types.</termref></phrase>
     </p>
 
 
@@ -568,8 +567,7 @@ return (
     <p> It is a <termref def="dt-static-error">static error</termref>
       <errorref code="0012" class="ST"/> if the set of definitions contained in all schemas imported
       by a Prolog do not satisfy the conditions for schema validity specified in Sections 3 and 5 of
-        <bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/> Part 1--i.e., each definition
-      must be valid, complete, and unique.</p>
+        <bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/> Part 1.</p>
     <p>The following example imports a schema, specifying both its target namespace and its
       location, and binding the prefix <code>soap</code> to the target namespace:</p>
 
@@ -1293,14 +1291,14 @@ declare function local:f() { $b }; </eg>
 
     <!-- ================================================= -->
 
-    <p>During query evaluation, each variable declaration causes a pair <code>(expanded QName N,
-        value V)</code> to be added to the <termref def="dt-variable-values">variable
-        values</termref>. The expanded QName N is the <code>VarName</code>. The value V is as
+    <p>During query evaluation, each variable declaration causes a pair <code>(expanded QName <var>N</var>,
+        value <var>V</var>)</code> to be added to the <termref def="dt-variable-values">variable
+        values</termref>. The expanded QName <var>N</var> is the <code>VarName</code>. The value <var>V</var> is as
       follows:</p>
 
     <ulist>
       <item>
-        <p>If <code>VarValue</code> is specified, then V is the result of evaluating
+        <p>If <code>VarValue</code> is specified, then <var>V</var> is the result of evaluating
             <code>VarValue</code>.</p>
       </item>
 
@@ -1309,14 +1307,14 @@ declare function local:f() { $b }; </eg>
 
         <ulist>
           <item>
-            <p> if a value is provided for the variable by the external environment, then V is that
+            <p> if a value is provided for the variable by the external environment, then <var>V</var> is that
               value. The means by which typed values of external variables are provided by the
               external environment is implementation-defined.</p>
           </item>
 
           <item>
             <p> if no value is provided for the variable by the external environment, and
-                <code>VarDefaultValue</code> is specified, then V is the result of evaluating
+                <code>VarDefaultValue</code> is specified, then <var>V</var> is the result of evaluating
                 <code>VarDefaultValue</code>.</p>
           </item>
 
@@ -1332,7 +1330,7 @@ declare function local:f() { $b }; </eg>
       </item>
     </ulist>
 
-    <p>In all cases the value V must match the type T according to the rules for SequenceType
+    <p>In all cases the value <var>V</var> must match the type <var>T</var> according to the rules for SequenceType
       matching; otherwise a <termref def="dt-type-error">type error</termref> is raised <errorref
         class="TY" code="0004"/>.</p>
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -533,11 +533,23 @@ return (
         schema documents referenced using <code>xs:import</code> declarations. This implies that the 
         several schema documents must together comprise a valid schema, for example there cannot be two 
         different type definitions with the same name.</p></item>
+      <item><p>Once one location hint has been successfully processed, subsequent location hints are
+      ignored.</p></item>
     </olist>
     
-    <note><p>Processors that adopted a different strategy in earlier releases <rfc2119>may</rfc2119>
+    <note diff="add" at="issue647"><p>Processors that adopted a different strategy in earlier releases <rfc2119>may</rfc2119>
       continue to use that strategy by default, in order to retain compatibility; however such
-      processors <rfc2119>should</rfc2119> offer the above strategy as an option. </p></note>
+      processors <rfc2119>should</rfc2119> offer the above strategy as an option. </p>
+    <p>The process described above is not intended to be totally prescriptive, or to guarantee complete 
+      interoperability. Processors are likely to exhibit variations, depending both on design decisions made
+      by the product vendor, and on decisions made when configuring the platform
+      and network infrastructure on which it runs. For example, when retrieving HTTP resources,
+      the details of the HTTP request are likely to vary, and the criteria used to decide whether
+      a request was successful may also vary. In addition, the XSD specification itself describes
+      some aspects of the process incompletely, including for example the criteria used to decide 
+      whether two components (such as type definitions) should be considered identical.</p>
+    
+    </note>
     
     <p>
       If the target

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -602,9 +602,39 @@ return (
       namespace <errorref class="ST" code="0033"/>.</p>
     <p>The first <nt def="URILiteral">URILiteral</nt> in a module import must be of nonzero length
         <errorref class="ST" code="0088"/>, and specifies the target namespace of the modules to be
-      imported. The URILiterals that follow the <code>at</code> keyword are optional location hints,
-      and can be interpreted or disregarded in an <termref def="dt-implementation-defined"
-        >implementation-defined</termref> way.</p>
+      imported.</p>
+    
+    <p diff="chg" at="issue647">The <nt def="URILiteral">URILiterals</nt> 
+      that follow the <code>at</code> keyword are 
+      optional location hints, intended to allow a processor to locate schema documents containing 
+      definitions of the required schema components in the target namespace. Processors <rfc2119>may</rfc2119> 
+      interpret or disregard these hints in an <termref def="dt-implementation-defined"
+        >implementation-defined</termref> way. The <rfc2119>recommended</rfc2119> strategy,
+      to be used by default unless the user dictates otherwise, is as follows:</p>
+    
+    <olist diff="add" at="issue647">
+      <item><p>All the location hints are dereferenced, treating them as relative URIs relative
+      to the static base URI of the query module.</p></item>
+      <item><p>If any location hint cannot be dereferenced, then that location hint is disregarded 
+        (optionally with a warning); but if none of the location hints can be dereferenced, then 
+        a static error is reported.</p></item>
+      <item><p>If dereferencing any location hint yields a resource that cannot be parsed as a valid
+      XSD schema document with the correct target namespace, then a static error is reported.</p></item>
+      <item><p>If multiple location hints are dereferenced, yielding multiple schema documents
+        <var>A</var>, <var>B</var>, and <var>C</var>, then they should be treated as if there were a 
+        single schema document (in the requested target namespace) containing <code>xs:include</code> 
+        declarations referencing <var>A</var>, <var>B</var>, and <var>C</var>. This implies that the 
+        several schema documents must together comprise a valid schema, for example there cannot be two 
+        different type definitions with the same name.</p></item>
+      <item><p>Notwithstanding the previous rule, if a processor is able to establish that two or more 
+        location hints refer to identical or equivalent schema documents, then the duplicates <rfc2119>should</rfc2119> 
+        be ignored.</p></item>
+    </olist>
+    
+    <note><p>Processors that adopted a different strategy in earlier releases <rfc2119>may</rfc2119>
+    continue to use that strategy by default, in order to retain compatibility; however such
+    processors <rfc2119>should</rfc2119> offer the above strategy as an option. </p></note>
+    
     <p>It is a <termref def="dt-static-error">static error</termref>
       <errorref class="ST" code="0047"/> if more than one module import in a <termref
         def="dt-prolog">Prolog</termref> specifies the same target namespace. It is a <termref

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -484,30 +484,68 @@ return (
       or a <termref def="dt-module-import">module declaration</termref>
       <errorref class="ST" code="0033"/>. </p>
     
+    <note diff="add" at="issue647">If schema definitions from the <code>xml</code> namespace
+    are to be used (for example, <code>schema-attribute(xml:space)</code>, then the prolog should
+      include a declaration in the form <code>import schema "http://www.w3.org/XML/1998/namespace"</code>.
+    No prefix should be supplied (the <code>xml</code> prefix is predeclared), and no location hint
+    should be provided (the schema definitions for the namespace are built in, and cannot be varied).</note>
+    
     <p diff="add" at="A">If the schema import declaration specifies <code>default element namespace</code>
       then the prolog must not contain a <termref def="dt-namespace-declaration">namespace declaration</termref>
       that specifies <code>default element namespace</code> or <code>default type namespace</code>.</p>
 
-    <p> The first <nt def="URILiteral">URILiteral</nt> in a schema import specifies the target
-      namespace of the schema to be imported. 
-      The URILiterals that follow the <code>at</code>
-      keyword are optional location hints, and can be interpreted or disregarded in an
-      implementation-dependent way. Multiple location hints might be used to indicate more than one
-      possible place to look for the schema or multiple physical resources to be assembled to form
-      the schema.
-    </p>
-    <p>
-      If the target
-      namespace is <code>http://www.w3.org/2005/xpath-functions</code> then the schema described in 
-      <xspecref spec="FO31" ref="schemata"/> is imported; any location hints are ignored.
-    </p>
+    <p>The first <nt def="URILiteral">URILiteral</nt> specifies the target namespace of the schema documents to be
+      imported.</p>
+    
     <p>A schema import that specifies a zero-length string as target namespace is considered to
       import a schema that has no target namespace. Such a schema import must not bind a namespace
       prefix <errorref class="ST" code="0057"/>, but it may set the default element and/or type namespace
       to a zero-length string (representing “no namespace”), thus enabling the definitions in the
       imported namespace to be referenced. If the default element and/or type namespace is not set to "no
       namespace", <phrase diff="chg" at="A">the only way to reference the definitions in an imported schema that has no
-      target namespace is using the EQName syntax <code>Q{}local-name</code></phrase>.</p>
+        target namespace is using the EQName syntax <code>Q{}local-name</code></phrase>.</p>
+    
+    <p diff="chg" at="issue647">The <nt def="URILiteral">URILiterals</nt> 
+      that follow the <code>at</code> keyword are 
+      optional location hints, intended to allow a processor to locate schema documents containing 
+      definitions of the required schema components in the target namespace. Processors <rfc2119>may</rfc2119> 
+      interpret or disregard these hints in an <termref def="dt-implementation-defined"
+        >implementation-defined</termref> way. The <rfc2119>recommended</rfc2119> strategy,
+      to be used by default unless the user dictates otherwise, is as follows:</p>
+    
+    <olist diff="add" at="issue647">
+      <item><p>If the target namespace is one for which the processor has built-in knowledge,
+      for example the schema for a <termref def="dt-reserved-namespaces">reserved namespace</termref>, the location hints
+      <rfc219>should</rfc219> be ignored, and the built-in schema used in preference.</p></item>
+      <item><p>In other cases, 
+       all the location hints are dereferenced, treating them as relative URIs relative
+        to the static base URI of the query module.</p></item>
+      <item><p>If any location hint cannot be dereferenced, then that location hint is disregarded 
+        (optionally with a warning); but if none of the location hints can be dereferenced, then 
+        a static error is reported.</p></item>
+      <item><p>If dereferencing any location hint yields a resource that cannot be parsed as a valid
+        XSD schema document with the correct target namespace, then a static error is reported.</p></item>
+      <item><p>If multiple location hints are dereferenced, yielding multiple schema documents
+        <var>A</var>, <var>B</var>, and <var>C</var>, then they should be treated as if there were a 
+        single schema document (in the requested target namespace) containing <code>xs:include</code> 
+        declarations referencing <var>A</var>, <var>B</var>, and <var>C</var>. This implies that the 
+        several schema documents must together comprise a valid schema, for example there cannot be two 
+        different type definitions with the same name.</p></item>
+      <item><p>Notwithstanding the previous rule, if a processor is able to establish that two or more 
+        location hints refer to identical or equivalent schema documents, then the duplicates <rfc2119>should</rfc2119> 
+        be ignored.</p></item>
+    </olist>
+    
+    <note><p>Processors that adopted a different strategy in earlier releases <rfc2119>may</rfc2119>
+      continue to use that strategy by default, in order to retain compatibility; however such
+      processors <rfc2119>should</rfc2119> offer the above strategy as an option. </p></note>
+    
+    <p>
+      If the target
+      namespace is <code>http://www.w3.org/2005/xpath-functions</code> then the schema described in 
+      <xspecref spec="FO31" ref="schemata"/> is imported; any location hints are ignored.
+    </p>
+    
     <p>It is a <termref def="dt-static-error">static error</termref>
       <errorref class="ST" code="0058"/> if more than one schema import in the same <termref
         def="dt-prolog">Prolog</termref> specifies the same target namespace. It is a <termref
@@ -602,38 +640,11 @@ return (
       namespace <errorref class="ST" code="0033"/>.</p>
     <p>The first <nt def="URILiteral">URILiteral</nt> in a module import must be of nonzero length
         <errorref class="ST" code="0088"/>, and specifies the target namespace of the modules to be
-      imported.</p>
+      imported. The <nt def="URILiteral">URILiterals</nt> that follow the <code>at</code> keyword are 
+      optional location hints, and can be interpreted or disregarded in
+      an <termref def="dt-implementation-defined"
+        >implementation-defined</termref> way.</p>
     
-    <p diff="chg" at="issue647">The <nt def="URILiteral">URILiterals</nt> 
-      that follow the <code>at</code> keyword are 
-      optional location hints, intended to allow a processor to locate schema documents containing 
-      definitions of the required schema components in the target namespace. Processors <rfc2119>may</rfc2119> 
-      interpret or disregard these hints in an <termref def="dt-implementation-defined"
-        >implementation-defined</termref> way. The <rfc2119>recommended</rfc2119> strategy,
-      to be used by default unless the user dictates otherwise, is as follows:</p>
-    
-    <olist diff="add" at="issue647">
-      <item><p>All the location hints are dereferenced, treating them as relative URIs relative
-      to the static base URI of the query module.</p></item>
-      <item><p>If any location hint cannot be dereferenced, then that location hint is disregarded 
-        (optionally with a warning); but if none of the location hints can be dereferenced, then 
-        a static error is reported.</p></item>
-      <item><p>If dereferencing any location hint yields a resource that cannot be parsed as a valid
-      XSD schema document with the correct target namespace, then a static error is reported.</p></item>
-      <item><p>If multiple location hints are dereferenced, yielding multiple schema documents
-        <var>A</var>, <var>B</var>, and <var>C</var>, then they should be treated as if there were a 
-        single schema document (in the requested target namespace) containing <code>xs:include</code> 
-        declarations referencing <var>A</var>, <var>B</var>, and <var>C</var>. This implies that the 
-        several schema documents must together comprise a valid schema, for example there cannot be two 
-        different type definitions with the same name.</p></item>
-      <item><p>Notwithstanding the previous rule, if a processor is able to establish that two or more 
-        location hints refer to identical or equivalent schema documents, then the duplicates <rfc2119>should</rfc2119> 
-        be ignored.</p></item>
-    </olist>
-    
-    <note><p>Processors that adopted a different strategy in earlier releases <rfc2119>may</rfc2119>
-    continue to use that strategy by default, in order to retain compatibility; however such
-    processors <rfc2119>should</rfc2119> offer the above strategy as an option. </p></note>
     
     <p>It is a <termref def="dt-static-error">static error</termref>
       <errorref class="ST" code="0047"/> if more than one module import in a <termref

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -249,7 +249,7 @@
       declaration is considered to be a “base URI embedded in content”. If no base URI declaration
       is present, <termref def="dt-static-base-uri">Static Base URI</termref> property is
       established according to the principles outlined in <bibref ref="RFC3986"/> Section
-      5.1&mdash;that is, it defaults first to the base URI of the encapsulating entity, then to the
+      5.1—that is, it defaults first to the base URI of the encapsulating entity, then to the
       URI used to retrieve the entity, and finally to an implementation-defined default. If the
       URILiteral in the base URI declaration is a relative URI, then it is made absolute by
       resolving it with respect to this same hierarchy. For example, if the URILiteral in the base
@@ -484,11 +484,11 @@ return (
       or a <termref def="dt-module-import">module declaration</termref>
       <errorref class="ST" code="0033"/>. </p>
     
-    <note diff="add" at="issue647">If schema definitions from the <code>xml</code> namespace
+    <note diff="add" at="issue647"><p>If schema definitions from the <code>xml</code> namespace
     are to be used (for example, <code>schema-attribute(xml:space)</code>, then the prolog should
       include a declaration in the form <code>import schema "http://www.w3.org/XML/1998/namespace"</code>.
     No prefix should be supplied (the <code>xml</code> prefix is predeclared), and no location hint
-    should be provided (the schema definitions for the namespace are built in, and cannot be varied).</note>
+    should be provided (the schema definitions for the namespace are built in, and cannot be varied).</p></note>
     
     <p diff="add" at="A">If the schema import declaration specifies <code>default element namespace</code>
       then the prolog must not contain a <termref def="dt-namespace-declaration">namespace declaration</termref>
@@ -510,13 +510,14 @@ return (
       optional location hints, intended to allow a processor to locate schema documents containing 
       definitions of the required schema components in the target namespace. Processors <rfc2119>may</rfc2119> 
       interpret or disregard these hints in an <termref def="dt-implementation-defined"
-        >implementation-defined</termref> way. The <rfc2119>recommended</rfc2119> strategy,
-      to be used by default unless the user dictates otherwise, is as follows:</p>
+        >implementation-defined</termref> way. The prefered strategy,
+      which <rfc2119>should</rfc2119> be used by default unless the user indicates otherwise, 
+      is as follows:</p>
     
     <olist diff="add" at="issue647">
       <item><p>If the target namespace is one for which the processor has built-in knowledge,
       for example the schema for a <termref def="dt-reserved-namespaces">reserved namespace</termref>, the location hints
-      <rfc219>should</rfc219> be ignored, and the built-in schema used in preference.</p></item>
+      <rfc2119>should</rfc2119> be ignored, and the built-in schema used in preference.</p></item>
       <item><p>In other cases, 
        all the location hints are dereferenced, treating them as relative URIs relative
         to the static base URI of the query module.</p></item>
@@ -663,7 +664,7 @@ return (
       it does not import other objects from the imported
       modules, such as <termref def="dt-issd">in-scope schema definitions</termref> or <termref
         def="dt-static-namespaces">statically known namespaces</termref>. Module imports are not
-      transitive&mdash;that is, importing a module provides access only to 
+      transitive—that is, importing a module provides access only to 
       <phrase diff="del" at="A">function and variable</phrase>
       declarations contained directly in the imported module. For example, if module A imports
       module B, and module B imports module C, module A does not have access to the functions and


### PR DESCRIPTION
Fix #647 

Note: Need to check that this builds successfully. In my working copy, the new text for "import schema" found its way into the "xquery-assembled.xml" file but not into the final HTML. I can't see any reason for this.