### PR TITLE
847 Allow uri-structure-record keys to have empty sequence values

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29,8 +29,8 @@
          <fos:field name="path" type="xs:string?" required="false"/>
          <fos:field name="query" type="xs:string?" required="false"/>
          <fos:field name="fragment" type="xs:string?" required="false"/>
-         <fos:field name="path-segments" type="array(xs:string)?" required="false"/>
-         <fos:field name="query-parameters" type="array(record(key? as xs:string, value? as xs:string, *))?" required="false"/>
+         <fos:field name="path-segments" type="xs:string*" required="false"/>
+         <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false"/>
       </fos:record>
    </fos:type>
    
@@ -28577,9 +28577,9 @@ path with an explicit <code>file:</code> scheme.</p>
         </fos:options>
 
         <p>The components are derived from the contents of the
-        <code>$parts</code> map. To simplify the description below,
-        any key whose value is the empty sequence is ignored; this is
-        equivalent to the key not being present in the map.</p>
+        <code>$parts</code> map. To simplify the description below, a
+        value is considered to be present in the map if the relevant
+        field exists and is non-empty.</p>
 
         <p>If the <code>scheme</code> key is present in the map,
         the URI begins with the value of that key. A URI is considered to be

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19,18 +19,18 @@
 
    <fos:type id="uri-structure-record">
       <fos:record extensible="true">
-         <fos:field name="uri" type="xs:string" required="false"/>
-         <fos:field name="scheme" type="xs:string" required="false"/>
-         <fos:field name="hierarchical" type="xs:boolean" required="false"/>
-         <fos:field name="authority" type="xs:string" required="false"/>
-         <fos:field name="userinfo" type="xs:string" required="false"/>
-         <fos:field name="host" type="xs:string" required="false"/>
-         <fos:field name="port" type="xs:string" required="false"/>
-         <fos:field name="path" type="xs:string" required="false"/>
-         <fos:field name="query" type="xs:string" required="false"/>
-         <fos:field name="fragment" type="xs:string" required="false"/>
-         <fos:field name="path-segments" type="array(xs:string)" required="false"/>
-         <fos:field name="query-parameters" type="array(record(key? as xs:string, value? as xs:string, *))" required="false"/>
+         <fos:field name="uri" type="xs:string?" required="false"/>
+         <fos:field name="scheme" type="xs:string?" required="false"/>
+         <fos:field name="hierarchical" type="xs:boolean?" required="false"/>
+         <fos:field name="authority" type="xs:string?" required="false"/>
+         <fos:field name="userinfo" type="xs:string?" required="false"/>
+         <fos:field name="host" type="xs:string?" required="false"/>
+         <fos:field name="port" type="xs:string?" required="false"/>
+         <fos:field name="path" type="xs:string?" required="false"/>
+         <fos:field name="query" type="xs:string?" required="false"/>
+         <fos:field name="fragment" type="xs:string?" required="false"/>
+         <fos:field name="path-segments" type="array(xs:string)?" required="false"/>
+         <fos:field name="query-parameters" type="array(record(key? as xs:string, value? as xs:string, *))?" required="false"/>
       </fos:record>
    </fos:type>
    
@@ -28576,8 +28576,10 @@ path with an explicit <code>file:</code> scheme.</p>
             </fos:option>
         </fos:options>
 
-        <p>The components are derived from the contents of the <code>$parts</code>
-        map in the following way:</p>
+        <p>The components are derived from the contents of the
+        <code>$parts</code> map. To simplify the description below,
+        any key whose value is the empty sequence is ignored; this is
+        equivalent to the key not being present in the map.</p>
 
         <p>If the <code>scheme</code> key is present in the map,
         the URI begins with the value of that key. A URI is considered to be

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3394,12 +3394,12 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
            <code>http://example.com/path/to/a%2fb</code>.
            The path portion has to be returned as <code>/path/to/a%2fb</code> because
            decoding the <code>%2f</code> would change the nature of the path.
-           The unescaped form is easily accessible from the <code>path-segments</code> array:</p>
+           The unescaped form is easily accessible from <code>path-segments</code>:</p>
 
            <eg>("", "path", "to", "a/b")</eg>
 
            <p>Note that the presence or absence of a leading slash on the path
-           will affect whether or not the array begins with an empty string.</p>
+           will affect whether or not the sequence begins with an empty string.</p>
 
            <p>The query parameters are decoded into a map. Consider the URI:
            <code>http://example.com/path?a=1&amp;b=2%264&amp;a=3</code>.


### PR DESCRIPTION
Fix #847 

The description of `build-uri` was written with the expectation that if a key was in the map, it's value should be used. I don't really want to replace every occurrence of 

    if `x` is present in the map

with

    if `x` is present in the map and its value is not the empty sequence

So I've attempted to justify that globally with the following paragraph at the beginning of the description:

> The components are derived from the contents of the $parts map. To simplify the description below, any key whose value is the empty sequence is ignored; this is equivalent to the key not being present in the map.

I'm not hugely proud of that bit of prose though. Suggestions for improvements most welcome.