### PR TITLE
866 Introduce and exploit new numeric-compare() function

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19431,11 +19431,12 @@ declare function transitive-closure (
             <item><p>NaN is equal to itself and less than any other value.</p></item>
             <item><p>Negative infinity is equal to itself and less than any other value except NaN.</p></item>
             <item><p>Positive infinity is equal to itself and greater than any other value.</p></item>
-            <item><p>Ordinary <code>xs:double</code> and <code>xs:decimal</code> values (that is, values other than the infinities
-            and NaN) are ordered according to their mathematical magnitude, the comparison being done without any rounding or
+            <item><p>Negative zero is equal to positive zero.</p></item>
+            <item><p>Other <code>xs:double</code> and <code>xs:decimal</code> values (that is, values other than the infinities,
+             NaN, and negative zero) are ordered according to their mathematical magnitude, the comparison being done without any rounding or
             loss of precision. This effect can be achieved by converting <code>xs:double</code> values to <code>xs:decimal</code>
-            using an implementation of <code>xs:decimal</code> that imposes no limits on precision or scale (or an implementation
-            whose limits are such that all <code>xs:double</code> values can be represented precisely).</p></item>
+            using an implementation of <code>xs:decimal</code> that imposes no limits on precision or scale, or an implementation
+            whose limits are such that all <code>xs:double</code> values can be represented precisely.</p></item>
          </olist>
          <p>The function returns <code>-1</code> if <code>$value1</code> is less than <code>$value2</code> according to this
             ordering, <code>0</code> if they are equal, or <code>+1</code> if <code>$value1</code> is greater.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14378,6 +14378,7 @@ declare function equal-strings(
          </fos:example>
       </fos:examples>
    </fos:function>
+   
    <fos:function name="max" prefix="fn">
       <fos:signatures>
          <fos:proto name="max" return-type="xs:anyAtomicType?">
@@ -14385,12 +14386,12 @@ declare function equal-strings(
             <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
-      <fos:properties arity="0">
+      <fos:properties arity="1">
          <fos:property>deterministic</fos:property>
          <fos:property dependency="collations implicit-timezone">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
-      <fos:properties arity="1">
+      <fos:properties arity="2">
          <fos:property>deterministic</fos:property>
          <fos:property dependency="collations static-base-uri implicit-timezone">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
@@ -14399,76 +14400,60 @@ declare function equal-strings(
          <p>Returns a value that is equal to the highest value appearing in the input sequence.</p>
       </fos:summary>
       <fos:rules>
-         <p>The following conversions are applied to the input sequence <code>$values</code>, in order:</p>
+         <p>Any item in <code>$values</code> that is an instance of <code>xs:untypedAtomic</code>
+            is first cast to <code>xs:double</code>. The resulting sequence is referred to as the
+            converted sequence.</p>
+         
+         <p>All pairs of values in the converted sequence must be mutually comparable. Two values are mutually
+            comparable if one or more of the following conditions applies:</p>
          <olist>
-            <item>
-               <p>Values of type <code>xs:untypedAtomic</code> in <code>$values</code> are cast to
-                     <code>xs:double</code>.</p>
-            </item>
-            <item>
-               <p>If the resulting sequence contains values that are instances of more than one primitive type
-                  (meaning the 19 primitive types defined in <bibref
-                     ref="xmlschema11-2"/>), then:
-               </p>
-               <olist>
-                  <item>
-                     <p>If each value is an instance of one of the types <code>xs:string</code> or <code>xs:anyURI</code>,
-                  then all the values are cast to type <code>xs:string</code>.</p>
-                  </item>
-                  <item>
-                     <p>If each value is an instance of one of the types <code>xs:decimal</code> or <code>xs:float</code>,
-                     then all the values are cast to type <code>xs:float</code>.</p>
-                  </item>
-                  <item>
-                     <p>If each value is an instance of one of the types <code>xs:decimal</code>, <code>xs:float</code>,
-                     or <code>xs:double</code>, then all the values are cast to type <code>xs:double</code>.</p>
-                  </item>
-                  <item>
-                     <p>Otherwise, a type error is raised <errorref class="RG" code="0006"/>.</p>
-                  </item>
-               </olist>
-               <note>
-                  <p>The primitive type of an <code>xs:integer</code> value for this purpose is <code>xs:decimal</code>.</p>
-               </note>
-            </item>
-
+            <item><p>Both values are instances of <code>xs:string</code> or <code>xs:anyURI</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:numeric</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:hexBinary</code> or <code>xs:base64Binary</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:date</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:dateTime</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:time</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:dayTimeDuration</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:yearMonthDuration</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:boolean</code>.</p></item>
          </olist>
-         <p>The items in the resulting sequence may be reordered in an arbitrary order. The
-            resulting sequence is referred to below as the converted sequence. The function returns
-            an item from the converted sequence rather than the input sequence. </p>
+         
+         <p>If the converted sequence contains a single value then it must be comparable to itself under the above rules. (So the
+            input cannot be, for example, a singleton <code>xs:QName</code>.)</p>
+         
          <p>If the converted sequence is empty, the function returns the empty sequence.</p>
-         <p>All items in the converted sequence must be derived from a single base type for which
-            the <code>le</code> operator is defined. In addition, the values in the sequence must
-            have a total order. If date/time values do not have a timezone, they are considered to
-            have the implicit timezone provided by the dynamic context for the purpose of
-            comparison. Duration values must either all be <code>xs:yearMonthDuration</code> values
-            or must all be <code>xs:dayTimeDuration</code> values.</p>
+         
          <p>If the converted sequence contains the value <code>NaN</code>, the value
-               <code>NaN</code> is returned 
+            <code>NaN</code> is returned
             <phrase>(as an <code>xs:float</code> or <code>xs:double</code> as appropriate)</phrase>.</p>
-         <p>If the items in the converted sequence are of type <code>xs:string</code> or types
-            derived by restriction from <code>xs:string</code>, then the determination of the item
-            with the smallest value is made according to the collation that is used. If the type of
-            the items in the converted sequence is not <code>xs:string</code> and
-               <code>$collation</code> is specified, the collation is ignored.</p>
-         <p>The collation used by this function is determined according to the rules in <specref
-               ref="choosing-a-collation"/>.</p>
-         <p>The function returns the result of the expression:</p>
-         <eg xml:space="preserve">
-   if (every $v in $c satisfies $c[1] ge $v)
-   then $c[1] 
-   else max(tail($c))</eg>
-         <p>evaluated with <code>$collation</code> as the default collation if specified, and with
-               <code>$c</code> as the converted sequence.</p>
-
+         
+         <p>Two items <code>$v1</code> and <code>$v2</code> from the converted sequence are compared as follows:</p>
+         
+         <olist>
+            <item><p>If both values are instances of <code>xs:string</code> or <code>xs:anyURI</code>, they
+               are compared using <code>fn:compare($v1, $v2, $collation)</code>, where <code>$collation</code>
+               is determined by the rules in <specref ref="choosing-a-collation"/>.</p>
+               <note><p>In other cases, <code>$collation</code> is ignored.</p></note></item>
+            <item><p>If both values are instances of <code>xs:numeric</code>, they are compared
+               using <code>fn:numeric-compare($v1, $v2)</code>.</p></item>
+            <item><p>In all other cases, the values are compared using the <code>lt</code> and <code>eq</code>
+               operators appropriate to their type.</p></item>
+         </olist>
+         
+         <p>The result of the function is a value from the converted sequence that is greater than 
+            or equal to every other value under the above rules. If there is more than one such value, then it is 
+            <termref def="implementation-dependent">implementation-dependent</termref>
+            which of them is returned.</p>
+         
+         
       </fos:rules>
       <fos:errors>
          <p>A type error is raised <errorref class="RG" code="0006"
-            /> if the input sequence contains
+         /> if the input sequence contains
             items of incompatible types, as described above.</p>
       </fos:errors>
       <fos:notes>
-         <p>Because the rules allow the sequence to be reordered, if there are two or more items that are
+         <p>If there are two or items that are
             “equal highest”, the specific item whose value is returned is <termref
                def="implementation-dependent"
                >implementation-dependent</termref>. This can arise for example if two different strings
@@ -14476,42 +14461,50 @@ declare function equal-strings(
             values compare equal despite being in different timezones.</p>
          <p>If the converted sequence contains exactly one value then that value is returned.</p>
          <p>The default type when the <code>fn:max</code> function is applied to
-               <code>xs:untypedAtomic</code> values is <code>xs:double</code>. This differs from the
-            default type for operators such as <code>gt</code>, and for sorting in XQuery and XSLT,
+            <code>xs:untypedAtomic</code> values is <code>xs:double</code>. This differs from the
+            default type for operators such as <code>lt</code>, and for sorting in XQuery and XSLT,
             which is <code>xs:string</code>.</p>
-         <p>The rules for the dynamic type of the result are stricter in version 3.1 of the specification than
-         in earlier versions. For example, if all the values in the input sequence belong to types derived from
-         <code>xs:integer</code>, version 3.0 required only that the result be an instance
-         of the least common supertype of the types present in the input sequence; Version 3.1
-         requires that the returned value retains its original type. This does not apply, however, where type promotion
-         is needed to convert all the values to a common primitive type.</p>
+         <p>In version 4.0, if <code>$values</code> is a sequence of <code>xs:decimal</code> values
+            (including the case where it is a sequence of <code>xs:integer</code> values), then
+            the result will be one of these <code>xs:decimal</code> or <code>xs:integer</code> values. 
+            In earlier versions it would
+            be the result of converting this <code>xs:decimal</code> to <code>xs:double</code>.</p>
+         
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression>max((3,4,5))</fos:expression>
-               <fos:result>5</fos:result>
+               <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression>max([3,4,5])</fos:expression>
-               <fos:result>5</fos:result>
+               <fos:result>3</fos:result>
                <fos:postamble>Arrays are atomized</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>max((xs:integer(5), xs:float(5.0), xs:double(0)))</fos:expression>
-               <fos:result>xs:double(5.0e0)</fos:result>
+               <fos:expression>max((xs:integer(5), xs:float(5), xs:double(0)))</fos:expression>
+               <fos:result>5</fos:result>
+               <fos:postamble>The result may be either the <code>xs:integer</code> or the <code>xs:float</code>,
+                  since they are equal.</fos:postamble>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>max((xs:float(0.0E0), xs:float(-0.0E0)))</fos:expression>
+               <fos:result>xs:float(0.0e0)</fos:result>
+               <fos:postamble>The result may be either positive or negative zero, since they are equal.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression>max((current-date(), xs:date("2100-01-01")))</fos:expression>
                <fos:result>xs:date("2100-01-01")</fos:result>
-               <fos:postamble>Assuming that the current date is during the 21st
-                  century.</fos:postamble>
+               <fos:postamble>Assuming that the current date is during the 21st century.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -14522,11 +14515,13 @@ declare function equal-strings(
             </fos:test>
          </fos:example>
          <fos:example>
-            <p><code>fn:max((3,4,"Zero"))</code> raises a type error <errorref class="RG"
-                  code="0006"/>. </p>
+            <p><code>max((3,4,"Zero"))</code> raises a type error <errorref class="RG"
+               code="0006"/>. </p>
          </fos:example>
       </fos:examples>
    </fos:function>
+   
+ 
    <fos:function name="min" prefix="fn">
       <fos:signatures>
          <fos:proto name="min" return-type="xs:anyAtomicType?">
@@ -14534,12 +14529,12 @@ declare function equal-strings(
             <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
-      <fos:properties arity="0">
+      <fos:properties arity="1">
          <fos:property>deterministic</fos:property>
          <fos:property dependency="collations implicit-timezone">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
-      <fos:properties arity="1">
+      <fos:properties arity="2">
          <fos:property>deterministic</fos:property>
          <fos:property dependency="collations static-base-uri implicit-timezone">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
@@ -14548,67 +14543,52 @@ declare function equal-strings(
          <p>Returns a value that is equal to the lowest value appearing in the input sequence.</p>
       </fos:summary>
       <fos:rules>
-         <p>The following rules are applied to the input sequence:</p>
-         <ulist>
-            <item>
-               <p>Values of type <code>xs:untypedAtomic</code> in <code>$values</code> are cast to
-                     <code>xs:double</code>.</p>
-            </item>
-            <item>
-               <p>If the resulting sequence contains values that are instances of more than one primitive type
-                  (meaning the 19 primitive types defined in <bibref
-                     ref="xmlschema11-2"/>), then:
-               </p>
-               <olist>
-                  <item>
-                     <p>If each value is an instance of one of the types <code>xs:string</code> or <code>xs:anyURI</code>,
-                     then all the values are cast to type <code>xs:string</code>.</p>
-                  </item>
-                  <item>
-                     <p>If each value is an instance of one of the types <code>xs:decimal</code> or <code>xs:float</code>,
-                     then all the values are cast to type <code>xs:float</code>.</p>
-                  </item>
-                  <item>
-                     <p>If each value is an instance of one of the types <code>xs:decimal</code>, <code>xs:float</code>,
-                     or <code>xs:double</code>, then all the values are cast to type <code>xs:double</code>.</p>
-                  </item>
-                  <item>
-                     <p>Otherwise, a type error is raised <errorref class="RG" code="0006"/>.</p>
-                  </item>
-               </olist>
-               <note>
-                  <p>The primitive type of an <code>xs:integer</code> value for this purpose is <code>xs:decimal</code>.</p>
-               </note>
-            </item>
-         </ulist>
-         <p>The items in the resulting sequence may be reordered in an arbitrary order. The
-            resulting sequence is referred to below as the converted sequence. The function returns
-            an item from the converted sequence rather than the input sequence. </p>
-         <p>If the converted sequence is empty, the empty sequence is returned.</p>
-         <p>All items in the converted sequence must be derived from a single base type for which
-            the <code>le</code> operator is defined. In addition, the values in the sequence must
-            have a total order. If date/time values do not have a timezone, they are considered to
-            have the implicit timezone provided by the dynamic context for the purpose of
-            comparison. Duration values must either all be <code>xs:yearMonthDuration</code> values
-            or must all be <code>xs:dayTimeDuration</code> values.</p>
+         <p>Any item in <code>$values</code> that is an instance of <code>xs:untypedAtomic</code>
+         is first cast to <code>xs:double</code>. The resulting sequence is referred to as the
+         converted sequence.</p>
+         
+         <p>All pairs of values in the converted sequence must be mutually comparable. Two values are mutually
+         comparable if one or more of the following conditions applies:</p>
+         <olist>
+            <item><p>Both values are instances of <code>xs:string</code> or <code>xs:anyURI</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:numeric</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:hexBinary</code> or <code>xs:base64Binary</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:date</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:dateTime</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:time</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:dayTimeDuration</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:yearMonthDuration</code>.</p></item>
+            <item><p>Both values are instances of <code>xs:boolean</code>.</p></item>
+         </olist>
+         
+         <p>If the converted sequence contains a single value then it must be comparable to itself under the above rules. (So the
+         input cannot be, for example, a singleton <code>xs:QName</code>.)</p>
+         
+         <p>If the converted sequence is empty, the function returns the empty sequence.</p>
+         
          <p>If the converted sequence contains the value <code>NaN</code>, the value
-               <code>NaN</code> is returned
+            <code>NaN</code> is returned
             <phrase>(as an <code>xs:float</code> or <code>xs:double</code> as appropriate)</phrase>.</p>
-         <p>If the items in the converted sequence are of type <code>xs:string</code> or types
-            derived by restriction from <code>xs:string</code>, then the determination of the item
-            with the smallest value is made according to the collation that is used. If the type of
-            the items in the converted sequence is not <code>xs:string</code> and
-               <code>$collation</code> is specified, the collation is ignored.</p>
-         <p>The collation used by this function is determined according to the rules in <specref
-               ref="choosing-a-collation"/>.</p>
-         <p>The function returns the result of the expression:</p>
-         <eg xml:space="preserve">
-   if (every $v in $c satisfies $c[1] le $v) 
-   then $c[1] 
-   else min(tail($c))</eg>
-         <p>evaluated with <code>$collation</code> as the default collation if specified, and with
-               <code>$c</code> as the converted sequence.</p>
-
+         
+         <p>Two items <code>$v1</code> and <code>$v2</code> from the converted sequence are compared as follows:</p>
+         
+         <olist>
+            <item><p>If both values are instances of <code>xs:string</code> or <code>xs:anyURI</code>, they
+            are compared using <code>fn:compare($v1, $v2, $collation)</code>, where <code>$collation</code>
+            is determined by the rules in <specref ref="choosing-a-collation"/>.</p>
+            <note><p>In other cases, <code>$collation</code> is ignored.</p></note></item>
+            <item><p>If both values are instances of <code>xs:numeric</code>, they are compared
+            using <code>fn:numeric-compare($v1, $v2)</code>.</p></item>
+            <item><p>In all other cases, the values are compared using the <code>lt</code> and <code>eq</code>
+               operators appropriate to their type.</p></item>
+         </olist>
+         
+         <p>The result of the function is a value from the converted sequence that is less than 
+            or equal to every other value under the above rules. If there is more than one such value, then it is 
+            <termref def="implementation-dependent">implementation-dependent</termref>
+            which of them is returned.</p>
+         
+ 
       </fos:rules>
       <fos:errors>
          <p>A type error is raised <errorref class="RG" code="0006"
@@ -14616,7 +14596,7 @@ declare function equal-strings(
             items of incompatible types, as described above.</p>
       </fos:errors>
       <fos:notes>
-         <p>Because the rules allow the sequence to be reordered, if there are two or items that are
+         <p>If there are two or items that are
             “equal lowest”, the specific item whose value is returned is <termref
                def="implementation-dependent"
                >implementation-dependent</termref>. This can arise for example if two different strings
@@ -14627,12 +14607,11 @@ declare function equal-strings(
                <code>xs:untypedAtomic</code> values is <code>xs:double</code>. This differs from the
             default type for operators such as <code>lt</code>, and for sorting in XQuery and XSLT,
             which is <code>xs:string</code>.</p>
-         <p>The rules for the dynamic type of the result are stricter in version 3.1 of the specification than
-            in earlier versions. For example, if all the values in the input sequence belong to types derived from
-            <code>xs:integer</code>, version 3.0 required only that the result be an instance
-            of the least common supertype of the types present in the input sequence; Version 3.1
-            requires that the returned value retains its original type. This does not apply, however, where type promotion
-            is needed to convert all the values to a common primitive type.</p>
+         <p>In version 4.0, if <code>$values</code> is a sequence of <code>xs:decimal</code> values
+            (including the case where it is a sequence of <code>xs:integer</code> values), then
+            the result will be one of these <code>xs:decimal</code> or <code>xs:integer</code> values. 
+            In earlier versions it would
+            be the result of converting this <code>xs:decimal</code> to <code>xs:double</code>.</p>
 
       </fos:notes>
       <fos:examples>
@@ -14652,14 +14631,17 @@ declare function equal-strings(
          <fos:example>
             <fos:test>
                <fos:expression>min((xs:integer(5), xs:float(5), xs:double(10)))</fos:expression>
-               <fos:result>xs:double(5.0e0)</fos:result>
+               <fos:result>5</fos:result>
+               <fos:postamble>The result may be either the <code>xs:integer</code> or the <code>xs:float</code>,
+               since they are equal.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p><code>fn:min((xs:float(0.0E0), xs:float(-0.0E0)))</code> can return either positive
-               or negative zero. The two items are equal, so it is <termref
-                  def="implementation-dependent"
-               >implementation-dependent</termref> which is returned.</p>
+            <fos:test>
+               <fos:expression>min((xs:float(0.0E0), xs:float(-0.0E0)))</fos:expression>
+               <fos:result>xs:float(0.0e0)</fos:result>
+               <fos:postamble>The result may be either positive or negative zero, since they are equal.</fos:postamble>
+            </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
@@ -14677,7 +14659,7 @@ declare function equal-strings(
             </fos:test>
          </fos:example>
          <fos:example>
-            <p><code>fn:min((3,4,"Zero"))</code> raises a type error <errorref class="RG"
+            <p><code>min((3,4,"Zero"))</code> raises a type error <errorref class="RG"
                   code="0006"/>. </p>
          </fos:example>
       </fos:examples>
@@ -18791,8 +18773,10 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
                      <eg>if ($k1 instance of union(xs:string, xs:anyURI, xs:untypedAtomic)
     and $k2 instance of union(xs:string, xs:anyURI, xs:untypedAtomic))
 then compare($k1, $k2, $C)
-else if ($k1 eq $k2 or (is-NaN($k1) and is-NaN($k2))) then 0
-else if (is-NaN($k1) or $k2 lt $k2) then -1
+else if ($k1 instance of xs:numeric and $k2 instance of xs:numeric)
+then numeric-compare($k1, $k2)
+else if ($k1 eq $k2) then 0
+else if ($k2 lt $k2) then -1
 else +1</eg>
                      <note><p>This raises an error if two keys are not comparable, for example
                         if one is a string and the other is a number, or if both belong to a non-ordered
@@ -19411,6 +19395,102 @@ declare function transitive-closure (
          function in 3.1</fos:version>
       </fos:history>
       
+   </fos:function>
+   
+   <fos:function name="numeric-compare" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="numeric-compare" return-type="xs:integer">
+            <fos:arg name="value1" type="xs:numeric"/>
+            <fos:arg name="value2" type="xs:numeric"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+         
+      </fos:properties>
+      <fos:summary>
+         <p>Returns <code>-1</code>, <code>0</code>, or <code>+1</code> depending on whether <code>$value1</code>
+         is numerically less than, equal to, or greater than <code>$value2</code>.</p>
+      </fos:summary>
+      <fos:rules>
+         
+         <p>This function differs from the operators <code>lt</code>, <code>eq</code>, and <code>gt</code> in that
+            decimal values are not converted to doubles. This means that the comparison is fully transitive, which makes
+            it safe for use in sorting algorithms. It is used to underpin sorting in XQuery 4.0 and XSLT 4.0, and is also
+            available as a free-standing function in its own right.
+         </p>
+         
+         <p>The function relies on a total ordering of <code>xs:numeric</code> values which is defined as follows:</p>
+         
+         <olist>
+            <item><p>A value <code>$f</code> of type <code>xs:float</code> is in all cases equal to the value
+               <code>xs:double($f)</code>. The remaining rules therefore only consider instances of <code>xs:double</code>
+                and <code>xs:decimal</code>.</p></item>
+            <item><p>NaN is equal to itself and less than any other value.</p></item>
+            <item><p>Negative infinity is equal to itself and less than any other value except NaN.</p></item>
+            <item><p>Positive infinity is equal to itself and greater than any other value.</p></item>
+            <item><p>Ordinary <code>xs:double</code> and <code>xs:decimal</code> values (that is, values other than the infinities
+            and NaN) are ordered according to their mathematical magnitude, the comparison being done without any rounding or
+            loss of precision. This effect can be achieved by converting <code>xs:double</code> values to <code>xs:decimal</code>
+            using an implementation of <code>xs:decimal</code> that imposes no limits on precision or scale (or an implementation
+            whose limits are such that all <code>xs:double</code> values can be represented precisely).</p></item>
+         </olist>
+         <p>The function returns <code>-1</code> if <code>$value1</code> is less than <code>$value2</code> according to this
+            ordering, <code>0</code> if they are equal, or <code>+1</code> if <code>$value1</code> is greater.</p>
+         
+
+         
+      </fos:rules>
+      <fos:notes>
+         <p>Consider the <code>xs:double</code> value written as <code>0.1e0</code> and the 
+            <code>xs:decimal</code> value written as <code>0.1</code>.</p>
+         <p>The mathematical magnitude of this <code>xs:double</code> value is 
+            <code>0.1000000000000000055511151231257827021181583404541015625</code>.
+         Therefore, <code>fn:numeric-compare(0.1e0, 0.1)</code> returns <code>+1</code>. By contrast,
+            <code>0.1e0 lt 0.1</code> is false, and <code>0.1e0 eq 0.1</code> is true, because those expressions
+         convert the <code>xs:decimal</code> value <code>0.1</code> to the <code>xs:double</code> value <code>0.1e0</code>
+         before the comparison.</p>
+         <p>Although operations such as sorting and the <code>fn:min</code> and <code>fn:max</code> functions
+         invoke <code>fn:numeric-compare</code> to perform numeric comparison, these functions in some cases treat
+         <code>NaN</code> differently.</p>
+
+ 
+      </fos:notes>
+      <fos:examples>
+       
+         <fos:example>
+            <fos:test>
+               <fos:expression>numeric-compare(xs:double('NaN'), xs:float('NaN'))</fos:expression>
+               <fos:result>0</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>numeric-compare(xs:double('NaN'), xs:double('-INF'))</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>            
+            <fos:test>
+               <fos:expression>numeric-compare(xs:double('-INF'), -23)</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>numeric-compare(1, 1e0)</fos:expression>
+               <fos:result>0</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>numeric-compare(1.1, 1.1e0)</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>numeric-compare(1.2, 1.2e0)</fos:expression>
+               <fos:result>+1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>numeric-compare(9999, xs:double('INF'))</fos:expression>
+               <fos:result>-1</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
    </fos:function>
 
    <fos:function name="merge" prefix="map">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1690,15 +1690,13 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
                values using the operators <code>=</code> and <code>eq</code> and the functions
                <code>fn:deep-equal</code> and <code>fn:atomic-equal</code>, 
                see <xspecref spec="XP40" ref="id-atomic-comparisons"/>.</p></note>
+            <note><p diff="add" at="2023-12-18">See also the function <code>fn:numeric-compare</code>.</p></note>
             <?local-function-index?>
             <div3 id="func-numeric-equal">
                <head><?function op:numeric-equal?></head>
             </div3>
             <div3 id="func-numeric-less-than">
                <head><?function op:numeric-less-than?></head>
-            </div3>
-            <div3 id="func-numeric-compare">
-               <head><?function fn:numeric-compare?></head>
             </div3>
          </div2>
          <div2 id="numeric-value-functions">
@@ -1741,6 +1739,9 @@ except when the argument is exactly midway between two values with the required 
             </div3>
             <div3 id="func-floor">
                <head><?function fn:floor?></head>
+            </div3>
+            <div3 id="func-numeric-compare">
+               <head><?function fn:numeric-compare?></head>
             </div3>
             <div3 id="func-round">
                <head><?function fn:round?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1697,8 +1697,9 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
             <div3 id="func-numeric-less-than">
                <head><?function op:numeric-less-than?></head>
             </div3>
-            
-            
+            <div3 id="func-numeric-compare">
+               <head><?function fn:numeric-compare?></head>
+            </div3>
          </div2>
          <div2 id="numeric-value-functions">
             <head>Functions on numeric values</head>
@@ -12115,6 +12116,12 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
            <item diff="add" at="issue216">
               <p>In version 3.1, end-of-line characters were adopted unchanged when calling <code>fn:unparsed-text</code>.
                  In version 4.0, they are normalized as known from XML (see <bibref ref="xml11"/>).</p>
+           </item>
+           <item diff="add" at="issue866">
+              <p>The way that <code>fn:min</code> and <code>fn:max</code> compare numeric values of different types
+              has changed. The most noticeable effect is that when these functions are applied to a sequence of
+                 <code>xs:integer</code> or <code>xs:decimal</code> values, the result is an <code>xs:integer</code> or 
+                 <code>xs:decimal</code>, rather than the result of converting this to an <code>xs:double</code>.</p>
            </item>
         </olist>
  

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -18125,7 +18125,7 @@ the following rules:</p>
                </item>
 
 
-               <item>
+ <!--              <item>
                   <p>If the value of an orderspec has the <termref def="dt-dynamic-type"
                         >dynamic type</termref>
                      <code>xs:untypedAtomic</code> (such as character
@@ -18160,13 +18160,13 @@ the following rules:</p>
                         </note>
                      </item>
                   </olist>
-               </item>
+               </item>-->
             </ulist>
 
 
             <!-- <change diff="chg" at="XQ.E17"> -->
             <p>For the purpose of determining their relative position in the ordering sequence, the <emph>greater-than</emph>
-             relationship between two orderspec values <emph>W</emph> and <emph>V</emph> is defined as follows:</p>
+             relationship between two orderspec values <var>W</var> and <var>V</var> is defined as follows:</p>
             <ulist>
                <item>
                   <p>When the orderspec specifies <code>empty least</code>,
@@ -18174,25 +18174,24 @@ the following rules:</p>
                 </p>
                   <olist>
                      <item>
-                        <p>If <emph>V</emph> is an empty sequence and <emph>W</emph> is not an empty sequence,
-                         then <emph>W</emph>
+                        <p>If <var>V</var> is an empty sequence and <var>W</var> is not an empty sequence,
+                         then <var>W</var>
                            <emph>greater-than</emph>
-                           <emph>V </emph> is true.</p>
+                           <var>V </var> is true.</p>
                      </item>
                      <item>
-                        <p>If <emph>V</emph> is <code>NaN</code> and <emph>W</emph> is neither <code>NaN</code>
+                        <p>If <var>V</var> is <code>NaN</code> and <var>W</var> is neither <code>NaN</code>
                          nor an empty sequence, then
-                         <emph>W</emph>
+                         <var>W</var>
                            <emph>greater-than</emph>
-                           <emph>V</emph> is true.</p>
+                           <var>V</var> is true.</p>
                      </item>
                      <item>
-                        <p>If a specific collation <emph>C</emph> is specified, and <emph>V</emph> and <emph>W</emph> are
-                         both of type <code>xs:string</code> or are convertible to
-                         <code>xs:string</code> by <termref
-                              def="dt-subtype-substitution"
-                              >subtype substitution</termref> and/or <termref
-                              def="dt-type-promotion">type promotion</termref>, then:</p>
+                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:string</code>,
+                        <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>, they are compared
+                           using the function <code>fn:compare(V, W, C)</code> where <var>C</var> is the
+                        requested collation, defaulting to the default collation from the static context.</p>
+                        
                         <p>If <code>fn:compare(V, W, C)</code> is less than
                          zero, then <emph>W</emph>
                            <emph>greater-than</emph>
@@ -18201,13 +18200,25 @@ the following rules:</p>
                            <emph>V</emph> is false.</p>
                      </item>
                      <item>
+                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:numeric</code>,
+                           they are compared
+                           using the function <code>fn:numeric-compare(V, W)</code>.</p>
+                        
+                        <p>If <code>fn:numeric-compare(V, W)</code> is less than
+                           zero, then <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true; otherwise <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is false.</p>
+                     </item>
+                     <item>
                         <p>If none of the above rules apply, then:</p>
                         <p>If <code>W gt V</code> is true,
-                         then <emph>W</emph>
+                         then <var>W</var>
                            <emph>greater-than</emph>
-                           <emph>V</emph> is true; otherwise <emph>W</emph>
+                           <var>V</var> is true; otherwise <var>W</var>
                            <emph>greater-than</emph>
-                           <emph>V</emph> is false.</p>
+                           <var>V</var> is false.</p>
                      </item>
                   </olist>
                </item>
@@ -18217,40 +18228,51 @@ the following rules:</p>
                 </p>
                   <olist>
                      <item>
-                        <p>If <emph>W</emph> is an empty sequence and <emph>V</emph> is not an empty sequence,
-                         then <emph>W</emph>
+                        <p>If <var>W</var> is an empty sequence and <emph>V</emph> is not an empty sequence,
+                         then <var>W</var>
                            <emph>greater-than</emph>
-                           <emph>V</emph> is true.</p>
+                           <var>V</var> is true.</p>
                      </item>
                      <item>
-                        <p>If <emph>W</emph> is <code>NaN</code> and <emph>V</emph> is neither <code>NaN</code>
+                        <p>If <var>W</var> is <code>NaN</code> and <var>V</var> is neither <code>NaN</code>
                          nor an empty sequence, then
-                         <emph>W</emph>
+                         <var>W</var>
                            <emph>greater-than</emph>
-                           <emph>V</emph> is true.</p>
+                           <var>V</var> is true.</p>
                      </item>
                      <item>
-                        <p>If a specific collation <emph>C</emph> is specified, and <emph>V</emph> and <emph>W</emph> are
-                         both of type <code>xs:string</code> or are convertible to
-                         <code>xs:string</code> by <termref
-                              def="dt-subtype-substitution"
-                              >subtype substitution</termref> and/or <termref
-                              def="dt-type-promotion">type promotion</termref>, then:</p>
+                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:string</code>,
+                           <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>, they are compared
+                           using the function <code>fn:compare(V, W, C)</code> where <var>C</var> is the
+                           requested collation, defaulting to the default collation from the static context.</p>
+                        
                         <p>If <code>fn:compare(V, W, C)</code> is less than
-                         zero, then <emph>W</emph>
+                           zero, then <emph>W</emph>
                            <emph>greater-than</emph>
                            <emph>V</emph> is true; otherwise <emph>W</emph>
                            <emph>greater-than</emph>
                            <emph>V</emph> is false.</p>
+                     </item>
+                     <item>
+                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:numeric</code>,
+                           they are compared
+                           using the function <code>fn:numeric-compare(V, W)</code>.</p>
+                        
+                        <p>If <code>fn:numeric-compare(V, W)</code> is less than
+                           zero, then <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true; otherwise <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is false.</p>
                      </item>
                      <item>
                         <p>If none of the above rules apply, then:</p>
                         <p>If <code>W gt V</code> is true,
-                         then <emph>W</emph>
+                           then <var>W</var>
                            <emph>greater-than</emph>
-                           <emph>V</emph> is true; otherwise <emph>W</emph>
+                           <var>V</var> is true; otherwise <var>W</var>
                            <emph>greater-than</emph>
-                           <emph>V</emph> is false.</p>
+                           <var>V</var> is false.</p>
                      </item>
                   </olist>
                </item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -22608,21 +22608,22 @@ for $i in 1 to count($V) return
                      processor is not required to evaluate or compare minor sort key values unless
                      the corresponding major sort key values are equal.</p>
                </note>
-               <!--Text replaced by erratum E13 change 1"-->
-               <p>In general, comparison of two ordinary values is performed according to the rules
-                  of the XPath <code>lt</code> operator. To ensure a total ordering, the same
-                  implementation of the <code>lt</code> operator <rfc2119>must</rfc2119> be used for
-                  all the comparisons: the one that is chosen is the one appropriate to the most
-                  specific type to which all the values can be converted by subtype substitution
-                  and/or type promotion. For example, if the sequence contains both
-                     <code>xs:decimal</code> and <code>xs:double</code> values, then the values are
-                  compared using <code>xs:double</code> comparison, even when comparing two
-                     <code>xs:decimal</code> values. <code>NaN</code> values, for sorting purposes, are
-                  considered to be equal to each other, and less than any other numeric value.
-                  Special rules also apply to the <code>xs:string</code> and <code>xs:anyURI</code>
-                  types, and types derived by restriction therefrom, as described in the next
-                  section.</p>
-               <!--End of text replaced by erratum E13-->
+ 
+               <p diff="chg" at="2023-12-06">Individual values are compared as follows:</p>
+               <olist diff="chg" at="2023-12-06">
+                  <item><p>If both values are instances of <code>xs:string</code>, <code>xs:anyURI</code>,
+                  or <code>xs:untypedAtomic</code>, they are compared using the appropriate collation,
+                  as described in the next section.</p></item>
+                  <item><p>If both values are instances of <code>xs:numeric</code>, they are compared
+                  using the <xfunction>numeric-compare</xfunction> function.</p>
+                  <note><p>This is a change from earlier versions, since <code>xs:decimal</code> values are now compared
+                  as decimals, rather than being first converted to <code>xs:double</code>.</p></note></item>
+                  <item><p>In all other cases, values are compared according to the rules
+                     of the XPath <code>lt</code> operator. This will raise an error if the values are
+                  not comparable (for example, if one is an <code>xs:integer</code> and the other is
+                  an <code>xs:date</code>).</p></item>
+               </olist>
+               
             </div3>
             <div3 id="collating-sequences">
                <head>Sorting Using Collations</head>


### PR DESCRIPTION
Fix #866

The proposal introduces a new fn:numeric-compare function that differs from lt/eq primarily in that decimals are compared retaining their full precision, rather than converting them to doubles which may lose precision. This makes the comparison fully transitive which makes it safe to use in all sorting algorithms.

The new comparison semantics are exploited in max(), min(), and sort(), and indirectly in highest() and lowest(); they are also referenced for comparing numeric values in XSLT `xsl:sort` (and therefore indirectly in `xsl:merge`) and in XQuery `order by`.

An effect of the change is that max() and min() applied to a sequence of integers now return an integer, not a double.