### PR TITLE
XPath minor edits, 4.16 through end

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1119,7 +1119,7 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
       [Geneva]: International Organization for Standardization.
       (See <loc href="http://www.iso.org">http://www.iso.org</loc> for the latest version.)</bibl>
 
-<bibl id="Unicode" key="Unicode">The Unicode Consortium. <emph>The Unicode Standard</emph>
+<bibl id="Unicode" key="Unicode">The Unicode Consortium. <emph>The Unicode Standard.</emph>
       Reading, Mass.: Addison-Wesley, 2003, as updated from time to time by the publication of new versions.
       See <loc href="http://www.unicode.org/standard/versions/">http://www.unicode.org/standard/versions/</loc>
       for the latest version and additional information on versions of the standard and of the Unicode Character Database.
@@ -1399,7 +1399,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       provided this does not cause ambiguity across multiple function definitions with the same name.
       Optional parameters are given a default value, which can be any expression, including one that
       depends on the context of the caller (so an argument can default to the context item).</p></item>
-      <item><p>In a static function call, arguments can be specified either positionally or using keywords,
+      <item><p>In a static function call, arguments can be specified either positionally or by keyword,
       or a combination of both.</p></item>
       <item><p>An <code>otherwise</code> operator is introduced: <code>A otherwise B</code> returns the
         value of <code>A</code>, unless it is an empty sequence, in which case it returns the value of <code>B</code>.</p></item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -9532,7 +9532,7 @@ return filter($days,$m)
                </olist>
 
                <note>
-                  <p>The semantics of the path operator can also be defined using the simple map operator as follows (forming the union with an empty sequence <code>($R | ())</code> has the effect of eliminating duplicates and sorting nodes into document order):</p>
+                  <p>The semantics of the path operator can also be defined using the simple map operator (<code>!</code>) as follows (forming the union with an empty sequence <code>($R | ())</code> has the effect of eliminating duplicates and sorting nodes into document order):</p>
                   <eg><![CDATA[E1/E2 ::= let $R := E1!E2
   return
     if (every $r in $R satisfies $r instance of node())
@@ -9540,6 +9540,7 @@ return filter($days,$m)
     else if (every $r in $R satisfies not($r instance of node()))
     then $R
     else error()]]></eg>
+                  <p>For a table comparing the step operator to the map operator, see <specref ref="id-map-operator"/>.</p>
                </note>
             </div4>
 
@@ -19337,7 +19338,7 @@ raised <errorref
                <p>Given a  <nt def="UnaryExpr">UnaryExpr</nt>
                   <code>U</code>, an <nt def="ArrowStaticFunction">ArrowStaticFunction</nt>
                <code>F</code>, and an <nt def="ArgumentList">ArgumentList</nt>
-               <code>(A, B, C...)</code>, the expression <code>U -!&gt; F(A, B, C...)</code> is equivalent to the
+               <code>(A, B, C...)</code>, the expression <code>U =!&gt; F(A, B, C...)</code> is equivalent to the
                expression <code>(for $u in U return F($u, A, B, C...))</code>.</p>
                
             </item>
@@ -19386,10 +19387,18 @@ raised <errorref
             <p diff="add" at="A">The difference between the two operators is seen when the left-hand
             operand evaluates to a sequence:</p>
             
+            <eg role="parse-test"><![CDATA[(1, 2, 3) => avg()]]></eg>
+         
+            <p diff="add" at="2023-07-24">returns a value of only one item, <code>2</code>, the average of all three items, whereas </p>
+            
+            <eg role="parse-test"><![CDATA[(1, 2, 3) =!> avg()]]></eg>
+         
+            <p diff="add" at="2023-07-24">returns the original sequence of three items, <code>(1, 2, 3)</code>, each item being the average of itself. The following example:</p>
+         
             <eg role="parse-test"
                ><![CDATA["The cat sat on the mat" => tokenize() =!> concat(".") =!> upper-case() => string-join(" ")]]></eg>
             
-            <p diff="add" at="A">which returns <code>"THE. CAT. SAT. ON. THE. MAT."</code>. The first arrow
+            <p diff="add" at="A">returns <code>"THE. CAT. SAT. ON. THE. MAT."</code>. The first arrow
             could be written either as <code>=></code> or <code>=!></code> because the operand is a singleton; the next two
             arrows have to be <code>=!></code> because the function is applied to each item in the tokenized
             sequence individually; the final arrow must be <code>=></code> because the <code>string-join</code>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -18416,7 +18416,7 @@ one <code>employee</code> element satisfies the given comparison expression:</p>
             </item>
             
             <item>
-               <p>This expression is <code>true</code> if at every
+               <p>This expression is <code>true</code> if every
                   <code>employee</code> element has at least one <code>salary</code> child with the attribute <code>current="true"</code>:</p>
                <eg role="parse-test"><![CDATA[every $emp in /emps/employee satisfies
      some $sal in $emp/salary satisfies $sal/@current='true']]></eg>
@@ -19100,7 +19100,6 @@ The result of a cast expression is one of the following:
 
                <prodrecap id="CastableExpr" ref="CastableExpr"/>
                <prodrecap ref="SingleType"/>
-               <prodrecap ref="LocalUnionType"/>
                <prodrecap ref="SimpleTypeName"/>
                <prodrecap ref="TypeName"/>
                <prodrecap ref="LocalUnionType"/>
@@ -19398,13 +19397,13 @@ raised <errorref
                   <p>
                      <code role="parse-test">$emp ! (@first, @middle, @last)</code>
                   </p>
-                  <p>Returns the values of the attributes <code>first</code>, <code>middle</code>, and <code>last</code> for element <code>$emp</code>, in the order given. (The <code>/</code> operator here returns the attributes in an unpredictable order.)</p>
+                  <p>Returns the values of the attributes <code>first</code>, <code>middle</code>, and <code>last</code> for each element in <code>$emp</code>, in the order given. (The <code>/</code> operator, if used here, would return the attributes in an unpredictable order.)</p>
                </item>
                <item>
                   <p>
                      <code role="parse-test">$docs ! ( //employee)</code>
                   </p>
-                  <p>Returns all the employees within all the documents identified by the variable docs, in document order within each document, but retaining the order of documents.</p>
+                  <p>Returns all the <code>employee</code> elements within all the documents identified by the variable <code>$docs</code>, in document order within each document, but retaining the order of documents.</p>
                </item>
                <item>
                   <p>
@@ -19429,7 +19428,7 @@ raised <errorref
                   <p>
                      <code role="parse-test">string-join(ancestor::*!name(), '/')</code>
                   </p>
-                  <p>Returns a path containing the names of the ancestors of an element, separated by <code>/</code> characters.</p>
+                  <p>Returns the names of ancestor elements, joined by <code>/</code> characters, i.e., the path to the parent of the context.</p>
                </item>
             </ulist>
          </example>
@@ -19503,8 +19502,8 @@ raised <errorref
             
          
             
-            <p diff="add" at="A">The sequence arrow operator thus applies the supplied function to the result
-               of the left-hand operand as a whole, while the mapping arrow operator applies the function to
+            <p diff="add" at="A">The sequence arrow operator thus applies the supplied function to 
+               the left-hand operand as a whole, while the mapping arrow operator applies the function to
                each item in the value of the left-hand operand individually. In the case where the result
                of the left-hand operand is a single item, the two operators have the same effect.</p>
          


### PR DESCRIPTION
Various small edits. I added two simple examples to help readers quickly understand the difference between `=>` and `=!>` before going to more complex examples. 