### PR TITLE
XQFO minor edits, with new examples and notes, 2 through 4.6

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -589,7 +589,7 @@
                   chooses.</p>
                <p>If no value is supplied for the <code>$value</code>
                   argument <phrase diff="add" at="2022-12-19">or if the value supplied
-                     is an empty sequence,</phrase>, then the
+                     is an empty sequence</phrase>, then the
                   effective value of the error object is <termref
                      def="implementation-dependent">implementation-dependent</termref>.</p>
             </item>
@@ -1187,6 +1187,12 @@
                <fos:result>10.5</fos:result>
             </fos:test>
          </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>abs(-math:log(0))</fos:expression>
+               <fos:result>INF</fos:result>
+            </fos:test>
+         </fos:example>
       </fos:examples>
    </fos:function>
    <fos:function name="ceiling" prefix="fn">
@@ -1217,7 +1223,8 @@
          <p>For <code>xs:float</code> and <code>xs:double</code> arguments, if the argument is
             positive zero, then positive zero is returned. If the argument is negative zero, then
             negative zero is returned. If the argument is less than zero and greater than -1,
-            negative zero is returned.</p>
+            negative zero is returned. If the argument is infinity, positive or negative, 
+            the value of the argument is returned.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -1230,6 +1237,12 @@
             <fos:test>
                <fos:expression>ceiling(-10.5)</fos:expression>
                <fos:result>-10</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>ceiling(math:log(0))</fos:expression>
+               <fos:result>-INF</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -1261,7 +1274,8 @@
          be an instance of <code>xs:integer</code>.</p>
          <p>For <code>xs:float</code> and <code>xs:double</code> arguments, if the argument is
             positive zero, then positive zero is returned. If the argument is negative zero, then
-            negative zero is returned.</p>
+            negative zero is returned. If the argument is infinity, positive or negative, 
+            the value of the argument is returned.</p>
 
       </fos:rules>
       <fos:examples>
@@ -1275,6 +1289,12 @@
             <fos:test>
                <fos:expression>floor(-10.5)</fos:expression>
                <fos:result>-11</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>math:log(0) => floor()</fos:expression>
+               <fos:result>-INF</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -1380,6 +1400,12 @@
                <fos:result>3.14e0</fos:result>
             </fos:test>
          </fos:example>
+         <fos:example>
+            <fos:test xslt-version="3.0">
+               <fos:expression>math:log(0) => round()</fos:expression>
+               <fos:result>-INF</fos:result>
+            </fos:test>
+         </fos:example>
       </fos:examples>
    </fos:function>
    <fos:function name="round-half-to-even" prefix="fn">
@@ -1480,6 +1506,12 @@
             <fos:test>
                <fos:expression>round-half-to-even(35612.25, -2)</fos:expression>
                <fos:result>35600</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>math:log(0) => round-half-to-even()</fos:expression>
+               <fos:result>-INF</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -2244,7 +2276,7 @@
          <p>After this process, the supplied value
           must consist of an optional sign (<code>+</code> or <code>-</code>)
          followed by a sequence of one or more generalized digits drawn from the first <code>$radix</code> characters
-         in the alphabet <code>0123456789abcdefghijklmnopqrstuvwxyz</code>; upper case alphabetics
+         in the alphabet <code>0123456789abcdefghijklmnopqrstuvwxyz</code>; upper-case alphabetics
          <code>A-Z</code> may be used in place of their lower-case equivalents.</p>
          <p>The value of a generalized digit corresponds to its position in this alphabet.
          More formally, in non-error cases the result of the function is given by the XQuery expression:</p>
@@ -26585,13 +26617,18 @@ declare function fn:some(
       <fos:signatures>
          <fos:proto name="stack-trace" return-type="xs:string"/>
       </fos:signatures>
-
+      <fos:properties>
+         <fos:property>nondeterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      
       <fos:summary>
          <p>Returns implementation-dependent information about the current state of execution.</p>
       </fos:summary>
       <fos:rules>
 
-         <p>The result of the function is an implementation-dependent string containing diagnostic
+         <p>The result of the function is an <termref def="implementation-dependent">implementation-dependent</termref> string containing diagnostic
             information about the current state of execution.</p>
 
          <p>The function is non-deterministic: multiple calls will typically produce different results.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1594,7 +1594,7 @@
                            <var>mandatory-digit-signs</var> within the format token
                            <rfc2119>must</rfc2119> be from the same digit family, where a digit
                         family is a sequence of ten consecutive characters in Unicode category <var>Nd</var>,
-                        having digit values <code>0</code> through <code>0</code>.
+                        having digit values <code>0</code> through <code>9</code>.
                         Within the format token, these digits are
                         interchangeable: a three-digit number may thus be indicated equivalently by
                         <code>000</code>, <code>001</code>, or <code>999</code>.</p>
@@ -1812,13 +1812,14 @@
                   token, it <rfc2119>must</rfc2119> use a format token of <code>1</code>.</p>
                <note>
                   <p>In some traditional numbering sequences additional signs are added to denote
-                     that the letters should be interpreted as numbers; these are not included in
-                     the format token. An example (see also the example below) is classical Greek
-                     where a <emph>dexia keraia</emph>
+                     that the letters should be interpreted as numbers, for example, in ancient Greek
+                     the <emph>dexia keraia</emph>
                      <phrase role="normalize-nfc"
-                        >(x0374, &#x0374;)</phrase> and sometimes an
+                        >(x0374, &#x0374;)</phrase> and sometimes the 
                      <emph>aristeri keraia</emph>
-                     <phrase role="normalize-nfc">(x0375, &#x0375;)</phrase> is added.</p>
+                     <phrase role="normalize-nfc">(x0375, &#x0375;)</phrase>. These should not be
+                     included in the format token.
+                  </p>
                </note>
             </item>
          </olist>
@@ -1987,7 +1988,24 @@
                   </p>
 
             </item>
-
+            <item>
+               <p>The following notes apply when the primary format token is neither a <var>digit-pattern</var>
+               nor one of the seven other defined format tokens (A, a, i, I, w, W, Ww), but is an arbitrary token
+               representing the number 1:</p>
+               <p>Unexpected results may occur for traditional numbering. For example, in an
+                  implementation that supports traditional numbering system in Greek, the example
+                     <code>format-integer(19, "α;t")</code> may return <code>δπιιιι</code> or
+                     <code>ιθ</code>, depending upon whether the ancient acrophonic or late antique
+                  alphabetic system is supported. </p>
+               <p>Unexpected results may also occur for alphabetic numbering. For example, in an
+                  implementation that supports alphabetic numbering system in Greek, the example
+                     <code>format-integer(19, "α;a")</code> may return <code>σ</code>, even though 
+                  sigma is the eighteenth, not the nineteenth, letter in the Greek alphabet. The
+                  Unicode sequence of lowercase Greek letters has two sigmas, one final and the
+                  other non-final (#x3C2 &#x3C2; and #x3C3 &#x3C3;). Because final capital sigma is
+                  not attested, <code>format-integer(18, "Α;a")</code> may return #x3A2, a reserved
+                  character currently assigned to no glyph. </p>
+            </item>
          </olist>
 
 
@@ -2025,6 +2043,12 @@
             <fos:test xslt-version="3.0">
                <fos:expression>format-integer(7, 'a')</fos:expression>
                <fos:result>"g"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test xslt-version="3.0">
+               <fos:expression>format-integer(27, 'a')</fos:expression>
+               <fos:result>"aa"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -2292,7 +2316,7 @@ return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
          <p>A dynamic error is raised <errorref class="RG" code="0011"/>
             if <code>$radix</code> is not in the range 2 to 36.</p>
          <p>A dynamic error is raised <errorref class="RG" code="0012"/>
-            if after stripping whitespace and underscores and the optional leading sign 
+            if, after stripping whitespace and underscores and the optional leading sign, 
             <code>$value</code> is a zero-length string,
             or if it contains a character
          that is not among the first <code>$radix</code> characters in the

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1273,7 +1273,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
 	         example with a call such as <code>fn:string(fn:abs#1)</code>. Host languages may allow type errors
 	         to be reported statically if they are discovered during static analysis.</p>
 	         <p> When function specifications indicate that an error is to be raised, the notation 
-	            <quote>[<emph>error code</emph>]</quote>. os used to specify an error code. Each error defined
+	            <quote>[<emph>error code</emph>]</quote> is used to specify an error code. Each error defined
 	                in this document is identified by an <code>xs:QName</code> that is in the
 	                <code>http://www.w3.org/2005/xqt-errors</code> namespace, represented in this document by the <code>err</code> prefix. It is this
 	                <code>xs:QName</code> that is actually passed as an argument to the
@@ -1335,9 +1335,9 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             <note>
                <p>
 This specification uses  <bibref ref="ieee754-2008"/> arithmetic for <code>xs:float</code> and <code>xs:double</code> values.
-One consequence of this is that some operations result in the value <code>NaN</code> (not-a number), which
+One consequence of this is that some operations result in the value <code>NaN</code> (not a number), which
 has the unusual property that it is not equal to itself. Another consequence is that some operations return the value negative zero.
-This differs from <bibref ref="xmlschema-2"/> which defines
+This differs from <bibref ref="xmlschema-2"/>, which defines
 <code>NaN</code> as being equal to itself and defines only a single zero in the value space.
  The text accompanying several functions defines behavior for both positive and negative zero inputs and outputs 
  in the interest of alignment with <bibref ref="ieee754-2008"/>. A conformant implementation must
@@ -1529,7 +1529,7 @@ This differs from <bibref ref="xmlschema-2"/> which defines
 			division and modulus operations, as well as the rules for handling special values such as infinity and <code>NaN</code>,
 			and exception conditions such as overflow and underflow, are described more explicitly since they are not necessarily obvious.</p>
 
-            <p>On overflow and underflow situations during arithmetic operations conforming
+            <p>On overflow and underflow situations during arithmetic operations, conforming
                     implementations <rfc2119>must</rfc2119> behave as follows:</p>
             <ulist>
                <item>
@@ -1604,9 +1604,9 @@ This differs from <bibref ref="xmlschema-2"/> which defines
                     of digits in the mathematical result exceeds the number of digits that the implementation
                     retains for that operation, the result is truncated or rounded in an <termref def="implementation-defined"/> manner.</p>
             
-            <note><p>This Recommendation does not specify whether <code>xs:decimal</code> operations are fixed point or floating point.
+            <note><p>This specification does not determine whether <code>xs:decimal</code> operations are fixed point or floating point.
             In an implementation using floating point it is possible for very simple operations to require more digits of precision than
-            are available; for example adding <code>1e100</code> to <code>1e-100</code> requires 200 digits of precision for an
+            are available; for example, adding <code>1e100</code> to <code>1e-100</code> requires 200 digits of precision for an
                accurate representation of the result.</p></note>
             
         
@@ -1628,7 +1628,7 @@ This differs from <bibref ref="xmlschema-2"/> which defines
                warning condition, but the observable effect on an application 
                using the functions and operators defined in this specification is simply to return
                the defined result (typically <code>-INF</code>, <code>+INF</code>, or <code>NaN</code>) with no error.</p>
-            <p>The <bibref ref="ieee754-2008"/> specification distinguishes two <code>NaN</code> values,
+            <p>The <bibref ref="ieee754-2008"/> specification distinguishes two <code>NaN</code> values:
                a quiet <code>NaN</code> and a signaling <code>NaN</code>. These two values are not distinguishable in the XDM model:
                the value spaces of <code>xs:float</code> and <code>xs:double</code> each include only a single
                <code>NaN</code> value. This does not prevent the implementation distinguishing them internally,
@@ -1688,12 +1688,12 @@ This differs from <bibref ref="xmlschema-2"/> which defines
                </item>
                <item>
                   <p>For <code>xs:float</code> and <code>xs:double</code> arguments, if the
-                            argument is <code>"NaN"</code>, <code>NaN</code> is returned.</p>
+                            argument is <code>NaN</code>, <code>NaN</code> is returned.</p>
                </item>
                <item>
-                  <p>Except for <code>fn:abs</code>, for <code>xs:float</code> and
-                            <code>xs:double</code> arguments, if the argument is positive or
-                            negative infinity, positive or negative infinity is returned.</p>
+                  <p>With the exception of <code>fn:abs</code>, functions with arguments of 
+                     type <code>xs:float</code> and <code>xs:double</code> that are positive or
+                            negative infinity return positive or negative infinity.</p>
                </item>
             </ulist>
             <?local-function-index?>


### PR DESCRIPTION
Minor edits here are motivated by clarity or localized consistency. In one case, the change of `0` to `0` to `0` to `9` appears to address an important typo.

I have introduced select examples, to illustrate points in the corresponding rules.

The notes I have introduced need some context. Option 9 for the primary format token is somewhat vague, and the attached note of clarification stokes the imagination. I have trimmed that note for clarity (without substantive changes) but introduced a set of notes later, to help caution developers on unexpected behaviors with option 9, and secondarily to caution processor implementers on the challenges inherent in supporting this option. If  I had my druthers, I would advocate deprecating option 9. It is--to use a technical term--squishy.

Spec editors: I am happy to pull back on any of this.