### PR TITLE
XQFO edits 5.4-5.6

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fos:functions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://www.w3.org/xpath-functions/spec/namespace fos.xsd"
+   xsi:schemaLocation="fos.xsd"
    xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace">
    <fos:global-variables>
       <fos:variable id="v-po" name="po" as="element()"
@@ -3832,7 +3832,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>concat('Ciao!',())</fos:expression>
+               <fos:expression>concat('Ciao!', ())</fos:expression>
                <fos:result>"Ciao!"</fos:result>
             </fos:test>
          </fos:example>
@@ -4153,6 +4153,19 @@ return normalize-unicode(concat($v1, $v2))</eg>
   "Harp not on that string, madam; that is past."
 )</eg></fos:expression>
                <fos:result>45</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>"ᾧ" => string-length()</eg></fos:expression>
+               <fos:result>1</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>"ᾧ" => normalize-unicode("NFD") => string-length()</eg></fos:expression>
+               <fos:result>4</fos:result>
+               <fos:postamble>For strings that consist of a base character with combining characters, each combining character is length 1.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -4894,12 +4907,13 @@ return normalize-unicode(concat($v1, $v2))</eg>
                   rule.</fos:postamble>
             </fos:test>
          </fos:example>
+         <fos:variable name="coll" id="v-contains-coll" as="xs:string">http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary</fos:variable>
          <fos:example>
             <fos:test>
                <fos:expression><eg>contains(
   "abcdefghi",
   "-d-e-f-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -4909,7 +4923,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>contains(
   "a*b*c*d*e*f*g*h*i*",
   "d-ef-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -4919,7 +4933,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>contains(
   "abcd***e---f*--*ghi",
   "def",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -4929,7 +4943,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>contains(
   (),
   "--***-*---",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -5008,12 +5022,13 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
+         <fos:variable name="coll" id="v-starts-with-coll" as="xs:string">http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary</fos:variable>
          <fos:example>
             <fos:test>
                <fos:expression><eg>starts-with(
   "abcdefghi",
   "-a-b-c-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -5023,7 +5038,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>starts-with(
   "a*b*c*d*e*f*g*h*i*",
   "a-bc-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -5033,7 +5048,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>starts-with(
   "abcd***e---f*--*ghi",
   "abcdef",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -5043,7 +5058,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>starts-with(
   (),
   "--***-*---",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -5055,7 +5070,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>starts-with(
   "-abcdefghi",
   "-abc",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -5133,12 +5148,13 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
+         <fos:variable name="coll" id="v-ends-with-coll" as="xs:string">http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary</fos:variable>
          <fos:example>
             <fos:test>
                <fos:expression><eg>ends-with(
   "abcdefghi",
   "-g-h-i-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -5148,7 +5164,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>ends-with(
   "abcd***e---f*--*ghi",
   "defghi",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -5158,7 +5174,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>ends-with(
   "abcd***e---f*--*ghi",
   "defghi",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -5168,7 +5184,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>ends-with(
   (),
   "--***-*---",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -5180,7 +5196,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>ends-with(
   "abcdefghi",
   "ghi-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -5257,12 +5273,13 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
+         <fos:variable name="coll" id="v-substring-before-coll" as="xs:string">http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary</fos:variable>
          <fos:example>
             <fos:test>
                <fos:expression><eg>substring-before(
   "abcdefghi",
   "--d-e-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>"abc"</fos:result>
             </fos:test>
@@ -5272,7 +5289,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>substring-before(
   "abc--d-e-fghi",
   "--d-e-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>"abc--"</fos:result>
             </fos:test>
@@ -5282,7 +5299,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>substring-before(
   "a*b*c*d*e*f*g*h*i*",
   "***cde",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>"a*b*"</fos:result>
             </fos:test>
@@ -5292,7 +5309,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>substring-before(
   "Eureka!",
   "--***-*---",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>""</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -5372,12 +5389,13 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:result>""</fos:result>
             </fos:test>
          </fos:example>
+         <fos:variable name="coll" id="v-substring-after-coll" as="xs:string">http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary</fos:variable>
          <fos:example>
             <fos:test>
                <fos:expression><eg>substring-after(
   "abcdefghi",
   "--d-e-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>"fghi"</fos:result>
             </fos:test>
@@ -5387,7 +5405,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>substring-after(
   "abc--d-e-fghi",
   "--d-e-",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>"-fghi"</fos:result>
             </fos:test>
@@ -5397,7 +5415,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>substring-after(
   "a*b*c*d*e*f*g*h*i*",
   "***cde***",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>"*f*g*h*i*"</fos:result>
             </fos:test>
@@ -5407,7 +5425,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>substring-after(
   "Eureka!",
   "--***-*---",
-  "http://www.w3.org/2013/collation/UCA?lang=en;alternate=blanked;strength=primary"
+  $coll
 )</eg></fos:expression>
                <fos:result>"Eureka!"</fos:result>
                <fos:postamble>The second argument contains only ignorable collation units and is
@@ -26333,23 +26351,22 @@ declare function every(
       <fos:rules>
          <p>The function returns a string, generally containing a single <termref
                def="character">character</termref> or glyph, identified by <code>$value</code>.</p>
-         <p>For example, <code>fn:char("nbsp")</code> returns a string containing the
-         non-breaking space character, <code>xA0</code>.</p>
          <p>The supplied value of <code>$value</code> must be one of the following:</p>
          <olist>
             <item><p>An HTML5 character reference name (often referred to as an entity name) as defined
-               at [https://html.spec.whatwg.org/multipage/named-characters.html]. The name is
+               at <loc href="https://html.spec.whatwg.org/multipage/named-characters.html">https://html.spec.whatwg.org/multipage/named-characters.html</loc>. The name is
                written with no leading ampersand and no trailing semicolon.
                For example <code>fn:char("pi")</code> represents the character
-               <code>π</code> (<code>x3C0</code>).</p>
+               <code>π</code> (<code>x3C0</code>) and <code>fn:char("nbsp")</code> returns the
+               non-breaking space character, <code>xA0</code>.</p>
                <p>A processor <rfc2119>may</rfc2119> recognize additional character reference names defined in
                   other versions of HTML. Character reference names are case-sensitive.</p>
                <p>In the event that the HTML5 character reference name identifies a string
                comprising multiple codepoints, that string is returned.</p>
                <p>[TODO: add a proper bibliographic reference.]</p></item>
-            <item><p>A backslash-escape sequence from the set <code>\n</code> (newline, x0A), 
-               <code>\r</code> (carriage return, <code>0xD</code>),
-               or <code>\t</code> (tab, <code>0x09</code>).</p></item>
+            <item><p>A backslash-escape sequence from the set <code>\n</code> (newline, <code>x0A</code>), 
+               <code>\r</code> (carriage return, <code>x0D</code>),
+               or <code>\t</code> (tab, <code>x09</code>).</p></item>
             <item><p>A decimal codepoint value in the form <code>#[0-9]+</code>, for example
             <code>fn:char("#10")</code> represents a newline character. Leading zeroes are optional.</p></item>
             <item><p>A hexadecimal codepoint value in the form <code>#x[0-9a-fA-F]+</code>, for example
@@ -26382,6 +26399,19 @@ declare function every(
       <fos:examples>
          <fos:example>
             <fos:test>
+               <fos:expression>char("aacute")</fos:expression>
+               <fos:result>"&#xE1;"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>char("eth")</fos:expression>
+               <fos:result>"&#xF0;"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>char("\t")</fos:expression>
+               <fos:result>codepoints-to-string(9)</fos:result>
+               <fos:postamble>The character <emph>tab</emph></fos:postamble>
+            </fos:test>
+            <fos:test>
                <fos:expression>char("#32")</fos:expression>
                <fos:result>" "</fos:result>
             </fos:test>
@@ -26390,22 +26420,9 @@ declare function every(
                <fos:result>" "</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>char("\t")</fos:expression>
-               <fos:result>codepoints-to-string(9)</fos:result>
-               <fos:postamble>The character <emph>tab</emph></fos:postamble>
-            </fos:test>
-            <fos:test>
                <fos:expression>char("#x1D1CA")</fos:expression>
                <fos:result>"&#x1D1CA;"</fos:result>
-               <fos:postamble>The character <emph>Tempus Imperfectum Cum Prolatione Perfecta</emph></fos:postamble>
-            </fos:test>
-            <fos:test>
-               <fos:expression>char("aacute")</fos:expression>
-               <fos:result>"&#xE1;"</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>char("eth")</fos:expression>
-               <fos:result>"&#xF0;"</fos:result>
+               <fos:postamble>The character MUSICAL SYMBOL TEMPUS IMPERFECTUM CUM PROLATIONE PERFECTA</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>char("NotEqualTilde")</fos:expression>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fos:functions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="fos.xsd"
+   xsi:schemaLocation="http://www.w3.org/xpath-functions/spec/namespace fos.xsd"
    xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace">
    <fos:global-variables>
       <fos:variable id="v-po" name="po" as="element()"

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -2753,7 +2753,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
          </div2>
          <div2 id="substring.functions">
             <head>Functions based on substring matching</head>
-            <p>The functions described in the section examine a string <code>$arg1</code> to see
+            <p>The functions described in this section examine a string <code>$arg1</code> to see
                     whether it contains another string <code>$arg2</code> as a substring. The result
                     depends on whether <code>$arg2</code> is a substring of <code>$arg1</code>, and
                if so, on the range of <termref def="character">characters</termref> in <code>$arg1</code> which <code>$arg2</code> matches.</p>
@@ -2820,7 +2820,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                     defined in this section may be a URI that identifies a collation that is able to
                     compare two strings, but that does not have the capability to split the string
                     into collation units. Such a collation may cause the function to fail, or to
-                    give unexpected results or it may be rejected as an unsuitable argument. The
+                    give unexpected results, or it may be rejected as an unsuitable argument. The
                     ability to decompose strings into collation units is an <termref def="implementation-defined"/> property of the collation.</p>
             <?local-function-index?>
             <div3 id="func-contains">
@@ -2841,8 +2841,8 @@ string conversion of the number as obtained above, and the appropriate <var>suff
          </div2>
          <div2 id="string.match">
             <head>String functions that use regular expressions</head>
-            <p>The three functions described in this section make use of a regular expression
-                    syntax for pattern matching. This is described below.</p>
+            <p>The four functions described in this section make use of a regular expression
+                    syntax for pattern matching, described below.</p>
             <?local-function-index?>
             <div3 id="regex-syntax">
                <head>Regular expression syntax</head>
@@ -2858,7 +2858,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                </note>
                <p>The regular expression syntax and semantics are identical to those
                             defined in <bibref ref="xmlschema-2"/> with the additions described in the 
-                  following sub-sections.</p>
+                  following subsections.</p>
                
                <note><p>In <bibref ref="xmlschema11-2"/> there are no substantive technical changes
                   to the syntax or semantics of regular expressions relative to XSD 1.0, but a number
@@ -3120,7 +3120,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                     parameter accepts a <code>xs:string</code>, in which individual letters
                     are used to set options. The presence of a letter within the string
                     indicates that the option is on; its absence indicates that the option
-                    is off. Letters may appear in any order and may be repeated. If there
+                    is off. Letters may appear in any order and may be repeated. They are case-sensitive. If there
                     are characters present that are not defined here as flags, then a dynamic error
                     is raised <errorref class="RX" code="0001"/>.</p>
                   <p>The following options are defined:</p>


### PR DESCRIPTION
Light edits for consistency.

- Examples in `char()` have been reordered so that the most interesting and useful examples are at top.
- Substring functions were difficult to read in the specs because of the overly long collation URI. These are now bound to a variable, to enhance legibility.
- Schema location fixed.
- extra examples in `string-length()`, to help users recognize the role of combining characters.