### PR TITLE
129 (1): XPath and XQuery changes for introduction of context value

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -346,7 +346,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:zeroOrMore>
     <g:zeroOrMore name="FunctionsAndVarsList" lookahead="2">
       <g:choice name="FunctionOrVar">
-        <g:ref name="ContextItemDecl" lookahead="2" if="xquery40"/>
+        <g:ref name="ContextValueDecl" lookahead="2" if="xquery40"/>
         <g:ref name="AnnotatedDecl" lookahead="2" if="xquery40"/>
         <g:ref name="OptionDecl" lookahead="2"/>
       </g:choice>
@@ -657,14 +657,25 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="ExprSingle"/>
   </g:production>
 
-  <g:production name="ContextItemDecl" if="xquery40">
+  <g:production name="ContextValueDecl" if="xquery40">
     <g:string>declare</g:string>
     <g:string>context</g:string>
-    <g:string>item</g:string>
-    <g:optional>
-      <g:string>as</g:string>
-      <g:ref name="ItemType"/>
-    </g:optional>
+    <g:choice>
+      <g:sequence>
+        <g:string>value</g:string>
+        <g:optional>
+          <g:string>as</g:string>
+          <g:ref name="SequenceType"/>
+        </g:optional>
+      </g:sequence>
+      <g:sequence>
+        <g:string>item</g:string>
+        <g:optional>
+          <g:string>as</g:string>
+          <g:ref name="ItemType"/>
+        </g:optional>
+      </g:sequence>
+    </g:choice>
     <g:choice>
       <g:sequence>
         <g:string>:=</g:string>
@@ -2060,8 +2071,7 @@ ErrorVal ::= "$" VarName
       <g:ref name="Literal"/>
       <g:ref name="VarRef"/>
       <g:ref name="ParenthesizedExpr"/>
-      <g:ref name="ContextItemExpr" if="xpath40 xquery40  xslt40-patterns"/>
-      <!--<g:ref name="TildeExpr" if="xpath40 xquery40"/>-->
+      <g:ref name="ContextValueExpr" if="xpath40 xquery40  xslt40-patterns"/>
       <g:ref name="FunctionCall" lookahead="2"/>
       <g:ref name="OrderedExpr" if=" xquery40" lookahead="2"/>
       <g:ref name="UnorderedExpr" if=" xquery40" lookahead="2"/>
@@ -2109,7 +2119,7 @@ ErrorVal ::= "$" VarName
     <g:string>)</g:string>
   </g:production>
 
-  <g:production name="ContextItemExpr">
+  <g:production name="ContextValueExpr">
     <g:string process-value="yes">.</g:string>
   </g:production>
   

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -453,11 +453,11 @@ per lexical scope.</td>
   <td>Only one definition per variable per lexical scope.</td></tr>
 
 <tr>
-  <td>Context item static type</td>
+  <td>Context value static type</td>
   <td>item()</td>
   <td>overwriteable</td>
-  <td>overwriteable by <specref ref="id-context-item-declarations"/></td>
-  <td>overwriteable by expresssions that set the context item</td>
+  <td>overwriteable by <specref ref="id-context-value-declarations"/></td>
+  <td>overwriteable by expresssions that set the context value</td>
   <td>None.</td></tr>
 <tr>
   <td>Ordering mode</td>
@@ -797,10 +797,10 @@ the value of the component for their subexpressions.</p></item>
 </tr>
 
 <tr>
-  <td>Context item</td>
+  <td>Context value</td>
   <td>none</td>
   <td>overwriteable</td>
-  <td>overwriteable by a  <specref ref="id-context-item-declarations"/> in the main module
+  <td>overwriteable by a  <specref ref="id-context-value-declarations"/> in the main module
   </td>
   <td>overwritten during evaluation of path expressions and predicates</td>
   <td>Must be the same in the dynamic context of every module in a query.
@@ -810,21 +810,21 @@ the value of the component for their subexpressions.</p></item>
   <td>Context position</td>
   <td>none</td>
   <td>overwriteable</td>
-  <td>overwriteable by a  <specref ref="id-context-item-declarations"/> in the main module
+  <td>overwriteable by a  <specref ref="id-context-value-declarations"/> in the main module
   </td>
   <td>overwritten during evaluation of path expressions and predicates</td>
-  <td>If context item is defined, context position must be &gt;0 and &lt;= context size; else  context position is <xtermref spec="DM31" ref="dt-absent"/>. </td>
+  <td>If context value is defined, context position must be &gt;0 and &lt;= context size; else  context position is <xtermref spec="DM31" ref="dt-absent"/>. </td>
 </tr>
 <tr>
   <td>Context size</td>
   <td>none
   </td>
   <td>overwriteable</td>
-  <td>overwriteable by a  <specref ref="id-context-item-declarations"/> in the main module
+  <td>overwriteable by a  <specref ref="id-context-value-declarations"/> in the main module
       
   </td>
   <td>overwritten during evaluation of path expressions and predicates</td>
-  <td>If context item is defined, context size must be &gt;0; else context size is <xtermref spec="DM31" ref="dt-absent"/>.</td></tr>
+  <td>If context value is defined, context size must be &gt;0; else context size is <xtermref spec="DM31" ref="dt-absent"/>.</td></tr>
 
 
 <tr>
@@ -955,7 +955,7 @@ defined.</p>
   <td>In-scope variables</td>
   <td>lexical; for-expressions, let-expressions, and quantified expressions can bind new variables</td></tr>
 <tr>
-  <td>Context item static type</td>
+  <td>Context value static type</td>
   <td>lexical</td></tr>
 <tr>
   <td>Statically known function signatures</td>
@@ -1002,7 +1002,7 @@ defined.</p>
 </tr>
 
 <tr>
-  <td>Context item</td>
+  <td>Context value</td>
   <td>dynamic; changes during evaluation of path expressions and predicates</td>
 </tr>
 <tr>
@@ -1395,10 +1395,12 @@ specification since the publication of XPath 3.1 Recommendation.</p>
   
   <p>The following changes have been agreed by the working group:</p>
     <olist>
+      <item><p>The concept of the context item has been generalized, so it is now a context value. That is,
+      it is no longer constrained to be a single item.</p></item>
       <item><p>Function definitions in the static context may now have optional parameters,
       provided this does not cause ambiguity across multiple function definitions with the same name.
       Optional parameters are given a default value, which can be any expression, including one that
-      depends on the context of the caller (so an argument can default to the context item).</p></item>
+      depends on the context of the caller (so an argument can default to the context value).</p></item>
       <item><p>In a static function call, arguments can be specified either positionally or by keyword,
       or a combination of both.</p></item>
       <item><p>An <code>otherwise</code> operator is introduced: <code>A otherwise B</code> returns the

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -621,10 +621,11 @@ inferred by static type inference as discussed in  <specref
 
                <item>
                   <p>
-                     <termdef term="context item static type" id="dt-context-item-static-type">
-                        <term>Context item static type.</term> This component defines the <termref
-                           def="dt-static-type"
-                        >static type</termref> of the context item within the scope of a given expression.</termdef>
+                     <termdef term="context value static type" id="dt-context-value-static-type">
+                        <term>Context value static type.</term> This is a <termref def="dt-sequence-type"/>; 
+                        it defines the <termref def="dt-static-type"
+                        >static type</termref> of the <termref def="dt-context-value"/> within the 
+                        scope of a given expression.</termdef>
                   </p>
                </item>
                
@@ -1164,7 +1165,7 @@ context</termref>, and the additional components listed below.</p>
 the <termref
                      def="dt-dynamic-context"
                      >dynamic context</termref>
-(context item, context position, and context size) are called the
+(context value, context position, and context size) are called the
 <term>focus</term> of the expression. </termdef> The focus enables the
 processor to keep track of which items are being processed by the
 expression.
@@ -1174,19 +1175,25 @@ expression.
                   >If any component in the focus is defined, all components of the focus are defined.</phrase>
 
 <phrase role="xpath"
-                  >If any component in the focus is defined, both the context item and context position are known.</phrase> 
-<note
-                  role="xpath">
+                  >If any component in the focus is defined, both the context value and context position are known.</phrase> 
+            </p>
+                <note role="xpath">
                   <p>If any component in the focus is defined, context size is usually defined as well.  However, when streaming, 
 the context size cannot be determined without lookahead, so it may be undefined.  If so, expressions like <code>last()</code> will raise a dynamic error because the context size is undefined.</p>
                </note>
-               <termdef id="dt-singleton-focus" term="singleton focus"
-                     >A <term>singleton focus</term> is a focus that refers to a single item; in a singleton focus, context item is set to the item, context position = 1, and context size = 1.</termdef>
-            </p>
-
+               <p><termdef id="dt-fixed-focus" term="fixed focus"
+                  >A <term>fixed focus</term> is a focus for an expression that is evaluated once, 
+                  rather than being applied to a series of values; in a fixed focus, 
+                  the context value is set to one specific value, the context position is 1, and the context size is 1.</termdef>
+               </p>
+               <p><termdef id="dt-singleton-focus" term="singleton focus"
+                     >A <term>singleton focus</term> is a <termref def="dt-fixed-focus"/> in which the
+                  <termref def="dt-context-value"/> is a <termref def="dt-singleton"/> item.</termdef>.
+               With a singleton focus, the context value is a single item, the context position is 1, and the context size is 1.
+               </p>
+            
             <p>Certain language constructs, notably the <termref def="dt-path-expression"
-                  >path
-operator</termref>
+                  >path operator</termref>
                <code role="parse-test">E1/E2</code>, the <nt def="SimpleMapExpr"
                   >simple map operator</nt>
                <code role="parse-test">E1!E2</code>, and the <termref def="dt-predicate"
@@ -1212,14 +1219,15 @@ focus</term>. The inner focus is used only for the evaluation of <code
 
                <item>
                   <p>
-                     <termdef id="dt-context-item" term="context item"
-                           >The <term>context item</term>
-is the <termref def="dt-item"
-                           >item</termref> currently being processed.</termdef>
+                     <termdef id="dt-context-value" term="context value"
+                           >The <term>context value</term>
+is the <termref def="dt-value">value</termref> currently being processed.</termdef>
+                     In many cases (but not always), the context value will be a single item.
                      <termdef id="dt-context-node" term="context node"
-                           >When the context item is a
-node, it can also be referred to as the <term>context
-node</term>.</termdef> The context item is returned by an expression
+                           >When the context value is a single item, it can also be referred
+                        to as the <term>context item</term>; when it is a single node,
+it can also be referred to as the <term>context
+node</term>.</termdef> The context value is returned by an expression
 consisting of a single dot (<code
                         role="parse-test">.</code>). When an expression <code role="parse-test"
                         >E1/E2</code> or <code role="parse-test"
@@ -1227,19 +1235,16 @@ consisting of a single dot (<code
 sequence obtained by evaluating <code
                         role="parse-test"
                         >E1</code>
-becomes the context item in the inner focus for an evaluation of <code
+becomes the context value in the inner focus for an evaluation of <code
                         role="parse-test">E2</code>. </p>
                   <p role="xquery">
-                     <termdef id="dt-initial-context-item" term="initial context item"
-                           >
+                     <termdef id="dt-initial-context-value" term="initial context value">
     
     
       In the dynamic context of every module in a query,
-      the context item component must have the same setting.
-      If this shared setting is not <xtermref
-                           spec="DM31" ref="dt-absent"
-                           />,
-      it is referred to as the <term>initial context item</term>.
+      the context value component must have the same setting.
+      If this shared setting is not <xtermref spec="DM31" ref="dt-absent"/>,
+      it is referred to as the <term>initial context value</term>.
     
   </termdef>
                   </p>
@@ -1250,8 +1255,8 @@ becomes the context item in the inner focus for an evaluation of <code
                   <p>
                      <termdef id="dt-context-position" term="context position"
                            >The <term>context
-position</term> is the position of the context item within the
-sequence of items currently being processed.</termdef> It changes whenever the context item
+position</term> is the position of the context value within the
+series of values currently being processed.</termdef> It changes whenever the context value
 changes. When the focus is defined, the value of the context position is an integer greater than zero. The context
 position is returned by the expression <code
                         role="parse-test">fn:position()</code>. When an expression <code
@@ -1260,7 +1265,7 @@ position is returned by the expression <code
 the inner focus for an evaluation of <code
                         role="parse-test"
                         >E2</code>
-is the position of the context item in the sequence obtained by
+is the position of the context value in the sequence obtained by
 evaluating <code
                         role="parse-test"
                      >E1</code>. The position of the
@@ -1272,7 +1277,7 @@ always less than or equal to the context size.</p>
                   <p>
                      <termdef id="dt-context-size" term="context size"
                         >The <term>context
-size</term> is the number of items in the sequence of items currently
+size</term> is the number of values in the series of values currently
 being processed.</termdef> Its value is always an
 integer greater than zero. The context size is returned by the
 expression <code
@@ -1974,7 +1979,7 @@ is <code>xs:anyAtomicType</code>.</p>
                   
                   <item><p>When the <nt def="KeySpecifier">KeySpecifier</nt> in a 
                      <nt def="Lookup">Lookup</nt> expression is such that the result of the lookup
-                  will inevitably be empty. For example if the context item is known to be of type
+                  will inevitably be empty. For example if the context value is known to be of type
                   <code>record(longitude, latitude)</code> then a static type error <rfc2119>may</rfc2119> be raised
                   against the expression <code>?altitude</code>.</p></item>
                </olist>
@@ -2326,11 +2331,9 @@ a type in <termref
                </item>
 
                <item>
-                  <p>The value of the <termref def="dt-context-item"
-                        >context item</termref> must match the <termref
-                        def="dt-context-item-static-type"
-                        >context item static type</termref>, using the
-matching rules in <specref
+                  <p>The <termref def="dt-context-value"/> must match the <termref
+                        def="dt-context-value-static-type"
+                        >context value static type</termref>, using the matching rules in <specref
                         ref="id-sequencetype-matching"/>.</p>
                </item>
 
@@ -2872,12 +2875,12 @@ would raise an error because it has an <code>id</code> child whose value is not 
                   is guarded by the value of the first operand being an empty sequence.</p></item>
                <item><p>In a path expression of the form <code>E1/E2</code> or <code>E1//E2</code>, and in a mapping
                expression of the form <code>E1!E2</code>, the right-hand operand <code>E2</code> is guarded by
-               the existence of the relevant context item in the result of evaluating <code>E1</code>.</p>
-                  <p>This rule applies even if <code>E2</code> does not reference the context item.
+               the existence of at least one item in the result of evaluating <code>E1</code>.</p>
+                  <p>This rule applies even if <code>E2</code> does not reference the context value.
                      For example, no dynamic error can be thrown by the expression 
                <code>(1 to $n)!doc('bad.xml')</code> in the case where <code>$n</code> is zero.</p></item>
                <item><p>In a filter expression of the form <code>E[P]</code>, the predicate <code>P</code> is guarded by
-                  the existence of the relevant context item in the result of evaluating <code>E</code>.</p>
+                  the existence of at least one item in the result of evaluating <code>E</code>.</p>
                <p>This rule has the consequence that in a filter expression with multiple predicates, such as <code>E[P1][P2]</code>,
                evaluation of <code>P2</code> must not raise a dynamic error unless <code>P1</code> returns <code>true</code>. This rule does
                not prevent reordering of predicates (for example, to take advantage of indexes), but it does require that any
@@ -3279,8 +3282,7 @@ defined in <xspecref
                   >dynamic context</termref> that is initialized by the external
     environment, such as a <termref
                   def="dt-variable-values">variable</termref> or
-    <termref def="dt-context-item"
-                  >context item</termref>.</p>
+    <termref def="dt-context-value"/>.</p>
 
 
 
@@ -6654,7 +6656,7 @@ and <nt def="OrExpr"
          <p>
             <termdef id="dt-primary-expression" term="primary expression">
                <term>Primary expressions</term> are the basic primitives of the
-	 language. They include literals, variable references,  context item expressions, <phrase
+	 language. They include literals, variable references,  context value expressions, <phrase
                   role="xquery"
                >constructors, </phrase> and function calls. A primary expression may also be created by enclosing any expression in parentheses, which is sometimes helpful in controlling the precedence of operators.</termdef>
             <phrase role="xquery">Node Constructors are described in <specref ref="id-constructors"
@@ -7045,28 +7047,26 @@ At evaluation time, the value of a variable reference is the value to which the 
                   ref="construct_seq"/>.</p>
          </div3>
 
-         <div3 id="id-context-item-expression">
-            <head>Context Item Expression</head>
+         <div3 id="id-context-value-expression">
+            <head>Context Value Expression</head>
             <scrap>
                <head/>
-               <prodrecap id="ContextItemExpr" ref="ContextItemExpr"/>
+               <prodrecap id="ContextValueExpr" ref="ContextValueExpr"/>
             </scrap>
 
-            <p>A <term>context item expression</term> evaluates to
-              the <termref
-                  def="dt-context-item"
-                  >context item</termref>, which may be either a node (as in the
-              expression
-              <code
-                  role="parse-test"
-                  >fn:doc("bib.xml")/books/book[fn:count(./author)&gt;1]</code>),
-              or an atomic value or function (as in the expression <code
-                  role="parse-test">(1 to
-              100)[. mod 5 eq 0]</code>).</p>
-            <p>If the <termref def="dt-context-item">context item</termref> is <xtermref spec="DM31"
-                  ref="dt-absent"/>, a context item expression raises a <termref
+            <p>A <term>context value expression</term> evaluates to
+              the <termref def="dt-context-value"/>.</p>
+            
+            <p>In many syntactic contexts, the context value will be a single item.
+               For example this appplies on the right-hand side of the <code>/</code> 
+               or <code>!</code> operators, or within a <nt def="Predicate">Predicate</nt>.</p>
+            
+            <p>If the <termref def="dt-context-value"/> is <xtermref spec="DM31"
+                  ref="dt-absent"/>, a context value expression raises a <termref
                   def="dt-dynamic-error">dynamic error</termref>
                <errorref class="DY" code="0002"/>.</p>
+            
+            <note><p>Being absent is not the same thing as being empty.</p></note>
 
          </div3>
 
@@ -7228,10 +7228,10 @@ At evaluation time, the value of a variable reference is the value to which the 
             
             <p>For each item in the input sequence, the predicate expression
                is evaluated using an <term>inner focus</term>, defined as
-               follows: The context item is the item currently being tested
+               follows: The context value is the item currently being tested
                against the predicate. The context size is the number of items
                in the input sequence. The context position is the position of
-               the context item within the input sequence. </p>
+               the context value within the input sequence. </p>
             
             <p>For each item in the input sequence, the result of the
                predicate expression is coerced to an <code>xs:boolean</code>
@@ -7911,7 +7911,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                           The <termref
                                                   def="dt-focus"
                                                   >focus</termref>
-                                          (context item, context position, and context size)
+                                          (context value, context position, and context size)
                                           is <xtermref
                                                   spec="DM31" ref="dt-absent"
                                                 />.
@@ -7992,21 +7992,27 @@ let $f := function($i as xs:decimal) as xs:decimal { $i + $incr }
 return $f(5)]]></eg>
                                  </example>
                                  <example>
-                                    <head>Using the Context Item in an Anonymous Function</head>
+                                    <head>Using the Context Value in an Anonymous Function</head>
                                     <p>The following example will raise a dynamic error <errorref
                                           class="DY" code="0002"/>:</p>
                                     <eg role="parse-test"><![CDATA[
 let $vat := function() { @vat + @price }
 return shop/article/$vat()]]></eg>
-                                    <p>Instead, the context item can be used as an argument to the anonymous function:</p>
+                                    <p>Instead, the context value can be used as an argument to the anonymous function:</p>
                                     <eg role="parse-test"><![CDATA[
 let $vat := function($art) { $art/@vat + $art/@price }
 return shop/article/$vat(.)]]></eg>
-                                    <p>Or, the value can be referenced as a nonlocal variable binding:</p>
+                                    <p>Alternatively, the value can be referenced as a nonlocal variable binding:</p>
                                     <eg role="parse-test"><![CDATA[
 let $ctx := shop/article,
 $vat := function() { for $a in $ctx return $a/@vat + $a/@price }
 return $vat()
+]]></eg>
+                                    <p>Finally, a <termref def="dt-focus-function"/> can be used.
+                                       This binds the value of the argument to the context value within the function body:</p>
+                                    <eg role="parse-test"><![CDATA[
+let $vat := function { @vat + @price }
+return $vat(shop/article)
 ]]></eg>
                                  </example>
 
@@ -8538,7 +8544,7 @@ return $a("A")]]></eg>
          
                <p>
           If a function parameter is declared using a name but no type, its default type is <code>item()*</code>.
-                  <!--<phrase diff="add" at="A">If it is bound to the context item using the notation <code>.</code>,
+                  <!--<phrase diff="add" at="A">If it is bound to the context value using the notation <code>.</code>,
                   the implicit type is <code>item()</code>.</phrase>-->
                If the result type is omitted, its default result type is <code>item()*</code>.
           </p>
@@ -8566,7 +8572,7 @@ return $a("A")]]></eg>
 
                <p>
           The static context for the function body is inherited from the location of the inline function expression, with the exception of the
-          static type of the context item which is initially <xtermref
+          static type of the context value which is initially <xtermref
                      spec="DM31" ref="dt-absent"/>.
           </p>
          
@@ -8628,7 +8634,7 @@ return $a("A")]]></eg>
                         <p diff="chg" at="2023-03-11">
                            <term>captured context</term>: the static context
                            is the static context of the inline function expression,
-                           with the exception of the static context item type which is
+                           with the exception of the static context value type which is
                            <xtermref spec="DM31" ref="dt-absent"/>. The dynamic context has an absent
                            <termref def="dt-focus"/>, and a set of variable bindings
                            comprising the <termref def="dt-variable-values"
@@ -8676,7 +8682,8 @@ return $incrementors[2](4)]]></eg>
                <head>Focus Functions</head>
                <p><termdef id="dt-focus-function" term="focus function">A <term>focus function</term>
                is an inline function expression in which the function signature is implicit: the function takes
-               a single argument of type <code>item()</code>, and binds this to the context item when evaluating
+               a single argument of type <code>item()*</code> (that is, any value), and binds this to the 
+                  context value when evaluating
                the function body, which returns a result of type <code>item()*</code>.</termdef></p>
                <p>Here are some examples of focus functions:</p>
                <ulist>
@@ -8686,6 +8693,8 @@ return $incrementors[2](4)]]></eg>
                   that number plus one.</p></item>
                   <item><p><code>function{`${.}`}</code> - a function that expects a string as its argument, and prepends
                      a <code>"$"</code> character.</p></item>
+                  <item><p><code>function{head(.)+foot(.)}</code> - a function that expects a sequence of numbers
+                     as its argument, and returns the sum of the first and last items in the sequence.</p></item>
                </ulist>
                <p>Focus functions are often useful as arguments to simple higher-order functions such as <code>fn:sort</code>.
                For example, to sort employees by salary, write <code>sort(//employee, (), fn { +@salary })</code>.
@@ -8695,77 +8704,14 @@ return $incrementors[2](4)]]></eg>
                For example, <code>$s => tokenize() =!> fn { `"{.}"` }()</code> first tokenizes the string <code>$s</code>,
                then wraps each token in double quotation marks.</p>
                <p>The expression <code>function{EXPR}</code> (or <code>fn{EXPR}</code>) is a syntactic shorthand for the expression
-               <code>function($Z as item()) as item()* {$Z!(EXPR)}</code>, where <code>$Z</code> is a variable name that is
-               otherwise unused. Note that the function body (<code>EXPR</code>) is evaluated with a singleton focus: 
+               <code>function($Z as item()*) as item()* {$Z!(EXPR)}</code>, where <code>$Z</code> is a variable name that is
+               otherwise unused. Note that the function body (<code>EXPR</code>) is evaluated with a <termref def="dt-fixed-focus"/>: 
                   the context position and context size will always be 1 (one).</p>
+               <ednote><date>2023-09-14</date><edtext>TODO: The above no longer works. We don't currently have any construct (other than this one) that sets
+               the context value to something other than a singleton.</edtext></ednote>
             </div4>
             
-         <!--<div4 id="id-lambda-expressions" diff="add" at="2023-04-18">
-            <head>Lambda Expressions</head>
-            
-            <scrap>
-               <head/>
-               <prodrecap id="LambdaExpr" ref="LambdaExpr"/>
-               <prodrecap id="LambdaParams" ref="LambdaParams"/>
-               <prodrecap id="LambdaParam" ref="LambdaParam"/>
-               <prodrecap ref="EnclosedExpr" role="xpath"/>
-            </scrap>
-            
-            <p>Lambda expressions provide an abbreviated syntax for inline functions.</p>
-            
-            <p>For example, the expression <code>($a) -> {$a+1}</code> is equivalent to 
-            <code>function($a){$a + 1}</code></p>
-            
-            <p>A lambda expression of the form <code>($x, $y, $z, ...) -> {EXPR}</code> has precisely the same effect, and is subject
-               to the same rules, as the expanded form <code>function($x, $y, $z, ...){EXPR}</code></p>
-            
-            <p>The parentheses around the parameter list are required even if the function takes only one argument.</p>
-            
-            <p>For example:</p>
-            
-            <ulist>
-               <item>
-                  <p>This example creates a function that prepends the string <code>"£"</code> to a supplied value:
-                     <eg role="parse-test"><![CDATA[($x) -> {`£{$x}`}]]></eg>
-                  </p>
-                  <p>It is equivalent to the function <code>concat("£", ?)</code>.</p>
-               </item>
-               <item>
-                  <p>This example creates a function that returns the <code>name</code>
-                     attribute of a supplied element node:
-                     <eg
-                        role="parse-test"
-                        ><![CDATA[($e) -> {$e!@name}]]></eg>
-                  </p>
-                  <p>It is equivalent to the function <code>function($x as item()) as item()* {$x ! @name}</code>.</p>
-               </item>
-               <item>
-                  <p>This example creates an arity-zero function that returns the value <code>INF</code> (positive infinity):
-                     <eg
-                        role="parse-test"
-                        ><![CDATA[() -> {xs:double('INF')}]]></eg>
-                  </p>
-                  <p>It is equivalent to the function <code>function() as item()* {xs:double('INF')}</code>.</p>
-               </item>
-               <item>
-                  <p>This example creates an arity-two function that adds the values of the supplied arguments:
-                     <eg
-                        role="parse-test"
-                        ><![CDATA[($x, $y) -> {$x + $y}]]></eg>
-                  </p>
-                  <p>It is equivalent to the function <code>op("+")</code>.</p>
-               </item>
-            </ulist>
-            
-            <note><p>The concise syntax is introduced in 4.0 because a compact notation aids readability
-            in simple higher-order function calls such as <code>fn:sort(//emp, (), ($e) -> {$e/@salary})</code>,
-            and also because it is familiar to users of other popular languages such as Java, C#, and Javascript.</p></note>
-            
-            <note><p>The grammar for lambda expressions involves unbounded lookahead: given an expression that starts
-            <code>($a, $b, $c, ...)</code> it is not possible to establish unambiguously that this introduces a lambda
-            expression until the arrow symbol (<code>-></code>) is encountered. Various strategies can be used
-            to address this difficulty.</p></note>
-         </div4>-->
+         
             
             <div4 id="id-function-identity" diff="add" at="2023-05-25">
                <head>Function Identity</head>
@@ -9240,7 +9186,7 @@ return
                            When <code>$p</code> is called inside the predicate, <termref
                               def="dt-coercion-rules"
                               >coercion</termref> 
-                           and SequenceType matching rules are applied to the context item argument,
+                           and SequenceType matching rules are applied to the context value argument,
             resulting in an <code>xs:string</code> value or a type error.
           </p>
                      </item>
@@ -9367,26 +9313,56 @@ return filter($days,$m)
          </scrap>
          <p>
             <termdef id="dt-path-expression" term="path expression"
-                  >A <term>path expression</term> can be used to locate nodes
-	 within trees. A path expression consists of a series of one or more
-	 <termref
-                  def="dt-step"
+                  >A path expression consists of a series of one or more
+	              <termref def="dt-step"
                   >steps</termref>, separated by <code>/</code> or
 	 <code>//</code>, and optionally beginning with
-	 <code>/</code> or <code>//</code>.</termdef> An initial
+               <code>/</code> or <code>//</code>.  
+               A <term>path expression</term> is typically used to locate nodes
+               within trees. </termdef></p>
+         
+         <p>Absolute path expressions (those starting with an initial <code>/</code>
+            or <code>//</code>), start their selection from the root node of a tree;
+            relative path expressions (those without a leading <code>/</code> or
+            <code>//</code>) start from the <termref def="dt-context-value"/>.</p>
+         
+         <p>A path expression consisting of a single step is evaluated as
+            described in <specref ref="id-steps"/>.</p>
+         
+         <div3 id="id-absolute-path-expressions">
+            <head>Absolute Path Expressions</head>
+       
+            
+         <p>A path expression consisting of <code>/</code> on its own
+            is treated as an abbreviation for <code>/.</code>.</p>
+         
+        <!-- An initial
 	 <code>/</code> or <code>//</code> is an abbreviation for
 	 one or more initial steps that are implicitly added to the
-	 beginning of the path expression, as described below.</p>
-         <p>A
-	 path expression consisting of a single step is evaluated as
-	 described in <specref
-               ref="id-steps"/>.</p>
-         <p>A <code>/</code>
-	 at the beginning of a path expression is an abbreviation for
-	 the initial step <code>(fn:root(self::node()) treat as document-node())/</code> (however, if the
-	 <code>/</code> is the entire path expression, the trailing <code>/</code> is omitted from the expansion.) The effect
-	 of this initial step is to begin the path at the root node of
-	 the tree that contains the context node. If the context item
+	 beginning of the path expression, as described below.</p>-->
+         
+         <p>An expression of the form <code>/PP</code> (that is, a path expression
+            with a leading <code>/</code>) is treated as an abbreviation for
+	 the expression <code>self::node()/(fn:root(.) treat as document-node())/PP</code>. 
+            The effect of this expansion is that for every item <var>J</var> 
+            in the context value <var>V</var>:</p>
+	 
+	 <olist>
+	    <item><p>A <termref def="dt-type-error"/> occurs if <var>J</var> is not a node
+	       <errorref class="TY" code="0020"/>.</p></item>
+	    <item><p>The root node <var>R</var> of the tree containing <var>J</var> is selected.</p></item>
+	    <item><p>A <termref def="dt-dynamic-error"/> occurs if <var>R</var> is not a document node
+	       <errorref class="DY" code="0050"/>.</p></item>
+	    <item><p>The expression that follows the leading <code>/</code> is evaluated with 
+	       <var>R</var> as the context value.</p></item>
+	 </olist>
+         
+    <p>The results of these multiple evaluations are then combined into a single sequence;
+       if the result is a set of nodes, the nodes are delivered in document order with
+       duplicates eliminated.</p>
+       
+	 <!--is to begin the path at the root node of
+	 the tree that contains the context node. If the context value
 	 is not a node, a <termref
                def="dt-type-error">type
 	 error</termref> is raised <errorref class="TY" code="0020"
@@ -9395,20 +9371,36 @@ return filter($days,$m)
 	 not a document node, a <termref
                def="dt-dynamic-error">dynamic error</termref> is
 	 raised <errorref class="DY"
-               code="0050"/>.</p>
+               code="0050"/>.</p>-->
 
-         <p>A <code>//</code> at the beginning of a path expression
+         <p>An expression of the form <code>//PP</code> (that is, a path expression
+            with a leading <code>//</code>) is treated as an abbreviation for
+            the expression <code>self::node()/(fn:root(.) treat as document-node())/descendant-or-self:node()/PP</code>. 
+            The effect of this expansion is that for every item <var>J</var> 
+            in the context value <var>V</var>:</p>
+
+         <!--<p>A <code>//</code> at the beginning of a path expression
 	 is an abbreviation for the initial steps
-	 <code>(fn:root(self::node()) treat as
-	 document-node())/descendant-or-self::node()/</code> (however, <code>//</code> by itself is not a valid path expression <errorref
-               class="ST" code="0003"
-               />.)  The
-	 effect of these initial steps is to establish an initial node
-	 sequence that contains the root of the tree in which the
-	 context node is found, plus all nodes descended from this
-	 root.
-	 This node sequence is used as the input to subsequent steps
-	 in the path expression. If the context item is not a node, a
+	 <code>. ! (fn:root(self::node()) treat as
+	 document-node())/descendant-or-self::node()/</code> </p>-->
+         
+         
+         <olist>
+            <item><p>A <termref def="dt-type-error"/> occurs if <var>J</var> is not a node
+               <errorref class="TY" code="0020"/>.</p></item>
+            <item><p>The root node <var>R</var> of the tree containing <var>J</var> is selected.</p></item>
+            <item><p>A <termref def="dt-dynamic-error"/> occurs if <var>R</var> is not a document node
+               <errorref class="DY" code="0050"/>.</p></item>
+            <item><p>The descendants of <var>R</var> are selected, along with <var>R</var> itself.</p></item>
+            <item><p>For every node <var>D</var> in this set of nodes, the expression that 
+               follows the leading <code>//</code> is evaluated with <var>D</var> as the context value.</p></item>
+         </olist>
+         
+         <p>The results of these multiple evaluations are then combined into a single sequence;
+            if the result is a set of nodes, the nodes are delivered in document order with
+            duplicates eliminated.</p>
+         
+         <p>If the context value is not a node, a
 	 <termref
                def="dt-type-error">type error</termref> is
 	 raised <errorref class="TY" code="0020"
@@ -9424,13 +9416,18 @@ return filter($days,$m)
 	 nodes<phrase role="xpath"
                   > or namespace nodes</phrase>.</p>
          </note>
+         
+         <note>
+            <p>A <code>//</code> on its own is not allowed by the grammar.</p>
+         </note>
 
-         <p>
+         <!--<p>
          A path expression that starts with <code>/</code>
          or <code>//</code> selects nodes starting from the root of
-         the tree containing the context item; it is often referred to
+         the tree containing the context value; it is often referred to
          as an absolute path expression.
-         </p>
+         </p>-->
+         </div3>
 
          <div3 id="id-relative-path-expressions">
             <head>Relative Path Expressions</head>
@@ -9443,8 +9440,8 @@ return filter($days,$m)
             <p>
           A relative path expression is a path expression that selects
           nodes within a tree by following a series of steps starting
-          at the context node (which, unlike an absolute path
-          expression, may be any node in a tree).
+          at the nodes in the context value (which may be any kind of node,
+          not necessarily the root of the tree).
           </p>
             <p>
           Each non-initial occurrence of <code>//</code> in a path expression is
@@ -9457,8 +9454,7 @@ return filter($days,$m)
           as <code>((E1/E2)/E3)/E4</code>. The semantics of a path
           expression are thus defined by the semantics of the
           binary <code>/</code> operator, which is defined in
-          <specref
-                  ref="id-path-operator"/>.
+          <specref ref="id-path-operator"/>.
           </p>
 
             <note>
@@ -9475,7 +9471,9 @@ return filter($days,$m)
          </p>
             </note>
 
-            <p>The following example illustrates the use of relative path expressions.</p>
+            <p>The following example illustrates the use of relative path expressions.
+            In each case it is assumed that the context value is a single node,
+            referred to as the context node.</p>
 
             <example>
                <ulist>
@@ -9495,7 +9493,8 @@ return filter($days,$m)
 
 
             <note>
-               <p>Since each step in a path provides context nodes for the following step, in effect, only the last step in a path is allowed to return a sequence of non-nodes.</p>
+               <p>Since each step in a path provides context nodes for the following step, 
+                  in effect, only the last step in a path is allowed to return a sequence of non-nodes.</p>
             </note>
 
 
@@ -9541,18 +9540,26 @@ return filter($days,$m)
 
             </note>
 
-
-            <div4 id="id-path-operator">
+         </div3>
+            <div3 id="id-path-operator">
                <head>Path operator (<code>/</code>)</head>
 
-               <p>The path operator <code>/</code> is used to build expressions for locating nodes within trees. Its left-hand side expression must return a sequence of nodes. The operator returns either a sequence of nodes, in which case it additionally performs document ordering and duplicate elimination, or a sequence of non-nodes.</p>
+               <p>The path operator <code>/</code> is primarily used for 
+                  locating nodes within trees. Its left-hand operand must return 
+                  a sequence of nodes. The result of the operator is either a sequence of nodes
+                  (in document order, with no duplicates), or a sequence of non-nodes.</p>
 
-               <p>Each operation <code>E1/E2</code> is evaluated as follows: Expression <code>E1</code> is evaluated, and if the result is not a (possibly empty) sequence <code>S</code> of nodes, a <termref
-                     def="dt-type-error">type error</termref> is raised <errorref class="TY"
+               <p>The operation <code>E1/E2</code> is evaluated as follows: Expression <code>E1</code> 
+                  is evaluated, and if the result is not a (possibly empty) sequence <code>S</code> of nodes, 
+                  a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
                      code="0019"
-                     />. Each node in <code>S</code> then serves in turn to provide an inner focus (the node as the context item, its position in <code>S</code> as the context position, the length of <code>S</code> as the context size) for an evaluation of <code>E2</code>, as described in  <specref
+                     />. Each node in <code>S</code> then serves in turn to provide an inner focus 
+                  (the node as the context value, its position in <code>S</code> as the context 
+                  position, the length of <code>S</code> as the context size) for an evaluation 
+                  of <code>E2</code>, as described in  <specref
                      ref="eval_context"
-                     />. The sequences resulting from all the evaluations of <code>E2</code> are combined as follows:</p>
+                     />. The sequences resulting from all the evaluations of <code>E2</code> 
+                  are combined as follows:</p>
 
 
                <olist>
@@ -9604,7 +9611,7 @@ return filter($days,$m)
     else error()]]></eg>
                   <p>For a table comparing the step operator to the map operator, see <specref ref="id-map-operator"/>.</p>
                </note>
-            </div4>
+    
 
          </div3>
 
@@ -9635,33 +9642,46 @@ return filter($days,$m)
                   ref="id-postfix-expression"/>.</p>
             <p>
                <termdef term="axis step" id="dt-axis-step"
-                     >An <term>axis step</term> returns a sequence of nodes that are reachable from the context node via a specified axis. Such a step has two parts: an
+                     >An <term>axis step</term> returns a sequence of nodes that are 
+                  reachable from a starting node via a specified axis. Such a step has two parts: an
 		<term>axis</term>, which defines the "direction of
 		movement" for the step, and a <termref
                      def="dt-node-test"
                      >node test</termref>,
 		which selects nodes based on their kind, name, and/or
-		<termref
-                     def="dt-type-annotation"
-                  >type annotation</termref>.</termdef> If the context item is a node, an axis
+		<termref def="dt-type-annotation">type annotation</termref> .</termdef></p> 
+            
+            <p>If the context value is a 
+               sequence of zero or more nodes, an axis
 		step returns a sequence of zero or more
-		nodes; otherwise, a <termref
-                  def="dt-type-error">type error</termref> is
-		raised <errorref class="TY"
-                  code="0020"/>.   <phrase role="xpath"
-                     >The resulting node sequence is returned in <termref def="dt-document-order"
+		nodes; otherwise, a <termref def="dt-type-error">type error</termref> is
+		raised <errorref class="TY" code="0020"/>.</p>
+            
+            <p>The step expression <code>S</code> is equivalent to <code>./S</code>.
+               Thus, if the context value is a sequence containing multiple nodes,
+               the semantics of a step expression are equivalent to a path expression
+               in which the step is always applied to a single node. The following
+               description therefore explains the semantics for the case where
+               the context value is a single node, called the context node.</p>
+            
+            
+            <note><p>The equivalence of a step <code>S</code> to the
+            path expression <code>./S</code> means that 
+            <phrase role="xpath"
+                     >the resulting node sequence is returned in <termref def="dt-document-order"
                      >document
 	 order</termref>.</phrase>
-               <phrase role="xquery">If <termref def="dt-ordering-mode"
+               <phrase role="xquery">if <termref def="dt-ordering-mode"
                      >ordering mode</termref> is <code>ordered</code>, the resulting node sequence is returned in <termref
                      def="dt-document-order"
                      >document
 	 order</termref>; otherwise it is returned in <termref
                      def="dt-implementation-dependent"
-                  >implementation-dependent</termref> order.</phrase> An axis step may be either a <term>forward
+                  >implementation-dependent</termref> order.</phrase></p></note> 
+            
+            <p>An axis step may be either a <term>forward
 		step</term> or a <term>reverse step</term>, followed
-		by zero or more <termref
-                  def="dt-predicate">predicates</termref>.</p>
+		by zero or more <termref def="dt-predicate">predicates</termref>.</p>
 
             <p>In the <term>abbreviated syntax</term> for a step, the axis can
 		be omitted and other shorthand notations can be used as described in
@@ -9669,7 +9689,7 @@ return filter($days,$m)
                   ref="abbrev"/>.</p>
             <p>The unabbreviated syntax for an axis step consists of the axis name
 		and node test separated by a double colon. The result of the step consists of the nodes
-		reachable from the context node via the specified axis that have the node kind, name,
+		reachable from the starting node via the specified axis that have the node kind, name,
 		and/or <termref
                   def="dt-type-annotation"
                   >type annotation</termref> specified by the node test. For example, the
@@ -9681,7 +9701,7 @@ return filter($days,$m)
                   ref="node-tests"/>. Examples of
 		steps are provided in <specref ref="unabbrev"
                   /> and <specref ref="abbrev"/>.</p>
-
+            
             <div4 id="axes">
                <head>Axes</head>
                <scrap>
@@ -10285,7 +10305,7 @@ return filter($days,$m)
             </div4>
             <div4 id="implausible-axis-steps" diff="add" at="Issue602">
                <head>Implausible Axis Steps</head>
-               <p>Certain axis steps, given an inferred type for the context item, are
+               <p>Certain axis steps, given an inferred type for the context value, are
                classified as <termref def="dt-implausible"/>. During the static analysis
                phase, a processor <rfc2119>may</rfc2119> (subject to the rules in
                <specref ref="id-implausible-expressions"/>) report a static error
@@ -10293,19 +10313,21 @@ return filter($days,$m)
                <p>More specifically, an axis step is classified as <termref def="dt-implausible"/>
                if any of the following conditions applies:</p>
                <olist>
-                  <item><p>The inferred type of the context item is a node kind for which the
-                     specified axis is always empty: for example, the inferred type
-                     of the context item is <code>attribute()</code> 
+                  <item><p>The inferred item type of the context value is a node kind for which the
+                     specified axis is always empty: for example, the inferred item type
+                     of the context value is <code>attribute()</code> 
                      and the axis is <code>child</code>.</p></item>
                   <item><p>The node test exclusively selects node kinds that cannot appear
                   on the specified axis: for example, the axis is <code>child</code>
                   and the node test is <code>document-node()</code>.</p></item>
                   <item><p>In a schema-aware environment, when using the <code>child</code>,
                      <code>descendant</code>, <code>descendant-or-self</code>, or <code>attribute</code>
-                     axes, the inferred type of the
-                     context item has a content type that does not allow any node matching
-                  the node test to be present on the relevant axis. For example, if the inferred context item type
+                     axes, the inferred item type of the
+                     context value has a content type that does not allow any node matching
+                  the node test to be present on the relevant axis. For example, if the inferred
+                  item type of the context value 
                   is <code>schema-element(list)</code> and the relevant element declaration 
+                     (taking into account substitution group membership and wildcards) 
                      only allows <code>item</code> children,
                   the axis step <code>child::li</code> will never select anything and is therefore
                   classified as <termref def="dt-implausible"/>.</p></item>
@@ -10414,6 +10436,12 @@ fact that the final result of the step <phrase
                in reverse document order. In the second expression, the predicate applies to the result of
                a union expression, so nodes are counted in document order.</p>
             </note>
+            
+            <p>When the context value for evaluation of a step includes multiple nodes, the step is evaluated
+            separately for each of those nodes, and the results are combined. This means, for example, that
+            if the context value contains three <code>list</code> nodes, and each of those nodes has multiple
+               <code>item</code> children, then the step <code>item[1]</code> will deliver a sequence of three <code>item</code>
+               elements, namely the first <code>item</code> from each <code>list</code>.</p>
          </div3>
          <div3 id="unabbrev">
             <head>Unabbreviated Syntax</head>
@@ -10425,6 +10453,8 @@ called the <term>unabbreviated syntax</term>. In many common cases, it is
 possible to write path expressions more concisely using an <term>abbreviated
 syntax</term>, as explained in <specref
                   ref="abbrev"/>.</p>
+            
+            <p>These examples assume that the context value is a single node, referred to as the context node.</p>
 
             <ulist>
 
@@ -10796,12 +10826,12 @@ for <code
                         role="parse-test">../title</code> is short for <code role="parse-test"
                         >parent::node()/child::title</code> and so will select the <code>title</code> children of the parent of the context node.</p>
                   <note>
-                     <p>The expression <code>.</code>, known as a <term>context item
+                     <p>The expression <code>.</code>, known as a <term>context value
    expression</term>, is a <termref
                            def="dt-primary-expression"
                            >primary expression</termref>,
    and is described in <specref
-                           ref="id-context-item-expression"/>.</p>
+                           ref="id-context-value-expression"/>.</p>
                   </note>
                </item>
             </olist>
@@ -10809,7 +10839,7 @@ for <code
 
 
             <p>Here are some examples of path expressions that use the abbreviated
-syntax:</p>
+syntax. These examples assume that the context value is a single node, referred to as the context node:</p>
 
             <ulist>
 
@@ -14863,7 +14893,7 @@ input:</p>
          <p>The following example transforms the input document into a list in
 which each author’s name appears only once, followed by a list of
 titles of books written by that author. This example assumes that the
-context item is the <code>bib</code> element in the input
+context value is the <code>bib</code> element in the input
 document.</p>
 
 
@@ -15471,12 +15501,22 @@ map {
                   <prodrecap id="KeySpecifier" ref="KeySpecifier"/>
                </scrap>
 
-
+               
                <p>Unary lookup is used in predicates (e.g. <code>$map[?name='Mike']</code> or with the simple map operator (e.g. <code>$maps ! ?name='Mike'</code>). See <specref
                      ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
+               
+               
 
                <p>UnaryLookup returns a sequence of values selected from the
-  context item, which must be a map or array. If the context item is
+  context value.</p>
+               
+               <p>If the context value is anything other than a single item, the semantics
+                  of the expression <code>?KS</code> are defined to be equivalent to 
+                  the expression <code>. ! ?KS</code>. The remainder of this section 
+                  therefore explains the semantics on the assumption that the <termref def="dt-context-value"/>
+                  is a single item, referred to as the context item.</p>
+               
+               <p>The context item must be a map or array. If the context item is
   not a map or an array, a
   <termref
                      def="dt-type-error">type error</termref> is raised <errorref class="TY"
@@ -15524,7 +15564,7 @@ for $k in map:keys(.)
 return .($k)
 ]]></eg>
                      <note>
-                        <p>The order of keys in map:keys() is implementation-dependent, so
+                        <p>The order of keys in <code>map:keys()</code> is implementation-dependent, so
   the order of values in the result sequence is also
   implementation-dependent.</p>
                      </note>
@@ -15612,10 +15652,10 @@ return .($k)
                   </item>
                   <item>
                      <p>
-                        <code>?(3.5)</code> raises a type error if the context item is an array because the parameter must be an integer.</p>
+                        <code>?(3.5)</code> raises a type error if the context value is an array because the parameter must be an integer.</p>
                   </item>
                   <item role="xquery">
-                     <p>If the context item is an array, <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i)</code> does not raise a type error because the attribute is untyped.</p>
+                     <p>If the context value is an array, <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i)</code> does not raise a type error because the attribute is untyped.</p>
                      <p>But <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i+1)</code> does raise a type error
     because the <code>+</code> operator with an untyped operand returns a double.</p>
                   </item>
@@ -15720,21 +15760,21 @@ return .($k)
                <p>More specifically, a unary or postfix lookup is classified as 
                   <termref def="dt-implausible"/> if any of the following conditions applies:</p>
                <olist>
-                  <item><p>The inferred type of the left-hand operand (or the context item, in the case
+                  <item><p>The inferred type of the left-hand operand (or the context value, in the case
                   of a unary expression) is a record test (see <specref ref="id-record-test"/>),
                   and the <code>KeySpecifier</code> is an <code>IntegerLiteral</code>.
                   </p></item>
-                  <item><p>The inferred type of the left-hand operand (or the context item, in the case
+                  <item><p>The inferred type of the left-hand operand (or the context value, in the case
                      of a unary expression) is a record test (see <specref ref="id-record-test"/>),
                      and the <code>KeySpecifier</code> is an <code>NCName</code> or <code>StringLiteral</code>
                      that cannot validly appear as a field name in the record.
                   </p></item>
-                  <item><p>The inferred type of the left-hand operand (or the context item, in the case
+                  <item><p>The inferred type of the left-hand operand (or the context value, in the case
                      of a unary expression) is a map type,
                      and the inferred type of the <code>KeySpecifier</code>, after coercion, is a type that
                      is disjoint with the key type of the map.
                   </p></item>
-                  <item><p>The inferred type of the left-hand operand (or the context item, in the case
+                  <item><p>The inferred type of the left-hand operand (or the context value, in the case
                      of a unary expression) is an array type,
                      and the <code>KeySpecifier</code> is the <code>IntegerLiteral</code> <code>0</code> (zero).
                   </p></item>
@@ -15760,7 +15800,7 @@ return .($k)
             
             <p>When an atomic value belonging to one of these atomic types appears as the first operand
             of the postfix lookup operator, or when the unary lookup operator is evaluated with the
-            atomic value as the context item, the atomic value is implicitly converted to a map, and
+            atomic value as the context value, the atomic value is implicitly converted to a map, and
             the lookup operator is then applied to this map.</p>
             
             <p>The mappable atomic types are defined by the table below. For each mappable atomic
@@ -18845,8 +18885,9 @@ matching</termref>; otherwise it returns <code>false</code>. For example:</p>
                   <p>
                      <code role="parse-test">. instance of element()</code>
                   </p>
-                  <p>This example returns <code>true</code> if the context item is an element node or <code>false</code> if the context item is defined but is not an element node. 
-  If the context item is <xtermref
+                  <p>This example returns <code>true</code> if the context value is a
+                     single element node or <code>false</code> if the context value is defined 
+                     but is not a single element node. If the context value is <xtermref
                         spec="DM31" ref="dt-absent"/>, a <termref def="dt-dynamic-error"
                         >dynamic error</termref> is raised <errorref class="DY" code="0002"/>.</p>
                </item>
@@ -19358,9 +19399,17 @@ raised <errorref
     duplicates.
   </p>
 
-         <p>Each operation <code>E1!E2</code> is evaluated as follows: Expression <code>E1</code> is evaluated to a sequence <code>S</code>. Each item in <code>S</code> then serves in turn to provide an inner focus (the item as the context item, its position in <code>S</code> as the context position, the length of <code>S</code> as the context size) for an evaluation of <code>E2</code> in the <termref
+         <p>Each operation <code>E1!E2</code> is evaluated as follows: 
+            Expression <code>E1</code> is evaluated to a sequence <code>S</code>. 
+            Each item in <code>S</code> then serves in turn to provide an inner focus 
+            (the item as the context value, its position in <code>S</code> as the 
+            context position, the length of <code>S</code> as the context size) 
+            for an evaluation of <code>E2</code> in the <termref
                def="dt-dynamic-context"
-               >dynamic context</termref>. The sequences resulting from all the evaluations of <code>E2</code> are combined as follows: Every evaluation of <code>E2</code> returns a (possibly empty) sequence of items. These sequences are concatenated and returned. <phrase
+               >dynamic context</termref>. The sequences resulting from all the 
+            evaluations of <code>E2</code> are combined as follows: Every evaluation 
+            of <code>E2</code> returns a (possibly empty) sequence of items. 
+            These sequences are concatenated and returned. <phrase
                role="xquery" at="bug28862">If ordering mode is ordered, the</phrase>
             <phrase role="xpath" at="bug28862"
                >The</phrase> returned sequence preserves the orderings within and among the subsequences generated by the evaluations of <code>E2</code>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1236,10 +1236,10 @@ return $i/xx:bing]]>
       In invoking the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
 
 
-    <p>In a module's dynamic context, a variable value (or the context item) may <termref
-        def="dt-depends-on">depend on</termref> another variable value (or the context item).
-        <termdef id="dt-depends-on" term="depends on">A variable value (or the context item)
-          <term>depends on</term> another variable value (or the context item) if, during the
+    <p>In a module's dynamic context, a variable value (or the context value) may <termref
+        def="dt-depends-on">depend on</termref> another variable value (or the context value).
+        <termdef id="dt-depends-on" term="depends on">A variable value (or the context value)
+          <term>depends on</term> another variable value (or the context value) if, during the
         evaluation of the initializing expression of the former, the latter is accessed through the
         module context.</termdef></p>
 
@@ -1252,7 +1252,7 @@ return $i/xx:bing]]>
 declare variable $b := 1;
 declare function local:f() { $b }; </eg>
 
-    <p>A directed graph can be built with all variable values and the context item as nodes, and
+    <p>A directed graph can be built with all variable values and the context value as nodes, and
       with the <termref def="dt-depends-on">depend on</termref> relation as edges. This graph must
       not contain cycles, as it makes the population of the dynamic context impossible. If it is
       discovered, during static analysis or during dynamic evaluation, that such a cycle exists,
@@ -1308,50 +1308,57 @@ declare function local:f() { $b }; </eg>
 
   </div2>
 
-  <div2 id="id-context-item-declarations">
-    <head>Context Item Declaration</head>
+  <div2 id="id-context-value-declarations">
+    <head>Context Value Declaration</head>
 
     <scrap>
       <head></head>
-      <prodrecap id="ContextItemDecl" ref="ContextItemDecl"/>
+      <prodrecap id="ContextValueDecl" ref="ContextValueDecl"/>
     </scrap>
 
     <!-- ================================================================== -->
 
-    <p>A context item declaration allows a query to specify the <termref def="dt-static-type">static
-        type</termref>, value, or default value for the <termref def="dt-initial-context-item"
-        >initial context item</termref>.</p>
+    <p>A context value declaration allows a query to specify the <termref def="dt-static-type">static
+        type</termref>, value, or default value for the <termref def="dt-initial-context-value"
+        >initial context value</termref>.</p>
 
-    <p>Only the main module can set the value of the <termref def="dt-initial-context-item">initial
-        context item</termref>. In a library module, a context item declaration must be external,
+    <p>Only the main module can set the <termref def="dt-initial-context-value">initial
+        context value</termref>. In a library module, a context value declaration must be external,
       and specifies only the static type. Specifying a <nt def="VarValue">VarValue</nt> or <nt
-        def="VarDefaultValue">VarDefaultValue</nt> for a context item declaration in a library
+        def="VarDefaultValue">VarDefaultValue</nt> for a context value declaration in a library
       module is a static error <errorref class="ST" code="0113"/>.</p>
+    
+    <p>The form <code>declare context value</code> allows the <termref def="dt-initial-context-value"/>
+    to set to any value, with any sequence type. The alternative form <code>declare context item</code>
+    is retained for compatibility with earlier versions of XQuery, and requires the value to be a single
+    item, and the type (if specified) to be an item type.</p>
 
-    <p>In every module that does not contain a context item declaration, the effect is as if the
+    <p>In every module that does not contain a context value declaration, the effect is as if the
       declaration</p>
 
-    <eg>declare context item as item() external;</eg>
+    <eg>declare context value as item()* external;</eg>
 
     <p>appeared in that module.</p>
 
-    <p>During static analysis, the context item declaration has the effect of setting the context
-      item static type <code>T</code> in the static context. The context item static type is set to
-        <code>ItemType</code> if specified, or to <code>item()</code> otherwise.</p>
+    <p>The context value declaration has the effect of setting the context
+      value static type <code>T</code> in the static context.
+      When the form <code>declare context value</code> is used, the default type is <code>item()*</code>.
+      When the alternative form <code>declare context item</code> is used, the default type is
+      <code>item()</code>.</p>
 
-    <p>If a module contains more than one context item declaration, a static error is raised
+    <p>If a module contains more than one context value declaration, a static error is raised
         <errorref class="ST" code="0099"/>.</p>
 
     <p>The static context for an initializing expression includes all functions, variables, and
       namespaces that are declared or imported anywhere in the Prolog.</p>
 
-    <p>During query evaluation, a <termref def="dt-singleton-focus">singleton focus</termref> is
+    <p>During query evaluation, a <termref def="dt-fixed-focus">fixed focus</termref> is
       created in the dynamic context for the evaluation of the <code>QueryBody</code> in the main
       module, and for the initializing expression of every variable declaration in every module.
       
       
-      The context item of this singleton focus is called
-      the <termref def="dt-initial-context-item">initial context item</termref>,
+      The context value of this fixed focus is called
+      the <termref def="dt-initial-context-value">initial context value</termref>,
       which is selected as follows:
       
       </p>
@@ -1359,13 +1366,13 @@ declare function local:f() { $b }; </eg>
     <ulist>
       <item>
         <p>If <code>VarValue</code> is specified, then
-          the initial context item is
+          the initial context value is
           the result of evaluating <code>VarValue</code>.</p>
         <note>
           <p>
             In such a case,
-            the initial context item does not obtain its value from the external environment.
-            If the external environment attempts to provide a value for the initial context item,
+            the initial context value does not obtain its value from the external environment.
+            If the external environment attempts to provide a value for the initial context value,
             it is outside the scope of this specification
             whether that is ignored, or results in an error.
           </p>
@@ -1375,17 +1382,17 @@ declare function local:f() { $b }; </eg>
         <p>If <code>external</code> is specified, then:</p>
         <ulist>
           <item>
-            <p>If the declaration occurs in a main module and a value is provided for the context item by the external environment, then
-              the initial context item is
-              that value. <note><p>If the declaration occurs in a library module, then it does not set the value of the initial context item, the value is set by the main module.</p></note></p>
+            <p>If the declaration occurs in a main module and a value is provided for the context value by the external environment, then
+              the initial context value is
+              that value. <note><p>If the declaration occurs in a library module, then it does not set the value of the initial context value, the value is set by the main module.</p></note></p>
             <p>The means by which an external value is provided by the external environment is
               implementation-defined.</p>
           </item>
 
           <item>
-            <p>If no value is provided for the context item by the external environment, and
+            <p>If no value is provided for the context value by the external environment, and
                 <code>VarDefaultValue</code> is specified, then
-                the initial context item is
+                the initial context value is
                 the result of evaluating
                 <code>VarDefaultValue</code> as described below. </p>
           </item>
@@ -1394,10 +1401,10 @@ declare function local:f() { $b }; </eg>
       </item>
     </ulist>
 
-    <p>In all cases where the context item has a value, that value must match the type
+    <p>In all cases where the context value has a value, that value must match the type
         <code>T</code> according to the rules for SequenceType matching; otherwise a type error is
-      raised <errorref class="TY" code="0004"/>. If more than one module contains a context item
-      declaration, the context item must match the type declared in each one.</p>
+      raised <errorref class="TY" code="0004"/>. If more than one module contains a context value
+      declaration, the context value must match the type declared in each one.</p>
 
     <p>If <code>VarValue</code> or <code>VarDefaultValue</code> is evaluated, the static and dynamic
       contexts for the evaluation are the current module's static and dynamic context.</p>
@@ -1408,21 +1415,32 @@ declare function local:f() { $b }; </eg>
       In invoking the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
     
 
-    <p>Here are some examples of context item declarations.</p>
+    <p>Here are some examples of context value declarations.</p>
 
     <ulist>
       <item>
-        <p>Declare the type of the context item:</p>
+        <p>Declare the type of the context value as a single element item with a required element name:</p>
         <eg role="frag-prolog-parse-test">declare namespace env="http://www.w3.org/2003/05/soap-envelope"; 
 
 declare context item as element(env:Envelope) external;</eg>
 
       </item>
       <item>
-        <p>Declare a default context item, which is a system log in a default location. If the
+        <p>Declare a default context value, which is a system log in a default location. If the
           system log is in a different location, it can be specified in the external
           environment:</p>
-        <eg role="frag-prolog-parse-test">declare context item as element(sys:log) external := doc("/var/xlogs/sysevent.xml")/sys:log; </eg>
+        <eg role="frag-prolog-parse-test">declare context value as element(sys:log) external := doc("/var/xlogs/sysevent.xml")/sys:log; </eg>
+      </item>
+      
+      <item>
+        <p>Declare a context value, which is collection whose collection URI is supplied as an external
+          parameter to the query. If the
+          system log is in a different location, it can be specified in the external
+          environment:</p>
+        <eg role="frag-prolog-parse-test">declare variable $uri as xs:string external;
+declare context value as document-node()* := collection($uri); </eg>
+        <p>With this declaration, a query body such as <code>//person[name="Mandela"]</code> returns all matching
+        <code>person</code> elements appearing in any document in the collection.</p>
       </item>
     </ulist>
   </div2>
@@ -1501,8 +1519,8 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
           def="dt-in-scope-variables">in-scope variables</termref> component also includes the
         parameters of the function being declared. 
   
-        However, its <termref def="dt-context-item-static-type">context item static type</termref> component is <xtermref spec="DM31" ref="dt-absent"/>,
-        and an implementation should raise a static error <errorref class="ST" code="0008"/> if an expression depends on the context item.
+        However, its <termref def="dt-context-value-static-type">context value static type</termref> component is <xtermref spec="DM31" ref="dt-absent"/>,
+        and an implementation should raise a static error <errorref class="ST" code="0008"/> if an expression depends on the context value.
       </p>
       
       <p>The properties of the <termref def="dt-function-definition"/> <var>F</var> are derived from the syntax of the
@@ -1636,7 +1654,7 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
        simple literal or constant expression, for example
      <code>$married as xs:boolean := false()</code> or <code>$options as map(*) := map{}</code>. However, to allow greater flexibility,
      the initial value can also be context-dependent. For example, <code>$node as node() := .</code> declares a parameter whose
-     default value is the context item from the dynamic context of the caller, while <code>$collation as xs:string := default-collation()</code>
+     default value is the context value from the dynamic context of the caller, while <code>$collation as xs:string := default-collation()</code>
      declares a parameter whose default value is the default collation from the dynamic context of the caller.
      The detailed rules are as follows. In these rules, the term <term>caller</term> means the function call or function reference
      that invokes the function being defined.</p>
@@ -1649,7 +1667,7 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         <item><p>The <termref def="dt-in-scope-variables"/> component is empty. This means that the 
           initializing expression cannot refer to any variables, other than local variables declared within the expression itself. 
           Note in particular that it cannot refer to other parameters of the function.</p></item>
-        <item><p>The <termref def="dt-context-item-static-type"/> is <code>item()*</code>.</p></item>
+        <item><p>The <termref def="dt-context-value-static-type"/> is <code>item()*</code>.</p></item>
         <item><p>The <termref def="dt-statically-known-function-definitions"/> excludes all user-defined functions.</p></item>
       </ulist>
       


### PR DESCRIPTION
Fix #129 This replaces the previous attempt from several months ago, which had too many conflicts to be salvageable.

This is a wide-ranging and pervasive change, and I would like the changes to be applied promptly and incrementally to reduce the risk of conflicts, even if further work is needed later. This first PR addresses the XQuery and XPath language specifications. Further changes (in subsequent PRs) are needed for F+O and for XSLT. There are also a couple of minor changes affecting Serialization (but none affecting the data model).