### PR TITLE
130 Binary Promotion

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -10770,7 +10770,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:opermap operator="eq" types="xs:hexBinary" other-operators="ne"
             >Defines the semantics of
          the <code>eq</code> and <code>ne</code> operators when applied to two <code>xs:hexBinary</code>
-         values.</fos:opermap>
+         values. Because of type promotion, either or both operands can also be of type 
+         <code>xs:base64Binary</code>.</fos:opermap>
       <fos:summary>
          <p>Returns <code>true</code> if two <code>xs:hexBinary</code> values contain the same octet
             sequence.</p>
@@ -10791,7 +10792,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       <fos:opermap operator="lt" types="xs:hexBinary" other-operators="ge"
             >Defines the semantics of
          the <code>lt</code> operator when applied to two <code>xs:hexBinary</code> values. Also used in the
-         definition of the <code>ge</code> operator.</fos:opermap>
+         definition of the <code>ge</code> operator. Because of type promotion, either or both operands can also be of type 
+         <code>xs:base64Binary</code>.</fos:opermap>
       <fos:summary>
          <p>Returns <code>true</code> if the first argument is less than the second.</p>
       </fos:summary>
@@ -10820,7 +10822,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       </fos:rules>
    </fos:function>
 
-   <fos:function name="base64Binary-equal" prefix="op">
+   <!--<fos:function name="base64Binary-equal" prefix="op">
       <fos:signatures>
          <fos:proto name="base64Binary-equal" return-type="xs:boolean">
             <fos:arg name="value1" type="xs:base64Binary"/>
@@ -10878,7 +10880,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
 
          <p>Otherwise, the function returns <code>false</code>.</p>
       </fos:rules>
-   </fos:function>
+   </fos:function>-->
 
    <fos:function name="NOTATION-equal" prefix="op">
       <fos:signatures>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5253,12 +5253,13 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <head>Operators on base64Binary and hexBinary</head>
          <div2 id="binary-value-comparisons">
             <head>Comparisons of base64Binary and hexBinary values</head>
-            <p>The following comparison operators on <code>xs:base64Binary</code> and
-                    <code>xs:hexBinary</code> values are defined. Comparisons take two operands of
-                    the same type; that is, both operands must be <code>xs:base64Binary</code> or
-                    both operands may be <code>xs:hexBinary</code>. Each returns a boolean value.</p>
-            <p>A value of type <code>xs:hexBinary</code> can be compared with a value of type
-                    <code>xs:base64Binary</code> by casting one value to the other type. See
+            <p diff="chg" at="2023-11-03">The following comparison operators on 
+                    <code>xs:hexBinary</code> values are defined. Each returns a boolean value.</p>
+            <p diff="chg" at="2023-11-03">As a consequence of the type promotion rules, these
+               functions can be used to compare any <code>xs:hexBinary</code> or <code>xs:base64Binary</code>
+               value with any other <code>xs:hexBinary</code> or <code>xs:base64Binary</code>;
+               a supplied operand of type <code>xs:base64Binary</code> is effectively
+               cast to <code>xs:hexBinary</code> prior to the comparison. See
                         <specref ref="casting-to-binary"/>.</p>
             <?local-function-index?>
             <div3 id="func-hexBinary-equal">
@@ -5266,12 +5267,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
             <div3 id="func-hexBinary-less-than">
                <head><?function op:hexBinary-less-than?></head>
-            </div3>
-            <div3 id="func-base64Binary-equal">
-               <head><?function op:base64Binary-equal?></head>
-            </div3>
-            <div3 id="func-base64Binary-less-than">
-               <head><?function op:base64Binary-less-than?></head>
             </div3>
          </div2>
       </div1>

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -6,52 +6,98 @@
 <head>Type Promotion</head>
 
 <p><termdef term="type promotion" id="dt-type-promotion">Under certain circumstances, an atomic value can be promoted from
-one type to another. <term>Type promotion</term> is used in evaluating function calls (see <specref ref="id-function-calls"/>)<phrase role="xquery">, <code>order by</code> clauses (see <specref ref="id-order-by-clause"/>),</phrase>  and operators that accept numeric or string operands (see <specref ref="mapping"/>).</termdef> The following type promotions are permitted:</p>
+  one type to another.</termdef> <term>Type promotion</term> is used in a number of contexts:</p>
+  
+  <ulist>
+    <item><p>It forms part of the process described by the <termref def="dt-coercion-rules"/>, invoked
+    for example when a value of one type is supplied as an argument of a function call where
+    the required type of the corresponding function parameter is declared with a different type.</p></item>
+    <item><p>It forms part of the process described in <specref ref="mapping"/>, which selects the implementation
+      of a binary operator based on the types of the supplied operands.</p></item>
+    <item><p>It is invoked (by explicit reference) in a number of other situations,
+    for example when computing an average of a sequence of numeric values (in the
+      <function>fn:avg</function> function)<phrase role="xquery">, and in <code>order by</code> clauses
+      (see <specref ref="id-order-by-clause"/>)</phrase>.</p></item>
+  </ulist>
+  
+  <p>In general, type promotion takes a set of one or more atomic values as input, potentially
+    having different types, and selects a single common type to which all the input values can
+    be converted by casting.</p>
+  
+  <p>There are three families of atomic types that can be mixed in this way:</p>
 
-<olist>
-<item><p>Numeric type promotion:</p><olist>
-<item><p>A value of type <code>xs:float</code> (or any type
-derived by restriction from <code>xs:float</code>) can be promoted to
-the type <code>xs:double</code>. The result is the
-<code>xs:double</code> value that is the same as the original
-value.</p></item>
-
-
-<item><p>A value of type <code>xs:decimal</code> (or any type derived
-by restriction from <code>xs:decimal</code>) can be promoted to either
-of the types <code>xs:float</code> or <code>xs:double</code>.  The
-result of this promotion is created by casting the original value to
-the required type. This kind of promotion may cause loss of
-precision.</p></item></olist></item>
-<item><p>URI type promotion: A value of type <code>xs:anyURI</code> (or any type derived by restriction from <code>xs:anyURI</code>) can be promoted to the type <code>xs:string</code>. The result of this promotion is created by casting the original value to the type <code>xs:string</code>.</p><note><p>Since <code>xs:anyURI</code> values can be promoted to <code>xs:string</code>, functions and operators that compare strings using the <termref def="dt-def-collation">default collation</termref> also compare <code>xs:anyURI</code> values using the <termref def="dt-def-collation">default collation</termref>. This ensures that orderings that include strings, <code>xs:anyURI</code> values, or any combination of the two types are consistent and well-defined.</p></note></item>
-
-
-</olist>
-<p>Note that <termref def="dt-type-promotion">type promotion</termref> is different from <termref def="dt-subtype-substitution">subtype substitution</termref>. For example:</p><ulist>
-<item><p>A function that expects a parameter <code>$p</code> of type <code>xs:float</code> can be invoked with a value of type <code>xs:decimal</code>. This is an example of <termref def="dt-type-promotion">type promotion</termref>. The value is actually converted to the expected type. Within the body of the function, <code>$p instance of xs:decimal</code> returns <code>false</code>.</p></item>
-<item><p>A function that expects a parameter <code>$p</code> of type <code>xs:decimal</code> can be invoked with a value of type <code>xs:integer</code>. This is an example of <termref def="dt-subtype-substitution">subtype substitution</termref>. The value retains its original type. Within the body of the function, <code>$p instance of xs:integer</code> returns <code>true</code>.</p></item></ulist></div2>
-
+  <olist>
+    <item><p>Numeric types. This applies when the input contains values of types
+      <code>xs:decimal</code>, <code>xs:float</code>, and <code>xs:double</code> (including
+      types derived from these, such as <code>xs:integer</code>).</p>
+      <p>The rules are:</p>
+      <olist>
+        <item><p>If any of the items is of type <code>xs:double</code>, then 
+        all the values are cast to type <code>xs:double</code>.</p></item>
+        <item><p>Otherwise, if any of the items is of type <code>xs:float</code>, then 
+          all the values are cast to type <code>xs:float</code>.</p></item>
+        <item><p>Otherwise, no casting takes place: the values remain as <code>xs:decimal</code>.</p></item>
+      </olist>
+    </item>
+    <item><p>String types. This applies when the input contains values of types
+      <code>xs:string</code> and <code>xs:anyURI</code> (including
+      types derived from these, such as <code>xs:NCName</code>).</p>
+      <p>The rule is that if any of the items is of type <code>xs:string</code>,
+      then all the values are cast to type <code>xs:string</code>.</p>
+    </item>
+    <item><p>Binary types. This applies when the input contains values of types
+      <code>xs:hexBinary</code> and <code>xs:base64Binary</code> (including
+      types derived from these).</p>
+      <p>The rule is that if any of the items is of type <code>xs:hexBinary</code>,
+        then all the values are cast to type <code>xs:hexBinary</code>.</p>
+    </item>
+  </olist>
+  
+</div2>
 <div2 id="mapping">
 <head>Operator Mapping</head> <p>The operator mapping tables in this section list the
-combinations of types for which the various operators of &language;
-are defined. <termdef term="operator function" id="dt-operator-function">For each operator and valid combination of operand types, the operator mapping tables specify a result type and an <term>operator function</term> that implements the semantics of the operator for the given types.</termdef> The definitions of the operator functions are given in  <bibref ref="xpath-functions-40"/>. The result of an operator may be the raising of an error by its operator function, as defined in <bibref ref="xpath-functions-40"/>. The operator function fully defines the semantics of a given operator for the case where the operands are single atomic values of the types given in the table. For the definition of each operator (including its
+combinations of types for which various operators of &language;
+are defined. The operators covered by this appendix are the value comparison
+operators <code>eq</code> and <code>lt</code>, and the arithmetic operators
+  <code>+</code>, <code>-</code>, <code>*</code>, <code>div</code>, 
+  <code>idiv</code>, and <code>mod</code>.</p>
+  
+  <p>Other operators (such as <code>and</code>,
+    <code>or</code>, <code>intersect</code>, <code>union</code>,
+    <code>=</code>, <code>||</code>, and <code>is</code>)
+    are defined directly in the main body of
+    this document, and do not occur in the operator mapping table.</p>
+  
+
+    
+    <p diff="chg" at="A">The operators <code>ne</code>, <code>le</code>, <code>gt</code>, and <code>ge</code> do not
+      occur in the operator mapping table, but are instead defined by the following equivalences:</p>
+    
+    <ulist diff="chg" at="A">
+      <item><p><code>A ne B</code> is equivalent to <code>not(A eq B)</code></p></item>
+      <item><p><code>A le B</code> is equivalent to <code>A lt B or A eq B</code></p></item>
+      <item><p><code>A gt B</code> is equivalent to <code>B lt A</code></p></item>
+      <item><p><code>A ge B</code> is equivalent to <code>B lt A or B eq A</code></p></item>
+    </ulist>
+    
+  
+  
+  <p><termdef term="operator function" id="dt-operator-function">For each 
+  operator and valid combination of operand types, the operator mapping tables 
+  specify a result type and an expression that invokes an <term>operator function</term>; 
+    the operator function implements 
+  the semantics of the operator for the given types.</termdef> The definitions 
+  of the operator functions are given in  <bibref ref="xpath-functions-40"/>. 
+  The result of an operator may be the raising of an error by its operator 
+  function, as defined in <bibref ref="xpath-functions-40"/>. The operator 
+  function fully defines the semantics of a given operator for the case 
+  where the operands are single atomic values of the types given in the table. 
+  For the definition of each operator (including its
 behavior for empty sequences or sequences of length greater than one),
 see the descriptive material in the main part of this
 document.</p>
   
-  <p>The <code>and</code> and
-<code>or</code> operators are defined directly in the main body of
-this document, and do not occur in the operator mapping table.</p>
-  
-  <p diff="chg" at="A">The operators <code>ne</code>, <code>le</code>, <code>gt</code>, and <code>ge</code> do not
-  occur in the operator mapping table, but are instead defined by the following equivalences:</p>
-  
-  <ulist diff="chg" at="A">
-    <item><p><code>A ne B</code> is equivalent to <code>not(A eq B)</code></p></item>
-    <item><p><code>A le B</code> is equivalent to <code>A lt B or A eq B</code></p></item>
-    <item><p><code>A gt B</code> is equivalent to <code>B lt A</code></p></item>
-    <item><p><code>A ge B</code> is equivalent to <code>B lt A or B eq A</code></p></item>
-  </ulist>
+
   
   <p>If an operator in the operator mapping tables expects an operand of type
 <emph>ET</emph>, that operator can be applied to an operand of type <emph>AT</emph> if type <emph>AT</emph> can
@@ -77,8 +123,19 @@ thought of as representing the following four operators:</p>
 <tr><td align="center"><code>+</code></td><td align="center"><code>xs:float</code></td><td align="center"><code>xs:float</code></td><td align="center"><code>xs:float</code></td></tr>
 <tr><td align="center"><code>+</code></td><td align="center"><code>xs:double</code></td><td align="center"><code>xs:double</code></td><td align="center"><code>xs:double</code></td></tr></tbody></table><p>A numeric operator may be validly applied to an operand of type <emph>AT</emph> if type
 <emph>AT</emph> can be converted to any of the four numeric types by a combination of
-<termref def="dt-type-promotion">type promotion</termref> and <termref def="dt-subtype-substitution">subtype substitution</termref>. If the result type of an
-operator is listed as numeric, it means "the first type in the ordered list <code>(xs:integer, xs:decimal, xs:float, xs:double)</code> into which all operands can be converted by <termref def="dt-subtype-substitution">subtype substitution</termref> and <termref def="dt-type-promotion">type promotion</termref>." As an example, suppose that the type <code>hatsize</code> is derived from <code>xs:integer</code> and the type <code>shoesize</code> is derived from <code>xs:float</code>.   Then if the <code>+</code> operator is invoked with operands of type <code>hatsize</code> and <code>shoesize</code>, it returns a result of type <code>xs:float</code>.  Similarly, if <code>+</code> is invoked with two operands of type <code>hatsize</code> it returns a result of type <code>xs:integer</code>.</p><p><termdef id="dt-gregorian" term="Gregorian">In the operator mapping tables,
+<termref def="dt-type-promotion">type promotion</termref> and <termref def="dt-subtype-substitution">subtype substitution</termref>. 
+  If the result type of an
+operator is listed as numeric, it means "the first type in the ordered list 
+  <code>(xs:integer, xs:decimal, xs:float, xs:double)</code> into which all 
+  operands can be converted by <termref def="dt-subtype-substitution">subtype substitution</termref> 
+  and <termref def="dt-type-promotion">type promotion</termref>." As an example, suppose that 
+  the type <code>hatsize</code> is derived from <code>xs:integer</code> and the type 
+  <code>shoesize</code> is derived from <code>xs:float</code>.   Then if the <code>+</code> 
+  operator is invoked with operands of type <code>hatsize</code> and <code>shoesize</code>, 
+  it returns a result of type <code>xs:float</code>.  Similarly, if <code>+</code> is invoked 
+  with two operands of type <code>hatsize</code> it returns a result of type <code>xs:integer</code>.</p>
+  
+  <p><termdef id="dt-gregorian" term="Gregorian">In the operator mapping tables,
 the term <term>Gregorian</term> refers to the types
 <code>xs:gYearMonth</code>, <code>xs:gYear</code>,
 <code>xs:gMonthDay</code>, <code>xs:gDay</code>, and
@@ -86,6 +143,13 @@ the term <term>Gregorian</term> refers to the types
 Gregorian-type operands, both operands must have the same type (for
 example, if one operand is of type <code>xs:gDay</code>, the other
 operand must be of type <code>xs:gDay</code>.)</p>
+  
+  <p diff="add" at="2023-11-03"><termdef id="dt-binary" term="binary">In the operator mapping tables,
+    the term <term>binary</term> refers to the types
+    <code>xs:hexBinary</code> and <code>xs:base64Binary</code>.</termdef>
+    For operators that accept two
+    binary operands, both operands are promoted to type 
+    <code>xs:hexBinary</code>.</p>
 
 <table border="1" role="small">
 <caption>Binary Operators</caption>
@@ -187,17 +251,13 @@ operand must be of type <code>xs:gDay</code>.)</p>
 
 <tr><td>A eq B</td><td>Gregorian</td><td>Gregorian</td><td>op:gYear-equal(A, B) etc.</td><td>xs:boolean</td></tr>
 
-<tr><td>A eq B</td><td>xs:hexBinary</td><td>xs:hexBinary</td><td>op:hexBinary-equal(A, B)</td><td>xs:boolean</td></tr>
-
-<tr><td>A eq B</td><td>xs:base64Binary</td><td>xs:base64Binary</td><td>op:base64Binary-equal(A, B)</td><td>xs:boolean</td></tr>
+<tr><td>A eq B</td><td>binary</td><td>binary</td><td>op:hexBinary-equal(A, B)</td><td>xs:boolean</td></tr>
 
 
 <tr><td>A eq B</td><td>xs:QName</td><td>xs:QName</td><td>op:QName-equal(A, B)</td><td>xs:boolean</td></tr>
 
 <tr><td>A eq B</td><td>xs:NOTATION</td><td>xs:NOTATION</td><td>op:NOTATION-equal(A, B)</td><td>xs:boolean</td></tr>
 
-<tr><td>A eq B</td><td>xs:hexBinary</td><td>xs:hexBinary</td><td>op:hexBinary-equal(A, B)</td><td>xs:boolean</td></tr>
-<tr><td>A eq B</td><td>xs:base64Binary</td><td>xs:base64Binary</td><td>op:hexBinary-equal(A, B)</td><td>xs:boolean</td></tr>
 
 
 
@@ -215,8 +275,7 @@ operand must be of type <code>xs:gDay</code>.)</p>
 
 <tr><td>A lt B</td><td>xs:yearMonthDuration</td><td>xs:yearMonthDuration</td><td>op:yearMonthDuration-less-than(A, B)</td><td>xs:boolean</td></tr>
 <tr><td>A lt B</td><td>xs:dayTimeDuration</td><td>xs:dayTimeDuration</td><td>op:dayTimeDuration-less-than(A, B)</td><td>xs:boolean</td></tr>
-<tr><td>A lt B</td><td>xs:hexBinary</td><td>xs:hexBinary</td><td>op:hexBinary-less-than(A, B)</td><td>xs:boolean</td></tr>
-<tr><td>A lt B</td><td>xs:base64Binary</td><td>xs:base64Binary</td><td>op:base64Binary-less-than(A, B)</td><td>xs:boolean</td></tr>
+<tr><td>A lt B</td><td>binary</td><td>binary</td><td>op:hexBinary-less-than(A, B)</td><td>xs:boolean</td></tr>
 
 
 
@@ -247,133 +306,7 @@ operand must be of type <code>xs:gDay</code>.)</p>
 
 </div2>
   
-  <!--<div2 id="id-math-symbols" diff="add" at="A">
-    <head>Mathematical Operator Symbols</head>
-    <p>Various operators written in the grammar using alphabetic keywords (such as <code>and</code>, <code>or</code>,
-    <code>le</code>, <code>ge</code>) can instead be written using mathematical symbols. The equivalents are given
-    in the table below:</p>
-    
-    <table border="1">
-      <caption>Mathematical Operator Symbols</caption>
-      <thead>
-        <tr>
-          <th>Operator</th>
-          <th>Symbol</th>
-          <th>Codepoint</th>
-        </tr>
-      </thead>
-      <tbody>
-        
-        <tr>
-          <td>and</td>
-          <td>∧</td>
-          <td>x2227</td>
-        </tr>
-        <tr>
-          <td>or</td>
-          <td>∨</td>
-          <td>x2228</td>
-        </tr>
-        <tr>
-          <td>eq</td>
-          <td>≐</td>
-          <td>x2250</td>
-        </tr>
-        <tr>
-          <td>ne</td>
-          <td>≠</td>
-          <td>x2260</td>
-        </tr>
-        <tr>
-          <td>lt</td>
-          <td>⋖</td>
-          <td>x22D6</td>
-        </tr>
-        <tr>
-          <td>gt</td>
-          <td>⋗</td>
-          <td>x22D7</td>
-        </tr>
-        <tr>
-          <td>le</td>
-          <td>≤</td>
-          <td>x2264</td>
-        </tr>
-        <tr>
-          <td>ge</td>
-          <td>≥</td>
-          <td>x2265</td>
-        </tr>
-        <tr>
-          <td>div</td>
-          <td>÷</td>
-          <td>xF7</td>
-        </tr>
-        <tr>
-          <td>mod</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td>idiv</td>
-          <td>⨸</td>
-          <td>x2A38</td>
-        </tr>
-        <tr>
-          <td>union (|)</td>
-          <td>∪</td>
-          <td>x222A</td>
-        </tr>
-        <tr>
-          <td>intersect</td>
-          <td>∩</td>
-          <td>x2229</td>
-        </tr>
-        <tr>
-          <td>except</td>
-          <td>∖</td>
-          <td>x2216</td>
-        </tr>
-        <tr>
-          <td>is</td>
-          <td>≡</td>
-          <td>x2261</td>
-        </tr>        
-        <tr>
-          <td>&lt;&lt; (precedes)</td>
-          <td>≪</td>
-          <td>x226A</td>
-        </tr>
-        <tr>
-          <td>>> (follows)</td>
-          <td>≫</td>
-          <td>x226B</td>
-        </tr>
-        <tr>
-          <td>otherwise</td>
-          <td>⊩</td>
-          <td>x22A9</td>
-        </tr>
-        <tr>
-          <td>some</td>
-          <td>∃</td>
-          <td>x2203</td>
-        </tr>
-        <tr>
-          <td>every</td>
-          <td>∀</td>
-          <td>x2200</td>
-        </tr>
-        <tr>
-          <td>satisfies</td>
-          <td>⧴</td>
-          <td>x29F4</td>
-        </tr>
-      </tbody>
-    </table>
-    <p>For example, the expression <code>some $x in $X satisfies $x le 17</code> can equivalently be written
-      <code>∃ $x in $X ⧴ $x ≤ 17</code></p>
-  </div2>-->
+
 </div1>
 
 <div1 role="xquery" id="id-xq-context-components">
@@ -1038,7 +971,8 @@ defined.</p>
     <td>global; overwriteable by implementation</td></tr>  
 </tbody>
 </table></div2></div1>
-<div1 id="id-impl-defined-items"><head>Implementation-Defined Items</head><p>The following items in this specification are <termref def="dt-implementation-defined">implementation-defined</termref>:</p><olist>
+<div1 id="id-impl-defined-items"><head>Implementation-Defined Items</head><p>The following items in this specification 
+  are <termref def="dt-implementation-defined">implementation-defined</termref>:</p><olist>
 <item><p>The version of Unicode that is used to construct expressions.</p></item>
 <item><p>The <termref def="dt-static-collations">statically-known collations</termref>.</p></item>
 <item><p>The <termref def="dt-timezone">implicit timezone</termref>.</p></item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6587,6 +6587,600 @@ declare function flatten($tree as tree) as item()* {
             </div3>
 
          </div2>
+      
+      
+         <div2 id="id-coercion-rules">
+               <head>Coercion Rules</head>
+
+               <p diff="chg" at="2022-11-17">
+                  <termdef term="coercion rules" id="dt-coercion-rules"
+                        >The <term>coercion rules</term> are rules used to convert a supplied value to a required type,
+                     for example when converting an argument of a function call to the declared type of the function parameter.
+                  </termdef> The required type is expressed as a <termref def="dt-sequence-type"
+                     >sequence type</termref>. The effect of the coercion rules may be to accept the value as supplied,
+                  to convert it to a value that matches the required type, or to reject it with a type error.</p>
+                        
+               <p diff="chg" at="2022-11-17">This section defines how the coercion rules operate; the situations in which the rules apply
+                  are defined elsewhere, by reference to this section.</p>
+                        
+                        <note diff="add" at="A">
+                           <p>In previous versions of this specification, the coercion rules were referred to as the
+                              <emph>function conversion</emph> rules. The terminology has changed because the rules are not exclusively
+                              associated with functions or function calling.</p>
+                        </note>
+            
+               <p diff="chg" at="2023-03-11">If the required type is <code>empty-sequence()</code>, 
+                  no coercion takes place (the supplied
+               value must be an empty sequence, or a type error occurs). In all other cases, the required 
+                  <termref def="dt-sequence-type"/> <var>T</var> comprises a required <termref def="dt-item-type"/> <var>R</var> 
+                  and an optional occurrence indicator.</p>
+		            
+                        <p diff="chg" at="2022-11-17">The coercion rules are applied to a supplied value <var>V</var> 
+		               and the required type <var>T</var> as follows:</p>
+
+               
+               <olist>
+
+                  <item role="xpath">
+                     <p>If  <termref def="dt-xpath-compat-mode">XPath
+                          1.0 compatibility mode</termref> is <code>true</code> and <var>V</var>
+                          is not an instance of the required type <var>T</var>, then the following conversions are applied
+                          sequentially to <var>V</var>:</p>
+
+                     <olist>
+
+                        <item>
+                           <p>If the occurrence indicator of <var>T</var> is either absent or <code>?</code>
+                              (examples: <code>xs:string</code>, <code>xs:string?</code>, 
+                              <code>xs:untypedAtomic</code>, <code>xs:untypedAtomic?</code>, 
+                              <code>node()</code>, <code>node()?</code>, <code>item()</code>, 
+                              <code>item()?</code>), then <var>V</var> is effectively replaced by <code>V[1]</code>.</p>
+                        </item>
+
+                        <item>
+                           <p>If <var>T</var> is <code>xs:string</code> or <code>xs:string?</code>,
+                      		then <var>V</var> is effectively replaced by
+                      		<code>fn:string(V)</code>.</p>
+                           <note diff="add" at="2022-11-17"><p>This rule does not apply where <var>T</var> is derived from <code>xs:string</code>
+                           or <code>xs:string?</code>, because derived types did not arise in XPath 1.0.</p></note>
+                        </item>
+
+                        <item>
+                           <p>If <var>T</var> is <code>xs:double</code> or <code>xs:double?</code>, then 
+                              <code>V</code> is effectively replaced by <code>fn:number(V)</code>.</p>
+                           <note diff="add" at="2022-11-17"><p>This rule does not apply where <var>T</var> is derived from <code>xs:double</code>
+                              or <code>xs:double?</code>, because derived types did not arise in XPath 1.0.</p></note>
+                        </item>
+                     </olist>
+
+                     <note>
+                        <p>
+                           The special rules for <termref def="dt-xpath-compat-mode"
+                              >XPath 1.0 compatibility
+    mode</termref> are used for converting the arguments of a static function call, and
+                           in certain XSLT constructs. They are not invoked in other contexts such as dynamic function calls,
+    for converting the result of an inline function to its required type,
+    for partial function application, or for implicit function calls such as
+    occur when evaluating functions such as <code>fn:for-each</code> and <code>fn:filter</code>.</p>
+                     </note>
+
+                  </item>
+
+                  <item>
+                     <p>If <var>R</var> is a <termref def="dt-generalized-atomic-type"/>, then the following conversions are applied,
+                        <phrase diff="add" at="2022-01-01">in order</phrase>:</p>
+                     
+                     <note><p>Enumeration types are generalized atomic types, so these rules apply.</p></note>
+
+                     <olist>
+
+                        <item>
+                           <p>
+                              <termref def="dt-atomization">Atomization</termref> is applied to <var>V</var>, 
+                              resulting in a sequence of atomic values <var>V1</var>.</p>
+                           
+                        </item>
+                        
+                        <item diff="chg" at="2023-11-03">
+                           <p>Each item <var>A</var> in <var>V1</var> is processed using one of the following
+                           rules, which are mutually exclusive.</p>
+                           <olist>
+                              <item><p>If <var>A</var> is an instance of type <code>xs:untypedAtomic</code>
+                              then <var>A</var> is cast to type <var>R</var>.</p>
+                                 <p>If <var>R</var> is an 
+                                    <termref def="dt-EnumerationType"/>,
+                                    <var>J</var> is cast to <code>xs:string</code>.  
+                                    If <var>R</var> is <termref
+                                       def="dt-namespace-sensitive"
+                                       >namespace-sensitive</termref>, a <termref def="dt-type-error"
+                                          >type error</termref>
+                                    <errorref class="TY" code="0117"/> is raised.</p></item>
+                              <item><p>If there is an entry (<var>from</var>, <var>to</var>)
+                                 in the following table such that <var>A</var> is an instance of <var>from</var>,
+                                 and <var>to</var> is <var>R</var>, then <var>A</var> is cast to type <var>R</var>.</p>
+                                 
+                                 <table border="1" role="medium">
+                                    <caption>Type Promotion</caption>
+                                    <thead>
+                                       <tr>
+                                          <th>from</th>
+                                          <th>to</th>
+                                       </tr>
+                                    </thead>
+                                    <tbody>
+                                       <tr><td><code>xs:decimal</code></td><td><code>xs:double</code></td></tr>
+                                       <tr><td><code>xs:decimal</code></td><td><code>xs:float</code></td></tr>
+                                       <tr><td><code>xs:float</code></td><td><code>xs:double</code></td></tr>
+                                       <tr><td><code>xs:string</code></td><td><code>xs:anyURI</code></td></tr>
+                                       <tr><td><code>xs:anyURI</code></td><td><code>xs:string</code></td></tr>
+                                       <tr><td><code>xs:hexBinary</code></td><td><code>xs:base64Binary</code></td></tr>
+                                       <tr><td><code>xs:base64Binary</code></td><td><code>xs:hexBinary</code></td></tr>
+                                    </tbody>
+                                    
+                                 </table>
+                                 
+                                 <note><p>The item type in the <var>to</var> column must match <var>R</var>
+                                    exactly; however, <var>A</var> may belong to a subtype of the type in the <var>from</var>
+                                    column. For example, an <code>xs:NCName</code> will be cast to type <code>xs:anyURI</code>,
+                                    but an <code>xs:anyURI</code> will not be cast to type <code>xs:NCName</code>.</p></note>
+                                 
+                              </item>
+                              <item><p>If <var>R</var> is derived from some primitive atomic type <var>P</var>, 
+                                 then <var>A</var> is <term>relabeled</term> as an instance of <var>R</var> if it satisfies
+                                 all the following conditions:</p> 
+                                 <ulist>
+                                    <item><p><var>A</var> is an instance of <var>P</var>.</p></item>
+                                    <item><p><var>A</var> is not an instance of <var>R</var>.</p></item>
+                                    <item><p>The <xtermref spec="DM40" ref="dt-datum"/> of <var>A</var> is 
+                                       within the value space of <var>R</var>.</p></item>
+                                 </ulist>
+                                 <p>Relabeling an atomic value changes the <termref def="dt-type-annotation"/> but not the 
+                                    <xtermref spec="DM40" ref="dt-datum"/>. For example, the
+                                    <code>xs:integer</code> value 3 can be relabeled as an instance of <code>xs:unsignedByte</code>, because
+                                    the datum is within the value space of <code>xs:unsignedByte</code>.</p>
+                                 <note><p>Relabeling is not the same as casting. For example, the <code>xs:decimal</code> value 10.1
+                                    can be cast to <code>xs:integer</code>, but it cannot be relabeled as <code>xs:integer</code>,
+                                    because its datum not within the value space of <code>xs:integer</code>.</p></note>
+                                 
+                                 <note><p>The effect of this rule is that if, for example, a function parameter is declared
+                                    with an expected type of <code>xs:positiveInteger</code>, then a call that supplies the literal
+                                    value 3 will succeed, whereas a call that supplies -3 will fail.</p></note>
+                                 
+                                 <note><p>This differs from previous versions of this specification, where both these calls would fail.</p>
+                                    <p>This change allows the arguments of existing functions to be defined with a 
+                                       more precise type. For example, the <code>$position</code> argument of <code>array:get</code>
+                                       can be defined as <code>xs:positiveInteger</code> rather than <code>xs:integer</code>. To enable
+                                       this to be done without breaking backwards compatibility in respect of error behavior, 
+                                       system functions in many cases define custom error codes to be raised where 
+                                       relabeling of argument values fails.</p></note>
+                                 
+                                 <note><p>Numeric promotion and <code>xs:anyURI</code> promotion occur only when <var>T</var>
+                                    is a primitive type (<code>xs:double</code>, <code>xs:float</code>, or <code>xs:string</code>).
+                                    Relabeling occurs only when <var>T</var> is a derived type. Promotion and relabeling are therefore
+                                    never combined.</p></note></item>
+                              <item><p>If <var>R</var> is a <termref def="dt-pure-union-type"/>,
+                                 then <var>A</var> is <term>relabeled</term> as an instance of 
+                                 some member type <var>M</var> in the transitive membership of <var>R</var> if <var>M</var> satisfies
+                                 all the conditions for relabeling defined in the previous rule, and if it is the first member type
+                                 in the transitive membership of <var>R</var> to satisfy those conditions.</p>
+                                 <note><p>For example, if <var>T</var>
+                                 is the type <code>union(xs:negativeInteger, xs:positiveInteger)*</code> and the supplied value is the
+                                 sequence <code>(20, -20)</code>, then the first item <code>20</code> is relabeled as type
+                                 <code>xs:positiveInteger</code> and the second item <code>-20</code>is relabeled as type 
+                                 <code>xs:negativeInteger</code>.</p></note>
+                                 <note>
+                                    <p>This rule also ensures that if the required type is <code>enum("red", "green", "blue")</code>
+                                       and the supplied value is <code>"green"</code>, then the supplied value will be accepted, and
+                                       will be relabeled as an instance of <code>xs:string</code>.</p>
+                                 </note>
+                              </item>
+
+                           </olist>
+                           
+                        </item>
+
+                       
+                     </olist>
+                  </item>
+
+                  <item diff="add" at="A">
+                     <p>If <var>R</var> is a <nt def="RecordTest"
+                           >RecordTest</nt>, then any item in <var>V</var> that is a map is converted
+                        to a new map as follows:</p>
+                     <olist>
+                        <item><p>The keys in the supplied map are unchanged.</p></item>
+                        <item><p>In any map entry whose key is an <code>xs:string</code> equal to the
+                        name of one of the field declarations in <var>R</var>, then the corresponding
+                           value is converted to the required type defined by that field declaration, 
+                           by applying the coercion rules recursively 
+                           (but with XPath 1.0 compatibility mode treated as false).</p></item>
+                     </olist>
+
+                     <note><p>For example, if the required type is
+                     <code>record(longitude as xs:double, latitude as xs:double)</code> and the supplied value is <code>map{"longitude": 0, "latitude":53.2}</code>,
+                        then the map is converted to <code>map{"longitude": 0.0e0, "latitude": 53.2e0}</code>.</p></note>
+                  </item>
+
+                  <item>
+                     <p>If <var>R</var> is a <nt def="TypedFunctionTest"
+                           >TypedFunctionTest</nt>, <termref
+                           def="dt-function-coercion"
+                        >function coercion</termref> is applied to each function in <var>V</var>.</p>
+                     <note>
+                        <p>Maps and arrays are functions, so function coercion applies to them as well.</p>
+                     </note>
+                  </item>
+
+                  <item>
+                     <p> If, after the
+		above conversions, the resulting value does not match
+		the expected type <var>T</var> according to the rules for <termref
+                           def="dt-sequencetype-matching"
+                           >SequenceType
+		Matching</termref>, a <termref def="dt-type-error"
+                           >type error</termref> is
+		raised <errorref class="TY" code="0004"
+                           />.</p>
+                     <note diff="add" at="Issue602">
+                        <p>Under the general rules for type errors 
+                           (see <specref ref="id-kinds-of-errors"/>), a processor
+                        <rfc2119>may</rfc2119> report a type error during static
+                        analysis if it will necessarily occur when the expression is evaluated.
+                        For example, the function call <code>fn:abs("beer")</code>
+                        will necessarily fail when evaluated, because the function requires
+                        a numeric value as its argument; this <rfc2119>may</rfc2119> be detected and reported
+                        as a static error.</p>
+                     </note>   
+		<p diff="del" at="2022-11-17"><phrase role="xquery"
+                              >If the function call takes place in a <termref def="dt-module"
+                              >module</termref> other
+		than the <termref def="dt-module"
+                              >module</termref> in which the function is defined, this
+		rule must be satisfied in both the module where the
+		function is called and the module where the function
+		is defined (the test is repeated because the two
+		modules may have different <termref
+                              def="dt-issd"
+                           >in-scope schema definitions</termref>.)</phrase>
+		Note that the rules for <termref
+                           def="dt-sequencetype-matching"
+                        >SequenceType
+		Matching</termref> permit a value of a derived type to
+		be substituted for a value of its base
+		type. </p>
+                  </item>
+               </olist>
+            <div3 id="id-implausible-coercions" diff="add" at="2023-06-01">
+               <head>Implausible Coercions</head>
+               
+            <p>An expression is deemed to be
+                     <termref def="dt-implausible"/> <errorref
+                        class="TY" code="0006"/> if the static type of the expression, after applying
+                     all necessary coercions, is <term>substantively disjoint</term>
+                     with the required type <var>T</var>. Two sequence types are
+                     considered to be substantively disjoint if (a) neither is a subtype
+                     of the other (see <specref ref="id-seqtype-subtype"/>) and 
+                     (b) the only values that
+                     are instances of both types are one or more of the following:</p>
+                     <ulist>
+                        <item><p>The empty sequence, <code>()</code>.</p></item>
+                        <item><p>The empty map, <code>map{}</code>.</p></item>
+                        <item><p>The empty array, <code>[]</code>.</p></item>
+                     </ulist>
+                     
+                     <note>
+                        <p>Examples of pairs of sequence types that are substantively disjoint
+                        include:</p>
+                        <ulist>
+                           <item><p><code>xs:integer*</code> and <code>xs:string*</code></p></item>
+                           <item><p><code>map(xs:integer, node())</code> and <code>map(xs:string, node())</code></p></item>
+                           <item><p><code>array(xs:integer)</code> and <code>array(xs:string)</code></p></item>
+                        </ulist>
+                     </note>
+                  <p>For example, supplying a value whose static type is <code>xs:integer*</code>
+                     when the required type is <code>xs:string*</code> is <termref def="dt-implausible"/>,
+                     because it can succeed only in the special case where the actual value supplied
+                     is an empty sequence.</p>
+                  <note><p>The case where the supplied type and the required type are completely
+                  disjoint (for example <code>map(*)</code> and <code>array(*)</code>) is covered
+                  by the general rules for type errors: that case can always be reported as a static
+                  error.</p></note>
+                  
+            </div3>
+               
+
+            <div3 id="id-function-coercion">
+               <head>Function Coercion</head>
+
+               <p>
+        Function coercion is a transformation applied to <termref def="dt-function-item"
+                     >function items</termref> during application of the
+        <termref
+                     def="dt-coercion-rules">coercion rules</termref>.
+        <termdef
+                     term="function coercion" id="dt-function-coercion">
+                     <term>Function coercion</term> wraps a <termref def="dt-function-item"/>
+        in a new function
+        whose signature is the same as the expected type.
+        This effectively delays the checking
+        of the argument and return types
+        until the function is called.</termdef>
+               </p>
+
+               <p>Given a function <var>F</var>, and an expected function type,
+                  <termref
+                     def="dt-function-coercion"
+                  >function coercion</termref>
+	proceeds as follows:</p>
+               <olist>
+                  <item>
+                     <p>If <var>F</var> has higher arity than the expected type,
+                     a type error is raised <errorref
+                           class="TY" code="0004"/></p>
+                  </item>
+                  <item diff="add" at="A">
+                     <p>If <var>F</var> has lower arity than the expected type,
+                     then <var>F</var> is wrapped in a new function that declares and ignores the
+                  additional argument; the following steps are then applied to this new function.</p>
+                     <p>For example, if the expected type is <code>function(node(), xs:boolean) as xs:string</code>,
+                  and the supplied function is <code>fn:name#1</code>, then the supplied function is effectively
+                  replaced by <code>function($n as node(), $b as xs:boolean) as xs:string {fn:name($n)}</code></p>
+                     <note>
+                        <p>This mechanism makes it easier to design versatile and extensible higher-order functions. 
+                     For example, in previous versions of this specification, the second argument of
+                     the <code>fn:filter</code> function expected an argument of type 
+                     <code>function(item()) as xs:boolean</code>. This has now been extended to
+                     <code>function(item(), xs:integer) as xs:boolean</code>, but existing code continues
+                     to work, because callback functions that are not interested in the value of the second
+                     argument simply ignore it.                    
+                  </p>
+                        <p>TODO: this change to fn:filter has not yet been made.</p>
+                     </note>
+                  </item>
+
+
+                  <item>
+                     <p>Function coercion then
+        returns a new <termref def="dt-function-item"/>
+        with the following properties
+        (as defined in <xspecref
+                           spec="DM40" ref="function-items"/>):
+
+        <ulist>
+                           <item>
+                              <p>
+                                 <term>name</term>:
+            The name of <var>F</var> <phrase diff="add" at="B">(if not absent)</phrase>.
+          </p>
+                           </item>
+           <item><p diff="add" at="2023-05-25"><term>identity</term>: A new function
+              identity distinct from the identity of any other function item.</p>
+              <note><p>See also <specref ref="id-function-identity"/>.</p></note>
+           </item>
+                           <item>
+                              <p>
+                                 <term>parameter names</term>:
+	      The parameter names of <var>F</var>.
+            </p>
+                           </item>
+                           <item>
+                              <p>
+                                 <term>signature</term>:
+            <code>Annotations</code> is set to the annotations of <var>F</var>. <code>TypedFunctionTest</code> is set to the expected type.
+          </p>
+                           </item>
+                           <item>
+                              <p>
+                                 <term>implementation</term>:
+            In effect,
+            a <code>FunctionBody</code> that calls <var>F</var>,
+            passing it the parameters of this new function,
+            in order.
+          </p>
+                           </item>
+                           <item>
+                              <p>
+                                 <term>nonlocal variable bindings</term>:
+            An empty mapping.
+          </p>
+                           </item>
+                        </ulist>
+                     </p>
+                  </item>
+               </olist>
+               <p>
+        If the result of invoking the new function would
+        necessarily result in a type error, that
+        error may be raised during
+                  <termref
+                     def="dt-function-coercion"
+                  >function coercion</termref>. It is implementation dependent whether this
+        happens or not.
+      </p>
+
+               <p>
+        These rules have the following consequences:
+
+        <ulist>
+                     <item>
+                        <p>
+            SequenceType matching of the function’s arguments and result are delayed until that function is called.
+          </p>
+                     </item>
+                     <item>
+                        <p>
+                           The <termref def="dt-coercion-rules"
+                              >coercion rules</termref> rules applied to the function’s arguments and result are defined by the SequenceType
+            it has most recently been coerced to. Additional coercion rules could apply when the wrapped function
+            is called.
+          </p>
+                     </item>
+                     <item>
+                        <p>
+            If an implementation has static type information about a function, that can be used to type check the
+            function’s argument and return types during static analysis.
+          </p>
+                     </item>
+                  </ulist>
+               </p>
+
+               <p role="xquery">
+      For instance, consider the following query:
+      <eg
+                     role="parse-test"><![CDATA[
+declare function local:filter($s as item()*, $p as function(xs:string) as xs:boolean) as item()*
+{
+  $s[$p(.)]
+};
+
+let $f := function($a) { starts-with($a, "E") }
+return
+  local:filter(("Ethel", "Enid", "Gertrude"), $f)
+      ]]></eg>
+               </p>
+
+               <p role="xquery"
+                     >
+        The function <code>$f</code> has a static type of <code>function(item()*) as item()*</code>. When the <code>local:filter()</code> function
+        is called, the following occurs to the function:
+
+        <olist>
+                     <item>
+                        <p>
+                           The <termref def="dt-coercion-rules"
+                              >coercion rules</termref> result in applying 
+                           <termref
+                              def="dt-function-coercion"
+                              >function coercion</termref> to 
+            <code>$f</code>,
+            wrapping $f in a new function (<code>$p</code>)
+            with the signature <code>function(xs:string) as xs:boolean</code>.
+          </p>
+                     </item>
+                     <item>
+                        <p>
+            <code>$p</code> is matched against the SequenceType of <code>function(xs:string) as xs:boolean</code>, and succeeds.
+          </p>
+                     </item>
+                     <item>
+                        <p>
+                           When <code>$p</code> is called inside the predicate, <termref
+                              def="dt-coercion-rules"
+                              >coercion</termref> 
+                           and SequenceType matching rules are applied to the context value argument,
+            resulting in an <code>xs:string</code> value or a type error.
+          </p>
+                     </item>
+                     <item>
+                        <p>
+            <code>$f</code> is called with the <code>xs:string</code>, which returns an <code>xs:boolean</code>.
+          </p>
+                     </item>
+                     <item>
+                        <p><code>$p</code> applies <termref def="dt-coercion-rules"
+                              >coercion rules</termref> to the result sequence from <code>$f</code>, 
+                           which already matches its declared return type of <code>xs:boolean</code>.
+          </p>
+                     </item>
+                     <item>
+                        <p>
+            The <code>xs:boolean</code> is returned as the result of <code>$p</code>.
+          </p>
+                     </item>
+                  </olist>
+               </p>
+
+               <note>
+                  <p>
+                     Although the semantics of <termref
+                        def="dt-function-coercion"
+                     >function coercion</termref> are specified in terms of wrapping the functions,
+        static typing will often be able to reduce the number of places where this is actually necessary.
+      </p>
+               </note>
+
+               <p>Since maps and arrays are also functions in &language;, 
+                  <termref
+                     def="dt-function-coercion"
+                  >function coercion</termref> applies to them as well.
+
+        For instance, consider the following expression:
+      </p>
+
+               <eg role="parse-test"><![CDATA[
+let $m := map {
+  "Monday" : true(),
+  "Wednesday" : true(),
+  "Friday" : true(),
+  "Saturday" : false(),
+  "Sunday" : false()
+},
+$days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+return filter($days,$m)
+      ]]></eg>
+
+               <p>
+        The map <code>$m</code> has a function signature of <code>function(xs:anyAtomicType) as item()*</code>. When the <code>fn:filter()</code> function is called, the following occurs to the map:
+
+<olist>
+                     <item>
+                        <p>The map <code>$m</code> is treated as <code>function($f)</code>,  equivalent to <code>map:get($m,?)</code>.</p>
+                     </item>
+                     <item>
+                        <p>The <termref def="dt-coercion-rules"
+                              >coercion rules</termref> result in applying 
+                           <termref
+                              def="dt-function-coercion"
+                              >function coercion</termref> 
+                           to <code>$f</code>, wrapping <code>$f</code> in a new function (<code>$p</code>) with the 
+                           signature <code>function(item()) as xs:boolean</code>.</p>
+                     </item>
+                     <item>
+                        <p>
+                           <code>$p</code> is matched against the SequenceType <code>function(item()) as xs:boolean</code>, and succeeds.</p>
+                     </item>
+                     <item>
+                        <p>When <code>$p</code> is called by <code>fn:filter()</code>, <termref
+                              def="dt-coercion-rules"
+                              >coercion</termref> 
+                           and SequenceType matching rules are applied to the argument, resulting in an <code>item()</code> value 
+                           (<code>$a</code>) or a type error.</p>
+                     </item>
+                     <item>
+                        <p>
+                           <code>$f</code> is called with <code>$a</code>, which returns an <code>xs:boolean</code> or the empty sequence.</p>
+                     </item>
+                     <item>
+                        <p>
+                           <code>$p</code> applies <termref def="dt-coercion-rules"
+                              >coercion rule</termref> and SequenceType matching to the result sequence from <code>$f</code>. When the result is an <code>xs:boolean</code> the SequenceType matching succeeds. When it is an empty sequence (such as when <code>$m</code> does not contain a key for <code>"Tuesday"</code>), SequenceType matching results in a type error  <errorref
+                              class="TY" code="0004"
+                              />, since the expected type is <code>xs:boolean</code> and the actual type is an empty sequence.</p>
+                     </item>
+                  </olist>
+               </p>
+
+               <p>Consider the following expression:
+      </p>
+
+               <eg role="parse-test"><![CDATA[
+let $m := map {
+   "Monday" : true(),
+   "Tuesday" : false(),
+   "Wednesday" : true(),
+   "Thursday" : false(),
+   "Friday" : true(),
+   "Saturday" : false(),
+   "Sunday" : false()
+}
+let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+return filter($days,$m)
+      ]]></eg>
+
+               <p>The result of the expression is the sequence <code>("Monday", "Wednesday", "Friday")</code>
+               </p>
+            </div3>
+            </div2>
          
 
       </div1>
@@ -8875,579 +9469,7 @@ return $incrementors[2](4)]]></eg>
             </div4>
          </div3>
          
-                     <div3 id="id-coercion-rules">
-               <head>Coercion Rules</head>
-
-               <p diff="chg" at="2022-11-17">
-                  <termdef term="coercion rules" id="dt-coercion-rules"
-                        >The <term>coercion rules</term> are rules used to convert a supplied value to a required type,
-                     for example when converting an argument of a function call to the declared type of the function parameter.
-                  </termdef> The required type is expressed as a <termref def="dt-sequence-type"
-                     >sequence type</termref>. The effect of the coercion rules may be to accept the value as supplied,
-                  to convert it to a value that matches the required type, or to reject it with a type error.</p>
-                        
-               <p diff="chg" at="2022-11-17">This section defines how the coercion rules operate; the situations in which the rules apply
-                  are defined elsewhere, by reference to this section.</p>
-                        
-                        <note diff="add" at="A">
-                           <p>In previous versions of this specification, the coercion rules were referred to as the
-                              <emph>function conversion</emph> rules. The terminology has changed because the rules are not exclusively
-                              associated with functions or function calling.</p>
-                        </note>
-		            
-                        <p diff="chg" at="2022-11-17">The coercion rules are applied to a supplied value <var>V</var> 
-		               and a required <termref def="dt-sequence-type"/> <var>T</var> as follows:</p>
-
-               
-               <ulist>
-
-                  <item role="xpath">
-                     <p>If  <termref def="dt-xpath-compat-mode">XPath
-                          1.0 compatibility mode</termref> is <code>true</code> and <var>V</var>
-                          is not of the required type <var>T</var>, then the following conversions are applied
-                          sequentially to <var>V</var>:</p>
-
-                     <olist>
-
-                        <item>
-                           <p>If <var>T</var> requires a single item or optional single item 
-                              (examples: <code>xs:string</code>, <code>xs:string?</code>, 
-                              <code>xs:untypedAtomic</code>, <code>xs:untypedAtomic?</code>, 
-                              <code>node()</code>, <code>node()?</code>, <code>item()</code>, 
-                              <code>item()?</code>), then <var>V</var> is effectively replaced by <code>V[1]</code>.</p>
-                        </item>
-
-                        <item>
-                           <p>If <var>T</var> is <code>xs:string</code> or <code>xs:string?</code>,
-                      		then <var>V</var> is effectively replaced by
-                      		<code>fn:string(V)</code>.</p>
-                           <note diff="add" at="2022-11-17"><p>This rule does not apply where <var>T</var> is derived from <code>xs:string</code>
-                           or <code>xs:string?</code>, because derived types did not arise in XPath 1.0.</p></note>
-                        </item>
-
-                        <item>
-                           <p>If <var>T</var> is <code>xs:double</code> or <code>xs:double?</code>, then 
-                              <code>V</code> is effectively replaced by <code>fn:number(V)</code>.</p>
-                           <note diff="add" at="2022-11-17"><p>This rule does not apply where <var>T</var> is derived from <code>xs:double</code>
-                              or <code>xs:double?</code>, because derived types did not arise in XPath 1.0.</p></note>
-                        </item>
-                     </olist>
-
-                     <note>
-                        <p>
-                           The special rules for <termref def="dt-xpath-compat-mode"
-                              >XPath 1.0 compatibility
-    mode</termref> are used for converting the arguments of a static function call, and
-                           in certain XSLT constructs. They are not invoked in other contexts such as dynamic function calls,
-    for converting the result of an inline function to its required type,
-    for partial function application, or for implicit function calls such as
-    occur when evaluating functions such as <code>fn:for-each</code> and <code>fn:filter</code>.</p>
-                     </note>
-
-                  </item>
-
-                  <item>
-                     <p>If <var>T</var> is <phrase diff="add" at="A">a <code>SequenceType</code>
-                     whose <code>ItemType</code> is a <termref def="dt-generalized-atomic-type"/></phrase> (possibly with an occurrence indicator 
-                        <code>*</code>, <code>+</code>, or <code>?</code>), then the following conversions are applied,
-                        <phrase diff="add" at="A">in order</phrase>:</p>
-                     
-                     <note><p>Enumeration types are generalized atomic types, so these rules apply.</p></note>
-
-                     <olist>
-
-                        <item>
-                           <p>
-                              <termref def="dt-atomization">Atomization</termref> is applied to the given value, 
-                              resulting in a sequence of atomic values.</p>
-                        </item>
-
-                        <item>
-                           <p>Each item in the atomic sequence that is of type
-		<code>xs:untypedAtomic</code> is cast to the expected 
-                              generalized atomic type. <phrase diff="add" at="A">If the expected atomic type is an 
-                                 <termref def="dt-EnumerationType"/>,
-		the value is cast to <code>xs:string</code></phrase>. If the item is of type <code>xs:untypedAtomic</code> 
-                              and the expected type is <termref
-                                 def="dt-namespace-sensitive"
-                                 >namespace-sensitive</termref>, a <termref def="dt-type-error"
-                                 >type error</termref>
-                              <errorref class="TY" code="0117"/> is raised.</p>
-                        </item>
-
-                        <item>
-                           <p>For each <termref def="dt-numeric">numeric</termref> item
-                      		in the atomic sequence that can be
-                      		<termref def="dt-type-promotion">promoted</termref> to the expected atomic type
-		                      using numeric promotion as described in <specref ref="promotion"/>, the promotion is
-		                      done.</p>
-                           <note diff="add" at="2022-11-17"><p>Numeric promotion is performed only when the required type is <code>xs:double</code>
-                           or <code>xs:float</code> (perhaps with an occurrence indicator). It is not performed
-                              when the required type is derived from <code>xs:double</code>
-                              or <code>xs:float</code>.</p></note>
-                        </item>
-
-                        <item>
-                           <p>For each item of type <code>xs:anyURI</code>
-                              in the atomic sequence that can be <termref def="dt-type-promotion">promoted</termref> to the 
-		                         expected atomic type using URI promotion as described in <specref
-                                 ref="promotion"/>, the promotion is done.</p>
-                           <note diff="add" at="2022-11-17"><p>Promotion of <code>xs:anyURI</code> values is performed 
-                              only when the required type is <code>xs:string</code> (perhaps with an occurrence indicator). It is not performed
-                              when the required type is derived from <code>xs:string</code>.</p></note>
-                        </item>
-                        
-                        <item diff="add" at="A">
-                           <p>If <var>T</var> is a sequence type whose item type is an atomic type <var>D</var>,
-                              where <var>D</var> is derived from some primitive type <var>P</var>, then any atomic value <var>A</var> in the 
-                              atomic sequence is <term>relabeled</term> as an instance of <var>D</var> if it satisfies
-                              all the following conditions: 
-                           </p>
-                           <olist>
-                              <item><p><var>A</var> is an instance of <var>P</var>.</p></item>
-                              <item><p><var>A</var> is not an instance of <var>D</var>.</p></item>
-                              <item><p>The <xtermref spec="DM40" ref="dt-datum"/> of <var>A</var> is 
-                                 within the value space of <var>D</var>.</p></item>
-                           </olist>
-                           <p>Relabeling an atomic value changes the <termref def="dt-type-annotation"/> but not the 
-                              <xtermref spec="DM40" ref="dt-datum"/>. For example, the
-                           <code>xs:integer</code> value 3 can be relabeled as an instance of <code>xs:unsignedByte</code>, because
-                              the datum is within the value space of <code>xs:unsignedByte</code>.</p>
-                           <note><p>Relabeling is not the same as casting. For example, the <code>xs:decimal</code> value 10.1
-                           can be cast to <code>xs:integer</code>, but it cannot be relabeled as <code>xs:integer</code>,
-                           because its datum not within the value space of <code>xs:integer</code>.</p></note>
-                           
-                           <note><p>The effect of this rule is that if, for example, a function parameter is declared
-                           with an expected type of <code>xs:positiveInteger</code>, then a call that supplies the literal
-                           value 3 will succeed, whereas a call that supplies -3 will fail.</p></note>
-                              
-                           <note><p>This differs from previous versions of this specification, where both these calls would fail.</p>
-                           <p>This change allows the arguments of existing functions to be defined with a 
-                           more precise type. For example, the <code>$position</code> argument of <code>array:get</code>
-                           can be defined as <code>xs:positiveInteger</code> rather than <code>xs:integer</code>. To enable
-                           this to be done without breaking backwards compatibility in respect of error behavior, 
-                           system functions in many cases define custom error codes to be raised where 
-                           relabeling of argument values fails.</p></note>
-                            
-                            <note><p>Numeric promotion and <code>xs:anyURI</code> promotion occur only when <var>T</var>
-                            is a primitive type (<code>xs:double</code>, <code>xs:float</code>, or <code>xs:string</code>).
-                            Relabeling occurs only when <var>T</var> is a derived type. Promotion and relabeling are therefore
-                            never combined.</p></note>
-                        </item>
-                        <item diff="add" at="issue688">
-                           <p>If <var>T</var> is a sequence type whose item type is a <termref def="dt-pure-union-type"/> <var>U</var>,
-                              then any atomic value <var>A</var> in the atomic sequence is <term>relabeled</term> as an instance of 
-                              some member type <var>M</var> in the transitive membership of <var>U</var> if <var>M</var> satisfies
-                              all the conditions for relabeling defined in the previous rule, and if it is the first member type
-                              in the transitive membership of <var>U</var> to satisfy those conditions. For example, if <var>T</var>
-                              is the type <code>union(xs:negativeInteger, xs:positiveInteger)*</code> and the supplied value is the
-                              sequence <code>(20, -20)</code>, then the first item <code>20</code> is relabeled as type
-                              <code>xs:positiveInteger</code> and the second item <code>-20</code>is relabeled as type 
-                              <code>xs:negativeInteger</code>.
-                           </p>
-                           <note>
-                              <p>This rule also ensures that if the required type is <code>enum("red", "green", "blue")</code>
-                              and the supplied value is <code>"green"</code>, then the supplied value will be accepted, and
-                              will be relabeled as an instance of the derived atomic type <code>enum("green")</code>.</p>
-                           </note>
-                        </item>
-                     </olist>
-                  </item>
-
-                  <item diff="add" at="A">
-                     <p>If <var>T</var> is a <nt def="RecordTest"
-                           >RecordTest</nt> (possibly with an occurrence indicator <code>*</code>,
-                        <code>+</code>, or <code>?</code>), then <var>V</var> must be a map or sequence of maps, and the values of any
-                     entries in these maps whose keys correspond to field declarations in the <code>RecordTest</code> are converted
-                     to the required type defined by that field declaration, by applying these rules recursively 
-                     (but with XPath 1.0 compatibility mode treated as false).</p>
-                     <p>For example, if the required type is
-                     <code>record(longitude as xs:double, latitude as xs:double)</code> and the supplied value is <code>map{"longitude": 0, "latitude":53.2}</code>,
-                        then the map is converted to <code>map{"longitude": 0.0e0, "latitude": 53.2e0}</code>.</p>
-                  </item>
-
-                  <item>
-                     <p>If the
-		expected type is a <nt def="TypedFunctionTest"
-                           >TypedFunctionTest</nt> (possibly with an occurrence indicator <code>*</code>,
-		<code>+</code>, or <code>?</code>), <termref
-                           def="dt-function-coercion"
-                        >function coercion</termref> is applied to each function in the given value.</p>
-                     <note>
-                        <p>Maps and arrays are functions, so function coercion applies to them as well.</p>
-                     </note>
-                  </item>
-
-                  <item>
-                     <p> If, after the
-		above conversions, the resulting value does not match
-		the expected type <var>T</var> according to the rules for <termref
-                           def="dt-sequencetype-matching"
-                           >SequenceType
-		Matching</termref>, a <termref def="dt-type-error"
-                           >type error</termref> is
-		raised <errorref class="TY" code="0004"
-                           />.</p>
-                     <note diff="add" at="Issue602">
-                        <p>Under the general rules for type errors 
-                           (see <specref ref="id-kinds-of-errors"/>), a processor
-                        <rfc2119>may</rfc2119> report a type error during static
-                        analysis if it will necessarily occur when the expression is evaluated.
-                        For example, the function call <code>fn:abs("beer")</code>
-                        will necessarily fail when evaluated, because the function requires
-                        a numeric value as its argument; this <rfc2119>may</rfc2119> be detected and reported
-                        as a static error.</p>
-                     </note>   
-		<p diff="del" at="2022-11-17"><phrase role="xquery"
-                              >If the function call takes place in a <termref def="dt-module"
-                              >module</termref> other
-		than the <termref def="dt-module"
-                              >module</termref> in which the function is defined, this
-		rule must be satisfied in both the module where the
-		function is called and the module where the function
-		is defined (the test is repeated because the two
-		modules may have different <termref
-                              def="dt-issd"
-                           >in-scope schema definitions</termref>.)</phrase>
-		Note that the rules for <termref
-                           def="dt-sequencetype-matching"
-                        >SequenceType
-		Matching</termref> permit a value of a derived type to
-		be substituted for a value of its base
-		type. </p>
-                  </item>
-                  <item diff="add" at="Issue602"><p>An expression is deemed to be
-                     <termref def="dt-implausible"/> <errorref
-                        class="TY" code="0006"/> if the static type of the expression, after applying
-                     all necessary coercions, is <term>substantively disjoint</term>
-                     with the required type <var>T</var>. Two sequence types are
-                     considered to be substantively disjoint if (a) neither is a subtype
-                     of the other (see <specref ref="id-seqtype-subtype"/>) and 
-                     (b) the only values that
-                     are instances of both types are one or more of the following:</p>
-                     <ulist>
-                        <item><p>The empty sequence, <code>()</code>.</p></item>
-                        <item><p>The empty map, <code>map{}</code>.</p></item>
-                        <item><p>The empty array, <code>[]</code>.</p></item>
-                     </ulist>
-                     
-                     <note>
-                        <p>Examples of pairs of sequence types that are substantively disjoint
-                        include:</p>
-                        <ulist>
-                           <item><p><code>xs:integer*</code> and <code>xs:string*</code></p></item>
-                           <item><p><code>map(xs:integer, node())</code> and <code>map(xs:string, node())</code></p></item>
-                           <item><p><code>array(xs:integer)</code> and <code>array(xs:string)</code></p></item>
-                        </ulist>
-                     </note>
-                  <p>For example, supplying a value whose static type is <code>xs:integer*</code>
-                     when the required type is <code>xs:string*</code> is <termref def="dt-implausible"/>,
-                     because it can succeed only in the special case where the actual value supplied
-                     is an empty sequence.</p>
-                  <note><p>The case where the supplied type and the required type are completely
-                  disjoint (for example <code>map(*)</code> and <code>array(*)</code>) is covered
-                  by the general rules for type errors: this case can always be reported as a static
-                  error.</p></note>
-                  
-                     </item>
-               </ulist>
-                        
-                        
-                     
-            </div3>
-
-
-            <div3 id="id-function-coercion">
-               <head>Function Coercion</head>
-
-               <p>
-        Function coercion is a transformation applied to <termref def="dt-function-item"
-                     >function items</termref> during application of the
-        <termref
-                     def="dt-coercion-rules">coercion rules</termref>.
-        <termdef
-                     term="function coercion" id="dt-function-coercion">
-                     <term>Function coercion</term> wraps a <termref def="dt-function-item"/>
-        in a new function
-        whose signature is the same as the expected type.
-        This effectively delays the checking
-        of the argument and return types
-        until the function is called.</termdef>
-               </p>
-
-               <p>Given a function <var>F</var>, and an expected function type,
-                  <termref
-                     def="dt-function-coercion"
-                  >function coercion</termref>
-	proceeds as follows:</p>
-               <olist>
-                  <item>
-                     <p>If <var>F</var> has higher arity than the expected type,
-                     a type error is raised <errorref
-                           class="TY" code="0004"/></p>
-                  </item>
-                  <item diff="add" at="A">
-                     <p>If <var>F</var> has lower arity than the expected type,
-                     then <var>F</var> is wrapped in a new function that declares and ignores the
-                  additional argument; the following steps are then applied to this new function.</p>
-                     <p>For example, if the expected type is <code>function(node(), xs:boolean) as xs:string</code>,
-                  and the supplied function is <code>fn:name#1</code>, then the supplied function is effectively
-                  replaced by <code>function($n as node(), $b as xs:boolean) as xs:string {fn:name($n)}</code></p>
-                     <note>
-                        <p>This mechanism makes it easier to design versatile and extensible higher-order functions. 
-                     For example, in previous versions of this specification, the second argument of
-                     the <code>fn:filter</code> function expected an argument of type 
-                     <code>function(item()) as xs:boolean</code>. This has now been extended to
-                     <code>function(item(), xs:integer) as xs:boolean</code>, but existing code continues
-                     to work, because callback functions that are not interested in the value of the second
-                     argument simply ignore it.                    
-                  </p>
-                        <p>TODO: this change to fn:filter has not yet been made.</p>
-                     </note>
-                  </item>
-
-
-                  <item>
-                     <p>Function coercion then
-        returns a new <termref def="dt-function-item"/>
-        with the following properties
-        (as defined in <xspecref
-                           spec="DM40" ref="function-items"/>):
-
-        <ulist>
-                           <item>
-                              <p>
-                                 <term>name</term>:
-            The name of <var>F</var> <phrase diff="add" at="B">(if not absent)</phrase>.
-          </p>
-                           </item>
-           <item><p diff="add" at="2023-05-25"><term>identity</term>: A new function
-              identity distinct from the identity of any other function item.</p>
-              <note><p>See also <specref ref="id-function-identity"/>.</p></note>
-           </item>
-                           <item>
-                              <p>
-                                 <term>parameter names</term>:
-	      The parameter names of <var>F</var>.
-            </p>
-                           </item>
-                           <item>
-                              <p>
-                                 <term>signature</term>:
-            <code>Annotations</code> is set to the annotations of <var>F</var>. <code>TypedFunctionTest</code> is set to the expected type.
-          </p>
-                           </item>
-                           <item>
-                              <p>
-                                 <term>implementation</term>:
-            In effect,
-            a <code>FunctionBody</code> that calls <var>F</var>,
-            passing it the parameters of this new function,
-            in order.
-          </p>
-                           </item>
-                           <item>
-                              <p>
-                                 <term>nonlocal variable bindings</term>:
-            An empty mapping.
-          </p>
-                           </item>
-                        </ulist>
-                     </p>
-                  </item>
-               </olist>
-               <p>
-        If the result of invoking the new function would
-        necessarily result in a type error, that
-        error may be raised during
-                  <termref
-                     def="dt-function-coercion"
-                  >function coercion</termref>. It is implementation dependent whether this
-        happens or not.
-      </p>
-
-               <p>
-        These rules have the following consequences:
-
-        <ulist>
-                     <item>
-                        <p>
-            SequenceType matching of the function’s arguments and result are delayed until that function is called.
-          </p>
-                     </item>
-                     <item>
-                        <p>
-                           The <termref def="dt-coercion-rules"
-                              >coercion rules</termref> rules applied to the function’s arguments and result are defined by the SequenceType
-            it has most recently been coerced to. Additional coercion rules could apply when the wrapped function
-            is called.
-          </p>
-                     </item>
-                     <item>
-                        <p>
-            If an implementation has static type information about a function, that can be used to type check the
-            function’s argument and return types during static analysis.
-          </p>
-                     </item>
-                  </ulist>
-               </p>
-
-               <p role="xquery">
-      For instance, consider the following query:
-      <eg
-                     role="parse-test"><![CDATA[
-declare function local:filter($s as item()*, $p as function(xs:string) as xs:boolean) as item()*
-{
-  $s[$p(.)]
-};
-
-let $f := function($a) { starts-with($a, "E") }
-return
-  local:filter(("Ethel", "Enid", "Gertrude"), $f)
-      ]]></eg>
-               </p>
-
-               <p role="xquery"
-                     >
-        The function <code>$f</code> has a static type of <code>function(item()*) as item()*</code>. When the <code>local:filter()</code> function
-        is called, the following occurs to the function:
-
-        <olist>
-                     <item>
-                        <p>
-                           The <termref def="dt-coercion-rules"
-                              >coercion rules</termref> result in applying 
-                           <termref
-                              def="dt-function-coercion"
-                              >function coercion</termref> to 
-            <code>$f</code>,
-            wrapping $f in a new function (<code>$p</code>)
-            with the signature <code>function(xs:string) as xs:boolean</code>.
-          </p>
-                     </item>
-                     <item>
-                        <p>
-            <code>$p</code> is matched against the SequenceType of <code>function(xs:string) as xs:boolean</code>, and succeeds.
-          </p>
-                     </item>
-                     <item>
-                        <p>
-                           When <code>$p</code> is called inside the predicate, <termref
-                              def="dt-coercion-rules"
-                              >coercion</termref> 
-                           and SequenceType matching rules are applied to the context value argument,
-            resulting in an <code>xs:string</code> value or a type error.
-          </p>
-                     </item>
-                     <item>
-                        <p>
-            <code>$f</code> is called with the <code>xs:string</code>, which returns an <code>xs:boolean</code>.
-          </p>
-                     </item>
-                     <item>
-                        <p><code>$p</code> applies <termref def="dt-coercion-rules"
-                              >coercion rules</termref> to the result sequence from <code>$f</code>, 
-                           which already matches its declared return type of <code>xs:boolean</code>.
-          </p>
-                     </item>
-                     <item>
-                        <p>
-            The <code>xs:boolean</code> is returned as the result of <code>$p</code>.
-          </p>
-                     </item>
-                  </olist>
-               </p>
-
-               <note>
-                  <p>
-                     Although the semantics of <termref
-                        def="dt-function-coercion"
-                     >function coercion</termref> are specified in terms of wrapping the functions,
-        static typing will often be able to reduce the number of places where this is actually necessary.
-      </p>
-               </note>
-
-               <p>Since maps and arrays are also functions in &language;, 
-                  <termref
-                     def="dt-function-coercion"
-                  >function coercion</termref> applies to them as well.
-
-        For instance, consider the following expression:
-      </p>
-
-               <eg role="parse-test"><![CDATA[
-let $m := map {
-  "Monday" : true(),
-  "Wednesday" : true(),
-  "Friday" : true(),
-  "Saturday" : false(),
-  "Sunday" : false()
-},
-$days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-return filter($days,$m)
-      ]]></eg>
-
-               <p>
-        The map <code>$m</code> has a function signature of <code>function(xs:anyAtomicType) as item()*</code>. When the <code>fn:filter()</code> function is called, the following occurs to the map:
-
-<olist>
-                     <item>
-                        <p>The map <code>$m</code> is treated as <code>function($f)</code>,  equivalent to <code>map:get($m,?)</code>.</p>
-                     </item>
-                     <item>
-                        <p>The <termref def="dt-coercion-rules"
-                              >coercion rules</termref> result in applying 
-                           <termref
-                              def="dt-function-coercion"
-                              >function coercion</termref> 
-                           to <code>$f</code>, wrapping <code>$f</code> in a new function (<code>$p</code>) with the 
-                           signature <code>function(item()) as xs:boolean</code>.</p>
-                     </item>
-                     <item>
-                        <p>
-                           <code>$p</code> is matched against the SequenceType <code>function(item()) as xs:boolean</code>, and succeeds.</p>
-                     </item>
-                     <item>
-                        <p>When <code>$p</code> is called by <code>fn:filter()</code>, <termref
-                              def="dt-coercion-rules"
-                              >coercion</termref> 
-                           and SequenceType matching rules are applied to the argument, resulting in an <code>item()</code> value 
-                           (<code>$a</code>) or a type error.</p>
-                     </item>
-                     <item>
-                        <p>
-                           <code>$f</code> is called with <code>$a</code>, which returns an <code>xs:boolean</code> or the empty sequence.</p>
-                     </item>
-                     <item>
-                        <p>
-                           <code>$p</code> applies <termref def="dt-coercion-rules"
-                              >coercion rule</termref> and SequenceType matching to the result sequence from <code>$f</code>. When the result is an <code>xs:boolean</code> the SequenceType matching succeeds. When it is an empty sequence (such as when <code>$m</code> does not contain a key for <code>"Tuesday"</code>), SequenceType matching results in a type error  <errorref
-                              class="TY" code="0004"
-                              />, since the expected type is <code>xs:boolean</code> and the actual type is an empty sequence.</p>
-                     </item>
-                  </olist>
-               </p>
-
-               <p>Consider the following expression:
-      </p>
-
-               <eg role="parse-test"><![CDATA[
-let $m := map {
-   "Monday" : true(),
-   "Tuesday" : false(),
-   "Wednesday" : true(),
-   "Thursday" : false(),
-   "Friday" : true(),
-   "Saturday" : false(),
-   "Sunday" : false()
-}
-let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-return filter($days,$m)
-      ]]></eg>
-
-               <p>The result of the expression is the sequence <code>("Monday", "Wednesday", "Friday")</code>
-               </p>
-            </div3>
+ 
       </div2>
       
 


### PR DESCRIPTION
Introduces mutual promotion between xs:base64Binary and xs:hexBinary. Fix #130.

Reorganises the material on type promotion. Supersedes PR #538.