### PR TITLE
900 fn:sort, array:sort: Parameter names

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18710,11 +18710,11 @@ for-each-pair(
          
          <olist>
             <item><p>The <term>sort key function</term> is <code>$keys[$n] otherwise data#1</code>.</p></item>
-            <item><p>The <term>collation</term> is <code>$scollation[$n] otherwise $scollation[last()]
+            <item><p>The <term>collation</term> is <code>$collations[$n] otherwise $collations[last()]
                otherwise default-collation()</code>.
             That is, it is the collation supplied in the corresponding item of the supplied
-             <code>$scollation</code> argument; or in its absence, the last entry in 
-            <code>$scollation</code>; or if <code>$scollation</code> is absent or empty, the
+             <code>$collations</code> argument; or in its absence, the last entry in 
+            <code>$collations</code>; or if <code>$collations</code> is absent or empty, the
             default collation from the static context of the caller.</p></item>
             <item><p>The <term>order direction</term> is 
                <code>$orders[$n] otherwise $orders[last()] otherwise "ascending"</code>.

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18717,11 +18717,11 @@ for-each-pair(
             <code>$scollation</code>; or if <code>$scollation</code> is absent or empty, the
             default collation from the static context of the caller.</p></item>
             <item><p>The <term>order direction</term> is 
-               <code>$sorder[$n] otherwise $sorder[last()] otherwise "ascending"</code>.
+               <code>$orders[$n] otherwise $orders[last()] otherwise "ascending"</code>.
             That is, it is <code>"ascending"</code> or <code>"descending"</code> according
-            to the value of the corresponding item in the supplied <code>$sorder</code>
-            argument; or in its absence, the last entry in <code>$sorder</code>; or
-            if <code>$sorder</code> is absent or empty, then <code>"ascending"</code>.</p></item>
+            to the value of the corresponding item in the supplied <code>$orders</code>
+            argument; or in its absence, the last entry in <code>$orders</code>; or
+            if <code>$orders</code> is absent or empty, then <code>"ascending"</code>.</p></item>
          </olist>
          
          <p>When comparing values of types other than <code>xs:string</code> or <code>xs:untypedAtomic</code>,

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18671,9 +18671,9 @@ for-each-pair(
       <fos:signatures>
          <fos:proto name="sort" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="collation" type="xs:string*" usage="absorption" default="fn:default-collation()"/>
-            <fos:arg name="key" type="(function(item()) as xs:anyAtomicType*)*" usage="inspection" default="fn:data#1"/>
-            <fos:arg name="order" type="enum('ascending', 'descending')*" usage="absorption" default="'ascending'"/>
+            <fos:arg name="collations" type="xs:string*" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="keys" type="(function(item()) as xs:anyAtomicType*)*" usage="inspection" default="fn:data#1"/>
+            <fos:arg name="orders" type="enum('ascending', 'descending')*" usage="absorption" default="'ascending'"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -18702,26 +18702,26 @@ for-each-pair(
          </olist>
          
          <p>The number of sort key definitions is determined by the number of function items supplied
-            in the <code>$key</code> argument. If the argument is absent or empty, the default is
+            in the <code>$keys</code> argument. If the argument is absent or empty, the default is
             a single sort key definition using the function <code>data#1</code>.</p>
          
          <p>The <code>$n</code>th sort key definition (where <code>$n</code> counts from one (1))
          is established as follows:</p>
          
          <olist>
-            <item><p>The <term>sort key function</term> is <code>$key[$n] otherwise data#1</code>.</p></item>
-            <item><p>The <term>collation</term> is <code>$collation[$n] otherwise $collation[last()]
+            <item><p>The <term>sort key function</term> is <code>$keys[$n] otherwise data#1</code>.</p></item>
+            <item><p>The <term>collation</term> is <code>$scollation[$n] otherwise $scollation[last()]
                otherwise default-collation()</code>.
             That is, it is the collation supplied in the corresponding item of the supplied
-             <code>$collation</code> argument; or in its absence, the last entry in 
-            <code>$collation</code>; or if <code>$collation</code> is absent or empty, the
+             <code>$scollation</code> argument; or in its absence, the last entry in 
+            <code>$scollation</code>; or if <code>$scollation</code> is absent or empty, the
             default collation from the static context of the caller.</p></item>
             <item><p>The <term>order direction</term> is 
-               <code>$order[$n] otherwise $order[last()] otherwise "ascending"</code>.
+               <code>$sorder[$n] otherwise $sorder[last()] otherwise "ascending"</code>.
             That is, it is <code>"ascending"</code> or <code>"descending"</code> according
-            to the value of the corresponding item in the supplied <code>$order</code>
-            argument; or in its absence, the last entry in <code>$order</code>; or
-            if <code>$order</code> is absent or empty, then <code>"ascending"</code>.</p></item>
+            to the value of the corresponding item in the supplied <code>$sorder</code>
+            argument; or in its absence, the last entry in <code>$sorder</code>; or
+            if <code>$sorder</code> is absent or empty, then <code>"ascending"</code>.</p></item>
          </olist>
          
          <p>When comparing values of types other than <code>xs:string</code> or <code>xs:untypedAtomic</code>,
@@ -18827,7 +18827,7 @@ else +1</eg>
          whether the empty sequence is sorted before or after all other values, can be achieved by adding an
          extra sort key definition that evaluates whether or not the actual sort key is empty (when sorting
          boolean values, <code>false</code> precedes <code>true</code>).</p>
-         <p>Supplying too many items in the <code>$collation</code> and/or <code>$order</code> arguments
+         <p>Supplying too many items in the <code>$collations</code> and/or <code>$orders</code> arguments
          is not an error; the excess values are ignored except for type-checking against the function
          signature.</p>
       </fos:notes>
@@ -25173,9 +25173,9 @@ return deep-equal(
       <fos:signatures>
          <fos:proto name="sort" return-type="item()*">
             <fos:arg name="array" type="array(*)"/>
-            <fos:arg name="collation" type="xs:string*" default="fn:default-collation()"/>
-            <fos:arg name="key" type="(function(item()*) as xs:anyAtomicType*)*" default="fn:data#1"/>
-            <fos:arg name="order" type="enum('ascending', 'descending')*" default="'ascending'"/>
+            <fos:arg name="collations" type="xs:string*" default="fn:default-collation()"/>
+            <fos:arg name="keys" type="(function(item()*) as xs:anyAtomicType*)*" default="fn:data#1"/>
+            <fos:arg name="orders" type="enum('ascending', 'descending')*" default="'ascending'"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25204,26 +25204,26 @@ return deep-equal(
          </olist>
          
          <p>The number of sort key definitions is determined by the number of function items supplied
-            in the <code>$key</code> argument. If the argument is absent or empty, the default is
+            in the <code>$keys</code> argument. If the argument is absent or empty, the default is
             a single sort key definition using the function <code>data#1</code>.</p>
          
          <p>The <code>$n</code>th sort key definition (where <code>$n</code> counts from one (1))
             is established as follows:</p>
          
          <olist>
-            <item><p>The <term>sort key function</term> is <code>$key[$n] otherwise data#1</code>.</p></item>
-            <item><p>The <term>collation</term> is <code>$collation[$n] otherwise $collation[last()]
+            <item><p>The <term>sort key function</term> is <code>$keys[$n] otherwise data#1</code>.</p></item>
+            <item><p>The <term>collation</term> is <code>$collations[$n] otherwise $collations[last()]
                otherwise default-collation()</code>.
                That is, it is the collation supplied in the corresponding item of the supplied
-               <code>$collation</code> argument; or in its absence, the last entry in 
-               <code>$collation</code>; or if <code>$collation</code> is absent or empty, the
+               <code>$collations</code> argument; or in its absence, the last entry in 
+               <code>$collations</code>; or if <code>$collations</code> is absent or empty, the
                default collation from the static context of the caller.</p></item>
             <item><p>The <term>order direction</term> is 
-               <code>$order[$n] otherwise $order[last()] otherwise "ascending"</code>.
+               <code>$orders[$n] otherwise $orders[last()] otherwise "ascending"</code>.
                That is, it is <code>"ascending"</code> or <code>"descending"</code> according
-               to the value of the corresponding item in the supplied <code>$order</code>
-               argument; or in its absence, the last entry in <code>$order</code>; or
-               if <code>$order</code> is absent or empty, then <code>"ascending"</code>.</p></item>
+               to the value of the corresponding item in the supplied <code>$orders</code>
+               argument; or in its absence, the last entry in <code>$orders</code>; or
+               if <code>$orders</code> is absent or empty, then <code>"ascending"</code>.</p></item>
          </olist>
          
          <p>When comparing values of types other than <code>xs:string</code> or <code>xs:untypedAtomic</code>,
@@ -25236,13 +25236,16 @@ return deep-equal(
          the result of the function is value of the expression:</p>
          
          <eg>array:of-members(
-  fn:sort( array:members($array),
-           $collation,
-           for $k in $key return 
-              function($mem as record(value)) as xs:anyAtomicType* {
-                 $k($mem?value)
-              },
-           $order)</eg>
+  sort(
+    array:members($array),
+    $collations,
+    for $key in ($keys otherwise data#1)
+    return function($member as record(value)) as xs:anyAtomicType* {
+      $key($member?value)
+    },
+    $orders
+  )
+)</eg>
          
       </fos:rules>
       <fos:errors>


### PR DESCRIPTION
Closes #900. In addition, the equivalent expression for `array:sort` was fixed.