### PR TITLE
765 Update version references etc to 4.0 status

### DIFF
--- a/schema/xsl-query.dtd
+++ b/schema/xsl-query.dtd
@@ -3,13 +3,13 @@
                             | DM11 | FO11 | FS11 | XP21 | XQ11 | XQX11 | SER11
                             | DM30 | FO30 | XP30 | XQ30 | XQX30 | SER30 | XT30
                             | DM31 | FO31 | XP31 | XQ31 | XQX31 | SER31
-                            | DM40 | FO40 | XP40 | XQ40 | XQX40 | SER40 | XT40
+                            | DM40 | FO40 | XP40 | XQ40 | XQX40 | SE40 | XT40
                             | FT | XU | SX
                             | FT30 | XU30 | SX30 
                             | XS1-1 | XS1-2 | XS11-1 | XS11-2">
 
 <!--
-   Note, XS1-1 and XS1-2 are aliases for XS1 and XS2 repsectively (XML
+   Note, XS1-1 and XS1-2 are aliases for XS1 and XS2 respectively (XML
    Schema 1.0).  New references should use XS1-1 and XS1-2.
 -->
 

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1092,7 +1092,8 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
 
 </olist>
 
-<note><p>Additional <termref def="dt-implementation-defined">implementation-defined</termref> items are listed in <bibref ref="xpath-datamodel-31"/> and <bibref ref="xpath-functions-40"/>.</p></note></div1>
+<note><p>Additional <termref def="dt-implementation-defined">implementation-defined</termref> 
+  items are listed in <bibref ref="xpath-datamodel-40"/> and <bibref ref="xpath-functions-40"/>.</p></note></div1>
 <div1 id="id-references">
 <head>References</head>
 <div2 id="id-normative-references">
@@ -1172,13 +1173,16 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
       See <loc href="http://www.w3.org/TR/xmlschema11-1/" id="schema1-11">http://www.w3.org/TR/xmlschema11-1/</loc>,
       and <loc href="http://www.w3.org/TR/xmlschema11-2/" id="schema2-11">http://www.w3.org/TR/xmlschema11-2/</loc>.</bibl>
 
-<bibl id="xpath-datamodel-31" key="XQuery and XPath Data Model (XDM) 3.1"/>
+<bibl id="xpath-datamodel-40" key="XQuery and XPath Data Model (XDM) 4.0"/>
 
 <bibl id="xpath-functions-40" key="XQuery and XPath Functions and Operators 4.0"/>
+  
+  <bibl id="xpath-40" key="XPath 4.0"/>
+  
 
-<bibl id="xslt-xquery-serialization-31" key="XSLT and XQuery Serialization 3.1"/>
+<bibl id="xslt-xquery-serialization-40" key="XSLT and XQuery Serialization 4.0"/>
 
-<bibl id="xquery-update-30" key="XQuery Update Facility 3.0" role="xquery"/>
+<!--<bibl id="xquery-update-30" key="XQuery Update Facility 3.0" role="xquery"/>-->
 
 
 </blist>
@@ -1196,9 +1200,9 @@ of the declared type).</p></item><item role="xquery"><p>Limits on ranges of valu
 
 <bibl id="xquery-semantics" key="XQuery 1.0 and XPath 2.0 Formal Semantics"/>
 
-<bibl id="xqueryx-31" key="XQueryX 3.1" role="xquery"/>
+<!--<bibl id="xqueryx-31" key="XQueryX 3.1" role="xquery"/>-->
 
-<bibl id="xslt-30" key="XSL Transformations (XSLT) Version 3.0"/>
+<bibl id="xslt-40" key="XSL Transformations (XSLT) Version 4.0"/>
 
 <bibl id="DOM" key="Document Object Model" role="xquery">World Wide Web Consortium. <emph>Document Object Model (DOM) Level 3 Core Specification.</emph> W3C Recommendation, April 7, 2004. See <loc href="http://www.w3.org/TR/DOM-Level-3-Core/">http://www.w3.org/TR/DOM-Level-3-Core/</loc>.</bibl>
 

--- a/specifications/xquery-40/src/conformance.xml
+++ b/specifications/xquery-40/src/conformance.xml
@@ -21,7 +21,7 @@
 
       <p role="xpath">XPath is intended primarily as a component that can be used by
       other specifications. Therefore, XPath relies on specifications that
-      use it (such as <bibref ref="XPTR"/> and <bibref ref="xslt-30"/>) to
+      use it (such as <bibref ref="XPTR"/> and <bibref ref="xslt-40"/>) to
       specify conformance criteria for XPath in their respective
       environments. Specifications that set conformance criteria for their
       use of XPath <termref def="mustnot">MUST NOT</termref> change the
@@ -41,7 +41,7 @@
       conformance to one or more optional features defined in <specref
       ref="id-conform-optional-features"/>.</p>
 
-      <div2 id="id-xpath-static-typing" role="xpath">
+      <div2 id="id-xpath-static-typing" role="xpath" diff="del" at="2023-10-19">
         <head>Static Typing Feature</head>
 
         <p>
@@ -83,7 +83,7 @@
                 </note>
             </item>
             <item>
-                <p>An implementation of <bibref ref="xpath-datamodel-31"/>, as specified in <specref
+                <p>An implementation of <bibref ref="xpath-datamodel-40"/>, as specified in <specref
                         ref="id-data-model-conformance"/>, and a definition of every item specified
                     to be <termref def="dt-implementation-defined">implementation-defined</termref>,
                     unless that item is part of an optional feature that is not provided by the
@@ -156,7 +156,7 @@
             </olist>
         </div3>
 
-        <div3 id="id-static-typing-feature">
+        <div3 id="id-static-typing-feature" diff="del" at="2023-10-19">
             <head>Static Typing Feature</head>
             <p>
                 <termdef id="dt-static-typing-feature" term="static
@@ -213,7 +213,7 @@
             <p>The means by which serialization is invoked is <termref
                     def="dt-implementation-defined">implementation-defined</termref>.</p>
             <p>If an error is raised during the serialization process as specified in <bibref
-                    ref="xslt-xquery-serialization-31"/>, an implementation <termref def="must"
+                    ref="xslt-xquery-serialization-40"/>, an implementation <termref def="must"
                     >MUST</termref> report the error to the calling environment.</p>
 
             <p>An implementation that does not provide the Serialization Feature <termref def="must"
@@ -221,7 +221,7 @@
                     def="dt-output-declaration">output declaration</termref>, and <termref
                     def="must">MUST</termref> implement <code>fn:serialize</code>; it <termref
                     def="may">MAY</termref>, however, raise an error when <code>fn:serialize</code>
-                is invoked, as specified in <xspecref spec="FO31" ref="func-serialize"/>. An
+                is invoked, as specified in <xspecref spec="FO40" ref="func-serialize"/>. An
                 implementation that does not provide the Serialization Feature <termref def="may"
                     >MAY</termref> provide results of a query using a vendor-defined
                 serialization.</p>
@@ -255,7 +255,7 @@
                 a function.</p>
 
             <p>If an implementation provides the Higher-Order Function Feature, then it <termref def="must">MUST</termref> provide
-                    all <xtermref spec="FO31" ref="dt-higher-order"/> functions defined in <bibref ref="xpath-functions-40"/>.
+                    all <xtermref spec="FO40" ref="dt-higher-order"/> functions defined in <bibref ref="xpath-functions-40"/>.
                 If an implementation does not provide the Higher
                 Order Function Feature, a <termref def="dt-static-error">static error</termref> is
                 raised <errorref class="ST" code="0017"/> if any of these functions is present in a
@@ -269,7 +269,7 @@
     <div2 id="id-data-model-conformance" role="xquery">
         <head>Data Model Conformance</head>
         <p>All XQuery implementations process data represented in the <termref def="dt-datamodel"
-                >data model</termref> as specified in <bibref ref="xpath-datamodel-31"/>. The data
+                >data model</termref> as specified in <bibref ref="xpath-datamodel-40"/>. The data
             model specification relies on languages such as XQuery to specify conformance criteria
             for the data model in their respective environments, and suggests that the following
             issues should be considered:</p>
@@ -278,7 +278,7 @@
                 <p>
                     <emph>Support for normative construction from an infoset.</emph> An
                     implementation <termref def="may">MAY</termref> choose to claim conformance to
-                        <xspecref spec="DM31" ref="const-infoset"/>, which defines a normative way
+                        <xspecref spec="DM40" ref="const-infoset"/>, which defines a normative way
                     to construct an <termref def="dt-data-model-instance">XDM instance</termref>
                     from an XML document that is merely well-formed or is governed by a DTD.</p>
             </item>
@@ -286,14 +286,14 @@
                 <p>
                     <emph>Support for normative construction from a PSVI.</emph> An implementation
                         <termref def="may">MAY</termref> choose to claim conformance to <xspecref
-                        spec="DM31" ref="const-psvi"/>, which defines a normative way to construct
+                        spec="DM40" ref="const-psvi"/>, which defines a normative way to construct
                     an <termref def="dt-data-model-instance">XDM instance</termref> from an XML
                     document that is governed by a W3C XML Schema.</p>
             </item>
             <item>
                 <p>
                     <emph>Support for versions of XML and XSD.</emph> As stated in <bibref
-                        ref="xpath-datamodel-31"/>, the
+                        ref="xpath-datamodel-40"/>, the
                     definitions of primitives such as strings, characters, and names <termref def="should">SHOULD</termref> be taken
                     from the latest applicable version of the base specifications in which they are
                     defined; it is implementation-defined which definitions are used in cases where

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -7,7 +7,7 @@
          <p> It is a <termref def="dt-static-error">static error</termref> if analysis of an
             expression relies on some component of the <termref def="dt-static-context">static
                context</termref> that <phrase diff="del">has not been assigned a
-               value</phrase><phrase diff="add">is <xtermref spec="DM31" ref="dt-absent"
+               value</phrase><phrase diff="add">is <xtermref spec="DM40" ref="dt-absent"
             /></phrase>.</p>
       </error>
 
@@ -15,7 +15,7 @@
          <p>It is a <termref def="dt-dynamic-error">dynamic error</termref> if evaluation of an
             expression relies on some part of the <termref def="dt-dynamic-context">dynamic
                context</termref> that <phrase diff="del">has not been assigned a
-               value</phrase><phrase diff="add">is <xtermref spec="DM31" ref="dt-absent"
+               value</phrase><phrase diff="add">is <xtermref spec="DM40" ref="dt-absent"
             /></phrase>.</p>
       </error>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -58,7 +58,7 @@ or a <termref def="dt-function-item">function item</termref>.</termdef></p>
          <p><termdef id="dt-node" term="node"
                >A <term>node</term> is an instance of one of the
 	  <term>node kinds</term> defined in <xspecref
-               spec="DM31" ref="Node"
+               spec="DM40" ref="Node"
             />.</termdef>
 Each node has a unique <term>node identity</term>, a <term>typed value</term>, and a <term>string value</term>. In addition, some nodes have a <term>name</term>. The <term>typed value</term> of a node is a sequence
 	 of zero or more atomic values. The <term>string value</term> of a node is a
@@ -103,10 +103,10 @@ As of XPath 2.0, the namespace axis is deprecated and need not be supported by a
       <note role="xquery">
          <p>In <bibref ref="xpath"
                />, the in-scope namespaces of an element node are represented by a collection of <term>namespace nodes</term> arranged on a <term>namespace axis</term>, which is optional and deprecated in <bibref
-               ref="xpath-31"
+               ref="xpath-40"
             />. XQuery does not support the namespace axis and does not represent namespace bindings in the form of nodes.</p>
 
-         <p>However, where other specifications such as <bibref ref="xslt-xquery-serialization-31"
+         <p>However, where other specifications such as <bibref ref="xslt-xquery-serialization-40"
                /> refer to namespace nodes, these nodes may be synthesized from the in-scope namespaces of an element node by interpreting each namespace binding as a namespace node. An application that needs to create a set of namespace nodes to represent these bindings for an element bound to <code>$e</code> can do so using the following code.
 
 
@@ -136,7 +136,7 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
       in the default namespace, the prefix is absent.</termdef> When
       comparing two expanded QNames, the prefixes are ignored: the
       local name parts must be equal under the Unicode codepoint
-      collation (<xspecref spec="FO31" ref="collations"/>), 
+      collation (<xspecref spec="FO40" ref="collations"/>), 
       and the namespace URI parts must either both be
       absent, or must be equal under the Unicode codepoint
       collation.</p>
@@ -438,7 +438,7 @@ and by <termref def="dt-namespace-decl-attr"
                   <p diff="chg" at="A">
                      <termdef id="dt-default-namespace-elements-and-types" term="default namespace for elements and types">
                         <term>Default namespace for elements and types.</term> This is a
-				namespace URI, <!--or the special value <code>"##any"</code>,--> or <xtermref spec="DM31" ref="dt-absent"
+				namespace URI, <!--or the special value <code>"##any"</code>,--> or <xtermref spec="DM40" ref="dt-absent"
                         />. This indicates how unprefixed QNames are interpreted when
                         they appear in a position  where an element name or type name is expected.</termdef></p>
                   <ulist>
@@ -452,7 +452,7 @@ and by <termref def="dt-namespace-decl-attr"
                         local name will be selected, regardless of their namespace (or lack of it). 
                         For an unprefixed QName representing an element or type
                         name in any other context, the name is interpreted as being in no namespace.</p></item>-->
-                     <item><p diff="chg" at="issue372">If the value is <xtermref spec="DM31" ref="dt-absent"/>,
+                     <item><p diff="chg" at="issue372">If the value is <xtermref spec="DM40" ref="dt-absent"/>,
                         an unprefixed QName representing an element or type
                         name is interpreted as being in no namespace.</p></item>
                   </ulist> 
@@ -463,7 +463,7 @@ and by <termref def="dt-namespace-decl-attr"
                <item>
                   <p>
                      <termdef id="dt-default-function-namespace" term="default function namespace">
-                        <term>Default function namespace.</term> This is either a namespace URI, or <xtermref spec="DM31"
+                        <term>Default function namespace.</term> This is either a namespace URI, or <xtermref spec="DM40"
                            ref="dt-absent"/>. The namespace URI, if present, is used for any unprefixed QName appearing
                      in a position where a function name is expected.</termdef> The URI value is whitespace-normalized according
                      to the rules for the <code>xs:anyURI</code> type in <xspecref
@@ -812,7 +812,7 @@ inferred by static type inference as discussed in  <specref
                            role="xquery">queries and</phrase> expressions.</termdef>
                      <termdef term="collation" id="dt-collation"
                            >A <term>collation</term> is a specification of the manner in which strings and URIs are compared and, by extension, ordered. For a more complete definition of collation, see <xspecref
-                           spec="FO31" ref="string-compare"/>.</termdef>
+                           spec="FO40" ref="string-compare"/>.</termdef>
                   </p>
                </item>
 
@@ -1139,7 +1139,7 @@ items that would result from calling the <code>fn:collection</code> function wit
 context</term> of an expression is defined as information that is needed for the dynamic evaluation of an expression.</termdef> If
 evaluation of an expression relies on some part of the <termref
                   def="dt-dynamic-context">dynamic context</termref> that 
-is <xtermref spec="DM31"
+is <xtermref spec="DM40"
                   ref="dt-absent"/>, a <termref def="dt-dynamic-error"
                   >dynamic
 error</termref> is raised <errorref class="DY" code="0002"/>.</p>
@@ -1245,7 +1245,7 @@ becomes the context value in the inner focus for an evaluation of <code
     
       In the dynamic context of every module in a query,
       the context value component must have the same setting.
-      If this shared setting is not <xtermref spec="DM31" ref="dt-absent"/>,
+      If this shared setting is not <xtermref spec="DM40" ref="dt-absent"/>,
       it is referred to as the <term>initial context value</term>.
     
   </termdef>
@@ -1730,7 +1730,7 @@ transformed into an <termref
                         def="dt-data-model-instance"
                         >XDM instance</termref>
 by a process described in <bibref
-                        ref="xpath-datamodel-31"/>. (See DM2 in
+                        ref="xpath-datamodel-40"/>. (See DM2 in
 Fig. 1.)</p>
                </item>
             </olist>
@@ -1748,7 +1748,7 @@ but it does not place any constraints on how XDM instances are constructed.</p>
                      >Each element node and attribute node in an <termref
                      def="dt-data-model-instance"
                      >XDM instance</termref> has a <term>type annotation</term> (described in <xspecref
-                     spec="DM31" ref="types"
+                     spec="DM40" ref="types"
                   />). 
 The type annotation of a node is a reference to an XML Schema type. 
 </termdef>  The <code>type-name</code> of a node is the name of the type referenced by its <termref
@@ -1756,7 +1756,7 @@ The type annotation of a node is a reference to an XML Schema type.
 If the <termref
                   def="dt-data-model-instance"
                   >XDM instance</termref> was derived from a validated XML document as described in <xspecref
-                  spec="DM31" ref="const-psvi"
+                  spec="DM40" ref="const-psvi"
                />, the type annotations of the element and attribute nodes are derived from schema
 validation. &language; does
 not provide a way to directly access the type annotation of an element
@@ -2079,14 +2079,14 @@ converting an <termref
                      >XDM
 instance</termref> to a sequence of octets (step DM4 in Figure 1.),
 as described in <bibref
-                     ref="xslt-xquery-serialization-31"/>.</termdef>
+                     ref="xslt-xquery-serialization-40"/>.</termdef>
             </p>
 
             <note>
                <p>This definition of serialization is the definition
 used in this specification. Any form of serialization that is
 not based on <bibref
-                     ref="xslt-xquery-serialization-31"
+                     ref="xslt-xquery-serialization-40"
                   /> is outside
 the scope of the &language; specification.</p>
             </note>
@@ -2109,7 +2109,7 @@ provide only a DOM interface (see <bibref
 based on an event stream. </p>
 
             <p role="xquery">
-               <bibref ref="xslt-xquery-serialization-31"
+               <bibref ref="xslt-xquery-serialization-40"
                   /> defines a set
 of <term>serialization parameters</term> that govern the serialization
 process. If an XQuery implementation provides a serialization
@@ -2126,7 +2126,7 @@ If an implementation does not support one of these parameters, it must ignore it
 is an option declaration in the namespace <code>http://www.w3.org/2010/xslt-xquery-serialization</code>;
 it is used to declare serialization parameters.</termdef>
 Except for <code>parameter-document</code>, each option corresponds to a serialization parameter element defined in <xspecref
-                  spec="SER31" ref="serparams-schema"
+                  spec="SE40" ref="serparams-schema"
                   />. 
 The name of each option is the same as the name of the corresponding serialization parameter element, 
 and the values permitted for each option are the same as the values allowed in the serialization parameter element. 
@@ -2195,7 +2195,7 @@ is not able to process the value of the
 an <code>output:parameter-document</code> output declaration specifies the values of
 serialization parameters in the manner defined by
 <xspecref
-                  spec="SER31" ref="serparams-in-xdm-instance"/>.
+                  spec="SE40" ref="serparams-in-xdm-instance"/>.
 It is a static error  <errorref
                   class="ST" code="0115"
                   />  if this
@@ -2681,7 +2681,7 @@ not required, but is permitted, to evaluate any other operands.</p>
                <termdef id="dt-error-value" term="error value"
                      >In addition to its identifying QName, a dynamic error may also carry a descriptive string and one or more additional values called <term>error values</term>.</termdef> An implementation may provide a mechanism whereby an application-defined error handler can process error values and produce diagnostic messages. 
   <phrase role="xquery">XQuery 3.1 provides standard error handling via <xspecref
-                  spec="XQ31" ref="id-try-catch"
+                  spec="XQ40" ref="id-try-catch"
                />.</phrase>
   <phrase role="xpath">The host language may also provide error handling mechanisms.</phrase>
 </p>
@@ -2696,7 +2696,7 @@ is equal to zero. Errors raised by system functions and operators are defined in
             <p>A dynamic error can also be raised explicitly by calling the
 <code>fn:error</code> function, which always raises a dynamic error and never
 returns a value.  This function is defined in <xspecref
-                  spec="FO31" ref="func-error"
+                  spec="FO40" ref="func-error"
                   />. For example, the following
 function call raises a dynamic
 error, providing a QName that identifies the error, a descriptive string, and a diagnostic value (assuming that the prefix <code>app</code> is bound to a namespace containing application-defined error codes):</p>
@@ -2986,7 +2986,7 @@ would raise an error because it has an <code>id</code> child whose value is not 
                   >expression</phrase>, which may consist of one or more <term>trees</term> (documents or fragments). 
 
 Document order is defined in <xspecref
-                  spec="DM31" ref="document-order"
+                  spec="DM40" ref="document-order"
                   />, and its definition is repeated here for convenience. 
 
 Document order is a total ordering, although the relative order of some nodes is <termref
@@ -3070,11 +3070,11 @@ applied to a value when the value is used in a context in which a
 sequence of atomic values is required. The result of atomization is
 either a sequence of atomic values or a <termref
                   def="dt-type-error">type error</termref>
-               <xerrorref spec="FO31" class="TY" code="0012"/>.  <termdef id="dt-atomization"
+               <xerrorref spec="FO40" class="TY" code="0012"/>.  <termdef id="dt-atomization"
                   term="atomization">
                   <term>Atomization</term> of a sequence
 is defined as the result of invoking the <code>fn:data</code> function, as defined in <xspecref
-                     spec="FO31" ref="func-data"/>.</termdef>
+                     spec="FO40" ref="func-data"/>.</termdef>
             </p>
             <p> The semantics of
 <code>fn:data</code> are repeated here for convenience. The result of
@@ -3093,7 +3093,7 @@ returned.</p>
 its <termref def="dt-typed-value"
                         >typed value</termref> is returned (a <termref def="dt-type-error"
                         >type error</termref>
-                     <xerrorref spec="FO31" class="TY" code="0012"
+                     <xerrorref spec="FO40" class="TY" code="0012"
                      /> is raised if the node has no typed value.)</p>
                </item>
 
@@ -3101,7 +3101,7 @@ its <termref def="dt-typed-value"
                   <p>If the item is a <termref def="dt-function-item"
                         >function item</termref> (other than an array) or map a <termref
                         def="dt-type-error">type error</termref>
-                     <xerrorref spec="FO31" class="TY" code="0013"/> is raised.</p>
+                     <xerrorref spec="FO40" class="TY" code="0013"/> is raised.</p>
                </item>
 
                <item>
@@ -3165,7 +3165,7 @@ value. <termdef id="dt-ebv"
 <term>effective boolean value</term> of a value is defined as the result
 of applying the <code>fn:boolean</code> function to the value, as
 defined in <xspecref
-                     spec="FO31" ref="func-boolean"/>.</termdef>
+                     spec="FO40" ref="func-boolean"/>.</termdef>
             </p>
 
             <p>The dynamic semantics of <code>fn:boolean</code> are repeated here for convenience:</p>
@@ -3198,7 +3198,7 @@ defined in <xspecref
 
                <item>
                   <p>In all other cases, <code>fn:boolean</code> raises a type error <xerrorref
-                        spec="FO31" class="RG" code="0006"/>.</p>
+                        spec="FO40" class="RG" code="0006"/>.</p>
                   <note>
                      <p>For instance, <code>fn:boolean</code> raises a type error if the operand is a function, a map, or an array.</p>
                   </note>
@@ -3272,7 +3272,7 @@ defined in <xspecref
             <head>Input Sources</head>
 
             <p>&language; has a set of functions that provide access to XML documents (<code>fn:doc</code>, <code>fn:doc-available</code>), collections (<code>fn:collection</code>, <code>fn:uri-collection</code>), text files (<code>fn:unparsed-text</code>, <code>fn:unparsed-text-lines</code>, <code>fn:unparsed-text-available</code>), and environment variables (<code>fn:environment-variable</code>, <code>fn:available-environment-variables</code>).  These functions are defined in <xspecref
-                  spec="FO31" ref="fns-on-docs"/>.</p>
+                  spec="FO40" ref="fns-on-docs"/>.</p>
 
 
 
@@ -3405,7 +3405,7 @@ defined in <xspecref
          which matches no items, the set of items matched by an item type consists either
          exclusively of <termref def="dt-atomic-value">atomic values</termref>,
          exclusively of <termref def="dt-node">nodes</termref>, 
-         or exclusively of <xtermref spec="DM31" ref="dt-function-item">function items</xtermref>.
+         or exclusively of <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>.
       </p>
       <note><p>These definitions require a caveat: types defined in a schema may be anonymous, in which case
          they cannot be referenced directly using the <nt def="ItemType">ItemType</nt> or 
@@ -3502,13 +3502,13 @@ represent the intersection between the categories of <termref
                   ref="XMLSchema10"/> or <bibref ref="XMLSchema11"
                   />
                  and augmented by additional types defined in <bibref
-                  ref="xpath-datamodel-31"
+                  ref="xpath-datamodel-40"
                   />. An implementation
                  that has based its type system on <bibref
                   ref="XMLSchema10"
                   /> is not required to support the <code>xs:dateTimeStamp</code> or <code>xs:error</code> types.</p>
 
-            <p>The schema types defined in  <xspecref spec="DM31" ref="types-predefined"
+            <p>The schema types defined in  <xspecref spec="DM40" ref="types-predefined"
                /> are summarized below.</p>
 
 
@@ -3523,11 +3523,11 @@ represent the intersection between the categories of <termref
                   ref="XMLSchema10"/> or  <bibref ref="XMLSchema11"
                   />
                  and augmented by additional types defined in <bibref
-                  ref="xpath-datamodel-31"
+                  ref="xpath-datamodel-40"
                   />.  Element and attribute
                    declarations in the <code>xs</code> namespace are
                    not implicitly included in the static context. The schema types defined in  <bibref
-                  ref="xpath-datamodel-31"/> are summarized below.</p>
+                  ref="xpath-datamodel-40"/> are summarized below.</p>
 
             <olist>
 
@@ -3595,7 +3595,7 @@ list, and union types, are derived. All primitive atomic types, such as
 
             <p>The relationships among the schema types in the <code>xs</code> namespace are illustrated in Figure 2. A more complete description of the &language; type hierarchy can be found in 
 <xspecref
-                  spec="FO31" ref="datatypes"/>.</p>
+                  spec="FO40" ref="datatypes"/>.</p>
             <graphic source="types.jpg" alt="Type Hierarchy Diagram"/>
             <p>Figure 2: Hierarchy of Schema Types used in &language;.</p>
          </div2>
@@ -3624,7 +3624,7 @@ list, and union types, are derived. All primitive atomic types, such as
                   >namespace-sensitive</termref> type raises 
  a <termref def="dt-type-error"
                   >type error</termref>
-               <xerrorref spec="FO31" class="NS" code="0004"
+               <xerrorref spec="FO40" class="NS" code="0004"
                /> if the namespace bindings for the result cannot be determined. </p>
          </div2>
 
@@ -3632,19 +3632,19 @@ list, and union types, are derived. All primitive atomic types, such as
             <head>Typed Value and String Value</head>
 
             <p>Every node has a <term>typed value</term> and a <term>string value</term>, except for nodes whose value is <xtermref
-                  spec="DM31" ref="dt-absent"/>.
+                  spec="DM40" ref="dt-absent"/>.
 
 <termdef term="typed value" id="dt-typed-value"
                      >The <term>typed
 value</term> of a node is a sequence of atomic values and can be
 extracted by applying the <xspecref
-                     spec="FO31" ref="func-data"/> function to the
+                     spec="FO40" ref="func-data"/> function to the
 node.</termdef>
                <termdef id="dt-string-value" term="string value"
                      >The
 <term>string value</term> of a node is a string and can be extracted
 by applying the <xspecref
-                     spec="FO31" ref="func-string"/>
+                     spec="FO40" ref="func-string"/>
 function to the node.</termdef>
             </p>
 
@@ -3660,7 +3660,7 @@ function to the node.</termdef>
                   def="dt-string-value">string value</termref>, and <termref
                   def="dt-type-annotation"
                   >type annotation</termref> of a node are closely related.  If the node was created by mapping from an Infoset or PSVI, the relationships among these properties are defined by rules in <xspecref
-                  spec="DM31" ref="types"/>.</p>
+                  spec="DM40" ref="types"/>.</p>
             <p role="xquery">The <termref def="dt-typed-value">typed value</termref>, <termref
                   def="dt-string-value">string value</termref>, and <termref
                   def="dt-type-annotation"
@@ -3670,7 +3670,7 @@ function to the node.</termdef>
 
                <item>
                   <p>If the node was created by mapping from an Infoset or PSVI, see rules in <xspecref
-                        spec="DM31" ref="types"/>.</p>
+                        spec="DM40" ref="types"/>.</p>
                </item>
 
                <item>
@@ -3815,11 +3815,11 @@ node is the empty sequence and its string value is the zero-length string.</p>
                         <p>If the type annotation
 denotes a complex type with element-only content, then the typed value
 of the node is <xtermref
-                              spec="DM31" ref="dt-absent"
+                              spec="DM40" ref="dt-absent"
                               />. The <code>fn:data</code> function raises a
 <termref
                               def="dt-type-error">type error</termref>
-                           <xerrorref spec="FO31" class="TY" code="0012"
+                           <xerrorref spec="FO40" class="TY" code="0012"
                            /> when applied to such a node. The string value of such a node is equal to the concatenated string values of all its text node descendants, in document order.</p>
                         <p>Example: E6 is an
 element node with the type annotation <code>weather</code>, which is a
@@ -3827,7 +3827,7 @@ complex type whose content type specifies
 <code>element-only</code>. E6 has two child elements named
 <code>temperature</code> and <code>precipitation</code>. The typed
 value of E6 is <xtermref
-                              spec="DM31" ref="dt-absent"
+                              spec="DM40" ref="dt-absent"
                            />, and the <code>fn:data</code> function
 applied to E6 raises an error.
 </p>
@@ -5022,7 +5022,7 @@ name.</p>
                <p>
     A <nt def="FunctionTest">FunctionTest</nt> matches a <termref 
                      def="dt-function-item"/>,
-    potentially also checking its <xtermref spec="DM31"
+    potentially also checking its <xtermref spec="DM40"
                      ref="dt-signature">function signature</xtermref>
                   <phrase role="xquery">and
     annotations (see <specref ref="id-annotations"
@@ -5039,7 +5039,7 @@ name.</p>
                      def="dt-function-item"
                      >function</termref> and the function’s type signature (as defined in
     <xspecref
-                     spec="DM31" ref="function-items"/>) is a <termref def="dt-subtype"
+                     spec="DM40" ref="function-items"/>) is a <termref def="dt-subtype"
                      >subtype</termref> of the <nt def="TypedFunctionTest"
                   >TypedFunctionTest</nt>.
   </p>
@@ -5564,14 +5564,14 @@ declare function flatten($tree as tree) as item()* {
                         <p>
                            <code role="parse-test"
                               >$x cast as xs:error</code> fails dynamically with error <xerrorref
-                                 spec="FO31" class="RG" code="0001"
+                                 spec="FO40" class="RG" code="0001"
                               />,  regardless of the value of <code>$x</code>.</p>
                      </item>
                      <item>
                         <p>
                            <code role="parse-test">$x cast as xs:error?</code> raises a <termref
                               def="dt-dynamic-error">dynamic error</termref>
-                           <xerrorref spec="FO31" class="RG" code="0001"
+                           <xerrorref spec="FO40" class="RG" code="0001"
                            /> if <code>exists($x)</code> returns <code>true</code>, and evaluates to the empty sequence if <code>empty($x)</code> returns <code>true</code>.</p>
                      </item>
                      <item>
@@ -6756,7 +6756,7 @@ and <nt def="OrExpr"
                </scrap>
             
             
-            
+         
                <p diff="add" at="2023-04-07">The value of a numeric literal is determined as follows (taking the rules in order):</p>
                
                <olist diff="chg" at="2023-04-07">
@@ -6777,18 +6777,18 @@ and <nt def="OrExpr"
                   <item><p>The value of a <term>numeric literal</term> containing no <code>.</code> and 
                      no <code>e</code> or <code>E</code> character is an atomic value of type <code>xs:integer</code>;
                      the value is obtained by casting from <code>xs:string</code> to <code>xs:integer</code> as specified in
-                     <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+                     <xspecref spec="FO40" ref="casting-from-strings"/>.</p>
                   </item>
                   <item><p>The value of a numeric literal containing <code>.</code> but no <code>e</code> or <code>E</code> 
                      character is an atomic value of type <code>xs:decimal</code>;
                      the value is obtained by casting from <code>xs:string</code> to <code>xs:decimal</code> as specified in
-                     <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+                     <xspecref spec="FO40" ref="casting-from-strings"/>.</p>
                   </item>
                   <item><p>The value of a numeric literal 
                      containing an <code>e</code> or <code>E</code> character is an atomic value of type 
                      <code>xs:double</code>;
                      the value is obtained by casting from <code>xs:string</code> to <code>xs:double</code> as specified in
-                     <xspecref spec="FO31" ref="casting-from-strings"/>.</p>
+                     <xspecref spec="FO40" ref="casting-from-strings"/>.</p>
                   </item>
                </olist>
                
@@ -6798,9 +6798,9 @@ and <nt def="OrExpr"
     
                <note>
                   <p>The effect of the above rules is that in the case of an integer or decimal literal, a dynamic error <xerrorref
-                        spec="FO31" class="AR" code="0002"
+                        spec="FO40" class="AR" code="0002"
                         /> will generally be raised if the literal is outside the range of values supported by the implementation (other options are available: see <xspecref
-                        spec="FO31" ref="op.numeric"/> for details.)</p>
+                        spec="FO40" ref="op.numeric"/> for details.)</p>
                   <p role="xquery">The limits of numeric datatypes are specified in <specref
                         ref="id-data-model-conformance"/>.</p>
                   <p role="xpath"
@@ -6883,6 +6883,7 @@ and <nt def="OrExpr"
                </scrap>
  
 
+
             <p>The value of a <term>string literal</term> is an atomic value whose type is
                <code>xs:string</code> and whose value is the string denoted by the characters between the
 		delimiting apostrophes or quotation marks. If the literal is delimited by apostrophes, two adjacent 
@@ -6963,39 +6964,7 @@ and <nt def="OrExpr"
                <errorref class="ST" code="0090"
                /> is raised if a character reference does not identify a valid character in the version of XML that is in use.</p>
                
-               <p>The interpretation of any
-                  <code>"&amp;"</code> within the string varies between XPath and XQuery:</p>
-               
-               <ulist>
-                  <item><p>In XQuery, <code>"&amp;"</code> introduces a character reference or predefined
-                     entity which is expanded. So the string literal <code>"AT&amp;amp;T"</code> represents
-                     a string of four characters, while <code>"AT&amp;T"</code> triggers a static error.</p></item>
-                  <item><p>In XPath, <code>"&amp;"</code> is treated as an ordinary character.
-                     So the string literal <code>"AT&amp;amp;T"</code> represents
-                     a string of eight characters (<code>"A"</code>, <code>"T"</code>,
-                     <code>"&amp;"</code>, <code>"a"</code>, <code>"m"</code>, <code>"p"</code>,
-                     <code>";"</code>, <code>"T"</code>), 
-                     while <code>"AT&amp;T"</code> is a string of four characters
-                     (<code>"A"</code>, <code>"T"</code>,
-                     <code>"&amp;"</code>, <code>"T"</code>).</p></item>
-               </ulist>
-               
-               <note>
-                  <p>The reason for the difference is that XPath is often embedded within XML-based languages
-                     such as XSLT, XSD, and XForms, where the XML parser will already have expanded entity and
-                     character references. In XSLT, for example, one might write
-                     <code><![CDATA[<xsl:if test="$company = 'AT&amp;T'">...]]></code>. The actual value of the
-                     <code>test</code> attribute here, as provided by the XML parser to the XSLT processor, is 
-                     <code><![CDATA[$company = 'AT&T']]></code>, so the
-                     XPath parser sees a bare unescaped ampersand.</p>
-                  <p>If it is necessary to write code that will be interpreted in the same way by XPath 4.0
-                     and XQuery 4.0 processors, string literals containing ampersands should be avoided. Instead,
-                     in most contexts where string literals can be used, an alternative is to write a
-                     <nt def="StringTemplate">StringTemplate</nt>, as described in <specref ref="id-string-templates"/>. 
-                     The four-character string <code>"AT&amp;T"</code> can be written either as
-                     <code>`AT&amp;T`</code>, or, if preferred, as <code>`AT{char(`amp`)}T`</code>.</p>
-               </note>
-               
+           
 
             <p>Here are some examples of string literals:</p>
                <ulist>
@@ -7016,18 +6985,16 @@ escaping may be needed.</p>
                   </note>
                </item>
 
-               <item>
+               <item role="xquery">
                   <p>
                      <code role="parse-test"
-                        >E"Ben &amp;amp; Jerry&amp;apos;s"</code> denotes the <code>xs:string</code> value  <code>"Ben &amp; Jerry's"</code>.
-                     This can also be written <code>L"Ben &amp; Jerry's"</code>.
-                  </p>
+                        >"Ben &amp;amp; Jerry&amp;apos;s"</code> denotes the <code>xs:string</code> value  <code>"Ben &amp; Jerry's"</code>.</p>
                </item>
 
-               <item>
+               <item role="xquery">
                   <p>
                      <code role="parse-test"
-                        >E"&amp;#8364;99.50"</code> denotes the <code>xs:string</code>  value <code>"€99.50"</code>.</p>
+                        >"&amp;#8364;99.50"</code> denotes the <code>xs:string</code>  value <code>"€99.50"</code>.</p>
                </item>
                <item>
                   <p>In XQuery, the string literal <code>"&amp;lt;"</code> denotes a string of length 1 containing the single character
@@ -7053,7 +7020,7 @@ escaping may be needed.</p>
                   def="dt-constructor-function"
                   >constructor function</termref> for the given type. The constructor functions for XML Schema
 		built-in types are defined in <xspecref
-                  spec="FO31" ref="constructor-functions-for-xsd-types"
+                  spec="FO40" ref="constructor-functions-for-xsd-types"
                />. In general, the name of a constructor function for a given type is the same as the name of the type (including its namespace). For
 		example:</p>
 
@@ -7193,7 +7160,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                For example this appplies on the right-hand side of the <code>/</code> 
                or <code>!</code> operators, or within a <nt def="Predicate">Predicate</nt>.</p>
             
-            <p>If the <termref def="dt-context-value"/> is <xtermref spec="DM31"
+            <p>If the <termref def="dt-context-value"/> is <xtermref spec="DM40"
                   ref="dt-absent"/>, a context value expression raises a <termref
                   def="dt-dynamic-error">dynamic error</termref>
                <errorref class="DY" code="0002"/>.</p>
@@ -7814,7 +7781,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                     <head>A System Function</head>
                                     <p>The following function call uses the function 
                                   <xspecref
-                                          spec="FO31" ref="func-base-uri"
+                                          spec="FO40" ref="func-base-uri"
                                           />.  Use of <code>SC</code> and <code>DC</code> and errors raised by this function are all defined in 
                                   <bibref
                                           ref="xpath-functions-40"/>.</p>
@@ -8045,7 +8012,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                                   >focus</termref>
                                           (context value, context position, and context size)
                                           is <xtermref
-                                                  spec="DM31" ref="dt-absent"
+                                                  spec="DM40" ref="dt-absent"
                                                 />.
                                         </p>
                                           </item>
@@ -8247,7 +8214,7 @@ return $vat(shop/article)
                            def="dt-partially-applied-function"
                            >partially applied function</termref> having
                         the following properties (which are defined in <xspecref
-                           spec="DM31" ref="function-items"/>):
+                           spec="DM40" ref="function-items"/>):
                      </p>
                      <ulist>
                         <item>
@@ -8370,7 +8337,7 @@ return $sum-of-squares(1 to 3)]]></eg>
                                  def="dt-partially-applied-function"
                                  >partially applied function</termref> with
                               the following properties (which are defined in <xspecref
-                                 spec="DM31" ref="function-items"
+                                 spec="DM40" ref="function-items"
                               />):
                             </p>
                            <ulist>
@@ -8705,7 +8672,7 @@ return $a("A")]]></eg>
                <p>
           The static context for the function body is inherited from the location of the inline function expression, with the exception of the
           static type of the context value which is initially <xtermref
-                     spec="DM31" ref="dt-absent"/>.
+                     spec="DM40" ref="dt-absent"/>.
           </p>
          
                <p>
@@ -8723,7 +8690,7 @@ return $a("A")]]></eg>
             
 
                <p>The result of an inline function expression is a single function with the following properties (as defined in <xspecref
-                     spec="DM31" ref="function-items"/>):</p>
+                     spec="DM40" ref="function-items"/>):</p>
 
           <ulist>
                      <item>
@@ -8767,7 +8734,7 @@ return $a("A")]]></eg>
                            <term>captured context</term>: the static context
                            is the static context of the inline function expression,
                            with the exception of the static context value type which is
-                           <xtermref spec="DM31" ref="dt-absent"/>. The dynamic context has an absent
+                           <xtermref spec="DM40" ref="dt-absent"/>. The dynamic context has an absent
                            <termref def="dt-focus"/>, and a set of variable bindings
                            comprising the <termref def="dt-variable-values"
                               >variable values</termref> component
@@ -9211,7 +9178,7 @@ return $incrementors[2](4)]]></eg>
         returns a new <termref def="dt-function-item"/>
         with the following properties
         (as defined in <xspecref
-                           spec="DM31" ref="function-items"/>):
+                           spec="DM40" ref="function-items"/>):
 
         <ulist>
                            <item>
@@ -9880,7 +9847,7 @@ return filter($days,$m)
 				contains the children of the context
 				node, which are the nodes returned by the
 				<xspecref
-                           spec="DM31" ref="dm-children"/>.
+                           spec="DM40" ref="dm-children"/>.
                                 </p>
 
 
@@ -9931,7 +9898,7 @@ return filter($days,$m)
                                           axis contains the sequence
                                           returned by the
 				          <xspecref
-                           spec="DM31" ref="dm-parent"
+                           spec="DM40" ref="dm-parent"
                         />, 
                                           which returns
                                           the parent of the context
@@ -10039,7 +10006,7 @@ return filter($days,$m)
 			 contains the attributes of the context node,
 			 which are the nodes returned by the
 			 <phrase diff="chg" at="B">
-			 <xspecref spec="DM31" ref="dm-attributes"/></phrase>; the axis will be
+			 <xspecref spec="DM40" ref="dm-attributes"/></phrase>; the axis will be
 			 empty unless the context node is an
 			 element.</p>
 
@@ -10072,7 +10039,7 @@ return filter($days,$m)
 				context node, which are the nodes
 				returned by the
                                 <xspecref
-                           spec="DM31" ref="dm-namespace-nodes"
+                           spec="DM40" ref="dm-namespace-nodes"
                            />; this axis
 				is empty unless the context node is an
 				element node. The
@@ -10104,10 +10071,10 @@ return filter($days,$m)
                            >in-scope namespaces</termref> of an element
 				should use the functions
 				<xspecref
-                           spec="FO31" ref="func-in-scope-prefixes"/>, 
+                           spec="FO40" ref="func-in-scope-prefixes"/>, 
 				and
 				<xspecref
-                           spec="FO31" ref="func-namespace-uri-for-prefix"
+                           spec="FO40" ref="func-namespace-uri-for-prefix"
                         />.
                                 </p>
 
@@ -11479,7 +11446,7 @@ the results are the same.
                   </item>
                </ulist>
             </example>
-            <p>In addition to the sequence operators described here, see <xspecref spec="FO31"
+            <p>In addition to the sequence operators described here, see <xspecref spec="FO40"
                   ref="sequence-functions"/> for functions defined on sequences.
 </p>
          </div3>
@@ -11590,7 +11557,7 @@ length greater than one, a <termref
 the cast fails, a <termref
                      def="dt-dynamic-error">dynamic
 error</termref> is raised. <xerrorref
-                     spec="FO31" class="RG" code="0001"/>
+                     spec="FO40" class="RG" code="0001"/>
                </p>
             </item>
          </olist>
@@ -11617,7 +11584,7 @@ type combination, including the dynamic errors that can be raised by the operato
                numeric division as well as division of duration values; the semantics are defined in
                <xspecref spec="FO40" ref="func-numeric-divide"/></p></item>
             <item><p>The <code>idiv</code> operator implements integer division; the semantics are defined
-               in <xspecref spec="FO31" ref="func-numeric-integer-divide"/></p></item>
+               in <xspecref spec="FO40" ref="func-numeric-integer-divide"/></p></item>
          </ulist> 
 
          <p>Here are some examples of arithmetic expressions:</p>
@@ -12190,7 +12157,7 @@ atomic values, one in the first operand sequence and the other in the second ope
 <code>false</code> or an error. The <term>magnitude relationship</term> between two atomic values is determined by
 applying the following rules. If a <code>cast</code> operation called for by these rules is not successful, a <termref
                         def="dt-dynamic-error">dynamic error</termref>  is raised. <xerrorref
-                        spec="FO31" class="RG" code="0001"/>
+                        spec="FO40" class="RG" code="0001"/>
                   </p>
 
                   <olist>
@@ -12248,7 +12215,7 @@ atomic values, one in the first operand sequence and the other in the second ope
 <code>false</code> or an error. The <term>magnitude relationship</term> between two atomic values is determined by
 applying the following rules. If a <code>cast</code> operation called for by these rules is not successful, a <termref
                         def="dt-dynamic-error">dynamic error</termref>  is raised. <xerrorref
-                        spec="FO31" class="RG" code="0001"/>
+                        spec="FO40" class="RG" code="0001"/>
                   </p>
                   <note role="xquery">
                      <p>The purpose of these rules is to preserve compatibility with XPath 1.0, in which (for example) <code
@@ -12388,7 +12355,7 @@ a <termref
                <item>
                   <p>A comparison with the <code>is</code> operator is <code>true</code> if the two operand nodes are the same node; otherwise it
 is <code>false</code>. See <bibref
-                        ref="xpath-datamodel-31"/> for  the definition of node identity.</p>
+                        ref="xpath-datamodel-40"/> for  the definition of node identity.</p>
                </item>
 
 
@@ -12706,7 +12673,7 @@ that creates a <code>book</code> element containing an attribute and some nested
                expansion of the <termref
                   def="dt-qname">lexical QName</termref>, as described in 
                <bibref
-                  ref="xpath-datamodel-31"/>. The resulting <termref def="dt-expanded-qname"
+                  ref="xpath-datamodel-40"/>. The resulting <termref def="dt-expanded-qname"
                   >expanded QName</termref> 
                becomes the <code>node-name</code> property of the constructed element node.</p>
             <p>In a direct element constructor, the name used in the end tag must exactly match the name
@@ -12763,7 +12730,7 @@ character (that is, the pair <code>"{{"</code> represents the
                      def="dt-namespace-decl-attr"
                      >namespace declaration attributes</termref> that are found inside the same element constructor. The namespace prefix of the attribute name is retained after expansion of the <termref
                      def="dt-qname">lexical QName</termref>, as described in <bibref
-                     ref="xpath-datamodel-31"/>. The resulting <termref def="dt-expanded-qname"
+                     ref="xpath-datamodel-40"/>. The resulting <termref def="dt-expanded-qname"
                      >expanded QName</termref> becomes the <code>node-name</code> property of the constructed attribute node.</p>
                <p>If the attributes in a direct element constructor do not have distinct <termref
                      def="dt-expanded-qname"
@@ -13010,7 +12977,7 @@ attribute is processed as follows:</p>
                 (overriding any existing binding of the zero-length prefix).</p>
                      <p>If the namespace URI is a zero-length string then 
                         the <termref def="dt-default-namespace-elements-and-types"/> of the constructor expression
-                        is set to <xtermref ref="dt-absent" spec="DM31"/>,
+                        is set to <xtermref ref="dt-absent" spec="DM40"/>,
                         and any no-prefix
                 namespace binding is removed from the
                 <termref
@@ -15186,7 +15153,7 @@ processing with JSON processing.</p>
 
             <p>Some of the functionality typically needed for maps and
   arrays is provided by functions defined in <xspecref
-                  spec="FO31" ref="maps-and-arrays"
+                  spec="FO40" ref="maps-and-arrays"
                />, including functions used to
   read JSON to create maps and arrays, serialize maps and arrays to
   JSON, combine maps to create a new map, remove map entries to create
@@ -15381,7 +15348,7 @@ map {
     then <code>$map($key)</code> is equivalent to <code>map:get($map, $key)</code>.
     The semantics of such a function call are formally defined in
     <xspecref
-                     spec="FO31" ref="func-map-get"/>.
+                     spec="FO40" ref="func-map-get"/>.
     
     </p>
 
@@ -15553,7 +15520,7 @@ map {
     then <code>$array($key)</code> is equivalent to <code>array:get($array, $key)</code>.
     The semantics of such a function call are formally defined in
     <xspecref
-                     spec="FO31" ref="func-array-get"/>.
+                     spec="FO40" ref="func-array-get"/>.
     
     </p>
 
@@ -15587,7 +15554,7 @@ map {
                   <item>
                      <p>
                         <code>array { "licorice", "ginger" }(20)</code> raises a dynamic error <xerrorref
-                           spec="FO31" class="AY" code="0001"/>.</p>
+                           spec="FO40" class="AY" code="0001"/>.</p>
                   </item>
 
                </ulist>
@@ -15873,7 +15840,7 @@ return .($k)
                   </item>
                   <item>
                      <p>
-                        <code>["a","b"]?3</code> raises a dynamic error <xerrorref spec="FO31"
+                        <code>["a","b"]?3</code> raises a dynamic error <xerrorref spec="FO40"
                            class="AY" code="0001"/>
                      </p>
                   </item>
@@ -17506,7 +17473,7 @@ group by $g1, $g2, $g3 collation "Spanish"]]></eg>
   sequence compare equal to each other, and (b) every input item that
   does not appear in the result sequence compares equal to some item
   that does appear in the result sequence. See <xspecref
-                           spec="FO31" ref="func-distinct-values"
+                           spec="FO40" ref="func-distinct-values"
                         /> for further discussion of
   this issue in a different context.</p> <note>
                         <p>The atomized grouping key will always be either an empty
@@ -19027,7 +18994,7 @@ matching</termref>; otherwise it returns <code>false</code>. For example:</p>
                   <p>This example returns <code>true</code> if the context value is a
                      single element node or <code>false</code> if the context value is defined 
                      but is not a single element node. If the context value is <xtermref
-                        spec="DM31" ref="dt-absent"/>, a <termref def="dt-dynamic-error"
+                        spec="DM40" ref="dt-absent"/>, a <termref def="dt-dynamic-error"
                         >dynamic error</termref> is raised <errorref class="DY" code="0002"/>.</p>
                </item>
             </ulist>
@@ -19260,7 +19227,7 @@ If <code>?</code> is not specified after the target type, a <termref
                   <p>If the result of atomization is a single
 atomic value, the result of the cast expression is determined by
 casting to the target type as described in <xspecref
-                        spec="FO31" ref="casting"
+                        spec="FO40" ref="casting"
                         />. When casting, an
 implementation may need to determine whether one type is derived by
 restriction from another. An implementation can determine this either
@@ -19373,7 +19340,7 @@ if ($x castable as hatsize)
             <head>Constructor Functions</head>
             <p>For every simple type in the <termref def="dt-is-types"
                   >in-scope schema types</termref>  (except <code>xs:NOTATION</code> and <code>xs:anyAtomicType</code>, and <code>xs:anySimpleType</code>, which are not instantiable), a <term>constructor function</term> is implicitly defined. In each case, the name of the constructor function is the same as the name of its target type (including namespace). The signature of the constructor function for  a given type depends on the type that is being constructed, and can be found in  <xspecref
-                  spec="FO31" ref="constructor-functions"/>.
+                  spec="FO40" ref="constructor-functions"/>.
             There is also a constructor function for every named item type in the <termref def="dt-item-type-aliases"/>
             that maps to a <termref def="dt-generalized-atomic-type"/>.</p> 
             
@@ -19900,7 +19867,7 @@ raised <errorref
                      ref="XINFO"
                      />) according to the “Infoset Mapping” rules
             defined in <bibref
-                     ref="xpath-datamodel-31"
+                     ref="xpath-datamodel-40"
                      />. Note that this process
             discards any existing <termref
                      def="dt-type-annotation"
@@ -20034,7 +20001,7 @@ raised <errorref
 
 
                     as described in <bibref
-                           ref="xpath-datamodel-31"
+                           ref="xpath-datamodel-40"
                            /> Section
                     3.3, “Construction from a PSVI”.
 
@@ -20095,7 +20062,7 @@ raised <errorref
                <code>xs:anyType</code>, and any attribute information items whose validity property is
         <code>notKnown</code> are converted into attribute nodes with <termref
                   def="dt-type-annotation">type annotation</termref>
-               <code>xs:untypedAtomic</code>, as described in <xspecref spec="DM31"
+               <code>xs:untypedAtomic</code>, as described in <xspecref spec="DM40"
                   ref="PSVI2NodeTypes"/>.
     </p>
          </note>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7157,7 +7157,7 @@ At evaluation time, the value of a variable reference is the value to which the 
               the <termref def="dt-context-value"/>.</p>
             
             <p>In many syntactic contexts, the context value will be a single item.
-               For example this appplies on the right-hand side of the <code>/</code> 
+               For example this applies on the right-hand side of the <code>/</code> 
                or <code>!</code> operators, or within a <nt def="Predicate">Predicate</nt>.</p>
             
             <p>If the <termref def="dt-context-value"/> is <xtermref spec="DM40"

--- a/specifications/xquery-40/src/introduction.xml
+++ b/specifications/xquery-40/src/introduction.xml
@@ -12,38 +12,37 @@
 	<p role="xquery">As increasing amounts of JSON are used for lightweight data-exchange, an XML query language
 	for Web data needs to handle JSON as well as XML and HTML.</p>
 
-	<p role="xquery">XQuery is designed to meet the requirements identified by the W3C XML Query
-		Working Group <bibref ref="xquery-31-requirements"/>. It is designed to be a language in which queries are concise and
-		easily understood. It is also flexible enough to query a broad spectrum of XML information
-		sources, including both databases and documents. The Query Working Group has identified a
-		requirement for both a non-XML query syntax and an XML-based query syntax. XQuery is
-		designed to meet the first of these requirements. XQuery is derived from an XML query
+	<p role="xquery" diff="chg" at="2023-10-19">XQuery is designed to be a language in which queries are concise and
+		easily understood. It is also flexible enough to query a broad spectrum of information
+		sources, both XML and non-XML, including both databases and documents. XQuery was originally derived from an XML query
 		language called Quilt <bibref ref="Quilt"/>, which in turn borrowed features from several
 		other languages, including XPath 1.0 <bibref ref="xpath"/>, XQL <bibref ref="XQL"/>, XML-QL
 			<bibref ref="XML-QL"/>, SQL <bibref ref="SQL"/>, and OQL <bibref ref="ODMG"/>. </p>
 
-	<p role="xpath">The primary purpose of XPath is to address the nodes of XML trees and JSON trees. 
+	<p role="xpath" diff="chg" at="2023-10-19">XPath was originally designed as an expression language 
+		to address the nodes of XML trees; it has since been extended to address a variety of non-XML data sources. 
 		XPath gets its name from its use of a path notation for
-		navigating through the hierarchical structure of an XML document. XPath uses a compact,
-		non-XML syntax, allowing XPath expressions to be embedded within URIs and to be used as XML attribute values. &language; adds a similar syntax for navigating JSON trees. </p>
+		navigating through the hierarchical structure of an XML document; similar capabilities for
+		navigating JSON structures were added in versions 3.0 and 3.1. XPath uses a compact,
+		non-XML syntax, allowing XPath expressions to be embedded within URIs and to be used as 
+		XML attribute values. XPath is designed to be embedded in (or invoked from) other
+		host languages, including both languages specialized towards XML processing (such as <bibref ref="xslt-40"/> and XSD),
+	   and general purpose programming languages such as Java, C#, Python, and Javascript. The interface
+	   between XPath and its host language is formalized with an abstract definition of a static and dynamic
+	   context, made available by the host language to the XPath processor.</p>
+	
+	<p diff="chg" at="2023-10-19" role="xpath"><termdef id="dt-host-language" term="host language">
+		A <term>host language</term> for XPath is any environment that provides capabilities
+		for XPath expressions to be defined and evaluated, and that supplies a static and dynamic
+		context for their evaluation.
+	</termdef></p>
 
 	<p>
 		<termdef id="dt-datamodel" term="data model">&language; operates on the abstract, logical
 			structure of an XML document or JSON object rather than its surface syntax. This logical structure,
-			known as the <term>data model</term>, is defined in <bibref ref="xpath-datamodel-31"
+			known as the <term>data model</term>, is defined in <bibref ref="xpath-datamodel-40"
 			/>.</termdef>
 	</p>
-
-	<p role="xpath">
-          XPath is designed to be embedded in a host language such as
-          <bibref ref="xslt-30"/> or <bibref ref="xquery-31"/>.
-          <termdef id="dt-host-language" term="host-language">
-          A <term>host language</term> for XPath is a language or
-          specification that incorporates XPath as a sublanguage and
-          that defines how the static and dynamic context for
-          evaluation of XPath expressions are to be
-          established.</termdef>
-        </p>
 
 
 	<p>
@@ -67,19 +66,18 @@
 			<item><p>If XPath 1.0 compatibility mode is enabled, XPath behaves differently from
 					XQuery in a number of ways, <phrase role="xpath">which are noted throughout this
 						document, and listed in <specref ref="id-incompat-in-false-mode"/>.</phrase>
-					<phrase role="xquery">which are discussed in <bibref ref="xpath-31"
+					<phrase role="xquery">which are discussed in <bibref ref="xpath-40"
 					/>.</phrase></p></item>
 		</ulist></p>
 
 	<p>Because these languages are so closely related, their grammars and language descriptions are
-		generated from a common source to ensure consistency, and their editors 
-		jointly work together.</p>
+		generated from a common source to ensure consistency.</p>
 
 	<p>&language; also depends on and is closely related to the following specifications:</p>
 
 	<ulist>
 		<item>
-			<p><bibref ref="xpath-datamodel-31"/> defines the data model that underlies all
+			<p><bibref ref="xpath-datamodel-40"/> defines the data model that underlies all
 				&language; expressions.</p>
 		</item>
 
@@ -94,14 +92,18 @@
 				in <bibref ref="xpath-functions-40"/>.</p>
 		</item>
 
-		<item role="xquery">
-			<p>XQuery also has an XML-based syntax, which is described in <bibref ref="xqueryx-31"
-				/>. </p>
+		<item role="xquery" diff="del" at="2023-10-19">
+			<p>XQuery also has an XML-based syntax, which is described in [XQueryX 3.1]. </p>
 		</item>
 
 	</ulist>
+	
+	<note diff="add" at="2023-10-19"><p>The XML-based syntax for XQuery known as XQueryX
+		is no longer maintained.</p></note>
 
 	<p role="xquery">
+		<termdef id="dt-xquery-40-processor" term="XQuery 4.0 Processor" diff="add" at="2023-10-19"> An <term>XQuery 4.0
+			Processor</term> processes a query according to the XQuery 4.0 specification. </termdef>
 		<termdef id="dt-xquery-31-processor" term="XQuery 3.1 Processor"> An <term>XQuery 3.1
 				Processor</term> processes a query according to the XQuery 3.1 specification. </termdef>
 		<termdef id="dt-xquery-30-processor" term="XQuery 3.0 Processor"> An <term>XQuery 3.0

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -71,29 +71,50 @@
       A <term>version declaration</term> can identify the applicable
       XQuery syntax and semantics for a <termref
       def="dt-module">module</termref>, as well as its
-      encoding.</termdef>
+      encoding.</termdef></p>
 
       
-      <termdef id="dt-version-number" term="XQuery version number">An <term>XQuery version number</term> consists of two integers separated by a dot. The first integer is referred to as the <term>major version number</term>; the second as the <term>minor version number</term>.</termdef>
+      <p><termdef id="dt-version-number" term="XQuery version number">An <term>XQuery version number</term> consists of two integers 
+        separated by a dot. The first integer is referred to as the <term>major version number</term>; the second as the 
+        <term>minor version number</term>.</termdef> <phrase diff="add" at="2023-10-19">An <term>integer</term> 
+          here means a sequence of decimal digits with no sign or other punctuation.</phrase></p>
+    
+      
   
-      Any XQuery processor that implements any version of XQuery with a given major number must accept any query with the same major version number. The processor may reject
-      queries labeled with a different major version number. The processor may reject queries with the same major version number and a greater minor version number than the processor recognizes.
+      <p>Any XQuery processor that implements any version of XQuery with a given major number must accept any query with 
+      the same major version number. The processor may reject
+      queries labeled with a different major version number. The processor may reject queries with the 
+      same major version number and a greater minor version number than the processor recognizes.</p>
+    
+      <note diff="add" at="2023-10-19"><p>The version numbers <code>“4.01”</code> and <code>“4.1”</code> are equivalent: 
+        both have a major number of 4 and a minor number of 1. Version <code>“4.10”</code> by the same reasoning
+        has a higher minor number than version <code>“4.2”</code>.</p></note>
 
-      If a query is rejected because of a version mismatch with the processor, a static error  <errorref code="0031" class="ST"/> must be raised.
+      <p>If a query is rejected because of a version mismatch with the processor, a static error  
+      <errorref code="0031" class="ST"/> must be raised.</p>
       
+      <note><p>The processor is allowed to provide an option to require that minor versions also match,
+        or that the minor number of the version in the query is not larger than the largest minor version 
+        understood by the processor in this major release of XQuery, or to allow more permissive version 
+        matching, perhaps with warnings, but the behavior is then outside the scope of this specification.</p></note>
 
-      <note><p>The processor is allowed to provide an option to require that minor versions also match, or that the minor number of the version in the query is not larger than the largest minor version understood by the processor in this major release of XQuery, or to allow more permissive version matching, perhaps with warnings, but the behaviour is then outside the scope of this specification.</p></note>
-    </p>
-      <p>The version number “1.0” indicates the intent that the module
+    <p>The version number “4.0” indicates the intent that the module
+      be processed by an <termref def="dt-xquery-40-processor">XQuery
+        4.0 processor</termref>.</p>
+        
+     <p>Similarly, the version number “1.0” indicates the intent that the module
       be processed by an <termref def="dt-xquery-10-processor">XQuery
-      1.0 processor</termref>, the version number “3.0” indicates the
-      intent that the module be processed by an <termref
+      1.0 processor</termref>, “3.0” an <termref
       def="dt-xquery-30-processor" >XQuery 3.0 processor</termref>, 
-      the version number “3.1” indicates the intent that the module be
-      processed by an <termref def="dt-xquery-31-processor" >XQuery
-      3.1 processor</termref>. If the version declaration is not
+      and “3.1” an <termref def="dt-xquery-31-processor">XQuery
+      3.1 processor</termref>.</p>
+    
+    <p>If the version declaration is not
       present or the version is not included in the declaration, an
-      XQuery 3.1 processor assumes a version of “3.1”.</p>
+      XQuery 4.0 processor assumes a version of “4.0”.</p>
+    
+    <note diff="add" at="2023-10-19"><p>This does not preclude the use of an external API or other configuration
+    mechanism that instructs a piece of software to behave as an XQuery 4.0 processor.</p></note>
 
       
 
@@ -116,14 +137,14 @@
       end of the version declaration. If such a <nt def="Comment">Comment</nt> is present, the
       result is <termref def="dt-implementation-dependent">implementation-dependent</termref>; an
       implementation may raise an implementation-dependent static error, or ignore the comment. <note>
-        <p>The effect of a Comment before the end of a version declaration is
+        <p>The effect of a <code>Comment</code> before the end of a version declaration is
           implementation-dependent because it may suppress query processing by interfering with
           detection of the encoding declaration.</p></note></p>
 
     <p>The following examples illustrate version declarations:</p>
 
-    <eg role="frag-prolog-parse-test">xquery version "1.0";</eg>
-    <eg role="frag-prolog-parse-test">xquery version "3.0" encoding "utf-8";</eg>
+    <eg role="frag-prolog-parse-test">xquery version "3.1";</eg>
+    <eg role="frag-prolog-parse-test">xquery version "4.0" encoding "utf-8";</eg>
   </div2>
 
   <div2 id="id-module-declaration">
@@ -259,9 +280,9 @@
 
     <p>It is not intrinsically an error if this process fails to establish an absolute base URI;
       however, the <termref def="dt-static-base-uri">Static Base URI</termref> property is then
-        <xtermref spec="DM31" ref="dt-absent"/>
+        <xtermref spec="DM40" ref="dt-absent"/>
       <errorref class="ST" code="0001"/>. When the <termref def="dt-static-base-uri">Static Base
-        URI</termref> property is <xtermref spec="DM31" ref="dt-absent"/>, any attempt to use its
+        URI</termref> property is <xtermref spec="DM40" ref="dt-absent"/>, any attempt to use its
       value to <termref def="dt-resolve-relative-uri">resolve a relative URI reference</termref>
       will result in an error <errorref class="ST" code="0001"/>. </p>
   </div2>
@@ -494,9 +515,21 @@ return (
       then the prolog must not contain a <termref def="dt-namespace-declaration">namespace declaration</termref>
       that specifies <code>default element namespace</code> or <code>default type namespace</code>.</p>
 
-    <p>The first <nt def="URILiteral">URILiteral</nt> specifies the target namespace of the schema documents to be
-      imported.</p>
-    
+
+    <p> The first <nt def="URILiteral">URILiteral</nt> in a schema import specifies the target
+      namespace of the schema to be imported. 
+      The URILiterals that follow the <code>at</code>
+      keyword are optional location hints, and can be interpreted or disregarded in an
+      implementation-dependent way. Multiple location hints might be used to indicate more than one
+      possible place to look for the schema or multiple physical resources to be assembled to form
+      the schema.
+    </p>
+    <p>
+      If the target
+      namespace is <code>http://www.w3.org/2005/xpath-functions</code> then the schema described in 
+      <xspecref spec="FO40" ref="schemata"/> is imported; any location hints are ignored.
+    </p>
+
     <p>A schema import that specifies a zero-length string as target namespace is considered to
       import a schema that has no target namespace. Such a schema import must not bind a namespace
       prefix <errorref class="ST" code="0057"/>, but it may set the default element and/or type namespace
@@ -961,7 +994,7 @@ return $i/xx:bing]]>
             where an element or type name is expected.</p></item>
             <item><p>The empty string <code>""</code>. In this case unprefixed names appearing where
               an element or type name is expected are treated as being in no namespace: the
-              <termref def="dt-default-namespace-elements-and-types"/> is set to <xtermref spec="DM31" ref="dt-absent"/>.</p></item>
+              <termref def="dt-default-namespace-elements-and-types"/> is set to <xtermref spec="DM40" ref="dt-absent"/>.</p></item>
             <!--<item><p>The string <code>"##any"</code>. In this case an unprefixed name appearing
               as a <nt def="NameTest">NameTest</nt> in an axis step whose principal node kind is element
               is interpreted as a wildcard (the unprefixed name <code>N</code> is treated as equivalent
@@ -995,7 +1028,7 @@ return $i/xx:bing]]>
           If the <nt def="URILiteral">URILiteral</nt> in a
           default type namespace declaration is a zero-length string, the <termref
             def="dt-def-type-ns">default type namespace</termref> is undeclared (set to
-          <xtermref spec="DM31" ref="dt-absent"/>), and unprefixed names of types are
+          <xtermref spec="DM40" ref="dt-absent"/>), and unprefixed names of types are
           considered to be in no namespace. The following example illustrates the declaration of a
           default namespace for types:</p>
         <eg role="frag-prolog-parse-test">declare default type namespace "http://www.w3.org/2001/XMLSchema";</eg>
@@ -1028,7 +1061,7 @@ return $i/xx:bing]]>
          <p>A <termref def="dt-prolog">Prolog</termref> may contain at most one
           default function namespace declaration <errorref class="ST" code="0066"/>. If the
           <code>StringLiteral</code> in a default function namespace declaration is a zero-length string, the
-          default function namespace is undeclared (set to <xtermref spec="DM31" ref="dt-absent"/>).
+          default function namespace is undeclared (set to <xtermref spec="DM40" ref="dt-absent"/>).
           In that case, any functions that are associated with a namespace can be called only by
           using an explicit namespace prefix.</p>
         <p>If no default function namespace declaration is present, the default function namespace
@@ -1561,7 +1594,7 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
           def="dt-in-scope-variables">in-scope variables</termref> component also includes the
         parameters of the function being declared. 
   
-        However, its <termref def="dt-context-value-static-type">context value static type</termref> component is <xtermref spec="DM31" ref="dt-absent"/>,
+        However, its <termref def="dt-context-value-static-type">context value static type</termref> component is <xtermref spec="DM40" ref="dt-absent"/>,
         and an implementation should raise a static error <errorref class="ST" code="0008"/> if an expression depends on the context value.
       </p>
       
@@ -1776,7 +1809,7 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       provided, the protocols by which parameters are passed to an external function, and the result
       of the function is returned to the invoking query, are <termref
         def="dt-implementation-defined">implementation-defined</termref>. An XQuery implementation
-      may augment the type system of <bibref ref="xpath-datamodel-31"/> with additional types that
+      may augment the type system of <bibref ref="xpath-datamodel-40"/> with additional types that
       are designed to facilitate exchange of data, or it may provide
       mechanism for the user to define such types. For example, a type might be provided that
       encapsulates an object returned by an external function, such as an SQL database connection.

--- a/specifications/xquery-40/src/xquery-header.xml
+++ b/specifications/xquery-40/src/xquery-header.xml
@@ -102,22 +102,23 @@
 
 <!--&status-section;-->
   <status>
-    <p>This is a first proposal by the editor, with no official standing whatsoever. Comments are invited.</p>
+    <p>This is a draft prepared by the QT4CG (officially registered in W3C as the
+      XSLT Extensions Community Group). Comments are invited.</p>
   </status>
 
 <abstract id="id-abstract"><p role="xpath" diff="chg">
 
 &language; is an expression language that allows the processing of
 values conforming to the data model defined in
-<bibref ref="xpath-datamodel-31"/>. The name of the language derives
+<bibref ref="xpath-datamodel-40"/>. The name of the language derives
 from its most distinctive feature, the path expression, which provides
 a means of hierarchic addressing of the nodes in an XML tree.  As well
 as modeling the tree structure of XML, the data model also includes
 atomic values, function items, maps, arrays, and sequences.  This version of XPath
 supports JSON as well as XML, and adds many new functions in <bibref ref="xpath-functions-40"/>.</p>
   
-<p role="xpath" diff="chg">&language; is a superset of <bibref ref="xpath-30"/>. A detailed list of changes
-made since XPath 3.0 can be found in <specref ref="id-revision-log"/>. 
+<p role="xpath" diff="chg">&language; is a superset of XPath 3.1. A detailed list of changes
+made since XPath 3.1 can be found in <specref ref="id-revision-log"/>. 
 </p>
 
 <p role="xquery">XML is a versatile markup language, capable of labeling the
@@ -130,18 +131,9 @@ This specification describes a query language called XQuery, which is
 designed to be broadly applicable across many types of XML data
 sources.</p>
 
-<p role="xquery" diff="add">JSON is a lightweight data-interchange format that is widely used to exchange data on the web and to store data in databases. Many applications use JSON
-together with XML and HTML. &language; extends XQuery to 
-support JSON as well as XML, adding maps and arrays to the data model
-and supporting them with new expressions in the
-language and new functions in <bibref ref="xpath-functions-40"/>. 
-A list of changes made since XQuery 3.1 can be found in <specref ref="id-revision-log"/>. 
-These are the most important new features in &language;:
+<p role="xquery" diff="add">A list of changes made since XQuery 3.1 can be found in <specref ref="id-revision-log"/>. 
 </p>
-<olist role="xquery" diff="add">
-<item><p><specref ref="id-maps"/>.</p></item>
-<item><p><specref ref="id-arrays"/>.</p></item>
-</olist>
+
 </abstract>
 
 <langusage>
@@ -152,7 +144,7 @@ These are the most important new features in &language;:
 </langusage>
 <revisiondesc id="id-DOESNOTEXIST">
 <slist>
-<sitem>XQuery 3.1 First Public Working Draft. (#####)</sitem>
+<sitem>XQuery 4.0 First Public Working Draft. (#####)</sitem>
 </slist>
 </revisiondesc>
 </header>


### PR DESCRIPTION
Includes the following changes:

* Clarification of the syntax and semantics of the version number in the XQuery version declaration
* Updates to front and back matter to reflect the current status of the 4.0 specs
* Update cross-spec references to point to the 4.0 specs rather than 3.1 specs
* A DTD change from spec="SER40" to spec="SE40" to reflect the name of the /etc file generated by the gradle script.

Fix #765