### PR TITLE
XQFO context/focus in/dependent functions clarification note

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1005,7 +1005,8 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <p><termdef id="dt-focus-independent" term="focus-dependent">A function that
                   is not <termref def="dt-focus-dependent">focus-dependent</termref> is called
                   <term>focus-independent</term>.</termdef></p>
-               
+
+               <notes>
                <note diff="add" at="2023-03-12">
                   <p>Some functions depend on aspects of the dynamic context that remain invariant
                   within an <termref def="execution-scope"/>, such as the implicit timezone.
@@ -1022,6 +1023,18 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                      of the caller — which is what concerns us here — is by defining optional
                      parameters whose default values are context-dependent.</p>
                </note>
+                  
+               <note diff="add" at="2023-09-05">
+               <p>Because the focus is a specific part of the dynamic context, all 
+                  <termref def="dt-focus-dependent">focus-dependent</termref> functions are also
+                  <termref def="dt-context-dependent">context-dependent</termref>. A
+                  <termref def="dt-context-dependent">context-dependent</termref> function, however,
+                  may be either <termref def="dt-focus-dependent">focus-dependent</termref> or
+                     <termref def="dt-focus-independent">focus-independent</termref>.</p>
+               </note>
+               </notes>
+               
+
                
                <p>A <phrase diff="chg" at="2023-03-12">function definition</phrase> that is context-dependent 
                   can be used as <phrase diff="add" at="2023-03-12">the target of</phrase> a named


### PR DESCRIPTION
Added note clarifying the relationship between context and focus, for the purpose of illustrating the relationships between focus/context in/dependent functions. Wrapped with companion `<note>`s in a parent `<notes>`.