### PR TITLE
QT4CG-048-01: xsl:mode/@as with built-in templates

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12124,7 +12124,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <error spec="XT" type="type" class="TE" code="0505">
                   <p>It is a <termref def="dt-type-error">type error</termref> if the result of
                      evaluating the <termref def="dt-sequence-constructor">sequence
-                        constructor</termref> cannot be converted to the required type.</p>
+                        constructor</termref> cannot be coerced to the required type.</p>
                </error>
             </p>
 
@@ -13405,8 +13405,8 @@ and <code>version="1.0"</code> otherwise.</p>
 
             </div3>
             
-            <div3 id="mode-result-type" diff="add" at="2022-01-01">
-               <head>Declaring the result type of a mode</head>
+            <div3 id="mode-result-type" diff="chg" at="2023-10-16">
+               <head>Declaring the Result Type of a Mode</head>
                <p>Traditionally, template rules have most commonly been used to construct XDM nodes, and the <elcode>xsl:apply-templates</elcode>
                instruction has been used to add nodes to a result tree. However, it is also possible to use template rules to produce
                other kinds of value, for example strings, booleans, or maps. For the <elcode>xsl:apply-templates</elcode> 
@@ -13424,20 +13424,32 @@ and <code>version="1.0"</code> otherwise.</p>
                   <var>T</var>, then:</p>
                
                <ulist>
-                  <item><p>If <code>R</code> has an <code>as</code> attribute, the <code>SequenceType</code> <var>S</var> declared
+                  <item><p>If <var>R</var> has an <code>as</code> attribute, the <code>SequenceType</code> <var>S</var> declared
                      by <var>R</var> must be a subtype of <var>T</var>,
                   according to the relationship <code>subtype(S, T)</code> defined in <xspecref spec="XP40" ref="id-seqtype-subtype"/>.</p></item>
-                  <item><p>If <code>R</code> has no <code>as</code> attribute, then it is treated as if it had an <code>as</code>
-                     attribute set to <var>T</var>. If <code>R</code> is applicable
-                     to more than one mode, then the implicit <code>SequenceType</code> inferred for any one of these modes
-                     must be consistent with the <code>SequenceType</code> declared on all the other modes to which <code>R</code>
-                  is applicable: for example, if <var>is</var> applicable to modes <var>M1</var> and <var>M2</var>, and if
-                  <var>M1</var> declares a result type of <code>element(A)</code>, then a static error occurs if 
-                     <code>element(A)</code> is not a subtype of the (explicit or implicit) result type for mode <var>M2</var>.</p>
-                  <note><p>In practice this means that if a template rule is applicable to more than one mode (including
+                  <item><p>If <var>R</var> has no <code>as</code> attribute, then it is treated as if it had an <code>as</code>
+                     attribute set to <var>T</var>. This means that a <termref def="dt-type-error"/> 
+                     <errorref spec="XT" class="TE" code="0505"/> occurs
+                     if the result of the template rule cannot be coerced to a value of type <var>T</var>.</p> 
+                     <p>If <var>R</var> is applicable
+                     to more than one mode, then it must meet the requirements of each one, which implies that these requirements
+                     must be consistent with each other: for example, if one mode specifies <code>as="node()"</code> and another specifies
+                        <code>as="map(*)"</code>, then a type error is inevitable if the template rule is actually evaluated, and
+                        like other type errors this can be reported statically if detected statically. An
+                     <xtermref spec="XP40" ref="dt-implausible">implausibility</xtermref> <rfc2119>may</rfc2119> 
+                        be reported if the only value that would satisfy both types is an empty sequence, map, or array.</p>
+                  <note><p>In practice the best way to satisfy this rule is to ensure 
+                     that if a template rule is applicable to more than one mode (including
                   the case <code>mode="#all"</code>), then either (a) all those modes should have the same declared result type,
                   or (b) the template rule should declare an explicit result type that is compatible with each one of the relevant modes.</p></note>
-                  <p>TODO: define the error code.</p></item>
+                  </item>
+                  <item><p>The requirement to return values of the correct type extends also to the built-in
+                     template rule for the mode (see <specref ref="built-in-rule"/>). Since it is not possible to
+                     determine statically whether the explicit template rules for a mode provide complete coverage
+                     of all possible inputs, any failure of the built-in template rule to return a value 
+                     that can be coerced to the expected type <rfc2119>must</rfc2119> be reported 
+                     dynamically <errorref spec="XT" class="TE" code="0505"/>.</p>
+                  </item>
                </ulist>
             </div3>
             


### PR DESCRIPTION
Fix #750.