### PR TITLE
Style fixes

### DIFF
--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -307,19 +307,21 @@
 	      <xsl:if test="fos:preamble">
 		<p><xsl:copy-of select="fos:preamble/node()" copy-namespaces="no"/></p>
 	      </xsl:if>
-	      <p>
-		<xsl:choose>
-		  <xsl:when test="fos:expression/@xml:space = 'preserve'">
+	      <xsl:choose>
+		<xsl:when test="fos:expression/@xml:space = 'preserve'">
+	          <p>
 		    <code><xsl:value-of select="translate(fos:expression, ' ', '&#xa0;')"/></code>
-		  </xsl:when>
-		  <xsl:when test="fos:expression/eg">
-		    <xsl:apply-templates select="fos:expression/node()"/>
-		  </xsl:when>
-		  <xsl:otherwise>
+                  </p>
+		</xsl:when>
+		<xsl:when test="fos:expression/eg">
+		  <xsl:apply-templates select="fos:expression/node()"/>
+		</xsl:when>
+		<xsl:otherwise>
+	          <p>
 		    <code><xsl:value-of select="fos:expression"/></code>
-		  </xsl:otherwise>
-		</xsl:choose>
-	      </p>
+                  </p>
+		</xsl:otherwise>
+	      </xsl:choose>
 	    </td>
           </tr>
 	  <tr>
@@ -356,19 +358,21 @@
 	      <xsl:if test="fos:preamble">
 		<p><xsl:copy-of select="fos:preamble/node()" copy-namespaces="no"/></p>
 	      </xsl:if>
-	      <p>
-		<xsl:choose>
-		  <xsl:when test="fos:expression/@xml:space = 'preserve'">
+	      <xsl:choose>
+		<xsl:when test="fos:expression/@xml:space = 'preserve'">
+                  <p>
 		    <code><xsl:value-of select="translate(fos:expression, ' ', '&#xa0;')"/></code>
-		  </xsl:when>
-		  <xsl:when test="fos:expression/eg">
-		    <xsl:apply-templates select="fos:expression/node()"/>
-		  </xsl:when>
-		  <xsl:otherwise>
+                  </p>
+		</xsl:when>
+		<xsl:when test="fos:expression/eg">
+		  <xsl:apply-templates select="fos:expression/node()"/>
+		</xsl:when>
+		<xsl:otherwise>
+                  <p>
 		    <code><xsl:value-of select="fos:expression"/></code>
-		  </xsl:otherwise>
-		</xsl:choose>
-	      </p>
+                  </p>
+		</xsl:otherwise>
+	      </xsl:choose>
 	    </td>
 	    <td valign="top">
 	      <xsl:if test="fos:result[2]"><p>One of the following:</p></xsl:if>

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -793,31 +793,29 @@
 -->
 <!-- ============ CREATE THE QUICK REFERENCE APPENDIX ===================== -->
 
-<!-- Generate a comment that identifies as much as we can about the XSLT processor being used -->
 <xsl:template match="/">
-    <xsl:variable name="XSLTprocessor">
-      <xsl:text>XSLT Processor: </xsl:text>
-      <xsl:value-of select="system-property('xsl:vendor')"/>
-      <xsl:if test="number(system-property('xsl:version')) ge 2.0">
-        <xsl:text> </xsl:text>
-        <xsl:value-of select="system-property('xsl:product-name')"/>
-        <xsl:text> </xsl:text>
-        <xsl:value-of select="system-property('xsl:product-version')"/>
-      </xsl:if>
-    </xsl:variable>
-    <!--<xsl:message><xsl:value-of select="$XSLTprocessor"/></xsl:message>-->
-    <xsl:comment><xsl:value-of select="$XSLTprocessor"/></xsl:comment>
   <xsl:choose>
     <xsl:when test="key('ids', 'quickref')">
       <xsl:apply-imports/>
     </xsl:when>
     <xsl:otherwise>
-        <xsl:variable name="transformed">
-          <xsl:apply-templates mode="transform"/>
-        </xsl:variable>
-        <xsl:apply-templates select="$transformed/spec"/>
+      <xsl:variable name="transformed">
+        <xsl:apply-templates mode="transform"/>
+      </xsl:variable>
+      <xsl:apply-templates select="$transformed/spec"/>
     </xsl:otherwise>
   </xsl:choose>
+  <xsl:variable name="XSLTprocessor">
+    <xsl:text>XSLT Processor: </xsl:text>
+    <xsl:value-of select="system-property('xsl:vendor')"/>
+    <xsl:if test="number(system-property('xsl:version')) ge 2.0">
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="system-property('xsl:product-name')"/>
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="system-property('xsl:product-version')"/>
+    </xsl:if>
+  </xsl:variable>
+  <xsl:comment><xsl:value-of select="$XSLTprocessor"/></xsl:comment>
 </xsl:template>
 
 <xsl:template match="head/meta">

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -107,6 +107,13 @@
   <!-- Template for the root node.  Creation of <html> element could
        go here, but that doesn't feel right. -->
   <xsl:template match="/">
+    <xsl:if test="//prod[@num] and //prod[not(@num)]">
+      <xsl:message terminate="yes">
+        <xsl:text>Manually and automatically numbered productions </xsl:text>
+        <xsl:text>cannot coexist.</xsl:text>
+      </xsl:message>
+    </xsl:if>
+    <xsl:apply-templates/>
     <xsl:comment>
       <xsl:text>{xmlspec} </xsl:text>
       <xsl:text>XSLT Processor: </xsl:text>
@@ -120,13 +127,6 @@
       <xsl:message>$show.diff.markup = <xsl:value-of select="$show.diff.markup"/></xsl:message>
 -->
     </xsl:comment>
-    <xsl:if test="//prod[@num] and //prod[not(@num)]">
-      <xsl:message terminate="yes">
-        <xsl:text>Manually and automatically numbered productions </xsl:text>
-        <xsl:text>cannot coexist.</xsl:text>
-      </xsl:message>
-    </xsl:if>
-    <xsl:apply-templates/>
   </xsl:template>
 
   <!-- abstract: appears only in header -->


### PR DESCRIPTION
1. Put the XSLT processor version comment at the end of the file instead of the beginning. Putting it before the `<!DOCTYPE html>` forces browsers into quirks mode.
2. Improve the XPath Functions stylesheets so that they don't put `div` elements inside `p` elements when outputting examples.