### PR TITLE
658: constructor functions

### DIFF
--- a/schema/xmlspec.dtd
+++ b/schema/xmlspec.dtd
@@ -1246,9 +1246,10 @@
 <!ATTLIST proto
         %common.att;
 	%local.proto.att;
-        name            NMTOKEN         #REQUIRED
-        return-type     %argtypes;      #IMPLIED
-        return-type-ref	IDREF		#IMPLIED
+        name                      NMTOKEN    #REQUIRED
+        return-type               %argtypes; #IMPLIED
+        return-type-ref	        IDREF		#IMPLIED
+        return-type-ref-occurs	 IDREF		#IMPLIED
 >
 ]]>
 
@@ -1278,6 +1279,7 @@
 	%local.arg.att;
         type            %argtypes;      #IMPLIED
         type-ref        IDREF           #IMPLIED
+        type-ref-occurs CDATA           #IMPLIED
         occur           (opt|req)       #IMPLIED
 >
 ]]>

--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -97,6 +97,13 @@
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="return-type-ref-occurs" type="fos:occurrence-indicator" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            Qualifies the @return-type-ref reference with an occurrence indicator.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attributeGroup ref="fos:diff-markup"/>
       <xs:assert test="count((@return-type, @return-type-ref)) eq 1"/>
     </xs:complexType>
@@ -109,6 +116,13 @@
         <xs:annotation>
           <xs:documentation>
             A reference to a fos:type definition, typically a record type definition.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="type-ref-occurs" type="fos:occurrence-indicator" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            Qualifies the @type-ref reference with an occurrence indicator.
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
@@ -337,6 +351,15 @@
 	  </xs:simpleType>
 	</xs:union>
   </xs:simpleType>
+  
+  <xs:simpleType name="occurrence-indicator">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="*"/>
+      <xs:enumeration value="+"/>
+      <xs:enumeration value="?"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
   <xs:simpleType name="operand-usage">
     <xs:restriction base="xs:NCName">
       <xs:enumeration value="inspection"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -41,6 +41,14 @@
       </fos:record>
    </fos:type>
    
+   <fos:type id="sort-key-record">
+      <fos:record extensible="true">
+         <fos:field name="key" type="function(item()) as xs:anyAtomicType*" required="true"/>
+         <fos:field name="ascending" type="xs:boolean" required="false"/>
+         <fos:field name="collation" type="xs:string" required="false"/>
+      </fos:record>
+   </fos:type>
+   
    <fos:type id="parse-html-options">
       <fos:record extensible="true">        
          <fos:field name="method" type="xs:string" required="false"/>
@@ -17791,102 +17799,121 @@ return for-each-pair($s, tail($s), function($a, $b) { $a * $b })</eg></fos:expre
       </fos:examples>
    </fos:function>
 
-   <fos:function name="sort" prefix="fn">
+   <fos:function name="sort" prefix="fn" diff="chg" at="2023-07-19">
       <fos:signatures>
          <fos:proto name="sort" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
             <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
+            <fos:arg name="sort-keys" type-ref="sort-key-record" type-ref-occurs="*" usage="inspection" default="()"/>
          </fos:proto>
       </fos:signatures>
-      <fos:properties arity="1">
+      <fos:properties>
          <fos:property>deterministic</fos:property>
          <fos:property dependency="collations">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
-      <fos:properties arity="2">
-         <fos:property>deterministic</fos:property>
-         <fos:property dependency="collations">context-dependent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:properties arity="3">
-         <fos:property>deterministic</fos:property>
-         <fos:property dependency="collations">context-dependent</fos:property>
-         <fos:property>focus-independent</fos:property>
-         
-      </fos:properties>
-
+ 
 
       <fos:summary>
-         <p>Sorts a supplied sequence, based on the value of a sort key supplied as a function.</p>
+         <p>Sorts a supplied sequence, based on the value of a one or more supplied sort keys supplied as functions.</p>
       </fos:summary>
       <fos:rules>
-         <p>Calling the single-argument version of the function is equivalent to calling the two-argument form
-         with <code>default-collation()</code> as the second argument: that is, it sorts a sequence of items according
-         to the typed value of the items, using the default collation to compare strings.</p>
+         <p>If the <code>$sort-keys</code> argument is omitted, or is set to an empty sequence, then
+         the function behaves as if the <code>$sort-keys</code> argument were present with a value
+         computed as follows:</p>
          
-         <p>Calling the two-argument version of the function is equivalent to calling the three-argument form 
-            with <code>fn:data#1</code> as the third argument: that is, it sorts a sequence of items according 
-            to the typed value of the items, using a specified collation to compare strings.</p>
-         
-         <p>In the case of both <code>fn:sort#2</code> and <code>fn:sort#3</code>, supplying an empty
-         sequence as the second argument is equivalent to supplying <code>fn:default-collation()</code>. For more
-         information on collations see <specref
-               ref="choosing-a-collation"/>.</p>
-
-         <p>The result of the function is obtained as follows:</p>
          <ulist>
+            <item><p>The effective value of <code>$sort-keys</code> is a sequence containing a
+            single map, conforming to the type <code>sort-key-record</code>.</p></item>
+            <item><p>The <code>key</code> field of the map is set to the value of the
+            <code>$key</code> argument if present and non-empty, or to the function <code>fn:data#1</code>
+            otherwise.</p></item>
+            <item><p>The <code>collation</code> field of the map is set to the value of
+            the <code>$collation</code> argument if present and non-empty, or to the default
+            collation (from the static context of the caller) otherwise.</p></item>
+            <item><p>The <code>ascending</code> field of the map is set to <code>true</code>.</p></item>
+         </ulist>
+         
+         <?type sort-key-record?>
+         
+         <p>Given a <code>$sort-keys</code> value, either supplied explicitly or constructed as
+         described above, the result of the function is obtained as follows:</p>
+         
+         <olist>
             <item>
-               <p>For each item in the sequence <code>$input</code>, the function supplied as <code>$key</code> 
-               is evaluated with that item as its argument. 
-               The resulting values are the sort keys of the items in the input sequence.
-            </p>
+               <p>The result sequence contains the same items as the input sequence <code>$input</code>, 
+                  but generally in a different order.</p>
             </item>
             <item>
-               <p>The result sequence contains the same items as the input sequence <code>$input</code>, but generally in a different order.</p>
+               <p>Each map in the value of <code>$sort-keys</code> represents one sort key definition.
+                  The sort key definitions are in major-to-minor order. That is, the position of two
+                  items <code>$A</code> and <code>$B</code> in the result sequence is determined first by the 
+                  relative magnitude of their
+                  primary sort keys, which are computed by evaluating the <code>key</code> function in the 
+                  first sort key definition.
+                  If those two sort keys are equal, then the position is determined by the relative magnitude
+                  of their secondary sort keys, computed by evaluating the 
+                  <code>key</code> function in the 
+                  second sort key definition, and so on.</p>              
             </item>
             <item>
-               <p>Let <var>$C</var> be the selected collation, or the default collation where applicable.</p>
+               <p>When a pair of corresponding sort keys of <code>$A</code> and <code>$B</code> are 
+                  found to be not equal,
+                  then <code>$A</code> precedes <code>$B</code> in the result sequence 
+                  if both the following conditions are true, or if both conditions are false:</p>
+                  <olist>
+                     <item>
+                        <p>The sort key for <code>$A</code> is less than the sort key for <code>$B</code>,
+                           as defined below.</p>
+                     </item>
+                     <item>
+                        <p>The value of <code>ascending</code> in the corresponding sort key definition
+                        is <code>true</code> or absent.</p>
+                     </item>
+                  </olist>
             </item>
-            <item diff="chg" at="A">
-               <p>The order of items in the result is such that, given two items <code>$A</code> and <code>$B</code>:</p>
+            <item><p>If all the sort keys for <code>$A</code> and <code>$B</code> are pairwise equal, then 
+               <code>$A</code> precedes <code>$B</code> in the result sequence if and only if
+               <code>$A</code> precedes <code>$B</code> in the input sequence.</p>
+            </item>
+            <item>
+               <p>Each sort key for a given item is obtained by applying the <code>key</code>
+               function of the corresponding sort key definition to that item. The result
+               of this function is in the general case a sequence of atomic values.
+               Two sort keys <code>$a</code> and <code>$b</code> are compared as follows:</p>
                <olist>
+                  <item><p>Let <var>$C</var> be the collation specified in the corresponding
+                     sort key definition; if this is absent or empty, then let <var>$C</var>
+                     be the value of the <code>$collation</code> argument, defaulting in turn
+                     to the default collation from the static context of the caller.</p>
+                  </item>
                   <item><p>Let <code>$REL</code> be the result of evaluating <code>op:lexicographic-compare($key($A), $key($B), $C)</code>
                      where <code>op:lexicographic-compare($a, $b, $C)</code> is defined as follows:</p>
-                     <eg
->if (empty($a) and empty($b)) then 0 
+                     <eg>if (empty($a) and empty($b)) then 0 
 else if (empty($a)) then -1
 else if (empty($b)) then +1
 else let $rel = op:simple-compare(head($a), head($b), $C)
      return if ($rel eq 0)
             then op:lexicographic-compare(tail($a), tail($b), $C)
-            else $rel</eg>
-                  </item>
+            else $rel</eg></item>
                   <item><p>Here <code>op:simple-compare($k1, $k2)</code> is defined as follows:</p>
-                     <eg
->if ($k1 instance of union(xs:string, xs:anyURI, xs:untypedAtomic)
-        and $k2 instance of union(xs:string, xs:anyURI, xs:untypedAtomic))
-    then compare($k1, $k2, $C)
-    else if ($k1 eq $k2 or (is-NaN($k1) and is-NaN($k2))) then 0
-    else if (is-NaN($k1) or $k2 lt $k2) then -1
-    else +1</eg>
+                     <eg>if ($k1 instance of union(xs:string, xs:anyURI, xs:untypedAtomic)
+    and $k2 instance of union(xs:string, xs:anyURI, xs:untypedAtomic))
+then compare($k1, $k2, $C)
+else if ($k1 eq $k2 or (is-NaN($k1) and is-NaN($k2))) then 0
+else if (is-NaN($k1) or $k2 lt $k2) then -1
+else +1</eg>
                      <note><p>This raises an error if two keys are not comparable, for example
-                     if one is a string and the other is a number, or if both belong to a non-ordered
-                     type such as <code>xs:QName</code>.</p></note>
-                  </item>
- 
-                </olist>
+                        if one is a string and the other is a number, or if both belong to a non-ordered
+                        type such as <code>xs:QName</code>.</p></note></item>
+                  <item><p>If <code>$REL</code> is zero, then the two sort key values are deemed
+                     equal; if <code>$REL</code> is -1 then <code>$a</code> is deemed less than
+                     <code>$b</code>, and if <code>$REL</code> is +1 then <code>$a</code> is deemed greater than
+                     <code>$b</code></p></item>
+               </olist>
             </item>
-                  <item>
-                     <p>If <code>$REL eq 0</code>, then the relative order of <code>$A</code> and <code>$B</code> 
-                  in the output is the same as their relative order in the input (that is, the sort is stable)
-               </p>
-                  </item>
-                  <item>
-                     <p>Otherwise, if <code>$REL lt 0</code>, then <code>$A</code> precedes <code>$B</code> in the output.
-                     </p>
-                  </item>
-         </ulist>
+         </olist>
       </fos:rules>
       <fos:errors>
          <p>If the set of computed sort keys contains values that are not comparable using the <code>lt</code> operator then the sort 
@@ -17895,7 +17922,7 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
          </p>
       </fos:errors>
       <fos:notes>
-         <p>XSLT and XQuery both provide native sorting capability, but previous releases of XPath provided no sorting functionality
+         <p>XSLT and XQuery both provide native sorting capability, but earlier releases of XPath provided no sorting functionality
          for use in standalone environments.</p>
          <p>In addition there are cases where this function may be more flexible than the built-in sorting capability for XQuery or XSLT,
          for example when the sort key or collation is chosen dynamically, or when the sort key is a sequence of items rather than a single
@@ -17904,6 +17931,12 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
          length zero or one, given the options <code>stable="yes"</code> and <code>order="ascending"</code>.</p>
          <p>The results are compatible with the results of XQuery sorting (using the <code>order by</code> clause) in the case where the sort key evaluates to a sequence of
             length zero or one, given the options <code>stable</code>, <code>ascending</code>, and <code>empty least</code>.</p>
+         <p>The function has been enhanced in 4.0 to allow multiple sort keys to be defined, each potentially with
+         a different collation, and to allow sorting in descending order.</p>
+         <p>The effect of the XQuery option <code>empty least|greatest</code>, which controls
+         whether the empty sequence is sorted before or after all other values, can be achieved by adding an
+         extra sort key definition that evaluates whether or not the actual sort key is empty (when sorting
+         boolean values, <code>false</code> precedes <code>true</code>).</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -17918,18 +17951,29 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
          </fos:example>
          <fos:example>
             <p>To sort a set of strings <code>$in</code> using Swedish collation:</p>
-            <eg>
-let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
-return sort($in, $SWEDISH)
-            </eg>
+            <eg>let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
+return sort($in, $SWEDISH)</eg>
          </fos:example>
          <fos:example>
             <p>To sort a sequence of employees by last name as the major sort key and first name as the minor sort key,
                using the default collation:
             </p>
-            <eg>sort($employees, (), function($emp) {$emp/name ! (last, first)})</eg>
+            <eg>sort($employees, (), fn{name ! (last, first)})</eg>
+         </fos:example>
+         <fos:example>
+            <p>To sort a sequence of employees first by increasing last name (using Swedish collation order)
+               and then by decreasing salary:
+            </p>
+            <eg>let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
+return sort($employees, sort-keys := 
+    (map{"key": fn{name/last}, "collation": $SWEDISH},
+     map{"key": fn{xs:decimal(salary)}, "ascending":false()}))</eg>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Substantially revised in 4.0 to allow multiple sort
+            key definitions.</fos:version>
+      </fos:history>
    </fos:function>
    
    <fos:function name="transitive-closure" prefix="fn">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17799,13 +17799,13 @@ return for-each-pair($s, tail($s), function($a, $b) { $a * $b })</eg></fos:expre
       </fos:examples>
    </fos:function>
 
-   <fos:function name="sort" prefix="fn" diff="chg" at="2023-07-19">
+   <fos:function name="sort" prefix="fn" diff="chg" at="2023-08-15">
       <fos:signatures>
          <fos:proto name="sort" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
-            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
-            <fos:arg name="sort-keys" type-ref="sort-key-record" type-ref-occurs="*" usage="inspection" default="()"/>
+            <fos:arg name="collation" type="xs:string*" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="key" type="(function(item()) as xs:anyAtomicType*)+" usage="inspection" default="fn:data#1"/>
+            <fos:arg name="order" type="enum('ascending', 'descending')*" usage="absorption" default="'ascending'"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17816,29 +17816,53 @@ return for-each-pair($s, tail($s), function($a, $b) { $a * $b })</eg></fos:expre
  
 
       <fos:summary>
-         <p>Sorts a supplied sequence, based on the value of a one or more supplied sort keys supplied as functions.</p>
+         <p>Sorts a supplied sequence, based on the value of one or more supplied sort keys supplied as functions.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the <code>$sort-keys</code> argument is omitted, or is set to an empty sequence, then
-         the function behaves as if the <code>$sort-keys</code> argument were present with a value
-         computed as follows:</p>
+         <p>The result of the function is a sequence that contains all the items from <code>$input</code>,
+         typically in a different order, the order being defined by one or more <term>sort key definitions</term>.</p>
          
-         <ulist>
-            <item><p>The effective value of <code>$sort-keys</code> is a sequence containing a
-            single map, conforming to the type <code>sort-key-record</code>.</p></item>
-            <item><p>The <code>key</code> field of the map is set to the value of the
-            <code>$key</code> argument if present and non-empty, or to the function <code>fn:data#1</code>
-            otherwise.</p></item>
-            <item><p>The <code>collation</code> field of the map is set to the value of
-            the <code>$collation</code> argument if present and non-empty, or to the default
-            collation (from the static context of the caller) otherwise.</p></item>
-            <item><p>The <code>ascending</code> field of the map is set to <code>true</code>.</p></item>
-         </ulist>
+         <p>A <term>sort key definition</term> has three parts:</p>
          
-         <?type sort-key-record?>
+         <olist>
+            <item><p>A <term>sort key function</term>, which is applied to each item in the input sequence to
+            determine a <term>sort key value</term>.</p></item>
+            <item><p>A <term>collation</term>, which is used when comparing <term>sort key values</term>
+               that are of type <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p></item>
+            <item><p>An <term>order direction</term>, which is <code>ascending</code> or
+            <code>descending</code>.</p></item>
+         </olist>
          
-         <p>Given a <code>$sort-keys</code> value, either supplied explicitly or constructed as
-         described above, the result of the function is obtained as follows:</p>
+         <p>The number of sort key definitions is determined by the number of function items supplied
+            in the <code>$key</code> argument. If the argument is absent or empty, the default is
+            a single sort key definition using the function <code>data#1</code>.</p>
+         
+         <p>The <code>$n</code>'th sort key definition (where <code>$n</code> counts from one (1))
+         is established as follows:</p>
+         
+         <olist>
+            <item><p>The <term>sort key function</term> is <code>$key[$n] otherwise data#1</code>.</p></item>
+            <item><p>The <term>collation</term> is <code>$collation[$n] otherwise $collation[last()]
+               otherwise default-collation()]</code>.
+            That is, it is the collation supplied in the corresponding item of the supplied
+             <code>$collation</code> argument; or in its absence, the last entry in 
+            <code>$collation</code>; or if <code>$collation</code> is absent or empty, the
+            default collation from the static context of the caller.</p></item>
+            <item><p>The <term>order direction</term> is 
+               <code>$order[$n] otherwise $order[last()] otherwise "ascending"</code>.
+            That is, it is <code>"ascending"</code> or <code>"descending"</code> according
+            to the value of the corresponding item in the supplied <code>$order</code>
+            argument; or in its absence, the last entry in <code>$order</code>; or
+            if <code>$order</code> is absent or empty, then <code>"ascending"</code>.</p></item>
+         </olist>
+         
+         <p>When comparing values of types other than <code>xs:string</code> or <code>xs:untypedAtomic</code>,
+         the corresponding collation is ignored, and no error is reported if the supplied value is
+         not a known or valid collation name. If it is necessary to supply such an ignored value
+         (for example, in the case where a non-string sort key is followed by another sort key 
+         that requires a collation) the empty string can be supplied.</p>
+        
+         <p>The result of the function is obtained as follows:</p>
          
          <olist>
             <item>
@@ -17846,47 +17870,45 @@ return for-each-pair($s, tail($s), function($a, $b) { $a * $b })</eg></fos:expre
                   but generally in a different order.</p>
             </item>
             <item>
-               <p>Each map in the value of <code>$sort-keys</code> represents one sort key definition.
+               <p>The sort key definitions are established as described above.
                   The sort key definitions are in major-to-minor order. That is, the position of two
                   items <code>$A</code> and <code>$B</code> in the result sequence is determined first by the 
                   relative magnitude of their
-                  primary sort keys, which are computed by evaluating the <code>key</code> function in the 
+                  primary sort key values, which are computed by evaluating the <term>sort key function</term> in the 
                   first sort key definition.
-                  If those two sort keys are equal, then the position is determined by the relative magnitude
-                  of their secondary sort keys, computed by evaluating the 
-                  <code>key</code> function in the 
-                  second sort key definition, and so on.</p>              
+                  If those two sort key values are equal, then the position is determined by the relative magnitude
+                  of their secondary sort key values, computed by evaluating the 
+                  sort key function in the second sort key definition, and so on.</p>              
             </item>
             <item>
-               <p>When a pair of corresponding sort keys of <code>$A</code> and <code>$B</code> are 
+               <p>When a pair of corresponding sort key values of <code>$A</code> and <code>$B</code> are 
                   found to be not equal,
                   then <code>$A</code> precedes <code>$B</code> in the result sequence 
                   if both the following conditions are true, or if both conditions are false:</p>
                   <olist>
                      <item>
-                        <p>The sort key for <code>$A</code> is less than the sort key for <code>$B</code>,
+                        <p>The sort key value for <code>$A</code> is less than the sort key value for <code>$B</code>,
                            as defined below.</p>
                      </item>
                      <item>
-                        <p>The value of <code>ascending</code> in the corresponding sort key definition
-                        is <code>true</code> or absent.</p>
+                        <p>The <term>order direction</term> in the corresponding sort key definition
+                        is <code>"ascending"</code>.</p>
                      </item>
                   </olist>
             </item>
-            <item><p>If all the sort keys for <code>$A</code> and <code>$B</code> are pairwise equal, then 
+            <item><p>If all the sort key values for <code>$A</code> and <code>$B</code> are pairwise equal, then 
                <code>$A</code> precedes <code>$B</code> in the result sequence if and only if
                <code>$A</code> precedes <code>$B</code> in the input sequence.</p>
+               <note><p>That is, the sort is <emph>stable</emph>.</p></note>
             </item>
             <item>
-               <p>Each sort key for a given item is obtained by applying the <code>key</code>
+               <p>Each sort key value for a given item is obtained by applying the sort key
                function of the corresponding sort key definition to that item. The result
                of this function is in the general case a sequence of atomic values.
-               Two sort keys <code>$a</code> and <code>$b</code> are compared as follows:</p>
+               Two sort key values <code>$a</code> and <code>$b</code> are compared as follows:</p>
                <olist>
-                  <item><p>Let <var>$C</var> be the collation specified in the corresponding
-                     sort key definition; if this is absent or empty, then let <var>$C</var>
-                     be the value of the <code>$collation</code> argument, defaulting in turn
-                     to the default collation from the static context of the caller.</p>
+                  <item><p>Let <var>$C</var> be the collation in the corresponding
+                     sort key definition.</p>
                   </item>
                   <item><p>Let <code>$REL</code> be the result of evaluating <code>op:lexicographic-compare($key($A), $key($B), $C)</code>
                      where <code>op:lexicographic-compare($a, $b, $C)</code> is defined as follows:</p>
@@ -17928,7 +17950,7 @@ else +1</eg>
          for example when the sort key or collation is chosen dynamically, or when the sort key is a sequence of items rather than a single
          item.</p>
          <p>The results are compatible with the results of XSLT sorting (using <code>xsl:sort</code>) in the case where the sort key evaluates to a sequence of
-         length zero or one, given the options <code>stable="yes"</code> and <code>order="ascending"</code>.</p>
+         length zero or one, given the options <code>stable="yes"</code>.</p>
          <p>The results are compatible with the results of XQuery sorting (using the <code>order by</code> clause) in the case where the sort key evaluates to a sequence of
             length zero or one, given the options <code>stable</code>, <code>ascending</code>, and <code>empty least</code>.</p>
          <p>The function has been enhanced in 4.0 to allow multiple sort keys to be defined, each potentially with
@@ -17937,12 +17959,19 @@ else +1</eg>
          whether the empty sequence is sorted before or after all other values, can be achieved by adding an
          extra sort key definition that evaluates whether or not the actual sort key is empty (when sorting
          boolean values, <code>false</code> precedes <code>true</code>).</p>
+         <p>Supplying too many items in the <code>$collation</code> and/or <code>$order</code> arguments
+         is not an error; the excess values are ignored except for type-checking against the function
+         signature.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression>sort((1, 4, 6, 5, 3))</fos:expression>
                <fos:result>(1, 3, 4, 5, 6)</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>sort((1, 4, 4e0, 6, 5, 3), order:="descending")</fos:expression>
+               <fos:result>(6, 5, 4, 4e0, 3, 1)</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>sort((1, -2, 5, 10, -10, 10, 8), (), abs#1)</fos:expression>
@@ -17965,9 +17994,10 @@ return sort($in, $SWEDISH)</eg>
                and then by decreasing salary:
             </p>
             <eg>let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
-return sort($employees, sort-keys := 
-    (map{"key": fn{name/last}, "collation": $SWEDISH},
-     map{"key": fn{xs:decimal(salary)}, "ascending":false()}))</eg>
+               return sort($employees, 
+                           $SWEDISH, 
+                           (fn{name/last}, fn{xs:decimal(salary)}), 
+                           ("ascending", "descending"))</eg>
          </fos:example>
       </fos:examples>
       <fos:history>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17843,7 +17843,7 @@ return for-each-pair($s, tail($s), function($a, $b) { $a * $b })</eg></fos:expre
          <olist>
             <item><p>The <term>sort key function</term> is <code>$key[$n] otherwise data#1</code>.</p></item>
             <item><p>The <term>collation</term> is <code>$collation[$n] otherwise $collation[last()]
-               otherwise default-collation()]</code>.
+               otherwise default-collation()</code>.
             That is, it is the collation supplied in the corresponding item of the supplied
              <code>$collation</code> argument; or in its absence, the last entry in 
             <code>$collation</code>; or if <code>$collation</code> is absent or empty, the

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7461,7 +7461,7 @@ The form of the constructor function for an atomic type
                 <example role="signature">
                     <proto name="TYPE" prefix="eg" return-type="eg:TYPE" role="example"
                         returnEmptyOk="yes" isSpecial="yes">
-                        <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                        <arg name="value" type="xs:anyAtomicType?" default="."/>
                     </proto>
                 </example>
                 <p>If <code>$arg</code> is the empty sequence, the empty sequence is returned. For
@@ -7470,7 +7470,7 @@ The form of the constructor function for an atomic type
                 <example role="signature">
                     <proto name="unsignedInt" return-type="xs:unsignedInt" isSchema="yes" prefix="xs"
                         returnEmptyOk="yes" role="example">
-                        <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                        <arg name="arg" type="xs:anyAtomicType?" />
                     </proto>
                 </example>
                 <p>Calling the constructor function <code>xs:unsignedInt(12)</code> returns
@@ -7496,30 +7496,32 @@ The form of the constructor function for an atomic type
  <p>Special rules apply to constructor functions for <code>xs:QName</code> and types derived from <code>xs:QName</code> and <code>xs:NOTATION</code>. See 
 <specref ref="constructor-qname-notation"/>.
 </p>
+               <p diff="add" at="Issue658">The argument is optional, and defaults to the context item (which
+               will be atomized if necessary).</p>
                <p>The following constructor functions for the built-in atomic types are supported:</p>
                 <ulist> 
                     <item>
                         <proto name="string" return-type="xs:string" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="boolean" return-type="xs:boolean" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="decimal" return-type="xs:decimal" returnEmptyOk="yes"
                            isSchema="yes" prefix="xs" role="example" >
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="float" return-type="xs:float" returnEmptyOk="yes"
                            isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                         <p>Implementations <rfc2119>should</rfc2119> return negative zero for <code>xs:float("-0.0E0")</code>.  
                            But because <bibref ref="xmlschema-2"/> does not distinguish between the values positive zero and negative zero,
@@ -7529,7 +7531,7 @@ The form of the constructor function for an atomic type
                     <item>
                         <proto name="double" return-type="xs:double" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                        <p>Implementations <rfc2119>should</rfc2119> return negative zero for <code>xs:double("-0.0E0")</code>.  
                           But because <bibref ref="xmlschema-2"/> does not distinguish between the values positive zero and negative zero,
@@ -7538,75 +7540,75 @@ The form of the constructor function for an atomic type
                     <item>
                         <proto name="duration" return-type="xs:duration" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="dateTime" return-type="xs:dateTime" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="time" return-type="xs:time" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="date" return-type="xs:date" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="gYearMonth" return-type="xs:gYearMonth" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="gYear" return-type="xs:gYear" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="gMonthDay" return-type="xs:gMonthDay" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="gDay" return-type="xs:gDay" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="gMonth" return-type="xs:gMonth" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="hexBinary" return-type="xs:hexBinary" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="base64Binary" return-type="xs:base64Binary" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="anyURI" return-type="xs:anyURI" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="QName" return-type="xs:QName" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                         <p>
                             See <specref ref='constructor-qname-notation'/> for special rules.</p>
@@ -7616,129 +7618,129 @@ The form of the constructor function for an atomic type
                     <item>
                         <proto name="normalizedString" return-type="xs:normalizedString"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="token" return-type="xs:token" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="language" return-type="xs:language" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="NMTOKEN" return-type="xs:NMTOKEN" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
 					<item>
                         <proto name="Name" return-type="xs:Name" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="NCName" return-type="xs:NCName" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="ID" return-type="xs:ID" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="IDREF" return-type="xs:IDREF" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="ENTITY" return-type="xs:ENTITY" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
  <p>See <specref ref='casting-to-ENTITY'/> for rules related to constructing values of type <code>xs:ENTITY</code> and types derived from it.</p>
                     </item>
 					<item>
                         <proto name="integer" return-type="xs:integer" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="nonPositiveInteger" return-type="xs:nonPositiveInteger"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="negativeInteger" return-type="xs:negativeInteger"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="long" return-type="xs:long" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="int" return-type="xs:int" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="short" return-type="xs:short" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="byte" return-type="xs:byte" returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="nonNegativeInteger" return-type="xs:nonNegativeInteger"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="unsignedLong" return-type="xs:unsignedLong" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="unsignedInt" return-type="xs:unsignedInt" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="unsignedShort" return-type="xs:unsignedShort"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="unsignedByte" return-type="xs:unsignedByte" returnEmptyOk="yes"
                             isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="positiveInteger" return-type="xs:positiveInteger"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                 </ulist>
@@ -7746,19 +7748,19 @@ The form of the constructor function for an atomic type
                     <item>
                         <proto name="yearMonthDuration" return-type="xs:yearMonthDuration"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
                         <proto name="dayTimeDuration" return-type="xs:dayTimeDuration"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                     <item>
-                        <proto name="untypedAtomic" return-type="xs:untypedAtomic"
+                        <proto name="untypedAtomic" return-type="xs:untypedAtomic?"
                             returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                            <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                            <arg name="value" default="." type="xs:anyAtomicType?"/>
                         </proto>
                     </item>
                 </ulist>
@@ -7766,7 +7768,7 @@ The form of the constructor function for an atomic type
                   <item>
                      <proto name="dateTimeStamp" return-type="xs:dateTimeStamp"
                         returnEmptyOk="yes" isSchema="yes" prefix="xs" role="example">
-                        <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                        <arg name="value" default="." type="xs:anyAtomicType?"/>
                      </proto>
                      <p><emph>Available only if the implementation supports XSD 1.1.</emph></p>
                   </item>
@@ -7838,19 +7840,19 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                  <item>
                     <proto name="NMTOKENS" return-type="xs:NMTOKEN*" 
                        isSchema="yes" prefix="xs" role="example">
-                       <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                       <arg name="value" default="." type="xs:anyAtomicType?" />
                     </proto>
                  </item>
                  <item>
                     <proto name="ENTITIES" return-type="xs:ENTITY*" 
                        isSchema="yes" prefix="xs" role="example">
-                       <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                       <arg name="value" default="." type="xs:anyAtomicType?"/>
                     </proto>
                  </item>
                  <item>
                     <proto name="IDREFS" return-type="xs:IDREF*" 
                        isSchema="yes" prefix="xs" role="example">
-                       <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                       <arg name="value" default="." type="xs:anyAtomicType?"/>
                     </proto>
                  </item>
               </ulist>
@@ -7882,7 +7884,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                  <item>
                     <proto name="numeric" return-type="xs:numeric?" 
                        isSchema="yes" prefix="xs" role="example">
-                       <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                       <arg  name="value" default="." type="xs:anyAtomicType?"/>
                     </proto>
                  </item>
               </ulist>
@@ -7922,7 +7924,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                  <item>
                     <proto name="error" return-type="xs:error?" 
                        isSchema="yes" prefix="xs" role="example">
-                       <arg name="arg" type="xs:anyAtomicType" emptyOk="yes"/>
+                       <arg name="value" default="." type="xs:anyAtomicType?"/>
                     </proto>
                  </item>
               </ulist>
@@ -11445,6 +11447,16 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
 	              arguments that can be omitted can now also be set to an empty sequence;
 	           the effect of supplying an empty sequence is equivalent to the effect of not supplying the argument.</p></item>
 	           
+	        </olist>
+	     </div2>
+	     <div2 id="changes-to-casts-and-constructors">
+	        <head>Changes to Casts and Constructor Functions</head>
+	        <olist>
+	           <item><p>The keyword for the argument has changed from <code>arg</code> to <code>value</code>.</p></item>
+	           <item><p>The argument is now optional, and defaults to the context item (which is atomized if necessary).
+	           This change aligns constructor functions such as <code>xs:string</code>, <code>xs:boolean</code>,
+	              and <code>xs:numeric</code> with <code>fn:string</code>, <code>fn:boolean</code>,
+	              and <code>fn:number</code>.</p></item>
 	        </olist>
 	     </div2>
 	     <div2 id="editorial-changes">

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -225,7 +225,7 @@
                                         else if ($isOp)
                                              then 'op'
                                              else 'fn'}">
-				<xsl:copy-of select="@name, @return-type, @return-type-ref, @diff, @at"/>
+				<xsl:copy-of select="@name, @return-type, @return-type-ref, @return-type-ref-occurs, @diff, @at"/>
 				<xsl:apply-templates/>
 			</proto>
 		</example>
@@ -233,7 +233,7 @@
 
 	<xsl:template match="fos:arg">
 		<arg>
-			<xsl:copy-of select="@name, @type, @type-ref, @diff, @at, @default"/>
+			<xsl:copy-of select="@name, @type, @type-ref, @type-ref-occurs, @diff, @at, @default"/>
 		</arg>
 	</xsl:template>
 

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -357,8 +357,9 @@
                   <code class="as">as&#160;</code>
                   <code>
                     <a href="#{@type-ref}">
-                      <xsl:value-of select="@type-ref"/>
+                      <xsl:value-of select="@type-ref"/>                
                     </a>
+                    <xsl:value-of select="@type-ref-occurs"/>    
                   </code>
                   <xsl:if test="not (@default) and not($last)">,</xsl:if>
                 </xsl:if>
@@ -393,9 +394,10 @@
                     <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
                   </xsl:when>
                   <xsl:when test="@return-type-ref">
-                    <a href="#{@return-type-ref}">
+                    <a href="#{replace(@return-type-ref, '[*+?]$', '')}">
                       <xsl:value-of select="@return-type-ref"/>
                     </a>
+                    <xsl:value-of select="@return-type-ref-occurs"/>
                     <xsl:if test="@returnEmptyOk='yes'">?</xsl:if>
                   </xsl:when>
                   <!--<xsl:otherwise>


### PR DESCRIPTION
Changes argument name of constructor functions to `value`, makes the argument optional, revises the way the `proto` markup is used to indicate emptyOk arguments.

Fix #658