### PR TITLE
913-new-examples-for-local-name-etc

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -156,6 +156,45 @@
             part is the namespace prefix being bound.</p>
          <p>For all other kinds of node, the function returns the empty sequence.</p>
       </fos:notes>
+      <fos:examples>
+         <fos:variable name="e" id="v-name-e"><![CDATA[<doc>
+  <p id="alpha" xml:id="beta">One</p>
+  <p id="gamma" xmlns="http://example.com/ns">Two</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</p>
+  <?pi 3.14159?>
+</doc>}]]>
+         </fos:variable>
+         <fos:example>
+            <fos:test use="v-node-name-e" spec="XQuery">
+               <fos:expression>node-name($e//*[@id='alpha'])</fos:expression>
+               <fos:result>fn:QName("", "p")</fos:result>
+            </fos:test>
+            <fos:test use="v-node-name-e" spec="XQuery">
+               <fos:expression>node-name($e//*[@id='gamma'])</fos:expression>
+               <fos:result>fn:QName("http://example.com/ns", "p")</fos:result>
+            </fos:test>
+            <fos:test use="v-node-name-e" spec="XQuery">
+               <fos:expression>node-name($e//*[@id='delta'])</fos:expression>
+               <fos:result>fn:QName("http://example.com/ns", "ex:p")</fos:result>
+            </fos:test>
+            <fos:test use="v-node-name-e" spec="XQuery">
+               <fos:expression>node-name($e//processing-instruction[1])</fos:expression>
+               <fos:result>fn:QName("", "pi")</fos:result>
+            </fos:test>
+            <fos:test use="v-node-name-e" spec="XQuery">
+               <fos:expression>node-name($e//*[@id='alpha']/text())</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+            <fos:test use="v-node-name-e" spec="XQuery">
+               <fos:expression>node-name($e//*[@id='alpha']/@id)</fos:expression>
+               <fos:result>fn:QName("", "id")</fos:result>
+            </fos:test>
+            <fos:test use="v-node-name-e" spec="XQuery">
+               <fos:expression>node-name($e//*[@id='alpha']/@xml:id</fos:expression>
+               <fos:result>fn:QName("http://www.w3.org/XML/1998/namespace", "xml:id")</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
    </fos:function>
    <fos:function name="nilled" prefix="fn">
       <fos:signatures>
@@ -10984,6 +11023,45 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          document uses an unexpected namespace prefix. Such a test (assuming it relates to an element node) 
          is better written as <code>boolean(self::my:profile)</code>.</p>
       </fos:notes>
+      <fos:examples>
+         <fos:variable name="e" id="v-name-e"><![CDATA[<doc>
+  <p id="alpha" xml:id="beta">One</p>
+  <p id="gamma" xmlns="http://example.com/ns">Two</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</p>
+  <?pi 3.14159?>
+</doc>}]]>
+         </fos:variable>
+         <fos:example>
+            <fos:test use="v-name-e" spec="XQuery">
+               <fos:expression>name($e//*[@id='alpha'])</fos:expression>
+               <fos:result>"p"</fos:result>
+            </fos:test>
+            <fos:test use="v-name-e" spec="XQuery">
+               <fos:expression>name($e//*[@id='gamma'])</fos:expression>
+               <fos:result>"p"</fos:result>
+            </fos:test>
+            <fos:test use="v-name-e" spec="XQuery">
+               <fos:expression>name($e//*[@id='delta'])</fos:expression>
+               <fos:result>"ex:p"</fos:result>
+            </fos:test>
+            <fos:test use="v-name-e" spec="XQuery">
+               <fos:expression>name($e//processing-instruction[1])</fos:expression>
+               <fos:result>"pi"</fos:result>
+            </fos:test>
+            <fos:test use="v-name-e" spec="XQuery">
+               <fos:expression>name($e//*[@id='alpha']/text())</fos:expression>
+               <fos:result>""</fos:result>
+            </fos:test>
+            <fos:test use="v-name-e" spec="XQuery">
+               <fos:expression>name($e//*[@id='alpha']/@id)</fos:expression>
+               <fos:result>"id"</fos:result>
+            </fos:test>
+            <fos:test use="v-name-e" spec="XQuery">
+               <fos:expression>name($e//*[@id='alpha']/@xml:id</fos:expression>
+               <fos:result>"xml:id"</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
    </fos:function>
    <fos:function name="local-name" prefix="fn">
       <fos:signatures>
@@ -11038,6 +11116,45 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          </ulist>
 
       </fos:errors>
+      <fos:examples>
+         <fos:variable name="e" id="v-local-name-e"><![CDATA[<doc>
+  <p id="alpha" xml:id="beta">One</p>
+  <p id="gamma" xmlns="http://example.com/ns">Two</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</p>
+  <?pi 3.14159?>
+</doc>}]]>
+         </fos:variable>
+         <fos:example>
+            <fos:test use="v-local-name-e" spec="XQuery">
+               <fos:expression>local-name($e//*[@id='alpha'])</fos:expression>
+               <fos:result>"p"</fos:result>
+            </fos:test>
+            <fos:test use="v-local-name-e" spec="XQuery">
+               <fos:expression>local-name($e//*[@id='gamma'])</fos:expression>
+               <fos:result>"p"</fos:result>
+            </fos:test>
+            <fos:test use="v-local-name-e" spec="XQuery">
+               <fos:expression>local-name($e//*[@id='delta'])</fos:expression>
+               <fos:result>"p"</fos:result>
+            </fos:test>
+            <fos:test use="v-local-name-e" spec="XQuery">
+               <fos:expression>local-name($e//processing-instruction[1])</fos:expression>
+               <fos:result>"pi"</fos:result>
+            </fos:test>
+            <fos:test use="v-local-name-e" spec="XQuery">
+               <fos:expression>local-name($e//*[@id='alpha]/text())</fos:expression>
+               <fos:result>""</fos:result>
+            </fos:test>
+            <fos:test use="v-local-name-e" spec="XQuery">
+               <fos:expression>local-name($e//*[@id='alpha]/@id)</fos:expression>
+               <fos:result>"id"</fos:result>
+            </fos:test>
+            <fos:test use="v-local-name-e" spec="XQuery">
+               <fos:expression>local-name($e//*[@id='alpha]/@xml:id</fos:expression>
+               <fos:result>"id"</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
    </fos:function>
    <fos:function name="namespace-uri" prefix="fn">
       <fos:signatures>
@@ -11092,6 +11209,45 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             </item>
          </ulist>
       </fos:errors>
+      <fos:examples>
+         <fos:variable name="e" id="v-namespace-uri-e"><![CDATA[<doc>
+  <p id="alpha" xml:id="beta">One</p>
+  <p id="gamma" xmlns="http://example.com/ns">Two</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</p>
+  <?pi 3.14159?>
+</doc>}]]>
+         </fos:variable>
+         <fos:example>
+            <fos:test use="v-namespace-uri-e" spec="XQuery">
+               <fos:expression>namespace-uri($e//*[@id='alpha'])</fos:expression>
+               <fos:result>""</fos:result>
+            </fos:test>
+            <fos:test use="v-namespace-uri-e" spec="XQuery">
+               <fos:expression>namespace-uri($e//*[@id='gamma'])</fos:expression>
+               <fos:result>"http://example.com/ns"</fos:result>
+            </fos:test>
+            <fos:test use="v-namespace-uri-e" spec="XQuery">
+               <fos:expression>namespace-uri($e//*[@id='delta'])</fos:expression>
+               <fos:result>"http://example.com/ns"</fos:result>
+            </fos:test>
+            <fos:test use="v-namespace-uri-e" spec="XQuery">
+               <fos:expression>namespace-uri($e//processing-instruction[1])</fos:expression>
+               <fos:result>""</fos:result>
+            </fos:test>
+            <fos:test use="v-namespace-uri-e" spec="XQuery">
+               <fos:expression>namespace-uri($e//*[@id='alpha']/text())</fos:expression>
+               <fos:result>""</fos:result>
+            </fos:test>
+            <fos:test use="v-namespace-uri-e" spec="XQuery">
+               <fos:expression>namespace-uri($e//*[@id='alpha']/@id)</fos:expression>
+               <fos:result>""</fos:result>
+            </fos:test>
+            <fos:test use="v-namespace-uri-e" spec="XQuery">
+               <fos:expression>namespace-uri($e//*[@id='alpha']/@xml:id</fos:expression>
+               <fos:result>"http://www.w3.org/XML/1998/namespace"</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
    </fos:function>
    <fos:function name="number" prefix="fn">
       <fos:signatures>
@@ -11150,21 +11306,44 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             result of atomization does not match the required argument type.</p>
       </fos:notes>
       <fos:examples>
+         <fos:variable name="e" id="v-number-e"><![CDATA[<e price="12.1" discount="NONE"/>]]></fos:variable>
          <fos:example>
-            <fos:test use="v-po v-item1" spec="XQuery">
-               <fos:expression>number($item1/quantity)</fos:expression>
-               <fos:result>5.0e0</fos:result>
+            <fos:test>
+               <fos:expression>number(12)</fos:expression>
+               <fos:result>1.2e1</fos:result>
             </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test use="v-po v-item2" spec="XQuery">
-               <fos:expression>number($item2/description)</fos:expression>
+            <fos:test>
+               <fos:expression>number('12')</fos:expression>
+               <fos:result>1.2e1</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>number('INF')</fos:expression>
+               <fos:result>xs:double('INF')</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>number('NaN')</fos:expression>
                <fos:result>xs:double('NaN')</fos:result>
             </fos:test>
-         </fos:example>
-         <fos:example>
-            <p>Assume that the context item is the <code>xs:string</code> value <code>"15"</code>.
-               Then <code>fn:number()</code> returns <code>1.5e1</code>.</p>
+            <fos:test>
+               <fos:expression>number('non-numeric')</fos:expression>
+               <fos:result>xs:double('NaN')</fos:result>
+            </fos:test>
+            <fos:test use="v-number-e" spec="XQuery">
+               <fos:expression>number($e/@price)</fos:expression>
+               <fos:result>1.21e1</fos:result>
+            </fos:test>
+            <fos:test use="v-number-e" spec="XQuery">
+               <fos:expression>number($e/@discount)</fos:expression>
+               <fos:result>xs:double('NaN')</fos:result>
+            </fos:test>
+            <fos:test use="v-number-e" spec="XQuery">
+               <fos:expression>number($e/@misspelt)</fos:expression>
+               <fos:result>xs:double('NaN')</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>("10", "11", "12")!number()</fos:expression>
+               <fos:result>1.0e1, 1.1e1, 1.2e1</fos:result>
+            </fos:test>
          </fos:example>
       </fos:examples>
 
@@ -11611,6 +11790,45 @@ let $newi := $o/tool</eg>
          <p>Although the function was introduced to support streaming use cases, it has general
             utility as a convenience function.</p>
       </fos:notes>
+      <fos:examples>
+         <fos:variable name="e" id="v-has-children-e"><![CDATA[<doc>
+  <p id="alpha">One</p>
+  <p/>
+  <p> </p>
+  <?pi 3.14159?>
+</doc>}]]>
+         </fos:variable>
+         <fos:example>
+            <fos:test use="v-has-children-e" spec="XQuery">
+               <fos:expression>has-children($e)</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test use="v-has-children-e" spec="XQuery">
+               <fos:expression>has-children($e//p[1])</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test use="v-has-children-e" spec="XQuery">
+               <fos:expression>has-children($e//p[2])</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test use="v-has-children-e" spec="XQuery">
+               <fos:expression>has-children($e//p[3])</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test use="v-has-children-e" spec="XQuery">
+               <fos:expression>has-children($e//processing-instruction[1])</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test use="v-has-children-e" spec="XQuery">
+               <fos:expression>has-children($e//p[1]/text())</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test use="v-has-children-e" spec="XQuery">
+               <fos:expression>has-children($e//p[1]/@id)</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
 
    </fos:function>
    <fos:function name="innermost" prefix="fn">
@@ -14252,13 +14470,13 @@ declare function equal-strings(
          <p>returns <code>0</code>.if <code>$input</code> is the empty sequence.</p>
       </fos:notes>
       <fos:examples>
-         <fos:variable name="seq1" id="v-count-seq1" select="($item1, $item2)"/>
+         <fos:variable name="tree" id="v-count-tree"><![CDATA[<doc><chap><p/><p/><p/></chap></doc>]]></fos:variable>
          <fos:variable name="seq2" id="v-count-seq2" select="(98.5, 98.3, 98.9)"/>
          <fos:variable name="seq3" id="v-count-seq3" select="()"/>
          <fos:example>
-            <fos:test use="v-po v-item1 v-item2 v-count-seq1" spec="XQuery">
-               <fos:expression>count($seq1)</fos:expression>
-               <fos:result>2</fos:result>
+            <fos:test use="v-count-tree">
+               <fos:expression>count($tree//chap/p)</fos:expression>
+               <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -14290,7 +14508,7 @@ declare function equal-strings(
                <fos:expression>count([1,2,3])</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
-         </fos:example>
+         </fos:example>        
       </fos:examples>
    </fos:function>
    <fos:function name="avg" prefix="fn">
@@ -14993,8 +15211,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
                <last>Brown</last>
             </employee>
           }
-        }]]>
-         </fos:variable>
+        }]]></fos:variable>
          <fos:example>
             <fos:test xslt-version="3.0" use="v-id-emp" spec="XQuery">
                <fos:expression>$emp/id('ID21256')/name()</fos:expression>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5308,7 +5308,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <p>This section specifies functions and operators on nodes. Nodes are formally defined
                 in <xspecref spec="DM31" ref="Node"/>.</p>
          <?local-function-index?>
-         <p>For the illustrative examples below assume an XQuery or transformation operating on a
+         <!--<p>For the illustrative examples below assume an XQuery or transformation operating on a
                 <code>PurchaseOrder</code> document containing a number of <code>line-item</code> elements. Each line-item has
                 child elements called <code>description</code>, <code>price</code>, <code>quantity</code>, etc. whose content is different
                 for each <code>line-item</code>. Quantity has simple content of type <code>xs:decimal</code>.
@@ -5337,7 +5337,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <eg role="global-variable-binding">let $item1 := $po/line-item[1]</eg>
          <eg role="global-variable-binding">let $item2 := $po/line-item[2]</eg>
          <eg role="global-variable-binding">let $item3 := $po/line-item[3]</eg>
- 
+ -->
          <div2 id="func-name">
             <head><?function fn:name?></head>
             </div2>


### PR DESCRIPTION
I have created new (executable) examples for functions name, local-name, namespace-uri, node-name, count, number.

There are of course many other functions that would benefit from the same treatment.

Fix #913