### PR TITLE
653: Add string literals E".." and L".." to control entity expansion

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -4373,10 +4373,6 @@ ErrorVal ::= "$" VarName
     <g:choice>
       <g:ref name="AposStringLiteral"/>
       <g:ref name="QuotStringLiteral"/>
-      <g:ref name="AposStringLiteralExpand"/>
-      <g:ref name="QuotStringLiteralExpand"/>
-      <g:ref name="AposStringLiteralNoExpand"/>
-      <g:ref name="QuotStringLiteralNoExpand"/>
     </g:choice>
   </g:token>
   
@@ -4401,44 +4397,7 @@ ErrorVal ::= "$" VarName
     </g:sequence>
   </g:token>
   
-  <g:token name="AposStringLiteralExpand" inline="false" value-type="string"
-    whitespace-spec="explicit" delimiter-type="delimiting">
-    <g:sequence>
-      <g:string>E'</g:string>
-      <g:zeroOrMore>
-        <g:choice>
-          <g:ref name="PredefinedEntityRef"/>
-          <g:ref name="CharRef" token-user-action="checkCharRef(token.image);"/>
-          <g:ref name="EscapeApos" />
-          <g:complement>
-            <g:charClass>
-              <g:char>'</g:char>
-              <g:char>&amp;</g:char>
-            </g:charClass>
-          </g:complement>
-        </g:choice>
-      </g:zeroOrMore>
-      <g:string>'</g:string>
-    </g:sequence>
-  </g:token>
-  
-  <g:token name="AposStringLiteralNoExpand" inline="false" value-type="string"
-    whitespace-spec="explicit" delimiter-type="delimiting">
-    <g:sequence>
-      <g:string>L'</g:string>
-      <g:zeroOrMore>
-        <g:choice>
-          <g:ref name="EscapeApos" />
-          <g:complement>
-            <g:charClass>
-              <g:char>'</g:char>
-            </g:charClass>
-          </g:complement>
-        </g:choice>
-      </g:zeroOrMore>
-      <g:string>'</g:string>
-    </g:sequence>
-  </g:token>
+
   
   <g:token name="QuotStringLiteral" inline="false" value-type="string"
     whitespace-spec="explicit" delimiter-type="delimiting">
@@ -4453,45 +4412,6 @@ ErrorVal ::= "$" VarName
             <g:charClass>
               <g:char>"</g:char>
               <g:char if="xquery40">&amp;</g:char>
-            </g:charClass>
-          </g:complement>
-        </g:choice>
-      </g:zeroOrMore>
-      <g:string>"</g:string>
-    </g:sequence>
-  </g:token>
-  
-  <g:token name="QuotStringLiteralExpand" inline="false" value-type="string"
-    whitespace-spec="explicit" delimiter-type="delimiting">
-    <g:sequence>
-      <g:string>E"</g:string>
-      <g:zeroOrMore>
-        <g:choice>
-          <g:ref name="PredefinedEntityRef"/>
-          <g:ref name="CharRef" token-user-action="checkCharRef(token.image);"/>
-          <g:ref name="EscapeQuot" />
-          <g:complement>
-            <g:charClass>
-              <g:char>"</g:char>
-              <g:char if="xquery40">&amp;</g:char>
-            </g:charClass>
-          </g:complement>
-        </g:choice>
-      </g:zeroOrMore>
-      <g:string>"</g:string>
-    </g:sequence>
-  </g:token>
-  
-  <g:token name="QuotStringLiteralNoExpand" inline="false" value-type="string"
-    whitespace-spec="explicit" delimiter-type="delimiting">
-    <g:sequence>
-      <g:string>L"</g:string>
-      <g:zeroOrMore>
-        <g:choice>
-          <g:ref name="EscapeQuot" />
-          <g:complement>
-            <g:charClass>
-              <g:char>"</g:char>
             </g:charClass>
           </g:complement>
         </g:choice>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -4370,43 +4370,136 @@ ErrorVal ::= "$" VarName
 
   <g:token name="StringLiteral" inline="false" value-type="string"
       whitespace-spec="explicit" delimiter-type="delimiting">
-    <g:choice name="StringDilimitType">
-      <g:sequence>
-        <g:string>"</g:string>
-        <g:zeroOrMore name="CharsInQuote">
-          <g:choice name="QuoteTypeChar">
-            <g:ref name="PredefinedEntityRef" if="xquery40"/>
-            <g:ref name="CharRef" if="xquery40" token-user-action="checkCharRef(token.image);"/>
-            <g:ref name="EscapeQuot" />
-            <g:complement>
-              <g:charClass>
-                <g:char>"</g:char>
-                <g:char if="xquery40">&amp;</g:char>
-              </g:charClass>
-            </g:complement>
-          </g:choice>
-        </g:zeroOrMore>
-        <g:string>"</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string>'</g:string>
-        <g:zeroOrMore name="CharsInApos">
-          <g:choice name="AposTypeChar">
-            <g:ref name="PredefinedEntityRef" if="xquery40"/>
-            <g:ref name="CharRef" if="xquery40" token-user-action="checkCharRef(token.image);"/>
-            <g:ref name="EscapeApos" />
-            <g:complement>
-              <g:charClass>
-                <g:char>'</g:char>
-                <g:char if="xquery40">&amp;</g:char>
-              </g:charClass>
-            </g:complement>
-          </g:choice>
-        </g:zeroOrMore>
-        <g:string>'</g:string>
-      </g:sequence>
+    <g:choice>
+      <g:ref name="AposStringLiteral"/>
+      <g:ref name="QuotStringLiteral"/>
+      <g:ref name="AposStringLiteralExpand"/>
+      <g:ref name="QuotStringLiteralExpand"/>
+      <g:ref name="AposStringLiteralNoExpand"/>
+      <g:ref name="QuotStringLiteralNoExpand"/>
     </g:choice>
   </g:token>
+  
+  <g:token name="AposStringLiteral" inline="false" value-type="string"
+    whitespace-spec="explicit" delimiter-type="delimiting">
+    <g:sequence>
+      <g:string>'</g:string>
+      <g:zeroOrMore>
+        <g:choice>
+          <g:ref name="PredefinedEntityRef" if="xquery40"/>
+          <g:ref name="CharRef" if="xquery40" token-user-action="checkCharRef(token.image);"/>
+          <g:ref name="EscapeApos" />
+          <g:complement>
+            <g:charClass>
+              <g:char>'</g:char>
+              <g:char if="xquery40">&amp;</g:char>
+            </g:charClass>
+          </g:complement>
+        </g:choice>
+      </g:zeroOrMore>
+      <g:string>'</g:string>
+    </g:sequence>
+  </g:token>
+  
+  <g:token name="AposStringLiteralExpand" inline="false" value-type="string"
+    whitespace-spec="explicit" delimiter-type="delimiting">
+    <g:sequence>
+      <g:string>E'</g:string>
+      <g:zeroOrMore>
+        <g:choice>
+          <g:ref name="PredefinedEntityRef"/>
+          <g:ref name="CharRef" token-user-action="checkCharRef(token.image);"/>
+          <g:ref name="EscapeApos" />
+          <g:complement>
+            <g:charClass>
+              <g:char>'</g:char>
+              <g:char>&amp;</g:char>
+            </g:charClass>
+          </g:complement>
+        </g:choice>
+      </g:zeroOrMore>
+      <g:string>'</g:string>
+    </g:sequence>
+  </g:token>
+  
+  <g:token name="AposStringLiteralNoExpand" inline="false" value-type="string"
+    whitespace-spec="explicit" delimiter-type="delimiting">
+    <g:sequence>
+      <g:string>L'</g:string>
+      <g:zeroOrMore>
+        <g:choice>
+          <g:ref name="EscapeApos" />
+          <g:complement>
+            <g:charClass>
+              <g:char>'</g:char>
+            </g:charClass>
+          </g:complement>
+        </g:choice>
+      </g:zeroOrMore>
+      <g:string>'</g:string>
+    </g:sequence>
+  </g:token>
+  
+  <g:token name="QuotStringLiteral" inline="false" value-type="string"
+    whitespace-spec="explicit" delimiter-type="delimiting">
+    <g:sequence>
+      <g:string>"</g:string>
+      <g:zeroOrMore>
+        <g:choice>
+          <g:ref name="PredefinedEntityRef" if="xquery40"/>
+          <g:ref name="CharRef" if="xquery40" token-user-action="checkCharRef(token.image);"/>
+          <g:ref name="EscapeQuot" />
+          <g:complement>
+            <g:charClass>
+              <g:char>"</g:char>
+              <g:char if="xquery40">&amp;</g:char>
+            </g:charClass>
+          </g:complement>
+        </g:choice>
+      </g:zeroOrMore>
+      <g:string>"</g:string>
+    </g:sequence>
+  </g:token>
+  
+  <g:token name="QuotStringLiteralExpand" inline="false" value-type="string"
+    whitespace-spec="explicit" delimiter-type="delimiting">
+    <g:sequence>
+      <g:string>E"</g:string>
+      <g:zeroOrMore>
+        <g:choice>
+          <g:ref name="PredefinedEntityRef"/>
+          <g:ref name="CharRef" token-user-action="checkCharRef(token.image);"/>
+          <g:ref name="EscapeQuot" />
+          <g:complement>
+            <g:charClass>
+              <g:char>"</g:char>
+              <g:char if="xquery40">&amp;</g:char>
+            </g:charClass>
+          </g:complement>
+        </g:choice>
+      </g:zeroOrMore>
+      <g:string>"</g:string>
+    </g:sequence>
+  </g:token>
+  
+  <g:token name="QuotStringLiteralNoExpand" inline="false" value-type="string"
+    whitespace-spec="explicit" delimiter-type="delimiting">
+    <g:sequence>
+      <g:string>L"</g:string>
+      <g:zeroOrMore>
+        <g:choice>
+          <g:ref name="EscapeQuot" />
+          <g:complement>
+            <g:charClass>
+              <g:char>"</g:char>
+            </g:charClass>
+          </g:complement>
+        </g:choice>
+      </g:zeroOrMore>
+      <g:string>"</g:string>
+    </g:sequence>
+  </g:token>
+  
 
   <g:token name="URIQualifiedName" inline="false" whitespace-spec="explicit" if="xpath40 xquery40  xslt40-patterns">
     <g:ref name="BracedURILiteral"/>
@@ -4432,7 +4525,7 @@ ErrorVal ::= "$" VarName
     <g:string>}</g:string>
   </g:token>
 
-  <g:token name="PredefinedEntityRef" if="xquery40" inline="false" whitespace-spec="explicit" delimiter-type="hide">
+  <g:token name="PredefinedEntityRef"  inline="false" whitespace-spec="explicit" delimiter-type="hide">
     <g:string>&amp;</g:string>
     <g:choice name="PredefinedEntityNames">
       <g:string>lt</g:string>
@@ -4490,7 +4583,7 @@ ErrorVal ::= "$" VarName
     <g:ref name="NCNameTok"/>
   </g:token>
 
-  <g:token name="CharRef" if="xquery40" inline="false" is-xml="yes" xhref="http://www.w3.org/TR/REC-xml#NT-CharRef" xgc-id="xml-version" delimiter-type="hide">
+  <g:token name="CharRef" inline="false" is-xml="yes" xhref="http://www.w3.org/TR/REC-xml#NT-CharRef" xgc-id="xml-version" delimiter-type="hide">
     <g:string>&amp;#</g:string>
     <g:choice name="CharRefChars">
       <g:ref name="Digits"/>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -684,7 +684,7 @@
                def="dt-expanded-qname">expanded QNames</termref>).</p>
       </error>
 
-      <error spec="XQ" code="0090" class="ST" type="static">
+      <error spec="XQ" role="xquery" code="0090" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> if a <termref
                def="dt-character-reference">character reference</termref> does not identify a valid
             character in the version of XML that is in use.</p>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -684,7 +684,7 @@
                def="dt-expanded-qname">expanded QNames</termref>).</p>
       </error>
 
-      <error spec="XQ" role="xquery" code="0090" class="ST" type="static">
+      <error spec="XQ" code="0090" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> if a <termref
                def="dt-character-reference">character reference</termref> does not identify a valid
             character in the version of XML that is in use.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6993,7 +6993,7 @@ and <nt def="OrExpr"
                      in most contexts where string literals can be used, an alternative is to write a
                      <nt def="StringTemplate">StringTemplate</nt>, as described in <specref ref="id-string-templates"/>. 
                      The four-character string <code>"AT&amp;T"</code> can be written either as
-                     <code>`AT&amp;T`</code>, or, if preferred, as <code>`AT{char("&amp;amp;")}T`</code>.</p>
+                     <code>`AT&amp;T`</code>, or, if preferred, as <code>`AT{char(`&amp;amp;`)}T`</code>.</p>
                </note>
                
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6993,7 +6993,7 @@ and <nt def="OrExpr"
                      in most contexts where string literals can be used, an alternative is to write a
                      <nt def="StringTemplate">StringTemplate</nt>, as described in <specref ref="id-string-templates"/>. 
                      The four-character string <code>"AT&amp;T"</code> can be written either as
-                     <code>`AT&amp;T`</code>, or, if preferred, as <code>`AT{char(`&amp;amp;`)}T`</code>.</p>
+                     <code>`AT&amp;T`</code>, or, if preferred, as <code>`AT{char(`amp`)}T`</code>.</p>
                </note>
                
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6724,98 +6724,210 @@ and <nt def="OrExpr"
 -->
          <div3 id="id-literals">
             <head>Literals</head>
+            
+            <scrap>
+               <head/>
+               <prodrecap id="Literal" ref="Literal"/>
+            </scrap>
             <p>
                <termdef id="dt-literal" term="literal"
                   >A <term>literal</term> is a direct syntactic representation of an
 		atomic value.</termdef> &language; supports two kinds of literals: numeric literals and
 		string literals.</p>
-            <scrap>
-               <head/>
-               <prodrecap id="Literal" ref="Literal"/>
-               <prodrecap id="NumericLiteral" ref="NumericLiteral"/>
-               <prodrecap id="IntegerLiteral" ref="IntegerLiteral"/>
-               <prodrecap id="HexIntegerLiteral" ref="HexIntegerLiteral"/>
-               <prodrecap id="BinaryIntegerLiteral" ref="BinaryIntegerLiteral"/>
-               <prodrecap id="DecimalLiteral" ref="DecimalLiteral"/>
-               <prodrecap id="DoubleLiteral" ref="DoubleLiteral"/>
-               <prodrecap id="StringLiteral" ref="StringLiteral"/>
-               <prodrecap id="PredefinedEntityRef" ref="PredefinedEntityRef" role="xquery"/>
-               <prodrecap id="EscapeQuot" ref="EscapeQuot"/>
-               <prodrecap id="EscapeApos" ref="EscapeApos"/>
-               <prodrecap id="Digits" ref="Digits"/>
-               <prodrecap id="DecDigit" ref="DecDigit"/>
-               <prodrecap id="HexDigits" ref="HexDigits"/>
-               <prodrecap id="HexDigit" ref="HexDigit"/>
-               <prodrecap id="BinaryDigits" ref="BinaryDigits"/>
-               <prodrecap id="BinaryDigit" ref="BinaryDigit"/>
-            </scrap>
             
             
-            <p diff="add" at="2023-04-07">The value of a numeric literal is determined as follows (taking the rules in order):</p>
+            <div4 id="id-numeric-literals">
+               <head>Numeric Literals</head>
+               
+               <scrap>
+                  <head/>
+                  <prodrecap id="NumericLiteral" ref="NumericLiteral"/>
+                  <prodrecap id="IntegerLiteral" ref="IntegerLiteral"/>
+                  <prodrecap id="HexIntegerLiteral" ref="HexIntegerLiteral"/>
+                  <prodrecap id="BinaryIntegerLiteral" ref="BinaryIntegerLiteral"/>
+                  <prodrecap id="DecimalLiteral" ref="DecimalLiteral"/>
+                  <prodrecap id="DoubleLiteral" ref="DoubleLiteral"/>
+                  <prodrecap id="Digits" ref="Digits"/>
+                  <prodrecap id="DecDigit" ref="DecDigit"/>
+                  <prodrecap id="HexDigits" ref="HexDigits"/>
+                  <prodrecap id="HexDigit" ref="HexDigit"/>
+                  <prodrecap id="BinaryDigits" ref="BinaryDigits"/>
+                  <prodrecap id="BinaryDigit" ref="BinaryDigit"/>
+               </scrap>
             
-            <olist diff="chg" at="2023-04-07">
-               <item><p>Underscore characters are stripped out. Underscores may be included in a numeric
-               literal to aid readability, but have no effect on the value. For example, <code>1_000_000</code>
-               is equivalent to <code>1000000</code>.</p>
-                  <note><p diff="add" at="2023-04-25">Underscores must not appear at the beginning or end of a sequence of digits, only
-               in intermediate positions. Multiple adjacent underscores are allowed.</p></note>
-               </item>
-               <item><p>A <code>HexIntegerLiteral</code> represents a non-negative integer
-                   expressed in hexadecimal: for example <code>0xffff</code> represents the integer 65535, and
-                  <code>0xFFFF_FFFF</code> represents the integer 4294967295.</p>
-               </item>
-               <item><p>A <code>BinaryIntegerLiteral</code> represents a non-negative integer
-                  expressed in binary: for example <code>0b101</code> represents the integer 5, and
-                  <code>0b1111_1111</code> represents the integer 255.</p>
-               </item>
-               <item><p>The value of a <term>numeric literal</term> containing no <code>.</code> and 
-                  no <code>e</code> or <code>E</code> character is an atomic value of type <code>xs:integer</code>;
-                  the value is obtained by casting from <code>xs:string</code> to <code>xs:integer</code> as specified in
-                  <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
-               </item>
-               <item><p>The value of a numeric literal containing <code>.</code> but no <code>e</code> or <code>E</code> 
-                  character is an atomic value of type <code>xs:decimal</code>;
-                  the value is obtained by casting from <code>xs:string</code> to <code>xs:decimal</code> as specified in
-                  <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
-               </item>
-               <item><p>The value of a numeric literal 
-                  containing an <code>e</code> or <code>E</code> character is an atomic value of type 
-                  <code>xs:double</code>;
-                  the value is obtained by casting from <code>xs:string</code> to <code>xs:double</code> as specified in
-                  <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
-               </item>
-            </olist>
             
-            <note diff="add" at="2023-04-07"><p>The value of a numeric literal is always non-negative. An expression may
-               appear to include a negative number such as <code>-1</code>, but this is technically
-               an arithmetic expression comprising a unary minus operator followed by a numeric literal.</p></note>
+            
+               <p diff="add" at="2023-04-07">The value of a numeric literal is determined as follows (taking the rules in order):</p>
+               
+               <olist diff="chg" at="2023-04-07">
+                  <item><p>Underscore characters are stripped out. Underscores may be included in a numeric
+                  literal to aid readability, but have no effect on the value. For example, <code>1_000_000</code>
+                  is equivalent to <code>1000000</code>.</p>
+                     <note><p diff="add" at="2023-04-25">Underscores must not appear at the beginning or end of a sequence of digits, only
+                  in intermediate positions. Multiple adjacent underscores are allowed.</p></note>
+                  </item>
+                  <item><p>A <code>HexIntegerLiteral</code> represents a non-negative integer
+                      expressed in hexadecimal: for example <code>0xffff</code> represents the integer 65535, and
+                     <code>0xFFFF_FFFF</code> represents the integer 4294967295.</p>
+                  </item>
+                  <item><p>A <code>BinaryIntegerLiteral</code> represents a non-negative integer
+                     expressed in binary: for example <code>0b101</code> represents the integer 5, and
+                     <code>0b1111_1111</code> represents the integer 255.</p>
+                  </item>
+                  <item><p>The value of a <term>numeric literal</term> containing no <code>.</code> and 
+                     no <code>e</code> or <code>E</code> character is an atomic value of type <code>xs:integer</code>;
+                     the value is obtained by casting from <code>xs:string</code> to <code>xs:integer</code> as specified in
+                     <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+                  </item>
+                  <item><p>The value of a numeric literal containing <code>.</code> but no <code>e</code> or <code>E</code> 
+                     character is an atomic value of type <code>xs:decimal</code>;
+                     the value is obtained by casting from <code>xs:string</code> to <code>xs:decimal</code> as specified in
+                     <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+                  </item>
+                  <item><p>The value of a numeric literal 
+                     containing an <code>e</code> or <code>E</code> character is an atomic value of type 
+                     <code>xs:double</code>;
+                     the value is obtained by casting from <code>xs:string</code> to <code>xs:double</code> as specified in
+                     <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+                  </item>
+               </olist>
+               
+               <note diff="add" at="2023-04-07"><p>The value of a numeric literal is always non-negative. An expression may
+                  appear to include a negative number such as <code>-1</code>, but this is technically
+                  an arithmetic expression comprising a unary minus operator followed by a numeric literal.</p></note>
+    
+               <note>
+                  <p>The effect of the above rules is that in the case of an integer or decimal literal, a dynamic error <xerrorref
+                        spec="FO31" class="AR" code="0002"
+                        /> will generally be raised if the literal is outside the range of values supported by the implementation (other options are available: see <xspecref
+                        spec="FO31" ref="op.numeric"/> for details.)</p>
+                  <p role="xquery">The limits of numeric datatypes are specified in <specref
+                        ref="id-data-model-conformance"/>.</p>
+                  <p role="xpath"
+                        >The XML Schema specification allows implementations to impose a limit (which
+   must not be less than 18 digits) on the size of integer and decimal
+   values. The full range of values of built-in subtypes of <code>xs:integer</code>,
+   such as <code>xs:long</code> and <code>xs:unsignedLong</code>, can be supported only if the
+   limit is 20 digits or higher. Negative numbers such as the minimum
+   value of <code>xs:long</code> (<code>-9223372036854775808</code>) are technically unary
+   expressions rather than literals, but implementations may prefer to
+   ensure that they are expressible.</p>
+               </note>
+               
+               <p>Here are some examples of numeric literals:</p>
+               
+               <ulist>
+                  
+                  
+                  <item>
+                     <p>
+                        <code role="parse-test"
+                           >"12.5"</code> denotes the string containing the characters <code>1</code>, <code>2</code>, <code>.</code>, and
+                        <code>5</code>.</p>
+                  </item>
+                  
+                  
+                  <item>
+                     <p>
+                        <code role="parse-test"
+                           >12</code> denotes the <code>xs:integer</code> value twelve.</p>
+                  </item>
+                  
+                  <item>
+                     <p>
+                        <code role="parse-test"
+                           >1_000_000</code> denotes the <code>xs:integer</code> value one million.</p>
+                  </item>
+                  
+                  
+                  <item>
+                     <p>
+                        <code role="parse-test"
+                           >12.5</code> denotes the <code>xs:decimal</code> value twelve and one half.</p>
+                  </item>
+                  
+                  
+                  <item>
+                     <p>
+                        <code role="parse-test"
+                           >125E2</code> denotes the <code>xs:double</code> value twelve thousand, five hundred.</p>
+                  </item>
+                  
+                  <item>
+                     <p>
+                        <code role="parse-test"
+                           >0xffff</code> denotes the <code>xs:integer</code> value 65535.</p>
+                  </item>
+                  
+                  <item>
+                     <p>
+                        <code role="parse-test"
+                           >0b1000_0001</code> denotes the <code>xs:integer</code> value 129.</p>
+                  </item>
+               </ulist>
+                  
+            </div4>
+            
+            <div4 id="id-string-literal">
+               <head>String Literals</head>
+               
+               <scrap>
+                  <head/>
+                  <prodrecap id="StringLiteral" ref="StringLiteral"/>
+                  <prodrecap id="AposStringLiteral" ref="AposStringLiteral"/>
+                  <prodrecap id="AposStringLiteralExpand" ref="AposStringLiteralExpand"/>
+                  <prodrecap id="AposStringLiteralNoExpand" ref="AposStringLiteralNoExpand"/>
+                  <prodrecap id="QuotStringLiteral" ref="QuotStringLiteral"/>
+                  <prodrecap id="QuotStringLiteralExpand" ref="QuotStringLiteralExpand"/>
+                  <prodrecap id="QuotStringLiteralNoExpand" ref="QuotStringLiteralNoExpand"/>
+                  <prodrecap id="PredefinedEntityRef" ref="PredefinedEntityRef"/>
+                  <prodrecap id="CharRef" ref="CharRef"/>
+                  <prodrecap id="EscapeQuot" ref="EscapeQuot"/>
+                  <prodrecap id="EscapeApos" ref="EscapeApos"/>
+               </scrap>
  
-            <note>
-               <p>The effect of the above rules is that in the case of an integer or decimal literal, a dynamic error <xerrorref
-                     spec="FO31" class="AR" code="0002"
-                     /> will generally be raised if the literal is outside the range of values supported by the implementation (other options are available: see <xspecref
-                     spec="FO31" ref="op.numeric"/> for details.)</p>
-               <p role="xquery">The limits of numeric datatypes are specified in <specref
-                     ref="id-data-model-conformance"/>.</p>
-               <p role="xpath"
-                     >The XML Schema specification allows implementations to impose a limit (which
-must not be less than 18 digits) on the size of integer and decimal
-values. The full range of values of built-in subtypes of <code>xs:integer</code>,
-such as <code>xs:long</code> and <code>xs:unsignedLong</code>, can be supported only if the
-limit is 20 digits or higher. Negative numbers such as the minimum
-value of <code>xs:long</code> (<code>-9223372036854775808</code>) are technically unary
-expressions rather than literals, but implementations may prefer to
-ensure that they are expressible.</p>
-            </note>
 
-            <p id="id-string-literal"
-                  >The value of a <term>string literal</term> is an atomic value whose  type is <code>xs:string</code> and whose value is the string denoted by the characters between the
-		delimiting apostrophes or quotation marks. If the literal is delimited by apostrophes, two adjacent apostrophes within the literal are interpreted as a single apostrophe. Similarly, if the literal is delimited by quotation marks, two adjacent quotation marks within the literal are interpreted as one quotation mark.</p>
+            <p>The value of a <term>string literal</term> is an atomic value whose type is
+               <code>xs:string</code> and whose value is the string denoted by the characters between the
+		delimiting apostrophes or quotation marks. If the literal is delimited by apostrophes, two adjacent 
+		apostrophes within the literal are interpreted as a single apostrophe. Similarly, if the literal 
+		is delimited by quotation marks, two adjacent quotation marks within the literal are interpreted 
+		as one quotation mark.</p>
 
-            <p role="xquery"
-                  >A string literal may contain a <term>predefined entity reference</term>. <termdef
+            <p diff="add" at="2023-10-15">A string literal may be preceded by the character <code>"E"</code> 
+               (for <emph>expand entities</emph>)
+            to indicate that the character <code>"&amp;"</code> is treated specially, introducing an XML-like
+            character reference or predefined entity reference which is replaced by its expansion.</p>
+               
+            <p diff="add" at="2023-10-15">Alternatively, a string literal may be preceded by the character <code>"L"</code> 
+               (for <emph>literal</emph>)
+               to indicate that <code>"&amp;"</code> is treated as an ordinary character.</p>
+               
+            <p>In the absence of a leading <code>"E"</code> or <code>"L"</code>, the interpretation of any
+               <code>"&amp;"</code> within the string varies between XPath and XQuery:</p>
+               
+               <ulist>
+                  <item><p>In XQuery, <code>"&amp;"</code> introduces a character reference or predefined
+                  entity which is expanded.</p></item>
+                  <item><p>In XPath, <code>"&amp;"</code> is treated as an ordinary character.</p></item>
+               </ulist>
+               
+               <note>
+                  <p>The reason for the difference is that XPath is often embedded within XML-based languages
+                  such as XSLT, XSD, and XForms, where the XML parser will already have expanded entity and
+                  character references; it is important that the expansion is not done twice.</p>
+                  <p>In contexts where an expression might be interpreted either by an XPath or by an XQuery
+                  processor, the leading <code>"E"</code> or <code>"L"</code> can be used to achieve
+                  interoperable behavior.</p>
+               </note>
+               
+               <p><termdef
                   term="predefined entity reference" id="dt-predefined-entity-reference"
-                     >A <term>predefined entity reference</term> is a short sequence of characters, beginning with an ampersand, that represents a single character that might otherwise have syntactic significance.</termdef> Each predefined entity reference is replaced by the character it represents when the string literal is processed. The predefined entity references recognized by XQuery are as follows:</p>
+                     >A <term>predefined entity reference</term> is a short sequence of characters, 
+                  beginning with an ampersand, that represents a single character that might otherwise 
+                  have syntactic significance.</termdef> Each predefined entity reference is replaced 
+                  by the character it represents when the string literal is processed. The predefined 
+                  entity references recognized by XPath and XQuery are as follows:</p>
             <p role="xquery">
                <table width="60%" border="1" role="medium">
                   <tbody>
@@ -6866,77 +6978,30 @@ ensure that they are expressible.</p>
                   </tbody>
                </table>
             </p>
-            <p role="xquery"
-                  >A string literal may also contain a <term>character reference</term>. <termdef
+            <p><termdef
                   term="character reference" id="dt-character-reference"
                      >A <term>character reference</term> is an XML-style reference to a <bibref
                      ref="Unicode"
-                  /> character, identified by its decimal or hexadecimal codepoint.</termdef> For example, the Euro symbol (€) can be represented by the character reference <code>&amp;#8364;</code>. Character references are normatively defined in Section 4.1 of the XML specification (it is <termref
+                  /> character, identified by its decimal or hexadecimal codepoint.</termdef> For example, the Euro symbol 
+               (€) can be represented by the character reference <code>&amp;#8364;</code>. Character references are 
+               normatively defined in Section 4.1 of the XML specification (it is <termref
                   def="dt-implementation-defined"
-                  >implementation-defined</termref> whether the rules in   <bibref ref="XML"
+                  >implementation-defined</termref> whether the rules in <bibref ref="XML"
                   /> or <bibref ref="XML1.1"/> apply.) A <termref def="dt-static-error"
                   >static error</termref>
                <errorref class="ST" code="0090"
                /> is raised if a character reference does not identify a valid character in the version of XML that is in use.</p>
 
-            <p>Here are some examples of literal expressions:</p>
-
-            <ulist>
-
-
-               <item>
-                  <p>
-                     <code role="parse-test"
-                     >"12.5"</code> denotes the string containing the characters <code>1</code>, <code>2</code>, <code>.</code>, and
-			 <code>5</code>.</p>
-               </item>
-
-
-               <item>
-                  <p>
-                     <code role="parse-test"
-                     >12</code> denotes the <code>xs:integer</code> value twelve.</p>
-               </item>
-               
-               <item>
-                  <p>
-                     <code role="parse-test"
-                        >1_000_000</code> denotes the <code>xs:integer</code> value one million.</p>
-               </item>
-
-
-               <item>
-                  <p>
-                     <code role="parse-test"
-                     >12.5</code> denotes the <code>xs:decimal</code> value twelve and one half.</p>
-               </item>
-
-
-               <item>
-                  <p>
-                     <code role="parse-test"
-                     >125E2</code> denotes the <code>xs:double</code> value twelve thousand, five hundred.</p>
-               </item>
-               
-               <item>
-                  <p>
-                     <code role="parse-test"
-                        >0xffff</code> denotes the <code>xs:integer</code> value 65535.</p>
-               </item>
-               
-               <item>
-                  <p>
-                     <code role="parse-test"
-                        >0b1000_0001</code> denotes the <code>xs:integer</code> value 129.</p>
-               </item>
-
+            <p>Here are some examples of string literals:</p>
+               <ulist>
                <item>
                   <p>
                      <code role="parse-test"
                      >"He said, ""I don't like it."""</code> denotes a string containing two quotation marks and one apostrophe.</p>
-                  <note role="xpath">
-                     <p>When XPath expressions are embedded in contexts where quotation
-marks have special significance, such as inside XML attributes, additional
+                  <note>
+                     <p>When XPath or XQuery expressions are embedded in contexts where quotation
+marks have special significance, such as inside XML attributes, or in string literals in a host language such
+as Java or C#, then additional
 escaping may be needed.</p>
                      <p diff="add" at="2023-04-25">An alternative solution is to use a 
                         <nt def="StringTemplate">StringTemplate</nt>, for example
@@ -6946,20 +7011,33 @@ escaping may be needed.</p>
                   </note>
                </item>
 
-               <item role="xquery">
+               <item>
                   <p>
                      <code role="parse-test"
-                        >"Ben &amp;amp; Jerry&amp;apos;s"</code> denotes the <code>xs:string</code> value  <code>"Ben &amp; Jerry's"</code>.</p>
+                        >E"Ben &amp;amp; Jerry&amp;apos;s"</code> denotes the <code>xs:string</code> value  <code>"Ben &amp; Jerry's"</code>.
+                     This can also be written <code>L"Ben &amp; Jerry's"</code>.
+                  </p>
                </item>
 
-               <item role="xquery">
+               <item>
                   <p>
                      <code role="parse-test"
-                        >"&amp;#8364;99.50"</code> denotes the <code>xs:string</code>  value <code>"€99.50"</code>.</p>
+                        >E"&amp;#8364;99.50"</code> denotes the <code>xs:string</code>  value <code>"€99.50"</code>.</p>
+               </item>
+               <item>
+                  <p>In XQuery, the string literal <code>"&amp;lt;"</code> denotes a string of length 1 containing the single character
+                     <code>"&lt;"</code>. In XPath, the string literal <code>"&amp;lt;"</code> denotes a string of length 4 containing the four 
+                     characters <code>"&amp;"</code>, <code>"l"</code>, <code>"t"</code>, <code>";"</code>. (However, when the XPath
+                     expression is embedded in an XML document, the sequence <code>"&amp;lt;"</code> will typically have already been converted
+                     to <code>"&lt;"</code> by the XML parser.)</p>
                </item>
             </ulist>
-
+            </div4>
+            <div4 id="id-constants-other-types">
+               <head>Constants of Other Types</head>
+ 
             <p>
+               
       The <code>xs:boolean</code> values <code>true</code> and <code>false</code> can be constructed by calls to the
       <termref
             def="dt-system-function">system functions</termref>
@@ -7031,6 +7109,7 @@ string in its lexical space.</p>
 			 whose type is  <code>hatsize</code>.</p>
                </item>
             </ulist>
+            </div4>
          </div3>
          <div3 id="id-variables">
             <head>Variable References</head>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6875,13 +6875,9 @@ and <nt def="OrExpr"
                   <head/>
                   <prodrecap id="StringLiteral" ref="StringLiteral"/>
                   <prodrecap id="AposStringLiteral" ref="AposStringLiteral"/>
-                  <prodrecap id="AposStringLiteralExpand" ref="AposStringLiteralExpand"/>
-                  <prodrecap id="AposStringLiteralNoExpand" ref="AposStringLiteralNoExpand"/>
                   <prodrecap id="QuotStringLiteral" ref="QuotStringLiteral"/>
-                  <prodrecap id="QuotStringLiteralExpand" ref="QuotStringLiteralExpand"/>
-                  <prodrecap id="QuotStringLiteralNoExpand" ref="QuotStringLiteralNoExpand"/>
-                  <prodrecap id="PredefinedEntityRef" ref="PredefinedEntityRef"/>
-                  <prodrecap id="CharRef" ref="CharRef"/>
+                  <prodrecap id="PredefinedEntityRef" role="xquery" ref="PredefinedEntityRef"/>
+                  <prodrecap id="CharRef"  role="xquery" ref="CharRef"/>
                   <prodrecap id="EscapeQuot" ref="EscapeQuot"/>
                   <prodrecap id="EscapeApos" ref="EscapeApos"/>
                </scrap>
@@ -6894,34 +6890,9 @@ and <nt def="OrExpr"
 		is delimited by quotation marks, two adjacent quotation marks within the literal are interpreted 
 		as one quotation mark.</p>
 
-            <p diff="add" at="2023-10-15">A string literal may be preceded by the character <code>"E"</code> 
-               (for <emph>expand entities</emph>)
-            to indicate that the character <code>"&amp;"</code> is treated specially, introducing an XML-like
-            character reference or predefined entity reference which is replaced by its expansion.</p>
-               
-            <p diff="add" at="2023-10-15">Alternatively, a string literal may be preceded by the character <code>"L"</code> 
-               (for <emph>literal</emph>)
-               to indicate that <code>"&amp;"</code> is treated as an ordinary character.</p>
-               
-            <p>In the absence of a leading <code>"E"</code> or <code>"L"</code>, the interpretation of any
-               <code>"&amp;"</code> within the string varies between XPath and XQuery:</p>
-               
-               <ulist>
-                  <item><p>In XQuery, <code>"&amp;"</code> introduces a character reference or predefined
-                  entity which is expanded.</p></item>
-                  <item><p>In XPath, <code>"&amp;"</code> is treated as an ordinary character.</p></item>
-               </ulist>
-               
-               <note>
-                  <p>The reason for the difference is that XPath is often embedded within XML-based languages
-                  such as XSLT, XSD, and XForms, where the XML parser will already have expanded entity and
-                  character references; it is important that the expansion is not done twice.</p>
-                  <p>In contexts where an expression might be interpreted either by an XPath or by an XQuery
-                  processor, the leading <code>"E"</code> or <code>"L"</code> can be used to achieve
-                  interoperable behavior.</p>
-               </note>
-               
-               <p><termdef
+            
+             
+               <p role="xquery"><termdef
                   term="predefined entity reference" id="dt-predefined-entity-reference"
                      >A <term>predefined entity reference</term> is a short sequence of characters, 
                   beginning with an ampersand, that represents a single character that might otherwise 
@@ -6978,7 +6949,7 @@ and <nt def="OrExpr"
                   </tbody>
                </table>
             </p>
-            <p><termdef
+               <p role="xquery"><termdef
                   term="character reference" id="dt-character-reference"
                      >A <term>character reference</term> is an XML-style reference to a <bibref
                      ref="Unicode"
@@ -6991,6 +6962,40 @@ and <nt def="OrExpr"
                   >static error</termref>
                <errorref class="ST" code="0090"
                /> is raised if a character reference does not identify a valid character in the version of XML that is in use.</p>
+               
+               <p>The interpretation of any
+                  <code>"&amp;"</code> within the string varies between XPath and XQuery:</p>
+               
+               <ulist>
+                  <item><p>In XQuery, <code>"&amp;"</code> introduces a character reference or predefined
+                     entity which is expanded. So the string literal <code>"AT&amp;amp;T"</code> represents
+                     a string of four characters, while <code>"AT&amp;T"</code> triggers a static error.</p></item>
+                  <item><p>In XPath, <code>"&amp;"</code> is treated as an ordinary character.
+                     So the string literal <code>"AT&amp;amp;T"</code> represents
+                     a string of eight characters (<code>"A"</code>, <code>"T"</code>,
+                     <code>"&amp;"</code>, <code>"a"</code>, <code>"m"</code>, <code>"p"</code>,
+                     <code>";"</code>, <code>"T"</code>), 
+                     while <code>"AT&amp;T"</code> is a string of four characters
+                     (<code>"A"</code>, <code>"T"</code>,
+                     <code>"&amp;"</code>, <code>"T"</code>).</p></item>
+               </ulist>
+               
+               <note>
+                  <p>The reason for the difference is that XPath is often embedded within XML-based languages
+                     such as XSLT, XSD, and XForms, where the XML parser will already have expanded entity and
+                     character references. In XSLT, for example, one might write
+                     <code><![CDATA[<xsl:if test="$company = 'AT&amp;T'">...]]></code>. The actual value of the
+                     <code>test</code> attribute here, as provided by the XML parser to the XSLT processor, is 
+                     <code><![CDATA[$company = 'AT&T']]></code>, so the
+                     XPath parser sees a bare unescaped ampersand.</p>
+                  <p>If it is necessary to write code that will be interpreted in the same way by XPath 4.0
+                     and XQuery 4.0 processors, string literals containing ampersands should be avoided. Instead,
+                     in most contexts where string literals can be used, an alternative is to write a
+                     <nt def="StringTemplate">StringTemplate</nt>, as described in <specref ref="id-string-templates"/>. 
+                     The four-character string <code>"AT&amp;T"</code> can be written either as
+                     <code>`AT&amp;T`</code>, or, if preferred, as <code>`AT{char("&amp;amp;")}T`</code>.</p>
+               </note>
+               
 
             <p>Here are some examples of string literals:</p>
                <ulist>


### PR DESCRIPTION
Allows for expressions interoperable between XPath and XQuery. Fix #653.