### PR TITLE
877 revised rules for op:binary-less-than

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -11073,27 +11073,30 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <p>Returns <code>true</code> if the first argument is less than the second.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns <code>true</code> if any of the following conditions is <code>true</code>:</p>
+         <p>Each of the two arguments are converted to a sequence of octets, <code>$A</code> and
+               <code>$B</code>, and the first octet in each sequence, <code>$a</code> and
+               <code>$b</code>, are compared.</p>
          <olist>
             <item>
-               <p><code>$arg1</code> is zero-length (contains no octets) and <code>$arg2</code> is
-                  not zero-length.</p>
+               <p>If <code>$a</code> is empty and <code>$b</code> is non-empty return <code>true</code>.</p>
             </item>
             <item>
-               <p>Neither argument is zero-length, and the first octet of <code>$arg1</code> is less
-                  than the first octet of <code>$arg2</code>, treating the value of the octet as an
-                  unsigned integer in the range 0 to 255.</p>
+               <p>If <code>$b</code> is empty return <code>false</code>.</p>
             </item>
             <item>
-               <p>Neither argument is zero-length, the first octet of <code>$arg1</code> is equal to
-                  the first octet of <code>$arg2</code>, and the binary value
-                  formed by taking all octets of <code>arg1</code> after the first is less than the
-                     binary value formed by taking all octets of
-                     <code>arg2</code> after the first.</p>
+               <p>Otherwise (neither <code>$a</code> nor <code>$b</code> are empty):</p>
+               <olist>
+                  <item><p>If <code>$a</code> and <code>$b</code> are identical the result is obtained
+                     by applying these same rules recursively to <code>fn:tail($A)</code> and
+                        <code>fn:tail($B)</code>. </p></item>
+                  <item>
+                     <p>Otherwise, if <code>$a</code> is less than <code>$b</code>, 
+                        treating the value of each octet as an unsigned integer in the range 0 to 
+                        255, then return <code>true</code>, otherwise return <code>false</code>.</p>
+                  </item>
+               </olist>
             </item>
          </olist>
-
-         <p>Otherwise, the function returns <code>false</code>.</p>
       </fos:rules>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -2520,7 +2520,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                converted to a sequence of integers using the <code>fn:string-to-codepoints</code>
                function. These two sequences <code>$A</code> and <code>$B</code> are then compared as follows: </p>
                
-               <ulist>
+               <olist>
                   <item><p>If both sequences are empty, the strings are equal.</p></item>                
                   <item><p>If one sequence is empty and the other is not, then the string
                      corresponding to the empty sequence is less than the other string.</p></item>
@@ -2534,7 +2534,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                   <item><p>Otherwise (the first pair of integers are equal), the result is obtained
                     by applying the same rules recursively to <code>fn:tail($A)</code> and
                     <code>fn:tail($B)</code></p></item>
-               </ulist>
+               </olist>
                
                <note><p>While the Unicode codepoint collation does not produce results suitable for quality publishing of
                printed indexes or directories, it is adequate for many purposes where a restricted alphabet


### PR DESCRIPTION
Rule 3 for `op:binary-less-than` was a bit of a mess (see #877), and needed to be expressed as a recursive operation. 

My proposed revision depends of phraseology drawn from `fn:decode-from-uri`, `fn:deep-equal`, and 5.3.2 Unicode Codepoint Collation (here slightly adjusted from unordered to ordered list).