### PR TITLE
413: Spec for CSV-related functions

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -59,6 +59,7 @@
       </fos:record>
    </fos:type>
 
+   <!-- MP - FIXUP -->
    <fos:type id="common-csv-options">
       <fos:record extensible="false">
          <fos:field name="row-delimiter" type="xs:string" required="false"/>
@@ -67,7 +68,7 @@
       </fos:record>
    </fos:type>
 
-   <fos:type id="parse-csv-options">
+   <fos:type id="csv-parsing-options">
       <fos:record extensible="false">
          <fos:field name="row-delimiter" type="xs:string" required="false"/>
          <fos:field name="column-delimiter" type="xs:string" required="false"/>
@@ -21766,193 +21767,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
    <fos:function name="parse-csv" prefix="fn">
       <fos:signatures>
-         <fos:proto name="parse-csv" return-type="array(xs:string)*">
-            <fos:arg name="csv" type="xs:string?"/>
-            <fos:arg name="options" type-ref="parse-csv-options" usage="inspection" default="map{}"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Parses CSV data supplied as a string, returning the results in the form of a sequence of arrays of strings.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The effect of the one-argument form of this function is the same as calling the
-            two-argument form with an empty map as the value of the <code>$options</code>
-            argument.</p>
-
-         <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
-            sequence of <code>xs:string</code> values. The function parses this sequence to return
-            an XDM value.</p>
-
-         <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
-            return the empty sequence as the value of the <code>body</code> field of the returned
-            map.</p>
-
-         <p>The <code>$options</code> argument can be used to control the way in which the parsing
-            takes place. The <termref
-               def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
-
-         <p>Implementations <rfc2119>must</rfc2119> treat any of CRLF, CR, or LF as a single line
-            separator, as with <code>fn:unparsed-text-lines</code>.</p>
-
-         <p>Fields are regarded as simple <code>xs:string</code> values. Implementations
-            <rfc2119>must</rfc2119> leave whitespace within a field untouched, without
-            normalizing or otherwise altering it, unless whitespace trimming is explicitly requested
-            by the user using the <code>trim-whitespace</code> option.</p>
-
-         <p>When whitespace trimming is requested, implementations <rfc2119>must</rfc2119> only
-            strip leading and trailing whitespace, this is not equivalent to calling
-            <code>fn:normalize-space()</code>.</p>
-
-         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
-
-         <fos:options>
-            <fos:option key="field-delimiter">
-               <fos:meaning>The character used to delimit fields within a record. An instance of
-                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>","</fos:default>
-            </fos:option>
-            <fos:option key="row-delimiter">
-               <fos:meaning>The sequence of strings used to delimit rows within the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
-               <fos:type>xs:string+</fos:type>
-               <fos:default>("&amp;#13;&amp;#10;", "&amp;#10;", "&amp;#13;")</fos:default>
-            </fos:option>
-            <fos:option key="quote-character">
-               <fos:meaning>The character used to quote fields within the CSV string. An instance of
-                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>'"'</fos:default>
-            </fos:option>
-            <fos:option key="trim-whitespace">
-               <fos:meaning>Determines whether fields should have leading and trailing whitespace
-                  removed before being returned.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false</fos:default>
-               <fos:values>
-                  <fos:value value="false">Fields will be returned with any leading or trailing
-                     whitespace intact. Implementations <rfc2119>must</rfc2119> preserve whitespace
-                     as it occurred in the CSV string.
-                  </fos:value>
-                  <fos:value value="true">Fields will be returned with leading or trailing
-                     whitespace removed, and all non-leading or -trailing whitespace preserved.
-                  </fos:value>
-               </fos:values>
-            </fos:option>
-         </fos:options>
-
-         <p>The result of the function is a sequence of arrays-of-strings
-            <code>array(xs:string)*</code>.</p>
-         <p>A blank row is represented as an empty array.</p>
-         <p>An empty field is represented by the empty string.</p>
-      </fos:rules>
-      <fos:errors>
-         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
-            <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
-            fields.</p>
-         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
-            for <code>field-delimiter</code> or <code>quote-character</code> are specified and are
-            not a single character.</p>
-         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
-            <code>field-delimiter</code>, <code>row-delimiter</code>,
-            <code>quote-character</code> are equal.</p>
-      </fos:errors>
-      <fos:notes>
-         <p>All fields are returned as <code>xs:string</code> values.</p>
-         <p>Quoted fields in the input are returned without the quotes.</p>
-         <p>For more discussion of the returned data, see <specref ref="csv"/>.</p>
-      </fos:notes>
-      <fos:examples>
-         <fos:variable name="lf" id="escaped-lf"><![CDATA[char('\n')]]></fos:variable>
-         <fos:variable name="cr" id="escaped-cr"><![CDATA[char('\r')]]></fos:variable>
-         <fos:variable name="crlf" id="escaped-crlf"><![CDATA[char('\r')||char('\n')]]></fos:variable>
-         <fos:example>
-            <p>Handling any of the default record separators:</p>
-            <fos:test use="escaped-crlf">
-               <fos:expression>parse-csv(`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`)</fos:expression>
-               <fos:result>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
-)</fos:result>
-            </fos:test>
-            <fos:test use="escaped-cr">
-               <fos:expression>parse-csv(`name,city{$cr}Bob,Berlin{$cr}Alice,Aachen{$cr}`)</fos:expression>
-               <fos:result>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
-)</fos:result>
-            </fos:test>
-            <fos:test use="escaped-lf">
-               <fos:expression>parse-csv(`name,city{$lf}Bob,Berlin{$lf}Alice,Aachen{$lf}`)</fos:expression>
-               <fos:result>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Quote handling:</p>
-            <fos:test use="escaped-crlf">
-               <fos:expression>parse-csv(`"name","city"{$crlf}"Bob","Berlin"{$crlf}"Alice","Aachen"{$crlf}`)</fos:expression>
-               <fos:result>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
-)</fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf">
-               <fos:expression>parse-csv(`"name","city"{$crlf}"Bob ""The Exemplar"" Mustermann","Berlin"{$crlf}`)</fos:expression>
-               <fos:result>(
-   ["name", "city"],
-   ['Bob "The Exemplar" Mustermann', "Berlin"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Non-default record- and field-delimiters:</p>
-            <fos:test>
-               <fos:expression>parse-csv("name;city§Bob;Berlin§Alice;Aachen", map{"row-delimiter": "§", "field-delimiter": ";"})</fos:expression>
-               <fos:result>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Non-default quote character:</p>
-            <fos:test use="escaped-crlf">
-               <fos:expression>parse-csv(`|name|,|city|{$crlf}|Bob|,|Berlin|{$crlf}`, map{"quote-character": "|"})</fos:expression>
-               <fos:result>(
-   ["name", "city"],
-   ["Bob", "Berlin"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Trimming whitespace in fields:</p>
-            <fos:test use="escaped-crlf">
-               <fos:expression xml:space="preserve">parse-csv(`name  ,city  {$crlf}Bob   ,Berlin{$crlf}Alice ,Aachen{$crlf}`, map{"trim-whitespace": true()})</fos:expression>
-               <fos:result>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-   </fos:function>
-
-   <fos:function name="csv-to-xdm" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="csv-to-xdm" return-type-ref="parsed-csv-structure-record">
+         <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record">
             <fos:arg name="csv" type="xs:string?"/>
             <fos:arg name="options" type="map(*)" usage="inspection" default="map{}"/>
          </fos:proto>
@@ -21975,7 +21790,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
          <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
             sequence of <code>xs:string</code> values. The function parses this sequence using
-            <code>fn:parse-csv</code>, and then processes its result to return an XDM value.</p>
+            <code>fn:csv-to-simple-rows</code>, and then processes its result to return an XDM value.</p>
 
          <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
             return a <code>parsed-csv-structure-record</code> whose <code>rows</code> entry is the empty sequence.</p>
@@ -21991,7 +21806,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
 
          <p>Handling of delimiters, and whitespace trimming, are handled using
-            <code>fn:parse-csv</code>, and the options controlling their use are defined
+            <code>fn:csv-to-simple-rows</code>, and the options controlling their use are defined
             there.</p>
 
          <p>If the <code>column-names</code> option is true, implementations <rfc2119>must</rfc2119>
@@ -22155,14 +21970,26 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                         supplied <var>$key</var> is a string and does not occur in the map of column
                         names.</p>
                   </item>
-               </ulist>
+                  <item>
+                     <p>rules: The function returns the field in the sequence <code>fields</code> entry of this
+                        <code>csv-row-record</code> at the position in
+                        the sequence either explicitly provided (when the <code>$key</code> argument is an
+                        <code>xs:integer</code>), or looked up from the map of name to position in the
+                        <code>names</code> entry of the <code>csv-columns-record</code> of the
+                        <code>parsed-csv-structure-record</code> this <code>csv-row-record</code>
+                        was returned as part of.</p>
 
-               <p>This function behaves identically to <code>fn:csv-fetch-field-by-column</code>
-                  would had the <code>header</code> entry of the containing
-                  <code>parsed-csv-structure-record</code> and the <code>fields</code> entry of
-                  this <code>csv-row-record</code> been supplied as its first two arguments, and
-                  <var>$key</var> as its last. See the definition of
-                  <code>fn:csv-fetch-field-by-column</code> for more details</p>
+                     <p>When the argument is a string, if the string is missing from the keys
+                        of the <code>names</code> map , then implementations <rfc2119>must</rfc2119>
+                        raise an <errorref class="CV" code="0004"/>.</p>
+
+                     <p>When the argument is an integer, if the integer position is outside the
+                        bounds of the sequence contained in the <code>fields</code> entry of this
+                        <code>csv-row-record</code> (i.e. is greater than the size of the
+                        sequence), then implementations <rfc2119>must</rfc2119> return the empty
+                        string.</p>
+                  </item>
+               </ulist>
             </item>
          </olist>
 
@@ -22201,7 +22028,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             zero.</p>
          <p>A dynamic error <errorref class="CV" code="0006"/> occurs if both the
             <code>number-of-columns</code> and <code>filter-columns</code> options are set in a
-            call to <code>fn:csv-to-xdm</code>.</p>
+            call to <code>fn:parse-csv</code>.</p>
       </fos:errors>
       <fos:notes>
          <p>All fields are returned as <code>xs:string</code> values.</p>
@@ -22216,57 +22043,57 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>With defaults for delimiters and quotes, and default column extraction (false):</p>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>map:keys(csv-to-xdm($csv-string))</fos:expression>
+               <fos:expression>map:keys(parse-csv($csv-string))</fos:expression>
                <fos:result>("columns", "rows")</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string)?columns</fos:expression>
+               <fos:expression>parse-csv($csv-string)?columns</fos:expression>
                <fos:result>map {
   "names": map {},
   "fields": ()
 }</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>count(csv-to-xdm($csv-string)?rows)</fos:expression>
+               <fos:expression>count(parse-csv($csv-string)?rows)</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string)?rows[1]?field("name")</fos:expression>
+               <fos:expression>parse-csv($csv-string)?rows[1]?field("name")</fos:expression>
                <fos:error-result error-code="FOCV0004"/>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string)?rows[1]?field(2)</fos:expression>
+               <fos:expression>parse-csv($csv-string)?rows[1]?field(2)</fos:expression>
                <fos:result>"city"</fos:result>
             </fos:test>
             <p>With defaults for delimiters and quotes, and <code>columns: true()</code> set:</p>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string, map {"column-names": true()})?columns</fos:expression>
+               <fos:expression>parse-csv($csv-string, map {"column-names": true()})?columns</fos:expression>
                <fos:result>map {
   "names": map { "name": 1, "city": 2 },
   "fields": ("name", "city")
 }</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>count(csv-to-xdm($csv-string, map {"column-names": true()})?rows)</fos:expression>
+               <fos:expression>count(parse-csv($csv-string, map {"column-names": true()})?rows)</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string, map {"column-names": true()})?rows[1]?fields</fos:expression>
+               <fos:expression>parse-csv($csv-string, map {"column-names": true()})?rows[1]?fields</fos:expression>
                <fos:result>("Bob", "Berlin")</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string, map {"column-names": true()})?rows[1]?field("name")</fos:expression>
+               <fos:expression>parse-csv($csv-string, map {"column-names": true()})?rows[1]?field("name")</fos:expression>
                <fos:result>"Bob"</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string, map {"column-names": true()})?rows[1]?field(2)</fos:expression>
+               <fos:expression>parse-csv($csv-string, map {"column-names": true()})?rows[1]?field(2)</fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Non-default record- and field-delimiters, non-default quotes:</p>
             <fos:test use="non-default-delims non-standard-csv-string">
-               <fos:expression>csv-to-xdm($non-std-csv, $options)?rows[3]?field(1)</fos:expression>
+               <fos:expression>parse-csv($non-std-csv, $options)?rows[3]?field(1)</fos:expression>
                <fos:result>"Alice"</fos:result>
             </fos:test>
          </fos:example>
@@ -22275,26 +22102,26 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Specifying column names explicitly:</p>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>map:keys(csv-to-xdm($csv-string, $options))</fos:expression>
+               <fos:expression>map:keys(parse-csv($csv-string, $options))</fos:expression>
                <fos:result>("columns", "rows")</fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>csv-to-xdm($csv-string, $options)?columns</fos:expression>
+               <fos:expression>parse-csv($csv-string, $options)?columns</fos:expression>
                <fos:result>map {
    "names": map { "Person": 1, "Location": 2 },
    "fields": ("Person", "Location")
 }</fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>count(csv-to-xdm($csv-string, $options)?rows)</fos:expression>
+               <fos:expression>count(parse-csv($csv-string, $options)?rows)</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>csv-to-xdm($csv-string, $options)?rows[1]?field(1)</fos:expression>
+               <fos:expression>parse-csv($csv-string, $options)?rows[1]?field(1)</fos:expression>
                <fos:result>"Alice"</fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>csv-to-xdm($csv-string, $options)?rows[2]?field("Location")</fos:expression>
+               <fos:expression>parse-csv($csv-string, $options)?rows[2]?field("Location")</fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
@@ -22305,11 +22132,11 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Filtering columns, with <code>column-names: true()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })?columns?fields</fos:expression>
+               <fos:expression>parse-csv($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })?columns?fields</fos:expression>
                <fos:result>("name","date","amount")</fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
+               <fos:expression>for $r in parse-csv($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
                <fos:result>(
    ["Bob","2023-07-19","10.00"],
    ["Alice","2023-07-20","15.00"],
@@ -22320,7 +22147,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Filtering columns, with <code>column-names: map { ... }</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { "Person": 1, "Amount": 3 }, "filter-columns": (2,1,4) })?columns</fos:expression>
+               <fos:expression>parse-csv($csv-uneven-cols, map { "column-names": map { "Person": 1, "Amount": 3 }, "filter-columns": (2,1,4) })?columns</fos:expression>
                <fos:result>map {
    "names": map { "Person": 1, "Amount": 3 },
    "fields": ("Person", "", "Amount")
@@ -22330,7 +22157,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Specifying the number of columns using <code>"first-row"</code> and <code>column-names: false()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "number-of-columns": "first-row" })?rows return array { $r?fields }</fos:expression>
+               <fos:expression>for $r in parse-csv($csv-uneven-cols, map { "number-of-columns": "first-row" })?rows return array { $r?fields }</fos:expression>
                <fos:result>(
    ["date","name","city","amount","currency","original amount","note"],
    ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
@@ -22342,18 +22169,204 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Specifying the number of columns with a number and <code>column-names: true()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?columns?fields</fos:expression>
+               <fos:expression>parse-csv($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?columns?fields</fos:expression>
                <fos:result>map {
    "names": map { "date": 1, "name": 2, "city": 3, "amount": 4, "currency": 5, "original amount": 6 },
    "fields": ("date","name","city","amount","currency","original amount")
 }</fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
+               <fos:expression>for $r in parse-csv($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
                <fos:result>(
    ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
    ["2023-07-20","Alice","Aachen","15.00","",""],
    ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
+
+   <fos:function name="csv-to-simple-rows" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="csv-to-simple-rows" return-type="array(xs:string)*">
+            <fos:arg name="csv" type="xs:string?"/>
+            <fos:arg name="options" type-ref="csv-parsing-options" usage="inspection" default="map{}"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Parses CSV data supplied as a string, returning the results in the form of a sequence of arrays of strings.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The effect of the one-argument form of this function is the same as calling the
+            two-argument form with an empty map as the value of the <code>$options</code>
+            argument.</p>
+
+         <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
+            sequence of <code>xs:string</code> values. The function parses this sequence to return
+            an XDM value.</p>
+
+         <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
+            return the empty sequence as the value of the <code>body</code> field of the returned
+            map.</p>
+
+         <p>The <code>$options</code> argument can be used to control the way in which the parsing
+            takes place. The <termref
+               def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
+
+         <p>Implementations <rfc2119>must</rfc2119> treat any of CRLF, CR, or LF as a single line
+            separator, as with <code>fn:unparsed-text-lines</code>.</p>
+
+         <p>Fields are regarded as simple <code>xs:string</code> values. Implementations
+            <rfc2119>must</rfc2119> leave whitespace within a field untouched, without
+            normalizing or otherwise altering it, unless whitespace trimming is explicitly requested
+            by the user using the <code>trim-whitespace</code> option.</p>
+
+         <p>When whitespace trimming is requested, implementations <rfc2119>must</rfc2119> only
+            strip leading and trailing whitespace, this is not equivalent to calling
+            <code>fn:normalize-space()</code>.</p>
+
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+
+         <fos:options>
+            <fos:option key="field-delimiter">
+               <fos:meaning>The character used to delimit fields within a record. An instance of
+                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>","</fos:default>
+            </fos:option>
+            <fos:option key="row-delimiter">
+               <fos:meaning>The sequence of strings used to delimit rows within the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
+               <fos:type>xs:string+</fos:type>
+               <fos:default>("&amp;#13;&amp;#10;", "&amp;#10;", "&amp;#13;")</fos:default>
+            </fos:option>
+            <fos:option key="quote-character">
+               <fos:meaning>The character used to quote fields within the CSV string. An instance of
+                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>'"'</fos:default>
+            </fos:option>
+            <fos:option key="trim-whitespace">
+               <fos:meaning>Determines whether fields should have leading and trailing whitespace
+                  removed before being returned.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">Fields will be returned with any leading or trailing
+                     whitespace intact. Implementations <rfc2119>must</rfc2119> preserve whitespace
+                     as it occurred in the CSV string.
+                  </fos:value>
+                  <fos:value value="true">Fields will be returned with leading or trailing
+                     whitespace removed, and all non-leading or -trailing whitespace preserved.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+         </fos:options>
+
+         <p>The result of the function is a sequence of arrays-of-strings
+            <code>array(xs:string)*</code>.</p>
+         <p>A blank row is represented as an empty array.</p>
+         <p>An empty field is represented by the empty string.</p>
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
+            <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
+            fields.</p>
+         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
+            for <code>field-delimiter</code> or <code>quote-character</code> are specified and are
+            not a single character.</p>
+         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
+            <code>field-delimiter</code>, <code>row-delimiter</code>,
+            <code>quote-character</code> are equal.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>All fields are returned as <code>xs:string</code> values.</p>
+         <p>Quoted fields in the input are returned without the quotes.</p>
+         <p>For more discussion of the returned data, see <specref ref="csv"/>.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:variable name="lf" id="escaped-lf"><![CDATA[char('\n')]]></fos:variable>
+         <fos:variable name="cr" id="escaped-cr"><![CDATA[char('\r')]]></fos:variable>
+         <fos:variable name="crlf" id="escaped-crlf"><![CDATA[char('\r')||char('\n')]]></fos:variable>
+         <fos:example>
+            <p>Handling any of the default record separators:</p>
+            <fos:test use="escaped-crlf">
+               <fos:expression>csv-to-simple-rows(`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"],
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+            <fos:test use="escaped-cr">
+               <fos:expression>csv-to-simple-rows(`name,city{$cr}Bob,Berlin{$cr}Alice,Aachen{$cr}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"],
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+            <fos:test use="escaped-lf">
+               <fos:expression>csv-to-simple-rows(`name,city{$lf}Bob,Berlin{$lf}Alice,Aachen{$lf}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"],
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Quote handling:</p>
+            <fos:test use="escaped-crlf">
+               <fos:expression>csv-to-simple-rows(`"name","city"{$crlf}"Bob","Berlin"{$crlf}"Alice","Aachen"{$crlf}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"],
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf">
+               <fos:expression>csv-to-simple-rows(`"name","city"{$crlf}"Bob ""The Exemplar"" Mustermann","Berlin"{$crlf}`)</fos:expression>
+               <fos:result>(
+   ["name", "city"],
+   ['Bob "The Exemplar" Mustermann', "Berlin"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Non-default record- and field-delimiters:</p>
+            <fos:test>
+               <fos:expression>csv-to-simple-rows("name;city§Bob;Berlin§Alice;Aachen", map{"row-delimiter": "§", "field-delimiter": ";"})</fos:expression>
+               <fos:result>(
+   ["name", "city"],
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Non-default quote character:</p>
+            <fos:test use="escaped-crlf">
+               <fos:expression>csv-to-simple-rows(`|name|,|city|{$crlf}|Bob|,|Berlin|{$crlf}`, map{"quote-character": "|"})</fos:expression>
+               <fos:result>(
+   ["name", "city"],
+   ["Bob", "Berlin"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Trimming whitespace in fields:</p>
+            <fos:test use="escaped-crlf">
+               <fos:expression xml:space="preserve">csv-to-simple-rows(`name  ,city  {$crlf}Bob   ,Berlin{$crlf}Alice ,Aachen{$crlf}`, map{"trim-whitespace": true()})</fos:expression>
+               <fos:result>(
+   ["name", "city"],
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
 )</fos:result>
             </fos:test>
          </fos:example>
@@ -22383,7 +22396,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
          <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
             sequence of <code>xs:string</code> values. The function parses this sequence using
-            <code>fn:parse-csv</code>, and then processes its result to return an XML document.</p>
+            <code>fn:csv-to-simple-rows</code>, and then processes its result to return an XML document.</p>
 
          <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
             return a <code><![CDATA[<fn:csv>]]></code> whose <code><![CDATA[<fn:rows>]]></code> element
@@ -22404,7 +22417,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
 
          <p>Handling of delimiters, and whitespace trimming, are handled using
-            <code>fn:parse-csv</code>, and the options controlling their use are defined
+            <code>fn:csv-to-simple-rows</code>, and the options controlling their use are defined
             there.</p>
 
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
@@ -22772,86 +22785,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
    </rows>
 </csv>
 ]]></fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-   </fos:function>
-
-   <fos:function name="csv-fetch-field-by-column" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="csv-fetch-field-by-column" return-type="xs:string">
-            <fos:arg name="columns" type-ref="csv-columns-record"/>
-            <fos:arg name="fields" type="xs:string*" usage="inspection"/>
-            <fos:arg name="key" type="union(xs:integer, xs:string)" usage="inspection"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Fetches a field from a parsed CSV row by name or position.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The first argument is a <code>csv-columns-record</code>, as provided in the
-            <code>header</code> entry of the <code>parsed-csv-structure-record</code> returned by
-            <code>fn:csv-to-xdm</code>.</p>
-
-         <p>The second argument is the row whose fields are being fetched, represented as a sequence
-            of strings as would be provided by the <code>fields</code> entry of a
-            <code>csv-row-record</code> returned by <code>fn:csv-to-xdm</code>.</p>
-
-         <p>The final argument is the key to use for the lookup, supplied as either an
-            <code>xs:string</code> (the column name) or <code>xs:integer</code> (the column
-            position).</p>
-
-         <p>When the argument is a string, if the string is missing from the keys of the map
-            contained in the <code>names</code> entry of the <code>$columns</code> argument’s
-            <code>csv-columns-record</code>, then implementations <rfc2119>must</rfc2119> raise
-            an <errorref class="CV" code="0004"/>.</p>
-
-         <p>When the argument is an integer, if the integer position is outside the bounds of the
-            <code>$fields</code> sequence (i.e. is greater than the size of the sequence), then
-            implementations <rfc2119>must</rfc2119> return the empty string.</p>
-
-         <p>The function returns the field in the sequence <code>$fields</code> at the position in
-            the sequence either explicitly provided (when <code>$key</code> is an
-            <code>xs:integer</code>), or looked up from the map of name to position in the
-            <code>csv-columns-record</code> provided in <code>$columns</code>.</p>
-      </fos:rules>
-      <fos:errors>
-         <p>A dynamic error <errorref class="CV" code="0004"/> occurs if the value of
-            <code>$key</code> is an <code>xs:string</code> but is not a member of the keys of the
-            map contained in the <code>names</code> entry of the <code>csv-columns-record</code> in
-            <code>$header</code>. fields.</p>
-      </fos:errors>
-      <fos:examples>
-         <fos:variable name="columns" id="csv-column-fetch-columns">map {
-   "names": map { "name": 1, "city": 2 },
-   "fields: ("name", "city")
-}</fos:variable>
-         <fos:variable name="fields" id="csv-column-fetch-fields">("Bob", "Berlin")</fos:variable>
-         <fos:example>
-            <p>With a string key:</p>
-            <fos:test use="csv-column-fetch-columns csv-column-fetch-fields">
-               <fos:expression>csv-fetch-field-by-column($columns, $fields, "name")</fos:expression>
-               <fos:result>"Bob"</fos:result>
-            </fos:test>
-            <fos:test use="csv-column-fetch-columns csv-column-fetch-fields">
-               <fos:expression>csv-fetch-field-by-column($columns, $fields, "amount")</fos:expression>
-               <fos:error-result error-code="FOCV0004"/>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>With an integer key</p>
-            <fos:test use="csv-column-fetch-columns csv-column-fetch-fields">
-               <fos:expression>csv-fetch-field-by-column($columns, $fields, 2)</fos:expression>
-               <fos:result>"Berlin"</fos:result>
-            </fos:test>
-            <fos:test use="csv-column-fetch-columns csv-column-fetch-fields">
-               <fos:expression>csv-fetch-field-by-column($columns, $fields, 3)</fos:expression>
-               <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21868,9 +21868,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>For more discussion of the returned data, see <specref ref="csv"/>.</p>
       </fos:notes>
       <fos:examples>
-         <fos:variable name="lf" id="escaped-lf"><![CDATA[char('x0A')]]></fos:variable>
-         <fos:variable name="cr" id="escaped-cr"><![CDATA[char('x0D')]]></fos:variable>
-         <fos:variable name="crlf" id="escaped-crlf"><![CDATA[char('x0D')||char('x0A')]]></fos:variable>
+         <fos:variable name="lf" id="escaped-lf"><![CDATA[char('\n')]]></fos:variable>
+         <fos:variable name="cr" id="escaped-cr"><![CDATA[char('\r')]]></fos:variable>
+         <fos:variable name="crlf" id="escaped-crlf"><![CDATA[char('\r')||char('\n')]]></fos:variable>
          <fos:example>
             <p>Handling any of the default record separators:</p>
             <fos:test use="escaped-crlf">
@@ -21901,7 +21901,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Quote handling:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression>parse-csv(`"name","city"${crlf}"Bob","Berlin"${crlf}"Alice","Aachen"${crlf}`)</fos:expression>
+               <fos:expression>parse-csv(`"name","city"{$crlf}"Bob","Berlin"{$crlf}"Alice","Aachen"{$crlf}`)</fos:expression>
                <fos:result>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -21909,18 +21909,17 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 )</fos:result>
             </fos:test>
             <fos:test use="escaped-crlf">
-               <fos:expression>parse-csv(`"name","city"${crlf}"Bob ""The Exemplar"" Mustermann","Berlin"${crlf}`)</fos:expression>
+               <fos:expression>parse-csv(`"name","city"{$crlf}"Bob ""The Exemplar"" Mustermann","Berlin"{$crlf}`)</fos:expression>
                <fos:result>(
    ["name", "city"],
-   ['Bob "The Exemplar" Mustermann', "Berlin"],
-   ["Alice", "Aachen"]
+   ['Bob "The Exemplar" Mustermann', "Berlin"]
 )</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Non-default record- and field-separators:</p>
             <fos:test>
-               <fos:expression>parse-csv("name;city§Bob;Berlin§Alice;Aachen", map{"record-separator": "§", "field-separator": ";"})</fos:expression>
+               <fos:expression>parse-csv("name;city§Bob;Berlin§Alice;Aachen", map{"row-delimiter": "§", "field-delimiter": ";"})</fos:expression>
                <fos:result>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -21931,18 +21930,17 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Non-default quote character:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression>parse-csv(`|name|,|city|${crlf}|Bob|,|Berlin|${crlf}`, map{"quote-character": "|"})</fos:expression>
+               <fos:expression>parse-csv(`|name|,|city|{$crlf}|Bob|,|Berlin|{$crlf}`, map{"quote-character": "|"})</fos:expression>
                <fos:result>(
    ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
+   ["Bob", "Berlin"]
 )</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Trimming whitespace in fields:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression xml:space="preserve">parse-csv(`name  ,city  ${crlf}Bob   ,Berlin${crlf}Alice ,Aachen${crlf}`, map{"trim-whitespace: true()})</fos:expression>
+               <fos:expression xml:space="preserve">parse-csv(`name  ,city  {$crlf}Bob   ,Berlin{$crlf}Alice ,Aachen{$crlf}`, map{"trim-whitespace": true()})</fos:expression>
                <fos:result>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -22177,7 +22175,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>For more discussion of the returned data, see <specref ref="csv"/>.</p>
       </fos:notes>
       <fos:examples>
-         <fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('x0D')||char('x0A')]]></fos:variable>
+         <fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('\r')||char('\n')]]></fos:variable>
          <fos:variable name="csv-string" id="csv-string">`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`</fos:variable>
          <fos:variable name="options" id="non-default-delims">map { "record-separator": "§", "field-separator": ";", "quote-character": "|" }</fos:variable>
          <fos:variable name="non-std-csv" id="non-standard-csv-string">`|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|`</fos:variable>
@@ -22475,7 +22473,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <code>quote-character</code> are equal.</p>
       </fos:errors>
       <fos:examples>
-         <fos:variable name="crlf" id="escaped-crlf-3"><![CDATA[char('x0D')||char('x0A')]]></fos:variable>
+         <fos:variable name="crlf" id="escaped-crlf-3"><![CDATA[char('\r')||char('\n')]]></fos:variable>
          <fos:variable name="csv-string" id="csv-string-2">`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`</fos:variable>
          <fos:example>
             <p>An empty CSV with default column extraction (false):</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22519,9 +22519,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test>
                <fos:expression>csv-to-xml("")</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:rows/>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <rows/>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>
@@ -22530,26 +22530,26 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test>
                <fos:expression>csv-to-xml("", map { "column-names": true() })</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:header/>
-   <fn:rows/>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns/>
+   <rows/>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>An empty CSV with explicit column names:</p>
             <fos:test>
-               <fos:expression>csv-to-xml("", map { "column-names": map { "name": 1, "city": 3 })</fos:expression>
+               <fos:expression>csv-to-xml("", map { "column-names": map { "name": 1, "city": 3 } })</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:header>
-      <fn:column>name</fn:field>
-      <fn:column/>
-      <fn:column>city</fn:field>
-   </fn:header>
-   <fn:rows/>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns>
+      <column>name</column>
+      <column/>
+      <column>city</column>
+   </columns>
+   <rows/>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>
@@ -22558,22 +22558,22 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf-3 csv-string-2">
                <fos:expression>csv-to-xml($csv-string, map { "column-names": true() })</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:header>
-      <fn:column>name</fn:field>
-      <fn:column>city</fn:field>
-   </fn:header>
-   <fn:rows>
-      <fn:row>
-         <fn:field column="name">Bob</fn:field>
-         <fn:field column="city">Berlin</fn:field>
-      </fn:row>
-      <fn:row>
-         <fn:field column="name">Alice</fn:field>
-         <fn:field column="city">Aachen</fn:field>
-      </fn:row>
-   </fn:rows>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns>
+      <column>name</column>
+      <column>city</column>
+   </columns>
+   <rows>
+      <row>
+         <field column="name">Bob</field>
+         <field column="city">Berlin</field>
+      </row>
+      <row>
+         <field column="name">Alice</field>
+         <field column="city">Aachen</field>
+      </row>
+   </rows>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>
@@ -22582,22 +22582,22 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf-3 csv-string-2">
                <fos:expression>csv-to-xml($csv-string, map { "column-names": true() })</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:header>
-      <fn:field>name</fn:field>
-      <fn:field>city</fn:field>
-   </fn:header>
-   <fn:rows>
-      <fn:row>
-         <fn:field column="name">Bob</fn:field>
-         <fn:field column="city">Berlin</fn:field>
-      </fn:row>
-      <fn:row>
-         <fn:field column="name">Alice</fn:field>
-         <fn:field column="city">Aachen</fn:field>
-      </fn:row>
-   </fn:rows>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns>
+      <column>name</column>
+      <column>city</column>
+   </columns>
+   <rows>
+      <row>
+         <field column="name">Bob</field>
+         <field column="city">Berlin</field>
+      </row>
+      <row>
+         <field column="name">Alice</field>
+         <field column="city">Aachen</field>
+      </row>
+   </rows>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>
@@ -22608,32 +22608,32 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Filtering columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-string, map { "column-names": true(), "filter-columns": (2,1,4) })</fos:expression>
+               <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:header>
-      <fn:field>name</fn:field>
-      <fn:field>date</fn:field>
-      <fn:field>amount</fn:field>
-   </fn:header>
-   <fn:rows>
-      <fn:row>
-         <fn:field column="name">Bob</fn:field>
-         <fn:field column="date">2023-07-19</fn:field>
-         <fn:field column="amount">10.00</fn:field>
-      </fn:row>
-      <fn:row>
-         <fn:field column="name">Alice</fn:field>
-         <fn:field column="date">2023-07-20</fn:field>
-         <fn:field column="amount">15.00</fn:field>
-      </fn:row>
-      <fn:row>
-         <fn:field column="name">Charlie</fn:field>
-         <fn:field column="date">2023-07-20</fn:field>
-         <fn:field column="amount">15.00</fn:field>
-      </fn:row>
-   </fn:rows>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns>
+      <column>name</column>
+      <column>date</column>
+      <column>amount</column>
+   </columns>
+   <rows>
+      <row>
+         <field column="name">Bob</field>
+         <field column="date">2023-07-19</field>
+         <field column="amount">10.00</field>
+      </row>
+      <row>
+         <field column="name">Alice</field>
+         <field column="date">2023-07-20</field>
+         <field column="amount">15.00</field>
+      </row>
+      <row>
+         <field column="name">Charlie</field>
+         <field column="date">2023-07-20</field>
+         <field column="amount">15.00</field>
+      </row>
+   </rows>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>
@@ -22642,43 +22642,43 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "all" })</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:header>
-      <fn:field>date</fn:field>
-      <fn:field>name</fn:field>
-      <fn:field>city</fn:field>
-      <fn:field>amount</fn:field>
-      <fn:field>currency</fn:field>
-      <fn:field>original amount</fn:field>
-      <fn:field>note</fn:field>
-   </fn:header>
-   <fn:rows>
-      <fn:row>
-         <fn:field column="date">2023-07-19</fn:field>
-         <fn:field column="name">Bob</fn:field>
-         <fn:field column="city">Berlin</fn:field>
-         <fn:field column="amount">10.00</fn:field>
-         <fn:field column="currency">USD</fn:field>
-         <fn:field column="original amount">13.99</fn:field>
-      </fn:row>
-      <fn:row>
-         <fn:field column="date">2023-07-20</fn:field>
-         <fn:field column="name">Alice</fn:field>
-         <fn:field column="city">Aachen</fn:field>
-         <fn:field column="amount">15.00</fn:field>
-      </fn:row>
-      <fn:row>
-         <fn:field column="date">2023-07-20</fn:field>
-         <fn:field column="name">Charlie</fn:field>
-         <fn:field column="city">Celle</fn:field>
-         <fn:field column="amount">15.00</fn:field>
-         <fn:field column="currency">GBP</fn:field>
-         <fn:field column="original amount">11.99</fn:field>
-         <fn:field column="note">cake</fn:field>
-         <fn:field>not a lie</fn:field>
-      </fn:row>
-   </fn:rows>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns>
+      <column>date</column>
+      <column>name</column>
+      <column>city</column>
+      <column>amount</column>
+      <column>currency</column>
+      <column>original amount</column>
+      <column>note</column>
+   </columns>
+   <rows>
+      <row>
+         <field column="date">2023-07-19</field>
+         <field column="name">Bob</field>
+         <field column="city">Berlin</field>
+         <field column="amount">10.00</field>
+         <field column="currency">USD</field>
+         <field column="original amount">13.99</field>
+      </row>
+      <row>
+         <field column="date">2023-07-20</field>
+         <field column="name">Alice</field>
+         <field column="city">Aachen</field>
+         <field column="amount">15.00</field>
+      </row>
+      <row>
+         <field column="date">2023-07-20</field>
+         <field column="name">Charlie</field>
+         <field column="city">Celle</field>
+         <field column="amount">15.00</field>
+         <field column="currency">GBP</field>
+         <field column="original amount">11.99</field>
+         <field column="note">cake</field>
+         <field>not a lie</field>
+      </row>
+   </rows>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>
@@ -22687,46 +22687,46 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "first-row" })</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:header>
-      <fn:field>date</fn:field>
-      <fn:field>name</fn:field>
-      <fn:field>city</fn:field>
-      <fn:field>amount</fn:field>
-      <fn:field>currency</fn:field>
-      <fn:field>original amount</fn:field>
-      <fn:field>note</fn:field>
-   </fn:header>
-   <fn:rows>
-      <fn:row>
-         <fn:field column="date">2023-07-19</fn:field>
-         <fn:field column="name">Bob</fn:field>
-         <fn:field column="city">Berlin</fn:field>
-         <fn:field column="amount">10.00</fn:field>
-         <fn:field column="currency">USD</fn:field>
-         <fn:field column="original amount">13.99</fn:field>
-         <fn:field column="note"/>
-      </fn:row>
-      <fn:row>
-         <fn:field column="date">2023-07-20</fn:field>
-         <fn:field column="name">Alice</fn:field>
-         <fn:field column="city">Aachen</fn:field>
-         <fn:field column="amount">15.00</fn:field>
-         <fn:field column="currency"/>
-         <fn:field column="original amount"/>
-         <fn:field column="note"/>
-      </fn:row>
-      <fn:row>
-         <fn:field column="date">2023-07-20</fn:field>
-         <fn:field column="name">Charlie</fn:field>
-         <fn:field column="city">Celle</fn:field>
-         <fn:field column="amount">15.00</fn:field>
-         <fn:field column="currency">GBP</fn:field>
-         <fn:field column="original amount">11.99</fn:field>
-         <fn:field column="note">cake</fn:field>
-      </fn:row>
-   </fn:rows>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns>
+      <column>date</column>
+      <column>name</column>
+      <column>city</column>
+      <column>amount</column>
+      <column>currency</column>
+      <column>original amount</column>
+      <column>note</column>
+   </columns>
+   <rows>
+      <row>
+         <field column="date">2023-07-19</field>
+         <field column="name">Bob</field>
+         <field column="city">Berlin</field>
+         <field column="amount">10.00</field>
+         <field column="currency">USD</field>
+         <field column="original amount">13.99</field>
+         <field column="note"/>
+      </row>
+      <row>
+         <field column="date">2023-07-20</field>
+         <field column="name">Alice</field>
+         <field column="city">Aachen</field>
+         <field column="amount">15.00</field>
+         <field column="currency"/>
+         <field column="original amount"/>
+         <field column="note"/>
+      </row>
+      <row>
+         <field column="date">2023-07-20</field>
+         <field column="name">Charlie</field>
+         <field column="city">Celle</field>
+         <field column="amount">15.00</field>
+         <field column="currency">GBP</field>
+         <field column="original amount">11.99</field>
+         <field column="note">cake</field>
+      </row>
+   </rows>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>
@@ -22735,42 +22735,42 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })</fos:expression>
                <fos:result><![CDATA[
-<fn:csv>
-   <fn:header>
-      <fn:field>date</fn:field>
-      <fn:field>name</fn:field>
-      <fn:field>city</fn:field>
-      <fn:field>amount</fn:field>
-      <fn:field>currency</fn:field>
-      <fn:field>original amount</fn:field>
-   </fn:header>
-   <fn:rows>
-      <fn:row>
-         <fn:field column="date">2023-07-19</fn:field>
-         <fn:field column="name">Bob</fn:field>
-         <fn:field column="city">Berlin</fn:field>
-         <fn:field column="amount">10.00</fn:field>
-         <fn:field column="currency">USD</fn:field>
-         <fn:field column="original amount">13.99</fn:field>
-      </fn:row>
-      <fn:row>
-         <fn:field column="date">2023-07-20</fn:field>
-         <fn:field column="name">Alice</fn:field>
-         <fn:field column="city">Aachen</fn:field>
-         <fn:field column="amount">15.00</fn:field>
-         <fn:field column="currency"/>
-         <fn:field column="original amount"/>
-      </fn:row>
-      <fn:row>
-         <fn:field column="date">2023-07-20</fn:field>
-         <fn:field column="name">Charlie</fn:field>
-         <fn:field column="city">Celle</fn:field>
-         <fn:field column="amount">15.00</fn:field>
-         <fn:field column="currency">GBP</fn:field>
-         <fn:field column="original amount">11.99</fn:field>
-      </fn:row>
-   </fn:rows>
-</fn:csv>
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <columns>
+      <column>date</column>
+      <column>name</column>
+      <column>city</column>
+      <column>amount</column>
+      <column>currency</column>
+      <column>original amount</column>
+   </columns>
+   <rows>
+      <row>
+         <field column="date">2023-07-19</field>
+         <field column="name">Bob</field>
+         <field column="city">Berlin</field>
+         <field column="amount">10.00</field>
+         <field column="currency">USD</field>
+         <field column="original amount">13.99</field>
+      </row>
+      <row>
+         <field column="date">2023-07-20</field>
+         <field column="name">Alice</field>
+         <field column="city">Aachen</field>
+         <field column="amount">15.00</field>
+         <field column="currency"/>
+         <field column="original amount"/>
+      </row>
+      <row>
+         <field column="date">2023-07-20</field>
+         <field column="name">Charlie</field>
+         <field column="city">Celle</field>
+         <field column="amount">15.00</field>
+         <field column="currency">GBP</field>
+         <field column="original amount">11.99</field>
+      </row>
+   </rows>
+</csv>
 ]]></fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21994,9 +21994,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <code>fn:parse-csv</code>, and the options controlling their use are defined
             there.</p>
 
-         <p>If the <code>headers</code> option is true, implementations <rfc2119>must</rfc2119>
-            exclude the first record from the returned map’s <code>body</code> key, and return it as
-            the value of the returned map’s <code>headers-record</code> key.</p>
+         <p>If the <code>column-names</code> option is true, implementations <rfc2119>must</rfc2119>
+            exclude the first record from the returned map’s <code>rows</code> key, and use it to
+            construct a <code>csv-columns-record</code> that is returned as the value of the
+            returned map’s <code>columns</code> key.</p>
 
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
          <fos:options>
@@ -22102,12 +22103,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:option>
          </fos:options>
 
-         <p>If column names were extracted from the first row of the CSV, when there are duplicate
-            column names, implementations <rfc2119>must</rfc2119> include only the first occurrence
-            in the <code>names</code> entry of the <code>csv-columns-record</code>, ignoring
-            subsequent entries. Any fields in the first record whose value is the empty string
-            <rfc2119>must</rfc2119> also be omitted.</p>
-
          <p>The result of the function is a <code>parsed-csv-structure-record</code>, a map with
             string keys containing two entries, <code>columns</code>, and <code>rows</code>.</p>
          <olist>
@@ -22170,6 +22165,25 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   <code>fn:csv-fetch-field-by-column</code> for more details</p>
             </item>
          </olist>
+
+         <p>If column names were extracted from the first row of the CSV, when there are duplicate
+            column names, implementations <rfc2119>must</rfc2119> include only the first occurrence
+            in the <code>names</code> entry of the <code>csv-columns-record</code>, ignoring
+            subsequent entries. Any fields in the first record whose value is the empty string
+            <rfc2119>must</rfc2119> also be omitted.</p>
+
+         <p>If the <code>number-of-columns</code> options is set to <code>"first-row"</code> or an
+            integer, or the <code>filter-columns</code> option is set, and the
+            <code>column-names</code> option is set to <code>true()</code>, the filtering of
+            columns is performed before the extraction of the first row and creation of the
+            <code>csv-columns-record</code>.</p>
+
+         <p>If the <code>number-of-columns</code> options is set to <code>"first-row"</code> or an
+            integer, or the <code>filter-columns</code> option is set, and the
+            <code>column-names</code> option is set to a <code>map(xs:string, xs:integer)</code>,
+            then filtering of columns does not affect the creation of the
+            <code>csv-columns-record</code>, and it is possible that the number of fields in the
+            rows is smaller than the number of fields in the <code>csv-columns-record</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
@@ -22199,7 +22213,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:variable name="csv-string" id="csv-string">`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`</fos:variable>
          <fos:variable name="options" id="non-default-delims">map { "row-delimiter": "§", "field-delimiter": ";", "quote-character": "|" }</fos:variable>
          <fos:variable name="non-std-csv" id="non-standard-csv-string">`|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|`</fos:variable>
-         <fos:variable name="trim-opts" id="trim-whitespace-options">map { "trim-whitespace": true() }</fos:variable>
          <fos:example>
             <p>With defaults for delimiters and quotes, and default column extraction (false):</p>
             <fos:test use="csv-string escaped-crlf-2">
@@ -22268,9 +22281,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
                <fos:expression>csv-to-xdm($csv-string, $options)?columns</fos:expression>
                <fos:result>map {
-                  "names": map { 1: "Person", 2: "Location" },
-                  "fields": ("Person", "Location")
-                  }</fos:result>
+   "names": map { "Person": 1, "Location": 2 },
+   "fields": ("Person", "Location")
+}</fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
                <fos:expression>count(csv-to-xdm($csv-string, $options)?rows)</fos:expression>
@@ -22285,14 +22298,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
-         <fos:example>
-            <p>Trimming whitespace in fields:</p>
-            <fos:test use="escaped-crlf-2 trim-whitespace-options">
-               <fos:expression xml:space="preserve">csv-to-xdm(`name  ,city  {$crlf}Bob   ,Berlin{$crlf}Alice ,Aachen{$crlf}`, $trim-opts)?rows?fields</fos:expression>
-               <fos:result>("name", "city", "Bob", "Berlin", "Alice", "Aachen")</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string">`date,name,city,amount,currency,original amount,note{$crlf}2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}2023-07-20,Alice,Aachen,15.00{$crlf}2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`</fos:variable>
+         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string">concat(`date,name,city,amount,currency,original amount,note{$crlf}`,
+`2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}`,
+`2023-07-20,Alice,Aachen,15.00{$crlf}`,
+`2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`)</fos:variable>
          <fos:example>
             <p>Filtering columns, with <code>column-names: true()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
@@ -22309,18 +22318,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Filtering columns, with <code>column-names: false()</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
-   ["name","date","amount"],
-   ["Bob","2023-07-19","10.00"],
-   ["Alice","2023-07-20","15.00"],
-   ["Charlie","2023-07-20","15.00"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
             <p>Filtering columns, with <code>column-names: map { ... }</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
                <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Person", 3: "Amount" }, "filter-columns": (2,1,4) })?columns</fos:expression>
@@ -22328,56 +22325,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
    "names": map { "Person": 1, "Amount": 3 },
    "fields": ("Person", "", "Amount")
 }</fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Person", 3: "Amount" }, "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
-   ["name","date","amount"],
-   ["Bob","2023-07-19","10.00"],
-   ["Alice","2023-07-20","15.00"],
-   ["Charlie","2023-07-20","15.00"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Specifying the number of columns, using <code>"all"</code> (the default)</p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "all" })?columns?fields</fos:expression>
-               <fos:result>("date","name","city","amount","currency","original amount","note")</fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "all" })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
-   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
-   ["2023-07-20","Alice","Aachen","15.00"],
-   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake","not a lie"]
-)</fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "number-of-columns": "all" })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
-   ["date","name","city","amount","currency","original amount","note"],
-   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
-   ["2023-07-20","Alice","Aachen","15.00"],
-   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake","not a lie"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Specifying the number of columns, using <code>"all"</code> and <code>column-names: map { ... }</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Date", 6: "Amount", 5: "Currency" }, "number-of-columns": "all" })?columns</fos:expression>
-               <fos:result>map {
-   "names": map { "Date": 1, "Amount": 6, "Currency": 5 },
-   "fields": ("Date", "", "", "", "Currency", "Amount")
-}</fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map {
-   "column-names": map { 1: "Date", 6: "Amount", 5: "Currency" },
-   "number-of-columns": "all"
-})?rows return $r?field("Amount")</fos:expression>
-               <fos:result>("original amount", "13.99", "", "11.99")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -22393,47 +22340,13 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Specifying the number of columns using <code>"first-row"</code> and <code>column-names: true()</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "first-row" })?columns?fields</fos:expression>
-               <fos:result>("date","name","city","amount","currency","original amount","note")</fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "first-row" })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
-   ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
-   ["2023-07-20","Alice","Aachen","15.00","","",""],
-   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Specifying the number of columns, using <code>"first-row"</code> and <code>column-names: map { ... }</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Date", 4: "Amount" }, "number-of-columns": "first-row" })?columns</fos:expression>
-               <fos:result>map {
-   "names": map { "Date": 1, "Amount": 4 },
-   "fields": ("Date", "", "", "Amount")
-}</fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map {
-   "column-names": map { 1: "Date", 4: "Amount" },
-   "number-of-columns": "first-row"
-})?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
-   ["date","name","city","amount"],
-   ["2023-07-19","Bob","Berlin","10.00"],
-   ["2023-07-20","Alice","Aachen","15.00"],
-   ["2023-07-20","Charlie","Celle","15.00"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
             <p>Specifying the number of columns with a number and <code>column-names: true()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
                <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?columns?fields</fos:expression>
-               <fos:result>("date","name","city","amount","currency","original amount")</fos:result>
+               <fos:result>map {
+   "names": map { "date": 1, "name": 2, "city": 3, "amount": 4, "currency": 5, "original amount": 6 },
+   "fields": ("date","name","city","amount","currency","original amount")
+}</fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
                <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
@@ -22442,74 +22355,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
    ["2023-07-20","Alice","Aachen","15.00","",""],
    ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
 )</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Specifying the number of columns with a number and <code>column-names: false()</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
-   ["date","name","city","amount","currency","original amount"],
-   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
-   ["2023-07-20","Alice","Aachen","15.00","",""],
-   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Specifying the number of columns with a number and <code>column-names: map { ... }</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Date", 4: "Amount" }, "number-of-columns": "first-row" })?columns</fos:expression>
-               <fos:result>map {
-   "names": map { "Date": 1, "Amount": 4 },
-   "fields": ("Date", "", "", "Amount")
-}</fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map {
-   "column-names": map { 1: "Date", 4: "Amount" },
-   "number-of-columns": 6
-})?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
-   ["date","name","city","amount","currency","original amount"],
-   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
-   ["2023-07-20","Alice","Aachen","15.00","",""],
-   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
-)</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Specifying both <code>number-of-columns</code> and <code>filter-columns</code> is an error condition</p>
-            <fos:test use="escaped-crlf-2 csv-string">
-               <fos:expression>csv-to-xdm($csv-string, map { "filter-columns": (1,3), "number-of-columns": "first-row" })</fos:expression>
-               <fos:error-result error-code="FOCV0006"/>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Specifying negative integers, or zero, in options taking <code>xs:integer</code> values is an error condition</p>
-            <fos:test use="escaped-crlf-2 csv-string">
-               <fos:expression>csv-to-xdm($csv-string, map { "filter-columns": -1 })</fos:expression>
-               <fos:error-result error-code="FOCV0005"/>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 csv-string">
-               <fos:expression>csv-to-xdm($csv-string, map { "filter-columns": 0 })</fos:expression>
-               <fos:error-result error-code="FOCV0005"/>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 csv-string">
-               <fos:expression>csv-to-xdm($csv-string, map { "number-of-columns": -1 })</fos:expression>
-               <fos:error-result error-code="FOCV0005"/>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 csv-string">
-               <fos:expression>csv-to-xdm($csv-string, map { "number-of-columns": 0 })</fos:expression>
-               <fos:error-result error-code="FOCV0005"/>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 csv-string">
-               <fos:expression>csv-to-xdm($csv-string, map { "column-names": map { 0: "Name" } })</fos:expression>
-               <fos:error-result error-code="FOCV0005"/>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 csv-string">
-               <fos:expression>csv-to-xdm($csv-string, map { "column-names": map { -1: "Name" } })</fos:expression>
-               <fos:error-result error-code="FOCV0005"/>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -22756,7 +22601,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 ]]></fos:result>
             </fos:test>
          </fos:example>
-         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string-2">`date,name,city,amount,currency,original amount,note{$crlf}2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}2023-07-20,Alice,Aachen,15.00{$crlf}2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`</fos:variable>
+         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string-2">concat(`date,name,city,amount,currency,original amount,note{$crlf}`,
+`2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}`,
+`2023-07-20,Alice,Aachen,15.00{$crlf}`,
+`2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`)</fos:variable>
          <fos:example>
             <p>Filtering columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21876,7 +21876,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf">
                <fos:expression>parse-csv(`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`)</fos:expression>
                <fos:result>(
-   ["name", "city"]
+   ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
 )</fos:result>
@@ -21884,7 +21884,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-cr">
                <fos:expression>parse-csv(`name,city{$cr}Bob,Berlin{$cr}Alice,Aachen{$cr}`)</fos:expression>
                <fos:result>(
-   ["name", "city"]
+   ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
 )</fos:result>
@@ -21892,7 +21892,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-lf">
                <fos:expression>parse-csv(`name,city{$lf}Bob,Berlin{$lf}Alice,Aachen{$lf}`)</fos:expression>
                <fos:result>(
-   ["name", "city"]
+   ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
 )</fos:result>
@@ -21903,7 +21903,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf">
                <fos:expression>parse-csv(`"name","city"${crlf}"Bob","Berlin"${crlf}"Alice","Aachen"${crlf}`)</fos:expression>
                <fos:result>(
-   ["name", "city"]
+   ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
 )</fos:result>
@@ -21911,7 +21911,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf">
                <fos:expression>parse-csv(`"name","city"${crlf}"Bob ""The Exemplar"" Mustermann","Berlin"${crlf}`)</fos:expression>
                <fos:result>(
-   ["name", "city"]
+   ["name", "city"],
    ['Bob "The Exemplar" Mustermann', "Berlin"],
    ["Alice", "Aachen"]
 )</fos:result>
@@ -21922,7 +21922,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test>
                <fos:expression>parse-csv("name;city§Bob;Berlin§Alice;Aachen", map{"record-separator": "§", "field-separator": ";"})</fos:expression>
                <fos:result>(
-   ["name", "city"]
+   ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
 )</fos:result>
@@ -21933,7 +21933,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf">
                <fos:expression>parse-csv(`|name|,|city|${crlf}|Bob|,|Berlin|${crlf}`, map{"quote-character": "|"})</fos:expression>
                <fos:result>(
-   ["name", "city"]
+   ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
 )</fos:result>
@@ -21944,7 +21944,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test use="escaped-crlf">
                <fos:expression xml:space="preserve">parse-csv(`name  ,city  ${crlf}Bob   ,Berlin${crlf}Alice ,Aachen${crlf}`, map{"trim-whitespace: true()})</fos:expression>
                <fos:result>(
-   ["name", "city"]
+   ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
 )</fos:result>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22037,7 +22037,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:meaning>Determines whether the first row of the CSV should be treated as a list
                   of column names and returned as a <code>csv-columns-record</code> in the
                   <code>columns</code> entry of the returned map. Permitted values are a map of type
-                  <code>map(xs:integer, xs:string)</code> or an <code>xs:boolean</code>.
+                  <code>map(xs:string, xs:integer)</code> or an <code>xs:boolean</code>.
                </fos:meaning>
                <fos:type>item()</fos:type>
                <fos:default>false</fos:default>
@@ -22057,7 +22057,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      the returned <code>parsed-csv-structure-record</code>. Implementations
                      <rfc2119>must not</rfc2119> exclude the first row from the <code>rows</code>
                      entry of the <code>parsed-csv-structure-record</code>.</fos:value>
-                  <fos:value value="map(xs:integer, xs:string)">A <code>csv-columns-record</code> is
+                  <fos:value value="map(xs:string, xs:integer)">A <code>csv-columns-record</code> is
                      constructed using the supplied map and returned as the <code>header</code>
                      entry of the <code>parsed-csv-structure-record</code>. The supplied map is used
                      as the <code>names</code> entry, and a sequence of strings for the
@@ -22271,7 +22271,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
          </fos:example>
          <fos:variable name="csv-string" id="csv-string-no-headers">`Alice,Aachen{$crlf}Bob,Berlin{$crlf}`</fos:variable>
-         <fos:variable name="options" id="explicit-csv-column-opts">map { "column-names": map { 1: "Person", 2: "Location" } }</fos:variable>
+         <fos:variable name="options" id="explicit-csv-column-opts">map { "column-names": map { "Person": 1, "Location": 2 } }</fos:variable>
          <fos:example>
             <p>Specifying column names explicitly:</p>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
@@ -22320,7 +22320,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Filtering columns, with <code>column-names: map { ... }</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Person", 3: "Amount" }, "filter-columns": (2,1,4) })?columns</fos:expression>
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { "Person": 1, "Amount": 3 }, "filter-columns": (2,1,4) })?columns</fos:expression>
                <fos:result>map {
    "names": map { "Person": 1, "Amount": 3 },
    "fields": ("Person", "", "Amount")
@@ -22447,7 +22447,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:meaning>Determines whether the first row of the CSV should be treated as a list
                   of column headers and returned as <code><![CDATA[<column>]]></code> elements in
                   the <code><![CDATA[<header>]]></code> element. Permitted values are a map of type
-                  <code>map(xs:integer, xs:string)</code> or an <code>xs:boolean</code>.
+                  <code>map(xs:string, xs:integer)</code> or an <code>xs:boolean</code>.
                </fos:meaning>
                <fos:type>item()</fos:type>
                <fos:default>false</fos:default>
@@ -22459,7 +22459,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      element.</fos:value>
                   <fos:value value="false">Implementations <rfc2119>must not</rfc2119> include a
                      <code><![CDATA[<header>]]></code> element in the output.</fos:value>
-                  <fos:value value="map(xs:integer, xs:string)">The supplied map is used to
+                  <fos:value value="map(xs:string, xs:integer)">The supplied map is used to
                      construct a sequence of <code><![CDATA[<column>]]></code> elements to populate
                      the <code><![CDATA[<header>]]></code> element. The <code>xs:integer</code>
                      denotes the column number, and the <code>xs:string</code> the column name. Gaps
@@ -22540,7 +22540,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>An empty CSV with explicit column names:</p>
             <fos:test>
-               <fos:expression>csv-to-xml("", map { "column-names": map { 1: "name", 3: "city"})</fos:expression>
+               <fos:expression>csv-to-xml("", map { "column-names": map { "name": 1, "city": 3 })</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16723,7 +16723,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
                </tr>
                <tr>
                   <td>
-                     <code>item-separator</code>
+                     <code>item-delimiter</code>
                   </td>
                   <td>
                      <code>xs:string?</code>
@@ -21817,11 +21817,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:type>xs:string</fos:type>
                <fos:default>","</fos:default>
             </fos:option>
-            <fos:option key="record-delimiter">
-               <fos:meaning>The characters used to delimit records within the CSV string, if the
-                  default use of line separator as record separator is to be overridden.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>()</fos:default>
+            <fos:option key="row-delimiter">
+               <fos:meaning>The sequence of strings used to delimit rows within the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
+               <fos:type>xs:string+</fos:type>
+               <fos:default>("&amp;#13;&amp;#10;", "&amp;#10;", "&amp;#13;")</fos:default>
             </fos:option>
             <fos:option key="quote-character">
                <fos:meaning>The character used to quote fields within the CSV string. An instance of
@@ -21856,10 +21855,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
             fields.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
-            for <code>field-separator</code>, <code>record-separator</code>,
-            <code>quote-character</code> are specified and are not a single character.</p>
+            for <code>field-delimiter</code> or <code>quote-character</code> are specified and are
+            not a single character.</p>
          <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
-            <code>field-separator</code>, <code>record-separator</code>,
+            <code>field-delimiter</code>, <code>row-delimiter</code>,
             <code>quote-character</code> are equal.</p>
       </fos:errors>
       <fos:notes>
@@ -21917,7 +21916,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Non-default record- and field-separators:</p>
+            <p>Non-default record- and field-delimiters:</p>
             <fos:test>
                <fos:expression>parse-csv("name;city§Bob;Berlin§Alice;Aachen", map{"row-delimiter": "§", "field-delimiter": ";"})</fos:expression>
                <fos:result>(
@@ -22007,11 +22006,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:type>xs:string</fos:type>
                <fos:default>","</fos:default>
             </fos:option>
-            <fos:option key="record-delimiter">
-               <fos:meaning>The characters used to delimit records within the CSV string, if the
-                  default use of line separator as record separator is to be overridden.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>()</fos:default>
+            <fos:option key="row-delimiter">
+               <fos:meaning>The sequence of strings used to delimit rows within the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
+               <fos:type>xs:string+</fos:type>
+               <fos:default>("&amp;#13;&amp;#10;", "&amp;#10;", "&amp;#13;")</fos:default>
             </fos:option>
             <fos:option key="quote-character">
                <fos:meaning>The character used to quote fields within the CSV string. An instance of
@@ -22037,8 +22035,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:option key="column-names">
                <fos:meaning>Determines whether the first row of the CSV should be treated as a list
                   of column names and returned as a <code>csv-columns-record</code> in the
-                  <code>columns</code> entry of the returned map.</fos:meaning>
-               <fos:type>union(xs:boolean, map(xs:string, xs:integer))</fos:type>
+                  <code>columns</code> entry of the returned map. Permitted values are a map of type
+                  <code>map(xs:integer, xs:string)</code> or an <code>xs:boolean</code>.
+               </fos:meaning>
+               <fos:type>item()</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
                   <fos:value value="true">A <code>csv-columns-record</code> is constructed using the
@@ -22067,8 +22067,21 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
+            <fos:option key="filter-columns">
+               <fos:meaning>A sequence indicating which fields to return and in which order. If this
+                  option is missing or the empty sequence, all fields are returned in their natural
+                  order. Items in the sequence are treated as the index of the column to return. In
+                  the returned data, only fields from the specified columnms are returned, and in
+                  the order specified. This option is mutually exclusive with the
+                  <code>number-of-columns</code> option. Specifying both options will cause an <errorref
+                     class="CV" code="0006"/> error.</fos:meaning>
+               <fos:type>xs:integer*</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
             <fos:option key="number-of-columns">
-               <fos:meaning>Specifies how many columns to return.</fos:meaning>
+               <fos:meaning>Specifies how many columns to return. This option is mutually exclusive with the
+                  <code>filter-columns</code> option. Specifying both options will cause an <errorref
+                     class="CV" code="0006"/> error.</fos:meaning>
                <fos:type>union(enum("all", "first-row"), xs:integer)</fos:type>
                <fos:default>"all"</fos:default>
                <fos:values>
@@ -22102,7 +22115,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <p>The entry with key <code>"columns"</code> holds a <code>csv-columns-record</code>
                   record. If column names have been extracted, or supplied, then the record will
                   have a <code>names</code> entry whose value is a map of column-name to
-                  column-number, <code>map(xs:integer, xs:string)</code>. The record’s
+                  column-number, <code>map(xs:string, xs:integer)</code>. The record’s
                   <code>fields</code> entry will contains the column names as a sequence of
                   strings, <code>xs:string*</code>, replicating the row they were taken from.</p>
 
@@ -22163,11 +22176,18 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
             fields.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
-            for <code>field-separator</code>, <code>record-separator</code>,
-            <code>quote-character</code> are specified and are not a single character.</p>
+            for <code>field-delimiter</code> or <code>quote-character</code> are specified and are
+            not a single character.</p>
          <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
-            <code>field-separator</code>, <code>record-separator</code>,
+            <code>field-delimiter</code>, <code>row-delimiter</code>,
             <code>quote-character</code> are equal.</p>
+         <p>A dynamic error <errorref class="CV" code="0005"/> occurs if any column-index integers,
+            such as the values in a map supplied to <code>column-names</code>, or as the value of
+            <code>number-of-columns</code> or <code>filter-columns</code>, are negative or
+            zero.</p>
+         <p>A dynamic error <errorref class="CV" code="0006"/> occurs if both the
+            <code>number-of-columns</code> and <code>filter-columns</code> options are set in a
+            call to <code>fn:csv-to-xdm</code>.</p>
       </fos:errors>
       <fos:notes>
          <p>All fields are returned as <code>xs:string</code> values.</p>
@@ -22177,20 +22197,20 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:examples>
          <fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('\r')||char('\n')]]></fos:variable>
          <fos:variable name="csv-string" id="csv-string">`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`</fos:variable>
-         <fos:variable name="options" id="non-default-delims">map { "record-separator": "§", "field-separator": ";", "quote-character": "|" }</fos:variable>
+         <fos:variable name="options" id="non-default-delims">map { "row-delimiter": "§", "field-delimiter": ";", "quote-character": "|" }</fos:variable>
          <fos:variable name="non-std-csv" id="non-standard-csv-string">`|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|`</fos:variable>
          <fos:variable name="trim-opts" id="trim-whitespace-options">map { "trim-whitespace": true() }</fos:variable>
          <fos:example>
             <p>With defaults for delimiters and quotes, and default column extraction (false):</p>
             <fos:test use="csv-string escaped-crlf-2">
                <fos:expression>map:keys(csv-to-xdm($csv-string))</fos:expression>
-               <fos:result>("header", "rows")</fos:result>
+               <fos:result>("columns", "rows")</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
                <fos:expression>csv-to-xdm($csv-string)?columns</fos:expression>
                <fos:result>map {
   "names": map {},
-  "fields": (),
+  "fields": ()
 }</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
@@ -22199,7 +22219,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
                <fos:expression>csv-to-xdm($csv-string)?rows[1]?field("name")</fos:expression>
-               <fos:error-result error-code="CV"/>
+               <fos:error-result error-code="FOCV0004"/>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
                <fos:expression>csv-to-xdm($csv-string)?rows[1]?field(2)</fos:expression>
@@ -22207,68 +22227,112 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
             <p>With defaults for delimiters and quotes, and <code>columns: true()</code> set:</p>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string, map {"columns": true()})?columns</fos:expression>
+               <fos:expression>csv-to-xdm($csv-string, map {"column-names": true()})?columns</fos:expression>
                <fos:result>map {
   "names": map { "name": 1, "city": 2 },
-  "fields": ("name", "city"),
+  "fields": ("name", "city")
 }</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>count(csv-to-xdm($csv-string, map {"columns": true()})?rows)</fos:expression>
+               <fos:expression>count(csv-to-xdm($csv-string, map {"column-names": true()})?rows)</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string), map {"columns": true()}?rows[1]?fields</fos:expression>
+               <fos:expression>csv-to-xdm($csv-string, map {"column-names": true()})?rows[1]?fields</fos:expression>
                <fos:result>("Bob", "Berlin")</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string, map {"columns": true()})?rows[1]?field("name")</fos:expression>
+               <fos:expression>csv-to-xdm($csv-string, map {"column-names": true()})?rows[1]?field("name")</fos:expression>
                <fos:result>"Bob"</fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>csv-to-xdm($csv-string, map {"columns": true()})?rows[1]?field(2)</fos:expression>
+               <fos:expression>csv-to-xdm($csv-string, map {"column-names": true()})?rows[1]?field(2)</fos:expression>
                <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Non-default record- and field-delimiters, non-default quotes:</p>
             <fos:test use="non-default-delims non-standard-csv-string">
-               <fos:expression>map:keys(csv-to-xdm($non-std-csv, $options))</fos:expression>
-               <fos:result>("header", "rows")</fos:result>
-            </fos:test>
-            <fos:test use="non-default-delims non-standard-csv-string">
-               <fos:expression>csv-to-xdm($non-std-csv, $options)?columns</fos:expression>
-               <fos:result>map {
-                  "names": map {},
-                  "fields": (),
-                  }</fos:result>
-            </fos:test>
-            <fos:test use="non-default-delims non-standard-csv-string">
-               <fos:expression>count(csv-to-xdm($non-std-csv, $options)?rows)</fos:expression>
-               <fos:result>3</fos:result>
-            </fos:test>
-            <fos:test use="non-default-delims non-standard-csv-string">
                <fos:expression>csv-to-xdm($non-std-csv, $options)?rows[3]?field(1)</fos:expression>
                <fos:result>"Alice"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:variable name="csv-string" id="csv-string-no-headers">`Alice,Aachen{$crlf}Bob,Berlin{$crlf}`</fos:variable>
+         <fos:variable name="options" id="explicit-csv-column-opts">map { "column-names": map { 1: "Person", 2: "Location" } }</fos:variable>
+         <fos:example>
+            <p>Specifying column names explicitly:</p>
+            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
+               <fos:expression>map:keys(csv-to-xdm($csv-string, $options))</fos:expression>
+               <fos:result>("columns", "rows")</fos:result>
+            </fos:test>
+            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
+               <fos:expression>csv-to-xdm($csv-string, $options)?columns</fos:expression>
+               <fos:result>map {
+                  "names": map { 1: "Person", 2: "Location" },
+                  "fields": ("Person", "Location")
+                  }</fos:result>
+            </fos:test>
+            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
+               <fos:expression>count(csv-to-xdm($csv-string, $options)?rows)</fos:expression>
+               <fos:result>2</fos:result>
+            </fos:test>
+            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
+               <fos:expression>csv-to-xdm($csv-string, $options)?rows[1]?field(1)</fos:expression>
+               <fos:result>"Alice"</fos:result>
+            </fos:test>
+            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
+               <fos:expression>csv-to-xdm($csv-string, $options)?rows[2]?field("Location")</fos:expression>
+               <fos:result>"Berlin"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Trimming whitespace in fields:</p>
             <fos:test use="escaped-crlf-2 trim-whitespace-options">
-               <fos:expression xml:space="preserve">csv-to-xdm(`name  ,city  ${crlf}Bob   ,Berlin${crlf}Alice ,Aachen${crlf}`, $trim-opts)?rows?fields</fos:expression>
+               <fos:expression xml:space="preserve">csv-to-xdm(`name  ,city  {$crlf}Bob   ,Berlin{$crlf}Alice ,Aachen{$crlf}`, $trim-opts)?rows?fields</fos:expression>
                <fos:result>("name", "city", "Bob", "Berlin", "Alice", "Aachen")</fos:result>
             </fos:test>
          </fos:example>
          <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string">`date,name,city,amount,currency,original amount,note{$crlf}2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}2023-07-20,Alice,Aachen,15.00{$crlf}2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`</fos:variable>
          <fos:example>
-            <p>Filtering columns</p>
+            <p>Filtering columns, with <code>column-names: true()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "columns": true(), "filter-columns": (2,1,4) })?columns?fields</fos:expression>
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })?columns?fields</fos:expression>
                <fos:result>("name","date","amount")</fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "columns": true(), "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
                <fos:result>(
+   ["Bob","2023-07-19","10.00"],
+   ["Alice","2023-07-20","15.00"],
+   ["Charlie","2023-07-20","15.00"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Filtering columns, with <code>column-names: false()</code></p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["name","date","amount"],
+   ["Bob","2023-07-19","10.00"],
+   ["Alice","2023-07-20","15.00"],
+   ["Charlie","2023-07-20","15.00"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Filtering columns, with <code>column-names: map { ... }</code></p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Person", 3: "Amount" }, "filter-columns": (2,1,4) })?columns</fos:expression>
+               <fos:result>map {
+   "names": map { "Person": 1, "Amount": 3 },
+   "fields": ("Person", "", "Amount")
+}</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Person", 3: "Amount" }, "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["name","date","amount"],
    ["Bob","2023-07-19","10.00"],
    ["Alice","2023-07-20","15.00"],
    ["Charlie","2023-07-20","15.00"]
@@ -22278,12 +22342,21 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Specifying the number of columns, using <code>"all"</code> (the default)</p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": "all" })?columns?fields</fos:expression>
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "all" })?columns?fields</fos:expression>
                <fos:result>("date","name","city","amount","currency","original amount","note")</fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": "all" })?rows return array { $r?fields }</fos:expression>
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "all" })?rows return array { $r?fields }</fos:expression>
                <fos:result>(
+   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
+   ["2023-07-20","Alice","Aachen","15.00"],
+   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake","not a lie"]
+)</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "number-of-columns": "all" })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["date","name","city","amount","currency","original amount","note"],
    ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
    ["2023-07-20","Alice","Aachen","15.00"],
    ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake","not a lie"]
@@ -22291,13 +22364,42 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Specifying the number of columns using <code>"first-row"</code></p>
+            <p>Specifying the number of columns, using <code>"all"</code> and <code>column-names: map { ... }</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": "first-row" })?columns?fields</fos:expression>
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Date", 6: "Amount", 5: "Currency" }, "number-of-columns": "all" })?columns</fos:expression>
+               <fos:result>map {
+   "names": map { "Date": 1, "Amount": 6, "Currency": 5 },
+   "fields": ("Date", "", "", "", "Currency", "Amount")
+}</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map {
+   "column-names": map { 1: "Date", 6: "Amount", 5: "Currency" },
+   "number-of-columns": "all"
+})?rows return $r?field("Amount")</fos:expression>
+               <fos:result>("original amount", "13.99", "", "11.99")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns using <code>"first-row"</code> and <code>column-names: false()</code></p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "number-of-columns": "first-row" })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["date","name","city","amount","currency","original amount","note"],
+   ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
+   ["2023-07-20","Alice","Aachen","15.00","","",""],
+   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns using <code>"first-row"</code> and <code>column-names: true()</code></p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "first-row" })?columns?fields</fos:expression>
                <fos:result>("date","name","city","amount","currency","original amount","note")</fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": "first-row" })?rows return array { $r?fields }</fos:expression>
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "first-row" })?rows return array { $r?fields }</fos:expression>
                <fos:result>(
    ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
    ["2023-07-20","Alice","Aachen","15.00","","",""],
@@ -22306,18 +22408,108 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Specifying the number of columns with a number</p>
+            <p>Specifying the number of columns, using <code>"first-row"</code> and <code>column-names: map { ... }</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": 6 })?columns?fields</fos:expression>
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Date", 4: "Amount" }, "number-of-columns": "first-row" })?columns</fos:expression>
+               <fos:result>map {
+   "names": map { "Date": 1, "Amount": 4 },
+   "fields": ("Date", "", "", "Amount")
+}</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map {
+   "column-names": map { 1: "Date", 4: "Amount" },
+   "number-of-columns": "first-row"
+})?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["date","name","city","amount"],
+   ["2023-07-19","Bob","Berlin","10.00"],
+   ["2023-07-20","Alice","Aachen","15.00"],
+   ["2023-07-20","Charlie","Celle","15.00"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns with a number and <code>column-names: true()</code></p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?columns?fields</fos:expression>
                <fos:result>("date","name","city","amount","currency","original amount")</fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "columns": true(), "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
                <fos:result>(
    ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
    ["2023-07-20","Alice","Aachen","15.00","",""],
    ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
 )</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns with a number and <code>column-names: false()</code></p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map { "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["date","name","city","amount","currency","original amount"],
+   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
+   ["2023-07-20","Alice","Aachen","15.00","",""],
+   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying the number of columns with a number and <code>column-names: map { ... }</code></p>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>csv-to-xdm($csv-uneven-cols, map { "column-names": map { 1: "Date", 4: "Amount" }, "number-of-columns": "first-row" })?columns</fos:expression>
+               <fos:result>map {
+   "names": map { "Date": 1, "Amount": 4 },
+   "fields": ("Date", "", "", "Amount")
+}</fos:result>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
+               <fos:expression>for $r in csv-to-xdm($csv-uneven-cols, map {
+   "column-names": map { 1: "Date", 4: "Amount" },
+   "number-of-columns": 6
+})?rows return array { $r?fields }</fos:expression>
+               <fos:result>(
+   ["date","name","city","amount","currency","original amount"],
+   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
+   ["2023-07-20","Alice","Aachen","15.00","",""],
+   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
+)</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying both <code>number-of-columns</code> and <code>filter-columns</code> is an error condition</p>
+            <fos:test use="escaped-crlf-2 csv-string">
+               <fos:expression>csv-to-xdm($csv-string, map { "filter-columns": (1,3), "number-of-columns": "first-row" })</fos:expression>
+               <fos:error-result error-code="FOCV0006"/>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <p>Specifying negative integers, or zero, in options taking <code>xs:integer</code> values is an error condition</p>
+            <fos:test use="escaped-crlf-2 csv-string">
+               <fos:expression>csv-to-xdm($csv-string, map { "filter-columns": -1 })</fos:expression>
+               <fos:error-result error-code="FOCV0005"/>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 csv-string">
+               <fos:expression>csv-to-xdm($csv-string, map { "filter-columns": 0 })</fos:expression>
+               <fos:error-result error-code="FOCV0005"/>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 csv-string">
+               <fos:expression>csv-to-xdm($csv-string, map { "number-of-columns": -1 })</fos:expression>
+               <fos:error-result error-code="FOCV0005"/>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 csv-string">
+               <fos:expression>csv-to-xdm($csv-string, map { "number-of-columns": 0 })</fos:expression>
+               <fos:error-result error-code="FOCV0005"/>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 csv-string">
+               <fos:expression>csv-to-xdm($csv-string, map { "column-names": map { 0: "Name" } })</fos:expression>
+               <fos:error-result error-code="FOCV0005"/>
+            </fos:test>
+            <fos:test use="escaped-crlf-2 csv-string">
+               <fos:expression>csv-to-xdm($csv-string, map { "column-names": map { -1: "Name" } })</fos:expression>
+               <fos:error-result error-code="FOCV0005"/>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -22379,8 +22571,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:type>xs:string</fos:type>
                <fos:default>","</fos:default>
             </fos:option>
-            <fos:option key="record-delimiter">
-               <fos:meaning>The characters used to delimit records within the CSV string, if the
+            <fos:option key="row-delimiter">
+               <fos:meaning>The characters used to delimit rows within the CSV string, if the
                   default use of line separator as record separator is to be overridden.</fos:meaning>
                <fos:type>xs:string</fos:type>
                <fos:default>()</fos:default>
@@ -22408,9 +22600,11 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:option>
             <fos:option key="column-names">
                <fos:meaning>Determines whether the first row of the CSV should be treated as a list
-                  of column headers and returned as a <code>csv-columns-record</code> in the
-                  <code>header</code> entry of the returned map.</fos:meaning>
-               <fos:type>union(xs:boolean, map(xs:integer, xs:string))</fos:type>
+                  of column headers and returned as <code><![CDATA[<column>]]></code> elements in
+                  the <code><![CDATA[<header>]]></code> element. Permitted values are a map of type
+                  <code>map(xs:integer, xs:string)</code> or an <code>xs:boolean</code>.
+               </fos:meaning>
+               <fos:type>item()</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
                   <fos:value value="true">The <code><![CDATA[<header>]]></code> element is populated
@@ -22466,10 +22660,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
             fields.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
-            for <code>field-separator</code>, <code>record-separator</code>,
+            for <code>field-delimiter</code>, <code>row-delimiter</code>,
             <code>quote-character</code> are specified and are not a single character.</p>
          <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
-            <code>field-separator</code>, <code>record-separator</code>,
+            <code>field-delimiter</code>, <code>row-delimiter</code>,
             <code>quote-character</code> are equal.</p>
       </fos:errors>
       <fos:examples>
@@ -22489,7 +22683,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>An empty CSV with column extraction:</p>
             <fos:test>
-               <fos:expression>csv-to-xml("", map { "columns": true() })</fos:expression>
+               <fos:expression>csv-to-xml("", map { "column-names": true() })</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header/>
@@ -22501,7 +22695,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>An empty CSV with explicit column names:</p>
             <fos:test>
-               <fos:expression>csv-to-xml("", map { "columns": map { "name": 1, "city": 3 })</fos:expression>
+               <fos:expression>csv-to-xml("", map { "column-names": map { 1: "name", 3: "city"})</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header>
@@ -22517,7 +22711,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>With defaults for delimiters and quotes, and column extraction:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression>csv-to-xml($csv-string, map { "columns": true() })</fos:expression>
+               <fos:expression>csv-to-xml($csv-string, map { "column-names": true() })</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header>
@@ -22541,7 +22735,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>With defaults for delimiters and quotes, and column extraction:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression>csv-to-xml($csv-string, map { "columns": true() })</fos:expression>
+               <fos:expression>csv-to-xml($csv-string, map { "column-names": true() })</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header>
@@ -22566,7 +22760,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Filtering columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-string, map { "columns": true(), "filter-columns": (2,1,4) })</fos:expression>
+               <fos:expression>csv-to-xml($csv-string, map { "column-names": true(), "filter-columns": (2,1,4) })</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header>
@@ -22598,7 +22792,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Specifying the number of columns, using "all" (the default)</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-uneven-cols, map { "columns": true(), "number-of-columns": "all" })</fos:expression>
+               <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "all" })</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header>
@@ -22643,7 +22837,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Specifying the number of columns using <code>"first-row"</code></p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-uneven-cols, map { "columns": true(), "number-of-columns": "first-row" })</fos:expression>
+               <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "first-row" })</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header>
@@ -22691,7 +22885,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Specifying the number of columns with a number</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-uneven-cols, map { "columns": true(), "number-of-columns": 6 })</fos:expression>
+               <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })</fos:expression>
                <fos:result><![CDATA[
 <fn:csv>
    <fn:header>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5762,14 +5762,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-parse-csv">
                <head><?function fn:parse-csv?></head>
             </div3>
-            <div3 id="func-csv-to-xdm">
-               <head><?function fn:csv-to-xdm?></head>
-            </div3>
             <div3 id="func-csv-to-xml">
                <head><?function fn:csv-to-xml?></head>
             </div3>
-            <div3 id="func-csv-fetch-field-by-column">
-               <head><?function fn:csv-fetch-field-by-column?></head>
+            <div3 id="func-csv-to-simple-rows">
+               <head><?function fn:csv-to-simple-rows?></head>
             </div3>
          </div2>
 
@@ -6874,19 +6871,19 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                within a field. (See <specref ref="csv-field-quoting"/>.)</p>
 
             <p>The functions for processing CSV-formatted data are built on
-               <code>fn:parse-csv</code>, which provides a simple representation of a parsed CSV
+               <code>fn:csv-to-simple-rows</code>, which provides a simple representation of a parsed CSV
                as a sequence of arrays-of-strings, <code>array(xs:string)*</code>, handling row and
                column delimiters, and quoting.</p>
 
-            <p>The <code>fn:csv-to-xml</code> and <code>fn:csv-to-xdm</code> functions provide more
+            <p>The <code>fn:csv-to-xml</code> and <code>fn:parse-csv</code> functions provide more
                sophisticated processing.</p>
 
 
             <div3 id="common-parsing-options">
                <head>Common parsing options</head>
 
-               <p>All three functions: <code>fn:parse-csv</code>, <code>fn:csv-to-xml</code>, and
-                  <code>fn:csv-to-xdm</code>, take options to control basic parsing, consisting
+               <p>All three functions: <code>fn:csv-to-simple-rows</code>, <code>fn:csv-to-xml</code>, and
+                  <code>fn:parse-csv</code>, take options to control basic parsing, consisting
                   of specifying the various delimiters. These core delimiter options are used by the
                   functions that generate CSV data:</p>
 
@@ -6895,7 +6892,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>Additionally, the parsing functions share an additional option to control whether
                   leading and trailing whitespace should be stripped or not.</p>
 
-               <?type parse-csv-options ?>
+               <?type csv-parsing-options ?>
             </div3>
 
             <div3 id="csv-delimiters">
@@ -6984,11 +6981,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="basic-csv-to-xdm-mapping">
                <head>Basic mapping of CSV to XDM</head>
 
-               <p>The basic output from <code>fn:parse-csv</code> returns a sequence of rows, where
+               <p>The basic output from <code>fn:csv-to-simple-rows</code> returns a sequence of rows, where
                   each row is simply mapped to an array of <code>xs:string</code> values.</p>
 
                <p>The first row of the CSV is returned as with all the other rows.
-                  <code>fn:parse-csv</code> does not distinguish between a header row and data
+                  <code>fn:csv-to-simple-rows</code> does not distinguish between a header row and data
                   rows, and returns all of them.</p>
 
                <eg>
@@ -7031,16 +7028,16 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                   However, the reality is that CSVs can, and sometimes do, contain a variable number
                   of fields in a row. As a result, implementations of this function <rfc2119>must
                   not</rfc2119> truncate or pad the number of fields in each row for any reason.
-                  The <code>fn:csv-to-xml</code> and <code>fn:csv-to-xdm</code> functions provide
+                  The <code>fn:csv-to-xml</code> and <code>fn:parse-csv</code> functions provide
                   facilities to deal with enforcing uniformity and an expected number of
                   columns.</p>
             </div3>
 
             <div3 id="csv-to-xdm-mapping">
-               <head>Mapping CSV data to XDM in <code>fn:csv-to-xdm</code></head>
+               <head>Mapping CSV data to XDM in <code>fn:parse-csv</code></head>
 
 
-               <p>The <code>fn:csv-to-xdm</code> function returns a
+               <p>The <code>fn:parse-csv</code> function returns a
                   <code>parsed-csv-structure-record</code>:</p>
 
                <?type parsed-csv-structure-record ?>
@@ -7090,28 +7087,6 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                      <code>fields</code> sequence by either column position (when passed an
                      <code>xs:integer</code>) or column name (when passed an
                      <code>xs:string</code>).</p>
-
-                  <p>This function is, effectively, a partial application of
-                     <code>fn:csv-fetch-field-by-column</code> where its <code>$columns</code>
-                     argument is bound to the <code>columns</code> entry of the
-                     <code>parsed-csv-structure-record</code>, and its <code>$row</code> argument
-                     is bound to <code>array{csv-row?fields}</code>. This is described in more
-                     detail below:</p>
-
-                  <p>Given a string, <code>$csv-string</code> containing CSV data, implementations
-                     <rfc2119>must</rfc2119> return a function that will return identical results
-                     to <code>fn:csv-fetch-field-by-column</code> called with the same
-                     <code>csv-columns</code> and an <code>array()</code> containing the same
-                     items as the <code>fields</code> sequence:</p>
-
-                  <eg>let $csv-record := fn:csv-to-xdm($csv-string),
-   $csv-columns := $csv-record?columns,
-   $csv-row := head($csv-record?rows)
-   return if (empty($csv-row?field(1)))
-   then empty(fn:csv-fetch-field-by-column($csv-columns, array{$csv-row}, 1))
-   else $csv-row?field(1) = fn:csv-fetch-field-by-column($csv-columns, array{$csv-row}, 1)
-   (: must return true :)
-                  </eg>
                </div4>
             </div3>
             <div3 id="csv-represent-as-xml">
@@ -7180,21 +7155,21 @@ Bob,2023-07-14,2.34
                <head>Illustrative examples of processing CSV data</head>
 
 
-               <p>The following examples illustrate how an application can build more complex processing of the output of <code>fn:parse-csv</code>.</p>
+               <p>The following examples illustrate how an application can build more complex processing of the output of <code>fn:csv-to-simple-rows</code>.</p>
 
                <p>A variable, <code>$crlf</code> is assumed to be in scope containing the CR and LF characters</p>
 
                <eg>let $crlf := fn:char('x0D')||fn:char('x0A')</eg>
 
                <div4 id="csv-to-html-table">
-                  <head>Converting a CSV into an HTML-style table using <code>fn:csv-to-xdm</code></head>
+                  <head>Converting a CSV into an HTML-style table using <code>fn:parse-csv</code></head>
 
                   <p>Direct conversion is a matter of iterating across the records and fields to
                      generate <code>&lt;tr&gt;</code> and <code>&lt;td&gt;</code> elements.</p>
 
                   <p>Using XQuery:</p>
                   <eg><![CDATA[
-let $csv := fn:csv-to-xdm(`name,city{$crlf}Bob,Berlin`)
+let $csv := fn:parse-csv(`name,city{$crlf}Bob,Berlin`)
 return <table>
    <thead>{
       for $column in $csv?columns?fields
@@ -7232,7 +7207,7 @@ return <table>
   </xsl:function>
 
   <xsl:template name="xsl:initial-template">
-    <xsl:variable name="csv" select="csv-to-xdm(`name,city{$crlf}Bob,Berlin`)"/>
+    <xsl:variable name="csv" select="parse-csv(`name,city{$crlf}Bob,Berlin`)"/>
     <table>
       <thead>
         <tr>
@@ -10974,40 +10949,38 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="CV" code="0001" label="CSV field quoting error."
                type="dynamic">
-               <p>Raised by <code>fn:parse-csv</code> if a syntax error in the quoting of one of the
+               <p>Raised by <code>fn:csv-to-simple-rows</code> if a syntax error in the quoting of one of the
                   fields in the input CSV is found.</p>
             </error>
             <error class="CV" code="0002" label="Illegal CSV delimiter error."
                type="dynamic">
-               <p>Raised by <code>fn:parse-csv</code> if the <code>field-separator</code>,
+               <p>Raised by <code>fn:csv-to-simple-rows</code> if the <code>field-separator</code>,
                   <code>record-separator</code>, or <code>quote-character</code> option is set to
                   an illegal value.</p>
             </error>
             <error class="CV" code="0003" label="duplicate CSV delimiter error."
                type="dynamic">
-               <p>Raised by <code>fn:parse-csv</code> if any of the delimiter characters have been
+               <p>Raised by <code>fn:csv-to-simple-rows</code> if any of the delimiter characters have been
                   set to the same value.</p>
             </error>
             <error class="CV" code="0004" label="Argument supplied is not a known column name."
                type="dynamic">
-               <p>Raised by <code>fn:csv-fetch-field-by-column</code>, and the function from the
-                  <code>field</code> entry of <code>csv-columns-record</code>, if its
-                  <code>$key</code> argument is an <code>xs:string</code> and is not one of the
-                  known column names.</p>
+               <p>Raised by the function from the <code>field</code> entry of
+                  <code>csv-columns-record</code>, if its <code>$key</code> argument is an
+                  <code>xs:string</code> and is not one of the known column names.</p>
             </error>
             <error class="CV" code="0005" label="zero or negative integer provided as column index."
                type="dynamic">
-               <p>Raised by <code>fn:csv-to-xdm</code>, <code>fn:csv-to-xml</code>,
-                  <code>fn:csv-fetch-field-by-column</code>, and the function from the
-                  <code>field</code> entry of <code>csv-columns-record</code>, if an argument
-                  referring to a column index is zero or negative. (The options
+               <p>Raised by <code>fn:parse-csv</code>, <code>fn:csv-to-xml</code>, and the function
+                  from the <code>field</code> entry of <code>csv-columns-record</code>, if an
+                  argument referring to a column index is zero or negative. (The options
                   <code>number-of-columns</code>, <code>filter-columns</code>, or in a map passed
-                  to <code>column-names</code>, or the argument to the <code>field</code> function,
-                  or <code>fn:csv-fetch-field-by-column</code>.)</p>
+                  to <code>column-names</code>, or the argument to the <code>field</code> function.)
+               </p>
             </error>
             <error class="CV" code="0006" label="Both options number-of-columns and filter-columns set"
                type="dynamic">
-               <p>Raised by <code>fn:csv-to-xdm</code> and <code>fn:csv-to-xml</code>, if both the
+               <p>Raised by <code>fn:parse-csv</code> and <code>fn:csv-to-xml</code>, if both the
                   <code>number-of-columns</code> and <code>filter-columns</code> options are set:
                   they are mutually exclusive.</p>
             </error>
@@ -11962,9 +11935,8 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>map:replace</code></p></item>
               <item><p><code>map:substitute</code></p></item>
               <item><p><code>fn:parse-csv</code></p></item>
-              <item><p><code>fn:csv-to-xdm</code></p></item>
               <item><p><code>fn:csv-to-xml</code></p></item>
-              <item><p><code>fn:csv-fetch-field-by-column</code></p></item>
+              <item><p><code>fn:csv-to-simple-rows</code></p></item>
               <!--<item><p><code>array:partition</code></p></item>-->
               <item><p><code>array:replace</code></p></item>
               <item><p><code>array:slice</code></p></item>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -10995,6 +10995,22 @@ ISBN 0 521 77752 6.</bibl>
                   <code>$key</code> argument is an <code>xs:string</code> and is not one of the
                   known column names.</p>
             </error>
+            <error class="CV" code="0005" label="zero or negative integer provided as column index."
+               type="dynamic">
+               <p>Raised by <code>fn:csv-to-xdm</code>, <code>fn:csv-to-xml</code>,
+                  <code>fn:csv-fetch-field-by-column</code>, and the function from the
+                  <code>field</code> entry of <code>csv-columns-record</code>, if an argument
+                  referring to a column index is zero or negative. (The options
+                  <code>number-of-columns</code>, <code>filter-columns</code>, or in a map passed
+                  to <code>column-names</code>, or the argument to the <code>field</code> function,
+                  or <code>fn:csv-fetch-field-by-column</code>.)</p>
+            </error>
+            <error class="CV" code="0006" label="Both options number-of-columns and filter-columns set"
+               type="dynamic">
+               <p>Raised by <code>fn:csv-to-xdm</code> and <code>fn:csv-to-xml</code>, if both the
+                  <code>number-of-columns</code> and <code>filter-columns</code> options are set:
+                  they are mutually exclusive.</p>
+            </error>
             <error class="DC" code="0001" label="No context document." type="dynamic">
                <p>Raised by <code>fn:id</code>, <code>fn:idref</code>, and <code>fn:element-with-id</code>
                   if the node that identifies the tree to be searched is a node in a tree whose root is not

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7194,8 +7194,7 @@ Bob,2023-07-14,2.34
 
                   <p>Using XQuery:</p>
                   <eg><![CDATA[
-let $csv := fn:csv-to-xdm(`name,city{$crlf}Bob,Berlin`),
-    $headers := $parsed-csv?headers-record
+let $csv := fn:csv-to-xdm(`name,city{$crlf}Bob,Berlin`)
 return <table>
    <thead>{
       for $column in $csv?columns?fields


### PR DESCRIPTION
This PR contains error fixes (typos, examples that contradicted the spec text), some (hopefully) improved language and one breaking change.

The current draft uses the type `map(xs:integer, xs:string)` for the `column-names` option to `fn:csv-to-xdm` and `fn:csv-to-xml`. This PR flips that to `map(xs:string, xs:integer)`. It turns out that the examples were already using this, and it seems to me that having the `names` entry in the `csv-columns-record` record type be the transposed version of the `column-names` option that creates it, rather than be the same thing, is counterproductive.

I can think of some examples (a CSV split into several chunks, with only the first containing the headers) where being able to feed the `names` entry right back into another invocation of `fn:csv-to-xdm` would be useful. If nothing else it's confusing and not obvious, or I wouldn't have messed up the examples, and somebody would have noticed during the review process...