### PR TITLE
898 - relax the constraints on document-uri

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -518,23 +518,29 @@
 
       </fos:errors>
       <fos:notes>
-         <p>In the case of a document node <code>$D</code> returned by the <code>fn:doc</code>
-            function, or a document node at the root of a tree containing a node returned by the
-               <code>fn:collection</code> function, it will always be true that either
-               <code>fn:document-uri($D)</code> returns the empty sequence, or that the following
-            expression is <code>true</code>: <code>fn:doc(fn:document-uri($D))</code> is <code>$D</code>. It is
-               <termref
-               def="implementation-defined"
-            >implementation-defined</termref> whether this guarantee also holds for
-            document nodes obtained by other means, for example a document node passed as the
-            initial context node of a query or transformation.</p>
-         <p diff="add" at="A">A consequence of these rules is that it is not possible (within the
-         execution scope of a transformation) for two different documents to have the same
-         value for their <code>document-uri</code> property. This means that in situations where
-         URI stability is not guaranteed (for example, with streamed input documents in XSLT,
-         or for documents returned by <code>fn:collection</code> if document stability has been
-            disabled), the <code>document-uri</code> property <rfc2119>should</rfc2119> be absent, and
-            <code>fn:document-uri</code> <rfc2119>should</rfc2119> return an empty sequence.</p>
+         <p diff="chg" at="issue898">In the case of a document node <code>$D</code> returned by the <code>fn:doc</code>
+            function, it will generally be the case that <code>fn:document-uri($D)</code> returns a URI <code>$U</code>
+            such that a call on <code>fn:doc($U)</code> in the same dynamic context will return the same document
+            node <code>$D</code>. The URI <code>$U</code> will not necessarily be the same URI that was originally
+            passed to the <code>fn:doc</code> function, since several URIs may identify the same resource.</p>
+         
+         <p>This equivalence
+            does not apply if the second call on <code>fn:doc</code> uses a different dynamic context. For example,
+            in XSLT, a call on <code>fn:doc</code> in one stylesheet package might perform whitespace stripping
+            or schema validation, while the same call in a different stylesheet package does not; the two calls
+            might therefore return different documents both having the same <code>fn:document-uri</code> property.</p>
+         
+         <p diff="chg" at="issue898">It is <rfc2119>recommended</rfc2119> that implementations of <code>fn:collection</code>
+            should follow the same principle: any documents included in the returned collection, if they have a non-empty
+            <code>fn:document-uri</code> property, should be such that a call on <code>fn:doc</code> supplying this URI
+            (in the same dynamic context) returns the same document node.</p>
+         
+         <p diff="chg" at="issue898">The same guarantees do not hold for document nodes obtained by other mechanisms,
+            for example document nodes supplied as external parameters to a query or stylesheet. The <code>fn:document-uri</code>
+            property of such documents is under user control; it is entirely possible for two such documents to have
+            the same <code>fn:document-uri</code> property, in which case it is clearly impossible to use this property
+            to retrieve the original document.</p>
+         
       </fos:notes>
    </fos:function>
    <fos:function name="error" prefix="fn">
@@ -15406,9 +15412,18 @@ else $c[1] + sum(subsequence($c, 2))</eg>
             resolution to an absolute URI Reference) is supplied to both calls. Thus, the following
             expression (if it does not raise an error) will always return <code>true</code>:</p>
          <eg xml:space="preserve">doc("foo.xml") is doc("foo.xml")</eg>
-         <p>However, for performance reasons, implementations may provide a user option to evaluate
+         <note diff="add" at="issue898"><p>This equivalence applies only because the two calls on
+            the <code>doc</code> function have the same dynamic context. If two calls on <code>doc</code>
+           have different dynamic contexts, then the mapping from URIs to document
+         nodes in the two contexts may differ, which means that different document nodes may be returned
+         for the same URI.
+         This can happen, for example, if the two calls appear in different XSLT packages with different
+         validation options or whitespace-stripping options; one call might produce a schema-validated
+         document, the other an untyped document.</p></note>
+         <p>The requirement to deliver a deterministic result has performance implications, 
+            and for this reason implementations may provide a user option to evaluate
             the function without a guarantee of determinism. The manner in which any such option is
-            provided is implementation-defined. If the user has not selected such an option, a call
+            provided is <termref def="implementation-defined"/>. If the user has not selected such an option, a call
             of the function must either return a deterministic result or must raise a dynamic error
                <errorref
                class="DC" code="0003"/>.</p>


### PR DESCRIPTION
Fix #898

Changes non-normative text for the doc() and document-uri() functions to make it clearer that the consequences of the normative rules are not quite as previously stated.