### PR TITLE
566 A few minor fixes for parse-uri

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27536,13 +27536,13 @@ declare function some(
 
          <p>Strip off the fragment identifier and any query:</p>
 
-         <p>If the <emph>string</emph> matches <code>^(.*)#([^#]*)$</code>,
+         <p>If the <emph>string</emph> matches <code>^(.*?)#(.*)$</code>,
          the <emph>string</emph> is the first match group and the
          <emph>fragment</emph> is the second match group. Otherwise,
          the string is unchanged and the <emph>fragment</emph> is the empty
          sequence.</p>
 
-         <p>If the <emph>string</emph> matches <code>^(.*)\?([^\?]*)$</code>,
+         <p>If the <emph>string</emph> matches <code>^(.*?)\?(.*)$</code>,
          the <emph>string</emph> is the first match group and the
          <emph>query</emph> is the second match group. Otherwise,
          the string is unchanged and the <emph>query</emph> is the empty
@@ -27612,7 +27612,7 @@ declare function some(
          <ulist>
             <item>
          <p>If the scheme is not known or is known to be <code>file</code>
-         and the <emph>string</emph> matches <code>^//*([a-zA-Z]:.*)$</code>,
+         and the <emph>string</emph> matches <code>^/*(/[a-zA-Z]:.*)$</code>,
          the <emph>authority</emph> is empty and the <emph>string</emph> is
          the first match group.</p></item>
          <item><p>Otherwise, if the <emph>string</emph>


### PR DESCRIPTION
As CG observes in [issue 566](https://github.com/qt4cg/qtspecs/issues/566#issuecomment-1787666119), there are still a couple of small problems with `fn:parse-uri()`.

1. The regular expressions used to parse the fragment identifier and query are incorrect. The URI specification allows `?` to appear in a query string and `#` to appear in a fragment identifier, so the expressions have been rewritten to match everything after the first `?` and `#`, respectively, even if they contain additional `?` or `#` characters.
2. The description of how to interpret the regular expression for parsing a Windows file path preceded by slashes was incorrect. It caused the leading "/" to be lost. That's been corrected.