### PR TITLE
930 drop obsolete note about comments and PIs

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14063,9 +14063,11 @@ declare function equal-strings(
          <p>By default, the contents of comments and processing instructions are significant only if these nodes
             appear directly as items in the two sequences being compared. The content of a comment
             or processing instruction that appears as a descendant of an item in one of the
-            sequences being compared does not affect the result. However, the presence of a comment
-            or processing instruction, if it causes a text node to be split into two text nodes, may
-            affect the result.</p>
+            sequences being compared does not affect the result. <phrase diff="chg" at="issue930">In previous versions
+            of this specification, the presence of a comment
+            or processing instruction, if it caused text to be split across two text nodes, might
+            affect the result; this has been changed in 4.0 so that adjacent text nodes are merged
+            after comments and processing instructions have been stripped.</phrase></p>
          <p>Comparing items of different kind (for example, comparing an atomic
             value to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns <code>false</code>, 
             it does not return an error. So


### PR DESCRIPTION
Fix #930

The note is obsolete because adjacent text nodes are now combined after stripping comments and PIs.