### PR TITLE
QT4CG-047-01: Rename break-when to split-when, plus minor editorial cleanup

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -2317,14 +2317,12 @@
          <code>A-Z</code> may be used in place of their lower-case equivalents.</p>
          <p>The value of a generalized digit corresponds to its position in this alphabet.
          More formally, in non-error cases the result of the function is given by the XQuery expression:</p>
-         <eg><![CDATA[
-let $alphabet := characters("0123456789abcdefghijklmnopqrstuvwxyz")
+         <eg><![CDATA[let $alphabet := characters("0123456789abcdefghijklmnopqrstuvwxyz")
 let $preprocessed-value := translate($value, "_ &#x9;&#xa;&#xd;", "")
 let $digits := translate($preprocessed-value, "+-", "")
 let $abs := sum(
   for $char at $p in reverse(characters($digits))
-  return (index-of($alphabet, $char) - 1) * xs:integer(math:pow($radix, $p - 1))
-)
+  return (index-of($alphabet, $char) - 1) * xs:integer(math:pow($radix, $p - 1)))
 return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
       </fos:rules>
       <fos:errors>
@@ -28009,7 +28007,7 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:signatures>
          <fos:proto name="partition" return-type="array(item())*">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="break-when" type="function(item()*, item()) as xs:boolean"/>
+            <fos:arg name="split-when" type="function(item()*, item()) as xs:boolean"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -28024,20 +28022,20 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:rules>
          <p>Informally, the function starts by creating a partition containing the first item in the input sequence,
             if any. For each remaining item <var>J</var> in the input sequence,
-            other than the first, it calls the supplied <code>$break-when</code> function with two 
+            other than the first, it calls the supplied <code>$split-when</code> function with two 
             arguments: the contents of the current partition, and the item <var>J</var>.</p>
          <p>Each partition is a sequence of items; the function result wraps each partition as an array, and returns
             the sequence of arrays.</p>
-         <p>If the <code>$break-when</code> function returns <code>true</code>, the current partition is wrapped as an array and added to the result,
-            and a new current partition is created, initially containing the item <var>J</var> only. If the <code>$break-when</code> 
+         <p>If the <code>$split-when</code> function returns <code>true</code>, the current partition is wrapped as an array and added to the result,
+            and a new current partition is created, initially containing the item <var>J</var> only. If the <code>$split-when</code> 
             function returns <code>false</code>, the item <var>J</var> is added to the current partition.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>
-fold-left($input, (), function($partitions, $next) {
-  if (empty($partitions) or $break-when(foot($partitions)?*, $next))
-  then ($partitions, [ $next ])
-  else (trunk($partitions), array { foot($partitions)?*, $next }) 
-})</eg>
+         <eg>fold-left($input, (), function($partitions, $next) {
+              if (empty($partitions) or $split-when(foot($partitions)?*, $next))
+              then ($partitions, [$next])
+              else (trunk($partitions), array{foot($partitions)?*, $next}) 
+            })   
+         </eg>  
       </fos:rules>
       <fos:notes>
          <p>The function enables a variety of positional grouping problems to be solved. For example:</p>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -562,7 +562,7 @@
 
    <e:element-syntax name="for-each">
       <e:in-category name="instruction"/>
-      <e:attribute name="select">
+      <e:attribute name="select" required="yes">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:attribute name="separator">
@@ -581,7 +581,7 @@
 
    <e:element-syntax name="iterate">
       <e:in-category name="instruction"/>
-      <e:attribute name="select">
+      <e:attribute name="select" required="yes">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:sequence>
@@ -1371,7 +1371,7 @@
 
    <e:element-syntax name="for-each-group">
       <e:in-category name="instruction"/>
-      <e:attribute name="select">
+      <e:attribute name="select" required="yes">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:attribute name="group-by" required="no">
@@ -1386,7 +1386,7 @@
       <e:attribute name="group-ending-with" required="no">
          <e:data-type name="pattern"/>
       </e:attribute>
-      <e:attribute name="break-when" required="no">
+      <e:attribute name="split-when" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:attribute name="composite" default="'no'">

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -884,6 +884,7 @@ of problems processing the schema using various tools
           <xs:attribute name="group-adjacent" type="xsl:expression"/>
           <xs:attribute name="group-starting-with" type="xsl:pattern"/>
           <xs:attribute name="group-ending-with" type="xsl:pattern"/>
+          <xs:attribute name="split-when" type="xsl:expression"/>
           <xs:attribute name="composite" type="xsl:yes-or-no"/>
           <xs:attribute name="collation" type="xsl:avt"/>
           <xs:attribute name="_select" type="xs:string"/>
@@ -891,6 +892,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_group-adjacent" type="xs:string"/>
           <xs:attribute name="_group-starting-with" type="xs:string"/>
           <xs:attribute name="_group-ending-with" type="xs:string"/>
+          <xs:attribute name="_split_when" type="xs:string"/>
           <xs:attribute name="_composite" type="xs:string"/>
           <xs:attribute name="_collation" type="xs:string"/>
           <xs:assert test="exists(@select | @_select)"/>
@@ -909,7 +911,8 @@ of problems processing the schema using various tools
           <xs:assert test="count(((@group-by|@_group-by)[1], 
                                   (@group-adjacent|@_group-adjacent)[1], 
                                   (@group-starting-with|@_group-starting-with)[1], 
-                                  (@group-ending-with|@_group-ending-with)[1])) = 1">
+                                  (@group-ending-with|@_group-ending-with)[1]),
+                                  (@split-when|@_split-when)[1])) = 1">
             <xs:annotation>
               <xs:documentation>
                 <p>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -22870,8 +22870,7 @@ for $i in 1 to count($V) return
                instruction may be used anywhere within a <termref def="dt-sequence-constructor">sequence
                constructor</termref>.</p>
             
-            <p diff="add" at="2022-01-01">As with <code>xsl:for-each</code>, the instruction is extended in XSLT 4.0 to allow maps and arrays
-               to be processed.</p>
+            
             
  
  
@@ -22894,8 +22893,7 @@ for $i in 1 to count($V) return
                can be refered to as <code>?key</code> and <code>?value</code> respectively.</p>
             
             
-            <p>The <code>select</code> attribute <phrase diff="add" at="2022-01-01">(whether written explicitly, or constructed
-               as described above)</phrase> contains an
+            <p>The <code>select</code> attribute contains an
                <termref def="dt-expression">expression</termref> which is evaluated to produce a
                sequence, called the <termref def="dt-population"/>.</p>
             
@@ -22923,13 +22921,13 @@ for $i in 1 to count($V) return
                zero.</p>
             <p>The assignment of items to groups depends on the <code>group-by</code>,
                   <code>group-adjacent</code>, <code>group-starting-with</code>, 
-                  <code>group-ending-with</code>, <phrase diff="add" at="2022-01-01">and <code>break-when</code></phrase> attributes. </p>
+                  <code>group-ending-with</code>, <phrase diff="add" at="2023-10-10">and <code>split-when</code></phrase> attributes. </p>
             <p>
                <error spec="XT" type="static" class="SE" code="1080">
                   <p>These <phrase diff="add" at="2022-01-01">five</phrase> attributes <error.extra>the <code>group-by</code>,
                            <code>group-adjacent</code>, <code>group-starting-with</code>, 
                      <code>group-ending-with</code>, 
-                     <phrase diff="add" at="2022-01-01">and <code>break-when</code></phrase> attributes of
+                     <phrase diff="add" at="2023-10-10">and <code>split-when</code></phrase> attributes of
                            <elcode>xsl:for-each-group</elcode>
                      </error.extra> are mutually exclusive: it is a <termref def="dt-static-error">static error</termref> 
                      if none of these attributes is present or if
@@ -22982,7 +22980,7 @@ for $i in 1 to count($V) return
                </error>
             </p>
             <p diff="chg" at="2022-01-01">
-               <termref def="dt-grouping-key">Grouping keys</termref> are compared using
+               Atomic <termref def="dt-grouping-key">grouping keys</termref> are compared using
                the rules of the <function>distinct-values</function> function, using the relevant collation.
                The relevant collation is the collation specified as the 
                <termref def="dt-effective-value">effective value</termref> of the <code>collation</code>
@@ -22992,6 +22990,9 @@ for $i in 1 to count($V) return
                used. Given this collation, two grouping keys <var>K1</var> and <var>K2</var>
                are considered equal if <code>count(distinct-values(($K1, $K2), $collation)) = 1</code>.
             </p>
+            <p diff="add" at="2023-10-10">Composite grouping keys are equal if they contain the same number
+            of items and the items are pairwise equal when compared according to the rules in the previous
+            paragraph.</p>
             
     
             <p>
@@ -23005,7 +23006,7 @@ for $i in 1 to count($V) return
             <p>For more information on collations, see <specref ref="collating-sequences"/>.</p>
             
             <p>The way in which an <elcode>xsl:for-each-group</elcode> element is
-               evaluated depends on which of the four group-defining attributes is present:</p>
+               evaluated depends on which of the five group-defining attributes is present:</p>
             <ulist>
                <item>
                   <p>If the <code>group-by</code> attribute is present, the items in the <termref def="dt-population">population</termref> are examined, in population order.
@@ -23061,47 +23062,46 @@ the same group, and the-->
                         item within the population.</p>
                </item>
                <item diff="add" at="2022-01-01">
-                  <p>If the <code>break-when</code> attribute is present, then its value
+                  <p>If the <code>split-when</code> attribute is present, then its value
                      <rfc2119>must</rfc2119> be an expression.
                      This expression is evaluated once for every item in the <termref def="dt-population"/>
                      except the first. The context item is that item, the context position is its position
                      in the <termref def="dt-population"/>, and the context size is the size of the population.
-                     The <termref def="dt-current-group"/> is set to contain all items that have already
-                     been added to the latest group. It is supplied with two variables: <code>$group</code> is set to the 
-                     current group being constructed, and <code>$next</code> is the next item in the population. 
+                     The expression is supplied with two variables: <code>$group</code> is set to the 
+                     contents of the current group being constructed, and <code>$next</code> is the next item in the population. 
                      If the <xtermref ref="dt-ebv" spec="XP40">effective boolean value</xtermref>
                      of the expression is <code>true</code>, then this
                   item forms the start of a new group; if it is <code>false</code>, the item is added to the existing
                   group.</p>
                   <p>For example:</p>
                   <ulist>
-                     <item><p><code>break-when="count($group) = 3"</code> starts a new
+                     <item><p><code>split-when="count($group) = 3"</code> starts a new
                      group whenever the existing group has exactly three members; that is, it partitions the
                      population into groups of size 3 (with the last group being smaller if necessary).</p></item>
-                     <item><p><code>break-when="$next[self::h1]"</code> starts a new
+                     <item><p><code>split-when="$next[self::h1]"</code> starts a new
                         group whenever an <code>h1</code> element is encountered. The effect is the
                      same as specifying <code>group-starting-with="h1"</code></p></item>
-                     <item><p><code>break-when="$group[last()]/@continued='no'"</code> starts a new
+                     <item><p><code>split-when="foot($group)/@continued='no'"</code> starts a new
                         group immediately after any element having <code>@continued="no"</code>. The effect is the
                         same as specifying <code>group-ending-with="*[@continued='no']"</code></p></item>
-                     <item><p><code>break-when="node-name($group[last()] != node-name($next)"</code> 
+                     <item><p><code>split-when="node-name($group[last()] != node-name($next)"</code> 
                         starts a new group whenever the name of an item differs from the name of the previous
                      item. The effect is the same as specifying <code>group-adjacent="node-name(.)"</code>.</p></item>
-                     <item><p><code>break-when="$group[last()][self::hr] or $next[self::hr]"</code> 
+                     <item><p><code>split-when="foot($group)[self::hr] or $next[self::hr]"</code> 
                         starts a new group immediately before and immediately after every <code>hr</code>
                         element. (That is, <code>hr</code> elements become singleton groups.)</p></item>
-                     <item><p><code>break-when="$next ne $group[last()] + 1"</code> 
+                     <item><p><code>split-when="$next ne foot($group) + 1"</code> 
                         starts a new group whenever the current item is not equal to the previous item
                      plus one. For example <code>1, 2, 5, 6, 7, 10, 11</code> is grouped as <code>(1, 2), (5, 6, 7),
                      (10, 11)</code>.</p></item>
-                     <item><p><code>break-when="sum($group/string-length()) gt 40"</code> starts a new
+                     <item><p><code>split-when="sum($group/string-length()) gt 40"</code> starts a new
                      group when the sum of the string lengths of the items in the current group exceeds 40.</p></item>
-                     <item><p><code>break-when="ends-with($group[last()], '.') and matches($next, '^\p{Lu}')"</code> 
+                     <item><p><code>split-when="ends-with(foot($group), '.') and matches($next, '^\p{Lu}')"</code> 
                         starts a new group when the last item in the current group ends with <code>"."</code> and the
                         next item starts with a capital letter.</p></item>
-                     <item><p><code>break-when="deep-equal(slice($group, -2 to -1), ('', ''))"</code> 
+                     <item><p><code>split-when="deep-equal(slice($group, -2 to -1), ('', ''))"</code> 
                         starts a new group after two consecutive zero-length strings.</p></item>
-                     <item><p><code>break-when="count($group) gt 1 and $group[1]/@name = $group[last()]/@name"</code> 
+                     <item><p><code>split-when="count($group) gt 1 and head($group)/@name = foot($group)/@name"</code> 
                         starts a new group if the last item in the current group has the same value for <code>@name</code>
                         as the first item in that group (provided they are not the same item).</p></item>
                   </ulist>
@@ -23230,8 +23230,8 @@ the same group, and the-->
                the group whose <termref def="dt-sort-key-value">sort key value</termref> is being
                determined, and the <termref def="dt-current-grouping-key"/> is the grouping key for
                that group. If the <elcode>xsl:for-each-group</elcode> instruction uses the
-               <code>group-starting-with</code>, <code>group-ending-with</code><phrase diff="add" at="2022-01-01">,
-                  or <code>break-when</code></phrase>
+               <code>group-starting-with</code>, <code>group-ending-with</code><phrase diff="add" at="2023-10-10">,
+                  or <code>split-when</code></phrase>
                attributes, then the <termref def="dt-current-grouping-key"/> is <termref def="dt-absent"/>.</p>
             <example>
                <head>Sorting Groups</head>
@@ -23571,7 +23571,8 @@ the same group, and the-->
 }</eg>
                <p>This can be achieved as follows:</p>
                <eg><![CDATA[<xsl:map>
-   <xsl:for-each-group select="json-doc('tz.json') => map:pairs()" group-by="substring-before(?key, '/')">
+   <xsl:for-each-group select="json-doc('tz.json') => map:pairs()" 
+                       group-by="substring-before(?key, '/')">
      <xsl:map-entry key="current-grouping-key()">
        <xsl:map>
          <xsl:for-each select="current-group()">


### PR DESCRIPTION
Fulfils action QT4CG-047-01 : the CG decided to rename break-when as split-when. Also applies a few minor editorial corrections in the same general area.