### PR TITLE
372 Rollback the default namespace changes

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -559,7 +559,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>default</g:string>
     <g:choice name="DeclareDefaultElementOrFunction">
       <g:string process-value="yes">element</g:string>
-      <g:string process-value="yes" if="xquery40">type</g:string>
       <g:string process-value="yes">function</g:string>
     </g:choice>
     <g:string>namespace</g:string>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8139,8 +8139,8 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
       as the argument is resolved to a namespace URI using the statically known
       namespaces from the static context. If the lexical <code>xs:QName</code>
       has no prefix, the
-      namespace URI of the resulting expanded-QName is the default element/type
-      namespace from the static context. Components of the static context are
+      namespace URI of the resulting expanded-QName is the default namespace for elements and types,
+      taken from the static context. Components of the static context are
       defined in <xspecref spec="XP31" ref="static_context"/>. A dynamic error is raised <errorref class="NS" code="0004"/>
       if the prefix is not bound in the static context. As described in
       <xspecref spec="DM31" ref="terminology"/>, the supplied prefix is retained as part of the

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -436,26 +436,28 @@ and by <termref def="dt-namespace-decl-attr"
 
                <item>
                   <p diff="chg" at="A">
-                     <termdef id="dt-def-element-ns" term="default element namespace">
-                        <term>Default element namespace.</term> This is a
-				namespace URI or <xtermref
-                           spec="DM31" ref="dt-absent"
-                        />. The namespace URI, if present, is used for any unprefixed QName appearing in a
-				position where an element name is expected.</termdef> The URI value is
-whitespace-normalized according to the rules for the <code>xs:anyURI</code> type in <xspecref
-                        spec="XS1-2" ref="anyURI"/> or <xspecref spec="XS11-2" ref="anyURI"/>.</p>
+                     <termdef id="dt-default-namespace-elements-and-types" term="default namespace for elements and types">
+                        <term>Default namespace for elements and types.</term> This is a
+				namespace URI, <!--or the special value <code>"##any"</code>,--> or <xtermref spec="DM31" ref="dt-absent"
+                        />. This indicates how unprefixed QNames are interpreted when
+                        they appear in a position  where an element name or type name is expected.</termdef></p>
+                  <ulist>
+                     <item><p diff="chg" at="issue372">If the value is set to a namespace URI, 
+                        this namespace is used for any such unprefixed QName. The URI value is
+               whitespace-normalized according to the rules for the <code>xs:anyURI</code> type in <xspecref
+                           spec="XS1-2" ref="anyURI"/> or <xspecref spec="XS11-2" ref="anyURI"/>.</p></item>
+                     <!--<item><p diff="chg" at="issue372">The special value <code>"##any"</code> indicates that
+                        for an unprefixed QName used as a <termref def="dt-name-test"/> for selecting
+                        named elements in an <termref def="dt-axis-step"/>, all elements with a matching
+                        local name will be selected, regardless of their namespace (or lack of it). 
+                        For an unprefixed QName representing an element or type
+                        name in any other context, the name is interpreted as being in no namespace.</p></item>-->
+                     <item><p diff="chg" at="issue372">If the value is <xtermref spec="DM31" ref="dt-absent"/>,
+                        an unprefixed QName representing an element or type
+                        name is interpreted as being in no namespace.</p></item>
+                  </ulist> 
                </item>
-
-               <item>
-                  <p diff="add" at="A">
-                     <termdef id="dt-def-type-ns" term="default type namespace">
-                        <term>Default type namespace.</term> This is a namespace URI or <xtermref
-                           spec="DM31" ref="dt-absent"
-                        />. The namespace URI, if present, is used for any unprefixed QName appearing in a
-		                      position where a type name is expected.</termdef> The URI value is
-		                   whitespace-normalized according to the rules for the <code>xs:anyURI</code> type in <xspecref
-                        spec="XS1-2" ref="anyURI"/> or <xspecref spec="XS11-2" ref="anyURI"/>.</p>
-               </item>
+               
 
 
                <item>
@@ -2130,8 +2132,7 @@ The name of each option is the same as the name of the corresponding serializati
 and the values permitted for each option are the same as the values allowed in the serialization parameter element. 
 For QName values, prefixes are
 expanded to namespace URIs by means of the statically known namespaces, or 
-if unprefixed, <phrase
-                  diff="chg" at="A">the default element namespace</phrase>.</p>
+if unprefixed, the <termref def="dt-default-namespace-elements-and-types"/>.</p>
 
             <p role="xquery"
                >There is no output declaration for <code>use-character-maps</code>, it can be set only by means of a parameter document. 
@@ -3870,10 +3871,7 @@ types</term> (such as <code>xs:integer</code>) and function types
 		  <termref
                   def="dt-static-namespaces"
                   >statically known namespaces</termref> and (where applicable) the
-		  <phrase
-                  diff="chg" at="A"><termref def="dt-def-element-ns"
-                     >default element namespace</termref>
-               or <termref def="dt-def-type-ns">default type namespace</termref></phrase>.
+		    <termref def="dt-default-namespace-elements-and-types"/>.
       Equality of QNames is defined by the <code>eq</code> operator.</p>
 
 
@@ -4174,8 +4172,8 @@ the schema type named <code>us:address</code>.</p>
             <olist diff="add" at="A">
                <item><p>If the name is written as a lexical QName, then it is expanded using the
                <termref def="dt-in-scope-namespaces"/> in the <termref def="dt-static-context"/>. If the
-               name is an unprefixed <code>NCName</code>, then it is taken as being in the
-               <termref def="dt-def-type-ns"/>.</p></item>
+               name is an unprefixed <code>NCName</code>, then it is expanded according to the
+                  <termref def="dt-default-namespace-elements-and-types"/>.</p></item>
                <item><p>If the name matches an entry in the <termref def="dt-item-type-aliases"/> in the <termref def="dt-static-context"/>,
                   then it is taken as a reference to the corresponding item type. The rules that
                apply are the rules for the expanded item type definition.</p></item>
@@ -4348,7 +4346,8 @@ the schema type named <code>us:address</code>.</p>
                </ulist>
                
                <p diff="add" at="A">In these constructs, the type name <var>T</var> is expanded using the <termref def="dt-in-scope-namespaces"/>
-               in the <termref def="dt-static-context"/>, using the <termref def="dt-def-type-ns"/> if it is unprefixed. The resulting
+                  in the <termref def="dt-static-context"/>, using the <termref def="dt-default-namespace-elements-and-types"/> 
+                  if it is unprefixed. The resulting
                QName must identify a type in the <termref def="dt-issd"/>. This can be any <termref def="dt-schema-type"/>: either a simple type,
                or (except in the case of attributes) a complex type. If it is a simple type then it can be an atomic, union, or
                list type. It can be a built-in type (such as <code>xs:integer</code>) or a user-defined type. It must however
@@ -4488,15 +4487,15 @@ the schema type named <code>us:address</code>.</p>
                      def="dt-type-annotation">type annotation</termref>.
   </p>
                
-               <p diff="chg" at="Issue23">An unprefixed <nt def="EQName">EQName</nt>
-                  within the <code>NameTestUnion</code> refers to a name in the 
-                  <termref def="dt-def-element-ns">default element namespace</termref>.
+               <p diff="chg" at="Issue372">An unprefixed <nt def="EQName">EQName</nt>
+                  within the <code>NameTestUnion</code> is interpreted according to the
+                  <termref def="dt-default-namespace-elements-and-types"/>.
                   The name need not be present in the <termref
                      def="dt-is-attrs">in-scope element declarations</termref>.</p>
                
                <p diff="chg" at="Issue23">An unprefixed <nt def="TypeName"
-                  >TypeName</nt> refers to a name in the
-                  <phrase diff="chg" at="A"><termref def="dt-def-type-ns">default type namespace</termref></phrase>.
+                  >TypeName</nt> is interpreted according to the
+                  <termref def="dt-default-namespace-elements-and-types"/>.
                   The <nt def="TypeName">TypeName</nt> must be present in the <termref def="dt-is-types"
                      >in-scope schema types</termref>
                   <errorref class="ST" code="0008"/>                 
@@ -4560,7 +4559,7 @@ type annotation.</p>
                      <p>
                         <code role="parse-test"
                            >element(person)</code> matches any element node whose name is <code>person</code>,
-                     in the default namespace for elements.</p>
+                        in the <termref def="dt-default-namespace-elements-and-types"/>.</p>
                   </item>
                   
                   <item>
@@ -4568,7 +4567,7 @@ type annotation.</p>
                         <code role="parse-test"
                            >element(doctor|nurse)</code> matches any element node whose name is 
                         <code>doctor</code> or <code>nurse</code>,
-                        in the default namespace for elements.</p>
+                        in the <termref def="dt-default-namespace-elements-and-types"/>.</p>
                   </item>
 
                   <item diff="add" at="A">
@@ -4657,10 +4656,10 @@ matches any nilled or non-nilled element node whose type annotation is
     <termref
                      def="dt-static-namespaces"
                      >statically known namespaces</termref>, or if unprefixed, the
-    <phrase
-                     diff="chg" at="A"><termref def="dt-def-element-ns"
-                        >default element namespace</termref></phrase>.
-
+                  is interpreted according to the
+                  <termref def="dt-default-namespace-elements-and-types"/>.<!-- If this has the special
+                  value <code>"##any"</code>, an unprefixed name represents a name in no namespace.
+-->
     If the <nt
                      def="ElementName">ElementName</nt> specified in the <nt def="SchemaElementTest"
                      >SchemaElementTest</nt>
@@ -4753,8 +4752,8 @@ in the following two situations:
                      def="dt-is-attrs">in-scope attribute declarations</termref>.</p>
                
                <p diff="chg" at="Issue23">An unprefixed <nt def="TypeName"
-                  >TypeName</nt> is in the
-                  <phrase diff="chg" at="A"><termref def="dt-def-type-ns">default type namespace</termref></phrase>.
+                  >TypeName</nt> is interpreted according to the
+                  <termref def="dt-default-namespace-elements-and-types"/>.
                   The <nt def="TypeName">TypeName</nt> must be present in the <termref def="dt-is-types"
                         >in-scope schema types</termref>
                   <errorref class="ST" code="0008"/>
@@ -6595,7 +6594,8 @@ and <nt def="OrExpr"
             <item>
                <p>If the <code role="xquery">URILiteral</code><code role="xpath">StringLiteral</code> is a zero-length string:</p>
                <ulist>
-                  <item><p>The <termref def="dt-def-element-ns"/> is set to <emph>absent</emph>, meaning
+                  <item><p>The is interpreted according to the
+                     <termref def="dt-default-namespace-elements-and-types"/> is set to <emph>absent</emph>, meaning
                   that unprefixed element names are treated as being in no namespace.</p></item>
                   <item><p>Any binding for the zero-length prefix in the 
                      <termref def="dt-static-namespaces"/> is removed.</p></item>
@@ -6604,7 +6604,8 @@ and <nt def="OrExpr"
             <item>
                <p>If the <code role="xquery">URILiteral</code><code role="xpath">StringLiteral</code> is not zero-length:</p>
                <ulist>
-                  <item><p>The <termref def="dt-def-element-ns"/> is set to the supplied namespace URI, meaning
+                  <item><p>The is interpreted according to the
+                     <termref def="dt-default-namespace-elements-and-types"/> is set to the supplied namespace URI, meaning
                      that unprefixed element names are treated as being in that namespace.</p></item>
                   <item><p>A binding that maps the zero-length prefix to the specified namespace URI is
                      added to the <termref def="dt-static-namespaces"/>.</p></item>
@@ -10075,11 +10076,16 @@ return filter($days,$m)
           An unprefixed QName, when used as a
 		  name test on an axis whose <termref
                      def="dt-principal-node-kind"
-                     >principal node kind</termref> is
-		  element, has the namespace URI of the <termref
-                     def="dt-def-element-ns" diff="chg" at="A"
-                  >default element namespace</termref> in
-		  the expression context; otherwise, it has no namespace URI. </p>
+                     >principal node kind</termref> is interpreted as follows:</p>
+               <ulist>
+                  <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is a namespace URI,
+                  then the name is interpreted as having that namespace URI.</p></item>
+                  <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is absent,
+                     then the name is interpreted as being in no namespace.</p></item>
+                  <!--<item><p>If the <termref def="dt-default-namespace-elements-and-types"/> has the special value <code>"##any"</code>,
+                     then the name is treated as a wildcard matching names in any namespace: that is,
+                     the unprefixed name <code>N</code> is treated as <code>*:N</code>, described below.</p></item>-->
+               </ulist>
                <p>A name test is not satisfied by an element node whose name does not match the <termref
                      def="dt-expanded-qname"
                      >expanded QName</termref> of the name test, even if it is in a <termref
@@ -10122,9 +10128,11 @@ return filter($days,$m)
 		  to which the prefix is bound, regardless of the
 		  local part of the name.</p>
 
-               <p>A node test can contain a BracedURILiteral, e.g.
+               <p>A node test can contain an <nt def="BracedURILiteral">BracedURILiteral</nt>, for example
 		  <code role="parse-test"
-                     >Q{http://example.com/msg}*</code> Such a node test is true for any node of the principal node kind of the step axis whose expanded QName has the namespace URI specified in the BracedURILiteral, regardless of the local part of the name.</p>
+                     >Q{http://example.com/msg}*</code> Such a node test is true for any node of the principal 
+                  node kind of the step axis whose expanded QName has the namespace URI specified in 
+                  the <nt def="BracedURILiteral">BracedURILiteral</nt>, regardless of the local part of the name.</p>
 
                <p>A node test can also
 		  have the form <code role="parse-test"
@@ -12541,15 +12549,10 @@ that creates a <code>book</code> element containing an attribute and some nested
                is resolved to a namespace URI using the <termref
                   def="dt-static-namespaces"
                   >statically known namespaces</termref>. 
-               If the element name  has no namespace prefix, it is implicitly qualified by the
-               <phrase diff="chg" at="A">namespace bound to the zero-length prefix in the
-               statically known namespaces</phrase>: if there is no such binding, then the expanded
-               name of the element will be in no namespace.</p>
-               <note><p>Both the statically known namespaces and the <phrase
-                  diff="chg" at="A"
-                  >default element namespace</phrase> 
-               may be affected by <termref
-                  def="dt-namespace-decl-attr"
+               If the element name  has no namespace prefix, it is interpreted according to
+               the <termref def="dt-default-namespace-elements-and-types"/>.</p>
+            <note><p>Both the statically known namespaces and the <termref def="dt-default-namespace-elements-and-types"/> 
+               may be affected by <termref def="dt-namespace-decl-attr"
                   >namespace declaration attributes</termref> 
                found inside the element constructor.</p></note>
             <p>The namespace prefix of the element name is retained after 
@@ -12850,51 +12853,27 @@ attribute is processed as follows:</p>
              </p>
                   </item>
 
-                  <item diff="chg" at="A">
+                  <item>
                      <p>If the name of the namespace declaration attribute is <code>xmlns</code>
-                with no prefix, then a binding of the zero-length prefix to the namespace URI
-                is added to the  <termref def="dt-static-namespaces">statically known namespaces</termref>
-                        of the constructor expression (overriding any existing binding of
-                        the zero-length prefix),
-                and is also added (with no prefix) to the
-                <termref
-                           def="dt-in-scope-namespaces"
-                           >in-scope namespaces</termref>
-                of the constructed element (overriding any existing namespace binding
-                with no prefix). If the namespace URI is a zero-length string then any no-prefix
+                with no prefix, then the namespace URI specifies the 
+                        <termref def="dt-default-namespace-elements-and-types"/> 
+                        of the constructor expression (overriding any existing default), 
+                        and is added (with no prefix) to the <termref
+                           def="dt-in-scope-namespaces">in-scope namespaces</termref> of the constructed element 
+                (overriding any existing binding of the zero-length prefix).</p>
+                     <p>If the namespace URI is a zero-length string then 
+                        the <termref def="dt-default-namespace-elements-and-types"/> of the constructor expression
+                        is set to <xtermref ref="dt-absent" spec="DM31"/>,
+                        and any no-prefix
                 namespace binding is removed from the
                 <termref
                            def="dt-in-scope-namespaces"
                         >in-scope namespaces</termref>
                 of the constructed element.
              </p>
-                     <p diff="chg" at="A">For backwards compatibility reasons, if the query prolog does not contain an explicit
-                        default type namespace declaration, then the
-                        <termref def="dt-def-element-ns">default element namespace</termref>
-                           and <termref def="dt-def-type-ns">default type namespace</termref>
-                        of the constructor expression are set to <xtermref
-                           spec="DM31" ref="dt-absent"/>.
-                    </p>
-                     <note diff="chg" at="A"><p>In earlier versions of XQuery,
-                        given the expression <code><![CDATA[<output xmlns="">{$x/input}</output>]]></code>,
-                        both the unprefixed names <code>output</code> and <code>input</code> were
-                        interpreted as no-namespace names. Furthermore, the <code>xmlns=""</code>
-                        declaration would affect the interpretation
-                        of any unprefixed type names (though in practice, unprefixed type names were rarely used.)
-                        This behavior is retained in XQuery 4.0 for compatibility reasons. 
-                        However, the behavior can be changed by adding
-                        a declaration such as <code>declare default type namespace "http://www.w3.org/2001/XMLSchema"</code>
-                        to the query prolog. If a default type namespace is declared, then the attribute <code>xmlns=""</code>
-                        only affects the <code>output</code> namespace, not the <code>input</code> namespace; it also has
-                        no effect on unprefixed type names.
                      
-                     </p>
-                        <p>The same applies to a default namespace declaration such as 
-                           <code>xmlns="http://www.w3.org/1999/xhtml/</code>. If a default type namespace
-                        is declared, the default namespace declaration only affects names used in element constructors,
-                        it no longer affects the interpretation of names in path expressions. This removes a
-                        usability problem that otherwise arises when the input is no-namespace XML and the output
-                        is XHTML.</p></note>
+         
+                    
                   </item>
 
                   <item>
@@ -12933,12 +12912,9 @@ attribute is processed as follows:</p>
 
                   <item>
                      <p>In this element constructor, a namespace declaration attribute
-                        is used to set the <phrase
-                           diff="chg" at="A"><termref def="dt-def-element-ns"
-                              >default element namespace</termref>
-                           and <termref def="dt-def-type-ns">default type namespace</termref></phrase> 
+                        is used to set the <termref def="dt-default-namespace-elements-and-types"/> 
                         to <code>http://example.org/animals</code>:<eg
-                           role="parse-test"><![CDATA[<cat xmlns = "http://example.org/animals">
+                           role="parse-test"><![CDATA[<cat xmlns="http://example.org/animals">
   <breed>Persian</breed>
 </cat>]]></eg>
                      </p>
@@ -13632,8 +13608,8 @@ if the EQName is a  <termref
                            >expanded QName</termref> <phrase diff="add" at="A">as follows:</phrase></p>
                      <olist>
                         <item><p>Leading and trailing whitespace is removed.</p></item>
-                        <item><p>If the value is an unprefixed <code>NCName</code>, it is treated as a local name in the <termref
-                           def="dt-def-element-ns">default element namespace</termref>.</p></item>
+                        <item><p>If the value is an unprefixed <code>NCName</code>, it is interpreted
+                           according to the <termref def="dt-default-namespace-elements-and-types"/>.</p></item>
                         <item><p>If the value is a lexical QName with a prefix, that prefix is <termref
                            def="dt-resolve-relative-uri">resolved to a namespace URI</termref> using the <termref
                               def="dt-static-namespaces">statically known namespaces</termref>.</p></item>
@@ -19048,9 +19024,7 @@ The <phrase diff="chg" at="A">target type</phrase> must be either of:</p>
                <p>Otherwise, a static error is raised <errorref class="ST" code="0080"/>.</p> 
             <p>The optional occurrence indicator <code>?</code> denotes that an empty
 sequence is permitted.</p> 
-            <p>If the target type is a lexical QName that has no namespace prefix, it
-is considered to be in the <termref def="dt-def-type-ns" diff="chg" at="A">default type
-namespace</termref>.</p>
+            
 
             <p>Casting a node to <code>xs:QName</code> can cause surprises because it uses the static context of the cast expression to provide the namespace bindings for this operation. 
 Instead of casting to <code>xs:QName</code>, it is generally preferable to use the <code>fn:QName</code> function, which allows the namespace context to be taken from the document containing the QName.</p>
@@ -19275,8 +19249,8 @@ usa:zipcode?)</code>.</p>
                <eg role="parse-test"><![CDATA[17 cast as Q{}apple]]></eg>
                <eg role="parse-test"><![CDATA[Q{}apple(17)]]></eg>
                <p diff="chg" at="A">In either context, using an unqualified NCName might not work:
-                  in a cast expression, an unqualified name is resolved using the 
-                  <termref def="dt-def-type-ns" diff="chg" at="A">default type namespace</termref>,
+                  in a cast expression, an unqualified name is it is interpreted
+                  according to the <termref def="dt-default-namespace-elements-and-types"/>,
                   while an unqualified name in a constructor function call is resolved using the
                   <termref def="dt-default-function-namespace"/> which will often be inappropriate.
                </p>
@@ -19696,8 +19670,7 @@ raised <errorref
                def="dt-static-error">static error</termref> is raised <errorref class="ST"
                code="0104"
             />.  If the type name is unprefixed, it is
-        interpreted as a name in the default namespace for elements and
-        types. 
+        interpreted as a name in the <termref def="dt-default-namespace-elements-and-types"/>.
     </p>
 
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -474,8 +474,7 @@ return (
       The schema import may bind a namespace prefix to the target namespace of the imported schema,
       adding the (prefix, URI) pair to the <termref def="dt-static-namespaces">statically known
         namespaces</termref>, or it may declare that target namespace to be the <termref
-        def="dt-def-elem-ns">default element namespace</termref> <phrase diff="add" at="A">and the 
-          <termref def="dt-def-type-ns">default type namespace</termref></phrase>. The schema import may
+        def="dt-default-namespace-elements-and-types"/>. The schema import may
       also provide optional hints for locating the schema.</p>
     <p>The namespace prefix specified in a schema import must not be <code>xml</code> or
         <code>xmlns</code>
@@ -896,51 +895,42 @@ return $i/xx:bing]]>
     <ulist>
       
       <item>
-        <p><termdef id="dt-def-elem-ns" term="default element namespace">PLACEHOLDER</termdef></p>
-        <p>A <term>default element namespace declaration</term> declares a namespace URI that
-          is associated with unprefixed names of elements <phrase diff="del" at="A"> and types</phrase>. 
-          This declaration is recorded as
-          the <termref def="dt-def-elem-ns" diff="chg" at="A">default element namespace</termref> in the
-          <termref def="dt-static-context">static context</termref>. A <termref def="dt-prolog"
+        <p>A <term>default element namespace declaration</term> declares how unprefixed element and type
+          names are to be interpreted. The relevant value 
+          is recorded as the <termref def="dt-default-namespace-elements-and-types"/> in the
+          <termref def="dt-static-context">static context</termref> for the query module. A <termref def="dt-prolog"
             >Prolog</termref> may contain at most one default element namespace declaration
           <phrase diff="add" at="A">and it must not contain
           both a default element namespace declaration and an <code>import schema</code> declaration
-            that specifies a default element namespace</phrase> <errorref class="ST" code="0066"/> . 
-          If the <nt def="URILiteral">URILiteral</nt> in a
-          default <phrase diff="chg" at="A">element</phrase> namespace declaration is a zero-length string, the <termref
-            def="dt-def-elem-ns" diff="chg" at="A">default element namespace</termref> is undeclared (set to
-          <xtermref spec="DM31" ref="dt-absent"/>), and unprefixed names of elements <phrase diff="del" at="A">and types</phrase> are
-          considered to be in no namespace. The following example illustrates the declaration of a
+            that specifies a default element namespace</phrase> <errorref class="ST" code="0066"/>.</p>
+          <p>The <code>URILiteral</code> may take one of the following forms:</p>
+          <ulist>
+            <item><p>A namespace URI. This namespace will be used for all unprefixed names appearing
+            where an element or type name is expected.</p></item>
+            <item><p>The empty string <code>""</code>. In this case unprefixed names appearing where
+              an element or type name is expected are treated as being in no namespace: the
+              <termref def="dt-default-namespace-elements-and-types"/> is set to <xtermref spec="DM31" ref="dt-absent"/>.</p></item>
+            <!--<item><p>The string <code>"##any"</code>. In this case an unprefixed name appearing
+              as a <nt def="NameTest">NameTest</nt> in an axis step whose principal node kind is element
+              is interpreted as a wildcard (the unprefixed name <code>N</code> is treated as equivalent
+              to the wildcard <code>*:N</code>), while an unprefixed name appearing in any other context
+              where an element or type name is expected is treated as being in no namespace.</p>
+            </item>-->
+          </ulist>
+          <p>The following example illustrates the declaration of a
           default namespace for elements<phrase diff="del" at="A"> and types</phrase>:</p>
         <eg role="frag-prolog-parse-test">declare default element namespace "http://example.org/names";</eg>
         
-        <p>If no default <phrase diff="chg" at="A">element</phrase> namespace declaration is present, unprefixed element <phrase diff="del" at="A">and type</phrase>
+        <p>If no default element namespace declaration is present, unprefixed element and type
           names are in no namespace (however, an implementation may define a different default as
           specified in <specref ref="id-xq-static-context-components"/>.)</p>
-        <p>A default element namespace declaration also establishes a binding for the zero-length prefix
-        in the <termref def="dt-static-namespaces"/>.</p>
-        <note diff="add" at="A">
-          <p>The default element namespace is used primarily for resolving unprefixed element names appearing
-          in path expressions such as <code>/orders/order/price</code>. The binding for the zero-length prefix
-            in the <termref def="dt-static-namespaces"/> is used primarily for resolving unprefixed element
-          names in <termref def="dt-direct-elem-const">direct element constructors</termref> such as 
-            <code><![CDATA[<orders>{$x}</orders>]]></code>. Although the
-          default element namespace declaration sets both to the same namespace, they can be different
-          within the query: the binding for the zero-length prefix is affected by the presence of
-          a a <termref
-            def="dt-namespace-decl-attr">namespace declaration attribute</termref> 
-            (such as <code>xmlns=""</code>)in a <termref
-              def="dt-direct-elem-const">direct element constructor</termref></p>
-          <p>In the absence of a default type namespace declaration, 
-            such a <termref def="dt-namespace-decl-attr">namespace declaration attribute</termref> also
-            overrides the default element namespace.</p>
-        </note>
-        <p diff="add" at="A">For backwards compatibility reasons, if the prolog contains a default element namespace
-        declaration and no default type namespace declaration, then the default namespace for types is set to be the
-        same as the default namespace for elements.</p>
+        <!--<p>A default element namespace declaration also establishes a binding for the zero-length prefix
+        in the <termref def="dt-static-namespaces"/>.</p>-->
+        
+ 
         
       </item>
-      <item diff="add" at="A">
+      <!--<item diff="add" at="A">
         <p>A <term>default type namespace declaration</term> declares a namespace URI that
           is associated with unprefixed names of types. 
           This declaration is recorded as
@@ -977,7 +967,7 @@ return $i/xx:bing]]>
         <p diff="add" at="A">For backwards compatibility reasons, if the prolog contains a default element namespace
           declaration and no default type namespace declaration, then the default namespace for types is set to be the
           same as the default namespace for elements.</p>
-      </item>
+      </item>-->
       <item>
         <p>A <term>default function namespace declaration</term> declares a namespace URI that is
           associated with unprefixed function names in static function calls and function

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -40,12 +40,6 @@
       <e:attribute name="default-collation" required="no">
          <e:data-type name="uris"/>
       </e:attribute>
-      <e:attribute name="default-element-namespace" required="no">
-         <e:data-type name="uri"/>
-      </e:attribute>
-      <e:attribute name="default-type-namespace" required="no">
-         <e:data-type name="uri"/>
-      </e:attribute>
       <e:attribute name="extension-element-prefixes" required="no">
          <e:data-type name="prefixes"/>
       </e:attribute>
@@ -179,12 +173,6 @@
       <e:attribute name="default-collation">
          <e:data-type name="uris"/>
       </e:attribute>
-      <e:attribute name="default-element-namespace">
-         <e:data-type name="uri"/>
-      </e:attribute>
-      <e:attribute name="default-type-namespace">
-         <e:data-type name="uri"/>
-      </e:attribute>
       <e:attribute name="extension-element-prefixes">
          <e:data-type name="prefixes"/>
       </e:attribute>
@@ -230,12 +218,6 @@
       </e:attribute>
       <e:attribute name="default-collation">
          <e:data-type name="uris"/>
-      </e:attribute>
-      <e:attribute name="default-element-namespace">
-         <e:data-type name="uri"/>
-      </e:attribute>
-      <e:attribute name="default-type-namespace">
-         <e:data-type name="uri"/>
       </e:attribute>
       <e:attribute name="extension-element-prefixes">
          <e:data-type name="prefixes"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -2965,9 +2965,7 @@
                <termdef id="dt-standard-attributes" term="standard attributes">There are a number of
                      <term>standard attributes</term> that may appear on any <termref def="dt-xslt-element">XSLT element</termref>: specifically
                      <code>default-collation</code>, 
-                     <code diff="add" at="2022-01-01">default-element-namespace</code>, 
                      <code>default-mode</code>,
-                     <code diff="add" at="2022-01-01">default-type-namespace</code>, 
                      <code>default-validation</code>,
                      <code>exclude-result-prefixes</code>, <code>expand-text</code>, <code>extension-element-prefixes</code>,
                      <code>use-when</code>, <code>version</code>, and
@@ -2976,9 +2974,7 @@
             <p>These attributes may also appear on a <termref def="dt-literal-result-element">literal result element</termref>, but in this case, to distinguish them from
                user-defined attributes, the names of the attributes are in the <termref def="dt-xslt-namespace">XSLT namespace</termref>. They are thus typically written
                as <code>xsl:default-collation</code>,
-               <code diff="add" at="2022-01-01">xsl:default-element-namespace</code>,
                <code>xsl:default-mode</code>, 
-               <code diff="add" at="2022-01-01">xsl:default-type-namespace</code>,
                <code>xsl:default-validation</code>,
                   <code>xsl:exclude-result-prefixes</code>, <code>xsl:expand-text</code>, 
                <code>xsl:extension-element-prefixes</code>, <code>xsl:use-when</code>,
@@ -2996,8 +2992,6 @@
                the XSLT namespace have the same effect; the XSLT namespace is used for the attribute
                if and only if its parent element is <emph>not</emph> in the XSLT namespace.</p>
             <p>In the case of <code>[xsl:]default-collation</code>, 
-               <code diff="add" at="2022-01-01">[xsl:]default-element-namespace</code>,
-               <code diff="add" at="2022-01-01">[xsl:]default-type-namespace</code>, 
                <code>[xsl:]expand-text</code>, 
                <code>[xsl:]version</code>, and <code>[xsl:]xpath-default-namespace</code>, the value
                can be overridden by a different value for the same attribute appearing on a
@@ -3037,15 +3031,7 @@
                      </p>
                   </def>
                </gitem>
-               <gitem diff="add" at="2022-01-01">
-                  <label>
-                     <code>[xsl:]default-element-namespace</code>
-                  </label>
-                  <def>
-                     <p>see <specref ref="unprefixed-qnames"/>
-                     </p>
-                  </def>
-               </gitem>
+               
                
                <gitem>
                   <label>
@@ -3056,15 +3042,7 @@
                      </p>
                   </def>
                </gitem>
-               <gitem diff="add" at="2022-01-01">
-                  <label>
-                     <code>[xsl:]default-type-namespace</code>
-                  </label>
-                  <def>
-                     <p>see <specref ref="unprefixed-qnames"/>
-                     </p>
-                  </def>
-               </gitem>
+               
                <gitem>
                   <label>
                      <code>[xsl:]default-validation</code>
@@ -8900,58 +8878,79 @@ and <code>version="1.0"</code> otherwise.</p>
                <div4 id="unprefixed-element-names">
                   <head>Unprefixed Element Names</head>
                
-               <p>The attribute <code>[xsl:]default-element-namespace</code> (see <specref ref="standard-attributes"/>) 
+                  <p>The attribute <code>[xsl:]xpath-default-namespace</code> (see <specref ref="standard-attributes"/>) 
                   may be used on an element in the <termref def="dt-stylesheet">stylesheet</termref> to define the 
-                  namespace that will be used for an unprefixed element name within an XPath expression, and
+                  namespace that will be used for an unprefixed element or type name within an XPath expression, and
                   in certain other contexts listed below.</p>
-               <p>The attribute <code>[xsl:]xpath-default-namespace</code> (which is retained for backwards
-                  compatibility reasons) also has the same effect, but also affects unprefixed type names.</p>
-               <p>The value of the attribute, in each case, is the namespace URI to be used.</p>
-               <p>For any element <code>$E</code> in the <termref def="dt-stylesheet">stylesheet</termref>, there is an
-                  effective value for the default element namespace, which is the value of the
-                  XPath expression:</p>
-                  <eg>string(($E/ancestor-or-self::node()/
-     (self::xsl:*/@default-element-namespace 
-        otherwise
-      @xsl:default-element-namespace
-        otherwise
-      self::xsl:*/@xpath-default-namespace
-        otherwise
-      @xsl:xpath-default-namespace))[last()]).</eg>
-               <note><p>That is, the default element namespace is the value of the <code>[xsl:]default-element-namespace</code> or
-                  <code>[xsl:]xpath-default-namespace</code> attribute on that element or on the innermost
-                  containing element that specifies such an attribute, or a zero-length string if
-                  no containing element specifies such an attribute; and if both attributes are present
-                  on the same element, then <code>[xsl:]default-element-namespace</code> wins.</p></note>
                
-               <p>For any element in the <termref def="dt-stylesheet">stylesheet</termref>, the
-                  effective value of the default element namespace determines the value of the <emph>default
-                     namespace for element names</emph> in the static context of any XPath
-                  expression contained in an attribute or text
-                     node of that element (including XPath expressions in <termref def="dt-attribute-value-template">attribute value templates</termref>
-                  and <termref def="dt-text-value-template">text value
-                        templates</termref>). The effect of this is specified in <bibref ref="xpath-40"/>; in summary, it determines the namespace used for any
-                  unprefixed element name appearing in a path expression or in the <termref def="dt-sequence-type"/>
-                  production.</p>
-               <p>The effective value of this attribute similarly applies to any of the following
-                  constructs appearing within its scope:</p>
-               <ulist>
-                  <item>
-                     <p>any unprefixed element name used in a <termref def="dt-pattern">pattern</termref>
-                     </p>
-                  </item>
-                  <item>
-                     <p>any unprefixed element name used in the <code>elements</code> attribute of
-                        the <elcode>xsl:strip-space</elcode> or <elcode>xsl:preserve-space</elcode>
-                        instructions</p>
-                  </item>
-                  <item>
-                     <p>any unprefixed element name used in the <code>as</code>
-                        attribute of an <termref def="dt-xslt-element">XSLT element</termref>
-                     </p>
-                  </item>
+               <p>The value of the attribute is the namespace URI to be used.</p>
                   
-               </ulist>
+                  
+                  <p>For any element in the stylesheet, this attribute has an effective value, which is the value of 
+                     the <code>[xsl:]xpath-default-namespace</code> on that element or on the innermost containing 
+                     element that specifies such an attribute, or the zero-length string if no containing 
+                     element specifies such an attribute.</p>
+                  
+                  
+                  <p>For any element in the <termref def="dt-stylesheet">stylesheet</termref>, the
+                     effective value of the attribute determines the value of the 
+                     <xtermref ref="dt-default-namespace-elements-and-types" spec="XP40"/>
+                     in the static context of any XPath
+                     expression contained in an attribute or text
+                     node of that element (including XPath expressions in <termref def="dt-attribute-value-template">attribute value templates</termref>
+                     and <termref def="dt-text-value-template">text value
+                        templates</termref>). The effect of this is specified in <bibref ref="xpath-40"/>; in summary, 
+                     it determines the namespace used for any
+                     unprefixed type name or element name.</p>
+                  
+                  <!--<p>The special value <code>##any</code> only affects an unprefixed element name used in a 
+                     <xnt ref="prod-xpath40-NameTest" spec="XP40">NameTest</xnt>, either within an XPath expression or a <termref def="dt-pattern"/>.
+                     Its effect is that an unprefixed name matches any element having the required local name,
+                  irrespective of the namespace URI (or lack of it). A pattern such as <code>match="title"</code>
+                  is therefore interpreted as a wildcard match <code>match="*:title</code>. The default priority
+                  of such a pattern changes accordingly.</p>-->
+                  
+
+                  
+                  <p>The effective value of this attribute applies to any of the following
+                     constructs appearing within its scope:</p>
+                  <ulist>
+                     <item>
+                        <p>any unprefixed element name used in a <termref def="dt-pattern">pattern</termref>
+                        </p>
+                     </item>
+                     <item>
+                        <p>any unprefixed element name used in the <code>elements</code> attribute of
+                           the <elcode>xsl:strip-space</elcode> or <elcode>xsl:preserve-space</elcode>
+                           instructions</p>
+                     </item>
+                     <item>
+                        <p>any unprefixed element name used in the <code>as</code>
+                           attribute of an <termref def="dt-xslt-element">XSLT element</termref>
+                        </p>
+                     </item>
+                     <item>
+                        <p>any unprefixed type name used in the <code>type</code> attribute of an 
+                           <termref def="dt-xslt-element">XSLT element</termref>
+                        </p>
+                     </item>
+                     <item>
+                        <p>any unprefixed type name used in the <code>xsl:type</code> attribute of a 
+                           literal result element.
+                        </p>
+                     </item>
+                     
+                  </ulist>
+                  
+         
+                  
+                  
+                  
+                  
+                  
+ 
+               
+               
                <p>The <code>[xsl:]xpath-default-namespace</code> attribute <rfc2119>must</rfc2119>
                   be in the <termref def="dt-xslt-namespace">XSLT namespace</termref> if and only if
                   its parent element is <emph>not</emph> in the XSLT namespace.</p>
@@ -8959,85 +8958,15 @@ and <code>version="1.0"</code> otherwise.</p>
                   case if it is explicitly set to a zero-length string or if it is not specified at
                   all, then an unprefixed element name or type name refers to a name that is in no
                   namespace. The default namespace of the parent element (see <xspecref spec="DM30" ref="ElementNode"/>) is <emph>not</emph> used.</p>
+                  <p>The attribute does not affect other names, for example function names, 
+                     variable names, or template names, or strings that are interpreted 
+                     as lexical QNames during stylesheet evaluation, such as the effective value 
+                     of the name attribute of <elcode>xsl:element</elcode> or the string supplied as the first 
+                     argument to the <code>key</code> function.
+                  </p>
                </div4>
                
-               <div4 id="unprefixed-type-names">
-                  <head>Unprefixed Type Names</head>
-                  
-                  <p>The attribute <code>[xsl:]default-type-namespace</code> (see <specref ref="standard-attributes"/>) 
-                     may be used on an element in the <termref def="dt-stylesheet">stylesheet</termref> to define the 
-                     namespace that will be used for an unprefixed type name within an XPath expression, and
-                     in certain other contexts listed below.</p>
-                  <p>The attribute <code>[xsl:]xpath-default-namespace</code> (which is retained for backwards
-                     compatibility reasons) also has the same effect, but also affects unprefixed element names.</p>
-                  <p>The value of the attribute, in each case, is the namespace URI to be used.</p>
-                  <p>For any element <code>$E</code> in the <termref def="dt-stylesheet">stylesheet</termref>, there is an
-                     effective value for the default type namespace, which is the value of the
-                     XPath expression:</p>
-                  <eg>string(($E/ancestor-or-self::node()/
-   (self::xsl:*/@default-type-namespace 
-      otherwise
-   @xsl:default-type-namespace
-      otherwise
-   self::xsl:*/@xpath-default-namespace
-      otherwise
-   @xsl:xpath-default-namespace))[last()]).</eg>
-                  <note><p>That is, the default type namespace is the value of the <code>[xsl:]default-type-namespace</code> or
-                     <code>[xsl:]xpath-default-namespace</code> attribute on that element or on the innermost
-                     containing element that specifies such an attribute, or a zero-length string if
-                     no containing element specifies such an attribute; and if both attributes are present
-                     on the same element, then <code>[xsl:]default-type-namespace</code> wins.</p></note>
-                  
-                  <p>For any element in the <termref def="dt-stylesheet">stylesheet</termref>, the
-                     <termref def="dt-effective-value"/> of the default type namespace determines the value of the <emph>default
-                        namespace for type names</emph> in the static context of any XPath
-                     expression contained in an attribute or text
-                     node of that element (including XPath expressions in <termref def="dt-attribute-value-template">attribute value templates</termref>
-                     and <termref def="dt-text-value-template">text value
-                        templates</termref>). The effect of this is specified in <bibref ref="xpath-40"/>; in summary, it determines the namespace used for any
-                     unprefixed element name appearing in a path expression or in the <termref def="dt-sequence-type"/>
-                     production.</p>
-                  <p>The <termref def="dt-effective-value"/> of this attribute similarly applies to any of the following
-                     constructs appearing within its scope:</p>
-                  <ulist>
-                     <item>
-                        <p>any unprefixed type name used in a <termref def="dt-pattern">pattern</termref>
-                        </p>
-                     </item>
-                     <item>
-                        <p>any unprefixed type name used in the <code>as</code> or <code>type</code>
-                           attribute of an <termref def="dt-xslt-element">XSLT element</termref>
-                        </p>
-                     </item>
-                     <item>
-                        <p>any unprefixed type name used in the <code>xsl:type</code>
-                           attribute of a <termref def="dt-literal-result-element"/>.
-                        </p>
-                     </item>
-                     
-                  </ulist>
-                  
-                  <p>If the <termref def="dt-effective-value"/> of the attribute is a zero-length string, which will be the
-                     case if it is explicitly set to a zero-length string or if it is not specified at
-                     all, then an unprefixed element name or type name refers to a name that is in no
-                     namespace. The default namespace of the parent element (see <xspecref spec="DM30" ref="ElementNode"/>) 
-                     is <emph>not</emph> used.</p>
-                  
-                  <note><p>In a stylesheet that does not import any schema, all type names used are likely
-                  to be in the namespace <code>http://www.w3.org/2001/XMLSchema</code>, which is traditionally
-                  bound to the prefix <code>xs</code>. In such a stylesheet, it makes sense to declare (on the
-                     outermost <elcode>xsl:stylesheet</elcode> element) the attribute 
-                     <code>default-type-namespace="http://www.w3.org/2001/XMLSchema"</code>. With this
-                  declaration in place, variables and parameters can use type declarations such
-                  as <code>as="integer"</code> rather than <code>as="xs:integer"</code>, thus eliminating the need
-                  to declare this namespace.</p>
-                  <p>Note however that the default namespace for types does not apply to the names of constructor
-                  functions. In a function call such as <code>decimal(@price)</code> the rules for unprefixed
-                  function names, not type names, apply.</p>
-                  <p>In a stylesheet that imports a no-namespace schema, setting the default type namespace to
-                     <code>http://www.w3.org/2001/XMLSchema</code> is still possible; but in this case user-defined
-                  types in no namespace can only be referenced using the notation <code>Q{}my-type</code>.</p></note>
-               </div4>
+               
                <div4 id="unprefixed-function-names">
                   <head>Unprefixed Function Names</head>
                   <p>The interpretation of unprefixed function names is described in
@@ -9365,14 +9294,9 @@ and <code>version="1.0"</code> otherwise.</p>
                         for the containing element.</p>
                   </item>
                   <item>
-                     <p diff="chg" at="2022-01-01">The <xtermref spec="XP40" ref="dt-def-element-ns">default element
-                           namespace</xtermref> is determined as described in
+                     <p>The <xtermref spec="XP40" ref="dt-default-namespace-elements-and-types">default namespace
+                           for elements and types</xtermref> is determined as described in
                         <specref ref="unprefixed-element-names"/>.</p>
-                  </item>
-                  <item>
-                     <p diff="chg" at="2022-01-01">The <xtermref spec="XP40" ref="dt-def-type-ns">default type
-                        namespace</xtermref> is determined as described in
-                        <specref ref="unprefixed-type-names"/>..</p>
                   </item>
                   <item>
                      <p diff="chg" at="2022-11-25">The <xtermref ref="dt-default-function-namespace" 
@@ -9393,7 +9317,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         that are in scope for the containing element (see <specref ref="variables-and-parameters"/>).</p>
                   </item>
                   <item>
-                     <p>The <xtermref spec="XP40" ref="dt-context-item-static-type">context item
+                     <p>The <xtermref spec="XP40" ref="dt-context-value-static-type">context value
                            static type</xtermref> may be determined by an XSLT processor that
                         performs static type inferencing, using rules that are outside the scope of
                         this specification; if no static type inferencing is done, then the context
@@ -10647,19 +10571,18 @@ and <code>version="1.0"</code> otherwise.</p>
                   <code>type(item())</code> can be abbreviated as <code>item()</code>.</p>
                   <p>For example:</p>
                   <ulist>
-                     <item><p><code>type(integer)</code> matches any instance of
+                     <item><p><code>type(xs:integer)</code> matches any instance of
                         <code>xs:integer</code></p></item>
-                     <item><p><code>type(integer)[. gt 0]</code> matches
+                     <item><p><code>type(xs:integer)[. gt 0]</code> matches
                         any positive integer.</p></item>
-                     <item><p><code>union(string, untypedAtomic)[matches(., '[0-9]+')]</code> matches
+                     <item><p><code>union(xs:string, xs:untypedAtomic)[matches(., '[0-9]+')]</code> matches
                         any instance of <code>xs:string</code> or <code>xs:untypedAtomic</code> that
                         contains a sequence of decimal digits.</p></item>
                      <item><p><code>type(node())</code> matches any node. (This is not the same as the pattern
                         <code>node()</code>, which for historical reasons only matches  element, text, comment, 
                         and processing instruction nodes).</p></item>
                   </ulist>
-                  <note><p>The above examples assume the declaration 
-                     <code>default-type-namespace="http://www.w3.org/2001/XMLSchema"</code>.</p></note>
+                  
                   
                   <p>More formally, an item <var>$J</var> matches a pattern <code>type(T)[P1][P2][P3]</code> if
                   the XPath expression <code>$J instance of T and exists($J[P1][P2]P3])</code> is true.</p>
@@ -12492,8 +12415,7 @@ and <code>version="1.0"</code> otherwise.</p>
      "Price": 10.40
   }
 ]</eg>
-               <p>The following template rules are used. The settings <code>expand-text="yes"</code> 
-                  and <code>default-type-namespace="http://www.w3.org/2001/XMLSchema"</code> are assumed:</p>
+               <p>The following template rules are used. The setting <code>expand-text="yes"</code> is assumed:</p>
                <eg><![CDATA[
 <xsl:item-type name="book" as="record(Title, Authors, Category, *)"/>                  
 <xsl:template name="xsl:initial-template">
@@ -18653,7 +18575,7 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <ulist diff="add" at="2023-05-19">
                 
-                  <item><p>The <xtermref spec="XP40" ref="dt-context-item-static-type"/> is <code>item()*</code>.</p></item>
+                  <item><p>The <xtermref spec="XP40" ref="dt-context-value-static-type"/> is <code>item()*</code>.</p></item>
                </ulist>
                
                <p diff="add" at="2023-05-19">The <xtermref  spec="XP40" ref="dt-dynamic-context"/> for the initializing 
@@ -18662,7 +18584,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   with the following exceptions:</p>
                
                <ulist diff="add" at="2023-05-19">
-                  <item><p>The <xtermref spec="XP40" ref="dt-context-item"/>, <xtermref spec="XP40" ref="dt-context-position"/>,
+                  <item><p>The <xtermref spec="XP40" ref="dt-context-value"/>, <xtermref spec="XP40" ref="dt-context-position"/>,
                      and <xtermref spec="XP40" ref="dt-context-size"/> are taken from the dynamic context of the caller.</p></item>
                   <item><p>The <xtermref spec="XP40" ref="dt-def-collation"/> and <xtermref spec="XP40" ref="dt-executable-base-uri"/>
                   are taken from the dynamic context of the caller.</p></item>
@@ -19115,7 +19037,6 @@ and <code>version="1.0"</code> otherwise.</p>
                         <termref def="dt-template-rule">template rule</termref>. </p>
                   <eg xml:space="preserve" role="xslt-document">&lt;xsl:transform 
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  default-type-namespace="http://www.w3.org/2001/XMLSchema"
   xmlns:str="http://example.com/namespace"
   version="3.0"
   exclude-result-prefixes="str"&gt; 
@@ -19297,9 +19218,8 @@ and <code>version="1.0"</code> otherwise.</p>
                               in-scope namespaces of the <elcode>xsl:evaluate</elcode> instruction
                               (with the exception of any binding for the default namespace) are used
                               as the statically known namespaces for the target expression, and the
-                              values of the attributes <code>[xsl:]default-element-namespace</code>,
-                              <code>[xsl:]default-type-namespace</code>, and <code>[xsl:]xpath-default-namespace</code>
-                              if any, are used to establish the default namespaces for elements and
+                              value of the attribute <code>[xsl:]xpath-default-namespace</code>,
+                              if present, is used to establish the default namespace for elements and
                               types in the target expression, as described in <specref ref="unprefixed-qnames"/>.</p>
                         </item>
                      </ulist>


### PR DESCRIPTION
Implements the CG decision to roll back the changes that introduced two separate default namespaces for elements and types.

Fix #372 

