### PR TITLE
931 Add rules for duration precision

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3498,25 +3498,39 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
             </ulist>
             <p>No ordering relation is defined on <code>xs:duration</code> values.
 			Two <code>xs:duration</code> values may however be compared for equality.</p>
-		 
-			<p>Operations on durations (including equality comparison, casting to string, and extraction of components) 
-			all treat the duration as normalized. This means that the seconds and minutes components 
-			will always be less than 60, the hours component less than 24, and the months component 
-			less than 12.  Thus, for example, a duration of 120 seconds always gives the same result 
-			as a duration of two minutes.</p>
 	     
-	      <p>Conditions such as underflow and overflow may occur with arithmetic on
-	         durations: see <specref ref="duration-limits"/> </p>
+	     <div2 id="duration-data-types">
+	        <head>Duration data types</head>
+	        <p>A value of type <code>xs:duration</code> is considered to comprise two parts:</p>
+	        <ulist>
+	           <item><p>The total number of months, represented as a signed integer.</p></item>
+	           <item><p>The total number of seconds, represented as a signed decimal number.</p></item>
+	        </ulist>
+	        <p>If one of these values is negative (less than zero), the other must not be positive
+	        (greater than zero).</p>
+	     
+		 
+			<p>In effect this means that operations on durations (including equality comparison, 
+			   casting to string, and extraction of components) 
+			   all treat the duration as normalized. The duration <code>PT1M30S</code> (one minute and
+			   thirty seconds), for example,
+			   is precisely equivalent to the duration <code>PT90S</code> (ninety seconds); these are
+			   different representations of the same value, and the result of any operation will be
+			   the same regardless which representation is used. For example, the function
+			   <code>fn:seconds-from-duration</code> returns 30 in both cases.</p>
+	     
+	      <!--<p>Conditions such as underflow and overflow may occur with arithmetic on
+	         durations: see <specref ref="duration-limits"/> </p>-->
 
-			<note><p>This means that in practice, the information content of an <code>xs:duration</code>
+			<note><p>The information content of an <code>xs:duration</code>
 			value can be reduced to an <code>xs:integer</code> number of months, and an <code>xs:decimal</code>
 			number of seconds. For the two defined subtypes this is further simplified so that one of these two
 			components is fixed at zero. Operations such as comparison of durations and arithmetic on durations
 			can be expressed in terms of numeric operations applied to these two components.</p></note>
 
            
-         <div2 id="duration-subtypes">
-            <head>Two totally ordered subtypes of duration</head>
+         <div3 id="duration-subtypes">
+            <head>Subtypes of duration</head>
             
             <p>Two subtypes of <code>xs:duration</code>, namely <code>xs:yearMonthDuration</code>
                and <code>xs:dayTimeDuration</code>, are defined in <bibref ref="xmlschema11-2"/>. These types <rfc2119>must</rfc2119>
@@ -3526,9 +3540,39 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
             case for <code>xs:duration</code> values in general, because of the variable number of days in a month. For this reason, many of the functions
             and operators on durations require the arguments/operands to belong to these two subtypes.</p>
             
- 
+            <p>In an <code>xs:yearMonthDuration</code>, the seconds component is always zero. 
+            In an <code>xs:dayTimeDuration</code>, the months component is always zero.</p>
             
-            </div2>
+         </div3>
+	     
+	     <div3 id="duration-conformance" diff="add" at="issue931">
+	        <head>Limits and precision</head>
+	        
+	        <p>All <emph>minimally conforming</emph> processors
+	           <rfc2119>must</rfc2119>  support duration values in which:</p>
+	        <ulist>
+	           <item><p>The total number of months can be represented as a signed <code>xs:int</code> value;</p></item>
+	           <item><p>The total number of seconds can be represented as a signed <code>xs:decimal</code>
+	           value with facets <code>totalDigits=18</code> and <code>fractionalDigits=3</code>. That is,
+	           durations must be supported to millisecond precision.</p></item>
+	        </ulist>
+	        
+	        <p>Processors <rfc2119>may</rfc2119> support a greater range and/or precision.
+	           The limits are <termref def="implementation-defined"/>.</p>
+
+	        <p>A processor that limits the range or precision of duration values
+	           may encounter overflow and underflow conditions when it
+	           tries to evaluate operations on durations. In
+	           these situations, the processor <rfc2119>must</rfc2119> return a zero-length duration 
+	           in case of duration underflow, and <rfc2119>must</rfc2119> raise a dynamic 
+	           error <errorref class="DT" code="0001"/> in case of overflow.</p>
+	        
+	        
+	        
+	     </div3>
+	     </div2>
+	     
+	     
 		 <div2 id="comp.duration">
 		 <head>Comparison operators on durations</head>
 		    <?local-function-index?>


### PR DESCRIPTION
Fix #931 

Adds rules for the precision of durations and operations on durations, analogous to the existing rules for dates/times.