### PR TITLE
HTML namespace changes

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6366,6 +6366,21 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <item>
                            <p>The <emph>local name</emph> is the value of the
                               <code>Element.localName</code> property;</p>
+                           <note>
+                              <p>If the local name contains a character that is not a valid XML
+                                 <code>NameStartChar</code> or <code>NameChar</code>, then an
+                                 <termref def="implementation-defined">implementation-defined</termref>
+                                 replacement character is used. The result must be a valid
+                                 <code>NCName</code>.</p>
+                              <p>For example, in <bibref ref="dom-ls"/> section 13.2.9
+                                 <emph>Coercing an HTML DOM into an infoset</emph>, it uses a
+                                 <code>Unnnnnn</code> escape sequence. That would map <code>:</code>
+                                 to <code>U00003A</code>.</p>
+                              <p>This local name escaping only applies for the HTML parsing algorithm.
+                                 If the XHTML parsing algorithm is used, the <code>localName</code> and
+                                 <code>prefix</code> will be correctly set for QName-based
+                                 node names.</p>
+                           </note>
                         </item>
                         <item>
                            <p>The <emph>namespace prefix</emph> is the value of the
@@ -6385,6 +6400,21 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <item>
                            <p>The <emph>local name</emph> is the value of the
                               <code>Attr.localName</code> property;</p>
+                           <note>
+                              <p>If the local name contains a character that is not a valid XML
+                                 <code>NameStartChar</code> or <code>NameChar</code>, then an
+                                 <termref def="implementation-defined">implementation-defined</termref>
+                                 replacement character is used. The result must be a valid
+                                 <code>NCName</code>.</p>
+                              <p>For example, in <bibref ref="dom-ls"/> section 13.2.9
+                                 <emph>Coercing an HTML DOM into an infoset</emph>, it uses a
+                                 <code>Unnnnnn</code> escape sequence. That would map <code>:</code>
+                                 to <code>U00003A</code>.</p>
+                              <p>This local name escaping only applies for the HTML parsing algorithm.
+                                 If the XHTML parsing algorithm is used, the <code>localName</code> and
+                                 <code>prefix</code> will be correctly set for QName-based
+                                 node names.</p>
+                           </note>
                         </item>
                         <item>
                            <p>The <emph>namespace prefix</emph> is the value of the

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6030,6 +6030,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         namespace declarations are not supported; they are filtered out by this mapping. The
                         XHTML parsing algorithm does not generate <code>Attr</code> nodes for namespace
                         declarations.</p>
+                     <p>If an implementation allows these nodes to be passed in via an API or similar mechanism,
+                        their behaviour is <termref def="implementation-defined">implementation-defined</termref>.</p>
                   </note>
                </item>
                <item>
@@ -6071,6 +6073,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <specref ref="html-parser-options"/> map.</p>
                   </item>
                </olist>
+               <p>If an implementation allows these nodes to be passed in via an API or similar mechanism,
+                  their behaviour is <termref def="implementation-defined">implementation-defined</termref>.</p>
             </note>
 
             <div3 id="html-attributes-accessor">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6025,26 +6025,26 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <item>
                   <p>The HTML DOM <code>ProcessingInstruction</code> interface maps to
                      <xspecref spec="DM40" ref="ProcessingInstructionNode"/>.</p>
+
+                  <note>
+                     <p>The HTML parsing algorithm does not support processing instructions. If encountered
+                        they are parsed as comment nodes. The HTML DOM <code>ProcessingInstruction</code>
+                        interface is for when the XHTML parsing algorithm is used, where the document is a
+                        valid XML document.</p>
+                  </note>
                </item>
                <item>
                   <p>The HTML DOM <code>Comment</code> interface maps to <xspecref spec="DM40" ref="CommentNode"/>.</p>
                </item>
                <item>
                   <p>The HTML DOM <code>Text</code> interface maps to <xspecref spec="DM40" ref="TextNode"/>.</p>
+
+                  <note>
+                     <p>The HTML DOM <code>CDATASection</code> interface is an instance of HTML DOM
+                        <code>Text</code>, so CDATA sections also map to <xspecref spec="DM40" ref="TextNode"/>.</p>
+                  </note>
                </item>
             </olist>
-
-            <note>
-               <p>The HTML parsing algorithm does not support processing instructions. If encountered
-                  they are parsed as comment nodes. The HTML DOM <code>ProcessingInstruction</code>
-                  interface is for when the XHTML parsing algorithm is used, where the document is a
-                  valid XML document.</p>
-            </note>
-
-            <note>
-               <p>The HTML DOM <code>CDATASection</code> interface is an instance of HTML DOM
-                  <code>Text</code>, so CDATA sections also map to <xspecref spec="DM40" ref="TextNode"/>.</p>
-            </note>
 
             <note>
                <p>The HTML DOM <code>DocumentFragment</code> interface is not supported as an XML node.

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6009,6 +6009,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   HTML DOM nodes.</p>
             </note>
 
+            <p>The <bibref ref="dom-ls"/> defines two parsing algorithms. The HTML parsing algorithm constructs
+               a HTML DOM <code>HTMLDocument</code> document object for the HTML document. The XHTML parsing
+               algorithm constructs a HTML DOM <code>XMLDocument</code> object for the HTML document, following
+               XML parsing rules. This mapping supports both of these document types.</p>
+
             <p>The <bibref ref="dom-ls"/> specification defines HTML DOM nodes that are mapped to XDM
                nodes as follows:</p>
             <olist>
@@ -6019,8 +6024,13 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <p>The HTML DOM <code>Element</code> interface maps to <xspecref spec="DM40" ref="ElementNode"/>.</p>
                </item>
                <item>
-                  <p>The HTML DOM <code>Attr</code> interface maps to <xspecref spec="DM40" ref="AttributeNode"/> or
-                     <xspecref spec="DM40" ref="NamespaceNode"/>.</p>
+                  <p>The HTML DOM <code>Attr</code> interface maps to <xspecref spec="DM40" ref="AttributeNode"/>.</p>
+                  <note>
+                     <p>HTML DOM <code>Attr</code> instances in an HTML DOM <code>HTMLDocument</code> that are
+                        namespace declarations are not supported; they are filtered out by this mapping. The
+                        XHTML parsing algorithm does not generate <code>Attr</code> nodes for namespace
+                        declarations.</p>
+                  </note>
                </item>
                <item>
                   <p>The HTML DOM <code>ProcessingInstruction</code> interface maps to
@@ -6121,7 +6131,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <note>
                   <p>When the resulting document is an HTML DOM <code>HTMLDocument</code>, the
                      <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
-                     <code>Attr</code> nodes are both set to the qualified name.</p>
+                     <code>Attr</code> nodes are both set to the qualified name. This includes
+                     namespace declarations which are filtered out by the logic in this section.</p>
                </note>
 
                <note>
@@ -6298,126 +6309,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
 
 
                <p>The result of the <xspecref spec="DM40" ref="dm-namespace-nodes"/>
-                  <code>dm:namespace-nodes($node)</code> for an HTML DOM <code>Node</code> is as follows:</p>
-               <olist>
-                  <item>
-                     <p>If the node is an instance of HTML DOM <code>Element</code> then the result
-                        is determined as described below;</p>
-                  </item>
-                  <item>
-                     <p>Otherwise, the result is an empty sequence.</p>
-                  </item>
-               </olist>
-
-               <p>To compute the namespace nodes for an HTML DOM <code>Element</code>, the following
-                  algorithm is used:</p>
-               <olist>
-                  <item>
-                     <p>Let <code>$namespaces</code> be the list of currently computed namespace nodes;</p>
-                  </item>
-                  <item>
-                     <p>For each <code>$namespace</code> in the <specref ref="html-namespace-attributes"/>
-                        of the current element <code>$node</code>:</p>
-                     <olist>
-                        <item>
-                           <p>If <code>$namespace</code> is in <code>$namespaces</code>, do not add the
-                              namespace to the list;</p>
-                        </item>
-                        <item>
-                           <p>Otherwise, add <code>$namespace</code> to the <code>$namespaces</code> list;</p>
-                        </item>
-                     </olist>
-                  </item>
-                  <item>
-                     <p>Let <code>$parent</code> be the <specref ref="html-parent-accessor"/> of
-                        <code>$node</code>;</p>
-                  </item>
-                  <item>
-                     <p>If <code>$parent</code> is an empty sequence, the result is <code>$namespaces</code>
-                        and this algorithm stops.</p>
-                  </item>
-                  <item>
-                     <p>Otherwise, repeat from step 2 using <code>$parent</code> as <code>$node</code>.</p>
-                  </item>
-               </olist>
-
-               <note>
-                  <p>The HTML DOM <code>Node</code> API provides several functions for working with
-                     namespaces (<code>lookupPrefix</code>, <code>lookupNamespaceURI</code>, and
-                     <code>isDefaultNamespace</code>). These only work when an HTML implementation
-                     returns an HTML DOM <code>XMLDocument</code> node, such as when
-                     the <code>"application/xhtml+xml"</code> mimetype is passed to the
-                     <code>DOMParser.parseFromString</code> Web API.</p>
-                  <p>An implementation may use those APIs in the cases where it is known that the
-                     parsed document is an <code>XMLDocument</code>.</p>
-               </note>
-
-               <div4 id="html-namespace-attributes">
-                  <head>dm:namespace-attributes</head>
-
-
-                  <p>The result of <code>dm:namespace-attributes($element)</code> for an HTML DOM
-                     <code>Node</code> is as follows:</p>
-                  <olist>
-                     <item>
-                        <p>If the node is an instance of HTML DOM <code>Element</code> then the result the
-                           value of the <code>Node.attributes</code> property mapped to a sequence;</p>
-                     </item>
-                     <item>
-                        <p>Otherwise, the result is an empty sequence.</p>
-                     </item>
-                  </olist>
-
-                  <p>The resulting HTML DOM <code>NamedNodeMap</code> is mapped to a sequence as follows:</p>
-                  <olist>
-                     <item>
-                        <p><code>NamedNodeMap.length</code> is the length of the sequence, where a length
-                           of <code>0</code> results in an empty sequence;</p>
-                     </item>
-                     <item>
-                        <p><code>NamedNodeMap.item(n)</code> is the n<sup>th</sup> element of the sequence.</p>
-                     </item>
-                  </olist>
-
-                  <p>That sequence is then filtered as follows:</p>
-                  <olist>
-                     <item>
-                        <p>If the <code>Attr.namespaceURI</code> property is
-                           <code>"http://www.w3.org/2000/xmlns/"</code>, the attribute is included in
-                           this sequence using the XDM mapping rules described in this section;</p>
-                     </item>
-                     <item>
-                        <p>If the <code>Attr.localName</code> property is <code>"xmlns"</code>, the attribute
-                           is included in this sequence using the XDM mapping rules described in this section;</p>
-                     </item>
-                     <item>
-                        <p>If the <code>Attr.localName</code> property starts with <code>"xmlns:"</code>,
-                           the attribute is included in this sequence using the XDM mapping rules
-                           described in this section;</p>
-                     </item>
-                     <item>
-                        <p>Otherwise, the attribute is not included in this sequence.</p>
-                     </item>
-                  </olist>
-
-                  <note>
-                     <p>The HTML DOM <code>Element.attributes</code> property includes namespace and non-namespace
-                        attributes in the list when the HTML or XML parser is used. As such, the non-namespace
-                        attributes have to be filtered from the resulting XDM attribute sequence.</p>
-                  </note>
-
-                  <note>
-                     <p>When the resulting document is an HTML DOM <code>HTMLDocument</code>, the
-                        <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
-                        <code>Attr</code> nodes are both set to the qualified name.</p>
-                  </note>
-
-                  <note>
-                     <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
-                        <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
-                        ASCII upper alpha characters are appended to the attribute’s name in lowercase.</p>
-                  </note>
-               </div4>
+                  <code>dm:namespace-nodes($node)</code> for an HTML DOM <code>Node</code> is an
+                  empty sequence.</p>
             </div3>
             <div3 id="html-nilled-accessor">
                <head>nilled Accessor</head>
@@ -6443,25 +6336,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   </item>
                   <item>
                      <p>If the node is an instance of HTML DOM <code>Attr</code> then the result is
-                        determined as follows:</p>
-                     <olist>
-                        <item>
-                           <p>If the <code>Attr.namespaceURI</code> property is
-                              <code>"http://www.w3.org/2000/xmlns/"</code>, then the result is
-                              <code>"namespace"</code>;</p>
-                        </item>
-                        <item>
-                           <p>If the <code>Attr.localName</code> property is <code>"xmlns"</code>,
-                              then the result is <code>"namespace"</code>;</p>
-                        </item>
-                        <item>
-                           <p>If the <code>Attr.localName</code> property starts with <code>"xmlns:"</code>,
-                              then the result is <code>"namespace"</code>;</p>
-                        </item>
-                        <item>
-                           <p>Otherwise, the result is <code>"attribute"</code>.</p>
-                        </item>
-                     </olist>
+                        <code>"attribute"</code>.</p>
                   </item>
                   <item>
                      <p>If the node is an instance of HTML DOM <code>ProcessingInstruction</code> then
@@ -6476,18 +6351,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <code>"text"</code>.</p>
                   </item>
                </olist>
-
-               <note>
-                  <p>When the resulting document is an HTML DOM <code>HTMLDocument</code>, the
-                     <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
-                     <code>Attr</code> nodes are both set to the qualified name.</p>
-               </note>
-
-               <note>
-                  <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
-                     <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
-                     ASCII upper alpha characters are appended to the attribute’s name in lowercase.</p>
-               </note>
             </div3>
             <div3 id="html-node-name-accessor">
                <head>node-name Accessor</head>
@@ -6531,47 +6394,16 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         determined as follows:</p>
                      <olist>
                         <item>
-                           <p>If <code>Attr.localName</code> is <code>"xmlns"</code>, then the result is
-                              an empty sequence.</p>
+                           <p>The <emph>local name</emph> is the value of the
+                              <code>Attr.localName</code> property;</p>
                         </item>
                         <item>
-                           <p>If <code>Attr.localName</code> starts with <code>"xmlns:"</code>, then the
-                              result is an <code>xs:QName</code> constructed as follows:</p>
-                           <olist>
-                              <item>
-                                 <p>The <emph>local name</emph> is the value of the
-                                    <code>Attr.localName</code> property after the <code>"xmlns:"</code> part;</p>
-                              </item>
-                              <item>
-                                 <p>The <emph>namespace prefix</emph> is empty;</p>
-                              </item>
-                              <item>
-                                 <p>The <emph>namespace URI</emph> is empty;</p>
-                              </item>
-                           </olist>
+                           <p>The <emph>namespace prefix</emph> is the value of the
+                              <code>Attr.prefix</code> property, or empty if the value is null;</p>
                         </item>
                         <item>
-                           <p>If the <code>Attr.localName</code> property contains a ":" then the
-                              <code>xs:QName</code> properties are taken by parsing
-                              <code>Attr.localName</code> as an <code>xs:QName</code> in the current
-                              element context;</p>
-                        </item>
-                        <item>
-                           <p>Otherwise, the result is an <code>xs:QName</code> constructed as follows:</p>
-                           <olist>
-                              <item>
-                                 <p>The <emph>local name</emph> is the value of the
-                                    <code>Attr.localName</code> property;</p>
-                              </item>
-                              <item>
-                                 <p>The <emph>namespace prefix</emph> is the value of the
-                                    <code>Attr.prefix</code> property, or empty if the value is null;</p>
-                              </item>
-                              <item>
-                                 <p>The <emph>namespace URI</emph> is the value of the
-                                    <code>Attr.namespaceURI</code> property, or empty if the value is null;</p>
-                              </item>
-                           </olist>
+                           <p>The <emph>namespace URI</emph> is the value of the
+                              <code>Attr.namespaceURI</code> property, or empty if the value is null;</p>
                         </item>
                      </olist>
                   </item>
@@ -6797,25 +6629,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   </item>
                   <item>
                      <p>If the node is an instance of HTML DOM <code>Attr</code> then the result is
-                        determined as follows:</p>
-                     <olist>
-                        <item>
-                           <p>If the <code>Attr.namespaceURI</code> property is
-                              <code>"http://www.w3.org/2000/xmlns/"</code>, then the result is
-                              an empty sequence;</p>
-                        </item>
-                        <item>
-                           <p>If the <code>Attr.localName</code> property is <code>"xmlns"</code>,
-                              then the result is an empty sequence;</p>
-                        </item>
-                        <item>
-                           <p>If the <code>Attr.localName</code> property starts with <code>"xmlns:"</code>,
-                              then the result is am empty sequence;</p>
-                        </item>
-                        <item>
-                           <p>Otherwise, the result is <code>xs:untypedAtomic</code>.</p>
-                        </item>
-                     </olist>
+                        <code>xs:untypedAtomic</code>.</p>
                   </item>
                   <item>
                      <p>If the node is an instance of HTML DOM <code>Text</code> then the result is
@@ -6825,18 +6639,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <p>Otherwise, the result is an empty sequence.</p>
                   </item>
                </olist>
-
-               <note>
-                  <p>When the resulting document is an HTML DOM <code>HTMLDocument</code>, the
-                     <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
-                     <code>Attr</code> nodes are both set to the qualified name.</p>
-               </note>
-
-               <note>
-                  <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
-                     <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
-                     ASCII upper alpha characters are appended to the attribute’s name in lowercase.</p>
-               </note>
             </div3>
             <div3 id="html-typed-value-accessor">
                <head>typed-value Accessor</head>
@@ -6859,25 +6661,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   </item>
                   <item>
                      <p>If the node is an instance of HTML DOM <code>Attr</code> then the result is
-                        determined as follows:</p>
-                     <olist>
-                        <item>
-                           <p>If the <code>Attr.namespaceURI</code> property is
-                              <code>"http://www.w3.org/2000/xmlns/"</code>, then the result is
-                              <code>$string-value</code>;</p>
-                        </item>
-                        <item>
-                           <p>If the <code>Attr.localName</code> property is <code>"xmlns"</code>,
-                              then the result is <code>$string-value</code>;</p>
-                        </item>
-                        <item>
-                           <p>If the <code>Attr.localName</code> property starts with <code>"xmlns:"</code>,
-                              then the result is <code>$string-value</code>;</p>
-                        </item>
-                        <item>
-                           <p>Otherwise, the result is <code>$string-value</code> as an <code>xs:untypedAtomic</code>;</p>
-                        </item>
-                     </olist>
+                        <code>$string-value</code> as an <code>xs:untypedAtomic</code>;</p>
                   </item>
                   <item>
                      <p>If the node is an instance of HTML DOM <code>Text</code> then the result is
@@ -6887,18 +6671,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <p>Otherwise, the result is <code>$string-value</code>.</p>
                   </item>
                </olist>
-
-               <note>
-                  <p>When the resulting document is an HTML DOM <code>HTMLDocument</code>, the
-                     <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
-                     <code>Attr</code> nodes are both set to the qualified name.</p>
-               </note>
-
-               <note>
-                  <p>The <code>Attr.localName</code> property will be ASCII lowercase. The
-                     <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
-                     ASCII upper alpha characters are appended to the attribute’s name in lowercase.</p>
-               </note>
             </div3>
             <div3 id="html-unparsed-entity-public-id-accessor">
                <head>unparsed-entity-public-id Accessor</head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6364,28 +6364,17 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         determined as follows:</p>
                      <olist>
                         <item>
-                           <p>If the <code>Element.localName</code> property contains a ":" then the
-                              <code>xs:QName</code> properties are taken by parsing
-                              <code>Element.localName</code> as an <code>xs:QName</code> in the current
-                              element context;</p>
+                           <p>The <emph>local name</emph> is the value of the
+                              <code>Element.localName</code> property;</p>
                         </item>
                         <item>
-                           <p>Otherwise, the result is an <code>xs:QName</code> constructed as follows:</p>
-                           <olist>
-                              <item>
-                                 <p>The <emph>local name</emph> is the value of the
-                                    <code>Element.localName</code> property;</p>
-                              </item>
-                              <item>
-                                 <p>The <emph>namespace prefix</emph> is the value of the
-                                    <code>Element.prefix</code> property, or empty if the value is null;</p>
-                              </item>
-                              <item>
-                                 <p>The <emph>namespace URI</emph> is the value of the
-                                    <code>Element.namespaceURI</code> property, or empty if the value
-                                    is null;</p>
-                              </item>
-                           </olist>
+                           <p>The <emph>namespace prefix</emph> is the value of the
+                              <code>Element.prefix</code> property, or empty if the value is null;</p>
+                        </item>
+                        <item>
+                           <p>The <emph>namespace URI</emph> is the value of the
+                              <code>Element.namespaceURI</code> property, or empty if the value
+                              is null;</p>
                         </item>
                      </olist>
                   </item>


### PR DESCRIPTION
This PR applies my action items for updating the HTML XDM mapping around namespaces and local names.

Note: this currently makes `dm:namespace-nodes` return an empty sequence. I'm not currently sure what the best approach is here.