### PR TITLE
Highlight changed functions in the ToCs and headings

### DIFF
--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -125,3 +125,20 @@ div.new-function h4::before {
 span.content.new-function::after {
     content: " 🆕";
 }
+
+div.changed-function h2,
+div.changed-function h3,
+div.changed-function h4 {
+    text-indent: -1.5rem;
+}
+
+div.changed-function h2::before,
+div.changed-function h3::before,
+div.changed-function h4::before {
+    content: "🆙 ";
+    width: 1.5rem;
+}
+
+span.content.changed-function::after {
+    content: " 🆙";
+}

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -21,6 +21,8 @@
         <xsl:key name="id" match="*" use="@id"/>
         <xsl:variable name="new-functions"
                       select="key('id', 'new-functions')//code/string()"/>
+        <xsl:variable name="changed-functions"
+                      select="key('id', 'changes-to-existing-functions')//code/string()"/>
 
 	<xsl:template match="/">
 		<xsl:for-each select="1 to 20">
@@ -76,6 +78,11 @@
                 <xsl:if test="$fqfn = $new-functions
                               or $fspec//ednote[contains(., 'New in 4.0')]">
                   <xsl:attribute name="role" select="'new-function'"/>
+                </xsl:if>
+
+                <xsl:if test="$fqfn = $changed-functions
+                              or $fspec//ednote[contains(., 'Changed in 4.0')]">
+                  <xsl:attribute name="role" select="'changed-function'"/>
                 </xsl:if>
 
 		<head>

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -63,6 +63,9 @@
         <xsl:variable name="new-functions"
                       select="key('id', 'new-functions')//code/string()"/>
 
+        <xsl:variable name="changed-functions"
+                      select="key('id', 'changes-to-existing-functions')//code/string()"/>
+
         <xsl:for-each select="$prefixes">
           <xsl:variable name="prefix" select="."/>
           <select id="select-{$prefix}" 
@@ -79,6 +82,10 @@
                             select="$fqfn = $new-functions
                                     or .//ednote[contains(., 'New in 4.0')]"/>
 
+              <xsl:variable name="changed-function"
+                            select="$fqfn = $changed-functions
+                                    or .//ednote[contains(., 'Changed in 4.0')]"/>
+
               <option value="{$target}">
                 <xsl:if test="empty(key('id', $target, $spec))">
                   <xsl:attribute name="disabled" select="'disabled'"/>
@@ -94,6 +101,9 @@
 
                 <xsl:if test="$new-function">
                   <xsl:text> 🆕</xsl:text>
+                </xsl:if>
+                <xsl:if test="$changed-function">
+                  <xsl:text> 🆙</xsl:text>
                 </xsl:if>
               </option>
 


### PR DESCRIPTION
Obviously, I should have done icons for functions that have changed as well. So now I have. I'm not convinced that the 🆙 emoji is sufficiently different from the 🆕 emoji. Maybe I should try to make them different colors or something. But it's a start.