### PR TITLE
554/754 Simplify the new transitive-closure function

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18747,10 +18747,9 @@ return sort($in, $SWEDISH)</eg>
    
    <fos:function name="transitive-closure" prefix="fn">
       <fos:signatures>
-         <fos:proto name="transitive-closure" return-type="function(node()) as node()*"> 
+         <fos:proto name="transitive-closure" return-type="node()*">
+            <fos:arg name="start" type="node()?"/>
             <fos:arg name="step" type="function(node()) as node()*"/>
-            <fos:arg name="min" type="xs:nonNegativeInteger?" default="1"/>
-            <fos:arg name="max" type="xs:positiveInteger?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -18760,36 +18759,61 @@ return sort($in, $SWEDISH)</eg>
          
       </fos:properties>
       <fos:summary>
-         <p>Given a function <var>F</var> that navigates from one node to other nodes, 
-            returns a function that applies <var>F</var> repeatedly.</p>
+         <p>Returns all the nodes reachable from a given start node by applying a supplied function repeatedly.</p>
       </fos:summary>
       <fos:rules>
          
-         <p>The argument is a function <code>$step</code> that takes a single node as input, and returns a set of nodes as its result. 
-            The result of the <code>fn:transitive-closure</code> function is a function <var>TC</var> that takes a 
-            single node <var>N</var> as input, and returns all nodes that can be reached from
-            <var>N</var> by applying <code>$step</code> repeatedly between <code>$min</code> and <code>$max</code> times (inclusive).</p>
+         <p>The value of <code>$start</code> is a node from which navigation starts. If <code>$start</code> is an
+         empty sequence, the function returns an empty sequence.
+         </p>
+         <p>The value of <code>$step</code> is a function that takes a single node as input, and returns a set of nodes as its result.</p> 
+         <p>The result of the <code>fn:transitive-closure</code> function is the set of nodes that are reachable from
+            <code>$start</code> by applying the <code>$step</code> function one or more times.</p>
          
          <p>Although <code>$step</code> may return any sequence of nodes, the result is treated as a set: the order of nodes
-            in the sequence is ignored, and duplicates are ignored. The result of calling <var>TC</var> will always be
-         a sequence of nodes in document order with no duplicates.</p>
+            in the sequence is ignored, and duplicates are ignored. The result of of the
+            <code>transitive-closure</code> function will always be a sequence of nodes in document order with no duplicates.</p>
          
-         <p>The default value of <code>$min</code>, if the argument is not supplied or is set to an empty sequence,
-            is 1 (one). If <code>$min</code> is zero, the result of calling <var>TC</var> will include the argument node
-            <var>N</var>. If <code>$min</code> is greater than zero, the result will include <var>N</var> only if 
-            <var>N</var> is reachable by a cyclic path involving between <code>$min</code> and <code>$max</code> steps.</p>
+         <p>The result of the function is equivalent to the following XQuery implementation:</p>
          
-         <p>The default value of <code>$max</code>, if the argument is not supplied or is set to an empty sequence,
-            is unbounded. In this situation the function <var>TC</var> continues execution until no further nodes
-            are added to the result set. Note that if the <code>$step</code> function constructs new nodes, this
-            can lead to non-termination. Specifying an explicit value for <code>$max</code> guarantees termination.</p>
+         <eg><![CDATA[declare %private function tc-inclusive(
+       $start  as node()*,
+       $step as (function(node()) as node()*)	
+     ) as node()* {
+     let $nextStep := $start/$step(.)
+     let $newNodes := $nextStep except $start
+     return (if (exists($newNodes))
+             then $start | tc-inclusive($newNodes, $step)
+             else $start)
+};
+declare function fn:transitive-closure (
+       $start  as node(),
+       $step as (function(node()) as node()*)	
+    ) as node()* {
+    tc-inclusive($start/$step(.)), $step)
+};]]></eg>
          
+      <note><p><emph>Explanation:</emph> The private helper function <code>tc-inclusive</code> takes a set of nodes as input,
+      and calls the <code>$step</code> function on each one of those nodes; if the result includes nodes that are not
+      already present in the input, then it makes a recursive call to find nodes reachable from these new nodes, and returns
+      the union of the supplied nodes and the nodes returned from the recursive
+      call (which will always include the new nodes selected in the first step). 
+      If there are no new nodes, the recursion ends, returning the nodes that have been found up to this point.</p>
+         <p>The main function <code>tc-inclusive</code> finds the nodes that are reachable from the start node in a single
+            step, and then invokes the helper function <code>tc-inclusive</code> to add nodes that are reachable
+         in multiple steps</p></note>
  
     
       </fos:rules>
       <fos:notes>
-         <p>Cycles in the data are not a problem, even if <code>$max</code> is unbounded; 
+         <p>Cycles in the data are not a problem; 
             the function stops searching when it finds no new nodes.</p>
+         <p>The function may fail to terminate if the supplied <code>$step</code> function constructs and returns
+         new nodes. A processor <rfc2119>may</rfc2119> detect this condition but is not required to do so.</p>
+         <p>The <code>$start</code> node is not included in the result, unless it is reachable by applying
+         the <code>$step</code> function one or more times. If a result is required that does include the <code>$start</code>
+         node, it can be readily added to the result using the union operator:
+            <code>$start | transitive-closure($start, $step)</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="data" id="transitive-closure-data"><![CDATA[document{<doc>
@@ -18810,26 +18834,14 @@ return sort($in, $SWEDISH)</eg>
          </fos:variable>          
          <fos:example>
             <fos:test use="transitive-closure-data">
-               <fos:expression><eg>let $tc := transitive-closure($direct-reports)
-return $tc($data//person[@id="2"])/string(@id)</eg></fos:expression>
+               <fos:expression><eg>transitive-closure(
+   $data//person[@id="2"]),
+   $direct-reports)/string(@id)</eg></fos:expression>
                <fos:result>("3", "4", "6", "7", "8")</fos:result>
-            </fos:test>
+            </fos:test>            
             <fos:test use="transitive-closure-data">
-               <fos:expression><eg>let $tc := transitive-closure($direct-reports, min:=0)
-return $tc($data//person[@id="2"])/string(@id)</eg></fos:expression>
-               <fos:result>("2", "3", "4", "6", "7", "8")</fos:result>
-            </fos:test>   
-            <fos:test use="transitive-closure-data">
-               <fos:expression><eg>let $tc := transitive-closure($direct-reports, max:=2)
-return $tc($data//person[@id="2"])/string(@id)</eg></fos:expression>
-               <fos:result>("3", "4", "6")</fos:result>
-            </fos:test>               
-            <fos:test use="transitive-closure-data">
-               <fos:expression><eg>let $tc := transitive-closure(function { child::* })
-return $tc($data)/@id/string()</eg></fos:expression>
+               <fos:expression><eg>transitive-closure($data, function { child::* })/@id/string()</eg></fos:expression>
                <fos:result>("0", "1", "2", "3", "4", "5", "6", "7","8")</fos:result>
-               <fos:postamble>The transitive closure of the child axis is the ancestor axis
-               if <code>min=1</code>, or the ancestor-or-self axis if <code>min=0</code>.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -18838,12 +18850,6 @@ return $tc($data)/@id/string()</eg></fos:expression>
             <eg>let $tc := transitive-closure(function { document(//(xsl:import|xsl:include)/@href) }) 
 return $tc($root) =!> document-uri()</eg>
             <p>This example uses the XSLT-defined <code>document()</code> function.</p>
-         </fos:example>
-         <fos:example>
-            <p>The following example, given <code>$doc</code> as the root of a document consisting of nested sections with paths
-               such as <code>article/section/section/section</code>, returns the headings of all level-2 and level-3 sections:</p>
-            <eg>let $tc := transitive-closure(function { child::section }, min:=2, max:=3) 
-return $tc($doc/article)/head</eg>
          </fos:example>
       </fos:examples>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18748,7 +18748,7 @@ return sort($in, $SWEDISH)</eg>
    <fos:function name="transitive-closure" prefix="fn">
       <fos:signatures>
          <fos:proto name="transitive-closure" return-type="node()*">
-            <fos:arg name="start" type="node()?"/>
+            <fos:arg name="node" type="node()?"/>
             <fos:arg name="step" type="function(node()) as node()*"/>
          </fos:proto>
       </fos:signatures>
@@ -18763,12 +18763,12 @@ return sort($in, $SWEDISH)</eg>
       </fos:summary>
       <fos:rules>
          
-         <p>The value of <code>$start</code> is a node from which navigation starts. If <code>$start</code> is an
+         <p>The value of <code>$node</code> is a node from which navigation starts. If <code>$node</code> is an
          empty sequence, the function returns an empty sequence.
          </p>
          <p>The value of <code>$step</code> is a function that takes a single node as input, and returns a set of nodes as its result.</p> 
          <p>The result of the <code>fn:transitive-closure</code> function is the set of nodes that are reachable from
-            <code>$start</code> by applying the <code>$step</code> function one or more times.</p>
+            <code>$node</code> by applying the <code>$step</code> function one or more times.</p>
          
          <p>Although <code>$step</code> may return any sequence of nodes, the result is treated as a set: the order of nodes
             in the sequence is ignored, and duplicates are ignored. The result of of the
@@ -18777,20 +18777,20 @@ return sort($in, $SWEDISH)</eg>
          <p>The result of the function is equivalent to the following XQuery implementation:</p>
          
          <eg><![CDATA[declare %private function tc-inclusive(
-       $start  as node()*,
-       $step as (function(node()) as node()*)	
-     ) as node()* {
-     let $nextStep := $start/$step(.)
-     let $newNodes := $nextStep except $start
-     return (if (exists($newNodes))
-             then $start | tc-inclusive($newNodes, $step)
-             else $start)
+  $nodes as node()*,
+  $step as (function(node()) as node()*)	
+) as node()* {
+  let $nextStep := $nodes/$step(.)
+  let $newNodes := $nextStep except $nodes
+  return if (exists($newNodes))
+         then $nodes | tc-inclusive($newNodes, $step)
+         else $nodes
 };
 declare function fn:transitive-closure (
-       $start  as node(),
-       $step as (function(node()) as node()*)	
-    ) as node()* {
-    tc-inclusive($start/$step(.)), $step)
+  $node  as node(),
+  $step as (function(node()) as node()*)	
+) as node()* {
+  tc-inclusive($node/$step(.)), $step)
 };]]></eg>
          
       <note><p><emph>Explanation:</emph> The private helper function <code>tc-inclusive</code> takes a set of nodes as input,
@@ -18799,7 +18799,7 @@ declare function fn:transitive-closure (
       the union of the supplied nodes and the nodes returned from the recursive
       call (which will always include the new nodes selected in the first step). 
       If there are no new nodes, the recursion ends, returning the nodes that have been found up to this point.</p>
-         <p>The main function <code>tc-inclusive</code> finds the nodes that are reachable from the start node in a single
+         <p>The main function <code>fn:transitive-closure</code> finds the nodes that are reachable from the start node in a single
             step, and then invokes the helper function <code>tc-inclusive</code> to add nodes that are reachable
          in multiple steps</p></note>
  
@@ -18810,10 +18810,10 @@ declare function fn:transitive-closure (
             the function stops searching when it finds no new nodes.</p>
          <p>The function may fail to terminate if the supplied <code>$step</code> function constructs and returns
          new nodes. A processor <rfc2119>may</rfc2119> detect this condition but is not required to do so.</p>
-         <p>The <code>$start</code> node is not included in the result, unless it is reachable by applying
-         the <code>$step</code> function one or more times. If a result is required that does include the <code>$start</code>
-         node, it can be readily added to the result using the union operator:
-            <code>$start | transitive-closure($start, $step)</code>.</p>
+         <p>The <code>$node</code> node is not included in the result, unless it is reachable by applying
+         the <code>$step</code> function one or more times. If a result is required that does include <code>$node</code>,
+         it can be readily added to the result using the union operator:
+            <code>$node | transitive-closure($node, $step)</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="data" id="transitive-closure-data"><![CDATA[document{<doc>
@@ -18833,22 +18833,26 @@ declare function fn:transitive-closure (
 }]]>
          </fos:variable>          
          <fos:example>
-            <fos:test use="transitive-closure-data">
+            <fos:test use="transitive-closure-data transitive-closure-reports">
                <fos:expression><eg>transitive-closure(
-   $data//person[@id="2"]),
-   $direct-reports)/string(@id)</eg></fos:expression>
+  $data//person[@id="2"],
+  $direct-reports
+)/string(@id)</eg></fos:expression>
                <fos:result>("3", "4", "6", "7", "8")</fos:result>
             </fos:test>            
             <fos:test use="transitive-closure-data">
-               <fos:expression><eg>transitive-closure($data, function { child::* })/@id/string()</eg></fos:expression>
+               <fos:expression><eg>transitive-closure(
+  $data, 
+  function { child::* })/@id
+)/string()</eg></fos:expression>
                <fos:result>("0", "1", "2", "3", "4", "5", "6", "7","8")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>The following example, given <code>$root</code> as the root of an XSLT stylesheet module, returns the URIs
             of all stylesheet modules reachable using <code>xsl:import</code> and <code>xsl:include</code> declarations:</p>
-            <eg>let $tc := transitive-closure(function { document(//(xsl:import|xsl:include)/@href) }) 
-return $tc($root) =!> document-uri()</eg>
+            <eg>transitive-closure($root, fn { document(//(xsl:import|xsl:include)/@href) }) 
+      =!> document-uri()</eg>
             <p>This example uses the XSLT-defined <code>document()</code> function.</p>
          </fos:example>
       </fos:examples>


### PR DESCRIPTION
Drops the `$min` and `$max` parameters, with the effect that this corresponds much more closely to the general computer-science definition of a transitive closure.

The function now computes the set of nodes delivered by the transitive closure of the supplied `$step` function when applied to a given `$start` node, rather than returning a function item that must then be applied to the chosen $start node. This is hopefully easier for most users to understand, and does not lose any useful functionality.

The `$min` parameter of the old function is effectively forced to its default value of 1, and the $max value to its default of infinity.

Fix #754
Fix #554

This PR addresses the main points of #554 in making the function correspond more closely to the mathematical (or at least the computer-science) definition of transitive closure. It doesn't implement other ideas in #554, like returning the depth of search alongside the actual closure. That's because I believe in the principle that wherever possible a function should do one thing in as simple a way as possible.