### PR TITLE
XFO minor edits, chap. 1

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -374,7 +374,7 @@ for transition to Proposed Recommendation. </p>'>
             <termdef id="dt-permitted-character" term="permitted character">A <term>permitted character</term>
             is one within the repertoire accepted by the implementation.</termdef></p>
 
-            <p>In this document, text labeled as an example or as a Note is
+            <p>In this document, text labeled as an example or as a note is
             provided for explanatory purposes and is not normative.</p>
          </div2>
          <div2 id="namespace-prefixes">
@@ -700,7 +700,7 @@ for transition to Proposed Recommendation. </p>'>
                after conversion is not one of the permitted values for the option in question: the error codes
                for this error are defined in the specification of each function.</p>
                <note><p>It is the responsibility of each function implementation to invoke this conversion; it
-               does not happen automatically as a consequence of the function calling rules.</p></note></item>
+               does not happen automatically as a consequence of the function-calling rules.</p></note></item>
                <item><p>In cases where an option is list-valued, by convention the value may be supplied
                either as a sequence or as an array. Accepting a sequence is convenient if the
                value is generated programmatically using an XPath expression; while accepting an array 
@@ -723,11 +723,7 @@ This type system comprises two distinct subsystems that both include
 the primitive atomic types. 
 In the diagrams, connecting lines represent relationships between derived types
 and the types from which they are derived;
-the arrowheads point toward the type from which they are derived. 
-The dashed line represents relationships not present in this diagram,
-but that appear in one of the other diagrams. 
-Dotted lines represent additional relationships that follow an evident pattern.
-The information that appears in each diagram is recapitulated in tabular form.
+the former are always below and to the right of the latter.
 </p>
 
 <p>The <code>xs:IDREFS</code>, <code>xs:NMTOKENS</code>,
@@ -741,7 +737,7 @@ rather than types derived by extension or restriction.</p>
       <head>Item Types</head>
    
 
-<p>The first diagram and its corresponding table illustrate
+<p>The first diagram illustrates
 the relationship of various item types.</p>
       
       <p>Item types are used to characterize the various types of item that can appear
@@ -769,8 +765,8 @@ full model.</p>
    <head>Schema Type Hierarchy</head>
   
 
-<p>The next diagram and table illustrate the schema type subsystem, in which
-all types are derived from the distinguished type <code>xs:anyType</code>. </p>
+<p>The next diagram illustrate the schema type subsystem, in which
+all types are derived from <code>xs:anyType</code>. </p>
       
       <p>Schema types include built-in types defined in the XML Schema specification, and user-defined
       types defined using mechanisms described in the XML Schema specification. Schema types define the
@@ -784,7 +780,7 @@ all types are derived from the distinguished type <code>xs:anyType</code>. </p>
       <head>Atomic Type Hierarchy</head>
   
 
-<p id="hier_anyAtomicType">The final diagram and table show all of the atomic types, including the primitive simple types and the
+<p id="hier_anyAtomicType">The final diagram shows all of the atomic types, including the primitive simple types and the
 built-in types derived from the primitive simple types. 
 This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.</p>
       
@@ -835,14 +831,14 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p diff="chg" at="2023-01-17">Unless explicitly stated, the functions in this document do not ensure that any 
                   returned <code>xs:string</code> values are normalized in the sense of <bibref ref="charmod"/>.</p>
-               <notes>
+               <note>
                   <p>In functions that involve character counting such
                      as <code>fn:substring</code>, <code>fn:string-length</code> and
                      <code>fn:translate</code>, what is counted is the number of XML <termref def="character">characters</termref>
                      in the string (or equivalently, the number of Unicode codepoints). Some
                      implementations may represent a codepoint above xFFFF using two 16-bit
                      values known as a surrogate pair. A surrogate pair counts as one character, not two.</p>
-               </notes>
+               </note>
             </div3>
             <div3 id="namespace-terminology">
                <head>Namespaces and URIs</head>
@@ -865,7 +861,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   as defined in <bibref ref="xmlschema-2"/>.</termdef></p>
                <note>
                   <p>
-                     Note that this means, in practice, that where this 
+                     This means, in practice, that where this 
                      specification requires a “URI Reference”, an IRI as defined in <bibref ref="rfc3987"/> will be 
                      accepted, provided that other relevant specifications also permit an IRI. The term URI has been 
                      retained in preference to IRI to avoid introducing new names for concepts such as “Base URI” that 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -275,12 +275,12 @@ for transition to Proposed Recommendation. </p>'>
          
          <div2 id="operators" diff="add" at="2022-12-20">
             <head>Operators</head>
-            <p>Despite the title of this document, it does not attempt to define the semantics of all the operators available
+            <p>Despite its title, this document does not attempt to define the semantics of all the operators available
                in the <bibref ref="xpath-40"/> language; indeed, in the interests of avoiding duplication, the majority of
                operators (including all higher-order operators such as <code>x/y</code>, <code>x!y</code>, and <code>x[y]</code>,
                as well simple operators such as <code>x,y</code>, <code>x and y</code>, <code>x or y</code>,            
             <code>x&lt;&lt;y</code>, <code>x>>y</code>, <code>x is y</code>, <code>x||y</code>, <code>x|y</code>,
-            <code>x union x</code>, <code>x except y</code>, <code>x intersect y</code>, <code>x to y</code>
+            <code>x union y</code>, <code>x except y</code>, <code>x intersect y</code>, <code>x to y</code>
             and <code>x otherwise y</code>) are now defined entirely within <bibref ref="xpath-40"/>.</p>
             
             <p>The remaining operators that are described in this publication are those where the semantics of the operator


### PR DESCRIPTION
Most substantive change is the trimming of prose held over from before the revision of the diagrams.