### PR TITLE
844 New sequence functions: names

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13009,9 +13009,9 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       </fos:history>
    </fos:function>
    
-   <fos:function name="starts-with-sequence" prefix="fn">
+   <fos:function name="starts-with-subsequence" prefix="fn">
       <fos:signatures>
-         <fos:proto name="starts-with-sequence" return-type="xs:boolean">
+         <fos:proto name="starts-with-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
             <fos:arg name="compare" type="function(item(), item()) as xs:boolean" default="fn:deep-equal#2"/>
@@ -13047,27 +13047,27 @@ every(for-each-pair($input, $subsequence, $compare))]]></eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>starts-with-sequence((), ())</fos:expression>
+               <fos:expression>starts-with-subsequence((), ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>    
             <fos:test>
-               <fos:expression>starts-with-sequence(1 to 10, 1 to 5)</fos:expression>
+               <fos:expression>starts-with-subsequence(1 to 10, 1 to 5)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>starts-with-sequence(1 to 10, ())</fos:expression>
+               <fos:expression>starts-with-subsequence(1 to 10, ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>starts-with-sequence(1 to 10, 1 to 10)</fos:expression>
+               <fos:expression>starts-with-subsequence(1 to 10, 1 to 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>starts-with-sequence(1 to 10, 1)</fos:expression>
+               <fos:expression>starts-with-subsequence(1 to 10, 1)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>starts-with-sequence(
+               <fos:expression><eg>starts-with-subsequence(
   1 to 10,
   101 to 105,
   function($x, $y) { $x mod 100 = $y mod 100 }
@@ -13075,7 +13075,7 @@ every(for-each-pair($input, $subsequence, $compare))]]></eg>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>starts-with-sequence(
+               <fos:expression><eg>starts-with-subsequence(
   ("A", "B", "C"),
   ("a", "b"),
   function($x, $y) {
@@ -13090,7 +13090,7 @@ every(for-each-pair($input, $subsequence, $compare))]]></eg>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2]
-return starts-with-sequence(
+return starts-with-subsequence(
   $p/ancestor::*[1],
   $p/parent::*,
   op("is")
@@ -13098,11 +13098,11 @@ return starts-with-sequence(
                <fos:result>true()</fos:result>
             </fos:test>       
             <fos:test>
-               <fos:expression>starts-with-sequence(10 to 20, 1 to 5, op("gt"))</fos:expression>
+               <fos:expression>starts-with-subsequence(10 to 20, 1 to 5, op("gt"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>starts-with-sequence(
+               <fos:expression><eg>starts-with-subsequence(
   ("Alpha", "Beta", "Gamma"),
   ("A", "B"),
   starts-with#2
@@ -13110,7 +13110,7 @@ return starts-with-sequence(
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>starts-with-sequence(
+               <fos:expression><eg>starts-with-subsequence(
   ("Alpha", "Beta", "Gamma", "Delta"),
   1 to 3,
   function($x, $y) { ends-with($x, 'a' ) }
@@ -13125,9 +13125,9 @@ return starts-with-sequence(
       </fos:history>
    </fos:function>
    
-   <fos:function name="ends-with-sequence" prefix="fn">
+   <fos:function name="ends-with-subsequence" prefix="fn">
       <fos:signatures>
-         <fos:proto name="ends-with-sequence" return-type="xs:boolean">
+         <fos:proto name="ends-with-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
             <fos:arg name="compare" type="function(item(), item()) as xs:boolean" default="fn:deep-equal#2"/>
@@ -13150,7 +13150,7 @@ return starts-with-sequence(
          <p>Informally, the function returns <code>true</code> if <code>$input</code> ends with <code>$subsequence</code>,
             when items are compared using the supplied (or default) <code>$compare</code> function.</p>
          <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[starts-with-sequence(reverse($input), reverse($subsequence), $compare)]]></eg>
+         <eg><![CDATA[starts-with-subsequence(reverse($input), reverse($subsequence), $compare)]]></eg>
       </fos:rules>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
@@ -13161,27 +13161,27 @@ return starts-with-sequence(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>ends-with-sequence((), ())</fos:expression>
+               <fos:expression>ends-with-subsequence((), ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>    
             <fos:test>
-               <fos:expression>ends-with-sequence(1 to 10, 5 to 10)</fos:expression>
+               <fos:expression>ends-with-subsequence(1 to 10, 5 to 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>ends-with-sequence(1 to 10, ())</fos:expression>
+               <fos:expression>ends-with-subsequence(1 to 10, ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>ends-with-sequence(1 to 10, 1 to 10)</fos:expression>
+               <fos:expression>ends-with-subsequence(1 to 10, 1 to 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>ends-with-sequence(1 to 10, 10)</fos:expression>
+               <fos:expression>ends-with-subsequence(1 to 10, 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>ends-with-sequence(
+               <fos:expression><eg>ends-with-subsequence(
   1 to 10,
   108 to 110,
   function($x, $y) { $x mod 100 = $y mod 100 }
@@ -13189,7 +13189,7 @@ return starts-with-sequence(
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>ends-with-sequence(
+               <fos:expression><eg>ends-with-subsequence(
   ("A", "B", "C"),
   ("b", "c"),
   function($x, $y) {
@@ -13204,7 +13204,7 @@ return starts-with-sequence(
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[let $p := parse-xml("<doc><chap><p/><p/></chap></doc>")//p[2]
-return ends-with-sequence(
+return ends-with-subsequence(
   $p/ancestor::node()[last()],
   $p/root(),
   op("is")
@@ -13212,11 +13212,11 @@ return ends-with-sequence(
                <fos:result>true()</fos:result>
             </fos:test>       
             <fos:test>
-               <fos:expression>ends-with-sequence(10 to 20, 1 to 5, op("gt"))</fos:expression>
+               <fos:expression>ends-with-subsequence(10 to 20, 1 to 5, op("gt"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>ends-with-sequence(
+               <fos:expression><eg>ends-with-subsequence(
   ("Alpha", "Beta", "Gamma"),
   ("B", "G"),
   starts-with#2
@@ -13224,7 +13224,7 @@ return ends-with-sequence(
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>ends-with-sequence(
+               <fos:expression><eg>ends-with-subsequence(
   ("Alpha", "Beta", "Gamma", "Delta"),
   1 to 2,
   function($x, $y) { string-length($x) eq 5 }
@@ -13239,9 +13239,9 @@ return ends-with-sequence(
       </fos:history>
    </fos:function>
    
-   <fos:function name="contains-sequence" prefix="fn">
+   <fos:function name="contains-subsequence" prefix="fn">
       <fos:signatures>
-         <fos:proto name="contains-sequence" return-type="xs:boolean">
+         <fos:proto name="contains-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
             <fos:arg name="compare" type="function(item(), item()) as xs:boolean" default="fn:deep-equal#2"/>
@@ -13280,31 +13280,31 @@ some $i in 0 to count($input) - count($subsequence) satisfies (
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>contains-sequence((), ())</fos:expression>
+               <fos:expression>contains-subsequence((), ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>    
             <fos:test>
-               <fos:expression>contains-sequence(1 to 10, 3 to 6)</fos:expression>
+               <fos:expression>contains-subsequence(1 to 10, 3 to 6)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(1 to 10, (2, 4, 6))</fos:expression>
+               <fos:expression>contains-subsequence(1 to 10, (2, 4, 6))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(1 to 10, ())</fos:expression>
+               <fos:expression>contains-subsequence(1 to 10, ())</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(1 to 10, 1 to 10)</fos:expression>
+               <fos:expression>contains-subsequence(1 to 10, 1 to 10)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>contains-sequence(1 to 10, 5)</fos:expression>
+               <fos:expression>contains-subsequence(1 to 10, 5)</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>contains-sequence(
+               <fos:expression><eg>contains-subsequence(
   1 to 10,
   103 to 105,
   function($x, $y) { $x mod 100 = $y mod 100 }
@@ -13312,7 +13312,7 @@ some $i in 0 to count($input) - count($subsequence) satisfies (
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>contains-sequence(
+               <fos:expression><eg>contains-subsequence(
   ("A", "B", "C", "D"),
   ("b", "c"),
   function($x, $y) {
@@ -13327,7 +13327,7 @@ some $i in 0 to count($input) - count($subsequence) satisfies (
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[let $chap := parse-xml("<doc><chap><h1/><p/><p/><footnote/></chap></doc>")//chap
-return contains-sequence(
+return contains-subsequence(
   $chap ! child::*,
   $chap ! child::p,
   op("is")
@@ -13336,18 +13336,18 @@ return contains-sequence(
                <fos:postamble>True because the <code>p</code> children of the <code>chap</code> element form a contiguous subsequence.</fos:postamble>
             </fos:test>       
             <fos:test>
-               <fos:expression>contains-sequence(10 to 20, (5, 3, 1), op("gt"))</fos:expression>
+               <fos:expression>contains-subsequence(10 to 20, (5, 3, 1), op("gt"))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>contains-sequence(
+               <fos:expression><eg>contains-subsequence(
   ("Alpha", "Beta", "Gamma", "Delta"), ("B", "G"),
   starts-with#2
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>contains-sequence(
+               <fos:expression><eg>contains-subsequence(
   ("Zero", "Alpha", "Beta", "Gamma", "Delta", "Epsilon"),
   1 to 4,
   function($x, $y) { ends-with($x, 'a') }
@@ -27057,9 +27057,9 @@ return $pos</eg>
          
       </fos:function>-->
 
-   <fos:function name="items-after">
+   <fos:function name="subsequence-after">
       <fos:signatures>
-         <fos:proto name="items-after" return-type="item()*">
+         <fos:proto name="subsequence-after" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="predicate" type="function(item(), xs:integer) as xs:boolean"/>
          </fos:proto>
@@ -27079,38 +27079,38 @@ head(index-where($input, $predicate)) ! subsequence($input, . + 1)
 ]]></eg>
       </fos:rules>
       <fos:notes>
-         <p>To retain the first matching item, use <code>fn:items-starting-where</code>.</p>
+         <p>To retain the first matching item, use <code>fn:subsequence-starting-where</code>.</p>
       </fos:notes>
 
       <fos:examples>
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-after(10 to 20, function { . gt 12 })</fos:expression>
+               <fos:expression>subsequence-after(10 to 20, function { . gt 12 })</fos:expression>
                <fos:result>(14, 15, 16, 17, 18, 19, 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>items-after(
+               <fos:expression><eg>subsequence-after(
   ("January", "February", "March", "April", "May"),
   starts-with(?, "A")
 )</eg></fos:expression>
                <fos:result>("May")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-after(10 to 20, function { . gt 100 })</fos:expression>
+               <fos:expression>subsequence-after(10 to 20, function { . gt 100 })</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-after((), boolean#1)</fos:expression>
+               <fos:expression>subsequence-after((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
-=> items-after(function { boolean(self::h2) })]]></eg></fos:expression>
+=> subsequence-after(function { boolean(self::h2) })]]></eg></fos:expression>
                <fos:result><![CDATA[<img/>]]></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>items-after(10 to 20, fn($num, $pos) { $num > 15 and $pos > 8 })</eg></fos:expression>
+               <fos:expression><eg>subsequence-after(10 to 20, fn($num, $pos) { $num > 15 and $pos > 8 })</eg></fos:expression>
                <fos:result>(19, 20)</fos:result>
             </fos:test>
          </fos:example>
@@ -27122,9 +27122,9 @@ head(index-where($input, $predicate)) ! subsequence($input, . + 1)
 
    </fos:function>
 
-   <fos:function name="items-before">
+   <fos:function name="subsequence-before">
       <fos:signatures>
-         <fos:proto name="items-before" return-type="item()*">
+         <fos:proto name="subsequence-before" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="predicate" type="function(item(), xs:integer) as xs:boolean"/>
          </fos:proto>
@@ -27144,7 +27144,7 @@ subsequence($input, 1, head(index-where($input, $predicate)))
 ]]></eg>
       </fos:rules>
       <fos:notes>
-         <p>To retain the first matching item, use <code>fn:items-ending-where</code>.</p>
+         <p>To retain the first matching item, use <code>fn:subsequence-ending-where</code>.</p>
       </fos:notes>
       
 
@@ -27152,39 +27152,39 @@ subsequence($input, 1, head(index-where($input, $predicate)))
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-before(10 to 20, function { . gt 12 })</fos:expression>
+               <fos:expression>subsequence-before(10 to 20, function { . gt 12 })</fos:expression>
                <fos:result>(10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>items-before(
+               <fos:expression><eg>subsequence-before(
   ("January", "February", "March", "April", "May"),
   starts-with(?, "A")
 )</eg></fos:expression>
                <fos:result>("January", "February", "March")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-before(10 to 20, function { . gt 100 })</fos:expression>
+               <fos:expression>subsequence-before(10 to 20, function { . gt 100 })</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-before((), boolean#1)</fos:expression>
+               <fos:expression>subsequence-before((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
-=> items-before(function { boolean(self::img) })
+=> subsequence-before(function { boolean(self::img) })
 =!> name()]]></eg></fos:expression>
                <fos:result>"p", "p", "h2"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>("Aardvark", "Antelope", "Bison",
- "Buffalo", "Camel", "Dingo")
-=> items-starting-where(starts-with(?, "B"))
-=> items-before(starts-with(?, "D"))</eg></fos:expression>
+               <fos:expression><eg><![CDATA[
+("Aardvark", "Antelope", "Bison", "Buffalo", "Camel", "Dingo")
+=> subsequence-starting-where(starts-with(?, "B"))
+=> subsequence-before(starts-with(?, "D"))]]></eg></fos:expression>
                <fos:result>"Bison", "Buffalo", "Camel"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>items-before(10 to 20, fn($num, $pos) { $num > 11 and $pos > 2 })</eg></fos:expression>
+               <fos:expression><eg>subsequence-before(10 to 20, fn($num, $pos) { $num > 11 and $pos > 2 })</eg></fos:expression>
                <fos:result>(10, 11)</fos:result>
             </fos:test>
          </fos:example>
@@ -27196,9 +27196,9 @@ subsequence($input, 1, head(index-where($input, $predicate)))
 
    </fos:function>
 
-   <fos:function name="items-starting-where">
+   <fos:function name="subsequence-starting-where">
       <fos:signatures>
-         <fos:proto name="items-starting-where" return-type="item()*">
+         <fos:proto name="subsequence-starting-where" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="predicate" type="function(item(), xs:integer) as xs:boolean"/>
          </fos:proto>
@@ -27218,7 +27218,7 @@ head(index-where($input, $predicate)) ! subsequence($input, .)
 ]]></eg>
       </fos:rules>
       <fos:notes>
-         <p>To exclude the first item, use <code>fn:items-after</code>.</p>
+         <p>To exclude the first item, use <code>fn:subsequence-after</code>.</p>
       </fos:notes>
       
 
@@ -27226,32 +27226,32 @@ head(index-where($input, $predicate)) ! subsequence($input, .)
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-starting-where(10 to 20, function { . gt 12 })</fos:expression>
+               <fos:expression>subsequence-starting-where(10 to 20, function { . gt 12 })</fos:expression>
                <fos:result>(13, 14, 15, 16, 17, 18, 19, 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>items-starting-where(
+               <fos:expression><eg>subsequence-starting-where(
   ("January", "February", "March", "April", "May"),
   starts-with(?, "A")
 )</eg></fos:expression>
                <fos:result>("April", "May")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-starting-where(10 to 20, function { . gt 100 })</fos:expression>
+               <fos:expression>subsequence-starting-where(10 to 20, function { . gt 100 })</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-starting-where((), boolean#1)</fos:expression>
+               <fos:expression>subsequence-starting-where((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
-=> items-starting-where(function { boolean(self::h2) })
+=> subsequence-starting-where(function { boolean(self::h2) })
 =!> name()]]></eg></fos:expression>
                <fos:result>"h2", "img"</fos:result>
             </fos:test>
          <fos:test>
-             <fos:expression><eg>items-starting-where(10 to 20, fn($num, $pos) { $num > 15 and $pos > 8 })</eg></fos:expression>
+             <fos:expression><eg>subsequence-starting-where(10 to 20, fn($num, $pos) { $num > 15 and $pos > 8 })</eg></fos:expression>
              <fos:result>(18, 19, 20)</fos:result>
          </fos:test>
          </fos:example>
@@ -27263,9 +27263,9 @@ head(index-where($input, $predicate)) ! subsequence($input, .)
 
    </fos:function>
 
-   <fos:function name="items-ending-where">
+   <fos:function name="subsequence-ending-where">
       <fos:signatures>
-         <fos:proto name="items-ending-where" return-type="item()*">
+         <fos:proto name="subsequence-ending-where" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="predicate" type="function(item(), xs:integer) as xs:boolean"/>
          </fos:proto>
@@ -27285,7 +27285,7 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
 ]]></eg>
       </fos:rules>
       <fos:notes>
-         <p>To exclude the last item, use <code>fn:items-before</code>.</p>
+         <p>To exclude the last item, use <code>fn:subsequence-before</code>.</p>
       </fos:notes>
       
 
@@ -27293,32 +27293,32 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
 
          <fos:example>
             <fos:test>
-               <fos:expression>items-ending-where(10 to 20, function { . gt 12 })</fos:expression>
+               <fos:expression>subsequence-ending-where(10 to 20, function { . gt 12 })</fos:expression>
                <fos:result>(10, 11, 12, 13)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>items-ending-where(
+               <fos:expression><eg>subsequence-ending-where(
   ("January", "February", "March", "April", "May"),
   starts-with(?, "A")
 )</eg></fos:expression>
                <fos:result>("January", "February", "March", "April")</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-ending-where(10 to 20, function { . gt 100 })</fos:expression>
+               <fos:expression>subsequence-ending-where(10 to 20, function { . gt 100 })</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>items-ending-where((), boolean#1)</fos:expression>
+               <fos:expression>subsequence-ending-where((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
-=> items-ending-where(function { boolean(self::h2) })
+=> subsequence-ending-where(function { boolean(self::h2) })
 =!> name()]]></eg></fos:expression>
                <fos:result>"p", "p", "h2"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>items-ending-where(10 to 20, fn($num, $pos) { $num > 11 and $pos > 2 })</eg></fos:expression>
+               <fos:expression><eg>subsequence-ending-where(10 to 20, fn($num, $pos) { $num > 11 and $pos > 2 })</eg></fos:expression>
                <fos:result>(10, 11, 12)</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5433,14 +5433,14 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-atomic-equal">
                <head><?function fn:atomic-equal?></head>
             </div3>
-            <div3 id="func-starts-with-sequence" diff="add" at="B">
-               <head><?function fn:starts-with-sequence?></head>
+            <div3 id="func-starts-with-subsequence" diff="add" at="B">
+               <head><?function fn:starts-with-subsequence?></head>
             </div3>  
-            <div3 id="func-ends-with-sequence" diff="add" at="B">
-               <head><?function fn:ends-with-sequence?></head>
+            <div3 id="func-ends-with-subsequence" diff="add" at="B">
+               <head><?function fn:ends-with-subsequence?></head>
             </div3>  
-            <div3 id="func-contains-sequence" diff="add" at="B">
-               <head><?function fn:contains-sequence?></head>
+            <div3 id="func-contains-subsequence" diff="add" at="B">
+               <head><?function fn:contains-subsequence?></head>
             </div3>  
             <div3 id="func-distinct-values">
                <head><?function fn:distinct-values?></head>
@@ -7402,17 +7402,17 @@ return <table>
             <div3 id="func-index-where" diff="add" at="A">
                <head><?function fn:index-where?></head>
             </div3>
-            <div3 id="func-items-after" diff="add" at="A">
-               <head><?function fn:items-after?></head>
+            <div3 id="func-subsequence-after" diff="add" at="A">
+               <head><?function fn:subsequence-after?></head>
             </div3>
-            <div3 id="func-items-before" diff="add" at="A">
-               <head><?function fn:items-before?></head>
+            <div3 id="func-subsequence-before" diff="add" at="A">
+               <head><?function fn:subsequence-before?></head>
             </div3>
-            <div3 id="func-items-starting-where" diff="add" at="A">
-               <head><?function fn:items-starting-where?></head>
+            <div3 id="func-subsequence-starting-where" diff="add" at="A">
+               <head><?function fn:subsequence-starting-where?></head>
             </div3>
-            <div3 id="func-items-ending-where" diff="add" at="A">
-               <head><?function fn:items-ending-where?></head>
+            <div3 id="func-subsequence-ending-where" diff="add" at="A">
+               <head><?function fn:subsequence-ending-where?></head>
             </div3>
             <div3 id="func-iterate-while">
                <head><?function fn:iterate-while?></head>
@@ -11878,10 +11878,10 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:chain</code></p></item>
               <item><p><code>fn:char</code></p></item>
               <item><p><code>fn:characters</code></p></item>
-              <item><p><code>fn:contains-sequence</code></p></item>
+              <item><p><code>fn:contains-subsequence</code></p></item>
               <item><p><code>fn:decode-from-uri</code></p></item>
               <item><p><code>fn:duplicate-values</code></p></item>
-              <item><p><code>fn:ends-with-sequence</code></p></item>
+              <item><p><code>fn:ends-with-subsequence</code></p></item>
               <item><p><code>fn:every</code></p></item>
               <item><p><code>fn:expanded-QName</code></p></item>
               <item><p><code>fn:foot</code></p></item>
@@ -11893,11 +11893,7 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:intersperse</code></p></item>
               <item><p><code>fn:invisible-xml</code></p></item>
               <item><p><code>fn:is-NaN</code></p></item>
-              <item><p><code>fn:items-after</code></p></item>
               <item><p><code>fn:items-at</code></p></item>
-              <item><p><code>fn:items-before</code></p></item>
-              <item><p><code>fn:items-ending-where</code></p></item>
-              <item><p><code>fn:items-starting-where</code></p></item>
               <item><p><code>fn:iterate-while</code></p></item>
               <item><p><code>fn:lowest</code></p></item>
               <item><p><code>fn:message</code></p></item>
@@ -11910,7 +11906,11 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
               <item><p><code>fn:replicate</code></p></item>
               <item><p><code>fn:slice</code></p></item>
               <item><p><code>fn:some</code></p></item>
-              <item><p><code>fn:starts-with-sequence</code></p></item>
+              <item><p><code>fn:starts-with-subsequence</code></p></item>
+              <item><p><code>fn:subsequence-after</code></p></item>
+              <item><p><code>fn:subsequence-before</code></p></item>
+              <item><p><code>fn:subsequence-ending-where</code></p></item>
+              <item><p><code>fn:subsequence-starting-where</code></p></item>
               <item><p><code>fn:transitive-closure</code></p></item>
               <item><p><code>fn:trunk</code></p></item>
               <item><p><code>fn:void</code></p></item>

--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -44,7 +44,7 @@
    <!-- Exclude functions that are either (a) difficult to test, or (b) not yet agreed / implemented -->
    <xsl:template match="function[@name=('error', 'concat', 'transform',  
       'load-xquery-module', 'parts', 'stack-trace', 'group-by', 'substitute', 'collection', 'uri-collection',
-      'items-starting-where', 'random-number-generator')]" priority="5"/>
+      'subsequence-starting-where', 'random-number-generator')]" priority="5"/>
    
    <xsl:template match="function[@prefix='array'][@name=('replace', 'slice', 'from-sequence', 'of', 'partition')]" priority="6"/>
    


### PR DESCRIPTION
Closes #844. The `items` keyword in the function names (excluding `items-at`) has been changed to `subsequence`.

See #878 for the controversial discussion on what to do with `subsequence-(after|before|starting-where|ending-where)`.