### PR TITLE
Edits to parse-uri()

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27721,7 +27721,7 @@ declare function some(
          <p>The <emph>query separator</emph> is the value of the
          <code>query-separator</code> option, and is used to construct
          a <emph>query-parameters</emph> value as follows.
-         Start with an empty array. Tokenize the <emph>query</emph> on
+         Start with an empty map. Tokenize the <emph>query</emph> on
          the <emph>query separator</emph>. For each token, identify
          the <emph>key</emph> and the <emph>value</emph>. If the token
          contains an equal sign (<code>=</code>), the <emph>key</emph>
@@ -27730,10 +27730,10 @@ declare function some(
          of the token, after the first equal sign, uri decoded. If the
          token does not contain an equal sign, <emph>key</emph> is the
          empty string and the <emph>value</emph> is equal to the
-         token, uri decoded. To the array append a new member consisting of a 
-         <termref def="dt-key-value-pair-map">key-value pair map</termref> map with the 
-         current <emph>key</emph> and <emph>value</emph>. The resulting array, when all
-         tokens have been processed, is the <emph>query-parameters</emph> array.</p>
+         token, uri decoded. Add the <emph>key</emph>/<emph>value</emph> pair
+         to the map. If the <emph>key</emph> already exists in the map, add the <emph>value</emph>
+         to a list of values associated with that key. The resulting map, when all
+         tokens have been processed, is the <emph>query-parameters</emph> map.</p>
 
          <p>If the <emph>filepath</emph> is not the empty sequence,
          it is uri decoded. On a Windows system, any

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21,6 +21,7 @@
       <fos:record extensible="true">
          <fos:field name="uri" type="xs:string" required="false"/>
          <fos:field name="scheme" type="xs:string" required="false"/>
+         <fos:field name="hierarchical" type="xs:boolean" required="false"/>
          <fos:field name="authority" type="xs:string" required="false"/>
          <fos:field name="userinfo" type="xs:string" required="false"/>
          <fos:field name="host" type="xs:string" required="false"/>
@@ -27471,14 +27472,8 @@ declare function some(
          in URI-adjacent spaces, such as file names. Not all such strings
          can be successfully parsed as URIs.</p>
 
-         <p>This function is described as a series of transformations
-         over the input string to identify the parts of a URI that are
-         present. Some portions of the URI are identified by matching
-         with a regular expression. This approach is designed to make
-         the description clear and unambiguous, it is not implementation
-         advice.</p>
-
          <p>The following options are available:</p>
+
 
          <fos:options>
             <fos:option key="path-separator">
@@ -27513,9 +27508,16 @@ declare function some(
             </fos:option>
          </fos:options>
 
+         <p>This function is described as a series of transformations
+         over the input string to identify the parts of a URI that are
+         present. Some portions of the URI are identified by matching
+         with a regular expression. This approach is designed to make
+         the description clear and unambiguous; it is not implementation
+         advice.</p>
+
          <p>Processing begins with a <emph>string</emph> that is equal
          to the <code>$uri</code>. If the <emph>string</emph> contains
-         any backlashes (<code>\</code>), replace them with forward
+         any backslashes (<code>\</code>), replace them with forward
          slashes (<code>/</code>).</p>
 
          <p>If the <emph>string</emph> matches <code>^(.*)#([^#]*)$</code>,
@@ -27570,7 +27572,7 @@ declare function some(
          <termref def="implementation-defined">implementation-defined</termref>.
          If the implementation does not know if a <emph>scheme</emph> is or is not
          hierarchical, the <emph>hierarchical</emph> setting depends on the
-         <emph>string</emph>. If the <emph>string</emph> is the empty string,
+         <emph>string</emph>: if the <emph>string</emph> is the empty string,
          <emph>hierarchical</emph> is the empty sequence (<emph>i.e.</emph> not known),
          otherwise <emph>hierarchical</emph> is
          <code>true</code> if <emph>string</emph> begins with <code>/</code> and <code>false</code> otherwise.</p>
@@ -27679,27 +27681,13 @@ declare function some(
          <emph>path-segments</emph> sequence is constructed by
          tokenizing the <emph>string</emph> on the <emph>path
          separator</emph> and applying <emph>uri decoding</emph> on each
-         token.</p>
-
-         <p>Applying <emph>uri decoding</emph> replaces all occurrences of
-         plus (<code>+</code>) with spaces and all occurrences of
-         <code>%[a-fA-F0-9][a-fA-F0-9]</code> with a single character with the
-         codepoint represented by the two digit hexadecimal number that
-         follows the <code>%</code> character. In other words, <code>"A%42C"</code> becomes
-         <code>"ABC"</code> If there are any occurrences of <code>%</code> followed
-         by up to two characters that are not hexadecimal digits, they are
-         replaced by the character sequence <code>0xef</code>, <code>0xbf</code>, <code>0xbd</code>
-         (that is, <code>0xfffd</code>, the Unicode replacement character, in UTF-8).
-         After replacing all of the percent-escaped characters, the character sequence is
-         interpreted as UTF-8 to get the string. In other words <code>"A%XYC%Z%F0%9F%92%A9"</code> becomes
-         <code>"A&#xfffd;C&#xfffd;💩"</code>. <phrase diff="add" at="2023-07-07">If the character sequence is
-         not a valid sequence of UTF-8 characters, any invalid characters are replaced with the
-         <code>0xfffd</code>.</phrase></p>
+         token. All <emph>uri decoding</emph> <rfc2119>must</rfc2119> follows the rules 
+         for <code>fn:decode-from-uri</code>.</p>
 
          <p>The <emph>query separator</emph> is the value of the
-         <code>query-separator</code> option.
-         A <emph>query-parameters</emph> value is constructed as follows.
-         Start with an empty map. Tokenize the <emph>query</emph> on
+         <code>query-separator</code> option, and is used to construct
+         a <emph>query-parameters</emph> value as follows.
+         Start with an empty array. Tokenize the <emph>query</emph> on
          the <emph>query separator</emph>. For each token, identify
          the <emph>key</emph> and the <emph>value</emph>. If the token
          contains an equal sign (<code>=</code>), the <emph>key</emph>
@@ -27708,10 +27696,10 @@ declare function some(
          of the token, after the first equal sign, uri decoded. If the
          token does not contain an equal sign, <emph>key</emph> is the
          empty string and the <emph>value</emph> is equal to the
-         token, uri decoded. Add the <emph>key</emph>/<emph>value</emph> pair
-         to the map. If the <emph>key</emph> already exists in the map, add the <emph>value</emph>
-         to a list of values associated with that key. The resulting map, when all
-         tokens have been processed, is the <emph>query-parameters</emph> map.</p>
+         token, uri decoded. To the array append a new member consisting of a 
+         <termref def="dt-key-value-pair-map">key-value pair map</termref> map with the 
+         current <emph>key</emph> and <emph>value</emph>. The resulting array, when all
+         tokens have been processed, is the <emph>query-parameters</emph> array.</p>
 
          <p>If the <emph>filepath</emph> is not the empty sequence,
          it is uri decoded. On a Windows system, any
@@ -27736,7 +27724,7 @@ declare function some(
   "filepath": <emph>filepath</emph>
 }</eg>
 
-         <p>The map should only be populated with keys that have a non-empty value (keys
+         <p>The map should be populated with only those keys that have a non-empty value (keys
          whose value is the empty sequence <rfc2119>should</rfc2119>
          be omitted).</p>
 
@@ -27760,7 +27748,7 @@ declare function some(
          <p>Unlike <code>fn:resolve-uri</code>, this function is not attempting to resolve
          one URI against another and consequently, the errors that can arise under those
          circumstances do not apply here. The <code>fn:parse-uri</code> function will
-         accept strings that would raise errors if resolution was attempted,
+         accept strings that would raise errors if resolution was attempted;
          see <code>fn:build-uri</code>.</p>
       </fos:notes>
       

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3329,6 +3329,10 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                  <td>The URI scheme (e.g., “https” or “file”).</td>
                </tr>
                <tr>
+                 <td>hierarchical</td>
+                 <td>Whether the URI is hierarchical or not.</td>
+               </tr>
+               <tr>
                  <td>authority</td>
                  <td>The authority portion of the URI (e.g., “example.com:8080”).</td>
                </tr>
@@ -3361,8 +3365,12 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                  <td>Parsed and unescaped path segments.</td>
                </tr>
                <tr>
-                 <td>query-segments</td>
-                 <td>Parsed and unescaped query terms</td>
+                 <td>query-parameters</td>
+                 <td>Parsed and unescaped query key-value pairs.</td>
+               </tr>
+               <tr>
+                 <td>filepath</td>
+                 <td>The path of the URI, treated as a filepath.</td>
                </tr>
                <tr>
                  <td>*</td>
@@ -3371,15 +3379,15 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
              </tbody>
            </table>
 
-           <p>The segmented forms of the path and query parameters provide
-           convenient access to commonly used information. They’re represented
+           <p>The segmented forms of the <code>path</code> and <code>query</code> parameters provide
+           convenient access to commonly used information. They are represented
            in the map as arrays, instead of sequences, just for the convenience
            of serializing the structure.</p>
 
            <p>The path, if there is one, is tokenized on “/” characters and
            each segment is unesaped. Consider the URI <code>http://example.com/path/to/a%2fb</code>. The path portion has to be returned as <code>/path/to/a%2fb</code> because
            decoding the <code>%2f</code> would change the nature of the path.
-           The unescaped form is easily accessible from the path-segments array:</p>
+           The unescaped form is easily accessible from the <code>path-segments</code> array:</p>
 
 <eg>[
   "",
@@ -3388,11 +3396,11 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
   "a/b"
 ]</eg>
            <p>Note that the presence or absence of a leading slash on the path
-           will effect whether or not the array begins with an empty string.</p>
+           will affect whether or not the array begins with an empty string.</p>
 
            <p>The query parameters are similarly decoded. Consider the URI:
            <code>http://example.com/path?a=1&amp;b=2%264&amp;a=3</code>.
-           Here the decoded form in the query-segments gives quick access to
+           Here the decoded form in the <code>query-segments</code> gives quick access to
            the parameter values:</p>
 
            <eg>[
@@ -3403,7 +3411,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
   { "key": "a",
     "value": "3" }
 ]</eg>
-           <p>Note that both keys and values are unescaped and that it’s an array
+            <p>Note that both keys and values are unescaped and that the value of <code>query-segments</code> is an array
            of maps because key values can be repeated, as seen for <code>a</code>
            in this example.</p>
 


### PR DESCRIPTION
Attn @ndw -- these edits pertain to 6.6.1 `fn:parse-uri` and require your careful review.

- `hierarchical` option appears in the rules of the function but not its preamble
- "This function is described..." moved to anticipate the actual narrative. 
- I was a bit thrown by the phrase "This approach...is not implementation advice" because "approach" is vague and the reader is left with the impression that a good deal of _something_ that follows is non-normative. We offer non-normative prose in the rules, but that informal prose is normally followed by an equivalent description that _is_ normative. I did not make any edits in this area, but I would recommend clarification as to exactly what parts of the narrative are normative and which are non-normative.
- The period-to-colon change at 27573 is to make sure the reader remains aware of the governing "If..." clause.
- I deleted a paragraph that attempted to distill the rather complicated description of `fn:decode-from-uri`. A mere xref provides a cleaner narrative here and a more accurate description of uri decoding, and the xref is within the same document, so should not pose a burden on the reader.
- For the `query-parameters` there was a discrepancy in the data model presented (in the preamble versus in the function rules), and I opted for the array-of-maps model. If it's supposed to be the other way (simple map), let me know and I'll revise.
- `query-segments` versus `query-parameters`; I went with the latter.

Let me know where things ain't right.