### PR TITLE
783(part) - Editorial changes to Serialization spec

### DIFF
--- a/specifications/xslt-xquery-serialization-40/src/bibl.xml
+++ b/specifications/xslt-xquery-serialization-40/src/bibl.xml
@@ -9,13 +9,13 @@
       key="Character Model for the World Wide Web 1.0: Normalization"/>
 
 <!--* <bibl id="xpath-datamodel-30" key="XQuery and XPath Data Model (XDM) 3.0"/> *-->
-<bibl id="xpath-datamodel-31" key="XQuery and XPath Data Model (XDM) 3.1"/>
+<bibl id="xpath-datamodel-40" key="XQuery and XPath Data Model (XDM) 4.0"/>
 
 <!--* <bibl id="xpath-functions-30"
       key="XQuery and XPath Functions and Operators 3.0"/> *-->
 
-<bibl id="xpath-functions-31"
-      key="XQuery and XPath Functions and Operators 3.1"/>
+<bibl id="xpath-functions-40"
+      key="XQuery and XPath Functions and Operators 4.0"/>
 
 <bibl id="html5" key="HTML5"/>
 
@@ -78,12 +78,12 @@ Unicode Standard Annex #15.
 <bibl id="xmlschema-1" key="XML Schema"/>
 
 <!--* <bibl id="xpath-30" key="XML Path Language (XPath) 3.0"/> *-->
-<bibl id="xpath-31" key="XML Path Language (XPath) 3.1"/>
+<bibl id="xpath-40" key="XML Path Language (XPath) 4.0"/>
 
 <!--* <bibl id="xquery-30" key="XQuery 3.0: An XML Query Language"/> *-->
-<bibl id="xquery-31" key="XQuery 3.1: An XML Query Language"/>
+<bibl id="xquery-40" key="XQuery 4.0: An XML Query Language"/>
 
-<bibl id="xslt-30" key="XSL Transformations (XSLT) Version 3.0"/>
+<bibl id="xslt-40" key="XSL Transformations (XSLT) Version 4.0"/>
 
 <bibl id="xx-ECMA-404" key="The JSON Data Interchange Format" diff="del" at="2014-09-22">
 <titleref href="http://www.ecma-international.org/publications/standards/Ecma-404.htm">The JSON Data Interchange Format</titleref>,
@@ -130,8 +130,8 @@ ECMA International.
    World Wide Web Consortium, 14&#xA0; December&#xA0; 2010. 
    This version is http://www.w3.org/TR/2010/REC-xslt-xquery-serialization-20101214/</bibl>
    
-   <bibl id="serialization-31-fpwd" key="XSLT and XQuery Serialization 3.1 (First Public Working Draft)">
-     <titleref href="http://www.w3.org/TR/2014/WD-xslt-xquery-serialization-31-20140424/">XSLT and XQuery 
+   <bibl id="serialization-40-fpwd" key="XSLT and XQuery Serialization 4.0 (First Public Working Draft)">
+     <titleref href="http://www.w3.org/TR/2014/WD-xslt-xquery-serialization-40-20140424/">XSLT and XQuery 
      Serialization, W3C First Public Working Draft</titleref>, 
      Andrew Coleman, C.&#xA0;M.&#xA0;Sperberg-McQueen, <emph>et. al.</emph>, Editors. 
    World Wide Web Consortium, 24&#xA0;April&#xA0;2014.</bibl>

--- a/specifications/xslt-xquery-serialization-40/src/errors.xml
+++ b/specifications/xslt-xquery-serialization-40/src/errors.xml
@@ -134,9 +134,6 @@ diff="add" at="2014-09-22">
 method includes items for which no rules are provided in the
 appropriate section of the serialization rules.</p></error>
 
-<!--* I'm guessing that “RE” is the right class here; it seems to
-cover errors in representing the XDM instance using the serialized
-form *-->
 <error spec="SE" code="0022" class="RE" type="serialization" 
 diff="add" at="2014-09-22">
 <p>It is an error if a map being serialized using the JSON output method

--- a/specifications/xslt-xquery-serialization-40/src/errors.xml
+++ b/specifications/xslt-xquery-serialization-40/src/errors.xml
@@ -5,7 +5,7 @@
 
 <p>This document uses the <code>err</code> prefix which represents the
 same namespace URI (http://www.w3.org/2005/xqt-errors) as defined in
-<bibref ref="xpath-31" diff="chg" at="2013-12-07"/>.  Use of this
+<bibref ref="xpath-40" diff="chg" at="2013-12-07"/>.  Use of this
 namespace prefix binding in this document is not normative.</p>
 <error-list>
 

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -248,12 +248,12 @@ into a sequence of octets given the set of serialization parameter
 (<specref ref="serparam"/>) values specified.  A
 <term>serialization error</term> is said to occur in such an instance.</termdef>
 In some cases, a <termref def="serializer">serializer</termref> is
-<rfc2119>REQUIRED</rfc2119>  to signal such an error.
-What it means to signal a serialization error is determined by the
+<rfc2119>REQUIRED</rfc2119>  to <term>raise</term> such an error.
+What it means to raise a serialization error is determined by the
 relevant conformance criteria (<specref ref="conformance"/>) to which
 the <termref def="serializer">serializer</termref> conforms.  In other cases,
 there is an <termref def="impdef">implementation-defined</termref> choice
-between signaling a serialization error and performing a recovery action.
+between raising a serialization error and performing a recovery action.
 Such a recovery action will allow a
 <termref def="serializer">serializer</termref> to produce a sequence of
 octets that might not fully reflect the usual requirements of the
@@ -512,7 +512,7 @@ instance of the data model to which the rules of the appropriate
 output method are applied.  If the sequence
 normalization process results
 in a <termref def="serial-err">serialization error</termref>, the
-<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the error.</p>
+<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p>
 <note><p>If the <code>item-separator</code>
 serialization parameter is absent, the sequence normalization process
 for a sequence <code>$seq</code> is equivalent
@@ -1448,7 +1448,7 @@ as described in <specref ref="serphases"/>.
 The effects of the character expansion phase could result in the serialized output 
 being not well-formed, but will not result in a <termref def="serial-err">serialization error</termref>.  
 If a <termref def="serial-err">serialization error</termref> results, the 
-<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the error.</p>
+<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p>
 <p>If the document node of the
 normalized sequence has a single element
 node child and no text node children,
@@ -1609,7 +1609,7 @@ always be escaped, regardless of the value of the <code>version</code> parameter
 instance of the data model contains text nodes or multiple element nodes as children
 of the root node. The
 <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> either signal the error, or recover
+<rfc2119>MUST</rfc2119> either raise the error, or recover
 by ignoring the request to output a document type declaration or
 <code>standalone</code> parameter.</p>
 <div2 id="XML_PARAMS"><head>The Influence of Serialization Parameters upon the XML Output Method</head>
@@ -1627,7 +1627,7 @@ production of the XML Recommendation <bibref ref="xml"/> or <bibref ref="xml11"/
 A serialization error <errorref code="0013" class="SU"/> results if the value of the <code>version</code> parameter specifies 
 a version of XML that is not supported by the <termref def="serializer">serializer</termref>; 
 the <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119>
-signal the error.</p>
+raise the error.</p>
 <!-- Start:  added for Bug 6732 -->
 <p>This document provides the normative
 definition of serialization for the XML output method if the
@@ -1648,11 +1648,11 @@ the behavior is
 <xnt spec="Names" ref="NT-NCName">NCName</xnt> that contains a character that is not
 permitted by the version of Namespaces in XML specified by the
 <code>version</code> parameter, a <termref def="serial-err">serialization error</termref> <errorref code="0005" class="RE"/> results.
-The <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the error.</p>
+The <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p>
 <p>If the serialized result would contain a character
 that is not permitted by the version of XML specified by the
 <code>version</code> parameter, a <termref def="serial-err">serialization error</termref> <errorref code="0006" class="RE"/> results.  The
-<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the error.</p><example><p>For example, if the <code>version</code>
+<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p><example><p>For example, if the <code>version</code>
 parameter has the value <code>1.0</code>, and the instance of the data
 model contains a non-whitespace control character in the range #x1 to
 #x1F, a <termref def="serial-err">serialization error</termref> <errorref code="0006" class="RE"/> results.
@@ -1678,7 +1678,7 @@ are <rfc2119>REQUIRED</rfc2119>  to support values of <code>UTF-8</code> and
 encoding other than <code>UTF-8</code> or <code>UTF-16</code> is
 requested and the <termref def="serializer">serializer</termref>
 does not support that encoding. The <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> signal the error, or recover by using
+<rfc2119>MUST</rfc2119> raise the error, or recover by using
 <code>UTF-8</code> or <code>UTF-16</code> instead.
 The <termref def="serializer">serializer</termref>
 <rfc2119>MUST NOT</rfc2119> use an encoding whose name does not match the
@@ -1702,7 +1702,7 @@ node or text node), then the character <rfc2119>MUST</rfc2119> be output as a ch
 reference. A <termref def="serial-err">serialization error</termref> <errorref code="0008" class="RE"/> occurs if such a character appears in
 a context where character references are not allowed (for example, if
 the character occurs in the name of an element). The <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> signal the error.
+<rfc2119>MUST</rfc2119> raise the error.
 </p><example><p>For example,
 if a text node contains the character LATIN SMALL LETTER E WITH ACUTE (#xE9),
 and the value of the <code>encoding</code> parameter is
@@ -1880,7 +1880,7 @@ one of the values <code>yes</code>, <code>true</code> or <code>1</code>, and</p>
 <item><p>the <code>version</code> parameter has a value other than
 <code>1.0</code> and the <code>doctype-system</code>
 parameter is specified.</p></item></ulist>
-<p>The <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the error.
+<p>The <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.
 </p>
 <p>Otherwise, if the
 <code>omit-xml-declaration</code> parameter has 
@@ -1941,14 +1941,14 @@ If the output method is XML or XHTML, the value of the <code>undeclare-prefixes<
 one of <code>yes</code>, <code>true</code> or <code>1</code>,
 and the value of the <code>version</code> parameter is <code>1.0</code>,
 a <termref def="serial-err">serialization error</termref> <errorref code="0010" class="PM"/> results; the
-<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the error.</p></div3>
+<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p></div3>
 <div3 id="XML_NORMALIZATION-FORM"><head>XML Output Method: the <code>normalization-form</code> Parameter</head><p>The <code>normalization-form</code> parameter is applicable to the XML output method.
 The values <code>NFC</code> and <code>none</code> <rfc2119>MUST</rfc2119> be supported by the <termref def="serializer">serializer</termref>.
 A <termref def="serial-err">serialization error</termref> <errorref code="0011" class="SU"/> results if the value of the
 <code>normalization-form</code> parameter specifies a normalization form
 that is not supported by the
 <termref def="serializer">serializer</termref>; the
-<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the error.</p>
+<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p>
 <p>The meanings associated with the possible values of
 the <code>normalization-form</code> parameter are as follows:</p>
 <ulist><item><p><code>NFC</code> specifies the serialized result will be
@@ -1973,7 +1973,7 @@ the <code>normalization-form</code> parameter are as follows:</p>
 <emph>relevant construct</emph> of the parsed entity created by the <termref def="serializer">serializer</termref>
 may start with a composing character. The term <emph>relevant construct</emph>
 has the meaning defined in section 2.13 of <bibref ref="xml11"/>. If this condition is not
-satisfied, a <termref def="serial-err">serialization error</termref> <errorref code="0012" class="RE"/> <rfc2119>MUST</rfc2119> be signaled.</p><note><p>Specifying <code>fully-normalized</code> as the value of this parameter
+satisfied, a <termref def="serial-err">serialization error</termref> <errorref code="0012" class="RE"/> <rfc2119>MUST</rfc2119> be raised.</p><note><p>Specifying <code>fully-normalized</code> as the value of this parameter
 does not guarantee that the XML document output by the <termref def="serializer">serializer</termref> will in fact
 be fully normalized as defined in <bibref ref="xml11"/>. This is because the <termref def="serializer">serializer</termref> does
 not check that the text is <code>include normalized</code>, which would involve
@@ -2939,7 +2939,7 @@ and the value of the
 version</termref>
 is less than <code>5.0</code>. The
 <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> signal the error.</p>
+<rfc2119>MUST</rfc2119> raise the error.</p>
 <p>The HTML output method 
 <rfc2119>MUST</rfc2119> terminate processing
 instructions with <code>&gt;</code> rather than
@@ -2968,7 +2968,7 @@ If the <termref def="serializer">serializer</termref> does
 not support the version of HTML specified by
 the <termref def="req-html-ver">requested
 HTML version</termref>, it
-<rfc2119>MUST</rfc2119> signal a
+<rfc2119>MUST</rfc2119> raise a
 <termref def="serial-err">serialization error</termref> <errorref code="0013" class="SU"/>.</p>
 <!-- Start:  added for Bug 6732 -->
 <p>This document provides the normative
@@ -2996,7 +2996,7 @@ behavior is <termref def="impdef">implementation-defined</termref>.</imp-def-fea
 encoding other than <code>UTF-8</code> or <code>UTF-16</code> is
 requested and the <termref def="serializer">serializer</termref>
 does not support that encoding. The <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> signal the error.
+<rfc2119>MUST</rfc2119> raise the error.
 </p>
 <p>It is possible that the instance of the data model will contain a character that
 cannot be represented in the encoding that the <termref def="serializer">serializer</termref>
@@ -3008,7 +3008,7 @@ as a character entity reference or decimal numeric character
 reference; otherwise (for example, in a <code>script</code> or
 <code>style</code> element or in a comment), the <termref def="serializer">serializer</termref>
 <rfc2119>MUST</rfc2119>
-signal a <termref def="serial-err">serialization error</termref> <errorref code="0008" class="RE"/>.
+raise a <termref def="serial-err">serialization error</termref> <errorref code="0008" class="RE"/>.
 </p>
 <p>See <specref ref="HTML_INCLUDE-CONTENT-TYPE"/> regarding how this parameter is used with the <code>include-content-type</code> parameter.</p></div3>
 <div3 id="HTML_INDENT">
@@ -3125,7 +3125,7 @@ A <termref def="serial-err">serialization error</termref> <errorref code="0011" 
 parameter specifies a normalization form that is not supported by the
 <termref def="serializer">serializer</termref>;
 the <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> signal the error.</p></div3>
+<rfc2119>MUST</rfc2119> raise the error.</p></div3>
 <div3 id="HTML_MEDIA-TYPE"><head>HTML Output Method: the <code>media-type</code> Parameter</head><p>The <code>media-type</code> parameter is applicable to the
 HTML output method.
 See <specref ref="serparam"/> for more
@@ -3316,12 +3316,12 @@ occurs if the <termref def="serializer">serializer</termref>
 does not support the encoding specified
 by the <code>encoding</code> parameter.
 The <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> signal the error.
+<rfc2119>MUST</rfc2119> raise the error.
 If the instance of the data model contains a
 character that cannot be represented in the encoding that the
 <termref def="serializer">serializer</termref> is using for output, the <termref def="serializer">serializer</termref>
 <rfc2119>MUST</rfc2119>
-signal a <termref def="serial-err">serialization error</termref> <errorref code="0008" class="RE"/>.</p></div3>
+raise a <termref def="serial-err">serialization error</termref> <errorref code="0008" class="RE"/>.</p></div3>
 <div3 id="TEXT_INDENT">
 <head>Text Output Method: the <code>indent</code> and <code>suppress-indentation</code> Parameters</head>
 <p>The <code>indent</code>
@@ -3340,7 +3340,7 @@ and <code>none</code> <rfc2119>MUST</rfc2119> be supported by the <termref def="
 A <termref def="serial-err">serialization error</termref> <errorref code="0011" class="SU"/> results if the value of the
 <code>normalization-form</code> parameter specifies a normalization form
 that is not supported by the <termref def="serializer">serializer</termref>; the
-<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the
+<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the
 error.</p></div3>
 <div3 id="TEXT_MEDIA-TYPE"><head>Text Output Method: the <code>media-type</code> Parameter</head><p>The <code>media-type</code> parameter is applicable to the
 Text output method.
@@ -3441,7 +3441,7 @@ numeric value using any lexical representation of a JSON number defined in <bibr
  If the numeric value cannot be 
 represented in the JSON grammar (such as Infinity or NaN), then the 
 <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> 
-signal a serialization error <!--* [err:SERE0020]. *-->
+raise a serialization error <!--* [err:SERE0020]. *-->
 <errorref code="0020" class="RE"/>.
 </p></item>
 
@@ -3542,12 +3542,12 @@ occurs if the <termref def="serializer">serializer</termref>
 does not support the encoding specified
 by the <code>encoding</code> parameter.
 The <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> signal the error.
+<rfc2119>MUST</rfc2119> raise the error.
 If the instance of the data model contains a
 character that cannot be represented in the encoding that the
 <termref def="serializer">serializer</termref> is using for output, the <termref def="serializer">serializer</termref>
 <rfc2119>MUST</rfc2119>
-signal a <termref def="serial-err">serialization error</termref> 
+raise a <termref def="serial-err">serialization error</termref> 
 <errorref code="0008" class="RE"/>.</p>
 <note>
 <p>If an encoding other than UTF-8, UTF-16, UTF-32, US-ASCII, or an
@@ -3601,7 +3601,7 @@ and <code>none</code> <rfc2119>MUST</rfc2119> be supported by the <termref def="
 A <termref def="serial-err">serialization error</termref> <errorref code="0011" class="SU"/> results if the value of the
 <code>normalization-form</code> parameter specifies a normalization form
 that is not supported by the <termref def="serializer">serializer</termref>; the
-<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> signal the
+<termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the
 error.</p></div3>
 
 <div3 id="JSON_MEDIA-TYPE"><head>JSON Output Method: the <code>media-type</code> Parameter</head><p>The <code>media-type</code> parameter is applicable to the
@@ -4104,7 +4104,7 @@ marks.</p></note><p>If a character is mapped, then it is not subjected to XML or
 of a string containing a character that cannot be represented in the
 encoding that the <termref def="serializer">serializer</termref>
 is using for output. The <termref def="serializer">serializer</termref>
-<rfc2119>MUST</rfc2119> signal the error.</p></div1>
+<rfc2119>MUST</rfc2119> raise the error.</p></div1>
 
 <div1 id="conformance"><head>Conformance</head>
 <p>Serialization is intended primarily as a component

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -85,7 +85,7 @@
 <!ENTITY implementation-report-location "&xquery-impl-report;">
 <!ENTITY implementation-report-availability "&report-public;">
 <!ENTITY disclosure.one    "&disclosure.xquery;"> 
-<!ENTITY Bugzilla-key "SER31">
+<!ENTITY Bugzilla-key "SER40">
 <!ENTITY patent-policy-paragraph "&ppp-two;">
 <!ENTITY documents-and-relationships "&set-of-documents-30-preREC;">
 <!ENTITY advancement.statement "&advance.2WGs;">
@@ -100,8 +100,8 @@ for transition to Proposed Recommendation. </p>'>
 
 <!ENTITY customized-paragraph 
   '<p>This &doc.w3c-doctype-full; specifies XSLT and XQuery Serialization
-   version 3.1, a fully compatible extension of
-   <loc href="https://www.w3.org/TR/xslt-xquery-serialization-30/">Serialization version 3.0</loc>.</p>'>
+   version 4.0, a fully compatible extension of
+   <loc href="https://www.w3.org/TR/xslt-xquery-serialization-31/">Serialization version 3.1</loc>.</p>'>
 
 <!ENTITY status-section SYSTEM "../../../etc/status-general.xml">
 
@@ -132,11 +132,11 @@ for transition to Proposed Recommendation. </p>'>
     <loc href="&doc.latestloc;">&doc.latestloc;</loc>
   </latestloc>
 <!-- These prevlocs URIs are always hard-coded and are never computed from entities -->
-  <prevlocs doc="&language;">
+  <!--<prevlocs doc="&language;">
   <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/2017/PR-xslt-xquery-serialization-31-20170117/" xlink:type="simple" xlink:show="replace" xlink:actuate="onRequest">https://www.w3.org/TR/2017/PR-xslt-xquery-serialization-31-20170117/</loc>
   <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/2016/CR-xslt-xquery-serialization-31-20161213/" xlink:type="simple" xlink:show="replace" xlink:actuate="onRequest">https://www.w3.org/TR/2016/CR-xslt-xquery-serialization-31-20161213/</loc>
   <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="https://www.w3.org/TR/2015/CR-xslt-xquery-serialization-31-20151217/" xlink:type="simple" xlink:show="replace" xlink:actuate="onRequest">https://www.w3.org/TR/2015/CR-xslt-xquery-serialization-31-20151217/</loc>
-  </prevlocs>
+  </prevlocs>-->
   <latestloc-major doc="&language-major;">
     <loc href="&doc.latestloc-major;">&doc.latestloc-major;</loc>
   </latestloc-major>
@@ -144,7 +144,7 @@ for transition to Proposed Recommendation. </p>'>
     <loc href="&doc.latestloc-tech;">&doc.latestloc-tech;</loc>
   </latestloc-tech>
   <prevrec doc="&language-tech;">
-    <loc href="https://www.w3.org/TR/2014/REC-xslt-xquery-serialization-30-20140408/">https://www.w3.org/TR/2014/REC-xslt-xquery-serialization-30-20140408/</loc>
+    <loc href="https://www.w3.org/TR/xslt-xquery-serialization-31/">https://www.w3.org/TR/xslt-xquery-serialization-31/</loc>
   </prevrec>
 
   <authlist>
@@ -159,20 +159,20 @@ for transition to Proposed Recommendation. </p>'>
       <email href="http://www.blackmesatech.com/">http://blackmesatech.com/</email>
     </author>
   </authlist>
-  <errataloc href="https://www.w3.org/XML/2017/qt-errata/xslt-xquery-serialization-31-errata.html" 
+  <errataloc href="https://www.w3.org/XML/2017/qt-errata/xslt-xquery-serialization-40-errata.html" 
     xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"
   />
 
   <translationloc 
-    href="https://www.w3.org/2003/03/Translations/byTechnology?technology=xslt-xquery-serialization-31"/>
+    href="https://www.w3.org/2003/03/Translations/byTechnology?technology=xslt-xquery-serialization-40"/>
 
 &status-section;
 
 <abstract>
   <p>This document defines serialization of an instance of the data model as defined in
-     <bibref ref="xpath-datamodel-31"/> into a sequence of octets. 
+     <bibref ref="xpath-datamodel-40"/> into a sequence of octets. 
      Serialization is designed to be a component that can be used by other specifications
-     such as <bibref ref="xslt-30"/> or <bibref ref="xquery-31"/>.</p>
+     such as <bibref ref="xslt-40"/> or <bibref ref="xquery-40"/>.</p>
 </abstract>
 
 <langusage>
@@ -191,15 +191,15 @@ for transition to Proposed Recommendation. </p>'>
 
 <p>This document defines serialization of the W3C XQuery
 and XPath Data Model 4.0 (XDM),
-which is the data model of at least <bibref ref="xpath-31"/>,
-<bibref ref="xslt-30"/>, and
-<bibref ref="xquery-31"/>, and any other specifications that reference it.</p>
+which is the data model of at least <bibref ref="xpath-40"/>,
+<bibref ref="xslt-40"/>, and
+<bibref ref="xquery-40"/>, and any other specifications that reference it.</p>
 
 <p>In this document, examples and material labeled as <quote>Note</quote> are provided for
 explanatory purposes and are not normative. </p>
 
 <p>Serialization is the process of converting an instance of the
-<bibref ref="xpath-datamodel-31"/> into a sequence of octets. Serialization is
+<bibref ref="xpath-datamodel-40"/> into a sequence of octets. Serialization is
 well-defined for most data model instances.</p>
 
 <div2 id="terminology"><head>Terminology</head>
@@ -276,74 +276,74 @@ the second string.</termdef>
 </p>
 <!-- End of text added for Bug 8651 (Erratum SE.E17) -->
 <p>Many terms used in this document are defined in the XPath specification 
-<bibref ref="xpath-31"/> or the Data Model specification <bibref ref="xpath-datamodel-31"/>. Particular
+<bibref ref="xpath-40"/> or the Data Model specification <bibref ref="xpath-datamodel-40"/>. Particular
 attention is drawn to the following:</p>
 
 <ulist>
 
 <item>
 <p><termdef id="dt-atomization" term="atomize">The term <term>atomization</term> is defined
-in <xspecref spec="XP31" ref="id-atomization"/>.</termdef></p>
+in <xspecref spec="XP40" ref="id-atomization"/>.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-node" term="node">The term <term>node</term>
-is defined as part of   <xspecref spec="DM31" ref="Node"/>. 
+is defined as part of   <xspecref spec="DM40" ref="Node"/>. 
 There are seven kinds of <termref def="dt-node">nodes</termref> in the data model: document, element, attribute, text, namespace, processing instruction, and comment.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-sequence" term="sequence">The term <term>sequence</term>
-is defined in <xspecref spec="XP31" ref="id-basics"/>. 
+is defined in <xspecref spec="XP40" ref="id-basics"/>. 
 A <termref def="dt-sequence">sequence</termref> is an ordered collection of zero or more items.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-function-item" term="function item">The term
 <term>function</term> is defined in
-<xspecref spec="DM31" ref="function-items"/>.</termdef></p>
+<xspecref spec="DM40" ref="function-items"/>.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-map-item" term="map item">The term
 <term>map item</term> is defined in
-<xspecref spec="DM31" ref="map-items"/>.</termdef></p>
+<xspecref spec="DM40" ref="map-items"/>.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-array-item" term="array item">The term
 <term>array item</term> is defined in
-<xspecref spec="DM31" ref="array-items"/>.</termdef></p>
+<xspecref spec="DM40" ref="array-items"/>.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-string" term="string">The term
 <term>string</term> is defined in
-<xspecref spec="DM31" ref="xml-and-xsd-versions"/>.</termdef></p>
+<xspecref spec="DM40" ref="xml-and-xsd-versions"/>.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-character" term="character">The term
 <term>character</term> is defined in
-<xspecref spec="DM31" ref="xml-and-xsd-versions"/>.</termdef></p>
+<xspecref spec="DM40" ref="xml-and-xsd-versions"/>.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-codepoint" term="codepoint">The term
 <term>codepoint</term> is defined in
-<xspecref spec="DM31" ref="xml-and-xsd-versions"/>.</termdef></p>
+<xspecref spec="DM40" ref="xml-and-xsd-versions"/>.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-string-value" term="string value">The term <term>string value</term>
-is defined in <xspecref spec="DM31" ref="dm-string-value"/>. 
+is defined in <xspecref spec="DM40" ref="dm-string-value"/>. 
 Every <termref def="dt-node">node</termref> has a <termref def="dt-string-value">string value</termref>. For example, the <termref def="dt-string-value">string value</termref>
 of an element is the concatenation of the <termref def="dt-string-value">string values</termref> of all its descendant text <termref def="dt-node">nodes</termref>.</termdef></p>
 </item>
 
 <item>
 <p><termdef id="dt-expanded-qname" term="expanded QName">The term <term>expanded QName</term>
-is defined in <xspecref spec="XP31" ref="id-basics"/>. 
+is defined in <xspecref spec="XP40" ref="id-basics"/>. 
 An <termref def="dt-expanded-qname">expanded QName</termref> consists of an optional namespace URI and a local name. An <termref def="dt-expanded-qname">expanded QName</termref> also retains its original namespace prefix (if any), to facilitate casting the expanded QName into a string.</termdef></p>
 </item>
 
@@ -370,8 +370,8 @@ TAB character, CR character or NL character is referred to as a
 
 <p>Where this specification indicates that an
 XSLT instruction is evaluated, the behavior is as specified by
-<bibref ref="xslt-30"/>.  Where it indicates that an XQuery expression is
-evaluated, the behavior is as specified by <bibref ref="xquery-31"/>.</p>
+<bibref ref="xslt-40"/>.  Where it indicates that an XQuery expression is
+evaluated, the behavior is as specified by <bibref ref="xquery-40"/>.</p>
 </div2>
 
 <div2 id="namespaces">
@@ -440,8 +440,8 @@ process takes place.</imp-def-feature><!--Text replaced by erratum E6 change 1"-
 <p>Where the process of converting the input sequence
 to a normalized sequence indicates that a value <rfc2119>MUST</rfc2119> be cast to
 <code role="SCHEMATYPE">xs:string</code>, that operation is
-defined in <xspecref spec="FO31" ref="casting-to-string"/> of
-<bibref ref="xpath-functions-31"/>.
+defined in <xspecref spec="FO40" ref="casting-to-string"/> of
+<bibref ref="xpath-functions-40"/>.
 Where a
 step in the sequence normalization process indicates that a node should be
 copied, the copy is performed in the same way as an XSLT
@@ -449,62 +449,62 @@ copied, the copy is performed in the same way as an XSLT
 <code>validation</code> attribute whose value is
 <code>preserve</code> and has a
 <code>select</code> attribute whose effective value is the
-node, as described in <xspecref spec="XT30" ref="copy-of"/>
-of <bibref ref="xslt-30"/>,
+node, as described in <xspecref spec="XT40" ref="copy-of"/>
+of <bibref ref="xslt-40"/>,
 or equivalently in the same way as an XQuery
 content expression as described in Step 1e of
-<xspecref spec="XQ31" ref="id-content"/>
-of <bibref ref="xquery-31"/>, where the construction mode is
+<xspecref spec="XQ40" ref="id-content"/>
+of <bibref ref="xquery-40"/>, where the construction mode is
 <code>preserve</code>.
 
-Let <emph>S<sub>0</sub></emph> be the sequence that is input to serialization. 
+Let <var>S0</var> be the sequence that is input to serialization. 
 The steps in computing the normalized sequence are:
 </p>
       <!--End of text replaced by erratum E6-->
 <olist>
-<item><p>Create a new sequence <emph>S<sub>1</sub></emph> from <emph>S<sub>0</sub></emph> as follows. For
-each item in <emph>S<sub>0</sub></emph>, if the item is an array, copy the results of
+<item><p>Create a new sequence <var>S1</var> from <var>S0</var> as follows. For
+each item in <var>S0</var>, if the item is an array, copy the results of
 passing the item into the function <code>array:flatten()</code>; otherwise, copy the item
-itself. If <emph>S<sub>0</sub></emph> is empty, let <emph>S<sub>1</sub></emph> consist
+itself. If <var>S0</var> is empty, let <var>S1</var> consist
 of a zero-length string. </p></item>
-<item><p>Create a new sequence <emph>S<sub>2</sub></emph> from <emph>S<sub>1</sub></emph> as follows. For
-each item in <emph>S<sub>1</sub></emph>, if the item is atomic, copy to <emph>S<sub>2</sub></emph> only the lexical
+<item><p>Create a new sequence <var>S2</var> from <var>S1</var> as follows. For
+each item in <var>S1</var>, if the item is atomic, copy to <var>S2</var> only the lexical
 representation resulting from casting the item to an <code role="SCHEMATYPE">xs:string</code>, otherwise, 
-copy the item to <emph>S<sub>2</sub></emph>.</p></item>
+copy the item to <var>S2</var>.</p></item>
 <item>
-<p>Create a new sequence <emph>S<sub>3</sub></emph> from <emph>S<sub>2</sub></emph> as follows. If the
+<p>Create a new sequence <var>S3</var> from <var>S2</var> as follows. If the
 <code>item-separator</code> serialization parameter is present, then copy each item in
-<emph>S<sub>2</sub></emph> to <emph>S<sub>3</sub></emph>, inserting between each pair of items
+<var>S2</var> to <var>S3</var>, inserting between each pair of items
 a string whose value is equal to the value of the item-separator parameter. If the
 <code>item-separator</code> serialization parameter is not present, then first maximally 
-group the items in <emph>S<sub>2</sub></emph> into subsequences of <code role="SCHEMATYPE">xs:string</code> items 
+group the items in <var>S2</var> into subsequences of <code role="SCHEMATYPE">xs:string</code> items 
 and non-<code role="SCHEMATYPE">xs:string</code> items. For each group of items, if the group is a subsequence of
 non-<code role="SCHEMATYPE">xs:string</code> items, copy the subsequence to
-<emph>S<sub>3</sub></emph>; if the group is a subsequence of <code role="SCHEMATYPE">xs:string</code> 
-items, copy to <emph>S<sub>3</sub></emph> the results of passing to
+<var>S3</var>; if the group is a subsequence of <code role="SCHEMATYPE">xs:string</code> 
+items, copy to <var>S3</var> the results of passing to
 <code>fn:string-join()</code> the subsequence and the value of
 <code>item-separator</code> as the function’s two parameters. </p></item>
-<item><p>Create a new sequence <emph>S<sub>4</sub></emph> from <emph>S<sub>3</sub></emph> as follows.
-For each item in <emph>S<sub>3</sub></emph>, if the item is a string,
-copy to <emph>S<sub>4</sub></emph> a text node whose <termref def="dt-string-value">string value</termref> is equal to
-the string; otherwise, copy the item to <emph>S<sub>4</sub></emph>.</p></item>
+<item><p>Create a new sequence <var>S4</var> from <var>S3</var> as follows.
+For each item in <var>S3</var>, if the item is a string,
+copy to <var>S4</var> a text node whose <termref def="dt-string-value">string value</termref> is equal to
+the string; otherwise, copy the item to <var>S4</var>.</p></item>
 <item><p>
-Create a new sequence <emph>S<sub>5</sub></emph> from <emph>S<sub>4</sub></emph> as follows.
-For each item in <emph>S<sub>4</sub></emph>, if the item is a document node,
-copy its children to <emph>S<sub>5</sub></emph>; otherwise, copy the item to <emph>S<sub>5</sub></emph>.</p></item>
-<item><p>Create a new sequence <emph>S<sub>6</sub></emph> from <emph>S<sub>5</sub></emph> as follows. First,
-remove any text nodes with values of zero length from <emph>S<sub>5</sub></emph>, then
+Create a new sequence <var>S5</var> from <var>S4</var> as follows.
+For each item in <var>S4</var>, if the item is a document node,
+copy its children to <var>S5</var>; otherwise, copy the item to <var>S5</var>.</p></item>
+<item><p>Create a new sequence <var>S6</var> from <var>S5</var> as follows. First,
+remove any text nodes with values of zero length from <var>S5</var>, then
 maximally group the results into groups of text nodes and non-text nodes. For each group
 of items, if the group is a subsequence of text nodes, copy to
-<emph>S<sub>6</sub></emph> a single text node whose value is equal to the concatenated
+<var>S6</var> a single text node whose value is equal to the concatenated
 values of the subsequence; if the group is a subsequence of non-text nodes, copy the
-subsequence of items to <emph>S<sub>6</sub></emph>. It is a <termref def="serial-err">serialization error</termref>
-<errorref code="0001" class="NR"/> if any item in <emph>S<sub>6</sub></emph> is an
+subsequence of items to <var>S6</var>. It is a <termref def="serial-err">serialization error</termref>
+<errorref code="0001" class="NR"/> if any item in <var>S6</var> is an
 attribute node, a namespace node, or a <termref def="dt-function-item">function</termref>. </p></item>
-<item><p>Create a new sequence <emph>S<sub>7</sub></emph> from <emph>S<sub>6</sub></emph> as follows.
-Let <emph>S<sub>7</sub></emph> be a single document node. 
-Copy sequence <emph>S<sub>6</sub></emph> to the document node as its children.
-</p></item></olist><p><emph>S<sub>7</sub></emph> is the normalized sequence.</p>
+<item><p>Create a new sequence <var>S7</var> from <var>S6</var> as follows.
+Let <var>S7</var> be a single document node. 
+Copy sequence <var>S6</var> to the document node as its children.
+</p></item></olist><p><var>S7</var> is the normalized sequence.</p>
 <p>The <termref def="result-tree">result tree</termref> rooted at the document node that is
 created by the final step of this sequence
 normalization process is the
@@ -842,7 +842,7 @@ override the provisions of this specification.
 section, a mechanism by 
 which the settings of serialization parameters are supplied in the form of 
 an instance of the data model as specified in
-<bibref ref="xpath-datamodel-31"/>.  The instance of the data model used
+<bibref ref="xpath-datamodel-40"/>.  The instance of the data model used
 to determine the settings of 
 serialization parameters <rfc2119>MUST</rfc2119> be processed as if by the
 procedure described below.</p>
@@ -1024,7 +1024,7 @@ properties</td>
 instructions</td>
 <td>XSLT</td>
 <td>The set of all instructions defined
-by <bibref ref="xslt-30"/></td></tr>
+by <bibref ref="xslt-40"/></td></tr>
 </tbody>
 </table>
 <imp-def-feature>
@@ -1353,8 +1353,8 @@ apply <termref def="uri-escaping">URI escaping</termref> as defined below,
 and skip rules b-e. Otherwise, continue with rule b.</p>
 <p><termdef term="URI Escaping" id="uri-escaping"><term>URI escaping</term> consists of the following three steps applied in sequence to the content of 
 <termref def="uri-attribute-values">URI attribute values</termref>:</termdef>
-</p><olist><item><p>normalize to NFC using the method defined in <xspecref spec="FO31" ref="func-normalize-unicode"/></p></item>
-<item><p>percent-encode any special characters in the URI using the method defined in <xspecref spec="FO31" ref="func-escape-html-uri"/></p></item>
+</p><olist><item><p>normalize to NFC using the method defined in <xspecref spec="FO40" ref="func-normalize-unicode"/></p></item>
+<item><p>percent-encode any special characters in the URI using the method defined in <xspecref spec="FO40" ref="func-escape-html-uri"/></p></item>
 <item><p>escape according to
 <!-- Start of text changed for Bug 8206 (Erratum SE.E18) -->
 the rules of the XML or HTML output
@@ -1479,7 +1479,7 @@ or <bibref ref="xml-names11"/>.</p>
 <p><termdef id="reconstructed-tree" term="reconstructed tree">A <term>reconstructed tree</term> may be
 constructed by parsing the XML document and converting it into an
 instance of the data model as specified in 
-<bibref ref="xpath-datamodel-31"/>.</termdef>
+<bibref ref="xpath-datamodel-40"/>.</termdef>
 The result of serialization <rfc2119>MUST</rfc2119> be such that the <termref def="reconstructed-tree">reconstructed tree</termref>
 is the same as the <termref def="result-tree">result tree</termref> except for the following permitted differences:</p><ulist><item><p>If the document was produced by adding a document wrapper, as
 described above, then it will contain an extra <code>doc</code>
@@ -1537,8 +1537,8 @@ of that node did not have any namespace node that declared the same prefix.</p>
 The <termref def="result-tree">result tree</termref> <rfc2119>MAY</rfc2119> contain namespace nodes
 that are not present in the <termref def="reconstructed-tree">reconstructed tree</termref>, as the process of creating an instance
 of the data model <rfc2119>MAY</rfc2119> ignore namespace declarations in some circumstances.
-See <xspecref spec="DM31" ref="const-infoset-element"/> and
-<xspecref spec="DM31" ref="const-psvi-element"/> of <bibref ref="xpath-datamodel-31"/>
+See <xspecref spec="DM40" ref="const-infoset-element"/> and
+<xspecref spec="DM40" ref="const-psvi-element"/> of <bibref ref="xpath-datamodel-40"/>
 for additional information.
 </p></item>
 <item><p>If the <code>indent</code> parameter has
@@ -2147,7 +2147,7 @@ stylesheet, with the instance of the data model as the initial context item.
 <eg><![CDATA[
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-    version="3.0"
+    version="4.0"
     xmlns:xhtml="http://www.w3.org/1999/xhtml"
     xmlns:svg="http://www.w3.org/2000/svg"
     xmlns:mathml="http://www.w3.org/1998/Math/MathML">
@@ -2510,7 +2510,7 @@ user agent. Even in the case of non-ASCII characters, escaping can
 sometimes cause problems. More precise control of <termref def="uri-escaping">URI escaping</termref> is
 therefore available by setting <code>escape-uri-attributes</code> to
 <code>no</code>, and controlling the escaping of URIs by using methods defined in
-<xspecref spec="FO31" ref="func-encode-for-uri"/> and <xspecref spec="FO31" ref="func-iri-to-uri"/>.</p></note></div3>
+<xspecref spec="FO40" ref="func-encode-for-uri"/> and <xspecref spec="FO40" ref="func-iri-to-uri"/>.</p></note></div3>
 <div3 id="XHTML_INCLUDE-CONTENT-TYPE"><head>XHTML Output Method: the <code>include-content-type</code> Parameter</head><p>If the instance of the data model includes a <code>head</code> element
 <termref def="recognized-as-HTML">recognized as
 an HTML element</termref>,
@@ -2556,7 +2556,7 @@ the attribute solely for the purposes of comparison,
 <!-- End of changes for Bug 8651 (Erratum SE.E17) -->
 <rfc2119>MUST</rfc2119> be discarded. </p><note><p>This process removes possible parameters in the attribute value.  For example,</p>
 <eg xml:space="preserve">&lt;meta http-equiv="Content-Type" 
-      content="text/html;version='3.0'" /&gt;</eg>
+      content="text/html;version='4.0'" /&gt;</eg>
 <p>in the data model instance <phrase diff="chg" at="2023-02-09">might</phrase> be replaced by</p>
 <eg xml:space="preserve">&lt;meta http-equiv="Content-Type" 
       content="text/html;charset=utf-8" /&gt;</eg>
@@ -3153,7 +3153,7 @@ user agent. Even in the case of non-ASCII characters, escaping can
 sometimes cause problems. More precise control of <termref def="uri-escaping">URI escaping</termref> is
 therefore available by setting <code>escape-uri-attributes</code> to
 <code>no</code>, and controlling the escaping of URIs by using methods defined in
-<xspecref spec="FO31" ref="func-encode-for-uri"/> and <xspecref spec="FO31" ref="func-iri-to-uri"/>.</p></note></div3>
+<xspecref spec="FO40" ref="func-encode-for-uri"/> and <xspecref spec="FO40" ref="func-iri-to-uri"/>.</p></note></div3>
 <div3 id="HTML_INCLUDE-CONTENT-TYPE"><head>HTML Output Method: the <code>include-content-type</code> Parameter</head><p>If there is a <code>head</code> element,
 and the <code>include-content-type</code> parameter has 
 one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
@@ -3200,7 +3200,7 @@ the attribute solely for the purposes of comparison,
 <note><p>This process removes possible parameters in the
 attribute value.  For example,</p>
 <eg xml:space="preserve">&lt;meta http-equiv="Content-Type" 
-      content="text/html;version='3.0'"&gt;</eg>
+      content="text/html;version='4.0'"&gt;</eg>
   <p>in the data model instance <phrase diff="add" at="2023-02-09">might</phrase> be replaced by</p>
 <eg xml:space="preserve">&lt;meta http-equiv="Content-Type" 
       content="text/html;charset=utf-8"&gt;</eg>
@@ -3432,7 +3432,7 @@ The node is serialized with the serialization parameter <code>omit-xml-declarati
 
 </p></item>
 
-<item><p>An <xtermref spec="XP31" ref="dt-atomic-value">atomic
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic
 value</xtermref> in the data model instance with a numeric type, or
 derived from a numeric type <code>xs:float</code>, <code>xs:double</code> or <code>xs:decimal</code> is
 serialized to a JSON number.
@@ -3445,17 +3445,17 @@ raise a serialization error <!--* [err:SERE0020]. *-->
 <errorref code="0020" class="RE"/>.
 </p></item>
 
-<item><p>An <xtermref spec="XP31" ref="dt-atomic-value">atomic value</xtermref> 
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic value</xtermref> 
 in the data model instance
 of type <code>xs:boolean</code> and value <code>true</code>
 is serialized to the JSON token <code>true</code>.</p></item>
 
-<item><p>An <xtermref spec="XP31" ref="dt-atomic-value">atomic value</xtermref> 
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic value</xtermref> 
 in the data model instance
 of type <code>xs:boolean</code> and value <code>false</code> is
 serialized to the JSON token <code>false</code>.</p></item>
 
-<item><p>An <xtermref spec="XP31" ref="dt-atomic-value">atomic
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic
 value</xtermref> in the data model instance of any other type 
 is serialized <termref def="to-a-json-string">to a JSON string</termref> by outputting the 
 result of applying the <code>fn:string</code> function to the item.</p></item>
@@ -3717,7 +3717,7 @@ serialized as
 binding is not displayed.</p></note>
 </item>
 
-<item><p>An <xtermref spec="XP31" ref="dt-atomic-value">atomic
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic
 value</xtermref> is serialized as follows:</p>
 <ulist>
 <item><p>An instance of <code>xs:boolean</code> is serialized as <code>true()</code> or <code>false()</code>. </p></item>
@@ -3795,7 +3795,7 @@ described in <specref ref="text-output"/>.</p></item>
 
 <item><p>
 An <termref def="dt-array-item">array item</termref> is serialized using the syntax 
-of a <xspecref spec="XP31" ref="doc-xpath31-SquareArrayConstructor"/>, 
+of a <xspecref spec="XP40" ref="doc-xpath40-SquareArrayConstructor"/>, 
 that is as <code>[member,member, ... ]</code>. The members, which in general are sequences, 
 are serialized in the form <code>(item,item, ...)</code> where the items are serialized by 
 applying these rules recursively. The items are separated by commas 
@@ -3808,7 +3808,7 @@ to output parentheses around a singleton if this avoids buffering data in memory
 
 <item><p>
 A <termref def="dt-map-item">map item</termref> is serialized using the syntax of a 
-<xspecref spec="XP31" ref="doc-xpath31-MapConstructor"/>, that is as <code>map{key:value, key:value, ...}</code>.
+<xspecref spec="XP40" ref="doc-xpath40-MapConstructor"/>, that is as <code>map{key:value, key:value, ...}</code>.
 The order of entries is implementation-dependent. The key is serialized by applying the rules 
 for serializing an atomic value. The values are serialized in the same way as the members of an array (see above).
 </p></item>
@@ -3878,7 +3878,7 @@ generated text, then the serializer <rfc2119>MAY</rfc2119> include
 hyperlinks to provide additional information for example:</p>
 <ulist>
 <item><p>
-to allow the type of <xtermref spec="XP31" ref="dt-atomic-value">atomic values</xtermref>
+to allow the type of <xtermref spec="XP40" ref="dt-atomic-value">atomic values</xtermref>
 to be ascertained.
 </p></item>
 <item><p>
@@ -4063,8 +4063,8 @@ substituted is output "as is," and the <termref def="serializer">serializer</ter
 that the resulting document is well-formed. This mechanism can
 therefore be used to introduce arbitrary markup in the serialized
 output.
-See <xspecref spec="XT30" ref="character-maps"/>
-of <bibref ref="xslt-30"/> for examples of using character mapping in
+See <xspecref spec="XT40" ref="character-maps"/>
+of <bibref ref="xslt-40"/> for examples of using character mapping in
 XSLT.</p>
 <p>Character mapping is applied to the characters that actually appear
 in a text or attribute node or a string
@@ -4082,7 +4082,7 @@ parent elements are listed in the <code>cdata-section-elements</code>
 parameter,
 
 nor to characters for which output escaping has
-been disabled (disabling output escaping is an <bibref ref="xslt-30"/>
+been disabled (disabling output escaping is an <bibref ref="xslt-40"/>
 feature),
 
 nor to characters in attribute
@@ -4113,7 +4113,7 @@ of a <termref def="host-language">host language</termref>.
 A <term>host language</term> is another
 specification that includes, by reference, this specification and all of
 its requirements.  A host language might be a programming language
-such as <bibref ref="xslt-30"/> or <bibref ref="xquery-31"/>, or it
+such as <bibref ref="xslt-40"/> or <bibref ref="xquery-40"/>, or it
 might be an application programming interface (API) intended to be used by
 programs written in some other high-level programming language.  The use of
 the term <emph>language</emph> is not intended to preclude the possibility that
@@ -4301,9 +4301,9 @@ the mechanism described in <specref ref="serparams-in-xdm-instance"/>.</p>
   </olist>
 <!--<p>This appendix details the changes that have been made since the publication of
 the first public working draft of this version (3.1) of this specification
-(<bibref ref="serialization-31-fpwd"/>).  For differences between
+(<bibref ref="serialization-40-fpwd"/>).  For differences between
 that working draft and earlier versions of this specification, 
-see <loc href="http://www.w3.org/TR/xslt-xquery-serialization-31/#revision-log">the
+see <loc href="http://www.w3.org/TR/xslt-xquery-serialization-40/#revision-log">the
 Change Log</loc> in that draft.</p>
 
 <div2 id="id-changes-pr">
@@ -4760,7 +4760,7 @@ Draft.</p>
 </thead>
 <tbody>
 <tr>
-<td><loc href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=16311">Bugzilla bug 16311</loc></td>
+<td><loc href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=16401">Bugzilla bug 16311</loc></td>
 <td>None</td>
 <td>Substantive</td>
 <td>Added new serialization parameter for specifying a separator that is
@@ -5169,7 +5169,7 @@ to the serialization specification since the publication of the
 <bibref ref="serialization-10-2ed"/>.  All changes are of a minor nature.
 No change introduces an incompatibility, unless indicated below.
 Informally this means, unless indicated otherwise below, given a sequence
-that does not rely on any feature of <bibref ref="xpath-datamodel-31"/> that
+that does not rely on any feature of <bibref ref="xpath-datamodel-40"/> that
 was not available in <bibref ref="xpath-datamodel"/>, and a
 set of serialization parameters that does not include the
 <code>suppress-indentation</code> parameter, a serializer that conforms


### PR DESCRIPTION
1. Errors are raised, not signaled
2. Cross-references point to 4.0 specs rather than 3.0/3.1
3. Some internal markup changes for tidiness

Partial fix for #783 as it affects the serialization spec.