### PR TITLE
878 Proposed extension to subsequence

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12726,8 +12726,11 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       <fos:signatures>
          <fos:proto name="subsequence" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="transmission"/>
-            <fos:arg name="start" type="xs:double"/>
+            <fos:arg name="start" type="xs:double?" default="()"/>
             <fos:arg name="length" type="xs:double?" default="()"/>
+            <fos:arg name="from" type="(function(item(), xs:integer) as xs:boolean)?" default="()"/>
+            <fos:arg name="while" type="(function(item(), xs:integer) as xs:boolean)?" default="()"/>
+            <fos:arg name="until" type="(function(item(), xs:integer) as xs:boolean)?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -12736,29 +12739,51 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the contiguous sequence of items in <code>$input</code>
-            beginning at the position indicated by <code>$start</code> and
-            continuing for the number of items indicated by <code>$length</code>. </p>
+         <p>Returns a contiguous sequence of items from <code>$input</code>. </p>
       </fos:summary>
       <fos:rules>
-         <p>In the two-argument case <phrase diff="add" at="2022-12-19">(or where the 
-            third argument is an empty sequence),</phrase> the function returns:</p>
-         <eg xml:space="preserve">$input[round($start) le position()]</eg>
-         <p>In the three-argument case, the function returns:</p>
+         <p>In the following rules, an argument is said to be supplied if it is present and non-empty.</p>
+         
+         <p>The start of the subsequence to be returned is indicated using either the <code>$start</code>
+         or <code>$from</code> arguments. At most one of these must be supplied. If neither is supplied,
+         then <code>$start</code> defaults to 1 (one). If <code>$from</code> is supplied, then <code>$start</code>
+            is taken as <code>head(index-where($input, $from)) otherwise number('INF')</code>.</p>
+         
+         <p>Let <code>$temp</code> denote the sequence <code>$input[round($start) le position()]</code>.</p>
+         
+         <p>The end of the subsequence to be returned is indicated using any one of the <code>$length</code>,
+         <code>$while</code>, or <code>$until</code> arguments. At most one of these must be supplied. If none
+         of the three is supplied, then the function returns <code>$temp</code>.</p>
+         
+         <p>If <code>$until</code> is supplied, then <code>$length</code> is taken as
+         <code>head(index-where($temp, $until)) otherwise number('INF')</code></p>
+         
+         <p>If <code>$while</code> is supplied, then <code>$length</code> is taken as
+         <code>(head(index-where($temp, fn($it, $pos){not($while($it, $pos))})) otherwise number('INF')) - 1</code></p>
+         
+         <p>If <code>$start</code> is less than 1 (one) and <code>$until</code> or <code>$while</code> is supplied,
+         then <code>$start</code> is taken as 1 (one).</p>
+         
+         <p>The function then returns:</p>
+         
          <eg xml:space="preserve">$input[round($start) le position() 
          and position() lt round($start) + round($length)]</eg>
+         
+  
 
       </fos:rules>
       <fos:notes>
          <p>The first item of a sequence is located at position 1, not position 0.</p>
          <p>If <code>$input</code> is the empty sequence, the empty sequence is returned.</p>
 
-         <p>In the two-argument case, the function returns a sequence comprising those items of 
+         <p>In the case where only <code>$input</code> and <code>$start</code>
+            are supplied, the function returns a sequence comprising those items of 
             <code>$input</code> whose 1-based position  
             is greater than or equal to <code>$start</code> (rounded to an integer). 
             No error occurs if <code>$start</code> is zero or negative.</p>
 
-         <p>In the three-argument case, The function returns a sequence comprising those items of 
+         <p>In the case where <code>$input</code>, <code>$start</code>, and <code>$length</code>
+            are supplied, he function returns a sequence comprising those items of 
             <code>$input</code> whose 1-based position  
             is greater than or equal to <code>$start</code> (rounded to an integer), and 
             less than the sum of <code>$start</code> and <code>$length</code> (both rounded to integers). 
@@ -12778,19 +12803,79 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
             computations.</p>
       </fos:notes>
 
-      <fos:examples>
-         <fos:variable name="seq" id="v-reverse-seq"
-            select="(&quot;item1&quot;, &quot;item2&quot;, &quot;item3&quot;, &quot;item4&quot;, &quot;item5&quot;)"/>
+      <fos:examples role="wide">
+         <fos:variable name="seq" id="v-subseq-seq"
+            select="(&quot;Anna&quot;, &quot;Barbara&quot;, &quot;Catherine&quot;, &quot;Delia&quot;, &quot;Eliza&quot;, &quot;Freda&quot;, &quot;Gertrude&quot;, &quot;Hilda&quot;)"/>
          <fos:example>
-            <fos:test use="v-reverse-seq">
-               <fos:expression>subsequence($seq, 4)</fos:expression>
-               <fos:result>("item4", "item5")</fos:result>
+            <fos:test use="v-subseq-seq">
+               <fos:expression>subsequence($seq, 7)</fos:expression>
+               <fos:result>("Gertrude", "Hilda")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-            <fos:test use="v-reverse-seq">
-               <fos:expression>subsequence($seq, 3, 2)</fos:expression>
-               <fos:result>("item3", "item4")</fos:result>
+            <fos:test use="v-subseq-seq">
+               <fos:expression>subsequence($seq, 3, 4)</fos:expression>
+               <fos:result>("Catherine", "Delia", "Eliza", "Freda")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test use="v-subseq-seq">
+               <fos:expression>subsequence($seq, from:=starts-with(?, "E"))</fos:expression>
+               <fos:result>("Eliza", "Freda", "Gertrude", "Hilda")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test use="v-subseq-seq">
+               <fos:expression>subsequence($seq, from:=starts-with(?, "E"), length:=2)</fos:expression>
+               <fos:result>("Eliza", "Freda")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test use="v-subseq-seq">
+               <fos:expression>subsequence($seq, from:=starts-with(?, "E"), until:=starts-with(?, "G")</fos:expression>
+               <fos:result>("Eliza", "Freda", "Gertrude")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test use="v-subseq-seq">
+               <fos:expression>subsequence($seq, from:=starts-with(?, "D"), while:=fn{string-length(.)=5})</fos:expression>
+               <fos:result>("Delia", "Eliza", "Freda")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test use="v-subseq-seq">
+               <fos:expression>subsequence($seq, 4, while:=ends-with(?, "a")})</fos:expression>
+               <fos:result>("Delia", "Eliza", "Freda")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>subsequence(1 to 3)</fos:expression>
+               <fos:result>1, 2, 3</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>subsequence(1 to 3, length:=2)</fos:expression>
+               <fos:result>1, 2</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>subsequence(1 to 3, -6)</fos:expression>
+               <fos:result>1, 2, 3</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>subsequence(1 to 5, -2, 5)</fos:expression>
+               <fos:result>1, 2</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>subsequence(1 to 5, 2, 82)</fos:expression>
+               <fos:result>2, 3, 4, 5</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>


### PR DESCRIPTION
Following discussion under issue #844, I decided to explore the possibility of extending subsequence() with optional parameters, with the aim of making the quartet of items-before/after/starting-with/ending-with unnecessary.

This is the spec that results. I feel it's a good trade-off; by adding three optional parameters to `fn:subsequence`, we can eliminate 4 functions that we are having trouble finding names for. The examples feel to me to be intuitive and readable; and there is more capability in the new function than we had before, for example by combining a predicate for the start position with an integer for the length.

I haven't explored arity-2 callbacks - these certainly need some notes and examples. 