### PR TITLE
783 XSLT: errors are raised

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -460,7 +460,7 @@
                detailed rules in <specref ref="conformance"/>. </p>
             <p>Where the phrase <rfc2119>must</rfc2119>, <rfc2119>must not</rfc2119>, or
                   <rfc2119>required</rfc2119> relates to a stylesheet then the processor
-                  <rfc2119>must</rfc2119> enforce this constraint on stylesheets by reporting an
+                  <rfc2119>must</rfc2119> enforce this constraint on stylesheets by raising an
                error if the constraint is not satisfied.</p>
             <p>Where the phrase <rfc2119>should</rfc2119>, <rfc2119>should not</rfc2119>, or
                   <rfc2119>recommended</rfc2119> relates to a stylesheet then a processor
@@ -499,7 +499,7 @@
                         then</phrase> Arrays (see <specref ref="arrays"/>) are atomized by atomizing their
                         members, recursively.</termdef> For some items (for example, elements with element-only
                      content, function items, and maps, atomization
-                     generates a <termref def="dt-dynamic-error">dynamic error</termref>.</p>
+                     raises a <termref def="dt-dynamic-error">dynamic error</termref>.</p>
                </item>
                <item>
                   <p>
@@ -878,7 +878,7 @@
                            is permitted, is a value that is not one of the permitted values for that
                            attribute. If the processor is able to detect the error statically (for
                            example, when any XPath expressions within the curly brackets can be
-                           evaluated statically), then the processor may optionally signal this as a
+                           evaluated statically), then the processor may optionally raise this as a
                            static error.</p>
                      </error>
                   </p>
@@ -1973,7 +1973,7 @@
                because the user is executing the transformation in a way that does not invoke
                serialization, then the content of the <elcode>xsl:output</elcode> and
                   <elcode>xsl:character-map</elcode> declarations has no effect. Under these
-               circumstances the processor <rfc2119>may</rfc2119> report any errors in an
+               circumstances the processor <rfc2119>may</rfc2119> raise any errors in an
                   <elcode>xsl:output</elcode> or <elcode>xsl:character-map</elcode> declaration, or
                in the serialization attributes of <elcode>xsl:result-document</elcode>, but is not
                   <rfc2119>required</rfc2119> to do so.</p>
@@ -2215,7 +2215,7 @@
                situation:</p>
             <olist>
                <item>
-                  <p>The processor may signal a <termref def="dt-dynamic-error"> dynamic error</termref> if a source
+                  <p>The processor may raise a <termref def="dt-dynamic-error"> dynamic error</termref> if a source
                      document is found to contain a <termref def="dt-type-annotation"/> that is not
                      known to the processor.</p>
                </item>
@@ -2249,7 +2249,7 @@
                errors that would otherwise not be discovered until the transformation is actually
                executed. An XSLT processor is not <rfc2119>required</rfc2119> to perform such static
                type-checking. Under some circumstances (see <specref ref="errors"/>) type errors
-               that are detected early <rfc2119>may</rfc2119> be reported as static errors. In
+               that are detected early <rfc2119>may</rfc2119> be raised as static errors. In
                addition an implementation <rfc2119>may</rfc2119> report any condition found during
                static analysis as a warning, provided that this does not prevent the stylesheet
                being evaluated as described by this specification.</p>
@@ -2662,7 +2662,7 @@
             </p>
             <p>When a <termref def="dt-dynamic-error"/> occurs, and is not caught
                using <elcode>xsl:catch</elcode>, the <termref def="dt-processor">processor</termref>
-               <rfc2119>must</rfc2119> signal the error, and the transformation fails.</p>
+               <rfc2119>must</rfc2119> raise the error, and the transformation fails.</p>
             
             
 
@@ -2679,34 +2679,34 @@
                   <termref def="dt-variable">variable</termref> is declared but never referenced, an
                implementation <rfc2119>may</rfc2119> choose whether or not to evaluate the variable
                declaration, which means that if evaluating the variable declaration causes a dynamic
-               error, some implementations will signal this error and others will not.</p>
+               error, some implementations will raise this error and others will not.</p>
             <p>There are some cases where this specification requires that a construct <rfc2119>must
                   not</rfc2119> be evaluated: for example, the content of an <elcode>xsl:if</elcode>
                instruction <rfc2119>must not</rfc2119> be evaluated if the test condition is false.
-               This means that an implementation <rfc2119>must not</rfc2119> signal any dynamic
+               This means that an implementation <rfc2119>must not</rfc2119> raise any dynamic
                errors that would arise if the construct were evaluated.</p>
-            <p>An implementation <rfc2119>may</rfc2119> signal a <termref def="dt-dynamic-error">dynamic error</termref> before any source document is available, but only if it
-               can determine that the error would be signaled for every possible source document and
+            <p>An implementation <rfc2119>may</rfc2119> raise a <termref def="dt-dynamic-error">dynamic error</termref> before any source document is available, but only if it
+               can determine that the error would be raised for every possible source document and
                every possible set of parameter values. For example, some <termref def="dt-circularity">circularity</termref> errors fall into this category: see
                   <specref ref="circularity"/>.</p>
             <p>There are also some <termref def="dt-dynamic-error">dynamic
-                  errors</termref> where the specification gives a processor license to signal the
+                  errors</termref> where the specification gives a processor license to raise the
                error during the analysis phase even if the construct might never be executed; an
                example is the use of an invalid QName as a literal argument to a function such as
                   <function>key</function>, or the use of an invalid regular expression in the
                   <code>regex</code> attribute of the <elcode>xsl:analyze-string</elcode>
                instruction.</p>
             <p>A <termref def="dt-dynamic-error"/>
-               is also signaled during the static
+               is also raised during the static
                analysis phase if the error occurs during evaluation of a <termref def="dt-static-expression"/>.</p>
             <p>The XPath specification states (see <xspecref spec="XP40" ref="id-kinds-of-errors"/>)
                that if any expression (at any level) can be evaluated during the analysis phase
                (because all its explicit operands are known and it has no dependencies on the
                dynamic context), then any error in performing this evaluation <rfc2119>may</rfc2119>
-               be reported as a static error. For XPath expressions used in an XSLT stylesheet,
-               however, any such errors <rfc2119>must not</rfc2119> be reported as static errors in
+               be raised as a static error. For XPath expressions used in an XSLT stylesheet,
+               however, any such errors <rfc2119>must not</rfc2119> be raised as static errors in
                the stylesheet unless they would occur in every possible evaluation of that
-               stylesheet; instead, they must be signaled as dynamic errors, and signaled only if
+               stylesheet; instead, they must be raised as dynamic errors, and raised only if
                the XPath expression is actually evaluated.</p>
             <example>
                <head>Errors in Constant Subexpressions</head>
@@ -2733,23 +2733,23 @@
                   to an operation is of the wrong type for that operation, for example when an
                   integer is supplied to an operation that expects a node.</termdef> If a type error
                occurs in an instruction that is actually evaluated, then it <rfc2119>must</rfc2119>
-               be signaled in the same way as a <termref def="dt-dynamic-error"> dynamic error</termref>. Alternatively, an
-               implementation <rfc2119>may</rfc2119> signal a type error during the analysis phase
+               be raised in the same way as a <termref def="dt-dynamic-error"> dynamic error</termref>. Alternatively, an
+               implementation <rfc2119>may</rfc2119> raise a type error during the analysis phase
                in the same way as a <termref def="dt-static-error">static error</termref>, even if
                it occurs in part of the stylesheet that is never evaluated, provided it can
                establish that execution of a particular construct would never succeed.</p>
-            <p>It is <termref def="dt-implementation-defined"/> whether type errors are signaled
+            <p>It is <termref def="dt-implementation-defined"/> whether type errors are raised
                statically.</p>
-            <imp-def-feature id="idf-err-statictypechecking">It is <termref def="dt-implementation-defined"/> whether type errors are signaled
+            <imp-def-feature id="idf-err-statictypechecking">It is <termref def="dt-implementation-defined"/> whether type errors are raised
                statically.</imp-def-feature>
             <example>
                <head>A Type Error</head>
                <p>The following construct contains a type error, because
                      <code>42</code> is not allowed as the value of the <code>select</code>
                   expression of the <elcode>xsl:number</elcode> instruction (it must be a node). An
-                  implementation <rfc2119>may</rfc2119> optionally signal this as a static error,
+                  implementation <rfc2119>may</rfc2119> optionally raise this as a static error,
                   even though the offending instruction will never be evaluated, and the type error
-                  would therefore never be signaled as a dynamic error.</p>
+                  would therefore never be raised as a dynamic error.</p>
                <eg role="error" xml:space="preserve">&lt;xsl:if test="false()"&gt;
   &lt;xsl:number select="42"/&gt;
 &lt;/xsl:if&gt;</eg>
@@ -2763,12 +2763,12 @@
 &lt;/xsl:template&gt;</eg>
             </example>
             <p>If more than one error arises, an implementation is not <rfc2119>required</rfc2119>
-               to signal any errors other than the first one that it detects. It is <termref def="dt-implementation-dependent">implementation-dependent</termref> which of the
-               several errors is signaled. This applies both to static errors and to dynamic errors.
-               An implementation is allowed to signal more than one error, but if any errors have
-               been signaled, it <rfc2119>must not</rfc2119> finish as if the transformation were
+               to raise any errors other than the first one that it detects. It is <termref def="dt-implementation-dependent">implementation-dependent</termref> which of the
+               several errors is raised. This applies both to static errors and to dynamic errors.
+               An implementation is allowed to raise more than one error, but if any errors have
+               been raised, it <rfc2119>must not</rfc2119> finish as if the transformation were
                successful.</p>
-            <p>When a transformation signals one or more dynamic errors, the final state of any
+            <p>When a transformation raises one or more dynamic errors, the final state of any
                persistent resources updated by the transformation is <termref def="dt-implementation-dependent">implementation-dependent</termref>.
                Implementations are not <rfc2119>required</rfc2119> to restore such resources to
                their initial state. In particular, where a transformation produces multiple result
@@ -2786,7 +2786,7 @@
                   serialize the result  using the
                   encoding selected by the user. Such an error is referred to as a
                      <term>serialization error</term>.</termdef> If the processor performs
-               serialization, then it <rfc2119>must</rfc2119> do so as specified in <specref ref="serialization"/>, and in particular it <rfc2119>must</rfc2119> signal any
+               serialization, then it <rfc2119>must</rfc2119> do so as specified in <specref ref="serialization"/>, and in particular it <rfc2119>must</rfc2119> raise any
                serialization errors that occur.</p>
             <p>Errors are identified by a QName. For errors defined in this specification, the
                namespace of the QName is always <code>http://www.w3.org/2005/xqt-errors</code> (and
@@ -2796,7 +2796,7 @@
                (dynamic error),  or <code>TE</code>
                (type error). Note that the allocation of an error to one of these categories is
                purely for convenience and carries no normative implications about the way the error
-               is handled. Many errors, for example, can be reported either dynamically or
+               is handled. Many errors, for example, can be raised either dynamically or
                statically. These error codes are used to label error conditions in this
                specification, and are summarized in <specref ref="error-summary"/>. </p>
             <p>Errors defined in related specifications (<bibref ref="xpath-40"/>, <bibref ref="xpath-functions-40"/>
@@ -2805,7 +2805,7 @@
                processor <rfc2119>should</rfc2119> use the original error code reported by the XPath
                processor, unless a more specific XSLT error code is available.</p>
             <p>Implementations <rfc2119>must</rfc2119> use the codes
-               defined in these specifications when signaling dynamic errors, to ensure that
+               defined in these specifications when raising dynamic errors, to ensure that
                      <elcode>xsl:catch</elcode> behaves in an interoperable way across
                   implementations. Stylesheet authors should note, however, that there are many
                   examples of errors where more than one rule in this specification is violated, and
@@ -2885,7 +2885,7 @@
                   results
                 that a conformant XSLT 4.0
                processor might produce. They <rfc2119>must not</rfc2119> cause the processor to fail
-               to signal an error that a conformant processor is required to signal. This means that
+               to raise an error that a conformant processor is required to raise. This means that
                an extension attribute <rfc2119>must not</rfc2119> change the effect of any <termref def="dt-instruction">instruction</termref> except to the extent that the effect is
                   <termref def="dt-implementation-defined">implementation-defined</termref> or
                   <termref def="dt-implementation-dependent">implementation-dependent</termref>.</p>
@@ -5196,7 +5196,7 @@
                               <code>xsl:original</code>, there will always be exactly one non-hidden
                            component <var>D/P</var> whose containing package is <var>P</var> and
                            whose <termref def="dt-symbolic-identifier"/> matches <var>D</var>
-                           (otherwise a static error will have been reported). The reference is then
+                           (otherwise a static error will have been raised). The reference is then
                            bound to <var>D/P</var>.</p>
                      </item>
                      <item>
@@ -5731,7 +5731,7 @@
                <p>The global context item is available only within the <termref def="dt-top-level-package"/>. If a valid <elcode>xsl:global-context-item</elcode>
                   declaration appears within a <termref def="dt-library-package"/>, then it is
                   ignored, unless it specifies <code>use="required"</code>, in which case an error
-                  is signaled: <errorref spec="XT" class="TE" code="0590"/>.</p>
+                  is raised: <errorref spec="XT" class="TE" code="0590"/>.</p>
                
 
                <note>
@@ -5753,7 +5753,7 @@
 
 
 
-               <p>A <termref def="dt-type-error"/> is signaled if 
+               <p>A <termref def="dt-type-error"/> is raised if 
                   <phrase diff="chg" at="2022-01-01">the <termref def="dt-top-level-package"/> contains</phrase>
                   an <elcode>xsl:global-context-item</elcode>
                   declaration specifying a required type that does not match the supplied <termref def="dt-global-context-item"/>. The error code is the same as for
@@ -6394,7 +6394,7 @@ The processor <rfc2119>must</rfc2119> then process the stylesheet
 using the rules for <termref def="dt-backwards-compatible-behavior"/>.
 These rules require that if the processor does not support 
 <termref def="dt-backwards-compatible-behavior"/>, it <rfc2119>must</rfc2119>
-signal an error and <rfc2119>must not</rfc2119> execute the transformation.</p>
+raise an error and <rfc2119>must not</rfc2119> execute the transformation.</p>
             <p>When the value of the <code>version</code> attribute is greater than <phrase diff="chg" at="2022-01-01">3.0</phrase>, 
 <termref def="dt-forwards-compatible-behavior">forwards compatible behavior</termref> 
 is enabled (see <specref ref="forwards"/>).</p>
@@ -6856,12 +6856,12 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>If the <termref def="dt-effective-version">effective version</termref> is any
                      other value less than <phrase diff="chg" at="2023-02-24">4.0</phrase>, 
                      the <rfc2119>recommended</rfc2119> action is to
-                     report a static error; however, processors <rfc2119>may</rfc2119> recognize
+                     raise a static error; however, processors <rfc2119>may</rfc2119> recognize
                      such values and process the element in an <termref def="dt-implementation-defined"/> way.</p>
                   <imp-def-feature id="idf-err-unknownversion">If the 
                      <termref def="dt-effective-version">effective version</termref> of any element in the
                      stylesheet is not 1.0 or 2.0 but is less than <phrase diff="chg" at="2023-02-24">4.0</phrase>, the
-                        <rfc2119>recommended</rfc2119> action is to report a static error; however,
+                        <rfc2119>recommended</rfc2119> action is to raise a static error; however,
                      processors <rfc2119>may</rfc2119> recognize such values and process the element
                      in an <termref def="dt-implementation-defined"/> way.</imp-def-feature>
                   <note>
@@ -6992,7 +6992,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <elcode>xsl:fallback</elcode> child, an XSLT <phrase diff="chg" at="2023-02-24">4.0</phrase> processor will process the
                         <elcode>xsl:switch</elcode> instruction regardless whether the effective
                      version is 2.0, 3.0, <phrase diff="chg" at="2023-02-24">or 4.0</phrase>, while an 
-                     XSLT 2.0 processor will report a static error
+                     XSLT 2.0 processor will raise a static error
                      if the effective version is 2.0, and will take the fallback action if the
                      effective version is 3.0 or 4.0.</p>
                </note>
@@ -7014,7 +7014,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <elcode>xsl:fallback</elcode> child, an XSLT <phrase diff="chg" at="2023-02-24">4.0</phrase> processor will process the
                      <elcode>xsl:switch</elcode> instruction regardless whether the effective
                      version is 2.0, 3.0, <phrase diff="chg" at="2023-02-24">or 4.0</phrase>, while an 
-                     XSLT 3.0 processor will report a static error
+                     XSLT 3.0 processor will raise a static error
                      if the effective version is 2.0 or 3.0, and will take the fallback action if the
                      effective version is 4.0.</p>
                </note>
@@ -7075,7 +7075,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <olist>
                      <item>
                         <p>If the element has one or more <elcode>xsl:fallback</elcode> children,
-                           then no error is reported either statically or dynamically, and the
+                           then no error is raised either statically or dynamically, and the
                            result of evaluating the instruction is the concatenation of the
                            sequences formed by evaluating the sequence constructors within its
                               <elcode>xsl:fallback</elcode> children, in document order. Siblings of
@@ -7084,7 +7084,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      </item>
                      <item>
                         <p>If the element has no <elcode>xsl:fallback</elcode> children, then a
-                           static error is reported in the same way as if forwards compatible
+                           static error is raised in the same way as if forwards compatible
                            behavior were not enabled.</p>
                      </item>
                   </olist>
@@ -7149,7 +7149,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <note>
                <p>The XSLT 1.0 and XSLT 2.0 specifications did not anticipate the
                   introduction of the <elcode>xsl:package</elcode> element. An XSLT 1.0 or 2.0
-                  processor encountering this element will report a static error, regardless of the
+                  processor encountering this element will raise a static error, regardless of the
                      <code>version</code> setting.</p>
                <p>This problem can be circumvented by using the simplified package
                   syntax (whereby an
@@ -7733,10 +7733,10 @@ and <code>version="1.0"</code> otherwise.</p>
                      <termref def="dt-stylesheet-module">stylesheet module</termref>. When a node is
                   effectively excluded from a stylesheet module the stylesheet module has the same
                   effect as if the node were not there. Among other things this means that no static
-                  or dynamic errors will be reported in respect of the element and its contents,
+                  or dynamic errors will be raised in respect of the element and its contents,
                   other than errors in the <code>use-when</code> attribute itself.</p>
                <note>
-                  <p>This does not apply to XML parsing or validation errors, which will be reported
+                  <p>This does not apply to XML parsing or validation errors, which will be raised
                      in the usual way. It also does not apply to attributes that are necessarily
                      processed before <code>[xsl:]use-when</code>, examples being
                         <code>xml:space</code> and <code>[xsl:]xpath-default-namespace</code>.</p>
@@ -7782,7 +7782,7 @@ and <code>version="1.0"</code> otherwise.</p>
 &lt;/xsl:template&gt;</eg>
                   <p>The effect of these declarations is that a non-schema-aware processor ignores
                      the <elcode>xsl:import-schema</elcode> declaration and the first template rule,
-                     and therefore generates no errors in respect of the schema-related constructs
+                     and therefore raises no errors in respect of the schema-related constructs
                      in these declarations.</p>
                </example>
                <example>
@@ -7851,7 +7851,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>The statement that the non-shadow attribute is
                      ignored extends to error detection: it is not an error if the non-shadow
                      attribute has an invalid value. However, this is not reflected in the schema
-                     for XSLT stylesheets, so validation using this schema may report errors in such
+                     for XSLT stylesheets, so validation using this schema may raise errors in such
                      cases.</p>
                </note>
                <note>
@@ -8867,7 +8867,7 @@ and <code>version="1.0"</code> otherwise.</p>
                                  QName</termref>, then unless otherwise specified it is a <termref def="dt-dynamic-error"> dynamic error</termref> if the value
                               has a prefix and the <termref def="dt-defining-element">defining
                                  element</termref> has no namespace node whose name matches that
-                              prefix. This error <rfc2119>may</rfc2119> be signaled as a <termref def="dt-static-error">static error</termref> if the value of the
+                              prefix. This error <rfc2119>may</rfc2119> be raised as a <termref def="dt-static-error">static error</termref> if the value of the
                               expression can be determined statically.</p>
                         </error>
                      </p>
@@ -9213,7 +9213,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>The transformation fails with a <termref def="dt-type-error">type error</termref> if
                an XPath <termref def="dt-expression">expression</termref> raises a type error, or if
                the result of evaluating the XPath <termref def="dt-expression">expression</termref>
-               is evaluated and raises a type error, or if the XPath processor signals a type error
+               is evaluated and raises a type error, or if the XPath processor raises a type error
                during static analysis of an <termref def="dt-expression">expression</termref>. Error
                codes are defined in <bibref ref="xpath-30"/>.</p>
             <p>
@@ -9261,12 +9261,12 @@ and <code>version="1.0"</code> otherwise.</p>
             <note>
                <p>Note the distinction between the two kinds of error that may occur. Attempting to
                   convert an integer to a date is a type error, because such a conversion is never
-                  possible. Type errors can be reported statically if they can be detected
+                  possible. Type errors can be raised statically if they can be detected
                   statically, whether or not the construct in question is ever evaluated. Attempting
                   to convert the <phrase diff="chg" at="2022-01-01"><code>xs:untypedAtomic</code></phrase> value 
                   <code>2003-02-29</code> to a date is a dynamic error rather
                   than a type error, because the problem is with this particular value, not with its
-                  type. Dynamic errors are reported only if the instructions or expressions that
+                  type. Dynamic errors are raised only if the instructions or expressions that
                   cause them are actually evaluated. <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E21, bug 30236]</phrase></p>
             </note>
 
@@ -9537,7 +9537,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      name with the required local name and arity, and does not exclude that local name by listing it
                      in the <code>exclude</code> attribute, then that function is chosen.</p></item>
                      <item><p>Otherwise (if none of the <elcode>xsl:function-namespace</elcode> elements identifies
-                     such a function, or if more than one does so), the name is unresolved and a static error is reported.</p></item>
+                     such a function, or if more than one does so), the name is unresolved and a static error is raised.</p></item>
                   </olist>
                   <p>A prefixed function name (together with the required arity) is resolved as follows:</p>
                   <olist>
@@ -9876,7 +9876,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            <termref def="dt-implementation-defined"/>: it does not necessarily lead to an error. 
                            For example, if the version of a used package that is available
                            at evaluation time does not include all public user-defined functions that were available in the version that was
-                           used at analysis time, then a processor <rfc2119>may</rfc2119> recover by signaling an error only if the function
+                           used at analysis time, then a processor <rfc2119>may</rfc2119> recover by raising an error only if the function
                            is actually called. Conversely, if the evaluation-time version of the package includes additional public functions, these <rfc2119>may</rfc2119>
                         be included in the dynamic context even though they were absent from the static context. 
                         Dynamic calling of functions using <xfunction>function-lookup</xfunction>
@@ -10936,11 +10936,11 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>There is a risk that ignoring errors in this way may make programming mistakes
                      harder to debug. Implementations may mitigate this by providing warnings or
                      other diagnostics when evaluation of a pattern triggers an error condition.</p>
-                  <p>Static errors in patterns, including dynamic and type errors that are signaled
-                     statically as permitted by the specification, are reported in the normal way
+                  <p>Static errors in patterns, including dynamic and type errors that are raised
+                     statically as permitted by the specification, are raised in the normal way
                      and cause the transformation to fail.</p>
                </note>
-               <p>The requirement to detect and report a <termref def="dt-circularity"/> as a dynamic error overrides this rule.</p>
+               <p>The requirement to detect and raise a <termref def="dt-circularity"/> as a dynamic error overrides this rule.</p>
 
 
             </div3>
@@ -11172,7 +11172,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </item>
                <item>
                   <p>
-                     <code>minus-sign</code> specifies the character used to signal a negative
+                     <code>minus-sign</code> specifies the character used to raise a negative
                      number; the default value is the hyphen-minus character (<code>-</code>, #x2D).
                      The value <rfc2119>must</rfc2119> be a single character.</p>
                </item>
@@ -11246,7 +11246,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>It is a <termref def="dt-static-error">static error</termref> if the string contained
                between matching curly brackets in a value template does not match the XPath
                production <xnt spec="XP40" ref="prod-xpath40-Expr">Expr?</xnt>, or if it contains
-               other XPath static errors. The error is signaled using the appropriate XPath error
+               other XPath static errors. The error is raised using the appropriate XPath error
                code.</p>
             <p>
                <error spec="XT" type="static" class="SE" code="0370">
@@ -11277,7 +11277,7 @@ and <code>version="1.0"</code> otherwise.</p>
             </ulist>
 
             <note>
-               <p>This process can generate dynamic errors, for example if the sequence contains an
+               <p>This process can raise dynamic errors, for example if the sequence contains an
                   element with a complex content type (which cannot be atomized).</p>
             </note>
 
@@ -11757,8 +11757,8 @@ and <code>version="1.0"</code> otherwise.</p>
                         another attribute <var>B</var> that appears later in the sequence,
                         then attribute <var>A</var> is discarded from the sequence. Before
                         discarding attribute <var>A</var>, the processor <rfc2119>may</rfc2119>
-                        signal any <termref def="dt-type-error">type errors</termref> that would be
-                        signaled if attribute <var>B</var> were not present. </p>
+                        raise any <termref def="dt-type-error">type errors</termref> that would be
+                        raised if attribute <var>B</var> were not present. </p>
                      <!--End of text replaced by erratum E10-->
                   </item>
                   <item>
@@ -12700,7 +12700,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         <p>If the <termref def="dt-mode">mode</termref>
                            <var>M</var> has an <elcode>xsl:mode</elcode> declaration, and the
                            attribute value <code>on-multiple-match="fail"</code> is specified in the
-                           mode declaration, a dynamic error is signaled. The error is treated as
+                           mode declaration, a dynamic error is raised. The error is treated as
                            occurring in the <elcode>xsl:apply-templates</elcode> instruction, and
                            can be recovered by wrapping that instruction in an
                               <elcode>xsl:try</elcode> instruction.</p>
@@ -12722,7 +12722,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
                   <note>
                      <p>This was a recoverable error in XSLT 2.0, meaning that it was
-                        implementation-defined whether the error was signaled, or whether the
+                        implementation-defined whether the error was raised, or whether the
                         ambiguity was resolved by taking the last matching rule in declaration
                         order.  In XSLT 3.0 this situation is not an error unless the
                         attribute value <code>on-multiple-match="fail"</code> is specified in the
@@ -13494,7 +13494,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      to more than one mode, then it must meet the requirements of each one, which implies that these requirements
                      must be consistent with each other: for example, if one mode specifies <code>as="node()"</code> and another specifies
                         <code>as="map(*)"</code>, then a type error is inevitable if the template rule is actually evaluated, and
-                        like other type errors this can be reported statically if detected statically. An
+                        like other type errors this can be raised statically if detected statically. An
                      <xtermref spec="XP40" ref="dt-implausible">implausibility</xtermref> <rfc2119>may</rfc2119> 
                         be reported if the only value that would satisfy both types is an empty sequence, map, or array.</p>
                   <note><p>In practice the best way to satisfy this rule is to ensure 
@@ -13506,7 +13506,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      template rule for the mode (see <specref ref="built-in-rule"/>). Since it is not possible to
                      determine statically whether the explicit template rules for a mode provide complete coverage
                      of all possible inputs, any failure of the built-in template rule to return a value 
-                     that can be coerced to the expected type <rfc2119>must</rfc2119> be reported 
+                     that can be coerced to the expected type <rfc2119>must</rfc2119> be raised 
                      dynamically <errorref spec="XT" class="TE" code="0505"/>.</p>
                   </item>
                </ulist>
@@ -15481,7 +15481,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <elcode>xsl:catch</elcode> element.</p>
 
             <note>
-               <p>Within an <elcode>xsl:catch</elcode> it is possible to re-throw the error using
+               <p>Within an <elcode>xsl:catch</elcode> it is possible to re-raise the error using
                   the function call <code>error($err:code, $err:description, $err:value)</code>.</p>
             </note>
 
@@ -15521,8 +15521,8 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <item>
                   <p>The existence of an <elcode>xsl:try</elcode> instruction does not affect the
-                     obligation of the processor to signal certain errors as static errors, or its
-                     right to choose whether to signal some errors (such as <termref def="dt-type-error">type errors</termref>) statically or dynamically. Static
+                     obligation of the processor to raise certain errors as static errors, or its
+                     right to choose whether to raise some errors (such as <termref def="dt-type-error">type errors</termref>) statically or dynamically. Static
                      errors are never caught.</p>
                </item>
                <item>
@@ -15615,7 +15615,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      caught.</p>
 
                   <note>
-                     <p>Because processors are permitted to report type errors during static
+                     <p>Because processors are permitted to raise type errors during static
                         analysis, it is unwise to attempt to recover from type errors dynamically.
                         The best strategy is generally to prevent their occurrence. For example,
                         rather than writing <code>$p + 1</code> where <code>$p</code> is a parameter
@@ -16628,7 +16628,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>The effect of these rules is that specifying <code>&lt;xsl:param name="p"
                         as="xs:date" select="2"/&gt;</code> is an error, but if the default value of
                      the parameter is never used, then the processor has discretion whether or not
-                     to report the error. By contrast, <code>&lt;xsl:param name="p"
+                     to raise the error. By contrast, <code>&lt;xsl:param name="p"
                         as="xs:date"/&gt;</code> is treated as if <code>required="yes"</code> had
                      been specified: the empty sequence is not a valid instance of
                         <code>xs:date</code>, so in effect there is no default value and the
@@ -17032,7 +17032,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </item>
             </ulist>
 
-            <p>An XPath error will be reported if the evaluation of a global variable or parameter
+            <p>An XPath error will be raised if the evaluation of a global variable or parameter
                references the context item, context position, or context size when the <termref def="dt-focus"/> is <termref def="dt-absent"/>. The values of other components of
                the dynamic context are the initial values as defined in <specref ref="xpath-dynamic-context"/> and <specref ref="additional-dynamic-context"/>.</p>
             
@@ -17765,8 +17765,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      was defined as a static error. In XSLT 3.0 it is not always detectable
                      statically, because attribute sets can bind to each other across package
                      boundaries. Nevertheless, in cases where a processor can detect a static
-                     circularity, it can report this error during the analysis phase, under the
-                     general provision for reporting dynamic errors during stylesheet analysis if
+                     circularity, it can raise this error during the analysis phase, under the
+                     general provision for raising dynamic errors during stylesheet analysis if
                      execution can never succeed.</p>
                </note>
             </example>
@@ -17775,15 +17775,15 @@ and <code>version="1.0"</code> otherwise.</p>
                <error spec="XT" type="dynamic" class="DE" code="0640">
                   <p>In general, a <termref def="dt-circularity">circularity</termref> in a <termref def="dt-stylesheet">stylesheet</termref> is a <termref def="dt-dynamic-error">
                         dynamic error</termref>.</p>
-               </error> However, as with all other dynamic errors, an implementation will signal the
+               </error> However, as with all other dynamic errors, an implementation will raise the
                error only if it actually executes the instructions and expressions that participate
                in the circularity. Because different implementations may optimize the execution of a
                stylesheet in different ways, it is <termref def="dt-implementation-dependent">implementation-dependent</termref> whether a particular circularity will actually
-               be signaled.</p>
+               be raised.</p>
             <p>For example, in the following declarations, the function declares a local variable
                   <code>$b</code>, but it returns a result that does not require the variable to be
                evaluated. It is <termref def="dt-implementation-dependent">implementation-dependent</termref> whether the value is actually evaluated, and
-               it is therefore implementation-dependent whether the circularity is signaled as an
+               it is therefore implementation-dependent whether the circularity is raised as an
                error:</p>
             <eg role="error" xml:space="preserve">&lt;xsl:variable name="x" select="my:f(1)"/&gt;
 
@@ -17806,7 +17806,7 @@ and <code>version="1.0"</code> otherwise.</p>
                of the original key definition as an argument.</p>
             <p>Circularity is not the same as recursion. Stylesheet functions (see <specref ref="stylesheet-functions"/>) and named templates (see <specref ref="named-templates"/>) may call other functions and named templates without
                restriction. With careless coding, recursion may be non-terminating. Implementations
-               are <rfc2119>required</rfc2119> to signal circularity as a <termref def="dt-dynamic-error">dynamic error</termref>, but they are not
+               are <rfc2119>required</rfc2119> to raise circularity as a <termref def="dt-dynamic-error">dynamic error</termref>, but they are not
                   <rfc2119>required</rfc2119> to detect non-terminating recursion.</p>
             <p>The requirement to report a circularity as a dynamic error
                overrides the rule that dynamic errors in evaluating <termref def="dt-pattern">patterns</termref> are normally masked (by treating the pattern as not
@@ -18036,7 +18036,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            element</error.extra> when <code>use="absent"</code> is specified.</p>
                   </error></p>
 
-               <p>A <termref def="dt-type-error"/> is signaled if the supplied
+               <p>A <termref def="dt-type-error"/> is raised if the supplied
                   context item does not match its required type. No attempt is made to convert the
                   context item to the required type (using the coercion rules or
                   otherwise). The error code is the same as for <elcode>xsl:param</elcode>:
@@ -18091,7 +18091,7 @@ and <code>version="1.0"</code> otherwise.</p>
 
 
                <p> The processor <rfc2119>may</rfc2119>
-                  signal a <termref def="dt-type-error">type error</termref> statically if the
+                  raise a <termref def="dt-type-error">type error</termref> statically if the
                   required context item type is incompatible with the <code>match</code> pattern,
                   that is, if no item that satisfies the match pattern can also satisfy the required
                   context item type.</p>
@@ -19566,7 +19566,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            <p>If the result of evaluating the <code>context-item</code> expression
                                  <error.extra>of an <elcode>xsl:evaluate</elcode>
                                  instruction</error.extra> is a sequence containing more than one
-                              item, then a <termref def="dt-type-error"/> is signaled.</p>
+                              item, then a <termref def="dt-type-error"/> is raised.</p>
                         </error></p>
                   </item>
                   <item>
@@ -22410,7 +22410,7 @@ for $i in 1 to count($V) return
                         of ordinary values for which the result of the XPath <code>lt</code>
                         operator is an error. If the processor is
                            able to detect the error statically, it <rfc2119>may</rfc2119> optionally
-                           signal it as a <termref def="dt-static-error">static
+                           raise it as a <termref def="dt-static-error">static
                            error</termref>.</p>
                   </error>
                </p>
@@ -22586,7 +22586,7 @@ for $i in 1 to count($V) return
                   ignored when no string comparisons are performed during the sorting process; this 
                   includes the cases where (a) the sequences to be sorted are empty, (b) the sort 
                   keys are of a non-string type such as <code>xs:integer</code>, or (c) <code>data-type="number"</code> is 
-                  specified. In these cases, an implementation may report errors in the value 
+                  specified. In these cases, an implementation may raise errors in the value 
                   of these attributes, but is not required to do so. As always, an implementation 
                   may issue warnings. [XSLT 3.0 Erratum E45, bug 30386]
                </p>
@@ -24401,7 +24401,7 @@ the same group, and the-->
                      they have different <termref def="dt-effective-value">effective values</termref>. 
                      In the case of the <code>collation</code> attribute, the values are
                      compared as absolute URIs after resolving against the base URI. The error
-                        <rfc2119>may</rfc2119> be reported statically if it is detected
+                        <rfc2119>may</rfc2119> be raised statically if it is detected
                      statically.</p>
                </error>
             </p>
@@ -24575,7 +24575,7 @@ the same group, and the-->
                      <item><p>If any of the <elcode>xsl:merge-source</elcode> elements within the <elcode>xsl:merge</elcode> instruction specifies 
                         <code>streamable="yes"</code> (explicitly or implicitly), then absent.</p>
                         <note><p>This means that within the <elcode>xsl:merge-action</elcode> of a streamable <elcode>xsl:merge</elcode>, 
-                           calling <code>last()</code> throws error <xerrorref spec="XP40" class="DY" code="0002"/>.</p></note>
+                           calling <code>last()</code> raises error <xerrorref spec="XP40" class="DY" code="0002"/>.</p></note>
                      </item>
                      <item><p>Otherwise, the number of groups, that is, the number of distinct sets of merge key values.
                         </p></item>
@@ -25186,7 +25186,7 @@ the same group, and the-->
                         <rfc2119>required</rfc2119> syntax for regular expressions, as specified in
                         <bibref ref="xpath-functions-40"/>. If the regular expression is known
                      statically (for example, if the attribute does not contain any <termref def="dt-expression">expressions</termref> enclosed in curly brackets) then
-                     the processor <rfc2119>may</rfc2119> signal the error as a <termref def="dt-static-error">static error</termref>. </p>
+                     the processor <rfc2119>may</rfc2119> raise the error as a <termref def="dt-static-error">static error</termref>. </p>
                </error>
             </p>
             <p>
@@ -25196,7 +25196,7 @@ the same group, and the-->
                         instruction</error.extra> has a value other than the values defined in
                         <bibref ref="xpath-functions-40"/>. If the value of the attribute is known
                      statically (for example, if the attribute does not contain any <termref def="dt-expression">expressions</termref> enclosed in curly brackets) then
-                     the processor <rfc2119>may</rfc2119> signal the error as a <termref def="dt-static-error">static error</termref>. </p>
+                     the processor <rfc2119>may</rfc2119> raise the error as a <termref def="dt-static-error">static error</termref>. </p>
                </error>
             </p>
             
@@ -25624,7 +25624,7 @@ the same group, and the-->
                      should not present data to the stylesheet except to the extent that such data
                      could form the leading part of a valid document. If the document proves to be
                      invalid, the processor should not pass invalid data to the stylesheet to be
-                     processed, but should immediately signal the appropriate error. For the
+                     processed, but should immediately raise the appropriate error. For the
                      purposes of <elcode>xsl:try</elcode> and <elcode>xsl:catch</elcode>, this error
                      can only be caught at the level of the <elcode>xsl:source-document</elcode> instruction
                      that initiated validation, not at a finer level. If validation errors are
@@ -26264,7 +26264,7 @@ the same group, and the-->
                         <function>accumulator-after</function> function. When such function calls
                      exist in an accumulator rule, they impose a dependency of one accumulator on
                      another, and create the possibility of cyclic dependencies. Processors are
-                     allowed to report the error statically if they can detect it statically.
+                     allowed to raise the error statically if they can detect it statically.
                      Failing this, processors are allowed to fail catastrophically in the event of a
                      cycle, in the same way as they might fail in the event of infinite function or
                      template recursion. Catastrophic failure might manifest itself, for example, as
@@ -26400,13 +26400,13 @@ the same group, and the-->
                <p>If a dynamic error occurs when evaluating the <code>initial-value</code> expression
                of <elcode>xsl:accumulator</elcode>, or the <code>select</code> expression of <elcode>xsl:accumulator-rule</elcode>,
                   <phrase diff="add" at="2022-01-01">or the sequence constructor contained in <elcode>xsl:accumulator-rule</elcode>, </phrase>
-               then the error is signaled as an error from any subsequent call on <function>accumulator-before</function>
+               then the error is raised as an error from any subsequent call on <function>accumulator-before</function>
                   or <function>accumulator-after</function> that references the accumulator. If no such call on <function>accumulator-before</function>
                   or <function>accumulator-after</function> happens, then the error goes unreported.
                <phrase diff="add" at="2022-01-01">[XSLT 3.0 Erratum E38, bug 30376].</phrase></p>
                
                <note><p>In the above rule, the phrase <term>subsequent call</term> is to be understood in terms of functional dependency; that is, a call to
-                  <function>accumulator-before</function> or <function>accumulator-after</function> signals an error if the accumulator value at the node in question is
+                  <function>accumulator-before</function> or <function>accumulator-after</function> raises an error if the accumulator value at the node in question is
                functionally dependent on a computation that fails with a dynamic error.</p></note>
                
                <note><p>Particularly in the case of streamed accumulators, this may mean that the implementation has to “hold back” the error
@@ -26415,7 +26415,7 @@ the same group, and the-->
                
                <note><p>Errors that occur during the evaluation of the pattern in the <code>match</code> attribute of
                <elcode>xsl:accumulator-rule</elcode> are handled as described in <specref ref="pattern-errors"/>:
-               specifically, the pattern does not match the relevant node, and no error is signaled.</p></note>
+               specifically, the pattern does not match the relevant node, and no error is raised.</p></note>
 
             </div3>
             <div3 id="func-accumulator-before">
@@ -34559,14 +34559,14 @@ the same group, and the-->
                      option:</p>
                   <olist>
                      <item>
-                        <p>Signal a static error <errorref spec="XT" class="SE" code="3430"/></p>
+                        <p>Raise a static error <errorref spec="XT" class="SE" code="3430"/></p>
                      </item>
                      <item>
                         <p>Process the stylesheet as if it were a non-streaming processor (see
                            below)</p>
                      </item>
                      <item>
-                        <p>Process the stylesheet with streaming if it is able to do so, or signal a
+                        <p>Process the stylesheet with streaming if it is able to do so, or raise a
                            static error <errorref spec="XT" class="SE" code="3430"/> if it is not
                            able to do so.</p>
                      </item>
@@ -35037,7 +35037,7 @@ the same group, and the-->
                   constructor contained in the <elcode>xsl:map</elcode> instruction is severely
                   constrained: it doesn’t make sense, for example, for it to contain
                   instructions such as <elcode>xsl:element</elcode> that create new nodes. As with
-                  other type errors, processors are free to signal the error statically if they are
+                  other type errors, processors are free to raise the error statically if they are
                   able to determine that the sequence constructor would always fail when
                   evaluated.</p>
             </note>
@@ -36116,7 +36116,7 @@ return ($m?price - $m?discount)</eg>
             <p>If the <termref def="dt-effective-value"/> of the
                   <code>terminate</code> attribute is <code>yes</code>, then the <termref def="dt-processor">processor</termref>
                <rfc2119>must</rfc2119>
-               signal a <termref def="dt-dynamic-error"> dynamic error</termref> after
+               raise a <termref def="dt-dynamic-error"> dynamic error</termref> after
                sending the message. This error may be caught in the same
                   way as any other dynamic error using <elcode>xsl:catch</elcode>. The
                default value is <code>no</code>. Note that because the order of evaluation of
@@ -36187,7 +36187,7 @@ return ($m?price - $m?discount)</eg>
                   the instruction <code>&lt;xsl:message select="@code"/&gt;</code> (on the grounds
                   that free-standing attributes cannot be serialized). Making such errors
                   recoverable means that it is implementation-defined whether or not they are
-                  signaled to the user and whether they cause termination of the transformation. If
+                  raised to the user and whether they cause termination of the transformation. If
                   the processor chooses to recover from the error, the content of any resulting
                   message is implementation-dependent.</p>
                <p>One possible recovery action is to include a description of the error in the
@@ -36425,14 +36425,14 @@ return ($m?price - $m?discount)</eg>
                   <error spec="XT" type="dynamic" class="DE" code="1420">
                      <p>It is a <termref def="dt-dynamic-error"> dynamic error</termref> if the arguments
                         supplied to a call on an extension function do not satisfy the rules defined
-                        for that particular extension function, or if the extension function reports
+                        for that particular extension function, or if the extension function raises
                         an error, or if the result of the extension function cannot be converted to
                         an XPath value.</p>
                   </error>
                </p>
                <note>
                   <p>Implementations may also provide mechanisms allowing extension functions to
-                     report recoverable dynamic errors, or to execute within an environment that
+                     raise recoverable dynamic errors, or to execute within an environment that
                      treats some or all of the errors listed above as recoverable.</p>
                </note>
                <p>
@@ -36667,7 +36667,7 @@ return ($m?price - $m?discount)</eg>
                         <termref def="dt-expanded-qname">expanded QName</termref> of an <termref def="dt-output-definition">output definition</termref> in the containing <termref def="dt-package">package</termref>. If the processor is able to detect
                      the error statically (for example, when the <code>format</code> attribute
                      contains no curly brackets), then the processor <rfc2119>may</rfc2119>
-                     optionally signal this as a <termref def="dt-static-error">static
+                     optionally raise this as a <termref def="dt-static-error">static
                         error</termref>.</p>
                </error>
             </p>
@@ -36976,7 +36976,7 @@ return ($m?price - $m?discount)</eg>
                      <elcode>xsl:result-document</elcode> instruction that omits the
                      <code>href</code> attribute if an initial <termref def="dt-final-result-tree">final result tree</termref> is created implicitly.</p>
             </note>
-            <p>In addition, an implementation <rfc2119>may</rfc2119> report this
+            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
                error if it is able to detect that two or more final result trees are generated with
                different URIs that refer to the same physical resource.</p>
 
@@ -36989,7 +36989,7 @@ return ($m?price - $m?discount)</eg>
                         both cases. </p>
                </error>
             </p>
-            <p>In addition, an implementation <rfc2119>may</rfc2119> report this
+            <p>In addition, an implementation <rfc2119>may</rfc2119> raise this
                error if it is able to detect that a transformation writes to a resource and reads
                from the same resource using different URIs that refer to the same physical resource.
                Note that if the error is not detected, it is <termref def="dt-implementation-dependent"/> whether the document that is read from the
@@ -37317,7 +37317,7 @@ return ($m?price - $m?discount)</eg>
                            the <termref def="dt-effective-value"/> <code>strict</code>, and schema validity assessment
                            concludes that the validity of the element or attribute is invalid or
                            unknown, a <termref def="dt-type-error">type error</termref> occurs. As
-                           with other type errors, the error <rfc2119>may</rfc2119> be signaled
+                           with other type errors, the error <rfc2119>may</rfc2119> be raised
                            statically if it can be detected statically. </p>
                      </error>
                   </p>
@@ -37330,7 +37330,7 @@ return ($m?price - $m?discount)</eg>
                               <code>xsl:validation</code> attribute of a literal result element, has
                            the <termref def="dt-effective-value"/> <code>strict</code>, and there is no matching
                            top-level declaration in the schema, then a <termref def="dt-type-error">type error</termref> occurs. As with other type errors, the error
-                              <rfc2119>may</rfc2119> be signaled statically if it can be detected
+                              <rfc2119>may</rfc2119> be raised statically if it can be detected
                            statically. </p>
                      </error>
                   </p>
@@ -37343,7 +37343,7 @@ return ($m?price - $m?discount)</eg>
                               <code>xsl:validation</code> attribute of a literal result element, has
                            the <termref def="dt-effective-value"/> <code>lax</code>, and schema validity assessment
                            concludes that the element or attribute is invalid, a <termref def="dt-type-error">type error</termref> occurs. As with other type
-                           errors, the error <rfc2119>may</rfc2119> be signaled statically if it can
+                           errors, the error <rfc2119>may</rfc2119> be raised statically if it can
                            be detected statically. </p>
                      </error>
                   </p>
@@ -37448,11 +37448,11 @@ return ($m?price - $m?discount)</eg>
                      </error>
                   </p>
                   <note>
-                     <p>Like other type errors, this error may be signaled statically if it can be
+                     <p>Like other type errors, this error may be raised statically if it can be
                         detected statically. For example, the instruction <code>&lt;xsl:attribute
                            name="dob" type="xs:date"&gt;1999-02-29&lt;/xsl:attribute&gt;</code> may
-                        result in a static error being signaled. If the error is not signaled
-                        statically, it will be signaled when the instruction is evaluated.</p>
+                        result in a static error being raised. If the error is not raised
+                        statically, it will be raised when the instruction is evaluated.</p>
                   </note>
                </div4>
                <div4 id="validation-process">
@@ -37938,7 +37938,8 @@ return ($m?price - $m?discount)</eg>
             <item>
                <p> The value of the <code>html-version</code> attribute provides
                   the value of the <code>html-version</code> parameter to the serialization method.
-                  The set of permitted values, and the default value, are <termref def="dt-implementation-defined">implementation-defined</termref>. A <termref def="dt-serialization-error">serialization error</termref> will be reported if
+                  The set of permitted values, and the default value, are <termref def="dt-implementation-defined">implementation-defined</termref>. 
+                  A <termref def="dt-serialization-error">serialization error</termref> will be raised if
                   the requested version is not supported by the implementation. </p>
                <note>
                   <p>This serialization parameter is new in version 3.0. If it is
@@ -38033,7 +38034,8 @@ return ($m?price - $m?discount)</eg>
             <item>
                <p> The value of the <code>version</code> attribute provides the value of the
                      <code>version</code> parameter to the serialization method. The set of
-                  permitted values, and the default value, are <termref def="dt-implementation-defined">implementation-defined</termref>. A <termref def="dt-serialization-error">serialization error</termref> will be reported if
+                  permitted values, and the default value, are <termref def="dt-implementation-defined">implementation-defined</termref>. 
+                  A <termref def="dt-serialization-error">serialization error</termref> will be raised if
                   the requested version is not supported by the implementation.
                   <!--The default value depends on the output method: it is <code>1.0</code> for <code>xml</code>,
 						<code>4.01</code> for <code>html</code>, and <code>1.0</code> for <code>xhtml</code>. The 
@@ -38046,9 +38048,9 @@ return ($m?price - $m?discount)</eg>
             XML, HTML, and XHTML are supported in the <code>version</code> attribute of the
                <elcode>xsl:output</elcode> declaration.</imp-def-feature>
 
-         <p>If the processor performs serialization, then it must signal any  serialization errors that occur. These have the same
+         <p>If the processor performs serialization, then it must raise any  serialization errors that occur. These have the same
             effect as <termref def="dt-dynamic-error"> dynamic errors</termref>: that is, the processor must
-            signal the error and must not finish as if the transformation had been successful.</p>
+            raise the error and must not finish as if the transformation had been successful.</p>
          <div2 id="character-maps">
             <head>Character Maps</head>
             <p>
@@ -38370,17 +38372,17 @@ return ($m?price - $m?discount)</eg>
             convenience, a non-normative checklist of implementation-defined features is provided at
                <specref ref="implementation-defined-features"/>.</p>
          <p>A conforming <termref def="dt-processor">processor</termref>
-            <rfc2119>must</rfc2119> signal any <termref def="dt-static-error">static error</termref>
+            <rfc2119>must</rfc2119> raise any <termref def="dt-static-error">static error</termref>
             occurring in the stylesheet, or in any XPath <termref def="dt-expression">expression</termref>, except where specified otherwise either for individual error
             conditions or under the general provisions for <termref def="dt-forwards-compatible-behavior"/> (see <specref ref="forwards"/>). After
-            signaling such an error, the processor <rfc2119>may</rfc2119> continue for the purpose
-            of signaling additional errors, but <rfc2119>must</rfc2119> terminate abnormally without
+            raising such an error, the processor <rfc2119>may</rfc2119> continue for the purpose
+            of raising additional errors, but <rfc2119>must</rfc2119> terminate abnormally without
             performing any transformation.</p>
          <p>When a <termref def="dt-dynamic-error">dynamic error</termref> occurs during the course
             of a transformation, and is not caught using
                   <elcode>xsl:catch</elcode>,
              the processor
-               <rfc2119>must</rfc2119> signal it and <rfc2119>must</rfc2119> eventually terminate
+               <rfc2119>must</rfc2119> raise it and <rfc2119>must</rfc2119> eventually terminate
             abnormally. </p>
          <p>Some errors, notably <termref def="dt-type-error">type errors</termref>,
                <rfc2119>may</rfc2119> be treated as <termref def="dt-static-error">static
@@ -38465,7 +38467,7 @@ return ($m?price - $m?discount)</eg>
 
             <!--<p>A <termref def="dt-basic-xslt-processor">basic XSLT processor</termref> 
                <rfc2119>must</rfc2119> enforce the following restrictions. It
-                  <rfc2119>must</rfc2119> signal a static or dynamic error when the restriction is
+                  <rfc2119>must</rfc2119> raise a static or dynamic error when the restriction is
                violated, as described below.</p>-->
 
          </div2>
@@ -38497,7 +38499,7 @@ return ($m?price - $m?discount)</eg>
                <error spec="XT" type="static" class="SE" code="1650">
                   <p>A <termref def="dt-non-schema-aware-processor">non-schema-aware
                         processor</termref>
-                     <rfc2119>must</rfc2119> signal a <termref def="dt-static-error">static
+                     <rfc2119>must</rfc2119> raise a <termref def="dt-static-error">static
                         error</termref> if a <termref def="dt-package">package</termref> includes an
                         <elcode>xsl:import-schema</elcode> declaration.</p>
                </error>
@@ -38530,7 +38532,7 @@ return ($m?price - $m?discount)</eg>
                <error spec="XT" type="static" class="SE" code="1660">
                   <p>A <termref def="dt-non-schema-aware-processor">non-schema-aware
                         processor</termref>
-                     <rfc2119>must</rfc2119> signal a <termref def="dt-static-error">static
+                     <rfc2119>must</rfc2119> raise a <termref def="dt-static-error">static
                         error</termref> if a <termref def="dt-package">package</termref> includes an
                         <code>[xsl:]type</code> attribute; or an <code>[xsl:]validation</code> or
                         <code>[xsl:]default-validation</code> attribute with a value other than
@@ -38589,7 +38591,7 @@ return ($m?price - $m?discount)</eg>
                supports the setting <code>disable-output-escaping="yes"</code> on
                   <elcode>xsl:text</elcode>, or <elcode>xsl:value-of</elcode>. </p>
             <p>A processor that does not claim conformance with the serialization feature
-                  <rfc2119>must not</rfc2119> signal an error merely because the <termref def="dt-stylesheet">stylesheet</termref> contains <elcode>xsl:output</elcode> or
+                  <rfc2119>must not</rfc2119> raise an error merely because the <termref def="dt-stylesheet">stylesheet</termref> contains <elcode>xsl:output</elcode> or
                   <elcode>xsl:character-map</elcode> declarations, or serialization attributes on
                the <elcode>xsl:result-document</elcode> instruction. Such a processor
                   <rfc2119>may</rfc2119> check that these declarations and attributes have valid
@@ -38709,10 +38711,10 @@ return ($m?price - $m?discount)</eg>
                   described in this specification.</termdef>
             </p>
             <p>A processor that does not claim conformance with the dynamic evaluation feature
-                  <rfc2119>must</rfc2119> report a dynamic error if an <elcode>xsl:evaluate</elcode>
-               instruction is evaluated. It <rfc2119>must not</rfc2119> report a static error merely
+                  <rfc2119>must</rfc2119> raise a dynamic error if an <elcode>xsl:evaluate</elcode>
+               instruction is evaluated. It <rfc2119>must not</rfc2119> raise a static error merely
                because of the presence of an <elcode>xsl:evaluate</elcode> instruction in the
-               stylesheet, unless a processor that conforms with the feature would report the same
+               stylesheet, unless a processor that conforms with the feature would raise the same
                static error.</p>
 
             <p>A processor that conforms with the feature <rfc2119>must</rfc2119> return the value
@@ -38960,12 +38962,12 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
        <inform-div1 id="error-summary">
          <head>Summary of Error Conditions</head>
          <p>This appendix provides a summary of error conditions that a processor
-            may signal. This list includes all error codes defined in this specification, but this
+            may raise. This list includes all error codes defined in this specification, but this
             is not an exhaustive list of all errors that can occur. Implementations
-               <rfc2119>must</rfc2119> signal errors using these error codes, and applications can
+               <rfc2119>must</rfc2119> raise errors using these error codes, and applications can
             test for these codes; however, when more than one rule in the specification is violated,
-            different processors will not necessarily signal the same error code. Implementations
-            are not <rfc2119>required</rfc2119> to signal errors using the descriptive text used
+            different processors will not necessarily raise the same error code. Implementations
+            are not <rfc2119>required</rfc2119> to raise errors using the descriptive text used
             here.</p>
          <note>
             <p>The appendix is non-normative because the same information is given normatively


### PR DESCRIPTION
See issue #783.

Errors are raised, not signalled or reported or generated or thrown.