### PR TITLE
XQFO Examples: minor fixes, formatting

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -2317,12 +2317,14 @@
          <code>A-Z</code> may be used in place of their lower-case equivalents.</p>
          <p>The value of a generalized digit corresponds to its position in this alphabet.
          More formally, in non-error cases the result of the function is given by the XQuery expression:</p>
-         <eg><![CDATA[let $alphabet := characters("0123456789abcdefghijklmnopqrstuvwxyz")
+         <eg><![CDATA[
+let $alphabet := characters("0123456789abcdefghijklmnopqrstuvwxyz")
 let $preprocessed-value := translate($value, "_ &#x9;&#xa;&#xd;", "")
 let $digits := translate($preprocessed-value, "+-", "")
 let $abs := sum(
   for $char at $p in reverse(characters($digits))
-  return (index-of($alphabet, $char) - 1) * xs:integer(math:pow($radix, $p - 1)))
+  return (index-of($alphabet, $char) - 1) * xs:integer(math:pow($radix, $p - 1))
+)
 return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
       </fos:rules>
       <fos:errors>
@@ -3450,8 +3452,8 @@ return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
                ref="op.numeric"/>. The following rules apply when the values are finite and non-zero, 
             (subject to rules for overflow, underflow and approximation).</p>
          <p>If either argument is <code>NaN</code> then the result is <code>NaN</code>.</p>
-         <p diff="chg" at="B">If <code>$x</code> is positive, then  the value of <code>atan2($y,
-               $x)</code> is <code>atan($y div $x)</code>.</p>
+         <p diff="chg" at="B">If <code>$x</code> is positive, then  the value of
+            <code>atan2($y, $x)</code> is <code>atan($y div $x)</code>.</p>
          <p diff="chg" at="B">If <code>$x</code> is negative, then:</p>
          <ulist diff="chg" at="B">
             <item><p>If <code>$y</code> is positive, then the value of <code>atan2($y, $x)</code> is 
@@ -12159,7 +12161,8 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       <fos:rules>
          <p>The function returns a sequence consisting of all items of <code>$input</code> <phrase diff="chg" at="2023-01-17">whose
             1-based position is not equal to any of the integers in <code>$positions</code>. </phrase></p>
-         <p diff="add" at="2023-01-17">More formally, the function returns the result of the expression <code>$input[not(position() = $positions)]</code>.</p>
+         <p diff="add" at="2023-01-17">More formally, the function returns the result of the expression
+            <code>$input[not(position() = $positions)]</code>.</p>
       </fos:rules>
       <fos:notes>
          <p diff="chg" at="2023-01-17">Any integer in <code>$positions</code> that is less than 1 or greater than the number of items in
@@ -12911,8 +12914,9 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          <p>Informally, the function returns <code>true</code> if <code>$input</code> starts with <code>$subsequence</code>,
          when items are compared using the supplied (or default) <code>$compare</code> function.</p>
          <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[count($input) ge count($subsequence) 
-and all(for-each-pair($input, $subsequence, $compare))]]></eg>
+         <eg><![CDATA[
+count($input) ge count($subsequence) and
+every(for-each-pair($input, $subsequence, $compare))]]></eg>
       </fos:rules>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
@@ -13139,12 +13143,17 @@ return ends-with-sequence(
       <fos:rules>
          <p>Informally, the function returns <code>true</code> if <code>$input</code> contains a consecutive subsequence matching <code>$subsequence</code>,
             when items are compared using the supplied (or default) <code>$compare</code> function.</p>
-         <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[if (starts-with-sequence($input, $subsequence, $compare))
-then true()
-else if (empty($input))
-     then false()
-     else contains-sequence(tail($input, $subsequence, $compare))]]></eg>
+         <p>More formally, the effect of the function is equivalent to the following implementation in XQuery:</p>
+         <eg><![CDATA[
+declare function contains-sequence(
+  $input       as item()*,
+  $subsequence as item()*,
+  $compare     as function(item(), item()) as xs:boolean := fn:deep-equal#2
+) as xs:boolean {
+  starts-with-sequence($input, $subsequence, $compare) or
+  exists($input) and contains-sequence(tail($input), $subsequence, $compare)
+};
+]]></eg>
       </fos:rules>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
@@ -13593,21 +13602,23 @@ return contains-sequence(
             <item><p>The two strings are then compared for equality under the requested <code>$collation</code>.</p></item>
          </olist>
          
-         <p>More formally, the <code>equal-strings</code> function can be expressed as follows:</p>
-         
-         <eg><![CDATA[function($s1 as xs:string, $s2 as xs:string, 
-  $collation as xs:string, $options as map(*)
+         <p>More formally, the <code>equal-strings</code> function is equivalent to the following
+            implementation in XQuery:</p>
+         <eg><![CDATA[
+declare function equal-strings(
+  $string1   as xs:string,
+  $string2   as xs:string, 
+  $collation as xs:string,
+  $options   as map(*)
 ) as xs:boolean {
   let $n1 := if ($options?whitespace = "normalize"))
              then normalize-unicode(?, $options?normalization-form) 
-             else identity#1,
-  $n2 := if ($options?normalize-space)
+             else identity#1
+  let $n2 := if ($options?normalize-space)
              then normalize-space#1 
              else identity#1               
-}
-return compare($n1($n2($s1)), $n1($n2($s2)), $collation) eq 0    
+  return compare($n1($n2($string1)), $n1($n2($string2)), $collation) eq 0    
 }]]></eg>
-         
          <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
             are as follows. The two items are deep-equal
             if one or more of the following conditions are true:</p>
@@ -14623,12 +14634,9 @@ return compare($n1($n2($s1)), $n1($n2($s2)), $collation) eq 0
          <p>The result of the function is the value of the
             expression:</p>
          <eg xml:space="preserve">
-if (count($c) eq 0) then
-    $zero
-else if (count($c) eq 1) then
-    $c[1]
-else
-    $c[1] + sum(subsequence($c, 2))</eg>
+if (count($c) eq 0) then $zero
+else if (count($c) eq 1) then $c[1]
+else $c[1] + sum(subsequence($c, 2))</eg>
          <p>where <code>$c</code> is the converted sequence.</p>
          <p>The result of the function <phrase diff="chg" at="2023-01-17">when a single argument is supplied</phrase> is the result of the expression:
                <code>fn:sum($arg, 0)</code>.</p>
@@ -17546,7 +17554,10 @@ return map:keys($ann) || ': ' || string-join(map:values($ann), ', ')
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function for-each($input, $action) {
+declare function for-each(
+  $input  as item()*,
+  $action as function(item()) as item()*
+) as item()* {
   if (empty($input))
   then ()
   else ($action(head($input)), for-each(tail($input), $action))
@@ -17618,14 +17629,12 @@ declare function for-each($input, $action) {
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
 declare function filter(
-        $input as item()*,
-        $predicate as function(item()) as xs:boolean)
-        as item()* {
+  $input     as item()*,
+  $predicate as function(item()) as xs:boolean
+) as item()* {
   if (empty($input))
   then ()
-  else (head($input)[$predicate(.) eq true()], 
-        filter(tail($input), $predicate)
-       )
+  else (head($input)[$predicate(.)], filter(tail($input), $predicate))
 };]]></eg>
          <p>or its equivalent in XSLT:</p>
          <eg><![CDATA[
@@ -17691,10 +17700,10 @@ declare function filter(
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
 declare function fold-left(
-        $input as item()*,
-        $zero as item()*,
-        $action as function(item()*, item()) as item()*) 
-        as item()* {
+  $input  as item()*,
+  $zero   as item()*,
+  $action as function(item()*, item()) as item()*
+) as item()* {
   if (empty($input))
   then $zero
   else fold-left(tail($input), $action($zero, head($input)), $action)
@@ -17846,10 +17855,10 @@ declare function fold-left(
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
 declare function fold-right(
-        $input as item()*, 
-        $zero as item()*, 
-        $action as function(item(), item()*) as item()*) 
-        as item()* {
+  $input  as item()*, 
+  $zero   as item()*, 
+  $action as function(item(), item()*) as item()*
+) as item()* {
   if (empty($input))
   then $zero
   else $action(head($input), fold-right(tail($input), $zero, $action))
@@ -17963,16 +17972,14 @@ declare function fold-right(
          </olist>
          <p>More formally, the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function fn:iterate-while(
+declare function iterate-while(
   $input     as item()*,
   $predicate as function(item()*) as xs:boolean,
   $action    as function(item()*) as item()*
 ) as item()* {
-  if ($predicate($input)) then (
-    fn:iterate-while($action($input), $predicate, $action)
-  ) else (
-    $input
-  )
+  if ($predicate($input))
+  then iterate-while($action($input), $predicate, $action)
+  else $input
 };]]></eg>
       </fos:rules>
       <fos:notes>
@@ -18034,18 +18041,17 @@ return iterate-while(
             <p>The following example generates random doubles. It is interrupted once a number
                exceeds a given limit:</p>
             <eg><![CDATA[
-let $r := random-number-generator()
-let $map := iterate-while(
-  $r,
-  function($r) {
-    $r?number < 0.8
+let $result := iterate-while(
+  random-number-generator(),
+  function($random) {
+    $random?number < 0.8
   },
-  function($r) {
-    map:put($r?next(), 'numbers', ($r?numbers, $r?number))
+  function($random) {
+    map:put($random?next(), 'numbers', ($random?numbers, $random?number))
   }
 )
-return $map?numbers
-            ]]></eg>
+return $result?numbers
+]]></eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -18074,14 +18080,14 @@ return $map?numbers
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function fn:for-each-pair($input1, $input2, $action)
-{
-   if(fn:exists($input1) and fn:exists($input2)) 
-   then (
-     $action(fn:head($input1), fn:head($input2)),
-     fn:for-each-pair(fn:tail($input1), fn:tail($input2), $action)
-   )
-   else ()
+declare function for-each-pair(
+  $input1 as item()*,
+  $input2 as item()*,
+  $action as function(item(), item()) as item()*
+) as item()* {
+  if (empty($input1) or empty($input2)) 
+  then ()
+  else ($action(head($input1), head($input2)), for-each-pair(tail($input1), tail($input2), $action))
 };]]></eg>
          <p>or its equivalent in XSLT:</p>
          <eg><![CDATA[
@@ -18331,11 +18337,10 @@ return sort($in, $SWEDISH)</eg>
             <p>To sort a sequence of employees first by increasing last name (using Swedish collation order)
                and then by decreasing salary:
             </p>
-            <eg>let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
-               return sort($employees, 
-                           $SWEDISH, 
-                           (fn{name/last}, fn{xs:decimal(salary)}), 
-                           ("ascending", "descending"))</eg>
+            <eg>sort($employees, 
+  "http://www.w3.org/2013/collation/UCA?lang=se",
+  (fn { name/last }, fn { xs:decimal(salary) }), 
+  ("ascending", "descending"))</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -18404,7 +18409,7 @@ return sort($in, $SWEDISH)</eg>
 </doc>}]]>
          </fos:variable>
          <fos:variable name="direct-reports" id="transitive-closure-reports"><![CDATA[function($p as element(person)) as element(person)* {
-   $p/../person[@manager=$p/@id]
+  $p/../person[@manager=$p/@id]
 }]]>
          </fos:variable>          
          <fos:example>
@@ -19045,26 +19050,24 @@ return $tc($doc/article)/head</eg>
          is defined to be consistent with the result of the expression:</p>
 
          <eg><![CDATA[
-let $FOJS0003 := QName("http://www.w3.org/2005/xqt-errors", "FOJS0003"),
-
-$duplicates-handler := map {
-  "use-first":   function($a, $b) {$a},
-  "use-last":    function($a, $b) {$b},
-  "combine":     function($a, $b) {$a, $b},
-  "reject":      function($a, $b) {fn:error($FOJS0003)},
-  "use-any": function($a, $b) {fn:random-number-generator()?permute(($a, $b))[1]}
-},
-
-$combine-maps := function($A as map(*), $B as map(*), $deduplicator as function(*)) {
-    fold-left(map:keys($B), $A, function($z, $k) { 
-        if (map:contains($z, $k))
-        then map:put($z, $k, $deduplicator($z($k), $B($k)))
-        else map:put($z, $k, $B($k))
-    })
+let $FOJS0003 := QName("http://www.w3.org/2005/xqt-errors", "FOJS0003")
+let $duplicates-handler := map {
+  "use-first": function($a, $b) { $a },
+  "use-last":  function($a, $b) { $b },
+  "combine":   function($a, $b) { $a, $b },
+  "reject":    function($a, $b) { fn:error($FOJS0003) },
+  "use-any":   function($a, $b) { fn:random-number-generator()?permute(($a, $b))[1] }
 }
-return fold-left($MAPS, map{}, 
-    $combine-maps(?, ?, $duplicates-handler(($OPTIONS?duplicates, "use-first")[1]))]]></eg>
-
+let $combine-maps := function($A as map(*), $B as map(*), $deduplicator as function(*)) {
+  fold-left(map:keys($B), $A, function($z, $k) { 
+    if (map:contains($z, $k))
+    then map:put($z, $k, $deduplicator($z($k), $B($k)))
+    else map:put($z, $k, $B($k))
+  })
+}
+return fold-left($MAPS, map { },
+  $combine-maps(?, ?, $duplicates-handler($OPTIONS?duplicates otherwise "use-first"))
+)]]></eg>
          <note>
             <p>By way of explanation, <code>$combine-maps</code> is a function that combines
             two maps by iterating over the keys of the second map, adding each key and its corresponding
@@ -19333,15 +19336,16 @@ return fold-left($MAPS, map{},
                ref="properties-of-functions"
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
-         <p>More formally, the function returns the result of the following expression:</p>
-         <eg>
-map:for-each(
-   $map,
-   function($key, $value) {
-      if($predicate($value)) { $key }
-   }
-)
-         </eg>
+         <p>More formally, the effect of the function is equivalent to the following implementation in XQuery:</p>
+         <eg><![CDATA[
+declare function map:keys(
+  $map       as map(*),
+  $predicate as function(item()*) as xs:boolean
+) as xs:anyAtomicType* {
+  map:for-each($map, function($key, $value) {
+    if($predicate($value)) { $key }
+  })
+};]]></eg>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -20293,21 +20297,19 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             <item><p>If the key is already present, the processor calls the <code>$combine</code> function to combine the existing value 
                for the key with the new value, and replaces the entry with this combined value.</p></item>
          </ulist>
-            
          <p>More formally, the result of the function is the result of the following expression:</p>
-         
          <eg>
-fold-left($input, map{}, fn($map, $next) {
-   let $nextKey := $key($next)
-   let $nextValue := $value($next)
-   return
-      if (fn:exists($nextKey))
-      then
-         if (map:contains($map, $nextKey))
-         then map:put($map, $nextKey, $combine($map($nextKey), $nextValue))
-         else map:put($map, $nextKey, $nextValue)
-      else
-         $map
+fold-left($input, map { }, fn($map, $next) {
+  let $nextKey := $key($next)
+  let $nextValue := $value($next)
+  return
+    if (exists($nextKey))
+    then
+      if (map:contains($map, $nextKey))
+      then map:put($map, $nextKey, $combine($map($nextKey), $nextValue))
+      else map:put($map, $nextKey, $nextValue)
+    else
+      $map
 })
          </eg>
       </fos:rules>
@@ -23018,7 +23020,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function returns the number of members in the array.</p>
-         <p diff="chg" at="A">More formally, the function returns the value of <code>fn:count(array:members($array))</code>.</p>
+         <p diff="chg" at="A">More formally, the function returns the value of
+            <code>count(array:members($array))</code>.</p>
       </fos:rules>
       <fos:notes>
          <p>Note that because an array is an item, the <code>fn:count</code> function
@@ -23426,8 +23429,8 @@ else $fallback($position)</eg>
       <fos:rules>
          <p>Except in error cases, 
             the two-argument version of the function returns the same result as the three-argument
-            version when called with <code>$length</code> equal to the value of <code>array:size($array) -
-               $start + 1</code>.</p>
+            version when called with <code>$length</code> equal to the value of
+            <code>array:size($array) - $start + 1</code>.</p>
          <p diff="add" at="2022-12-19">Setting the third argument to the empty sequence has the same effect as omitting the argument.</p>
          <p>Except in error cases, the result of the three-argument version of the function is the 
             value of the expression
@@ -24150,14 +24153,7 @@ else $fallback($position)</eg>
       </fos:summary>
       <fos:rules>
          <p>The result of the function is the value of the expression 
-            <code role="example">array:members($array) => fn:fold-left($zero, function($a, $b) { $action($a, $b?value })</code></p>
-<!--         <eg>
-if (array:size($array) eq 0)
-then $zero
-else array:fold-left(array:tail($array), 
-                     $action($zero, array:head($array)), 
-                     $action )
-         </eg>-->
+            <code role="example">array:members($array) => fold-left($zero, function($a, $b) { $action($a, $b?value })</code></p>
       </fos:rules>
       <fos:notes>
          <p>If the supplied array is empty, the function returns <code>$zero</code>.</p>
@@ -24347,7 +24343,7 @@ return array:for-each-pair(
          <p>Informally, <code>array:build#2</code> applies the supplied function to each item 
             in the input sequence, and the resulting sequence becomes one member of the returned array.</p>
          <p>More formally, <code>array:build#2</code> returns the result of the expression:</p>
-         <eg>array:of-members($input ! map{'value':$action(.)})</eg>
+         <eg>array:of-members($input ! map { 'value': $action(.) })</eg>
       </fos:rules>
       <fos:notes>
          <p>The single-argument function <code>array:build($input)</code> is equivalent to the XPath
@@ -24680,14 +24676,14 @@ return array:sort($in, $SWEDISH)
             </item>
          </ulist>
          <p>The process is then repeated so long as the sequence contains an array among its items.</p>
-         <p>The function is equivalent to the following XQuery implementation (assuming static typing is not in force):</p>
-         <eg>declare function flatten ($S as item()*) {
-    for $s in $S return (
-      typeswitch($s)
-        case $a as array(*) return flatten($a?*)
-        default return $s
-)}</eg>
-
+         <p>The function is equivalent to the following implementation in XQuery:</p>
+         <eg><![CDATA[
+declare function flatten(
+  $input as item()*
+) as item()* {
+  for $item in $input
+  return if ($item instance of array(*)) then flatten($item?*) else $item
+};]]></eg>
       </fos:rules>
       <fos:notes>
          <p>The argument to the function will often be a single array item, but this is not essential.</p>
@@ -25839,13 +25835,14 @@ declare %public function r:random-sequence($length as xs:integer) as xs:double* 
   r:random-sequence($length, random-number-generator())
 };
 
-declare %private function r:random-sequence($length as xs:integer, 
-                                            $G as record(number as xs:double, next as function(*), *)) {
+declare %private function r:random-sequence(
+  $length as xs:integer, 
+  $record as record(number as xs:double, next as function(*), *)
+) {
   if ($length eq 0)
   then ()
-  else ($G?number, r:random-sequence($length - 1, $G?next()))
+  else ($record?number, r:random-sequence($length - 1, $record?next()))
 };
-
 r:random-sequence(200);
             </eg>
 
@@ -25874,11 +25871,11 @@ r:random-sequence(200);
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function fn:every(
-        $input as item()*,
-        $predicate as function(item()) as xs:boolean) 
-        as xs:boolean {
-  every $i in $input satisfies $predicate($i)
+declare function every(
+  $input     as item()*,
+  $predicate as function(item()) as xs:boolean
+) as xs:boolean {
+  every $item in $input satisfies $predicate($item)
 };]]></eg>
          <p>or its equivalent in XSLT:</p>
          <eg><![CDATA[
@@ -26136,10 +26133,11 @@ declare function fn:every(
          <p>Let <code>$modified-key</code> be the function:</p>
          <eg>
 function($item) {
-   $key($item) => data() ! (
-      if (. instance of xs:untypedAtomic)
-      then xs:double(.)
-      else .)
+  $key($item) => data() ! (
+    if (. instance of xs:untypedAtomic)
+    then xs:double(.)
+    else .
+  )
 }</eg>
          
          <p>That is, the supplied function for computing key values is wrapped in a function that
@@ -26257,7 +26255,7 @@ function($item) {
             the 1-based positions in the input sequence of those items for which the supplied predicate function
             returns <code>true</code>.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>index-of($input!$predicate(.), true())</eg>
+         <eg>index-of($input ! $predicate(.), true())</eg>
       </fos:rules>
 
       <fos:examples>
@@ -26802,11 +26800,11 @@ function($item) {
       <fos:rules>
          <p>The effect of the function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare function fn:some(
-        $input as item()*,
-        $predicate as function(item()) as xs:boolean) 
-        as xs:boolean {
-  some $i in $input satisfies $predicate($i)
+declare function some(
+  $input     as item()*,
+  $predicate as function(item()) as xs:boolean
+) as xs:boolean {
+  some $item in $input satisfies $predicate($item)
 };]]></eg>
          <p>or its equivalent in XSLT:</p>
          <eg><![CDATA[
@@ -27937,11 +27935,9 @@ path with an explicit <code>file:</code> scheme.</p>
         </p>
 
         <p>If any of <code>$userinfo</code>, <code>$host</code>, or <code>$port</code>
-        exist, the following authority is added to the URI
-        under construction:
-        <eg>concat((if (exists($userinfo)) then $userinfo || "@" else ""),
-       $host,
-       (if (exists($port)) then ":" || $port else ""))</eg></p>
+        exist, the following authority is added to the URI under construction:
+        <eg>concat((if (exists($userinfo)) then $userinfo || "@" else ""), $host,
+        (if (exists($port)) then ":" || $port else ""))</eg></p>
 
         <p>If none of <code>userinfo</code>, <code>host</code>, or <code>port</code>
         is present, and <code>authority</code> is present, the value of the
@@ -28036,12 +28032,12 @@ path with an explicit <code>file:</code> scheme.</p>
             and a new current partition is created, initially containing the item <var>J</var> only. If the <code>$break-when</code> 
             function returns <code>false</code>, the item <var>J</var> is added to the current partition.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>fold-left($input, (), function($partitions, $next) {
-              if (empty($partitions) or $break-when(foot($partitions)?*, $next))
-              then ($partitions, [$next])
-              else (trunk($partitions), array{foot($partitions)?*, $next}) 
-            })   
-         </eg>  
+         <eg>
+fold-left($input, (), function($partitions, $next) {
+  if (empty($partitions) or $break-when(foot($partitions)?*, $next))
+  then ($partitions, [ $next ])
+  else (trunk($partitions), array { foot($partitions)?*, $next }) 
+})</eg>
       </fos:rules>
       <fos:notes>
          <p>The function enables a variety of positional grouping problems to be solved. For example:</p>
@@ -28099,9 +28095,7 @@ path with an explicit <code>file:</code> scheme.</p>
             <fos:test>
                <fos:expression><eg>partition(
   (1, 2, 3, 6, 7, 9, 10),
-  function($partition, $next) {
-    $next != foot($partition) + 1
-  }
+  function($partition, $next) { $next != foot($partition) + 1 }
 )</eg></fos:expression>
                <fos:result>([1, 2, 3], [6, 7], [9, 10])</fos:result>
             </fos:test>


### PR DESCRIPTION
Editorial: Some XQuery equivalents were buggy, and the formatting was unified.