### PR TITLE
856 Drop reference to obsolete error condition in deep-equal()

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13609,15 +13609,6 @@ return contains-sequence(
                   <fos:type>xs:boolean</fos:type>
                   <fos:default>false</fos:default>
                </fos:option>
-               <fos:option key="false-on-error">
-                  <fos:meaning>If <code>true</code>, then in the event of a dynamic error occurring in the course of
-                     the comparison, the function will return <code>false</code> rather than throwing the error. (This option does
-                     not affect the handling of errors in the supplied values of the <code>$collation</code>
-                     and <code>$options</code> arguments.)
-                  </fos:meaning>
-                  <fos:type>xs:boolean</fos:type>
-                  <fos:default>false</fos:default>
-               </fos:option>
                <fos:option key="id-property">
                   <fos:meaning>Determines whether the <code>id</code> property of elements and attributes is significant.
                   </fos:meaning>
@@ -14091,12 +14082,6 @@ declare function equal-strings(
          <p>In all other cases the result is <code>false</code>.</p>
       </fos:rules>
       <fos:errors>
-         <p>A type error is raised <errorref class="TY" code="0015" type="type"
-               /> if either input
-            sequence contains a function item <phrase>that is not a map or
-               array</phrase>. </p>
-         <p>However, the above error is not raised if the <code>false-on-error</code> option is
-         <code>true</code>; in this case, the function returns <code>false</code> rather than raising an error.</p>
          <p>A type error is raised <xerrorref spec="XP" class="TY"
             code="0004" type="type"/> if the value of 
             <code>$options</code> includes an entry whose key is defined 
@@ -14107,7 +14092,7 @@ declare function equal-strings(
             in this specification, and whose value is not a permitted value for that key.</p>
       </fos:errors>
       <fos:notes>
-         <p>By default, whitespace in text nodes and attribute is considered significant. There are various ways
+         <p>By default, whitespace in text nodes and attributes is considered significant. There are various ways
          whitespace differences can be ignored:</p>
          <ulist>
             <item><p>If nodes have been schema-validated, setting the <code>typed-values</code> 
@@ -14137,8 +14122,7 @@ declare function equal-strings(
             value to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns <code>false</code>, 
             it does not return an error. So
             the result of <code>fn:deep-equal(1, current-dateTime())</code> is <code>false</code>.</p>
-         <p>Comparing a function (other than a map or array) to any other value raises a type error,
-         unless the error is suppressed using the <code>false-on-error</code> option.</p>
+         
       </fos:notes>
       <fos:examples>
          <fos:variable name="at" id="v-deep-equal-at" as="element()"><![CDATA[<attendees>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11222,18 +11222,18 @@ ISBN 0 521 77752 6.</bibl>
             <error class="TY" code="0013" label="The argument to fn:data contains a function item."
                type="dynamic">
                <p>Raised by <code>fn:data</code>, or by implicit atomization, if the sequence to be atomized contains
-                a function item.</p>
+                a function item other than an array.</p>
             </error>
             <error class="TY" code="0014" label="The argument to fn:string is a function item."
                type="dynamic">
                <p>Raised by <code>fn:string</code>, or by implicit string conversion, if the input sequence contains
                   a function item.</p>
             </error>
-            <error class="TY" code="0015" label="An argument to fn:deep-equal contains a function item."
+            <!--<error class="TY" code="0015" label="An argument to fn:deep-equal contains a function item."
                type="dynamic">
                <p>Raised by <code>fn:deep-equal</code> if either input sequence contains a
                   function item.</p> 
-            </error>
+            </error>-->
             <error class="UT" code="1170" label="Invalid URI reference."
                type="dynamic">
                <p>Raised by <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>


### PR DESCRIPTION
Fix #856