### PR TITLE
129 XSLT40 and SER40 changes for context item -> value

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -1049,6 +1049,10 @@
                         <p>Stylesheet authors wanting to write code that can be invoked using legacy
                            APIs should not rely on the caller being able to supply different values
                            for the <termref def="dt-initial-match-selection"/> and the <termref def="dt-global-context-item"/>.</p>
+                        <p diff="add" at="2023-10-30">In XPath 4.0, the concept of <termref def="dt-context-item"/>
+                        has been generalized and is now referred to as the <xtermref spec="XP40" ref="dt-context-value"/>.
+                        For XSLT 4.0, however, the <termref def="dt-global-context-item"/> is still constrained to be
+                        either a single item, or absent.</p>
                      </note>
                      
                      <p>The value given to the <termref def="dt-global-context-item"/>
@@ -1366,6 +1370,8 @@
                            template is evaluated with a <termref def="dt-singleton-focus"/> based on
                            this context item if it exists, or with an <termref def="dt-absent"/>
                            focus otherwise.</p>
+                     <note diff="add" at="2023-10-30"><p>The context item for evaluation of the named
+                     template must be either a single item or absent; it cannot be an arbitrary value.</p></note>
                   </item>
 
                   <item>
@@ -1922,11 +1928,18 @@
                complete, the dynamic context reverts to its previous state. An expression that
                accesses information from the dynamic context always uses the value at the top of the
                stack.</p>
-            <p>The most commonly used component of the dynamic context is the <termref def="dt-context-item">context item</termref>. This is an implicit variable whose
+            <p>The most commonly used component of the dynamic context is the <termref def="dt-context-item"/>. This is an implicit variable whose
                value is the item currently being processed (it may be a node, an atomic value,
                   or a function item). The value of the context
                item can be referenced within an XPath expression using the expression <code>.</code>
                (dot).</p>
+            <p diff="add" at="2023-10-30">XPath 4.0 generalizes the <termref def="dt-context-item"/> so it can be any value (not necessarily a single item),
+            and it is now known as the <xtermref spec="XP40" ref="dt-context-value"/>. In certain XPath expressions, the
+            value of the expression <code>.</code> can now be an arbitrary value, rather than a single item. However, there
+            is currently no construct in XSLT 4.0 that takes advantage of this; in the context supplied by XSLT to XPath
+            (except when using the <elcode>xsl:evaluate</elcode> instruction),
+            the context value is always either a single item, or absent. The XSLT specification therefore continues to refer
+            to the <termref def="dt-context-item"/> rather than the <xtermref spec="XP40" ref="dt-context-value"/>.</p>
             <p>Full details of the static and dynamic context are provided in <specref ref="static-and-dynamic-context"/>.</p>
          </div2>
          <div2 id="parsing-and-serialization">
@@ -9363,9 +9376,17 @@ and <code>version="1.0"</code> otherwise.</p>
                            static type</xtermref> may be determined by an XSLT processor that
                         performs static type inferencing, using rules that are outside the scope of
                         this specification; if no static type inferencing is done, then the context
-                        item static type for every XPath expression is <code>item()</code>. Note that some limited static type inferencing is
+                        value static type for every XPath expression is <code>item()</code>.</p>
+                        
+                        <note diff="add" at="2023-10-30"><p>Although XPath 4.0 allows the context value to be an arbitrary sequence,
+                        at the interface between XSLT 4.0 and XPath 4.0 it is always either a single item,
+                        or absent. The only exception to this is when an XPath 4.0 expression is evaluated
+                        using <elcode>xsl:evaluate</elcode>, in which case the <xtermref spec="XP40" ref="dt-context-value"/>
+                        may be supplied as an arbitrary sequence.</p></note>
+                        
+                        <note><p>Note that some limited static type inferencing is
                            required in the case of a processor that performs streamability analysis:
-                           see <specref ref="determining-static-type"/>.</p>
+                           see <specref ref="determining-static-type"/>.</p></note>
                   </item>
                   <item>
                      <p>The <xtermref spec="XP40" ref="dt-statically-known-function-definitions">statically known
@@ -9755,6 +9776,10 @@ and <code>version="1.0"</code> otherwise.</p>
                               that item is being processed.</termdef> The context item is returned
                            by the XPath <termref def="dt-expression">expression</termref>
                            <code>.</code> (dot).</p>
+                        <note diff="add" at="2023-10-30"><p>Although XPath 4.0 allows the context value to be an arbitrary sequence,
+                           at the interface between XSLT 4.0 and XPath 4.0 it is always either a single item,
+                           or absent. XSLT 4.0 therefore continues to use the term <termref def="dt-context-item"/>
+                        rather than <xtermref spec="XP40" ref="dt-context-value"/>.</p></note>
                      </item>
                      <item>
                         <p><termdef id="dt-context-position" term="context position">The
@@ -9795,12 +9820,12 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>Where the containing element of an XPath expression is an <termref def="dt-instruction">instruction</termref> or a <termref def="dt-literal-result-element">literal result element</termref>, the
                      initial context item, context position, and context size for the XPath <termref def="dt-expression">expression</termref> are the same as the <termref def="dt-context-item">context item</termref>, <termref def="dt-context-position">context position</termref>, and <termref def="dt-context-size">context size</termref> for the evaluation of the
                      containing instruction or literal result element.</p>
-                  <p>The context item for evaluating global
+                  <p>The <xtermref spec="XP40" ref="dt-context-value"/> for evaluating global
                         variables <phrase diff="add" at="2022-01-01">declared</phrase>
                      in the <termref def="dt-top-level-package"/> is set to the <termref def="dt-global-context-item"/>
                         supplied when the transformation is invoked (see <specref ref="initiating"/>).
                      <phrase diff="add" at="2022-01-01">For global variables declared in a </phrase> <termref def="dt-library-package">library
-                           package</termref>, the context item <phrase diff="del" at="2022-01-01">for evaluating global variables</phrase> is
+                           package</termref>, the context value <phrase diff="del" at="2022-01-01">for evaluating global variables</phrase> is
                      <termref def="dt-absent"/>. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E7, bug 30179].</phrase></p>
                   <p>For an XPath expression contained in a <termref def="dt-value-template"/>, the initial context item, context position, and
                      context size for the XPath <termref def="dt-expression">expression</termref>
@@ -14342,14 +14367,14 @@ and <code>version="1.0"</code> otherwise.</p>
             <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
             elements of an input array to a sequence of items, each item being a map having a single entry, whose
             key is the string <code>value</code> and whose corresponding value is the relevant element of the
-            array. Within the contained sequence constructor, the current array element can be refered to
+            array. Within the contained sequence constructor, the current array element can be referred to
             as <code>?value</code>.</p>
             <p diff="del" at="2022-11-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
                <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
-               can be refered to as <code>?key</code> and <code>?value</code> respectively.</p>
+               can be referred to as <code>?key</code> and <code>?value</code> respectively.</p>
             <p>The <elcode>xsl:for-each</elcode> instruction processes each  in a sequence of
                items, evaluating the <termref def="dt-sequence-constructor">sequence
                   constructor</termref> within the <elcode>xsl:for-each</elcode> instruction once
@@ -14548,14 +14573,14 @@ and <code>version="1.0"</code> otherwise.</p>
                <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
                elements of an input array to a sequence of items, each item being a map having a single entry, whose
                key is the string <code>value</code> and whose corresponding value is the relevant element of the
-               array. Within the contained sequence constructor, the current array element can be refered to
+               array. Within the contained sequence constructor, the current array element can be referred to
                as <code>?value</code>.</p>
             <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
                <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
-               can be refered to as <code>?key</code> and <code>?value</code> respectively.</p>
+               can be referred to as <code>?key</code> and <code>?value</code> respectively.</p>
             
             
             <p>The <code>select</code> attribute contains an
@@ -18009,6 +18034,9 @@ and <code>version="1.0"</code> otherwise.</p>
                   the context item if the same template is invoked using
                      <elcode>xsl:apply-templates</elcode>, <elcode>xsl:apply-imports</elcode>, or
                      <elcode>xsl:next-match</elcode>. </p>
+               
+               <note diff="add" at="2023-10-30"><p>The context item for a template must be either a single
+               item, or absent. It cannot be an arbitrary value.</p></note>
 
 
                <?element xsl:context-item?>
@@ -19542,20 +19570,23 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>The dynamic context for evaluation of the target expression is
                   as follows:</p>
                <ulist>
-                  <item>
-                     <p>The context item, position, and size depend on the result of evaluating the
+                  <item diff="chg" at="2023-10-30">
+                     <p>The <xtermref spec="XP40" ref="dt-context-value"/> depends on the result of evaluating the
                         expression in the <code>context-item</code> attribute. If this attribute is
-                        absent, or if the result is an empty sequence, then the context item,
-                        position, and size for evaluation of the target expression are all <termref def="dt-absent"/>. If the result of evaluating the
-                           <code>context-item</code> expression is a single item, then the target
-                        expression is evaluated with a <termref def="dt-singleton-focus"/> based on
-                        this item.</p>
-                     <p><error spec="XT" type="type" class="TE" code="3210">
+                        absent then the context value,
+                        position, and size for evaluation of the target expression are all <termref def="dt-absent"/>. 
+                        If the attribute is present then the result of evaluating the expression
+                        is used as the <xtermref spec="XP40" ref="dt-context-value"/>, and the <termref def="dt-context-position"/>
+                        and <termref def="dt-context-size"/> are both set to 1 (one).</p>
+                     <p diff="del" at="2023-10-30"><error spec="XT" type="type" class="TE" code="3210">
                            <p>If the result of evaluating the <code>context-item</code> expression
                                  <error.extra>of an <elcode>xsl:evaluate</elcode>
                                  instruction</error.extra> is a sequence containing more than one
                               item, then a <termref def="dt-type-error"/> is signaled.</p>
                         </error></p>
+                     <note><p>The attribute name <code>context-item</code> is a misnomer; it reflects the fact
+                     that in XSLT 3.0, the supplied expression was required to return a single item, rather than
+                     an arbitrary sequence.</p></note>
                   </item>
                   <item>
                      <p>The <term>variable values</term> consists of the values
@@ -19622,9 +19653,9 @@ and <code>version="1.0"</code> otherwise.</p>
             <div3 id="evaluation-as-optional-feature">
                <head><elcode>xsl:evaluate</elcode> as an optional feature</head>
 
-               <p>The <elcode>xsl:evaluate</elcode> instruction is newly introduced in XSLT 3.0. It
+               <p>The <elcode>xsl:evaluate</elcode> instruction was first introduced in XSLT 3.0. It
                   is part of the dynamic evaluation feature, which is an optional feature of the
-                  specification (see <specref ref="dynamic-evaluation-feature"/>). An XSLT 3.0
+                  specification (see <specref ref="dynamic-evaluation-feature"/>). An XSLT 4.0
                   processor <rfc2119>may</rfc2119> disable the feature, or allow users to disable
                   the feature. The processor <rfc2119>may</rfc2119> be able to determine during
                   static analysis whether or not the feature is available, or it
@@ -22895,14 +22926,14 @@ for $i in 1 to count($V) return
                <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
                elements of an input array to a sequence of items, each item being a map having a single entry, whose
                key is the string <code>value</code> and whose corresponding value is the relevant element of the
-               array. Within the contained sequence constructor, the current array element can be refered to
+               array. Within the contained sequence constructor, the current array element can be referred to
                as <code>?value</code>.</p>
             <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
                <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
-               can be refered to as <code>?key</code> and <code>?value</code> respectively.</p>
+               can be referred to as <code>?key</code> and <code>?value</code> respectively.</p>
             
             
             <p>The <code>select</code> attribute contains an

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -877,7 +877,7 @@ or equivalently the XSLT instructions
                         /data(@value)"/>
 </xsl:sequence>
 ]]></eg>
-<p>with the supplied instance of the data model as the context item, the 
+<p>with the supplied instance of the data model as the <phrase diff="chg" at="2023-10-30">context value</phrase>, the 
 <code>param-name</code> variable 
 <phrase>bound to</phrase> 
 a value of type
@@ -967,7 +967,7 @@ in-scope schema components
 <tr><td>In-scope variables</td>
 <td>Both</td>
 <td>{param-name}</td></tr>
-<tr><td>Context item static type</td>
+  <tr><td><phrase diff="chg" at="2023-10-30">Context value</phrase> static type</td>
 <td>Both</td>
 <td><code>node()</code></td></tr>
 <tr><td>Statically known
@@ -2142,7 +2142,7 @@ element.</termdef></p>
 The process of <termref def="PREFIXNORMALIZATION">prefix normalization</termref>
 is equivalent to replacing the instance of the data model that is to be
 serialized with the result of the transformation described by this XSLT
-stylesheet, with the instance of the data model as the initial context item.
+stylesheet, with the instance of the data model as the initial <phrase diff="chg" at="2023-10-30">context value</phrase>.
 </p>
 <eg><![CDATA[
 <xsl:stylesheet


### PR DESCRIPTION
Proposes XSLT 4.0 and Serialization 4.0 changes resulting from the generalization of context item to context value in XPath 4.0.

The serialization changes are purely editorial.

In XSLT, we acknowledge the introduction of the context value in XPath but don't take advantage of it; at the XSLT level, the context value for an instruction is still always a single item. The only technical change is that we allow xsl:evaluate to pass any value as the context value to the dynamically evaluated expression (while retaining the name of the relevant attribute "context-item").

Fulfils action QT4CG-046-01