### PR TITLE
780 Document incompatibility in format-number etc

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -2258,6 +2258,11 @@
             Both in the picture string and in the result string, digits with higher significance (that is, 
             representing higher powers of ten) always precede digits with lower significance, even when 
             the rendered text flow is from right to left.</p>
+         <p diff="add" at="issue780">The type of the third argument changes in version 4.0 from 
+            <code>xs:string</code> to <code>union(xs:string, xs:QName)</code>. This introduces a
+            minor incompatibility: for example, it is no longer possible to supply a value
+         of type <code>xs:anyURI</code>.</p>
+
       </fos:notes>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -12124,6 +12124,15 @@ declare function eg:distinct-nodes-stable ($arg as node()*) as node()* {
                  <code>xs:integer</code> or <code>xs:decimal</code> values, the result is an <code>xs:integer</code> or 
                  <code>xs:decimal</code>, rather than the result of converting this to an <code>xs:double</code>.</p>
            </item>
+           <item diff="add" at="issue780">
+              <p>The type of the third argument of <code>fn:format-number</code> has 
+                 changed from <code>xs:string</code> to <code>union(xs:string, xs:QName)</code>.
+                 Because the expected type of this parameter is no longer <code>xs:string</code>, the
+                 special coercion rules for <code>xs:string</code> parameters no longer apply.
+                 For example, it is no
+              longer possible to supply an instance of <code>xs:anyURI</code> or (when XPath 1.0 compatibility
+              mode is in force) an instance of <code>xs:boolean</code> or <code>xs:duration</code>.</p>
+           </item>
         </olist>
  
          <p>For compatibility issues regarding earlier versions, see the 3.1 version of this specification.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6777,25 +6777,45 @@ declare function flatten($tree as tree) as item()* {
                         </item>
                         
                         <item diff="chg" at="2023-11-03">
-                           <p>Each item <var>A</var> in <var>V1</var> is processed using one of the following
-                           rules, which are mutually exclusive.</p>
+                           <p diff="chg" at="2024-01-04">Each item <var>A</var> in <var>V1</var> is processed using the first rule 
+                              in the following list that is applicable.</p>
                            <olist>
+                              <item diff="chg" at="2024-01-04"><p>If <var>A</var> is an instance of 
+                                 <var>R</var> then it is used unchanged.</p></item>
                               <item><p>If <var>A</var> is an instance of type <code>xs:untypedAtomic</code>
-                              then <var>A</var> is cast to type <var>R</var>.</p>
-                                 <p>If <var>R</var> is an 
-                                    <termref def="dt-EnumerationType"/>,
-                                    <var>J</var> is cast to <code>xs:string</code>.  
-                                    If <var>R</var> is <termref
-                                       def="dt-namespace-sensitive"
-                                       >namespace-sensitive</termref>, a <termref def="dt-type-error"
-                                          >type error</termref>
-                                    <errorref class="TY" code="0117"/> is raised.</p></item>
+                              then:</p>
+                                 <olist>
+                                    <item>
+                                       <p>If <var>R</var> is an 
+                                       <termref def="dt-EnumerationType"/> then
+                                       <var>A</var> is cast to <code>xs:string</code>.</p></item>
+                                    <item>
+                                       <p>If <var>R</var> is <termref
+                                       def="dt-namespace-sensitive">namespace-sensitive</termref> then:</p>
+                                       <olist>
+                                          <item diff="chg" at="2024-01-04"><p>If the result of casting <var>A</var> to <code>xs:string</code>
+                                             is an instance of <var>R</var>, then <var>A</var> is cast to
+                                          <code>xs:string</code>.</p>
+                                          <note><p>This rule is new in 4.0. It allows
+                                          an <code>xs:untypedAtomic</code> value to be supplied where the
+                                          required type is <code>union(xs:string, xs:QName)</code>, which
+                                          was previously an error.</p></note></item>
+                                          <item><p>Otherwise, a <termref def="dt-type-error">type error</termref>
+                                             <errorref class="TY" code="0117"/> is raised.</p></item>
+                                       </olist>
+                                    </item>
+                                    <item><p>Otherwise,  <var>A</var> is cast to type <var>R</var>.</p>
+                                    </item>
+                                 </olist>
+                              </item>
+                              
+  
                               <item><p>If there is an entry (<var>from</var>, <var>to</var>)
                                  in the following table such that <var>A</var> is an instance of <var>from</var>,
                                  and <var>to</var> is <var>R</var>, then <var>A</var> is cast to type <var>R</var>.</p>
                                  
                                  <table border="1" role="medium">
-                                    <caption>Type Promotion</caption>
+                                    <caption>Implicit Casting</caption>
                                     <thead>
                                        <tr>
                                           <th>from</th>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -1463,7 +1463,7 @@
    <fos:function name="system-property">
       <fos:signatures>
          <fos:proto name="system-property" return-type="xs:string">
-            <fos:arg name="name" type="union(xs:QName, xs:string)"/>
+            <fos:arg name="name" type="union(xs:string, xs:QName)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1681,7 +1681,7 @@
    <fos:function name="function-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="function-available" return-type="xs:boolean">
-            <fos:arg name="name" type="union(xs:QName, xs:string)"/>
+            <fos:arg name="name" type="union(xs:string, xs:QName)"/>
             <fos:arg name="arity" type="xs:integer?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -1842,7 +1842,7 @@
    <fos:function name="element-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="element-available" return-type="xs:boolean">
-            <fos:arg name="name" type="union(xs:QName, xs:string)"/>
+            <fos:arg name="name" type="union(xs:string, xs:QName)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1958,7 +1958,7 @@
    <fos:function name="type-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="type-available" return-type="xs:boolean">
-            <fos:arg name="name" type="union(xs:QName, xs:string)"/>
+            <fos:arg name="name" type="union(xs:string, xs:QName)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -2081,7 +2081,7 @@
    <fos:function name="accumulator-before">
       <fos:signatures>
          <fos:proto name="accumulator-before" return-type="item()*">
-            <fos:arg name="name" type="union(xs:QName, xs:string)"/>
+            <fos:arg name="name" type="union(xs:string, xs:QName)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -2209,7 +2209,7 @@
    <fos:function name="accumulator-after">
       <fos:signatures>
          <fos:proto name="accumulator-after" return-type="item()*">
-            <fos:arg name="name" type="union(xs:QName, xs:string)"/>
+            <fos:arg name="name" type="union(xs:string, xs:QName)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -154,7 +154,7 @@
  
          <p>XSLT 4.0 also includes optional facilities to serialize the results of a transformation,
             by means of an interface to the serialization component described in 
-            <bibref ref="xslt-xquery-serialization-31"/>.
+            <bibref ref="xslt-xquery-serialization-40"/>.
          </p>
          <p>
             <emph>This document contains hyperlinks to specific sections or definitions within other
@@ -1652,7 +1652,7 @@
                   <note>
                      <p>The first phase of serialization, called <xtermref spec="SER30" ref="sequence-normalization"/>,
                      takes place for some output methods but not others. For example, if the <code>json</code> output method
-                        (defined in <bibref ref="xslt-xquery-serialization-31"/>) is selected, then the process of constructing
+                        (defined in <bibref ref="xslt-xquery-serialization-40"/>) is selected, then the process of constructing
                      a tree is bypassed.</p>
                   </note>
                   
@@ -36958,7 +36958,7 @@ return ($m?price - $m?discount)</eg>
                <rfc2119>must</rfc2119> be rejected as invalid, and the attributes
                   <code>allow-duplicate-names</code> and <code>json-node-output-method</code>
                <rfc2119>must</rfc2119> be ignored. The meaning of these output methods and
-               serialization parameters is defined in <bibref ref="xslt-xquery-serialization-31"/>.</p>
+               serialization parameters is defined in <bibref ref="xslt-xquery-serialization-40"/>.</p>
             <p>The <code>output-version</code> attribute on the <elcode>xsl:result-document</elcode>
                instruction overrides the <code>version</code> attribute on
                   <elcode>xsl:output</elcode> (it has been renamed because <code>version</code> is
@@ -37981,7 +37981,7 @@ return ($m?price - $m?discount)</eg>
             <rfc2119>must</rfc2119> be rejected as invalid, and the attributes
                <code>allow-duplicate-names</code> and <code>json-node-output-method</code>
             <rfc2119>must</rfc2119> be ignored. The meaning of these output methods and
-            serialization parameters is defined in <bibref ref="xslt-xquery-serialization-31"/>.</p>
+            serialization parameters is defined in <bibref ref="xslt-xquery-serialization-40"/>.</p>
          <p>If none of the <elcode>xsl:output</elcode> declarations within an <termref def="dt-output-definition">output definition</termref> specifies a value for a
             particular attribute, then the corresponding serialization parameter takes a default
             value. The default value depends on the chosen output method.</p>
@@ -39011,6 +39011,7 @@ See <loc href="http://www.w3.org/TR/xpath-functions/"/>
                   February 2013; continually updated.</bibl>
                <bibl id="xslt-xquery-serialization-30" key="XSLT and XQuery Serialization"/>
                <bibl id="xslt-xquery-serialization-31" key="XSLT and XQuery Serialization 3.1"/>
+               <bibl id="xslt-xquery-serialization-40" key="XSLT and XQuery Serialization 4.0"/>
                <!--<bibl id="UNICODE-NORMALIZATION" key="Unicode Normalization">Unicode Consortium.
 					<emph>Unicode Normalization Forms</emph>. Unicode Standard Annex #15.
 					See <loc href="http://www.unicode.org/unicode/reports/tr15/"/>
@@ -39637,6 +39638,22 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                of different types, two items in different groups could compare equal. Any change in behavior
                is confined to this edge case.</p>
             </item>
+            
+            <item diff="add" at="issue780">
+               <p>The functions <function>key</function>,
+                  <function>accumulator-before</function>,
+                  <function>accumulator-after</function>,
+                  <function>element-available</function>,
+                  <function>function-available</function>,
+                  <function>type-available</function>, and
+                  <function>system-property</function> have an argument whose type has changed
+                  from <code>xs:string</code> to <code>union(xs:string, xs:QName)</code>.
+                  This change means that certain non-string values are no longer accepted:
+                  for example <code>xs:anyURI</code> values or 
+                  (with <termref def="dt-backwards-compatible-behavior"/> enabled) 
+                  <code>xs:boolean</code> or <code>xs:duration</code> values. This is highly
+                  unlikely to arise in practical code.</p>
+            </item>
 
             
          </olist>
@@ -39651,6 +39668,10 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
             current template rule should be the calling template or the called template. This omission has
             been corrected.</p></item>
          </olist>
+         
+         <p>See also <bibref ref="xpath-40"/>, <bibref ref="xpath-functions-40"/>, and
+            <bibref ref="xslt-xquery-serialization-40"/> for incompatibilities in other related
+            specifications that may affect XSLT stylesheets.</p>
 
 
       </inform-div1>


### PR DESCRIPTION
Fix #780

Changes the XSLT and F+O specs to document a minor incompatibility arising from the change to functions such as `format-number()` to accept an argument of type `union(xs:string, xs:QName)` rather than `xs:string`.

In addition, in XSLT, all such functions now accept `union(xs:string, xs:QName)` rather than `union(xs:QName, xs:string)`. This is primarily to make them all consistent. 