### PR TITLE
Minor edits, XQFO chh. 7, 8

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -6407,10 +6407,9 @@ Tak, tak, tak! - da kommen sie.
                      <code>$input</code>.</p>
             </item>
             <item>
-               <p>If <code>$input</code> is a singleton value of type <code>xs:string</code> or a type
-                  derived from <code>xs:string</code>, <code>xs:anyURI</code> or a type derived from
-                     <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>,
-                     <code>fn:boolean</code> returns <code>false</code> if the operand value has
+               <p>If <code>$input</code> is a singleton value of type <code>xs:untypedAtomic</code>, 
+                  <code>xs:string</code>, <code>xs:anyURI</code>, or a type derived from <code>xs:string</code>
+                  or <code>xs:anyURI</code>, <code>fn:boolean</code> returns <code>false</code> if the operand value has
                   zero length; otherwise it returns <code>true</code>.</p>
             </item>
             <item>
@@ -6728,6 +6727,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>years-from-duration(
+  xs:duration("P1Y1000D")
+)</eg></fos:expression>
+               <fos:result>1</fos:result>
+               <fos:postamble>To capture whole portions of years reflected in the
+                     <code>xs:dayTimeDuration</code> component, it must first be converted to an
+                     <code>xs:yearMonthDuration</code>.</fos:postamble>
+            </fos:test>
+         </fos:example>
       </fos:examples>
    </fos:function>
    <fos:function name="months-from-duration" prefix="fn">
@@ -6778,6 +6788,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>0</fos:result>
             </fos:test>
          </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>monthss-from-duration(
+                  xs:duration("P1M100D")
+                  )</eg></fos:expression>
+               <fos:result>1</fos:result>
+               <fos:postamble>To capture whole portions of months reflected in the
+                     <code>xs:dayTimeDuration</code> component, it must first be converted to an
+                     <code>xs:yearMonthDuration</code>.</fos:postamble>
+            </fos:test>
+         </fos:example>
       </fos:examples>
    </fos:function>
    <fos:function name="days-from-duration" prefix="fn">
@@ -6825,6 +6846,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
   xs:yearMonthDuration("P3Y5M")
 )</eg></fos:expression>
                <fos:result>0</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>days-from-duration(
+                  xs:duration("P1Y1D")
+                  )</eg></fos:expression>
+               <fos:result>1</fos:result>
+               <fos:postamble>To capture days reflected in the <code>xs:yearMonthDuration</code>
+                  component, it must first be converted to an
+                  <code>xs:dayTimeDuration</code>.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -6884,6 +6916,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>-10</fos:result>
             </fos:test>
          </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>hours-from-duration(
+                  xs:duration("P1YT1H")
+                  )</eg></fos:expression>
+               <fos:result>1</fos:result>
+               <fos:postamble>To capture hours reflected in the <code>xs:yearMonthDuration</code>
+                  component, it must first be converted to an
+                  <code>xs:dayTimeDuration</code>.</fos:postamble>
+            </fos:test>
+         </fos:example>
       </fos:examples>
    </fos:function>
    <fos:function name="minutes-from-duration" prefix="fn">
@@ -6923,6 +6966,17 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
   xs:dayTimeDuration("-P5DT12H30M")
 )</eg></fos:expression>
                <fos:result>-30</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>minutes-from-duration(
+                  xs:duration("P1YT1M")
+                  )</eg></fos:expression>
+               <fos:result>1</fos:result>
+               <fos:postamble>To capture minutes reflected in the <code>xs:yearMonthDuration</code>
+                  component, it must first be converted to an
+                  <code>xs:dayTimeDuration</code>.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -6965,6 +7019,28 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
   xs:dayTimeDuration("-PT256S")
 )</eg></fos:expression>
                <fos:result>-16.0</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>seconds-from-duration(
+                  xs:duration("P1Y1D")
+                  )</eg></fos:expression>
+               <fos:result>1</fos:result>
+               <fos:postamble>To capture days reflected in the <code>xs:yearMonthDuration</code>
+                  component of an <code>xs:duration</code>, it must first be converted to an
+                  <code>xs:dayTimeDuration</code>.</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>seconds-from-duration(
+                  xs:duration("P1YT1S")
+                  )</eg></fos:expression>
+               <fos:result>1</fos:result>
+               <fos:postamble>To capture seconds reflected in the <code>xs:yearMonthDuration</code>
+                  component, it must first be converted to an
+                  <code>xs:dayTimeDuration</code>.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -6790,9 +6790,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>monthss-from-duration(
-                  xs:duration("P1M100D")
-                  )</eg></fos:expression>
+               <fos:expression><eg>months-from-duration(
+   xs:duration("P1M100D")
+)</eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>To capture whole portions of months reflected in the
                      <code>xs:dayTimeDuration</code> component, it must first be converted to an
@@ -6851,8 +6851,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test>
                <fos:expression><eg>days-from-duration(
-                  xs:duration("P1Y1D")
-                  )</eg></fos:expression>
+   xs:duration("P1Y1D")
+)</eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>To capture days reflected in the <code>xs:yearMonthDuration</code>
                   component, it must first be converted to an
@@ -6919,8 +6919,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test>
                <fos:expression><eg>hours-from-duration(
-                  xs:duration("P1YT1H")
-                  )</eg></fos:expression>
+   xs:duration("P1YT1H")
+)</eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>To capture hours reflected in the <code>xs:yearMonthDuration</code>
                   component, it must first be converted to an
@@ -6971,8 +6971,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test>
                <fos:expression><eg>minutes-from-duration(
-                  xs:duration("P1YT1M")
-                  )</eg></fos:expression>
+   xs:duration("P1YT1M")
+)</eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>To capture minutes reflected in the <code>xs:yearMonthDuration</code>
                   component, it must first be converted to an
@@ -7024,8 +7024,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test>
                <fos:expression><eg>seconds-from-duration(
-                  xs:duration("P1Y1D")
-                  )</eg></fos:expression>
+   xs:duration("P1Y1D")
+)</eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>To capture days reflected in the <code>xs:yearMonthDuration</code>
                   component of an <code>xs:duration</code>, it must first be converted to an
@@ -7035,8 +7035,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test>
                <fos:expression><eg>seconds-from-duration(
-                  xs:duration("P1YT1S")
-                  )</eg></fos:expression>
+   xs:duration("P1YT1S")
+)</eg></fos:expression>
                <fos:result>1</fos:result>
                <fos:postamble>To capture seconds reflected in the <code>xs:yearMonthDuration</code>
                   component, it must first be converted to an

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3532,7 +3532,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 		 </div2>
         <div2 id="component-extraction-durations">
             <head>Component extraction functions on durations</head>
-            <p>The duration datatype may be considered to be a composite datatypes
+            <p>The duration datatype may be considered to be a composite datatype
                     in that it contains distinct properties or components. The extraction functions specified
                     below extract a single component from a duration value. 
 For <code>xs:duration</code> and its subtypes, including the two subtypes <code>xs:yearMonthDuration</code> and


### PR DESCRIPTION
In addition to a minor typo, note the following:
- rearrangement of a rule for `$input` (the original syntax, mixing types and derived types, confused me)
- examples in `X-from-Y` duration functions to help illustrate the problem when mixing the two components of a duration.