### PR TITLE
840: Typo in fn:seconds-from-duration example

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -7026,10 +7026,10 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test>
                <fos:expression><eg>seconds-from-duration(
-   xs:duration("P1Y1D")
+   xs:duration("P1YT1S")
 )</eg></fos:expression>
                <fos:result>1</fos:result>
-               <fos:postamble>To capture days reflected in the <code>xs:yearMonthDuration</code>
+               <fos:postamble>To capture seconds reflected in the <code>xs:yearMonthDuration</code>
                   component of an <code>xs:duration</code>, it must first be converted to an
                   <code>xs:dayTimeDuration</code>.</fos:postamble>
             </fos:test>


### PR DESCRIPTION
Addresses #840 