### PR TITLE
663: Describe how calls to xsl:original with keywords work

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -4885,8 +4885,16 @@
                               the name of the overridden function, not
                               <code>xsl:original</code>.</p>
                         </note>
+                        
+
+                        <p diff="add" at="issue663">If the function <code>xsl:original</code> is
+                        called with keyword arguments, the keywords used are those of the overridden
+                        function.</p>
+               
+                        
                         <p>Neither <code>xsl:original</code>, nor the overridden function, is added
-                           to the <term>named functions</term> component of the dynamic context for
+                           to the <xtermref diff="add" at="issue663" spec="XP40" 
+                              ref="dt-dynamically-known-function-definitions">dynamically known function definitions</xtermref> component of the dynamic context for
                            XPath expressions within the overriding function. This means that any
                            attempt to bind the function name <code>xsl:original</code> dynamically
                            (for example using <xfunction>function-lookup</xfunction>, or


### PR DESCRIPTION
Rework PR 664 (fix for 663) on new baseline

Fix #663.