### PR TITLE
920 Allow xsl:break and xsl:next-iteration within branch of xsl:switch

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -14826,7 +14826,8 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p><var>J</var> is in a <termref def="dt-tail-position">tail position</termref>
                      within the sequence constructor that forms the body of an
                         <elcode>xsl:when</elcode> or <elcode>xsl:otherwise</elcode> branch of an
-                        <elcode>xsl:choose</elcode> instruction that is itself in a <termref def="dt-tail-position">tail position</termref> within <var>SC</var>.</p>
+                        <elcode>xsl:choose</elcode> <phrase diff="add" at="issue920">or <elcode>xsl:switch</elcode></phrase> 
+                     instruction that is itself in a <termref def="dt-tail-position">tail position</termref> within <var>SC</var>.</p>
                </item>
 
                <item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -14738,27 +14738,13 @@ and <code>version="1.0"</code> otherwise.</p>
             in order; unlike <code>xsl:for-each</code>, the result of processing one item can affect the way that
             subsequent items are processed.</p>
             
-            <p diff="add" at="2022-01-01">As with <code>xsl:for-each</code>, the instruction is extended in XSLT 4.0 to allow maps and arrays
-            to be processed.</p>
+            
             
             <?element xsl:iterate?>
             <?element xsl:next-iteration?>
             <?element xsl:break?>
             <?element xsl:on-completion?>
-            <p diff="del" at="2022-01-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
-               are mutually exclusive: exactly one of these three attributes must be present.</p>
-            <p diff="del" at="2022-01-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
-               <code>select="array:for-each(EXPR, fn($x) { { 'value': $x } })?*</code>. That is, it maps the
-               elements of an input array to a sequence of items, each item being a map having a single entry, whose
-               key is the string <code>value</code> and whose corresponding value is the relevant element of the
-               array. Within the contained sequence constructor, the current array element can be referred to
-               as <code>?value</code>.</p>
-            <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
-               <code>select="map:for-each(EXPR, fn($k, $v) { { 'key': $k, 'value': $v } })</code>. That is, it maps the
-               key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
-               two entries, one entry holding the key, and the other holding the value. 
-               Within the contained sequence constructor, the key and value of the current entry in the input map
-               can be referred to as <code>?key</code> and <code>?value</code> respectively.</p>
+
             
             
             <p>The <code>select</code> attribute contains an


### PR DESCRIPTION
Allow xsl:break and xsl:next-iteration within branch of xsl:switch

Fix #920 