### PR TITLE
479: fn:deep-equal: Input order

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13582,12 +13582,6 @@ return contains-sequence(
             for the interpretation of each option appear later.</p>
             
             <fos:options>
-               <fos:option key="unordered">
-                  <fos:meaning>Controls how the input is to be compared.
-                  </fos:meaning>
-                  <fos:type>xs:boolean</fos:type>
-                  <fos:default>false</fos:default>
-               </fos:option>
                <fos:option key="base-uri">
                   <fos:meaning>Determines whether the <code>base-uri</code> of a node is significant.
                   </fos:meaning>
@@ -13680,6 +13674,13 @@ return contains-sequence(
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>true</fos:default>
+               </fos:option>
+               <fos:option key="unorderd">
+                  <fos:meaning>Controls whether the top-level order of the items of the input sequences
+                    is considered.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
                </fos:option>
                <fos:option key="unordered-elements">
                   <fos:meaning>A list of QNames of elements considered to be unordered: that is, their child

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13566,7 +13566,7 @@ return contains-sequence(
          <p>If the two sequences are of different lengths, the function returns
             <code>false</code>.</p>
          <p>If the two sequences are of the same length, the comparison is controlled by the 
-            <code>unorderd</code> option:</p>
+            <code>unordered</code> option:</p>
          <ulist>
             <item><p>If the option is <code>false</code>, the function returns <code>true</code> if
             and only if every item in the sequence <code>$input1</code> is deep-equal to the
@@ -13582,7 +13582,7 @@ return contains-sequence(
             for the interpretation of each option appear later.</p>
             
             <fos:options>
-               <fos:option key="unorderd">
+               <fos:option key="unordered">
                   <fos:meaning>Controls how the input is to be compared.
                   </fos:meaning>
                   <fos:type>xs:boolean</fos:type>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13565,16 +13565,29 @@ return contains-sequence(
          <p>If the two sequences are both empty, the function returns <code>true</code>.</p>
          <p>If the two sequences are of different lengths, the function returns
             <code>false</code>.</p>
-         <p>If the two sequences are of the same length, the function returns <code>true</code> if
+         <p>If the two sequences are of the same length, the comparison is controlled by the 
+            <code>unorderd</code> option:</p>
+         <ulist>
+            <item><p>If the option is <code>false</code>, the function returns <code>true</code> if
             and only if every item in the sequence <code>$input1</code> is deep-equal to the
-            item at the same position in the sequence <code>$input2</code>. The rules for
+            item at the same position in the sequence <code>$input2</code>.
+            </p></item>
+            <item><p>Otherwise, the function returns <code>true</code> if for every item in
+            <code>$input1</code> there is a deep-equal item in <code>$input2</code> that
+            has not been matched to another item.</p></item>
+         </ulist>
+         <p>The rules for
             deciding whether two items are deep-equal appear below.</p>
-         
-
-            <p>The entries that may appear in the <code>$options</code> map are as follows. The detailed rules
-               for the interpretation of each option appear later.</p>
+         <p>The entries that may appear in the <code>$options</code> map are as follows. The detailed rules
+            for the interpretation of each option appear later.</p>
             
             <fos:options>
+               <fos:option key="unorderd">
+                  <fos:meaning>Controls how the input is to be compared.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
                <fos:option key="base-uri">
                   <fos:meaning>Determines whether the <code>base-uri</code> of a node is significant.
                   </fos:meaning>
@@ -14144,12 +14157,6 @@ declare function equal-strings(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>deep-equal(map{1:'a', 2:'b'}, map{2:'b', 1:'a'})</fos:expression>
-               <fos:result>true()</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
                <fos:expression>deep-equal([1, 2, 3], [1, 2, 3])</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -14162,9 +14169,39 @@ declare function equal-strings(
          </fos:example>
          <fos:example>
             <fos:test>
+               <fos:expression><eg>deep-equal(
+  map { 1: 'a', 2: 'b' },
+  map { 2: 'b', 1: 'a' }
+)</eg></fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>deep-equal(
+  (1, 2, 3, 4),
+  (1, 4, 3, 2),
+  map { 'unordered': true() }
+)</eg></fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>deep-equal(
+  (1, 1, 2, 3),
+  (1, 2, 3, 3),
+  map { 'unordered': true() }
+)</eg></fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml("<a xmlns='AA'/>"),
-    parse-xml("<p:a xmlns:p='AA'/>"))]]></eg></fos:expression>
+  parse-xml("<a xmlns='AA'/>"),
+  parse-xml("<p:a xmlns:p='AA'/>")
+)]]></eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>By default, namespace prefixes are ignored</fos:postamble>
             </fos:test>
@@ -14172,9 +14209,10 @@ declare function equal-strings(
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml("<a xmlns='AA'/>"),
-    parse-xml("<p:a xmlns:p='AA'/>"),
-    options := map{'namespace-prefixes':true()})]]></eg></fos:expression>
+  parse-xml("<a xmlns='AA'/>"),
+  parse-xml("<p:a xmlns:p='AA'/>"),
+  options := map { 'namespace-prefixes': true() }
+)]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>False because the namespace prefixes differ</fos:postamble>
             </fos:test>
@@ -14182,9 +14220,10 @@ declare function equal-strings(
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml("<a xmlns='AA'/>"),
-    parse-xml("<p:a xmlns:p='AA'/>"),
-    options := map{'in-scope-namespaces':true()})]]></eg></fos:expression>
+  parse-xml("<a xmlns='AA'/>"),
+  parse-xml("<p:a xmlns:p='AA'/>"),
+  options := map { 'in-scope-namespaces': true() }
+)]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>False because the in-scope namespace bindings differ</fos:postamble>
             </fos:test>
@@ -14192,8 +14231,9 @@ declare function equal-strings(
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml("<a><b/><c/></a>"),
-    parse-xml("<a><c/><b/></a>"))]]></eg></fos:expression>
+  parse-xml("<a><b/><c/></a>"),
+  parse-xml("<a><c/><b/></a>")
+)]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>By default, order of elements is significant</fos:postamble>
             </fos:test>
@@ -14201,9 +14241,10 @@ declare function equal-strings(
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml("<a><b/><c/></a>"),
-    parse-xml("<a><c/><b/></a>"),
-    options := map{'unordered-elements': parse-QName('a')})]]></eg></fos:expression>
+  parse-xml("<a><b/><c/></a>"),
+  parse-xml("<a><c/><b/></a>"),
+  options := map {'unordered-elements': xs:QName('a') }
+)]]></eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The <code>unordered-elements</code> option means that the ordering of the children
                of <code>a</code> is ignored.</fos:postamble>
@@ -14212,10 +14253,9 @@ declare function equal-strings(
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml(
-      "<para style='bold'><span>x</span></para>"),
-    parse-xml(
-      "<para style=' bold'> <span>x</span></para>"))]]></eg></fos:expression>
+  parse-xml("<para style='bold'><span>x</span></para>"),
+  parse-xml("<para style=' bold'> <span>x</span></para>")
+)]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>By default, both the leading whitespace in the <code>style</code> attribute
                   and the whitespace text node preceding the <code>span</code> element are significant.</fos:postamble>
@@ -14224,11 +14264,10 @@ declare function equal-strings(
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[deep-equal(
-    parse-xml(
-      "<para style='bold'><span>x</span></para>"),
-    parse-xml(
-      "<para style=' bold'> <span>x</span></para>"),
-    options := map{'whitespace': 'normalize'})]]></eg></fos:expression>
+  parse-xml("<para style='bold'><span>x</span></para>"),
+  parse-xml("<para style=' bold'> <span>x</span></para>"),
+  options := map { 'whitespace': 'normalize' }
+)]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>The <code>whitespace</code> option causes both the leading space
                   in the attribute value and the whitespace preceding the 


### PR DESCRIPTION
I decided to follow my initial suggestion and add `unordered` to `fn:deep-equal` instead of adding a separate function for it. My motivation:

* It’s convenient to be able to use the new option in combination with the other options.
* It will be used more often than many other options we’ve added recently.
* It seemed pretty straightforward to add, both in terms of documentation and implementation.

Closes #479