### PR TITLE
216: fn:unparsed-text: End-of-line characters

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -15747,6 +15747,11 @@ else $c[1] + sum(subsequence($c, 2))</eg>
          </olist>
          <p>The result of the function is a string containing the string representation of the
             resource retrieved using the URI.</p>
+         <p diff="add" at="2023-05-19">End-of-line characters are normalized as known from the
+            <xnt spec="XML" ref="sec-line-ends">end-of-line handling</xnt> in <bibref ref="xml"/>,
+            by translating both the two-character sequence <code>x0D</code> <code>x0A</code>
+            and any <code>x0D</code> that is not followed by <code>x0A</code>
+            to a single <code>x0A</code> character.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="UT" code="1170"
@@ -15857,6 +15862,9 @@ else $c[1] + sum(subsequence($c, 2))</eg>
 ]]></eg>
          </fos:example>
       </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">Changed in 4.0: end-of-line characters in the input are normalized.</fos:version>
+      </fos:history>
 
    </fos:function>
    <fos:function name="unparsed-text-lines" prefix="fn">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -12028,12 +12028,16 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               type error, rather than looking for a namespace binding for the prefix <code>PT1H</code>.</p>
            </item>
            <item diff="add" at="issue687">
-              <p>Version 4.0 makes it clear that the casting a value other than <code>xs:string</code>
+              <p>Version 4.0 makes it clear that the casting of a value other than <code>xs:string</code>
               or <code>xs:untypedAtomic</code> to a list type (whether using a cast expression or a
                  constructor function) is a type error <xerrorref spec="XP" class="TY" code="0004" type="type"/>. 
                  Previously this was defined as an error, but the kind of error and the error code were left unspecified.
               Accordingly, the function signatures of the constructor functions for built-in list types
               have been changed to use an argument type of <code>xs:string?</code>.</p>
+           </item>
+           <item diff="add" at="issue216">
+              <p>In version 3.1, end-of-line characters were adopted unchanged when calling <code>fn:unparsed-text</code>.
+                 In version 4.0, they are normalized as known from XML (see <bibref ref="xml"/>).</p>
            </item>
         </olist>
  


### PR DESCRIPTION
Closes #216. See this issue for more details on the proposed change.
