### PR TITLE
65: Allow xmlns="xxx" to NOT change the default namespace for NameTests

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -518,6 +518,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
         <g:string>=</g:string>
       </g:sequence>
       <g:sequence>
+        <g:optional>
+          <g:string>fixed</g:string>
+        </g:optional>
         <g:string>default</g:string>
         <g:string>element</g:string>
         <g:string>namespace</g:string>
@@ -556,6 +559,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   
   <g:production name="DefaultNamespaceDecl" if=" xquery40">
     <g:string>declare</g:string>
+    <g:optional>
+      <g:string>fixed</g:string>
+    </g:optional>
     <g:string>default</g:string>
     <g:choice name="DeclareDefaultElementOrFunction">
       <g:string process-value="yes">element</g:string>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1466,24 +1466,28 @@ specification since the publication of XPath 3.1 Recommendation.</p>
         improve interoperability, XQuery 4.0 recommends (but does not mandate)
         a specific strategy for interpreting these hints.</p></item>
 
+
       <item role="xquery"><p>The rules for the consistency of schemas imported by different query modules,
       and for consistency between imported schemas and those used for validating input documents, have
       been defined with greater precision. It is now recognized that these schemas will not always be
       identical, and that validation with respect to different schemas may produce different outcomes,
       even if the components of one are a subset of the components of the other.</p></item>
 
+      <item><p>Element and attribute tests of the form <code>element(N)</code>
+        and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
+        including a wildcard.</p></item>
+      <item role="xquery"><p>The <termref def="dt-default-namespace-elements-and-types"/> can now be declared to be fixed
+      for a query module, meaning it is unaffected by a namespace declaration appearing on a direct
+      element constructor.</p></item>
+
     </olist>
     
     <p>The following changes are present in this draft, but are awaiting review and agreement:</p>
   <olist>
-    <item><p>The static context now allows the default namespace for elements and
-    the default namespace for types to be different. XSLT 4.0 takes advantage of this,
-    XQuery 4.0 currently does not.</p></item>
+   
     <item><p>A new <code>with</code> expression allows namespace bindings to be defined
     within an expression (and to be redefined in nested expressions).</p></item>
-    <item><p>The static context now allows the unprefixed function names to be resolved
-    using an arbitrary algorithm, rather than requiring the resolution to use a
-    default namespace.</p></item>
+    
     <item><p>The rules for reporting type errors during static analysis have been changed
     so that a processor has more freedom to report errors in respect of constructs that
     are evidently wrong, such as <code>@price/@value</code>, even though dynamic evaluation
@@ -1495,9 +1499,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
     <item><p>Enumeration types are added as a new kind of <code>ItemType</code>, constraining
       the value space of strings.</p></item>
     
-    <item><p>Element and attribute tests of the form <code>element(N)</code>
-    and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
-    including a wildcard.</p></item>
+ 
     
     
     <item><p>The lookup operator <code>?</code> can now be followed by a string literal, for cases where

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6673,9 +6673,10 @@ and <nt def="OrExpr"
             <item>
                <p>If the <code role="xquery">URILiteral</code><code role="xpath">StringLiteral</code> is a zero-length string:</p>
                <ulist>
-                  <item><p>The is interpreted according to the
+                  <item><p>The 
                      <termref def="dt-default-namespace-elements-and-types"/> is set to <emph>absent</emph>, meaning
-                  that unprefixed element names are treated as being in no namespace.</p></item>
+                  that unprefixed element names are treated as being in no namespace.</p>
+                  <p>TODO: reconcile this with the "fixed" setting in the XQuery prolog.</p></item>
                   <item><p>Any binding for the zero-length prefix in the 
                      <termref def="dt-static-namespaces"/> is removed.</p></item>
                </ulist>
@@ -6683,9 +6684,10 @@ and <nt def="OrExpr"
             <item>
                <p>If the <code role="xquery">URILiteral</code><code role="xpath">StringLiteral</code> is not zero-length:</p>
                <ulist>
-                  <item><p>The is interpreted according to the
+                  <item><p>The 
                      <termref def="dt-default-namespace-elements-and-types"/> is set to the supplied namespace URI, meaning
-                     that unprefixed element names are treated as being in that namespace.</p></item>
+                     that unprefixed element names are treated as being in that namespace.</p>
+                     <p>TODO: reconcile this with the "fixed" setting in the XQuery prolog.</p></item>
                   <item><p>A binding that maps the zero-length prefix to the specified namespace URI is
                      added to the <termref def="dt-static-namespaces"/>.</p></item>
                </ulist>
@@ -10222,15 +10224,13 @@ return filter($days,$m)
           An unprefixed QName, when used as a
 		  name test on an axis whose <termref
                      def="dt-principal-node-kind"
-                     >principal node kind</termref> is interpreted as follows:</p>
+                     >principal node kind</termref> is <code>element</code>, is interpreted as follows:</p>
                <ulist>
                   <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is a namespace URI,
                   then the name is interpreted as having that namespace URI.</p></item>
                   <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is absent,
                      then the name is interpreted as being in no namespace.</p></item>
-                  <!--<item><p>If the <termref def="dt-default-namespace-elements-and-types"/> has the special value <code>"##any"</code>,
-                     then the name is treated as a wildcard matching names in any namespace: that is,
-                     the unprefixed name <code>N</code> is treated as <code>*:N</code>, described below.</p></item>-->
+                  
                </ulist>
                <p>A name test is not satisfied by an element node whose name does not match the <termref
                      def="dt-expanded-qname"
@@ -12695,12 +12695,11 @@ that creates a <code>book</code> element containing an attribute and some nested
     </author>
 </book>]]></eg>
             <p>If the element name in a direct element constructor has a namespace prefix, the namespace prefix
-               is resolved to a namespace URI using the <termref
-                  def="dt-static-namespaces"
-                  >statically known namespaces</termref>. 
-               If the element name  has no namespace prefix, it is interpreted according to
-               the <termref def="dt-default-namespace-elements-and-types"/>.</p>
-            <note><p>Both the statically known namespaces and the <termref def="dt-default-namespace-elements-and-types"/> 
+               is resolved to a namespace URI using the <termref def="dt-static-namespaces"/>. 
+               If the element name has no namespace prefix, <phrase diff="chg" at="2023-10-16">the 
+                  namespace binding for the zero-length prefix in the <termref def="dt-static-namespaces"/>
+               is used; if there is no such binding, the element name will be in no namespace</phrase>.</p>
+            <note><p>The statically known namespaces 
                may be affected by <termref def="dt-namespace-decl-attr"
                   >namespace declaration attributes</termref> 
                found inside the element constructor.</p></note>
@@ -12942,89 +12941,96 @@ attribute is processed as follows:</p>
                   <item at="XQ.E13">
                      <p>The value of the namespace declaration attribute (a <nt
                            def="DirAttributeValue"
-                           >DirAttributeValue</nt>) is processed as
-  follows. If the <nt
-                           def="DirAttributeValue">DirAttributeValue</nt>
-  contains an <nt
+                           >DirAttributeValue</nt>) is processed as follows. If the <nt
+                           def="DirAttributeValue">DirAttributeValue</nt> contains an <nt
                            def="EnclosedExpr"
-                           >EnclosedExpr</nt>, a static error
-  is raised <errorref class="ST"
+                           >EnclosedExpr</nt>, a static error is raised <errorref class="ST"
                            code="0022"
-                           />. Otherwise, it is
-  processed as described in rule 1 of <specref
+                           />. Otherwise, it is processed as described in rule 1 of <specref
                            ref="id-attributes"
-                           />. An implementation may raise a static error
-  <errorref class="ST"
-                           code="0046"
-                        /> if the resulting value is of
-  nonzero length and is neither an absolute URI nor a
-  relative URI. The resulting value is used as the namespace
-  URI in the following rules.
-  </p>
+                           />. An implementation may raise a static error<errorref class="ST"
+                            code="0046"/> if the resulting value is of
+                           nonzero length and is neither an absolute URI nor a
+                           relative URI. The resulting value is used as the namespace
+                           URI in the following rules.
+                           </p>
                   </item>
 
                   <item>
                      <p>If the prefix of the attribute name is <code>xmlns</code>, then the
-                local part of the attribute name is interpreted as a namespace prefix.
-                This prefix and the namespace URI are added to the
-                <termref
-                           def="dt-static-namespaces"
+                     local part of the attribute name is interpreted as a namespace prefix.
+                     This prefix and the namespace URI are added to the
+                     <termref def="dt-static-namespaces"
                            >statically known namespaces</termref>
-                of the constructor expression (overriding any existing binding of
-                the given prefix), and are also added as a namespace binding to the
-                <termref
-                           def="dt-in-scope-namespaces"
+                     of the constructor expression (overriding any existing binding of
+                     the given prefix), and are also added as a namespace binding to the
+                     <termref def="dt-in-scope-namespaces"
                            >in-scope namespaces</termref>
-                of the constructed element. If the namespace URI is a zero-length
-                string and the implementation supports <bibref
-                           ref="XMLNAMES11"
-                           />,
-                any existing namespace binding for the given prefix is removed from the
-                <termref
-                           def="dt-in-scope-namespaces"
-                           >in-scope namespaces</termref>
-                of the constructed element and from the
-                <termref
-                           def="dt-static-namespaces"
-                           >statically known namespaces</termref>
-                of the constructor expression. If the namespace URI is a zero-length
-                string and the implementation does not support <bibref
-                           ref="XMLNAMES11"/>,
-                a static error is raised <errorref
-                           code="0085" class="ST"/>. It is
-                <termref
-                           def="dt-implementation-defined"
-                           >implementation-defined</termref>
-                whether an implementation supports <bibref
-                           ref="XMLNAMES"/> or
-                <bibref ref="XMLNAMES11"
-                        />.
-             </p>
+                        of the constructed element. If the namespace URI is a zero-length
+                        string and the implementation supports <bibref
+                                   ref="XMLNAMES11"
+                                   />,
+                        any existing namespace binding for the given prefix is removed from the
+                        <termref
+                                   def="dt-in-scope-namespaces"
+                                   >in-scope namespaces</termref>
+                        of the constructed element and from the
+                        <termref
+                                   def="dt-static-namespaces"
+                                   >statically known namespaces</termref>
+                        of the constructor expression. If the namespace URI is a zero-length
+                        string and the implementation does not support <bibref
+                                   ref="XMLNAMES11"/>,
+                        a static error is raised <errorref
+                                   code="0085" class="ST"/>. It is
+                        <termref
+                                   def="dt-implementation-defined"
+                                   >implementation-defined</termref>
+                        whether an implementation supports <bibref
+                                   ref="XMLNAMES"/> or
+                        <bibref ref="XMLNAMES11"
+                                />.
+                     </p>
                   </item>
 
                   <item>
                      <p>If the name of the namespace declaration attribute is <code>xmlns</code>
-                with no prefix, then the namespace URI specifies the 
-                        <termref def="dt-default-namespace-elements-and-types"/> 
-                        of the constructor expression (overriding any existing default), 
-                        and is added (with no prefix) to the <termref
-                           def="dt-in-scope-namespaces">in-scope namespaces</termref> of the constructed element 
-                (overriding any existing binding of the zero-length prefix).</p>
-                     <p>If the namespace URI is a zero-length string then 
-                        the <termref def="dt-default-namespace-elements-and-types"/> of the constructor expression
-                        is set to <xtermref ref="dt-absent" spec="DM40"/>,
-                        and any no-prefix
-                namespace binding is removed from the
-                <termref
-                           def="dt-in-scope-namespaces"
-                        >in-scope namespaces</termref>
-                of the constructed element.
-             </p>
-                     
-         
+                        with no prefix, then:</p>
+                     <ulist>
+                        <item><p>If the namespace URI is a zero-length string, then:</p>
+                           <ulist>
+                              <item><p>Any no-prefix namespace binding is removed from the
+                                 <termref def="dt-in-scope-namespaces"
+                                    >in-scope namespaces</termref> of the constructed element
+                                 and from the <termref def="dt-static-namespaces"
+                                    >statically known namespaces</termref>
+                                 of the constructor expression.</p></item>
+                              <item><p>Unless
+                                 the query prolog contains a default namespace declaration or import schema declaration
+                                 defining the <termref def="dt-default-namespace-elements-and-types"/> as being
+                                 <code>fixed</code>, the <termref def="dt-default-namespace-elements-and-types"/> 
+                                 in the static context of the element constructor is set to <xtermref ref="dt-absent" spec="DM40"/>.</p></item>
+                           </ulist>
+                        </item>
+                        <item><p>Otherwise (when the namespace URI is not a zero-length string):
+                           <ulist>
+                              <item><p>The namespace URI is added (with no prefix) to the <termref
+                                 def="dt-in-scope-namespaces">in-scope namespaces</termref> of the constructed element 
+                                 (overriding any existing binding of the zero-length prefix), 
+                                 and to the <termref def="dt-static-namespaces"
+                                    >statically known namespaces</termref>
+                                 of the constructor expression.</p></item>
+                              <item><p>Unless
+                                 the query prolog contains a default namespace declaration or import schema declaration
+                                 defining the <termref def="dt-default-namespace-elements-and-types"/> as being
+                                 <code>fixed</code>, the <termref def="dt-default-namespace-elements-and-types"/> 
+                                 in the static context of the constructor expression is set to the specified namespace URI.</p></item>
+                           </ulist>
+                        </p></item>
+                     </ulist>
                     
                   </item>
-
+ 
                   <item>
                      <p>It is a <termref def="dt-static-error">static error</termref>
                         <errorref class="ST" code="0070"/> if a namespace declaration
@@ -13061,12 +13067,35 @@ attribute is processed as follows:</p>
 
                   <item>
                      <p>In this element constructor, a namespace declaration attribute
-                        is used to set the <termref def="dt-default-namespace-elements-and-types"/> 
+                        is used to set the default namespace
                         to <code>http://example.org/animals</code>:<eg
                            role="parse-test"><![CDATA[<cat xmlns="http://example.org/animals">
-  <breed>Persian</breed>
+  <breed>{variety/@name}</breed>
 </cat>]]></eg>
                      </p>
+                     <p diff="add" at="2023-10-16">More specifically:</p>
+                     <ulist>
+                        <item><p>The expanded name of the constructed element will be 
+                           <code>Q{http://example.org/animals}cat</code>.</p></item>
+                        <item><p>The constructed element will have a namespace binding
+                           that associates the empty prefix with the namespace URI 
+                           <code>http://example.org/animals</code>.</p></item>
+                        <item><p>The static context for evaluation of any expressions within the
+                        element constructor will include a binding of the empty prefix
+                        to the namespace URI <code>http://example.org/animals</code>. This ensures
+                        that the nested <code>breed</code> element will also be in the namespace
+                           <code>http://example.org/animals</code>.</p></item>
+                        <item><p>The <termref def="dt-default-namespace-elements-and-types"/>
+                           within the element constructor will be <code>http://example.org/animals</code>,
+                        which means that the element name <code>variety</code> is also interpreted
+                        as being in this namespace. This effect may be unwanted, since the document
+                        containing the context node may well use a different default namespace. 
+                        In XQuery 4.0 this effect can
+                        be prevented by declaring, in the query prolog, that the 
+                           <termref def="dt-default-namespace-elements-and-types"/> is <code>fixed</code>.
+                        Alternatively the path expression can be written <code>Q{}variety/@name</code>
+                        to make it explicit that <code>variety</code> refers to a no-namespace element.</p></item>
+                     </ulist>
                   </item>
 
                   <item>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -514,6 +514,11 @@ return (
     <p diff="add" at="A">If the schema import declaration specifies <code>default element namespace</code>
       then the prolog must not contain a <termref def="dt-namespace-declaration">namespace declaration</termref>
       that specifies <code>default element namespace</code> or <code>default type namespace</code>.</p>
+    
+    <p diff="add" at="2023-10-16">If the keyword <code>"fixed"</code>, is present, the 
+      <termref def="dt-default-namespace-elements-and-types"/> is fixed throughout the module,
+      and is not affected by default namespace declarations (<code>xmlns=""</code>) appearing
+      on direct element constructors.</p>
 
 
     <p> The first <nt def="URILiteral">URILiteral</nt> in a schema import specifies the target
@@ -534,7 +539,7 @@ return (
       import a schema that has no target namespace. Such a schema import must not bind a namespace
       prefix <errorref class="ST" code="0057"/>, but it may set the default element and/or type namespace
       to a zero-length string (representing “no namespace”), thus enabling the definitions in the
-      imported namespace to be referenced. If the default element and/or type namespace is not set to "no
+      imported namespace to be referenced. If the <termref def="dt-default-namespace-elements-and-types"/> is not set to "no
       namespace", <phrase diff="chg" at="A">the only way to reference the definitions in an imported schema that has no
         target namespace is using the EQName syntax <code>Q{}local-name</code></phrase>.</p>
     
@@ -1005,56 +1010,20 @@ return $i/xx:bing]]>
             </item>-->
           </ulist>
           <p>The following example illustrates the declaration of a
-          default namespace for elements<phrase diff="del" at="A"> and types</phrase>:</p>
+          default namespace for elements and types:</p>
         <eg role="frag-prolog-parse-test">declare default element namespace "http://example.org/names";</eg>
         
         <p>If no default element namespace declaration is present, unprefixed element and type
           names are in no namespace (however, an implementation may define a different default as
           specified in <specref ref="id-xq-static-context-components"/>.)</p>
-        <!--<p>A default element namespace declaration also establishes a binding for the zero-length prefix
-        in the <termref def="dt-static-namespaces"/>.</p>-->
-        
- 
+        <p diff="add" at="2023-10-16">If the keyword <code>"fixed"</code>, is present, the 
+          <termref def="dt-default-namespace-elements-and-types"/> is fixed throughout the module,
+          and is not affected by default namespace declarations (<code>xmlns=""</code>) appearing
+          on direct element constructors.</p>
         
       </item>
-      <!--<item diff="add" at="A">
-        <p>A <term>default type namespace declaration</term> declares a namespace URI that
-          is associated with unprefixed names of types. 
-          This declaration is recorded as
-          the <termref def="dt-def-type-ns">default type namespace</termref> in the
-          <termref def="dt-static-context">static context</termref>. A <termref def="dt-prolog"
-            >Prolog</termref> may contain at most one default type namespace declaration
-          <phrase diff="add" at="A">and it must not contain
-            both a default type namespace declaration and an <code>import schema</code> declaration
-            that specifies a default element namespace</phrase> <errorref class="ST" code="0066"/> . 
-          If the <nt def="URILiteral">URILiteral</nt> in a
-          default type namespace declaration is a zero-length string, the <termref
-            def="dt-def-type-ns">default type namespace</termref> is undeclared (set to
-          <xtermref spec="DM40" ref="dt-absent"/>), and unprefixed names of types are
-          considered to be in no namespace. The following example illustrates the declaration of a
-          default namespace for types:</p>
-        <eg role="frag-prolog-parse-test">declare default type namespace "http://www.w3.org/2001/XMLSchema";</eg>
-        <p>This declaration allows names of built-in types to be used without a prefix, for example a function
-          parameter can be declared as <code>$arg as integer</code> rather than <code>$arg as xs:integer</code>.
-        Note however that it does not apply to the names of constructor functions, which use the default namespace
-        for functions.</p>
-        <p>A default type namespace declaration applies throughout the query module and cannot be overridden.</p>
-        <p>For backwards compatibility reasons, if the prolog contains no explicit default type namespace declaration, then:</p>
-        <olist>
-          <item><p>A <code>default element namespace declaration</code> in the prolog also sets the default namespace for types;
-          and</p></item>
-          <item><p>A <termref
-            def="dt-namespace-decl-attr">namespace declaration attribute</termref> <code>xmlns="uuuu"</code> in a <termref
-              def="dt-direct-elem-const">direct element constructor</termref> overrides both the default element namespace
-          and the default type namespace declared in the query prolog.</p></item>
-        </olist>
-        <p>If no default <phrase diff="chg" at="A">element</phrase> namespace declaration is present, unprefixed element <phrase diff="del" at="A">and type</phrase>
-          names are in no namespace (however, an implementation may define a different default as
-          specified in <specref ref="id-xq-static-context-components"/>.)</p>
-        <p diff="add" at="A">For backwards compatibility reasons, if the prolog contains a default element namespace
-          declaration and no default type namespace declaration, then the default namespace for types is set to be the
-          same as the default namespace for elements.</p>
-      </item>-->
+
+
       <item>
         <p>A <term>default function namespace declaration</term> declares a namespace URI that is
           associated with unprefixed function names in static function calls and function
@@ -1084,6 +1053,9 @@ return $i/xx:bing]]>
           <p>Only <termref def="dt-constructor-function">constructor functions</termref> can be in
             no namespace.</p>
         </note>
+        <p diff="add" at="2023-10-16">The keyword <code>"fixed"</code> has no effect when declaring
+          a default function namespace, since there is no mechanism to change the default function
+          namespace within a query module.</p>
       </item>
     </ulist>
     <p> Unprefixed attribute names and variable names are in no namespace.</p>


### PR DESCRIPTION
Fix issue #65. Basically, fix the bug whereby `xmlns="xxx"` changes the default namespace for element NameTests, while retaining bug-compatibility.