### PR TITLE
469: array:of-members, map:of-pairs: Signatures, Examples

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19564,8 +19564,8 @@ return fold-left($MAPS, map { },
    <fos:function name="of-pairs" prefix="map">
       <fos:signatures>
          <fos:proto name="of-pairs" return-type="map(*)">
-            <fos:arg name="pairs" 
-                     type="record(key as xs:anyAtomicType, value as item()*, *)*" 
+            <fos:arg name="input" 
+                     type="record(key as xs:anyAtomicType, value as item()*)*" 
                      usage="inspection"
                      example="map{'key':'n','value':false()},map{'key':'y','value':true()}"/>
             <fos:arg name="combine" type="function(item()*, item()*) as item()*" usage="inspection" default="fn:op(',')"/>
@@ -19585,7 +19585,7 @@ return fold-left($MAPS, map { },
          <p>The function <code>map:of-pairs</code>
             <phrase>returns a map</phrase> that
             is formed by combining <termref def="dt-key-value-pair-map">key-value pair maps</termref> supplied in the 
-            <code>$key-value-pairs</code>
+            <code>$input</code>
             argument.</p>
          
          <p>The optional <code>$combine</code> argument can be used to define how
@@ -19593,7 +19593,7 @@ return fold-left($MAPS, map { },
          of the corresponding values, retaining their order in the input sequence.</p>
          
          <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:build($key-value-pairs, fn($kvp) { $kvp?key }, fn($kvp) { $kvp?value }, $combine)</eg>
+         <eg>map:pairs($week) => map:build(fn { ?key }, fn { ?value }, $combine)</eg>
 
 
       </fos:rules>


### PR DESCRIPTION
I’ve eventually renamed `$pairs` to `$input` (I didn’t rename `$input` to $members` as initially suggested, as we have `$member` parameters in other functions that are of type `item()*`, not `record(value as item()*)`).

Closes #469
