### PR TITLE
660: Static functions, default parameters, XPST0017

### DIFF
--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -1093,10 +1093,10 @@ It is a static error if the name of a feature in
          <termref def="dt-generalized-atomic-type"/>.</p>
       </error>
       
-      
-      
-      
-
+      <error spec="XQ" role="xquery" code="0148" class="ST" type="static">
+         <p>It is a <termref def="dt-static-error">static error</termref> if an optional parameter
+            in a function declaration is followed by a parameter that does not have a default value.</p>
+      </error>
 
    </error-list>
 </div1>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1721,7 +1721,7 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       <p>A parameter is
     optional if a default value is supplied using the construct <code>:= ExprSingle</code>; otherwise it is required. If a parameter
     is optional, then all subsequent parameters in the list must also be optional; otherwise, a
-    <termref def="dt-static-error">static error</termref> is raised <errorref class="ST" code="0017"/>.
+    <termref def="dt-static-error">static error</termref> is raised <errorref class="ST" code="0148"/>.
     In other words, the parameter list includes
     zero or more required parameters followed by zero or more optional parameters.</p>
     

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1720,7 +1720,9 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       
       <p>A parameter is
     optional if a default value is supplied using the construct <code>:= ExprSingle</code>; otherwise it is required. If a parameter
-    is optional, then all subsequent parameters in the list must also be optional. In other words, the parameter list includes
+    is optional, then all subsequent parameters in the list must also be optional; otherwise, a
+    <termref def="dt-static-error">static error</termref> is raised <errorref class="ST" code="0017"/>.
+    In other words, the parameter list includes
     zero or more required parameters followed by zero or more optional parameters.</p>
     
     <p>The number of arguments that may be supplied in a call to this family of functions is thus in the range <var>M</var> to <var>N</var>,


### PR DESCRIPTION
I’ve chosen XPST0017 over XPST0003 (it felt more intuitive to me).

Closes #660.
