### PR TITLE
860 Editorial rearrangement of spec for shallow lookup

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -15822,9 +15822,7 @@ map {
             <head>The Lookup Operators ("?" and "??") for Maps and Arrays</head>
 
             <p>&language; provides two lookup operators for maps and arrays. These provide a terse syntax
-  for simple strings as keys in maps or integers as keys in arrays,
-  supports wildcards, and iterates over sequences of maps and
-  arrays.</p>
+  for accessing the entries in a map or the members of an array.</p>
             
             <p diff="add" at="2023-11-15">The operator "?", known as the shallow lookup operator,
                returns values found immediately in the operand map or array. The operator "??",
@@ -15833,231 +15831,7 @@ map {
             
          
 
-            <div4 id="id-unary-lookup">
-               <head>Unary Lookup</head>
-
-               <scrap>
-                  <head/>
-                  <prodrecap id="UnaryLookup" ref="UnaryLookup"/>
-                  <prodrecap id="KeySpecifier" ref="KeySpecifier"/>
-                  <prodrecap id="LookupWildcard" ref="LookupWildcard"/>
-               </scrap>
-
-
-
-               <p>Unary lookup is used in predicates (for example, <code>$map[?name='Mike']</code> 
-                  or with the simple map operator (for example, <code>$maps ! ?name='Mike'</code>). See <specref
-                     ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
-               
-               
-
-               <p>UnaryLookup, using the shallow lookup operator "?", returns a sequence of values selected from the
-  context value.</p>
-               
-               <p>If the context value is anything other than a single item, the semantics
-                  of the expression <code>?KS</code> are defined to be equivalent to 
-                  the expression <code>. ! ?KS</code>. The remainder of this section 
-                  therefore explains the semantics on the assumption that the <termref def="dt-context-value"/>
-                  is a single item, referred to as the context item.</p>
-               
-               <p>The context item must be a map or array. If the context item is
-  not a map or an array, a
-  <termref
-                     def="dt-type-error">type error</termref> is raised <errorref class="TY"
-                     code="0004"/>.
-  </p>
-
-
-               <p>If the context item is a map:</p>
-               <olist>
-                  <item>
-                     <p>If the  <nt def="KeySpecifier">KeySpecifier</nt> is an <code>NCName</code>
-                        <phrase diff="add" at="A"
-                           >or a <code>StringLiteral</code></phrase>, 
-                        the  <nt
-                           def="UnaryLookup"
-                           >UnaryLookup</nt> operator is equivalent to 
-                        <code>.(KS)</code>, where <code>KS</code> is the value of the <code>NCName</code>
-                        <phrase diff="add" at="A">or <code>StringLiteral</code>.</phrase></p>
-                  </item>
-                  <item>
-                     <p>If the   <nt def="KeySpecifier">KeySpecifier</nt>  is an <nt
-                           def="IntegerLiteral">IntegerLiteral</nt>,  the  <nt def="UnaryLookup"
-                           >UnaryLookup</nt> operator is equivalent to <code>.(KS)</code>, where <code>KS</code> is the value of the <nt
-                           def="IntegerLiteral">IntegerLiteral</nt>.</p>
-                  </item>
-                  <item>
-                     <p>If the <nt def="KeySpecifier">KeySpecifier</nt> is a  <nt
-                           def="ParenthesizedExpr">ParenthesizedExpr</nt> <phrase diff="add" at="A">or a <nt def="VarRef">VarRef</nt></phrase> the  <nt
-                           def="UnaryLookup"
-                           >UnaryLookup</nt> operator is equivalent to the following expression,  where <code>KS</code> is the value of the  <nt
-                              def="ParenthesizedExpr">ParenthesizedExpr</nt> <phrase diff="add" at="A">or <nt def="VarRef">VarRef</nt></phrase>:</p>
-
-                     <eg><![CDATA[
-for $k in data(KS)
-return .($k)  
-]]></eg>
-                  </item>
-                  <item>
-                     <p diff="chg" at="2023-11-15">If the <nt def="KeySpecifier"
-                           >KeySpecifier</nt> is a wildcard (<code>*</code>) qualified by a SequenceType <var>ST</var>, the  <nt
-                           def="UnaryLookup"
-                        >UnaryLookup</nt> operator is equivalent to the following expression:</p>
-                     <eg diff="chg" at="2023-11-15"><![CDATA[
-map:for-each(., function($k, $v){if ($v instance of ST) {$v}})                         
-]]></eg>
-                     <p diff="add" at="2023-11-15">If no SequenceType is provided, it defaults to <code>item()*</code>.</p>
-                     <note>
-                        <p>The order of entries in <code>map:for-each()</code> is implementation-dependent, so
-  the order of values in the result sequence is also
-  implementation-dependent.</p>
-                     </note>
-                  </item>
-               </olist>
-
-               <p>If the context item is an array:</p>
-
-               <olist>
-                  <item>
-                     <p>If the  <nt def="KeySpecifier">KeySpecifier</nt>  is an <nt
-                           def="IntegerLiteral">IntegerLiteral</nt>,  the  <nt def="UnaryLookup"
-                           >UnaryLookup</nt> operator is equivalent to <code>.(KS)</code>, where <code>KS</code> is the value of the <nt
-                           def="IntegerLiteral">IntegerLiteral</nt>.</p>
-                  </item>
-
-                  <item>
-                     <p>If the <nt def="KeySpecifier">KeySpecifier</nt> is an <code>NCName</code>
-                        <phrase diff="add" at="A"
-                           >or <code>StringLiteral</code></phrase>, 
-                        the <nt
-                           def="UnaryLookup">UnaryLookup</nt> operator raises a type error <errorref
-                           class="TY" code="0004"/>.</p>
-                  </item>
-
-                  <item>
-                     <p>If the <nt def="KeySpecifier">KeySpecifier</nt> is a  <nt
-                           def="ParenthesizedExpr">ParenthesizedExpr</nt> 
-                        <phrase diff="add" at="A">or a <nt def="VarRef">VarRef</nt></phrase>, the  <nt
-                           def="UnaryLookup"
-                           >UnaryLookup</nt> operator is equivalent to the following expression,  where <code>KS</code> is the value of the  <nt
-                              def="ParenthesizedExpr">ParenthesizedExpr</nt> <phrase diff="add" at="A">or <nt def="VarRef">VarRef</nt></phrase>:</p>
-
-                     <eg><![CDATA[
-for $k in data(KS)
-return .($k)  
-]]></eg>
-                  </item>
-
-                  <item>
-                     <p diff="chg" at="2023-11-15">If the <nt def="KeySpecifier"
-                           >KeySpecifier</nt> is a wildcard (<code>*</code>) qualified by a SequenceType <var>ST</var>, the  <nt
-                           def="UnaryLookup"
-                        >UnaryLookup</nt> operator is equivalent to the following expression:</p>
-                     <eg diff="chg" at="2023-11-15"><![CDATA[
-for $k in 1 to array:size(.)
-let $v := .($k)
-return if ($v instance of ST) {$v} 
-]]></eg>
-                     <p diff="add" at="2023-11-15">If no SequenceType is provided, it defaults to <code>item()*</code>.</p>
-                     <note>
-                        <p>Note that array items are returned in order.</p>
-                     </note>
-                  </item>
-
-               </olist>
-
-
-               <p>Examples:</p>
-
-               <ulist>
-                  <item>
-                     <p>
-                        <code>?name</code> is equivalent to <code>.("name")</code>, an appropriate lookup for a map.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>?2</code> is equivalent to <code>.(2)</code>, an appropriate lookup for an array or an integer-valued map.</p>
-                  </item>
-                  <item>
-                     <p>If the context item is the result of parsing the JSON input:</p>
-                     <eg>{
-   "name": "John Smith",
-   "address": {"street": "18 Acacia Avenue", "postcode": "MK12 2EX"},
-   "previous-address": {"street": "12 Seaview Road", "postcode": "EX8 9AA"}
-}</eg>
-                     <p>then <code>?*::record(street, postcode)?postcode</code>
-                        returns <code>("MK12 2EX", "EX8 9AA")</code> (or some permutation thereof).</p>
-                     <note><p>Writing <code>?*?postcode</code> would raise a type error, because the result of the initial
-                     step <code>?*</code> includes an item (the string <code>"John Smith"</code>) that is neither
-                     a map nor an array.</p></note>
-                  </item>
-                  <item diff="add" at="A">
-                     <p><code>?"first name"</code> is equivalent to <code>.("first name")</code></p>
-                  </item>
-                  
-                  <item role="xquery">
-                     <p>
-                        <code>?("$funky / &lt;looking @string")</code> is equivalent to
-    <code>.("$funky / &lt;looking @string")</code>, an appropriate lookup for a map with rather odd conventions for keys.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>?($a)</code> <phrase diff="add" at="A">and <code>?$a</code> are</phrase> 
-                        equivalent to <code>for $k in $a return .($k)</code>, allowing keys for an array or map to be passed using a variable.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>?(2 to 4)</code> is equivalent to <code>for $k in (2,3,4) return .($k)</code>, a convenient way to return a range of values from an array.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>?(3.5)</code> raises a type error if the context value is an array because the parameter must be an integer.</p>
-                  </item>
-                  
-                  <item role="xquery">
-                     <p>If the context value is an array, <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i)</code> does not raise a type error because the attribute is untyped.</p>
-                     <p>But <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i+1)</code> does raise a type error
-    because the <code>+</code> operator with an untyped operand returns a double.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>([1,2,3], [1,2,5], [1,2])[?3 = 5]</code> raises an error because <code>?3</code> on one of the
-    items in the sequence fails.</p>
-                  </item>
-                  <item>
-                     <p>If <code>$m</code> is bound to the weekdays map described in <specref
-                           ref="id-maps"
-                           />, then <code>$m?*</code> returns the values <code>("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")</code>, in <termref
-                           def="dt-implementation-dependent"
-                        >implementation-dependent</termref> order.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[1, 2, 5, 7]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[[1, 2, 3], [4, 5, 6]]?*</code> evaluates to <code>([1, 2, 3], [4, 5, 6])</code>
-                     </p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[[1, 2, 3], 4, 5]?*::array(*)</code> evaluates to <code>([1, 2, 3])</code>
-                     </p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[[1, 2, 3], [4, 5, 6], 7]?*::array(*)?2</code> evaluates to <code>(2, 5)</code>
-                     </p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[[1, 2, 3], 4, 5]?*::xs:integer</code> evaluates to <code>(4, 5)</code>
-                     </p>
-                  </item>
-               </ulist>
-
-            </div4>
+            
             <div4 id="id-postfix-lookup">
                <head>Postfix Lookup Expressions</head>
 
@@ -16068,29 +15842,98 @@ return if ($v instance of ST) {$v}
                   <prodrecap ref="KeySpecifier"/>
                   <prodrecap ref="LookupWildcard"/>
                </scrap>
-
-               <p>
-      The semantics of a Postfix Lookup expression, using the shallow lookup operator "?", depend on the form of the KeySpecifier, as follows:
-      <ulist>
+               
+               
+ 
+               
+               <p>The semantics of a postfix lookup expression <code>E?KS</code> are defined as follows:</p>
+               
+               <olist>
+                  <item><p><var>E</var> is evaluated to produce a value <code>$V</code>.</p></item>
+                  <item><p>If <code>$V</code> is not a singleton (that is if <code>count($V) ne 1</code>),
+                  then the result (by recursive application of these rules) is the value of
+                  <code>for $v in $V return $v?KS</code>.</p></item>
+                  <item><p>If <code>$V</code> is a singleton array (that is, 
+                     if <code>$V instance of array(*)</code>) then:</p>
+                  <olist>
+                     <item><p>If <code>KS</code> is a <code>ParenthesizedExpr</code>,
+                        then it is evaluated to produce a value <code>$K</code>
+                        and the result is:</p>
+                        <eg><![CDATA[for $k in data($K) return array:get($V, $k)]]></eg>
+                        <note>
+                           <p>The focus for evaluating the key specifier expression is the 
+                              same as the focus for the <code>Lookup</code> expression itself.</p>
+                        </note></item>
                      <item>
-                        <p>If the <code>KeySpecifier</code> is an <code>NCName</code>, <code
-                              diff="add" at="A"
-                           >StringLiteral</code>, <code diff="add" at="A">VarRef</code>, <code>IntegerLiteral</code>, 
-                           or <code>LookupWildcard</code> (<code>*</code>, 
-                           <phrase diff="add" at="2023-11-15">optionally qualified by a <code>SequenceType</code></phrase>), 
-                           then the expression <code>E?S</code> is 
-                           equivalent to <code>E!?S</code>. (That is, the semantics of the postfix lookup operator 
-                           are defined in terms of the unary lookup operator).</p>
+                        <p>If the  <nt def="KeySpecifier">KeySpecifier</nt> is an <nt
+                           def="IntegerLiteral">IntegerLiteral</nt> with value <code>$i</code>, 
+                        the result is <code>array:get($V, $i)</code></p>
+                     </item>
+                     
+                     <item>
+                        <p>If the <nt def="KeySpecifier">KeySpecifier</nt> is an <code>NCName</code>
+                           <phrase diff="add" at="A">or <code>StringLiteral</code></phrase>, 
+                           the expression raises a type error <errorref class="TY" code="0004"/>.</p>
                      </item>
                      <item>
-                        <p>If the <code>KeySpecifier</code> is a <code>ParenthesizedExpr</code>, then the expression <code>E?(S)</code> is equivalent to</p>
-                           <eg><![CDATA[for $e in E, $s in data(S) return $e($s)]]></eg>
+                        <p diff="chg" at="2023-11-15">If <code>KS</code> is a wildcard
+                           (<code>*</code>) qualified by a SequenceType <var>ST</var>, 
+                           the result is given by the following expression:</p>
+                        <eg diff="chg" at="2023-11-15"><![CDATA[
+for $k in 1 to array:size($V)
+let $m := array:get($V, $k)
+return if ($m instance of ST) {$m} 
+]]></eg>
+                        <p diff="add" at="2023-11-15">If no SequenceType is provided, it defaults to <code>item()*</code>.</p>
                         <note>
-                           <p>The focus for evaluating <code>S</code> is the same as the focus for the <code>Lookup</code> expression itself.</p>
+                           <p>Note that array items are returned in order.</p>
                         </note>
                      </item>
-                  </ulist>
-               </p>
+                  </olist>
+                  </item>
+                  <item><p>If <var>$V</var> is a singleton map (that is, if <code>$V instance of map(*)</code>)
+                     then:</p>
+                     <olist>
+                        <item><p>If <code>KS</code> is a <code>ParenthesizedExpr</code>,
+                           then it is evaluated to produce a value <code>$K</code>
+                           and the result is:</p>
+                           <eg><![CDATA[for $k in data($K) return map:get($V, $k)]]></eg>
+                           <note>
+                              <p>The focus for evaluating the key specifier expression is the 
+                                 same as the focus for the <code>Lookup</code> expression itself.</p>
+                           </note>
+                        </item>
+                        <item>
+                           <p>If <code>KS</code> is an <code>NCName</code>
+                              <phrase diff="add" at="A"
+                                 >or a <code>StringLiteral</code></phrase>, 
+                              the result is <code>map:get($V, $k)</code>, where <code>$k</code> 
+                              is the value of the <code>NCName</code>
+                              <phrase diff="add" at="A">or <code>StringLiteral</code>.</phrase></p>
+                        </item>
+                        <item>
+                           <p>If <code>KS</code> is an <code>IntegerLiteral</code>, 
+                              the result is <code>map:get($V, $k)</code>, where <code>$k</code> 
+                              is the value of the <code>IntegerLiteral</code>.</p>
+                        </item>
+                        <item>
+                           <p diff="chg" at="2023-11-15">If the <nt def="KeySpecifier"
+                              >KeySpecifier</nt> is a wildcard (<code>*</code>) qualified by a SequenceType <var>ST</var>, 
+                              the result is given by the following expression:</p>
+                           <eg diff="chg" at="2023-11-15"><![CDATA[map:for-each($V, function($k, $v){if ($v instance of ST) {$v}})]]></eg>
+                           <p diff="add" at="2023-11-15">If no SequenceType is provided, it defaults to <code>item()*</code>.</p>
+                           <note>
+                              <p>The order of entries in <code>map:for-each</code> is implementation-dependent,
+                                 so the order of values in the result sequence is also implementation-dependent.</p>
+                           </note>
+                        </item>
+                     </olist>
+                  </item>
+                  <item><p>Otherwise (that is, if <code>$V</code> is neither a map nor an array)
+                     a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
+                           code="0004"/>.</p></item>
+               </olist>
+
 
 
 
@@ -16127,6 +15970,118 @@ return if ($v instance of ST) {$v}
                      </p>
                   </item>
                </ulist>
+            </div4>
+            
+            <div4 id="id-unary-lookup">
+               <head>Unary Lookup</head>
+               
+               <scrap>
+                  <head/>
+                  <prodrecap id="UnaryLookup" ref="UnaryLookup"/>
+                  <prodrecap id="KeySpecifier" ref="KeySpecifier"/>
+                  <prodrecap id="LookupWildcard" ref="LookupWildcard"/>
+               </scrap>
+               
+               
+               
+               <p>Unary lookup is most commonly used in predicates (for example, <code>$map[?name='Mike']</code>)
+                  or with the simple map operator (for example, <code>avg($maps ! (?price - ?discount))</code>).</p>
+               
+               <p>The unary lookup expression <code>?KS</code> is defined to be equivalent to the postfix lookup
+                  expression <code>.?KS</code> which has the context value (<code>.</code>) as the implicit first operand.
+                  See <specref ref="id-postfix-lookup"/> for the postfix lookup operator.</p>
+               
+               
+               <p>Examples:</p>
+               
+               <ulist>
+                  <item>
+                     <p>
+                        <code>?name</code> is equivalent to <code>.("name")</code>, an appropriate lookup for a map.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>?2</code> is equivalent to <code>.(2)</code>, an appropriate lookup for an array or an integer-valued map.</p>
+                  </item>
+                  <item>
+                     <p>If the context item is the result of parsing the JSON input:</p>
+                     <eg>{
+                        "name": "John Smith",
+                        "address": {"street": "18 Acacia Avenue", "postcode": "MK12 2EX"},
+                        "previous-address": {"street": "12 Seaview Road", "postcode": "EX8 9AA"}
+                        }</eg>
+                     <p>then <code>?*::record(street, postcode)?postcode</code>
+                        returns <code>("MK12 2EX", "EX8 9AA")</code> (or some permutation thereof).</p>
+                     <note><p>Writing <code>?*?postcode</code> would raise a type error, because the result of the initial
+                        step <code>?*</code> includes an item (the string <code>"John Smith"</code>) that is neither
+                        a map nor an array.</p></note>
+                  </item>
+                  <item diff="add" at="A">
+                     <p><code>?"first name"</code> is equivalent to <code>.("first name")</code></p>
+                  </item>
+                  
+                  <item role="xquery">
+                     <p>
+                        <code>?("$funky / &lt;looking @string")</code> is equivalent to
+                        <code>.("$funky / &lt;looking @string")</code>, an appropriate lookup for a map with rather odd conventions for keys.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>?($a)</code> <phrase diff="add" at="A">and <code>?$a</code> are</phrase> 
+                        equivalent to <code>for $k in $a return .($k)</code>, allowing keys for an array or map to be passed using a variable.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>?(2 to 4)</code> is equivalent to <code>for $k in (2,3,4) return .($k)</code>, a convenient way to return a range of values from an array.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>?(3.5)</code> raises a type error if the context value is an array because the parameter must be an integer.</p>
+                  </item>
+                  
+                  <item role="xquery">
+                     <p>If the context value is an array, <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i)</code> does not raise a type error because the attribute is untyped.</p>
+                     <p>But <code>let $x:= &lt;node i="3"/&gt; return ?($x/@i+1)</code> does raise a type error
+                        because the <code>+</code> operator with an untyped operand returns a double.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>([1,2,3], [1,2,5], [1,2])[?3 = 5]</code> raises an error because <code>?3</code> on one of the
+                        items in the sequence fails.</p>
+                  </item>
+                  <item>
+                     <p>If <code>$m</code> is bound to the weekdays map described in <specref
+                        ref="id-maps"
+                     />, then <code>$m?*</code> returns the values <code>("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")</code>, in <termref
+                        def="dt-implementation-dependent"
+                        >implementation-dependent</termref> order.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[1, 2, 5, 7]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[[1, 2, 3], [4, 5, 6]]?*</code> evaluates to <code>([1, 2, 3], [4, 5, 6])</code>
+                     </p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[[1, 2, 3], 4, 5]?*::array(*)</code> evaluates to <code>([1, 2, 3])</code>
+                     </p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[[1, 2, 3], [4, 5, 6], 7]?*::array(*)?2</code> evaluates to <code>(2, 5)</code>
+                     </p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[[1, 2, 3], 4, 5]?*::xs:integer</code> evaluates to <code>(4, 5)</code>
+                     </p>
+                  </item>
+               </ulist>
+               
             </div4>
             
             <div4 id="id-deep-lookup" diff="add" at="2023-11-15">


### PR DESCRIPTION
Rearranges the spec for lookup expressions so that unary lookup is now defined in terms of postfix lookup, not the other way around; this simplifies the rules when the context value is not a singleton, or when the key specifier expression is context-dependent.

Fix #860