### PR TITLE
530 Fix typo, escape-solidus not escape-uri-attributes

### DIFF
--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -2022,7 +2022,8 @@ when the encoding is UTF-16,
 even though the XML 1.0 and XML 1.1 specifications state that entities encoded in UTF-16 <rfc2119>MUST</rfc2119> begin with a byte order mark.  
 Consequently, this specification does not guarantee that the resulting XML fragment, 
 without a byte order mark, will not cause an error when processed by a conforming XML processor.</p></note></div3>
-  <div3 id="XML_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>XML Output Method: the <code>escape-solidus</code> Parameter</head><p>The <code>escape-uri-attributes</code> parameter is
+  <div3 id="XML_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>XML Output Method: the <code>escape-solidus</code> Parameter</head>
+    <p>The <code>escape-solidus</code> parameter is
     not applicable to the XML output method.  It
     is the responsibility of the <termref def="host-language">host language</termref> to specify whether an error occurs if this parameter is specified in combination with the XML output method, or if the parameter is simply dropped.</p></div3>
   
@@ -2516,7 +2517,8 @@ name of the element.</p>
 <div3 id="XHTML_MEDIA-TYPE"><head>XHTML Output Method: the <code>media-type</code> Parameter</head><p>The behavior for <code>media-type</code> parameter for the XHTML output method is described in <specref ref="XML_MEDIA-TYPE"/>.</p></div3>
 <div3 id="XHTML_USE-CHARACTER-MAPS"><head>XHTML Output Method: the <code>use-character-maps</code> Parameter</head><p>The behavior for <code>use-character-maps</code> parameter for the XHTML output method is described in <specref ref="XML_USE-CHARACTER-MAPS"/>.</p></div3>
 <div3 id="XHTML_BYTE-ORDER-MARK"><head>XHTML Output Method: the <code>byte-order-mark</code> Parameter</head><p>The behavior for <code>byte-order-mark</code> parameter for the XHTML output method is described in <specref ref="XML_BYTE-ORDER-MARK"/>.</p></div3>
-  <div3 id="XHTML_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>XHTML Output Method: the <code>escape-solidus</code> Parameter</head><p>The <code>escape-uri-attributes</code> parameter is
+  <div3 id="XHTML_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>XHTML Output Method: the <code>escape-solidus</code> Parameter</head>
+    <p>The <code>escape-solidus</code> parameter is
     not applicable to the XHTML output method.  It
     is the responsibility of the <termref def="host-language">host language</termref> to specify whether an error occurs if this parameter is specified in combination with the XML output method, or if the parameter is simply dropped.</p></div3>
   
@@ -3167,7 +3169,8 @@ information.</p></div3>
 <div3 id="HTML_BYTE-ORDER-MARK"><head>HTML Output Method: the <code>byte-order-mark</code> Parameter</head><p>The <code>byte-order-mark</code> parameter is
 applicable to the HTML output method.  See
 <specref ref="serparam"/> for more information.</p></div3>
-  <div3 id="HTML_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>HTML Output Method: the <code>escape-solidus</code> Parameter</head><p>The <code>escape-uri-attributes</code> parameter is
+  <div3 id="HTML_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>HTML Output Method: the <code>escape-solidus</code> Parameter</head>
+    <p>The <code>escape-solidus</code> parameter is
     not applicable to the HTML output method.  It
     is the responsibility of the <termref def="host-language">host language</termref> to specify whether an error occurs if this parameter is specified in combination with the XML output method, or if the parameter is simply dropped.</p></div3>
   
@@ -3386,7 +3389,8 @@ information.</p></div3>
 <div3 id="TEXT_BYTE-ORDER-MARK"><head>Text Output Method: the <code>byte-order-mark</code> Parameter</head><p>The <code>byte-order-mark</code> parameter is
 applicable to the Text output method.  See
 <specref ref="serparam"/> for more information.</p></div3>
-  <div3 id="TEXT_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>Text Output Method: the <code>escape-solidus</code> Parameter</head><p>The <code>escape-uri-attributes</code> parameter is
+  <div3 id="TEXT_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>Text Output Method: the <code>escape-solidus</code> Parameter</head>
+    <p>The <code>escape-solidus</code> parameter is
     not applicable to the Text output method.  It
     is the responsibility of the <termref def="host-language">host language</termref> to specify whether an error occurs if this parameter is specified in combination with the XML output method, or if the parameter is simply dropped.</p></div3>
   
@@ -3661,7 +3665,7 @@ the byte-order mark).</p>
 </div3>
   
   <div3 id="JSON_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>JSON Output Method: the <code>escape-solidus</code> Parameter</head>
-    <p>The <code>escape-uri-attributes</code> parameter is
+    <p>The <code>escape-solidus</code> parameter is
       applicable to the JSON output method. If the value is <code>yes</code>, <code>true</code>, or <code>1</code>,
       then the solidus character (<code>"/"</code>) appearing in a string is escaped with a backslash
       (as <code>"\/"</code>). If the value is <code>no</code>, <code>false</code>, or <code>0</code>,
@@ -4041,7 +4045,8 @@ Adaptive output method. See
 Therefore, this parameter does not get passed down to any delegated output method.</p></note>
 </div3>
   
-  <div3 id="ADAPTIVE_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>Adaptive Output Method: the <code>escape-solidus</code> Parameter</head><p>The <code>escape-uri-attributes</code> parameter is
+  <div3 id="ADAPTIVE_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>Adaptive Output Method: the <code>escape-solidus</code> Parameter</head>
+    <p>The <code>escape-solidus</code> parameter is
     applicable to the Adaptive output method only as elsewhere specified.</p></div3>
   
 


### PR DESCRIPTION
Fix #530. 

On half a dozen occasions, `escape-uri-attributes` is used where `escape-solidus` is clearly intended.