### PR TITLE
637: allow true() and false() as function annotation values

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -596,13 +596,29 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="_QName_or_EQName" unfold="yes"/>
     <g:optional>
       <g:string>(</g:string>
-      <g:ref name="Literal"/>
+      <g:ref name="AnnotationValue"/>
       <g:zeroOrMore>
         <g:string>,</g:string>
-        <g:ref name="Literal"/>
+        <g:ref name="AnnotationValue"/>
       </g:zeroOrMore>
       <g:string>)</g:string>
     </g:optional>
+  </g:production>
+  
+  <g:production name="AnnotationValue" if="xquery40">
+    <g:choice>
+      <g:ref name="Literal"/>
+      <g:sequence>
+        <g:string>true</g:string>
+        <g:string>(</g:string>
+        <g:string>)</g:string>
+      </g:sequence>
+      <g:sequence>
+        <g:string>false</g:string>
+        <g:string>(</g:string>
+        <g:string>)</g:string>
+      </g:sequence>
+    </g:choice>
   </g:production>
 
   <g:production name="VarDecl" if="xquery40">

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -607,7 +607,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   
   <g:production name="AnnotationValue" if="xquery40">
     <g:choice>
-      <g:ref name="Literal"/>
+      <g:ref name="StringLiteral"/>
+      <g:sequence>
+        <g:optional>
+          <g:string>-</g:string>
+        </g:optional>
+        <g:ref name="NumericLiteral"/>
+      </g:sequence>
       <g:sequence>
         <g:string>true</g:string>
         <g:string>(</g:string>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1448,7 +1448,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       <item role="xquery"><p>The <code>start</code> clause in window expressions has become optional, as well as
       the <code>when</code> keyword and its associated expression.</p></item>
       <item role="xquery"><p>The values <code>true()</code> and <code>false()</code> are allowed
-      in function annotations.</p></item>
+      in function annotations, and negated numeric literals are also allowed.</p></item>
       <item role="xquery"><p>All implementations must now predeclare the namespace prefixes
       <code>math</code>, <code>map</code>, <code>array</code>, and <code>err</code>. In XQuery 3.1 it was permitted
         but not required to predeclare these namespaces.</p></item>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1447,6 +1447,8 @@ specification since the publication of XPath 3.1 Recommendation.</p>
         <code>&#xFF1C;</code> and <code>&#xFF1E;</code> to avoid the need for XML escaping.</p></item>
       <item role="xquery"><p>The <code>start</code> clause in window expressions has become optional, as well as
       the <code>when</code> keyword and its associated expression.</p></item>
+      <item role="xquery"><p>The values <code>true()</code> and <code>false()</code> are allowed
+      in function annotations.</p></item>
       <item role="xquery"><p>All implementations must now predeclare the namespace prefixes
       <code>math</code>, <code>map</code>, <code>array</code>, and <code>err</code>. In XQuery 3.1 it was permitted
         but not required to predeclare these namespaces.</p></item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8487,6 +8487,7 @@ return $a("A")]]></eg>
                <head/>
                <prodrecap id="InlineFunctionExpr" ref="InlineFunctionExpr"/>
                <prodrecap ref="Annotation" role="xquery"/>
+               <prodrecap ref="AnnotationValue" role="xquery"/>
                <prodrecap ref="FunctionSignature" id="FunctionSignature"/>
                <prodrecap id="ParamList" ref="ParamList"/>
                <prodrecap id="Param" ref="Param"/>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1046,13 +1046,24 @@ return $i/xx:bing]]>
      </p>
 
 
-    <p> An annotation can provide values explicitly using a parenthesized list of <termref
-        def="id-literals">literals</termref>. For instance, the annotation
+    <p diff="chg" at="issue637"> An annotation can provide values explicitly using a parenthesized list of 
+      constant values. These values may take any of the following forms:</p>
+    
+    <ulist diff="chg" at="issue637">
+      <item><p>A string literal, for example <code>"Paris"</code> or <code>'London'</code>, denoting
+      a value of type <code>xs:string</code>.</p></item>
+      <item><p>A numeric literal, for example <code>0</code>, <code>0.1</code>, <code>0x7FFF</code>,
+        or <code>1e-6</code>,
+        denoting a value of type <code>xs:decimal</code>, <code>xs:integer</code>, 
+        or <code>xs:double</code>. The literal may be preceded by a minus sign to represent a negative
+        number.</p></item>
+      <item><p>One of the constructs <code>true()</code> or <code>false()</code>, denoting
+      the <code>xs:boolean</code> values <code>true</code> and <code>false</code> respectively.</p></item>
+    </ulist>
+ 
+    <p>For example, the annotation
         <code>%java:method("java.lang.Math.sin")</code> sets the value of the
         <code>java:method</code> annotation to the string value <code>java.lang.Math.sin</code>.
-        <phrase diff="add" at="issue637">In addition, the constructs <code>true()</code> and <code>false()</code>
-        can be used to set the annotation value to the <code>xs:boolean</code> values <code>true</code> and
-        <code>false</code> respectively.</phrase>
     </p>
 
     <note diff="add" at="issue637"><p>The constructs <code>true()</code> and <code>false()</code> must be written as

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1020,6 +1020,7 @@ return $i/xx:bing]]>
       <prodrecap id="AnnotatedDecl" ref="AnnotatedDecl"/>
       <prodrecap ref="InlineFunctionExpr"/>
       <prodrecap id="Annotation" ref="Annotation"/>
+      <prodrecap id="AnnotationValue" ref="AnnotationValue"/>
     </scrap>
 
     <p>XQuery uses annotations to declare properties associated with functions (inline or declared
@@ -1048,8 +1049,16 @@ return $i/xx:bing]]>
     <p> An annotation can provide values explicitly using a parenthesized list of <termref
         def="id-literals">literals</termref>. For instance, the annotation
         <code>%java:method("java.lang.Math.sin")</code> sets the value of the
-        <code>java:method</code> annotation to the string value <code>java.lang.Math.sin</code>.</p>
+        <code>java:method</code> annotation to the string value <code>java.lang.Math.sin</code>.
+        <phrase diff="add" at="issue637">In addition, the constructs <code>true()</code> and <code>false()</code>
+        can be used to set the annotation value to the <code>xs:boolean</code> values <code>true</code> and
+        <code>false</code> respectively.</phrase>
+    </p>
 
+    <note diff="add" at="issue637"><p>The constructs <code>true()</code> and <code>false()</code> must be written as
+    prescribed by the grammar. No namespace prefix is allowed; although the values resemble calls to
+    functions in the default function namespace, they are unaffected by the namespace
+    context.</p></note>
   </div2>
 
 


### PR DESCRIPTION
Fix #637