### PR TITLE
861 Rewrite spec of deep lookup operator

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16209,6 +16209,17 @@ declare function recursive-content($item as item()) as map(*)* {
                   <p>The result of the deep lookup operator retains order when processing sequences and
                   arrays, but not when processing maps.</p>
                </note>
+               <note>
+                  <p>An expression involving multiple deep lookup operators may return duplicates.
+                     For example, the result of the expression 
+                     <code>[[["a"],["b"]],[["c"],["d"]]] ?? 1 ?? 1</code>
+                     is <code>(["a"], "a", "b", "a", "c")</code>. This is because the first <code>??</code> operator
+                     selects members in position 1 at all three levels, that is it selects the arrays
+                     <code>[["a"],["b"]]</code>, <code>["a"]</code>, and <code>["c"]</code> as well
+                     as each of the four string values. The second <code>??</code> operator 
+                  selects members in position 1 within each of these values, which results in the string
+                  <code>"a"</code> being selected twice.</p>
+               </note>
                
  
                

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16132,32 +16132,76 @@ return if ($v instance of ST) {$v}
             <div4 id="id-deep-lookup" diff="add" at="2023-11-15">
                <head>Deep Lookup</head>
                
-               <p>The deep lookup operator "??" has both unary and binary forms. The unary form <code>??KS</code>
-               (where <var>KS</var> is any KeySpecifier) has the same effect as the binary form <code>.??KS</code>.
-               The semantics are as follows.</p>
+               <p>The deep lookup operator "??" has both unary and postfix forms. The unary form <code>??KS</code>
+               (where <var>KS</var> is any <code>KeySpecifier</code>) has the same effect as the binary form <code>.??KS</code>.
+               </p>
                
-               <p>We define the recursive content of a value to consist of all items found in a depth-first traversal of the value
-               that proceeds as follows:</p>
+               <p>The semantics are defined as follows.</p>
                
-               <p>For each item in the value:</p>
+               <p>First we define the <term>recursive content</term> of an item as follows:</p>
                
-               <olist>
-                  <item><p>Add the item to the result.</p></item>
-                  <item><p>If the item is an array, process all the members of the array (in order) by applying these rules
-                     recursively.</p></item>
-                  <item><p>If the item is a map, process the values in each entry of the map (in arbitrary order) 
-                     by applying these rules recursively.</p></item>
-               </olist>
+               <eg><![CDATA[ declare function immediate-content($item as item()) as map(*)* {
+   if ($item instance of map(*)) {
+      map:entries($item)
+   } else if ($item instance of array(*)) {
+      (1 to array:size($A))!map:entry(., array:get(.))
+   }
+};    
+declare function recursive-content($item as item()) as map(*)* {
+   immediate-content($item) ! (., map:values(.) =!> recursive-content())
+};]]>
+               </eg>
                
-               <p>The effect of the deep lookup expression <code>E??KS</code> is obtained by evaluating
-                  <var>E</var>, establishing its recursive content <var>C</var>, removing any item that is not
-                  a map or array to yield a sequence <var>D</var>, and then evaluating the shallow lookup
-               expression <code>D?KS</code>, but with one exception: if evaluation of any shallow lookup fails,
-               then the error is not propagated, but instead its result is taken to be an empty sequence.</p>
+               <note><p>Explanation: the immediate content of a map is obtained by splitting it
+               into a sequence of singleton maps, each representing one entry. The immediate
+               content of an array is obtained by consructing a sequence of singleton maps,
+               one for each array member, where the key of the map is the array index and the
+               value is the corresponding member. The recursive content of an item contains
+               the singleton maps in its immediate content, each followed by the recursive
+               content obtained by expanding any maps or arrays in the immediate content.
+               </p></note>
                
-               <p>Specifically, no dynamic error occurs when an item in the recursive content is an array
-               and the KeySpecifier is not an integer, or when it is an integer that is out of range for the
-               array.</p>
+               <p>The result of the expression <code>E??KS</code>, where <code>E</code> is any expression
+               and <code>KS</code> is any <code>KeySpecifier</code>, is then <code>(E ! recursive-content(.))?KS</code>.</p>
+               
+               <note>
+                  <p>This is best explained by considering examples.</p>
+                  <p>Consider the expression <code>let $value := [map{"first":"John", "last":"Smith"}, map{"first":"Mary", "last":"Evans"}]</code>.</p>
+                  <p>The recursive content of this array is the sequence of six singleton maps:</p>
+                  <olist>
+                     <item><p><code>map{1: map{"first":"John", "last":"Smith"}}</code></p></item>
+                     <item><p><code>map{2: map{"first":"Mary", "last":"Evans"}}</code></p></item>
+                     <item><p><code>map{"first":"John"}</code></p></item>
+                     <item><p><code>map{"last":"Smith"}</code></p></item>
+                     <item><p><code>map{"first":"Mary"}</code></p></item>
+                     <item><p><code>map{"last":"Evans"}</code></p></item>
+                  </olist>
+                  <p>The expression <code>$value??*</code> returns the sequence 
+                     <code>map{"first":"John", "last":"Smith"}, map{"first":"Mary", "last":"Evans"},
+                     "John", "Smith", "Mary", "Evans"</code>.</p>
+                  <p>The expression <code>$value??first</code> returns the sequence <code>"John", "Mary"</code>.</p>
+                  <p>The expression <code>$value??last</code> returns the sequence <code>"Smith", "Evans"</code>.</p>
+                  <p>The expression <code>$value??1</code> returns the sequence <code>map{"first":"John", "last":"Smith"}</code>.</p>
+               </note>
+               <note>
+                  <p>The effect of evaluating all shallow lookups on maps rather than arrays is that no error arises
+                  if an array subscript is out of bounds. In the above example, <code>$value?3</code> would
+                  return an empty sequence, it would not raise an error.</p>
+               </note>
+               <note>
+                  <p>The definition of the <code>recursive-content</code> function is such that items
+                  in the top-level value that are not maps or arrays are ignored, whereas items that
+                  are not themselves maps or arrays, but which appear in the content of a map or array
+                  at the top level, are included. This means that <code>E??X</code> mirrors the
+                  behavior of <code>E//X</code>, in that it includes all items that are one-or-more levels
+                  deep in the tree.</p>
+               </note>
+               <note>
+                  <p>The result of the deep lookup operator retains order when processing sequences and
+                  arrays, but not when processing maps.</p>
+               </note>
+               
+ 
                
                <example id="ex-deep-lookup">
                   <head>Examples of Deep Lookup Expressions</head>
@@ -16205,6 +16249,118 @@ return if ($v instance of ST) {$v}
                   <eg>$tree ??$cities => 
      map:for-each( fn($key, $val){$val ??to ! ($key || "-" || .)} )</eg>
                   
+               </example>
+               <example>
+                  <head>Comparison with JSONPath</head>
+                  <p>This example provides XPath equivalents to some examples given in the
+                  JSONPath specification. [TODO: add a reference].</p>
+                  <p>The examples query the result of parsing the following JSON value, representing
+                     a store whose stock consists of four books and a bicycle:</p>
+                  <eg><![CDATA[{ "store": {
+       "book": [
+         { "category": "reference",
+           "author": "Nigel Rees",
+           "title": "Sayings of the Century",
+           "price": 8.95
+         },
+         { "category": "fiction",
+           "author": "Evelyn Waugh",
+           "title": "Sword of Honour",
+           "price": 12.99
+         },
+         { "category": "fiction",
+           "author": "Herman Melville",
+           "title": "Moby Dick",
+           "isbn": "0-553-21311-3",
+           "price": 8.99
+         },
+         { "category": "fiction",
+           "author": "J. R. R. Tolkien",
+           "title": "The Lord of the Rings",
+           "isbn": "0-395-19395-8",
+           "price": 22.99
+         }
+       ],
+       "bicycle": {
+         "color": "red",
+         "price": 399
+       }
+     }
+   }]]></eg>
+                  <p>The following table illustrates some queries on this data, expressed
+                  both in JSONPath and in &language;.</p>
+                  <table role="small" width="100%">
+                     <caption>JSONPath vs &language; Comparison</caption>
+                     <thead>
+                        <tr>
+                           <th>Query</th>
+                           <th>JSONPath</th>
+                           <th>&language;</th>
+                        </tr>
+                     </thead>
+                     <tbody>
+                        <tr>
+                           <td>The authors of all books in the store</td>
+                           <td><code>$.store.book[*].author</code></td>
+                           <td><code>$m?store?book??author</code></td>
+                        </tr>
+                        <tr>
+                           <td>All authors</td>
+                           <td><code>$..author</code></td>
+                           <td><code>$m??author</code></td>
+                        </tr>
+                        <tr>
+                           <td>All things in store (four books and a red bicycle)</td>
+                           <td><code>$.store.*  </code></td>
+                           <td><code>$m?store?*</code></td>
+                        </tr>
+                        <tr>
+                           <td>The prices of everything in the store</td>
+                           <td><code>$.store..price</code></td>
+                           <td><code>$m?store??price</code></td>
+                        </tr>
+                        <tr>
+                           <td>The third book</td>
+                           <td><code>$..book[2]  </code></td>
+                           <td><code>$m??book?3</code></td>
+                        </tr>
+                        <tr>
+                           <td>The third book's author</td>
+                           <td><code>$..book[2].author</code></td>
+                           <td><code>$m??book?3?author</code></td>
+                        </tr>
+                        <tr>
+                           <td>The third book's publisher (empty result)</td>
+                           <td><code>$..book[2].publisher</code></td>
+                           <td><code>$m??book?3?publisher</code></td>
+                        </tr>
+                        <tr>
+                           <td>The last book (in order)</td>
+                           <td><code>$..book[-1]</code></td>
+                           <td><code>$m??book => array:foot()</code></td>
+                        </tr>
+                        <tr>
+                           <td>The first two books</td>
+                           <td><code>$..book[0,1]</code></td>
+                           <td><code>$m??book?(1,2)</code></td>
+                        </tr>
+                        <tr>
+                           <td>All books with an ISBN</td>
+                           <td><code>$..book[?@.isbn]</code></td>
+                           <td><code>$m??book[?isbn]</code></td>
+                        </tr>
+                        <tr>
+                           <td>All books cheaper than 10</td>
+                           <td><code>$..book[?@.price&lt;10]</code></td>
+                           <td><code>$m??book[?price lt 10]</code></td>
+                        </tr>
+                        <tr>
+                           <td>All member values and array elements contained in the input value</td>
+                           <td><code>$..*</code></td>
+                           <td><code>$m??*</code></td>
+                        </tr>
+                     </tbody>
+                  </table>
                </example>
             </div4>
             

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16187,6 +16187,15 @@ declare function recursive-content($item as item()) as map(*)* {
                   <p>The effect of evaluating all shallow lookups on maps rather than arrays is that no error arises
                   if an array subscript is out of bounds. In the above example, <code>$value?3</code> would
                   return an empty sequence, it would not raise an error.</p>
+                  <p>This also affects the way an <code>xs:untypedAtomic</code> key value is handled. 
+                     Given the shallow lookup
+                     expression <code>$A?$x</code>, if <code>$A</code> is an array and <code>$x</code>
+                     (after atomization) is <code>xs:untypedAtomic</code> then the value of <code>$x</code>
+                     is converted to an integer (by virtue of the coercion rules applying to a call
+                     on <code>array:get</code>). With a deep lookup expression <code>$A??$x</code>, by
+                     contrast, the semantics are defined in terms of a map lookup, in which 
+                     <code>xs:untypedAtomic</code> values are always treated as strings.
+                  </p>
                </note>
                <note>
                   <p>The definition of the <code>recursive-content</code> function is such that items


### PR DESCRIPTION
Fix #861

This is a complete rewrite of the spec for deep-lookup, hopefully clarifying some edge cases and fixing bugs, but not intended to introduce any major changes.