### PR TITLE
238: First draft of an fn:invisible-xml function

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28542,17 +28542,20 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Create an Invisible XML parser for a grammar.</p>
+         <p>Creates an Invisible XML parser for a grammar.</p>
       </fos:summary>
       <fos:rules>
-         <p>Conceptually, an Invisible XML processor takes two
-         arguments: a grammar, a description of a some input, and an
-         input string. It returns an XML representation of the input
-         string as parsed by the provided grammar. (If parsing fails,
-         it returns an XML representation that signals the error.)</p>
+         <p>Conceptually, an <bibref ref="invisible-xml"/> processor
+         takes two arguments: a grammar and an input string. The grammar
+         is a description of some format and the parser will attempt to
+         interpret the input string according to that description. The parser
+         returns an XML representation of the input string as parsed
+         by the provided grammar. If parsing fails, it returns an XML
+         representation that indicates an error occurred and may
+         provide additional error information.</p>
 
-         <p>For example, the following grammar says that a date consists
-         of a year, month, and day. Each are a sequence of digits and they are
+         <p>For example, the following grammar describes a date as consisting
+         of a year, a month, and a day. Each are a sequence of digits and they are
          separated by hyphens:</p>
 
          <eg> date = year, -'-', month, -'-', day .
@@ -28575,9 +28578,9 @@ month = '0', d | '1', ['0'|'1'|'2'] .
    <permitted>'3', ['0'; '1'; '2']</permitted>
 </fail>]]></eg>
 
-         <p>(The exact format of the error output will vary between implementations.
+         <p>The exact format of the error output will vary between implementations.
          The only required part of the output is the <code>ixml:state</code> attribute
-         that contains the value <code>failed</code>.)</p>
+         that contains the value <code>failed</code>.</p>
 
          <note><p>Careful readers will observe that the example grammar
          will parse “2023-00-00” as a date. The grammar could easily be extended to
@@ -28585,7 +28588,7 @@ month = '0', d | '1', ['0'|'1'|'2'] .
          an illustrative example.</p></note>
 
          <p>The <code>fn:invisible-xml</code> function takes a grammar and
-         returns a function that can be used to parse the input. In practice,
+         returns a function that can be used to parse input strings. In practice,
          constructing a parser from a grammar may be an expensive operation.
          Returning a parsing function makes it easy to efficiently reuse
          a parser.</p>
@@ -28594,36 +28597,34 @@ month = '0', d | '1', ['0'|'1'|'2'] .
 
          <fos:options>
             <fos:option key="fail-on-error">
-               <fos:meaning>Signal an error if the parse function fails</fos:meaning>
+               <fos:meaning>Raise an error if the parse function fails</fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
             </fos:option>
          </fos:options>
 
          <p>Additional, <termref def="implementation-defined"
-         >implementation-defined</termref> options may be available. (For example, to control
+         >implementation-defined</termref> options may be available, for example, to control
          aspects of the XML serialization, to specify the grammar start symbol,
-         or to produce output formats other than XML.)</p>
+         or to produce output formats other than XML.</p>
 
-         <p>If the <code>grammar</code> is the empty sequence, a parser is returned
-         for the Invisible XML specification grammar. If the <code>grammar</code> is not
+         <p>If <code>$grammar</code> is the empty sequence, a parser is returned
+         for the Invisible XML specification grammar. If <code>$grammar</code> is not
          empty, it <rfc2119>must</rfc2119> be a valid Invisible XML grammar.
-         If it is not, <code>fn:invisible-xml</code> signals
+         If it is not, <code>fn:invisible-xml</code> raises
          <code>err:FOIX0001</code>.</p>
 
          <p>If the <code>fail-on-error</code> option is
-         <code>true()</code>, the parsing function will signal
-         <code>err:FOIX0002</code> if the input provide cannot be
-         parsed. Otherwise, it returns an XML representation of the
-         error as described by <bibref ref="invisible-xml"/>.</p>
+         <code>true()</code>, the parsing function will raise
+         <code>err:FOIX0002</code> if the input provided cannot be
+         parsed successfully. Otherwise, it returns an XML representation of the
+         error as described by the <bibref ref="invisible-xml"/> specification.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>invisible-xml("S=A. A='a'.")("a")</eg></fos:expression>
-               <fos:result><eg><![CDATA[<S>
-  <A>a</A>
-</S>]]></eg></fos:result>
+               <fos:result><eg><![CDATA[<S><A>a</A></S>]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -28635,7 +28636,7 @@ return $p("b")</eg></fos:expression>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $p := invisible-xml("S=A. A='a'.")
+               <fos:expression><eg>let $p := invisible-xml("S=A. A='a'.",
                         map { "fail-on-error": true() })
 return $p("b")</eg></fos:expression>
                <fos:error-result error-code="FOIX0002"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28528,5 +28528,123 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:version version="4.0">Proposed for 4.0</fos:version>
       </fos:history>
    </fos:function>
+
+   <fos:function name="invisible-xml" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="invisible-xml" return-type="function(xs:string) as item()">
+            <fos:arg name="grammar" type="item()?" default="()"/>
+            <fos:arg name="options" type="map(*)" default="map{}"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Create an Invisible XML parser for a grammar.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>Conceptually, an Invisible XML processor takes two
+         arguments: a grammar, a description of a some input, and an
+         input string. It returns an XML representation of the input
+         string as parsed by the provided grammar. (If parsing fails,
+         it returns an XML representation that signals the error.)</p>
+
+         <p>For example, the following grammar says that a date consists
+         of a year, month, and day. Each are a sequence of digits and they are
+         separated by hyphens:</p>
+
+         <eg> date = year, -'-', month, -'-', day .
+ year = d, d, d, d .
+month = '0', d | '1', ['0'|'1'|'2'] .
+  day = ['0'|'1'|'2'], d | '3', ['0'|'1'] .
+   -d = ['0'-'9'] .</eg>
+
+         <p>Using this grammar to parse “2023-10-31” will produce:</p>
+
+         <eg><![CDATA[<date><year>2023</year><month>10</month><day>31</day></date>]]></eg>
+
+         <p>Using this grammar to parse “2023-10-32” will produce something like this:</p>
+
+         <eg><![CDATA[<fail xmlns:ixml='http://invisiblexml.org/NS' ixml:state='failed'>
+   <line>1</line>
+   <column>10</column>
+   <pos>9</pos>
+   <unexpected>3</unexpected>
+   <permitted>'3', ['0'; '1'; '2']</permitted>
+</fail>]]></eg>
+
+         <p>(The exact format of the error output will vary between implementations.
+         The only required part of the output is the <code>ixml:state</code> attribute
+         that contains the value <code>failed</code>.)</p>
+
+         <note><p>Careful readers will observe that the example grammar
+         will parse “2023-00-00” as a date. The grammar could easily be extended to
+         exclude the “00” forms for month and day, but this is only intended to be
+         an illustrative example.</p></note>
+
+         <p>The <code>fn:invisible-xml</code> function takes a grammar and
+         returns a function that can be used to parse the input. In practice,
+         constructing a parser from a grammar may be an expensive operation.
+         Returning a parsing function makes it easy to efficiently reuse
+         a parser.</p>
+
+         <p>The following options are available:</p>
+
+         <fos:options>
+            <fos:option key="fail-on-error">
+               <fos:meaning>Signal an error if the parse function fails</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+            </fos:option>
+         </fos:options>
+
+         <p>Additional, <termref def="implementation-defined"
+         >implementation-defined</termref> may be available. (For example, to control
+         aspects of the XML serialization, to specify the grammar start symbol,
+         or to produce output formats other than XML.)</p>
+
+         <p>If the <code>grammar</code> is the empty sequence, a parser is returned
+         for the Invisible XML specification grammar. If the <code>grammar</code> is not
+         empty, it <rfc2119>must</rfc2119> be a valid Invisible XML grammar.
+         If it is not, <code>fn:invisible-xml</code> signals
+         <code>err:FOIX0001</code>.</p>
+
+         <p>If the <code>fail-on-error</code> option is
+         <code>true()</code>, the parsing function will signal
+         <code>err:FOIX0002</code> if the input provide cannot be
+         parsed. Otherwise, it returns an XML representation of the
+         error as described by <bibref ref="invisible-xml"/>.</p>
+      </fos:rules>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>invisible-xml("S=A. A='a'.")("a")</eg></fos:expression>
+               <fos:result><eg><![CDATA[<S>
+  <A>a</A>
+</S>]]></eg></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>let $p := invisible-xml("S=A. A='a'.")
+return $p("b")</eg></fos:expression>
+               <fos:result>A “failed” XML document.</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>let $p := invisible-xml("S=A. A='a'.")
+                        map { "fail-on-error": true() })
+return $p("b")</eg></fos:expression>
+               <fos:error-result error-code="FOIX0002"/>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0</fos:version>
+      </fos:history>
+   </fos:function>
    
 </fos:functions>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28601,7 +28601,7 @@ month = '0', d | '1', ['0'|'1'|'2'] .
          </fos:options>
 
          <p>Additional, <termref def="implementation-defined"
-         >implementation-defined</termref> may be available. (For example, to control
+         >implementation-defined</termref> options may be available. (For example, to control
          aspects of the XML serialization, to specify the grammar start symbol,
          or to produce output formats other than XML.)</p>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3277,15 +3277,6 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                <head><?function fn:replace-with?></head>
             </div3>-->
          </div2>
-
-         <div2 id="string.ixml">
-            <head>String functions that use Invisible XML</head>
-            <p>The <code>fn:invisible-xml</code> function adds support for
-            <bibref ref="invisible-xml"/> parsing.</p>
-            <div3 id="func-invisible-xml">
-               <head><?function fn:invisible-xml?></head>
-            </div3>
-         </div2>
       </div1>
       <div1 id="anyURI-functions">
          <head>Functions that manipulate URIs</head>
@@ -5783,6 +5774,16 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <head><?function fn:csv-fetch-field-by-column?></head>
             </div3>
          </div2>
+
+         <div2 id="ixml-functions">
+            <head>Functions on Invisible XML</head>
+            <p>The <code>fn:invisible-xml</code> function adds support for
+            <bibref ref="invisible-xml"/> parsing.</p>
+            <div3 id="func-invisible-xml">
+               <head><?function fn:invisible-xml?></head>
+            </div3>
+         </div2>
+
          <div2 id="json">
             <head>Conversion to and from JSON</head>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3277,6 +3277,15 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                <head><?function fn:replace-with?></head>
             </div3>-->
          </div2>
+
+         <div2 id="string.ixml">
+            <head>String functions that use Invisible XML</head>
+            <p>The <code>fn:invisible-xml</code> function adds support for
+            <bibref ref="invisible-xml"/> parsing.</p>
+            <div3 id="func-invisible-xml">
+               <head><?function fn:invisible-xml?></head>
+            </div3>
+         </div2>
       </div1>
       <div1 id="anyURI-functions">
          <head>Functions that manipulate URIs</head>
@@ -10781,6 +10790,16 @@ currently, Version 9.0.0.
                </bibl>
                <bibl id="xmlschema11-2"      key="Schema 1.1 Part 2"/>
                <bibl  id="xml-names" key="Namespaces in XML"/> 
+
+               <bibl id="invisible-xml" key="Invisible XML">
+                  <titleref href="https://invisiblexml.org/1.0/"
+                     >Invisible XML Specification</titleref>,
+                  Steven Pemberton, editor.
+                  World Wide Web Consortium,
+                  20 June 2020.
+                  This version is https://invisiblexml.org/1.0/.
+                  The <loc href="https://invisiblexml.org/current/">latest version</loc>
+                  is available at https://invisiblexml.org/current/.</bibl>
             </blist>
          </div2>
          


### PR DESCRIPTION
Pursuant to action QT4CG-051-02, here is a proposal for `fn:invisible-xml`.

There are a number of different design choices that could be made. For example, one could argue that a function of the form `fn:invisible-xml($grammar as xs:anyURI, $input as xs:anyURI)` would be the easiest thing for users in many cases. But not in all cases. You might want versions where either the grammar or the input were strings instead of URIs.

I've attempted to craft the smallest proposal that could get the job done.

