### PR TITLE
687 Clarify constructor functions for user-defined types

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8359,19 +8359,19 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                  <item>
                     <proto name="NMTOKENS" return-type="xs:NMTOKEN*" 
                        isSchema="yes" prefix="xs" role="example">
-                       <arg name="value" default="." type="xs:anyAtomicType?" />
+                       <arg name="value" default="." type="xs:string?" />
                     </proto>
                  </item>
                  <item>
                     <proto name="ENTITIES" return-type="xs:ENTITY*" 
                        isSchema="yes" prefix="xs" role="example">
-                       <arg name="value" default="." type="xs:anyAtomicType?"/>
+                       <arg name="value" default="." type="xs:string?"/>
                     </proto>
                  </item>
                  <item>
                     <proto name="IDREFS" return-type="xs:IDREF*" 
                        isSchema="yes" prefix="xs" role="example">
-                       <arg name="value" default="." type="xs:anyAtomicType?"/>
+                       <arg name="value" default="." type="xs:string?"/>
                     </proto>
                  </item>
               </ulist>
@@ -8461,27 +8461,62 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
               
             <div2 id="constructor-functions-for-user-defined-types">
                 <head>Constructor functions for user-defined types</head>
-                <p> For every user-defined simple type in the static context (See <xspecref spec="XP31"
+                <p>For every <phrase diff="add" at="issue687">named</phrase> 
+                   user-defined simple type in the static context (See <xspecref spec="XP31"
                     ref="static_context"/>), there is a
-                    constructor function whose name is the same as the name of the type and whose
+                   constructor function whose name is the same as the name of the 
+                   type<phrase diff="del" at="issue687">and whose
                     effect is to create a value of that type from the supplied argument. The rules
                     for constructing user-defined types are defined in the same way as the rules for
                     constructing built-in derived types defined in <specref
-                    ref="constructor-functions-for-xsd-types"/>. </p>
-<p>
-                            Special rules apply to constructor functions for namespace-sensitive types, that is,
+                    ref="constructor-functions-for-xsd-types"/></phrase>.</p>
+               
+               <p diff="add" at="issue687">For named atomic types, the rules
+                  are the same as the rules for constructing built-in derived atomic types defined in <specref
+                     ref="constructor-functions-for-xsd-types"/>. For a named atomic type <code>T</code>,
+               the signature of the function takes the form <code>T($value as xs:anyAtomicType? := .) as T?</code>,
+                  and the semantics are the same as casting to derived types: see <specref ref="casting-to-derived-types"/>..</p>
+               
+               <p diff="add" at="issue687">For named union types, the rules
+                  follow the same principles as the rules for constructing built-in union types defined in <specref
+                     ref="constructor-functions-for-xsd-union-types"/>. For a named union type <code>U</code>,
+                  the signature of the function takes the form <code>U($value as xs:anyAtomicType? := .) as U?</code>,
+                  and the semantics are the same as casting to union types: see <specref ref="casting-to-union"/>.</p>
+               
+               <p diff="add" at="issue687">For named list types, the rules
+                  follow the same principles as the rules for constructing built-in list types defined in <specref
+                     ref="constructor-functions-for-xsd-list-types"/>. For a named list type <code>L</code>,
+                  where the item type of <code>L</code> is <code>I</code>,
+                  the signature of the function takes the form <code>L($value as xs:string? := .) as I*</code>,
+                  and the semantics are the same as casting to list types: see <specref ref="casting-to-list"/>.</p>
+               
+               <p diff="add" at="issue687">Constructor functions are available both for named types defined in an imported schema (that is,
+                  named simple types in the <xtermref ref="dt-is-types" spec="XP40">in-scope schema types</xtermref>), 
+                  and for types defined by means of <xtermref ref="dt-item-type-aliases" spec="XP40"/>.
+                  Specifically, named enumeration types follow the same rules as schema types derived by
+                  restricting <code>xs:string</code>, and named local union types follow the same rules as
+                  union types defined in a schema.</p>
+               
+ 
+               
+               <p>Special rules apply to constructor functions for namespace-sensitive types, that is,
                             atomic types derived from <code>xs:QName</code> and <code>xs:NOTATION</code>, list types that have
    a namespace-sensitive item type, and union types that have a namespace-sensitive member type. See <specref ref='constructor-qname-notation'/>.</p>
-                <p>Consider a situation where the static context contains an atomic type
+                
+               <example>
+                  <head>Using a Constructor Function for a User-Defined Atomic Type</head>
+               <p>Consider a situation where the static context contains an atomic type
                     called <code>hatSize</code> defined in a schema whose target namespace is bound
                     to the prefix <code>eg</code>. In such a case the following constructor function is available to users:</p>
                 <example role="signature">
                     <proto prefix="eg" name="hatSize" return-type="my:hatSize" isSpecial="yes" returnEmptyOk='yes' role="example">
-                        <arg name="arg" type="xs:anyAtomicType" emptyOk='yes'/>
+                        <arg name="value" type="xs:anyAtomicType" emptyOk='yes'/>
                     </proto>
                 </example>
+                  <p>The resulting function may be used in an expression such as <code>eg:hatSize("10½")</code>.</p>
+               </example>
                
-               <p>In the case of an atomic type <var>A</var>, the return type of the function is <code>A?</code>, reflecting
+               <p diff="del" at="issue687">In the case of an atomic type <var>A</var>, the return type of the function is <code>A?</code>, reflecting
                the fact that the result will be an empty sequence if the input is an empty sequence. For a union or list type,
                the return type of the function is specified only as <code>xs:anyAtomicType*</code>. Implementations performing
                static type checking will often be able to compute a more specific result type. For example, if the target type
@@ -8490,11 +8525,11 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                In general, however, applications needing interoperable behavior on implementations that do strict static type
                checking will need to use a <code>treat as</code> expression to assert the specific type of the result.</p>
                 
-               <p> To construct an instance of a user-defined type 
+               <note><p> To construct an instance of a user-defined type 
                   that is not in a namespace, it is possible to use an
                   <code>EQName</code> (for example <code>Q{}hatsize(17)</code>). Alternatives are
                     to use a cast expression (<code>17 cast as hatsize</code>) or (if the host language allows it) 
-                  to undeclare the default function namespace. </p>
+                  to undeclare the default function namespace. </p></note>
             </div2>
         </div1>
       <div1 id="casting">
@@ -10630,6 +10665,10 @@ purposes of this rule that casting to <code>xs:NOTATION</code> succeeds.
             <code>xs:untypedAtomic</code>. The rules follow the general principle for
             all casts from <code>xs:string</code> outlined in <specref ref="casting-from-strings"/>.</p>
             
+            <p diff="add" at="issue687">If the supplied value is not of type <code>xs:string</code> or
+               <code>xs:untypedAtomic</code>, a type error is raised 
+               <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
+            
             <p>The semantics of the operation are consistent with validation: that is,
             the effect of casting a string <var>S</var> to a list type <var>L</var> is the same as
             constructing an element or attribute node whose string value is <var>S</var>,
@@ -12090,6 +12129,14 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               special coercion rules for <code>xs:string</code> parameters in XPath 1.0 compatibility mode no longer apply.
               For example, supplying <code>xs:duration('PT1H')</code> as the first argument will now raise a
               type error, rather than looking for a namespace binding for the prefix <code>PT1H</code>.</p>
+           </item>
+           <item diff="add" at="issue687">
+              <p>Version 4.0 makes it clear that the casting a value other than <code>xs:string</code>
+              or <code>xs:untypedAtomic</code> to a list type (whether using a cast expression or a
+                 constructor function) is a type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>. 
+                 Previously this was defined as an error, but the kind of error and the error code were left unspecified.
+              Accordingly, the function signatures of the constructor functions for built-in list types
+              have been changed to use an argument type of <code>xs:string?</code>.</p>
            </item>
         </olist>
  


### PR DESCRIPTION
Clarifies the rules for constructor functions, especially for list and union types, and for types defined by means of type aliases rather than in an imported schema. Fix #687.