### PR TITLE
295: Boost the capability of recursive record types

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2916,10 +2916,7 @@ ErrorVal ::= "$" VarName
     </g:optional>
     <g:optional>
       <g:string>as</g:string>
-      <g:choice>
-        <g:ref name="SequenceType"/>
-        <g:ref name="SelfReference"/>
-      </g:choice>
+      <g:ref name="SequenceType"/>
     </g:optional>
   </g:production>
   
@@ -2930,12 +2927,12 @@ ErrorVal ::= "$" VarName
     </g:choice>
   </g:production>
   
-  <g:production name="SelfReference" if="xpath40 xquery40 xslt40-patterns">
+  <!--<g:production name="SelfReference" if="xpath40 xquery40 xslt40-patterns">
     <g:string>..</g:string>
     <g:optional>
       <g:ref name="OccurrenceIndicator"/>
     </g:optional>
-  </g:production>
+  </g:production>-->
   
   <g:production name="ExtensibleFlag" if="xpath40 xquery40 xslt40-patterns">
     <g:string>,</g:string>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -36,7 +36,7 @@
    <fos:type id="random-number-generator-record">
       <fos:record extensible="true">
          <fos:field name="number" type="xs:double" required="true"/>
-         <fos:field name="next" type="function() as #random-number-generator-record" required="true"/>
+         <fos:field name="next" type="function() as random-number-generator-record" required="true"/>
          <fos:field name="permute" type="function(item()*) as item()*" required="true"/>
       </fos:record>
    </fos:type>
@@ -26116,11 +26116,7 @@ return $result?output//body
          
          <?type random-number-generator-record?>
 
-         <note diff="add" at="2022-12-19"><p>This type is self-referential in a way that the 
-            current syntax for record type declarations does not allow. The
-         use of the type <code>#random-number-generator-record</code> as the return type of the <code>next</code>
-         function is purely for expository purposes; an approximation allowed by the grammar would be
-            <code>next as (function() as record(number, next, permute, *))</code>.</p></note>
+         
          
          <p>That is, the result of the function is a map containing three entries. 
             The keys of each entry are strings:</p>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -413,7 +413,8 @@
          <p>It is a <termref def="dt-static-error">static error</termref> if an <termref
                def="dt-expanded-qname">expanded QName</termref> used as an <nt def="ItemType">ItemType</nt>
                in a <nt def="SequenceType">SequenceType</nt> is not defined
-            in the <termref def="dt-static-context"/> either as a <termref def="dt-type-alias"/>
+            in the <termref def="dt-static-context"/> either as a <termref def="dt-named-item-type"/>
+            in the <termref def="dt-in-scope-named-item-types"/>,
             or as a <termref
                def="dt-generalized-atomic-type">generalized atomic type</termref>
             in the <termref def="dt-is-types">in-scope schema types</termref>.</p>
@@ -1056,9 +1057,8 @@ It is a static error if the name of a feature in
 -->
       
       <error spec="XQ" code="0140" class="ST" type="static">
-         <p> It is a <termref def="dt-static-error">static error</termref> if an item type alias refers
-            directly or indirectly to itself, unless at least one of the references in the chain is
-            <termref def="dt-shielded"/>.</p>
+         <p> It is a <termref def="dt-static-error">static error</termref> if a named item type declaration 
+            is recursive, unless it satisfies the conditions defined in <specref ref="id-recursive-record-tests"/>.</p>
       </error>
       
       <error spec="XP" code="0141" class="TY" type="type">

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -1055,10 +1055,10 @@ It is a static error if the name of a feature in
       </error>
 -->
       
-      <error spec="XP" code="0140" class="ST" type="static">
-         <p> It is a <termref def="dt-static-error">static error</termref> if a self-reference
-            within a <code>RecordTest</code> appears as the type of a field declaration that is not
-            optional and not emptiable.</p>
+      <error spec="XQ" code="0140" class="ST" type="static">
+         <p> It is a <termref def="dt-static-error">static error</termref> if an item type alias refers
+            directly or indirectly to itself, unless at least one of the references in the chain is
+            <termref def="dt-shielded"/>.</p>
       </error>
       
       <error spec="XP" code="0141" class="TY" type="type">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5924,8 +5924,8 @@ declare function t:flatten($tree as t:tree) as item()* {
                <p diff="chg" at="Issue451">The rules in this section apply to 
                   <termref def="dt-item-type">item types</termref>, not to 
                   <termref def="dt-item-type-designator">item type designators</termref>.
-                  For example, if a the name <code>STR</code> has been defined in the
-                  static context as a <termref def="dt-type-alias"/> for the type <code>xs:string</code>,
+                  For example, if the name <code>STR</code> has been defined in the
+                  static context as a <termref def="dt-named-item-type"/> referring to the type <code>xs:string</code>,
                   then anything said here about the type <code>xs:string</code> applies equally
                   whether it is designated as <code>xs:string</code> or as <code>STR</code>,
                   or indeed as the parenthesized forms <code>(xs:string)</code> or

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -633,23 +633,28 @@ inferred by static type inference as discussed in  <specref
                
                <item diff="add" at="A">
                   <p>
-                     <termdef id="dt-item-type-aliases" term="item type aliases">
-                        <term>Item type aliases.</term> This is a mapping from 
+
+                     <termdef id="dt-in-scope-named-item-types" term="in-scope named item types">
+                        <term>In-scope named item types.</term> This is a mapping from 
                         <termref def="dt-expanded-qname">expanded QName</termref> to 
-                        <termref def="dt-item-type">item types</termref>.</termdef></p>
-                   <p><termdef id="dt-type-alias" term="type alias">A <term>type alias</term>
-                        is an <termref def="dt-expanded-qname">expanded QName</termref> that
-                      is mapped to an <termref def="dt-item-type"/> in the 
-                      <termref def="dt-item-type-aliases"/> of
-                     the <termref def="dt-static-context"/>.</termdef>
+                        <termref def="dt-named-item-type">named item types</termref>.</termdef></p>
+                   <p><termdef id="dt-named-item-type" term="named item type">A <term>named item type</term>
+                      is an <code>ItemType</code> identified by an <termref def="dt-expanded-qname"/>.</termdef>
                   </p>
-                  <p>Item type aliases allow frequently used item types, especially complex item types such as
-                  record types, to be given simple names, to avoid repeating the definition 
-                  every time it is used.</p>
+                  <p>Named item types serve two purposes:</p>
+                  <ulist>
+                     <item><p>They allow frequently used item types, especially complex item types such as
+                        record types, to be given simple names, to avoid repeating the definition 
+                        every time it is used.</p></item>
+                     <item><p>They allow the definition of recursive types, which are useful for
+                     describing recursive data structures such as lists and trees. For details see
+                     <specref ref="id-recursive-record-tests"/>. </p></item>
+                  </ulist>
                   <note>
                      <p role="xquery">In XQuery, named item types can be declared in the Query Prolog.</p>
-                     <p role="xpath">Item type aliases can be defined in a <termref def="dt-host-language">host language</termref> 
-                        such as XQuery 4.0 and in XSLT 4.0, but not in XPath 4.0 itself.</p>
+                     <p role="xpath">Named item types can be defined in a <termref def="dt-host-language">host language</termref> 
+                        such as XQuery 4.0 and in XSLT 4.0, but not in XPath 4.0 itself. They are available in XPath
+                        only if the host language provides the ability to define them.</p>
                   </note>
                </item>
 
@@ -4249,7 +4254,7 @@ the schema type named <code>us:address</code>.</p>
                   <ulist>
                      <item><p>Using the QName of a type in the <termref def="dt-issd"/> that is an atomic type
                      or a <termref def="dt-pure-union-type"/>.</p></item>
-                     <item><p>Using a QName that identifies a <termref def="dt-type-alias"/> that resolves
+                     <item><p>Using a QName that identifies a <termref def="dt-named-item-type"/> that resolves
                         to a <termref def="dt-generalized-atomic-type"/>.</p></item>
                      <item><p>Using a <nt def="ParenthesizedItemType">ParenthesizedItemType</nt> where the parentheses enclose
                         a <termref def="dt-generalized-atomic-type"/>.</p></item>
@@ -4405,7 +4410,7 @@ the schema type named <code>us:address</code>.</p>
                QName must identify a type in the <termref def="dt-issd"/>. This can be any <termref def="dt-schema-type"/>: either a simple type,
                or (except in the case of attributes) a complex type. If it is a simple type then it can be an atomic, union, or
                list type. It can be a built-in type (such as <code>xs:integer</code>) or a user-defined type. It must however
-               be the name of a type defined in a schema; it cannot be a <termref def="dt-type-alias"/>.</p>
+               be the name of a type defined in a schema; it cannot be a <termref def="dt-named-item-type"/>.</p>
             
                <div4 id="id-simple-node-tests">
                   <head>Simple Node Tests</head>
@@ -5454,12 +5459,11 @@ name.</p>
             <div4 id="id-recursive-record-tests" diff="add" at="issue295">
                <head>Recursive Record Tests</head>
                
-               <p>The declared type of a field within a record test is a SequenceType, and as such
-               it may contain a reference to a <termref def="dt-type-alias"/> that is present in 
-               the static context.</p>
+               <p>A <termref def="dt-named-item-type"/> <var>N</var> is said to be recursive if its 
+                  definition includes a direct or indirect reference to <var>N</var>. 
+               </p>
                
-               <p>This allows recursive definitions to be created. For example, the following
-               XQuery declaration defines a linked list:</p>
+               <p>For example, the following XQuery declaration defines a linked list:</p>
                
                <p><eg>declare item type my:list as record(value as item()*, next? as my:list);</eg></p>
                
@@ -5468,24 +5472,35 @@ name.</p>
                <eg><![CDATA[<xsl:item-type name="my:list" 
                as="record(value as item()*, next? as my:list)"/>]]></eg>
                
-               <p>To ensure that finite instances of a recursive record test can exist, a cycle of references
-               is not allowed unless at least one of the references is <termref def="dt-shielded"/>.
-               <termdef id="dt-shielded" term="shielded">A reference to an item type is <term>shielded</term>
-               if it occurs within a <nt def="FieldDeclaration">FieldDeclaration</nt> that satisfies one
-               or more of the following conditions:</termdef> </p>
+               
+               
+               <p>A recursive named item type <var>N</var> is permitted only if it satisfies 
+                  all the following conditions:</p>
                
                <ulist>
-                  <item><p>The field declaration is optional (for example <code>next? as my:list</code>).</p></item>
-                  <item><p>The type of the field declaration matches an empty sequence (for example
-                     <code>next as my:list?</code>).</p></item>
-                  <item><p>The type of the field declaration  
-                     is a subtype of <code>function(*)*</code>
-                     (for example <code>next as (function() as my:list)</code>).</p>
-                     <note><p>This rule allows a field declaration that matches an array test
-                        (for example <code>next as array(my:list)</code>) or a map test
-                        (for example <code>next as map(xs:integer, my:list)</code>).</p></note>
+                  <item><p>The item type must be a record test.</p></item>
+                  <item><p>Within the record test, every item type reference <var>R</var> that refers
+                  directly or indirectly to <var>N</var> must satisfy one or more of the following
+                  conditions, where <var>F</var> is the field declaration of <var>N</var>
+                  in which <var>R</var> appears:</p>
+                     <ulist>
+                        <item><p><var>F</var> is an optional field declaration: for example
+                           <code>next? as N</code>.</p></item>
+                        <item><p>The SequenceType of <var>F</var> has an occurrence indicator
+                        of <code>?</code> or <code>*</code>: for example <code>next as N?</code>
+                        or <code>next as N*</code>.</p></item>
+                        <item><p>The item type of <var>F</var> is a function test, map test, or array test:
+                        for example <code>next as (function() as N)</code> or <code>next as array(N)</code>.</p></item>
+                     </ulist>
+                     <note>
+                        <p>These conditions are designed to ensure that finite instances of <var>N</var>
+                        can be constructed.</p>
+                     </note>
                   </item>
                </ulist>
+               
+               
+               
                
                <p>Instances of recursive record types can be constructed and interrogated in the normal way.
                For example a list of length 3 can be constructed as:</p>
@@ -5497,7 +5512,7 @@ name.</p>
                specification of the function <code>fn:random-number-generator</code>.</p></note>
                
                <p>Recursive type definitions need to be handled specially by the subtyping rules; 
-                  a naïve approach of simply replacing each item type alias
+                  a naïve approach of simply replacing each reference to a named item type 
                with its definition would make the assessment of the subtype relationship non-terminating.
                For details see <specref ref="id-itemtype-subtype"/>.</p>
                
@@ -5919,7 +5934,7 @@ declare function t:flatten($tree as t:tree) as item()* {
 
 
                
-               <p diff="chg" at="issue295">References to <termref def="dt-type-alias">type aliases</termref> 
+               <p diff="chg" at="issue295">References to <termref def="dt-named-item-type">named item types</termref> 
                   are handled as described in <specref ref="id-itemtype-subtype-aliases"/>.</p>            
                
                <p>The relationship <code>A ⊆ B</code> is true
@@ -6586,47 +6601,49 @@ declare function t:flatten($tree as t:tree) as item()* {
                   </olist>
                </div4>
                <div4 id="id-itemtype-subtype-aliases" diff="add" at="issue295">
-                  <head>Type Aliases</head>
-                  <p>This section describes how item types that reference <termref def="dt-type-alias">type aliases</termref>
+                  <head>Named Item Types</head>
+                  <p>This section describes how references to <termref def="dt-named-item-type">named item types</termref>
                   are handled when evaluating the subtype relationship.</p>
-                  <p>Types can be classified as recursive or non-recursive. A recursive type is one that references
-                  itself, directly or indirectly.</p>
-                  <p>Where an item type contains a reference to a type alias that is non-recursive, the reference
+                  <p>Named item types can be classified as recursive or non-recursive. 
+                     A recursive type is one that references itself, directly or indirectly. Only record
+                  tests are allowed to be recursive.</p>
+                  <p>Where an item type contains a reference to a named item type that is non-recursive, the reference
                   is expanded, recursively, as the first step in evaluating the subtype relationship. For example
-                  this means that if <var>U</var> is a type alias for <code>union(xs:integer, xs:double)</code>,
+                  this means that if <var>U</var> is a named item type with the expansion 
+                     <code>union(xs:integer, xs:double)</code>,
                      then <code>xs:integer ⊆ U</code> is true, because 
                      <code>xs:integer ⊆ union(xs:integer, xs:double)</code> is true.</p>
                   <p>Recursive types are considered to be, in the terminology of the computer science
                   literature, <term>iso-recursive</term> (rather than <term>equi-recursive</term>). 
                      This means that a recursive type name is not
                   treated as being equivalent to its expansion (at any depth). 
-                  For example, if the type alias <var>T</var>
-                  refers to the type <code>record(A as item()*, B as T?)</code>, then the type 
+                  For example, if the named item type <var>T</var>
+                  has the expansion <code>record(A as item()*, B as T?)</code>, then the type 
                      <code>array(T)</code> is not considered to be equivalent to 
                      <code>array(record(A as item()*, B as T?))</code>, despite the fact
                   that the two types have exactly the same instances.</p>
                   <p>The rules are therefore defined as follows:</p>
                   <ulist>
-                     <item><p>If <var>B</var> is the type alias of a recursive type, then
+                     <item><p>If <var>B</var> is a reference to a recursive named item type, then
                         <var>A</var> ⊆ <var>B</var> is true if and only if 
                         <var>A</var> and <var>B</var>
-                        are references to the same type alias.</p></item>
-                     <item><p>If <var>A</var> is the type alias of a recursive type, then
+                        are references to the same named item type.</p></item>
+                     <item><p>If <var>A</var> is a reference to a recursive named item type, then
                         <var>A</var> ⊆ <var>B</var> is true if either:</p>
                         <ulist>
                            <item><p><var>A</var> and <var>B</var>
-                              are references to the same type alias.</p></item>
+                              are references to the same named item type.</p></item>
                            <item><p><code>record(*) ⊆ B</code>.</p>
-                           <note><p>This is because only record types are allowed to be recursive.</p></note></item>
+                           <note><p>This is because only record tests are allowed to be recursive.</p></note></item>
                         </ulist>
                      </item>
                   </ulist>
 
                   <note><p>The decision to make recursive types iso-recursive rather than equi-recursive
                   was made largely because it saves a great deal of implementation complexity without any serious
-                  adverse effects for users. It practice, the rules for subtyping largely affect substitutability
-                  of different function signatures, and any problems can be avoided by using type alias names
-                  in function signatures consistently, especially when recursive types are involved.</p>
+                  adverse effects for users. It practice, problems can be avoided by using named item type references
+                  consistently (for example, avoiding having two named item types with
+                  different names but identical definitions).</p>
                   </note>
                </div4>
    

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5518,14 +5518,13 @@ name.</p>
                
                <example id="e-binary-tree">
                   <head>A Binary Tree</head>
-                  <p>A record used to represent a node in a binary tree might be represented as:</p>
-                  <eg>record(left? as .., value, right? as ..)</eg>
+                  <p>A record used to represent a node in a binary tree might be represented (using XQuery syntax) as:</p>
+                  <eg>declare item-type t:binary-tree 
+    as record(left? as t:binary-tree, value, right? as t:binary-tree)</eg>
                   <p>A function to walk this tree and enumerate all the values in depth-first order might be written 
-                     (using XQuery syntax) as:</p>
-                  <eg><![CDATA[declare item-type t:binary-tree as
-    record(left? as t:binary-tree, value, right? as t:binary-tree);                 
-declare function t:flatten($tree as t:binary-tree?) as item()* {
-    $tree ! (t:flatten(?left), ?value, t:flatten(?right))   
+                     (again using XQuery syntax) as:</p>
+                  <eg><![CDATA[declare function t:values($tree as t:binary-tree?) as item()* {
+    $tree ! (t:values(?left), ?value, t:values(?right))   
 }]]></eg>
                </example>
                

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3443,6 +3443,10 @@ defined in <xspecref
          <term>item type designator</term> is a syntactic construct conforming to the grammar rule
          <nt def="ItemType">ItemType</nt>. An item type designator is said
          to <term>designate</term> an <termref def="dt-item-type"/>.</termdef></p>
+      
+      <note><p>Two <termref def="dt-item-type-designator">item type designators</termref> may designate the
+      same item type. For example, <code>element()</code> and <code>element(*)</code> are equivalent,
+      as are <code>attribute(A)</code> and <code>attribute(A, xs:anySimpleType)</code>.</p></note>
          <p>
             <termdef id="dt-schema-type" term="schema type"
                   >A <term>schema type</term> is a type that is (or could be) defined using the facilities of <bibref
@@ -5344,7 +5348,7 @@ name.</p>
 		             matches a map if it has an entry with key <code>"e"</code> whose value matches <code>element(Employee)</code>,
 		             regardless what other entries the map might contain.</p>
                
-               <p>For generality, the syntax <code>record(*)</code> define an extensible record type that has no explicit
+               <p>For generality, the syntax <code>record(*)</code> defines an extensible record type that has no explicit
                   field declarations. The item type denoted by <code>record(*)</code> is equivalent to the item type
                   <code>map(*)</code>: that is, it allows any map.
                </p>
@@ -5355,7 +5359,7 @@ name.</p>
 		             NCName syntax, or using a (quoted) string literal otherwise.</p>
 
                <note>
-                  <p>Lookup expressions have been extended so that non-NCName keys can be used without
+                  <p>Lookup expressions have been extended in 4.0 so that non-NCName keys can be used without
 		             parentheses: <code>employee?"middle name"</code></p>
                </note>
 
@@ -5411,7 +5415,7 @@ name.</p>
 		             of the code, and in the ability of the processor to detect and diagnose type errors and to optimize
 		             execution.</p>
 
-               <p>In particular, if a variable <code>$rec</code> is known to conform to a particular
+               <p>If a variable <code>$rec</code> is known to conform to a particular
 		             record type, then when a lookup expression <code>$rec?field</code> is used, (a) the processor
 		             can report a type error if <code>$rec</code> cannot contain an entry with name <code>field</code>
                    (see <specref ref="id-implausible-lookup-expressions"/>),
@@ -5419,7 +5423,7 @@ name.</p>
 		             <code>$rec?field</code>.</p>
 
                <note>
-                  <p>A number of functions in the standard function library use maps as function arguments;
+                  <p>(TODO: change function signatures as suggested here!) A number of functions in the standard function library use maps as function arguments;
 		                this is a useful technique where the information to be supplied across the interface is highly
 		                variable. However, the type signature for such functions typically declares the argument type
 		                as <code>map(*)</code>, which gives very little information (and places very few constraints)
@@ -5451,7 +5455,7 @@ name.</p>
 		                <code>match="record(longitude, latitude)"</code></p>
                </note>
 
-               <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
+               <p>Rules defining whether one record test is a <termref def="dt-subtype"/> of another
                   are given in <specref ref="id-item-subtype-records"/>.</p>
 
             </div4>
@@ -5540,6 +5544,21 @@ declare function t:flatten($tree as t:tree) as item()* {
     $tree?value, $tree?children ! t:flatten(.))   
 }</eg>
                </example>
+               
+               <example id="e-mutually-recursive-types">
+                  <head>Mutually Recursive Types</head>
+                  <p>The usual textbook example of mutually-recursive types is that of a <emph>forest</emph>
+                  consisting of a list of <emph>trees</emph>, where each <emph>tree</emph> is a record 
+                  comprising a value and a <emph>forest</emph>.
+                  As the previous example shows, this structure can be defined straightforwardly in &language; without 
+                  recourse to mutual recursion.</p>
+                  <p>A more realistic example where mutual recursion is needed is for the schema component model
+                     used in <bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/>. Simplifying greatly,
+                     the data representing an element declaration in XSD may contain references to a
+                     complex type, which in turn will typically contain references to further 
+                     element declarations. The structure therefore involves mutual recursion.</p>
+               </example>
+   
                
             </div4>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4206,7 +4206,7 @@ the schema type named <code>us:address</code>.</p>
                <termref def="dt-in-scope-namespaces"/> in the <termref def="dt-static-context"/>. If the
                name is an unprefixed <code>NCName</code>, then it is expanded according to the
                   <termref def="dt-default-namespace-elements-and-types"/>.</p></item>
-               <item><p>If the name matches an entry in the <termref def="dt-item-type-aliases"/> in the <termref def="dt-static-context"/>,
+               <item><p>If the name matches a <termref def="dt-named-item-type"/> in the <termref def="dt-static-context"/>,
                   then it is taken as a reference to the corresponding item type. The rules that
                apply are the rules for the expanded item type definition.</p></item>
                <item><p>Otherwise, it must match the name of a type in the <termref def="dt-is-types">in-scope schema types</termref>
@@ -19302,7 +19302,7 @@ expression</term> and a <term>target type</term>. The type of the
 atomized value of the input expression is called the <term>input type</term>. 
 The <phrase diff="chg" at="A">target type</phrase> must be one of:</p>
             <ulist>
-               <item diff="add" at="issue688"><p>The name of an <termref def="dt-item-type-aliases">item type alias</termref>
+               <item diff="add" at="issue688"><p>The name of an <termref def="dt-named-item-type">named item type</termref>
                defined in the <termref def="dt-static-context"/>, which in turn must refer to an item
                type in one of the following categories.</p></item>
                <item><p>The name of a type defined in the  <termref def="dt-is-types">in-scope schema types</termref>, 
@@ -19444,7 +19444,7 @@ is castable into a given target type.
 The <phrase diff="chg" at="A">target type</phrase> must be one of:</p>
             
             <ulist>
-               <item diff="add" at="issue688"><p>The name of an <termref def="dt-item-type-aliases">item type alias</termref>
+               <item diff="add" at="issue688"><p>The name of an <termref def="dt-named-item-type">named item type</termref>
                   defined in the <termref def="dt-static-context"/>, which in turn must refer to an item
                   type in one of the following categories.</p></item>
                <item><p>The name of a type defined in the  <termref def="dt-is-types">in-scope schema types</termref>, 
@@ -19489,8 +19489,9 @@ if ($x castable as hatsize)
             <head>Constructor Functions</head>
             <p>For every simple type in the <termref def="dt-is-types"
                   >in-scope schema types</termref>  (except <code>xs:NOTATION</code> and <code>xs:anyAtomicType</code>, and <code>xs:anySimpleType</code>, which are not instantiable), a <term>constructor function</term> is implicitly defined. In each case, the name of the constructor function is the same as the name of its target type (including namespace). The signature of the constructor function for  a given type depends on the type that is being constructed, and can be found in  <xspecref
+
                   spec="FO40" ref="constructor-functions"/>.
-            There is also a constructor function for every named item type in the <termref def="dt-item-type-aliases"/>
+               There is also a constructor function for every <termref def="dt-named-item-type"/> in the <termref def="dt-static-context"/>
             that maps to a <termref def="dt-generalized-atomic-type"/>.</p> 
             
                <p>All such constructor functions are classified as
@@ -19554,7 +19555,7 @@ usa:zipcode?)</code>.</p>
                   <eg role="parse-test"><![CDATA[usa:zipcode("12345")]]></eg>
                </item>
                <item>
-                  <p>If <code>my:chrono</code> is defined as a type alias for 
+                  <p>If <code>my:chrono</code> is a named item type that expands to
                      <code>union(xs:date, xs:time, xs:dateTime)</code>, then the result
                      of <code>my:chrono("12:00:00Z")</code> is the <code>xs:time</code>
                      value <code>12:00:00Z</code>.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6659,7 +6659,7 @@ declare function t:flatten($tree as t:tree) as item()* {
 
                   <note><p>The decision to make recursive types iso-recursive rather than equi-recursive
                   was made largely because it saves a great deal of implementation complexity without any serious
-                  adverse effects for users. It practice, problems can be avoided by using named item type references
+                  adverse effects for users. In practice, problems can be avoided by using named item type references
                   consistently (for example, avoiding having two named item types with
                   different names but identical definitions).</p>
                   </note>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5319,7 +5319,7 @@ name.</p>
                   <prodrecap id="TypedRecordTest" ref="TypedRecordTest"/>
                   <prodrecap id="FieldDeclaration" ref="FieldDeclaration"/>
                   <prodrecap id="FieldName" ref="FieldName"/>
-                  <prodrecap id="SelfReference" ref="SelfReference"/>    
+                  <!--<prodrecap id="SelfReference" ref="SelfReference"/>  -->  
                   <prodrecap id="ExtensibleFlag" ref="ExtensibleFlag"/>    
                </scrap>
 
@@ -5375,19 +5375,19 @@ name.</p>
                      documentary value.</p>
                </note>
                
-               <p>If a field is declared using <code>..</code> (optionally followed
+               <p diff="del" at="issue295">If a field is declared using <code>..</code> (optionally followed
                by an occurrence indicator) in place of a <code>SequenceType</code>,
                   this indicates that the record type is recursive: the value
                of this field, if present, must be an instance of the record type being declared. For example, a record
                designed to hold error information might be declared as:</p>
                
-               <eg>record(error-code as xs:QName, message as xs:string, cause? as ..)</eg>
+               <eg diff="del" at="issue295">record(error-code as xs:QName, message as xs:string, cause? as ..)</eg>
                
-               <p>A map conforms to this type if it has entries with keys <code>error-code</code> and <code>message</code>
+               <p diff="del" at="issue295">A map conforms to this type if it has entries with keys <code>error-code</code> and <code>message</code>
                of the correct types, and if the <code>cause</code> entry is either absent, or is a map that itself conforms
                to this type.</p>
                
-               <p>A <code>FieldDeclaration</code> that a <code>SelfReference</code> to identify its type must either
+               <p diff="del" at="issue295">A <code>FieldDeclaration</code> that a <code>SelfReference</code> to identify its type must either
                be optional (marked with a question mark after the name), or must allow the empty sequence as a permitted
                value (marked by using the occurrence indicator <code>?</code> or <code>*</code> after the item type).
                   If the field is not optional and does not allow an empty sequence, a 
@@ -5396,37 +5396,7 @@ name.</p>
                This rule ensures that finite instances of the type can be constructed.</p>
                
               
-               <example id="e-binary-tree">
-                  <p>A record used to represent a node in a binary tree might be represented as:</p>
-                  <eg>record(left? as .., value, right? as ..)</eg>
-                  <p>A function to walk this tree and enumerate all the values in depth-first order might be written 
-                     (using XQuery syntax) as:</p>
-                  <eg><![CDATA[declare item-type binary-tree as
-    record(left? as .., value, right? as ..);                 
-declare function flatten($tree as binary-tree?) as item()* {
-    $tree ! (flatten(?left), ?value, flatten(?right))   
-}]]></eg>
-               </example>
                
-               <example id="e-arbitrary-tree">
-                  <p>A record used to represent a node in a tree where each node has an arbitrary number
-                     of children might be represented as:</p>
-                  <eg>record(value, children as ..*)</eg>
-                  <p>A function to walk this tree and enumerate all the values in order might be written 
-                     (using XQuery syntax) as:</p>
-                  <eg><![CDATA[declare item-type tree as
-    record(value, children as ..*);                 
-declare function flatten($tree as tree) as item()* {
-    $tree?value, $tree?children ! flatten(.))   
-}]]></eg>
-               </example>
-               
-               <note>
-                  <p>If a <code>RecordTest</code> contains a <code>SelfReference</code> field that is not optional,
-                  and whose type does not permit an empty sequence, then it will not be possible to construct an instance.
-                  So a <code>RecordTest</code> such as <code>record(a as ..)</code> serves no practical
-                  purpose; but it is not disallowed.</p>
-               </note>
 
                
 
@@ -5479,6 +5449,84 @@ declare function flatten($tree as tree) as item()* {
                <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
                   are given in <specref ref="id-item-subtype-records"/>.</p>
 
+            </div4>
+            
+            <div4 id="id-recursive-record-tests" diff="add" at="issue295">
+               <head>Recursive Record Tests</head>
+               
+               <p>The declared type of a field within a record test is a SequenceType, and as such
+               it may contain a reference to a <termref def="dt-type-alias"/> that is present in 
+               the static context.</p>
+               
+               <p>This allows recursive definitions to be created. For example, the following
+               XQuery declaration defines a linked list:</p>
+               
+               <p><eg>declare item type my:list as record(value as item()*, next? as my:list);</eg></p>
+               
+               <p>The equivalent in XSLT is:</p>
+               
+               <eg><![CDATA[<xsl:item-type name="my:list" 
+               as="record(value as item()*, next? as my:list)"/>]]></eg>
+               
+               <p>To ensure that finite instances of a recursive record test can exist, a cycle of references
+               is not allowed unless at least one of the references is <termref def="dt-shielded"/>.
+               <termdef id="dt-shielded" term="shielded">A reference to an item type is <term>shielded</term>
+               if it occurs within a <nt def="FieldDeclaration">FieldDeclaration</nt> that satisfies one
+               or more of the following conditions:</termdef> </p>
+               
+               <ulist>
+                  <item><p>The field declaration is optional (for example <code>next? as my:list</code>).</p></item>
+                  <item><p>The type of the field declaration matches an empty sequence (for example
+                     <code>next as my:list?</code>).</p></item>
+                  <item><p>The type of the field declaration  
+                     is a subtype of <code>function(*)*</code>
+                     (for example <code>next as (function() as my:list)</code>).</p>
+                     <note><p>This rule allows a field declaration that matches an array test
+                        (for example <code>next as array(my:list)</code>) or a map test
+                        (for example <code>next as map(xs:integer, my:list)</code>).</p></note>
+                  </item>
+               </ulist>
+               
+               <p>Instances of recursive record types can be constructed and interrogated in the normal way.
+               For example a list of length 3 can be constructed as:</p>
+               <p><eg>map{"value":1, "next":map{"value":2, "next":map{"value":3}}}</eg></p>
+               <p>and the third value in the map can be retrieved as <code>$list?next?next?value</code>.
+               In practice, recursive data structures are usually manipulated using recursive functions.</p>
+               
+               <note><p>For an example of a practical use of recursive record types, see the
+               specification of the function <code>fn:random-number-generator</code>.</p></note>
+               
+               <p>Recursive type definitions need to be handled specially by the subtyping rules; 
+                  a naïve approach of simply replacing each item type alias
+               with its definition would make the assessment of the subtype relationship non-terminating.
+               For details see <specref ref="id-itemtype-subtype"/>.</p>
+               
+               <example id="e-binary-tree">
+                  <head>A Binary Tree</head>
+                  <p>A record used to represent a node in a binary tree might be represented as:</p>
+                  <eg>record(left? as .., value, right? as ..)</eg>
+                  <p>A function to walk this tree and enumerate all the values in depth-first order might be written 
+                     (using XQuery syntax) as:</p>
+                  <eg><![CDATA[declare item-type t:binary-tree as
+    record(left? as t:binary-tree, value, right? as t:binary-tree);                 
+declare function t:flatten($tree as t:binary-tree?) as item()* {
+    $tree ! (t:flatten(?left), ?value, t:flatten(?right))   
+}]]></eg>
+               </example>
+               
+               <example id="e-arbitrary-tree">
+                  <head>An Arbitrary Tree</head>
+                  <p>A record used to represent a node in a tree where each node has an arbitrary number
+                     of children might be represented (using XQuery syntax) as:</p>
+                  <eg>declare item-type t:tree as record(value, children as t:tree*);</eg>
+                  <p>A function to walk this tree and enumerate all the values in order might be written 
+                     as:</p>
+                  <eg>               
+declare function t:flatten($tree as t:tree) as item()* {
+    $tree?value, $tree?children ! t:flatten(.))   
+}</eg>
+               </example>
+               
             </div4>
 
             <div4 id="id-array-test">
@@ -5857,6 +5905,7 @@ declare function flatten($tree as tree) as item()* {
                   This section defines the rules for deciding whether any two item types have this relationship.</p>
                
 
+
              
                <p diff="chg" at="Issue451">The rules in this section apply to 
                   <termref def="dt-item-type">item types</termref>, not to 
@@ -5868,6 +5917,10 @@ declare function flatten($tree as tree) as item()* {
                   or indeed as the parenthesized forms <code>(xs:string)</code> or
                  <code>(STR)</code>.</p>
 
+
+               
+               <p diff="chg" at="issue295">References to <termref def="dt-type-alias">type aliases</termref> 
+                  are handled as described in <specref ref="id-itemtype-subtype-aliases"/>.</p>            
                
                <p>The relationship <code>A ⊆ B</code> is true
                if and only if at least one of the conditions listed in the following subsections applies:</p>
@@ -6531,6 +6584,50 @@ declare function flatten($tree as tree) as item()* {
                         
                         
                   </olist>
+               </div4>
+               <div4 id="id-itemtype-subtype-aliases" diff="add" at="issue295">
+                  <head>Type Aliases</head>
+                  <p>This section describes how item types that reference <termref def="dt-type-alias">type aliases</termref>
+                  are handled when evaluating the subtype relationship.</p>
+                  <p>Types can be classified as recursive or non-recursive. A recursive type is one that references
+                  itself, directly or indirectly.</p>
+                  <p>Where an item type contains a reference to a type alias that is non-recursive, the reference
+                  is expanded, recursively, as the first step in evaluating the subtype relationship. For example
+                  this means that if <var>U</var> is a type alias for <code>union(xs:integer, xs:double)</code>,
+                     then <code>xs:integer ⊆ U</code> is true, because 
+                     <code>xs:integer ⊆ union(xs:integer, xs:double)</code> is true.</p>
+                  <p>Recursive types are considered to be, in the terminology of the computer science
+                  literature, <term>iso-recursive</term> (rather than <term>equi-recursive</term>). 
+                     This means that a recursive type name is not
+                  treated as being equivalent to its expansion (at any depth). 
+                  For example, if the type alias <var>T</var>
+                  refers to the type <code>record(A as item()*, B as T?)</code>, then the type 
+                     <code>array(T)</code> is not considered to be equivalent to 
+                     <code>array(record(A as item()*, B as T?))</code>, despite the fact
+                  that the two types have exactly the same instances.</p>
+                  <p>The rules are therefore defined as follows:</p>
+                  <ulist>
+                     <item><p>If <var>B</var> is the type alias of a recursive type, then
+                        <var>A</var> ⊆ <var>B</var> is true if and only if 
+                        <var>A</var> and <var>B</var>
+                        are references to the same type alias.</p></item>
+                     <item><p>If <var>A</var> is the type alias of a recursive type, then
+                        <var>A</var> ⊆ <var>B</var> is true if either:</p>
+                        <ulist>
+                           <item><p><var>A</var> and <var>B</var>
+                              are references to the same type alias.</p></item>
+                           <item><p><code>record(*) ⊆ B</code>.</p>
+                           <note><p>This is because only record types are allowed to be recursive.</p></note></item>
+                        </ulist>
+                     </item>
+                  </ulist>
+
+                  <note><p>The decision to make recursive types iso-recursive rather than equi-recursive
+                  was made largely because it saves a great deal of implementation complexity without any serious
+                  adverse effects for users. It practice, the rules for subtyping largely affect substitutability
+                  of different function signatures, and any problems can be avoided by using type alias names
+                  in function signatures consistently, especially when recursive types are involved.</p>
+                  </note>
                </div4>
    
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -647,7 +647,7 @@ return (
           def="dt-library-module">library modules</termref> into the <termref
           def="dt-statically-known-function-definitions"/>, <termref
           def="dt-in-scope-variables">in-scope variables</termref><phrase diff="add" at="A">,
-          or <termref def="dt-item-type-aliases"/></phrase> of the importing <termref
+          or <termref def="dt-in-scope-named-item-types"/></phrase> of the importing <termref
           def="dt-module">module</termref>.</termdef> Each module import names a <termref
         def="dt-target-namespace">target namespace</termref> and imports an <termref
         def="dt-implementation-defined">implementation-defined</termref> set of modules that share
@@ -1867,7 +1867,7 @@ local:depth(doc("partlist.xml"))
     
     <p>An item type declaration defines a name for an item type. Defining a name for an item type
     allows it to be referenced <phrase diff="chg" at="issue275">by name</phrase> rather than repeating
-    the item type definition in full.</p>
+    the item type definition in full. It also allows recursive types to be defined.</p>
     
     <scrap>
       <head></head>
@@ -1876,7 +1876,7 @@ local:depth(doc("partlist.xml"))
       <prodrecap id="ItemTypeDecl" ref="ItemTypeDecl"/>
     </scrap>
     
-    <p>An item-type declaration adds a named item type to the <termref def="dt-item-type-aliases"/>
+    <p>An item-type declaration adds a named item type to the <termref def="dt-in-scope-named-item-types"/>
     of the containing module. This enables the item type to be referred to using a simple name.</p>
     
     <example>
@@ -1906,11 +1906,11 @@ local:depth(doc("partlist.xml"))
       declaration is public. <termdef id="dt-private-item-type" term="private item type">A <term>private
         item type</term> is a named item type with a <code>%private</code> annotation. A private item type
         is hidden from <termref def="dt-module-import">module import</termref>, which can not import
-        it into the <termref def="dt-item-type-aliases"/> of another module. </termdef>
+        it into the <termref def="dt-in-scope-named-item-types"/> of another module. </termdef>
       <termdef id="dt-public-item-type" term="public item type">A <term>public item type</term> is an
          item type declaration without a <code>%private</code> annotation. A public item type is accessible to
         <termref def="dt-module-import">module import</termref>, which can import it into the
-        <termref def="dt-item-type-aliases"/> of
+        <termref def="dt-in-scope-named-item-types"/> of
         another module. </termdef> Using <code>%public</code> and <code>%private</code> annotations
       in a main module is not an error, but it does not affect module imports, since a main module
       cannot be imported. It is a <termref def="dt-static-error">static error</termref>
@@ -1929,11 +1929,9 @@ local:depth(doc("partlist.xml"))
       declared item types and <termref def="dt-generalized-atomic-type">generalized atomic types</termref>
       in the <termref def="dt-static-context"/> of the query module. <errorref class="ST" code="0146"/></p>
     
-    <p diff="add" at="issue275">The definition of an item type must not refer directly or indirectly to itself, unless
-      at least one of the references in the chain is <termref def="dt-shielded"/>. 
-      Shielded references occur only within record tests, and allow types to be defined that match
-      recursive data structures such as linked lists and trees. They are described further in 
-      <specref ref="id-recursive-record-tests"/>
+    <p diff="add" at="issue275">A recursive named item type is one whose expansion refers directly or 
+      indirectly to itself. A named item type is allowed to be recursive only if it satisfies
+      the conditions defined in <specref ref="id-recursive-record-tests"/>
       <errorref class="ST" code="0140"/>.</p>
     
  

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1895,7 +1895,7 @@ local:depth(doc("partlist.xml"))
     </example>
     
     <p>If the name of the item type being declared is written as an (unprefixed) NCName, then 
-      it is interpreted as being in no namespace.</p>
+      it is interpreted as being in the <termref def="dt-default-namespace-elements-and-types"/>.</p>
     
     <p>All item type names declared in a library module must (when expanded) be in the target namespace of the 
       library module <errorref class="ST" code="0048"/>.
@@ -1934,8 +1934,14 @@ local:depth(doc("partlist.xml"))
       the conditions defined in <specref ref="id-recursive-record-tests"/>
       <errorref class="ST" code="0140"/>.</p>
     
- 
-    
+    <note><p>It is possible to import a public variable or function into a different module
+    even if its declaration refers to named item types that are not themselves imported (because they
+    are declared as <code>%private</code>). This is because it is entirely possible to use
+    and create instances of an item type even when the name of the item type is not known. This
+    is true even for recursive item types. However,
+    it is generally more convenient if any named item types used
+    in public function and variable declarations are themselves public. This is likely
+    to be especially true in the case of higher-order functions.</p></note>
     
 
     

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1866,7 +1866,7 @@ local:depth(doc("partlist.xml"))
     <head>Item Type Declarations</head>
     
     <p>An item type declaration defines a name for an item type. Defining a name for an item type
-    allows it to be referenced by name rather than repeating
+    allows it to be referenced <phrase diff="chg" at="issue275">by name</phrase> rather than repeating
     the item type definition in full.</p>
     
     <scrap>
@@ -1917,16 +1917,29 @@ local:depth(doc("partlist.xml"))
       <errorref class="ST" code="0106"/> if an item type declaration contains both a
       <code>%private</code> and a <code>%public</code> annotation, more than one
       <code>%private</code> annotation, or more than one <code>%public</code> annotation. </p>
-    
-    <p>It is a static error if two item type declarations (whether locally declared in a module or
-      imported from a public declaration in an imported module) share the same name
-      <errorref class="ST" code="0146"/></p>
+
     
     <p>The declaration of an item type (whether locally declared in a module or
       imported from a public declaration in an imported module) must precede any use of the
       item type name: that is, the name only becomes available in the static context of constructs
       that lexically follow the relevant item type declaration or module import. A consequence
       of this rule is that cyclic and self-referential definitions are not allowed.</p>
+
+    <p diff="add" at="issue275">The name of an item type must be unique among the names of all
+      declared item types and <termref def="dt-generalized-atomic-type">generalized atomic types</termref>
+      in the <termref def="dt-static-context"/> of the query module. <errorref class="ST" code="0146"/></p>
+    
+    <p diff="add" at="issue275">The definition of an item type must not refer directly or indirectly to itself, unless
+      at least one of the references in the chain is <termref def="dt-shielded"/>. 
+      Shielded references occur only within record tests, and allow types to be defined that match
+      recursive data structures such as linked lists and trees. They are described further in 
+      <specref ref="id-recursive-record-tests"/>
+      <errorref class="ST" code="0140"/>.</p>
+    
+ 
+    
+    
+
     
   </div2>
   

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -91,6 +91,7 @@
          <e:constant value="attribute-set"/>
          <e:constant value="variable"/>
          <e:constant value="mode"/>
+         <e:constant value="item-type"/>
          <e:constant value="*"/>
       </e:attribute>
       <e:attribute name="names" required="yes">
@@ -116,6 +117,7 @@
          <e:constant value="attribute-set"/>
          <e:constant value="variable"/>
          <e:constant value="mode"/>
+         <e:constant value="item-type"/>
          <e:constant value="*"/>
       </e:attribute>
       <e:attribute name="names" required="yes">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -4061,7 +4061,8 @@
                      on its own (that is, with no arity) cannot be used to identify a function. [XSLT 3.0 Erratum E36, bug 30323].</phrase></p>
 
                   <p>The visibility of a 
-                     named template, function, variable, attribute set, or mode
+                     named template, function, variable, attribute set, mode,
+                     <phrase diff="add" at="2024-01-12">or named item type</phrase>
                      declared within a package is the first of the following that applies, subject to consistency
                      constraints which are defined below:</p>
 
@@ -4782,7 +4783,8 @@
 
                   </ulist>
 
-                  <p><termdef id="dt-identical-types" term="identical (types)">Types S and T are considered <term>identical</term> for the purpose of
+                  <p><termdef id="dt-identical-types" term="identical (types)">Types <var>S</var> 
+                     and <var>T</var> are considered <term>identical</term> for the purpose of
                         these rules if and only if <code>subtype(S, T)</code> and <code>subtype(T,
                            S)</code> both hold, where the subtype relation is defined in <xspecref spec="XP40" ref="id-seqtype-subtype"/>.</termdef></p>
 
@@ -4818,6 +4820,14 @@
                               type definitions, which will always apply in this case. For named
                               atomic types, the final result of these rules is that two atomic types
                               are identical if and only if they have the same name.</p>
+                        </item>
+                        
+                        <item>
+                           <p>Except where recursive types are involved, a named item type
+                           (declared in an <elcode>xsl:item-type</elcode> declaration) is considered
+                           identical to its expansion. With recursive types, the same type names must
+                           be used. By implication, the named type must itself be declared or exposed
+                           with <code>visibility="final"</code>.</p>
                         </item>
                      </olist>
                   </note>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10989,12 +10989,22 @@ and <code>version="1.0"</code> otherwise.</p>
             A lexical QName with no prefix is treated as a no-namespace name.</p>
             <p>If two <elcode>xsl:item-type</elcode> declarations in a <termref def="dt-package"/> have the same
             name, then the one with higher <termref def="dt-import-precedence"/> is used. </p>
-            <p><error spec="XT" type="static" class="SE" code="9ZZZ">
+            <p><error spec="XT" type="static" class="SE" code="4030">
                <p>It is a <termref def="dt-static-error">static error</termref> if a package contains two 
                   <elcode>xsl:item-type</elcode>
                   declarations having the same <termref def="dt-import-precedence">import
                      precedence</termref>, unless there is another definition of the same
                   item type with higher import precedence.</p>
+            </error></p>
+            <p diff="add" at="issue295">An item type declaration may refer directly or indirectly to itself only if
+            one or more of the references in the chain is <xtermref spec="XP40" ref="dt-shielded"/>.
+            This allows types to be declared that match recursive data structures such as linked lists
+            and trees.</p>
+            <p><error spec="XT" type="static" class="SE" code="4035">
+               <p>It is a <termref def="dt-static-error">static error</termref> for an item type named
+                  <var>N</var> to contain in its <code>as</code> attribute a reference to <var>N</var>,
+                  or to an item type that references <var>N</var> directly or indirectly, unless at least
+                  one reference in the chain of references is <xtermref spec="XP40" ref="dt-shielded"/>.</p>
             </error></p>
             <p>TODO: add named item types to xsl:accept and xsl:expose. Clarify that when a function or variable
             is exported to a different package, its declared type/signature uses the expanded form of any named

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10978,7 +10978,7 @@ and <code>version="1.0"</code> otherwise.</p>
             library. However, named item types do not provide true encapsulation or information hiding; users of the 
             function library can still treat complex numbers as raw maps if they wish.</p>
             <p>The <elcode>xsl:item-type</elcode> declaration adds an entry to the 
-               <xtermref spec="XP40" ref="dt-type-alias"/>
+               <xtermref spec="XP40" ref="dt-in-scope-named-item-types"/>
             component of the static context for XPath expressions, and also becomes available for use wherever
             XSLT allows an <code>ItemType</code> to appear.</p>
             <p>The scope of a named item type is the <termref def="dt-package"/> in which it is declared. If it
@@ -10996,15 +10996,15 @@ and <code>version="1.0"</code> otherwise.</p>
                      precedence</termref>, unless there is another definition of the same
                   item type with higher import precedence.</p>
             </error></p>
-            <p diff="add" at="issue295">An item type declaration may refer directly or indirectly to itself only if
-            one or more of the references in the chain is <xtermref spec="XP40" ref="dt-shielded"/>.
+            <p diff="add" at="issue295">An item type declaration may refer directly or indirectly to itself if
+               it satisfies the conditions defined in <xspecref spec="XP40" ref="id-recursive-record-tests"/>.
             This allows types to be declared that match recursive data structures such as linked lists
             and trees.</p>
             <p><error spec="XT" type="static" class="SE" code="4035">
                <p>It is a <termref def="dt-static-error">static error</termref> for an item type named
                   <var>N</var> to contain in its <code>as</code> attribute a reference to <var>N</var>,
-                  or to an item type that references <var>N</var> directly or indirectly, unless at least
-                  one reference in the chain of references is <xtermref spec="XP40" ref="dt-shielded"/>.</p>
+                  or to an item type that references <var>N</var> directly or indirectly, unless it satisfies
+                  the conditions defined in <xspecref spec="XP40" ref="id-recursive-record-tests"/>.</p>
             </error></p>
             <p>TODO: add named item types to xsl:accept and xsl:expose. Clarify that when a function or variable
             is exported to a different package, its declared type/signature uses the expanded form of any named
@@ -17307,7 +17307,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <td rowspan="1" colspan="1"><termref def="dt-absent">Absent</termref></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">Item type aliases</td>
+                     <td rowspan="1" colspan="1">In-scope named item types</td>
                      <td rowspan="1" colspan="1">None</td>
                   </tr>
                   <tr>


### PR DESCRIPTION
Fix issue #295 

The main changes are:

* In place of the special self-reference syntax "..", we now allow recursive use of type aliases, allowing types to be mutually recursive
* We generalise the places that recursive references are allowed, for example the record type used by fn:random-number-generator is now legal
* Subtyping rules for recursive record types are now defined (this was previously a gap in the specification). Acknowledgements to a John Snelson blog post for pointing me in the right direction.