### PR TITLE
Reorganise F+O chapter 15 [editorial]

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22574,7 +22574,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:notes>
          <p>All fields are returned as <code>xs:string</code> values.</p>
          <p>Quoted fields in the input are returned without the quotes.</p>
-         <p>For more discussion of the returned data, see <specref ref="csv"/>.</p>
+         <p>For more discussion of the returned data, see <specref ref="csv-to-xdm-mapping"/>.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('\r')||char('\n')]]></fos:variable>
@@ -22828,7 +22828,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:notes>
          <p>All fields are returned as <code>xs:string</code> values.</p>
          <p>Quoted fields in the input are returned without the quotes.</p>
-         <p>For more discussion of the returned data, see <specref ref="csv"/>.</p>
+         <p>For more discussion of the returned data, see <specref ref="csv-to-xdm-mapping"/>.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="lf" id="escaped-lf"><![CDATA[char('\n')]]></fos:variable>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5613,6 +5613,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <div2 id="xml-functions">
             <head>Functions on XML Data</head>
             <p>These functions convert between the lexical representation of XML and the tree representation.</p>
+            <p>(The <code>fn:serialize</code> function also handles HTML and JSON output, but is included in this section
+            for editorial convenience.)</p>
             <?local-function-index?>
             <div3 id="func-parse-xml">
                <head><?function fn:parse-xml?></head>
@@ -5624,520 +5626,102 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <head><?function fn:serialize?></head>
             </div3>
          </div2>
-         <div2 id="json-functions">
-            <head>Functions on JSON Data</head>
-            <p>The functions listed parse or serialize JSON data.</p>
-            <?local-function-index?>
-            <p>Note also that the function <code>fn:serialize</code> has an option to act as the inverse function to <code>fn:parse-json</code>.</p>
-            <div3 id="func-parse-json">
-               <head><?function fn:parse-json?></head>
-            </div3>
-            <div3 id="func-json-doc">
-               <head><?function fn:json-doc?></head>
-            </div3>
-            <div3 id="func-json-to-xml">
-               <head><?function fn:json-to-xml?></head>
-            </div3>
-            <div3 id="func-xml-to-json">
-               <head><?function fn:xml-to-json?></head>
-            </div3>
-            <div3 id="func-json" diff="add" at="A">
-               <head><?function fn:json?></head>
-            </div3>
-         </div2>
+         
          <div2 id="html-functions">
             <head>Functions on HTML Data</head>
             <p>These functions convert between the lexical representation of HTML and the tree representation.</p>
             <?local-function-index?>
-            <div3 id="html-parser-options">
-               <head>HTML parser options</head>
-               <example role="record">
-                  <record id="parse-html-options">
-                     <arg name="method" type="union(enum(&quot;html&quot;, &quot;xhtml&quot;), xs:string)"/>
-                     <arg name="html-version" type="union(enum(&quot;LS&quot;), xs:decimal)"/>
-                     <arg name="encoding?" type="xs:string?"/>
-                     <arg name="include-template-content?" type="xs:boolean?"/>
-                     <arg name="*"/>
-                  </record>
-               </example>
-               <p>The keys of this record type are:</p>
-               <table border="0" role="data">
-                  <caption>The parse-html options record</caption>
-                  <tbody>
-                     <tr>
-                        <td>method</td>
-                        <td>
-                           <p>The approach used to parse the HTML document into XDM nodes.</p>
-                           <note>
-                              <p>An implementation may use this to specify a specific algorithm, tool, or
-                                 library that is used, such as <code>tidy</code> or <code>tagsoup</code>.</p>
-                              <p>An implementation may also use this to specify a non-standard variant of
-                                 HTML to support, such as <code>word</code> for the Microsoft Word HTML variant.</p>
-                           </note>
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>html-version</td>
-                        <td>
-                           <p>The version of HTML to support when parsing HTML strings or sequences of octets.</p>
-                           <p>Valid values an implementation must support for the <code>html</code> method are:</p>
-                           <olist>
-                              <item>
-                                 <p><code>3</code>, <code>3.2</code> for HTML 3.2 W3C Recommendation, 14 January 1997</p>
-                              </item>
-                              <item>
-                                 <p><code>4</code>, <code>4.01</code> for HTML 4.01 W3C Recommendation, 24 December 1999</p>
-                              </item>
-                              <item>
-                                 <p><code>5.0</code> for HTML5 W3C Recommendation, 28 October 2014</p>
-                              </item>
-                              <item>
-                                 <p><code>5.1</code> for HTML 5.1 W3C Recommendation, 1 November 2016</p>
-                              </item>
-                              <item>
-                                 <p><code>5.2</code> for HTML 5.2 W3C Recommendation, 14 December 2017</p>
-                              </item>
-                              <item>
-                                 <p><code>LS</code> for HTML Living Standard, WHATWG</p>
-                              </item>
-                              <item>
-                                 <p><code>5</code> may be equivalent to any of <code>5.0</code>, <code>5.1</code>, <code>5.2</code>, or <code>LS</code></p>
-                              </item>
-                           </olist>
-                           <p>Valid values an implementation must support for the <code>xhtml</code> method are:</p>
-                           <olist>
-                              <item>
-                                 <p><code>1.0</code> for XHTML 1.0 W3C Recommendation, 26 January 2000</p>
-                              </item>
-                              <item>
-                                 <p><code>1.1</code> for XHTML 1.1 W3C Recommendation, 31 May 2001</p>
-                              </item>
-                           </olist>
-                           <p>Any other <code>method</code> and <code>html-version</code> combinations are
-                              <termref def="implementation-defined">implementation-defined</termref>.</p>
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>encoding</td>
-                        <td>The character encoding to use to decode a sequence of octets that represents
-                           an HTML document.</td>
-                     </tr>
-                     <tr>
-                        <td>include-template-content</td>
-                        <td>
-                           <p>Defines how to handle elements in the <code>HTMLTemplateElement.content</code>
-                              property.</p>
-                           <p>If this option is <code>true()</code>, the <code>template</code> element’s
-                              children are the children of the <code>content</code> property’s document
-                              fragment node.</p>
-                           <p>If this option is <code>false()</code>, the <code>template</code> element’s
-                              children are the empty sequence.</p>
-                           <p>The default behaviour is
-                              <termref def="implementation-defined">implementation-defined</termref>.</p>
-                           <note>
-                              <p>This allows an implementation to support the behaviour defined in
-                                 <bibref ref="html5"/> section 4.12.3.1, <emph>Interaction of
-                                 <code>template</code> elements with XSLT and XPath</emph>:</p>
-                              <olist>
-                                 <item>
-                                    <p>This option would default to <code>true()</code> for an XSLT processor
-                                       operating on an HTML DOM constructed from an XHTML document.</p>
-                                 </item>
-                                 <item>
-                                    <p>This option would default to <code>false()</code> for an XPath processor
-                                       using the <bibref ref="dom-ls"/> section 8, <emph>XPath</emph> APIs.</p>
-                                 </item>
-                              </olist>
-                           </note>
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>*</td>
-                        <td>
-                           <p>Additional <termref def="implementation-defined"/> parser options.</p>
-                           <example>
-                              <head>Example:</head>
-                              <p>An implementation may provide keys for options to the <emph>tidy</emph>
-                                 HTML parser, allowing a user to configure the behaviour of that parser.</p>
-                           </example>
-                        </td>
-                     </tr>
-                  </tbody>
-               </table>
-            </div3>
-            <div3 id="func-parse-html">
-               <head><?function fn:parse-html?></head>
-            </div3>
-         </div2>
-         <div2 id="csv-functions">
-            <head>Functions on CSV Data</head>
-            <p>The functions listed parse CSV data.</p>
-            <?local-function-index?>
-            <p>The structured representation of a parsed CSV is described by the
-               <code>parsed-csv-structure-record</code>, see <specref ref="csv-to-xdm-mapping"/>.</p>
-
-            <div3 id="func-parse-csv">
-               <head><?function fn:parse-csv?></head>
-            </div3>
-            <div3 id="func-csv-to-xml">
-               <head><?function fn:csv-to-xml?></head>
-            </div3>
-            <div3 id="func-csv-to-simple-rows">
-               <head><?function fn:csv-to-simple-rows?></head>
-            </div3>
-         </div2>
-
-         <div2 id="ixml-functions">
-            <head>Functions on Invisible XML</head>
-            <p>The <code>fn:invisible-xml</code> function adds support for
-            <bibref ref="invisible-xml"/> parsing.</p>
-            <div3 id="func-invisible-xml">
-               <head><?function fn:invisible-xml?></head>
-            </div3>
-         </div2>
-
-         <div2 id="json">
-            <head>Conversion to and from JSON</head>
-
-
-            <p>JSON is a popular format for exchange of structured data on the web: it is specified in <bibref ref="rfc7159"/>.
-               This section describes facilities
-               allowing JSON data to be converted to and from XDM values.</p>
-
-            <p>This specification describes two ways of representing JSON data losslessly
-               using XDM constructs. The first method uses XDM maps to represent JSON objects, and XDM arrays to
-               represent JSON arrays. The second method represents all JSON constructs using XDM element and attribute nodes.</p>
-
-
-            <div3 id="json-to-maps-and-arrays">
-               <head>Representing JSON using maps and arrays</head>
-
-
-               <p>This section defines a mapping from JSON data to XDM maps and arrays. Two functions are available
-                  to support this mapping: <code>fn:parse-json</code> and <code>fn:serialize</code> (with options
-                  selecting JSON as the output method).
-                  The <code>fn:parse-json</code> function will accept any JSON text as input, and converts it
-                  to XDM data values. The <code>fn:serialize</code> function (with JSON as the output method) will accept any XDM
-                  value produced using <code>fn:parse-json</code> and convert it back to the original JSON text
-                  (subject to insignificant variations such as reordering the properties in a JSON object). </p>
-
-               <note><p>The conversion is lossless if recommended JSON good practice is followed. Information may however be lost if
-                  (a) JSON numbers are not exactly representable as double-precision floating point, or (b) duplicate key
-                  values appear within a JSON object.</p></note>
-
-               <p>The representation of JSON data produced by the <code>fn:parse-json</code> function
-                  has been chosen with ease of manipulation as a design aim. For example, a simple JSON object
-                  such as <code>{"Sun":1, "Mon":2, "Tue":3, ...}</code> produces a simple map, so if the result
-                  of parsing is held in <code>$weekdays</code>, the number for a given weekday can be extracted
-                  using an expression such as <code>$weekdays?Tue</code>. Similarly, a simple array such as
-                  <code>["Sun", "Mon", "Tue", ...]</code> produces an array that can be addressed as, for example,
-                  <code>$weekdays(3)</code>. A more deeply nested structure can be addressed in a similar way:
-                  for example if the JSON text is an array of person objects, each of which has a property named
-                  <code>phones</code> which is an array of strings containing phone numbers, then the first phone number of
-                  each person in the data can be addressed as <code>$data?phones(1)</code>.</p>
-            </div3>
-
-
-            <div3 id="json-to-xml-mapping">
-               <head>XML Representation of JSON</head>
-
-
-               <p>This section defines a mapping from JSON data to XML (specifically, to XDM element and attribute nodes). A
-                  function <code>fn:json-to-xml</code> is provided to take a JSON string as input and convert it
-                  to the XML representation, and a second function <code>fn:xml-to-json</code> performs the reverse operation.</p>
-
-               <p>The XML representation is designed to be capable of representing any valid JSON text including
-                  one that uses characters which are not valid in XML. The transformation is normally lossless: that is,
-                  distinct JSON texts convert to distinct XML representations. When converting JSON to XML, options are provided
-                  to reject unsupported characters, to replace them with a substitute character, or to leave them in
-                  backslash-escaped form.</p>
-
-               <note><p>The conversion is lossless if recommended JSON good practice is followed. Information may however be lost if
-                  (a) JSON numbers are not exactly representable as double-precision floating point, or (b) duplicate key
-                  values appear within a JSON object.</p></note>
-
-               <p>The following example demonstrates the correspondence of a JSON text and the corresponding XML
-                  representation. </p>
-
-               <example>
-                  <head>A JSON Text and its XML Representation</head>
-                  <p>Consider the following JSON text:</p>
-                  <eg><![CDATA[
-{
-    "desc"    : "Distances between several cities, in kilometers.",
-    "updated" : "2014-02-04T18:50:45",
-    "uptodate": true,
-    "author"  : null,
-    "cities"  : {
-        "Brussels": [
-                      {"to": "London",    "distance": 322},
-                      {"to": "Paris",     "distance": 265},
-                      {"to": "Amsterdam", "distance": 173}
-                    ],
-        "London": [
-                      {"to": "Brussels",  "distance": 322},
-                      {"to": "Paris",     "distance": 344},
-                      {"to": "Amsterdam", "distance": 358}
-                  ],
-        "Paris": [
-                      {"to": "Brussels",  "distance": 265},
-                      {"to": "London",    "distance": 344},
-                      {"to": "Amsterdam", "distance": 431}
-                 ],
-        "Amsterdam": [
-                      {"to": "Brussels",  "distance": 173},
-                      {"to": "London",    "distance": 358},
-                      {"to": "Paris",     "distance": 431}
-                     ]
-     }
-}]]></eg>
-                  <p>The XML representation of this text is as follows. Whitespace is included in the XML representation for purposes of illustration,
-                     but it will not necessarily be present in the output of the
-                     <function>json-to-xml</function> function.</p>
-                  <eg><![CDATA[
-  <map xmlns="http://www.w3.org/2005/xpath-functions">
-    <string key='desc'>Distances between several cities, in kilometers.</string>
-    <string key='updated'>2014-02-04T18:50:45</string>
-    <boolean key="uptodate">true</boolean>
-    <null key="author"/>
-    <map key='cities'>
-      <array key="Brussels">
-        <map>
-            <string key="to">London</string>
-            <number key="distance">322</number>
-        </map>
-        <map>
-            <string key="to">Paris</string>
-            <number key="distance">265</number>
-        </map>
-        <map>
-            <string key="to">Amsterdam</string>
-            <number key="distance">173</number>
-        </map>
-      </array>
-      <array key="London">
-        <map>
-            <string key="to">Brussels</string>
-            <number key="distance">322</number>
-        </map>
-        <map>
-            <string key="to">Paris</string>
-            <number key="distance">344</number>
-        </map>
-        <map>
-            <string key="to">Amsterdam</string>
-            <number key="distance">358</number>
-        </map>
-      </array>
-      <array key="Paris">
-        <map>
-            <string key="to">Brussels</string>
-            <number key="distance">265</number>
-        </map>
-        <map>
-            <string key="to">London</string>
-            <number key="distance">344</number>
-        </map>
-        <map>
-            <string key="to">Amsterdam</string>
-            <number key="distance">431</number>
-        </map>
-      </array>
-      <array key="Amsterdam">
-        <map>
-            <string key="to">Brussels</string>
-            <number key="distance">173</number>
-        </map>
-        <map>
-            <string key="to">London</string>
-            <number key="distance">358</number>
-        </map>
-        <map>
-            <string key="to">Paris</string>
-            <number key="distance">431</number>
-        </map>
-      </array>
-    </map>
-  </map>]]></eg>
-               </example>
-
-               <p>An XSD 1.0 schema for the XML representation is provided in <specref ref="schema-for-json"/>.
-                  It is not necessary to import this schema into the static context unless the stylesheet or query
-                  makes explicit reference to the components defined in the schema. If the stylesheet or query does import a schema
-                  for the namespace <code>http://www.w3.org/2005/xpath-functions</code>, then:</p>
-
-               <olist>
-                  <item><p>Unless the host language specifies otherwise, the processor (if it is schema-aware)
-                     <rfc2119>must</rfc2119> recognize an import declaration for
-                     this namespace, whether or not a schema location is supplied.</p></item>
-                  <item><p>If a schema location is provided, then the schema document at that location <rfc2119>must</rfc2119>
-                     be equivalent to the schema document at <specref ref="schema-for-json"/>; the effect if it is not equivalent is
-                     <termref def="implementation-dependent"/></p></item>
-               </olist>
-
-               <p>The rules governing the mapping from JSON to XML are as follows. In these rules, the phrase
-                  “an element named N” is to be interpreted as meaning “an element node whose local name is N and whose
-                  namespace URI is <code>http://www.w3.org/2005/xpath-functions</code>”.</p>
-
-               <olist>
-                  <item><p>The JSON value <code>null</code> is represented by an element named <code>null</code>, with empty content.</p></item>
-                  <item><p>The JSON values <code>true</code> and <code>false</code> are represented by an element named <code>boolean</code>,
-                     with content conforming to the type <code>xs:boolean</code>. When the element is created by the
-                     <code>fn:json-to-xml</code> function, the string value of the element will be <code>true</code> or <code>false</code>.
-                     The <code>fn:xml-to-json</code> function also recognizes other strings that validate as <code>xs:boolean</code>,
-                     for example <code>1</code> and <code>0</code>. Leading and trailing whitespace is accepted.
-                  </p></item>
-                  <item><p>A JSON number is represented by an element named <code>number</code>,
-                     with content conforming to the type <code>xs:double</code>, with the additional restriction that the value
-                     must not be positive or negative infinity, nor <code>NaN</code>. The
-                     <code>fn:json-to-xml</code> function creates an element whose string value is lexically the same as the JSON representation
-                     of the number. The <code>fn:xml-to-json</code> function generates a JSON representation that is the result of casting the
-                     (typed or untyped) value of the node to <code>xs:double</code> and then casting the result to <code>xs:string</code>.
-                     Leading and trailing whitespace is accepted.
-                     Since JSON does not impose limits on the range or precision
-                     of numbers, these rules mean that conversion from JSON to XML will always succeed, and will retain full precision
-                     in the lexical representation unless the data model implementation is one that reconstructs the string value from
-                     the typed value. In the reverse direction, conversion from XML to JSON may fail if the value is infinity or <code>NaN</code>,
-                     or if the string value is such that casting to <code>xs:double</code> produces positive or negative infinity.
-                  </p>
-                  </item>
-                  <item><p>A JSON string is represented by an element named <code>string</code>, with
-                     content conforming to the type <code>xs:string</code>. The <code>string</code> element has two
-                     alternative representations: escaped form, and unescaped form.</p></item>
-                  <item><p>A JSON array is represented by an element named <code>array</code>. The content is a sequence of
-                     child elements representing the members of the array in order, each such element being the representation
-                     of the array member obtained by applying these rules recursively.</p></item>
-                  <item><p>A JSON object is represented by an element named <code>map</code>. The content is a sequence
-                     of child elements each of which represents one of the name/value pairs in the object. The representation of the
-                     name/value pair <var>N:V</var> is obtained by taking the element that represents the value <var>V</var> (by applying these
-                     rules recursively) and adding an attribute with name <code>key</code> (in no namespace), whose
-                     value is <var>N</var> as an instance of <code>xs:string</code>. The functions <code>fn:json-to-xml</code> and
-                     <code>fn:xml-to-json</code> both retain the order of entries, subject to rules about how duplicate keys are handled. The
-                     key may be represented in escaped or unescaped form.</p></item>
-
-               </olist>
-
-               <p>The attribute <code>escaped="true"</code> may be specified on a <code>string</code> element to indicate
-                  that the string value contains backslash-escaped characters that are to be interpreted according to the JSON
-                  rules. The attribute <code>escaped-key="true"</code> may be specified on any element with a <code>key</code> attribute to indicate
-                  that the key contains backslash-escaped characters that are to be interpreted according to the JSON
-                  rules. Both attributes have the default value <code>false</code>, signifying that the relevant value is in unescaped form.
-                  In unescaped form, the backslash character has no special significance (it represents itself).</p>
-
-               <p>The JSON grammar for <code>number</code> is a subset of the lexical space of
-                  the XSD type <code>xs:double</code>. The mapping from JSON <code>number</code> values to <code>xs:double</code>
-                  values is defined by the XPath rules for casting from <code>xs:string</code> to <code>xs:double</code>. Note that
-                  these rules will never generate an error for out-of-range values; instead very large or very small values will be
-                  converted to <code>+INF</code> or <code>-INF</code>. Since JSON does not impose limits on the range or precision
-                  of numbers, the conversion is not guaranteed to retain full precision.</p>
-
-               <p>Although the order of entries in a JSON object is generally considered to have no significance, the functions
-                  <code>json-to-xml</code> and <code>json-to-xml</code> both retain order.</p>
-
-               <p>The XDM representation of a JSON value may either be untyped (all elements annotated as <code>xs:untyped</code>, attributes
-                  as <code>xs:untypedAtomic</code>), or it may be typed. If it is typed, then it <rfc2119>must</rfc2119> have the type
-                  annotations obtained by validating the untyped representation against the schema given in <specref ref="schema-for-json"/>.
-                  If it is untyped, then it <rfc2119>must</rfc2119> be an XDM instance such that validation against this schema would succeed;
-                  with the proviso that all attributes other than those in no namespace or in namespace <code>http://www.w3.org/2005/xpath-functions</code>
-                  are ignored, including attributes such as <code>xsi:type</code> and <code>xsi:nil</code> that would normally influence the process
-                  of schema validation.</p>
-
-               <p>The namespace prefix associated with the namespace <code>http://www.w3.org/2005/xpath-functions</code> (if any) is immaterial.
-                  The effect of the <code>fn:xml-to-json</code> function does not depend on the choice of prefix, and the prefix (if any) generated by the
-                  <code>fn:json-to-xml</code> function is <termref def="implementation-dependent">implementation-dependent</termref>.</p>
-            </div3>
-         </div2>
-         <div2 id="html">
-            <head>XDM Mapping from HTML DOM Nodes</head>
-
-
-            <p>The HTML5 format is specified in <bibref ref="html5"/>. This section describes facilities
-               allowing HTML5 documents as defined by <bibref ref="dom-ls"/> HTML DOM nodes to be mapped
-               to XDM accessors/nodes.</p>
-
-            <note>
-               <p>Because the <bibref ref="dom-ls"/> and <bibref ref="html5"/> are not fixed, it is
-                  <termref def="implementation-defined">implementation-defined</termref> which versions are used.</p>
-            </note>
-
-            <p>An implementation must match the semantics of the mapping described in this section, but
-               the specific way it achieves that is <termref def="implementation-dependent">implementation-dependent</termref>.</p>
-
-            <note>
-               <p>An implementation may use the HTML DOM directly, using XDM accessor bindings for the
-                  HTML DOM nodes.</p>
-            </note>
-
-            <p>The <bibref ref="dom-ls"/> defines two parsing algorithms. The HTML parsing algorithm constructs
-               a HTML DOM <code>HTMLDocument</code> document object for the HTML document. The XHTML parsing
-               algorithm constructs a HTML DOM <code>XMLDocument</code> object for the HTML document, following
-               XML parsing rules. This mapping supports both of these document types.</p>
-
-            <p>The <bibref ref="dom-ls"/> specification defines HTML DOM nodes that are mapped to XDM
-               nodes as follows:</p>
-            <olist>
-               <item>
-                  <p>The HTML DOM <code>Document</code> interface maps to <xspecref spec="DM40" ref="DocumentNode"/>.</p>
-               </item>
-               <item>
-                  <p>The HTML DOM <code>Element</code> interface maps to <xspecref spec="DM40" ref="ElementNode"/>.</p>
-               </item>
-               <item>
-                  <p>The HTML DOM <code>Attr</code> interface maps to <xspecref spec="DM40" ref="AttributeNode"/>.</p>
-                  <p>HTML DOM <code>Attr</code> instances in an HTML DOM <code>HTMLDocument</code> that are
-                     namespace declarations are filtered out by this mapping. The XHTML parsing algorithm does
-                     not generate <code>Attr</code> nodes for namespace declarations.</p>
-                  <note>
-                     <p>If an implementation allows these nodes to be passed in via an API or similar mechanism,
-                        their behaviour is <termref def="implementation-defined">implementation-defined</termref>.</p>
-                  </note>
-               </item>
-               <item>
-                  <p>The HTML DOM <code>ProcessingInstruction</code> interface maps to
-                     <xspecref spec="DM40" ref="ProcessingInstructionNode"/>.</p>
-
-                  <note>
-                     <p>The HTML parsing algorithm does not support processing instructions. If encountered
-                        they are parsed as comment nodes. The HTML DOM <code>ProcessingInstruction</code>
-                        interface is for when the XHTML parsing algorithm is used, where the document is a
-                        valid XML document.</p>
-                  </note>
-               </item>
-               <item>
-                  <p>The HTML DOM <code>Comment</code> interface maps to <xspecref spec="DM40" ref="CommentNode"/>.</p>
-               </item>
-               <item>
-                  <p>The HTML DOM <code>Text</code> interface maps to <xspecref spec="DM40" ref="TextNode"/>.</p>
-
-                  <note>
-                     <p>The HTML DOM <code>CDATASection</code> interface is an instance of HTML DOM
-                        <code>Text</code>, so CDATA sections also map to <xspecref spec="DM40" ref="TextNode"/>.</p>
-                     <p>Adjacent HTML DOM <code>Text</code> nodes are combined into a single
-                        <xspecref spec="DM40" ref="TextNode"/>.</p>
-                  </note>
-               </item>
-            </olist>
-
-            <note>
-               <p>The HTML DOM <code>DocumentFragment</code> interface is not supported as an XML node.
-                  There are two places in the HTML DOM where this is used:</p>
+            <div3 id="html">
+               <head>XDM Mapping from HTML DOM Nodes</head>
+   
+   
+               <p>The HTML5 format is specified in <bibref ref="html5"/>. This section describes facilities
+                  allowing HTML5 documents as defined by <bibref ref="dom-ls"/> HTML DOM nodes to be mapped
+                  to XDM accessors/nodes.</p>
+   
+               <note>
+                  <p>Because the <bibref ref="dom-ls"/> and <bibref ref="html5"/> are not fixed, it is
+                     <termref def="implementation-defined">implementation-defined</termref> which versions are used.</p>
+               </note>
+   
+               <p>An implementation must match the semantics of the mapping described in this section, but
+                  the specific way it achieves that is <termref def="implementation-dependent">implementation-dependent</termref>.</p>
+   
+               <note>
+                  <p>An implementation may use the HTML DOM directly, using XDM accessor bindings for the
+                     HTML DOM nodes.</p>
+               </note>
+   
+               <p>The <bibref ref="dom-ls"/> defines two parsing algorithms. The HTML parsing algorithm constructs
+                  a HTML DOM <code>HTMLDocument</code> document object for the HTML document. The XHTML parsing
+                  algorithm constructs a HTML DOM <code>XMLDocument</code> object for the HTML document, following
+                  XML parsing rules. This mapping supports both of these document types.</p>
+   
+               <p>The <bibref ref="dom-ls"/> specification defines HTML DOM nodes that are mapped to XDM
+                  nodes as follows:</p>
                <olist>
                   <item>
-                     <p>The HTML DOM <code>ShadowRoot</code> interface is not present in the main HTML DOM
-                        tree. It is only accessible via JavaScript.</p>
+                     <p>The HTML DOM <code>Document</code> interface maps to <xspecref spec="DM40" ref="DocumentNode"/>.</p>
                   </item>
                   <item>
-                     <p>The <code>template</code> element’s <code>content</code> property contains
-                        the child nodes of the <code>template</code> element. The behaviour of this
-                        is defined by the <code>include-template-content</code> key in the
-                        <specref ref="html-parser-options"/> map.</p>
+                     <p>The HTML DOM <code>Element</code> interface maps to <xspecref spec="DM40" ref="ElementNode"/>.</p>
+                  </item>
+                  <item>
+                     <p>The HTML DOM <code>Attr</code> interface maps to <xspecref spec="DM40" ref="AttributeNode"/>.</p>
+                     <p>HTML DOM <code>Attr</code> instances in an HTML DOM <code>HTMLDocument</code> that are
+                        namespace declarations are filtered out by this mapping. The XHTML parsing algorithm does
+                        not generate <code>Attr</code> nodes for namespace declarations.</p>
+                     <note>
+                        <p>If an implementation allows these nodes to be passed in via an API or similar mechanism,
+                           their behaviour is <termref def="implementation-defined">implementation-defined</termref>.</p>
+                     </note>
+                  </item>
+                  <item>
+                     <p>The HTML DOM <code>ProcessingInstruction</code> interface maps to
+                        <xspecref spec="DM40" ref="ProcessingInstructionNode"/>.</p>
+   
+                     <note>
+                        <p>The HTML parsing algorithm does not support processing instructions. If encountered
+                           they are parsed as comment nodes. The HTML DOM <code>ProcessingInstruction</code>
+                           interface is for when the XHTML parsing algorithm is used, where the document is a
+                           valid XML document.</p>
+                     </note>
+                  </item>
+                  <item>
+                     <p>The HTML DOM <code>Comment</code> interface maps to <xspecref spec="DM40" ref="CommentNode"/>.</p>
+                  </item>
+                  <item>
+                     <p>The HTML DOM <code>Text</code> interface maps to <xspecref spec="DM40" ref="TextNode"/>.</p>
+   
+                     <note>
+                        <p>The HTML DOM <code>CDATASection</code> interface is an instance of HTML DOM
+                           <code>Text</code>, so CDATA sections also map to <xspecref spec="DM40" ref="TextNode"/>.</p>
+                        <p>Adjacent HTML DOM <code>Text</code> nodes are combined into a single
+                           <xspecref spec="DM40" ref="TextNode"/>.</p>
+                     </note>
                   </item>
                </olist>
-               <p>If an implementation allows these nodes to be passed in via an API or similar mechanism,
-                  their behaviour is <termref def="implementation-defined">implementation-defined</termref>.</p>
-            </note>
+   
+               <note>
+                  <p>The HTML DOM <code>DocumentFragment</code> interface is not supported as an XML node.
+                     There are two places in the HTML DOM where this is used:</p>
+                  <olist>
+                     <item>
+                        <p>The HTML DOM <code>ShadowRoot</code> interface is not present in the main HTML DOM
+                           tree. It is only accessible via JavaScript.</p>
+                     </item>
+                     <item>
+                        <p>The <code>template</code> element’s <code>content</code> property contains
+                           the child nodes of the <code>template</code> element. The behaviour of this
+                           is defined by the <code>include-template-content</code> key in the
+                           <specref ref="html-parser-options"/> map.</p>
+                     </item>
+                  </olist>
+                  <p>If an implementation allows these nodes to be passed in via an API or similar mechanism,
+                     their behaviour is <termref def="implementation-defined">implementation-defined</termref>.</p>
+               </note>
 
-            <div3 id="html-attributes-accessor">
+            <div4 id="html-attributes-accessor">
                <head>attributes Accessor</head>
 
 
@@ -6204,8 +5788,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <bibref ref="html5"/> section 13.2.5.33, <emph>Attribute name state</emph> specifies that
                      ASCII upper alpha characters are appended to the attribute’s name in lowercase.</p>
                </note>
-            </div3>
-            <div3 id="html-base-uri-accessor">
+            </div4>
+            <div4 id="html-base-uri-accessor">
                <head>base-uri Accessor</head>
 
 
@@ -6220,8 +5804,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <p>Otherwise, the string value is cast to an <code>xs:anyURI</code>.</p>
                   </item>
                </olist>
-            </div3>
-            <div3 id="html-children-accessor">
+            </div4>
+            <div4 id="html-children-accessor">
                <head>children Accessor</head>
 
 
@@ -6293,8 +5877,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      including the first text node and providing logic to ensure that the text content
                      is merged into a single text block.</p>
                </note>
-            </div3>
-            <div3 id="html-document-uri-accessor">
+            </div4>
+            <div4 id="html-document-uri-accessor">
                <head>document-uri Accessor</head>
 
 
@@ -6317,8 +5901,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <p>Otherwise, the result is an empty sequence.</p>
                   </item>
                </olist>
-            </div3>
-            <div3 id="html-is-id-accessor">
+            </div4>
+            <div4 id="html-is-id-accessor">
                <head>is-id Accessor</head>
 
 
@@ -6360,15 +5944,15 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   <p>If an HTML <code>id</code> is not a valid <code>xs:NCName</code> then that
                      attribute is not an XML ID.</p>
                </note>
-            </div3>
-            <div3 id="html-is-idrefs-accessor">
+            </div4>
+            <div4 id="html-is-idrefs-accessor">
                <head>is-idrefs Accessor</head>
 
 
                <p>The result of the <xspecref spec="DM40" ref="dm-is-idrefs"/>
                   <code>dm:is-idrefs($node)</code> for an HTML DOM <code>Node</code> is an empty sequence.</p>
-            </div3>
-            <div3 id="html-namespace-nodes-accessor">
+            </div4>
+            <div4 id="html-namespace-nodes-accessor">
                <head>namespace-nodes Accessor</head>
 
                <p>The result of the <xspecref spec="DM40" ref="dm-namespace-nodes"/>
@@ -6424,15 +6008,15 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   </item>
                </olist>
                <p>No other namespaces are supported by the HTML parser.</p>
-            </div3>
-            <div3 id="html-nilled-accessor">
+            </div4>
+            <div4 id="html-nilled-accessor">
                <head>nilled Accessor</head>
 
 
                <p>The result of the <xspecref spec="DM40" ref="dm-nilled"/>
                   <code>dm:nilled($node)</code> for an HTML DOM <code>Node</code> is <code>false()</code>.</p>
-            </div3>
-            <div3 id="html-node-kind-accessor">
+            </div4>
+            <div4 id="html-node-kind-accessor">
                <head>node-kind Accessor</head>
 
 
@@ -6464,8 +6048,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <code>"text"</code>.</p>
                   </item>
                </olist>
-            </div3>
-            <div3 id="html-node-name-accessor">
+            </div4>
+            <div4 id="html-node-name-accessor">
                <head>node-name Accessor</head>
 
 
@@ -6640,8 +6224,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <code>Attr.localName</code> and <code>Attr.name</code> properties of HTML DOM
                      <code>Attr</code> nodes are both set to the qualified name.</p>
                </note>
-            </div3>
-            <div3 id="html-parent-accessor">
+            </div4>
+            <div4 id="html-parent-accessor">
                <head>parent Accessor</head>
 
 
@@ -6697,8 +6281,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      has access to that internal property, the implementation may choose to use that
                      instead of traversing the parsed HTML tree.</p>
                </note>
-            </div3>
-            <div3 id="html-string-value-accessor">
+            </div4>
+            <div4 id="html-string-value-accessor">
                <head>string-value Accessor</head>
 
 
@@ -6722,7 +6306,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   </item>
                </olist>
 
-               <div4 id="html-tree-string-construction">
+               <div5 id="html-tree-string-construction">
                   <head>Tree string construction</head>
 
 
@@ -6749,8 +6333,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         <p>The result is <code>$text</code>.</p>
                      </item>
                   </olist>
-               </div4>
-               <div4 id="html-text-node-string-construction">
+               </div5>
+               <div5 id="html-text-node-string-construction">
                   <head>Text node string construction</head>
 
 
@@ -6781,9 +6365,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         including the first text node and providing logic to ensure that the text content
                         is merged into a single text block.</p>
                   </note>
-               </div4>
-            </div3>
-            <div3 id="html-type-name-accessor">
+               </div5>
+            </div4>
+            <div4 id="html-type-name-accessor">
                <head>type-name Accessor</head>
 
 
@@ -6806,8 +6390,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <p>Otherwise, the result is an empty sequence.</p>
                   </item>
                </olist>
-            </div3>
-            <div3 id="html-typed-value-accessor">
+            </div4>
+            <div4 id="html-typed-value-accessor">
                <head>typed-value Accessor</head>
 
 
@@ -6838,26 +6422,428 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <p>Otherwise, the result is <code>$string-value</code>.</p>
                   </item>
                </olist>
-            </div3>
-            <div3 id="html-unparsed-entity-public-id-accessor">
+            </div4>
+            <div4 id="html-unparsed-entity-public-id-accessor">
                <head>unparsed-entity-public-id Accessor</head>
 
 
                <p>The result of the <xspecref spec="DM40" ref="dm-unparsed-entity-public-id"/>
                   <code>dm:unparsed-entity-public-id($node)</code> for an HTML DOM <code>Node</code>
                   is an empty sequence.</p>
-            </div3>
-            <div3 id="html-unparsed-entity-system-id-accessor">
+            </div4>
+            <div4 id="html-unparsed-entity-system-id-accessor">
                <head>unparsed-entity-system-id Accessor</head>
 
 
                <p>The result of the <xspecref spec="DM40" ref="dm-unparsed-entity-system-id"/>
                   <code>dm:unparsed-entity-system-id($node)</code> for an HTML DOM <code>Node</code>
                   is an empty sequence.</p>
+            </div4>
+         </div3>
+            <div3 id="html-parser-options">
+               <head>HTML parser options</head>
+               <p>This section describes the record structure used to pass options to the
+               <code>fn:parse-html</code> function.</p>
+               <example role="record">
+                  <record id="parse-html-options">
+                     <arg name="method" type="union(enum(&quot;html&quot;, &quot;xhtml&quot;), xs:string)"/>
+                     <arg name="html-version" type="union(enum(&quot;LS&quot;), xs:decimal)"/>
+                     <arg name="encoding?" type="xs:string?"/>
+                     <arg name="include-template-content?" type="xs:boolean?"/>
+                     <arg name="*"/>
+                  </record>
+               </example>
+               <p>The keys of this record type are:</p>
+               <table border="0" role="data">
+                  <caption>The parse-html options record</caption>
+                  <tbody>
+                     <tr>
+                        <td>method</td>
+                        <td>
+                           <p>The approach used to parse the HTML document into XDM nodes.</p>
+                           <note>
+                              <p>An implementation may use this to specify a specific algorithm, tool, or
+                                 library that is used, such as <code>tidy</code> or <code>tagsoup</code>.</p>
+                              <p>An implementation may also use this to specify a non-standard variant of
+                                 HTML to support, such as <code>word</code> for the Microsoft Word HTML variant.</p>
+                           </note>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>html-version</td>
+                        <td>
+                           <p>The version of HTML to support when parsing HTML strings or sequences of octets.</p>
+                           <p>Valid values an implementation must support for the <code>html</code> method are:</p>
+                           <olist>
+                              <item>
+                                 <p><code>3</code>, <code>3.2</code> for HTML 3.2 W3C Recommendation, 14 January 1997</p>
+                              </item>
+                              <item>
+                                 <p><code>4</code>, <code>4.01</code> for HTML 4.01 W3C Recommendation, 24 December 1999</p>
+                              </item>
+                              <item>
+                                 <p><code>5.0</code> for HTML5 W3C Recommendation, 28 October 2014</p>
+                              </item>
+                              <item>
+                                 <p><code>5.1</code> for HTML 5.1 W3C Recommendation, 1 November 2016</p>
+                              </item>
+                              <item>
+                                 <p><code>5.2</code> for HTML 5.2 W3C Recommendation, 14 December 2017</p>
+                              </item>
+                              <item>
+                                 <p><code>LS</code> for HTML Living Standard, WHATWG</p>
+                              </item>
+                              <item>
+                                 <p><code>5</code> may be equivalent to any of <code>5.0</code>, <code>5.1</code>, <code>5.2</code>, or <code>LS</code></p>
+                              </item>
+                           </olist>
+                           <p>Valid values an implementation must support for the <code>xhtml</code> method are:</p>
+                           <olist>
+                              <item>
+                                 <p><code>1.0</code> for XHTML 1.0 W3C Recommendation, 26 January 2000</p>
+                              </item>
+                              <item>
+                                 <p><code>1.1</code> for XHTML 1.1 W3C Recommendation, 31 May 2001</p>
+                              </item>
+                           </olist>
+                           <p>Any other <code>method</code> and <code>html-version</code> combinations are
+                              <termref def="implementation-defined">implementation-defined</termref>.</p>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>encoding</td>
+                        <td>The character encoding to use to decode a sequence of octets that represents
+                           an HTML document.</td>
+                     </tr>
+                     <tr>
+                        <td>include-template-content</td>
+                        <td>
+                           <p>Defines how to handle elements in the <code>HTMLTemplateElement.content</code>
+                              property.</p>
+                           <p>If this option is <code>true()</code>, the <code>template</code> element’s
+                              children are the children of the <code>content</code> property’s document
+                              fragment node.</p>
+                           <p>If this option is <code>false()</code>, the <code>template</code> element’s
+                              children are the empty sequence.</p>
+                           <p>The default behaviour is
+                              <termref def="implementation-defined">implementation-defined</termref>.</p>
+                           <note>
+                              <p>This allows an implementation to support the behaviour defined in
+                                 <bibref ref="html5"/> section 4.12.3.1, <emph>Interaction of
+                                 <code>template</code> elements with XSLT and XPath</emph>:</p>
+                              <olist>
+                                 <item>
+                                    <p>This option would default to <code>true()</code> for an XSLT processor
+                                       operating on an HTML DOM constructed from an XHTML document.</p>
+                                 </item>
+                                 <item>
+                                    <p>This option would default to <code>false()</code> for an XPath processor
+                                       using the <bibref ref="dom-ls"/> section 8, <emph>XPath</emph> APIs.</p>
+                                 </item>
+                              </olist>
+                           </note>
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>*</td>
+                        <td>
+                           <p>Additional <termref def="implementation-defined"/> parser options.</p>
+                           <example>
+                              <head>Example:</head>
+                              <p>An implementation may provide keys for options to the <emph>tidy</emph>
+                                 HTML parser, allowing a user to configure the behaviour of that parser.</p>
+                           </example>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div3>
+            <div3 id="func-parse-html">
+               <head><?function fn:parse-html?></head>
             </div3>
          </div2>
-         <div2 id="csv">
-            <head>Conversion from CSV</head>
+         <div2 id="json-functions">
+            <head>Functions on JSON Data</head>
+            <p>The functions listed in this section parse or serialize JSON data.</p>
+            
+            <p>JSON is a popular format for exchange of structured data on the web: it is specified in <bibref ref="rfc7159"/>.
+               This section describes facilities
+               allowing JSON data to be converted to and from XDM values.</p>
+            
+            <p>This specification describes two ways of representing JSON data losslessly
+               using XDM constructs. The first method uses XDM maps to represent JSON objects, and XDM arrays to
+               represent JSON arrays. The second method represents all JSON constructs using XDM element and attribute nodes.</p>
+            
+            
+            <?local-function-index?>
+            <p>Note also that the function <code>fn:serialize</code> has an option to act as the inverse function to <code>fn:parse-json</code>.</p>
+            
+  
+               
+               <div3 id="json-to-maps-and-arrays">
+                  <head>Representing JSON using maps and arrays</head>
+                  
+                  
+                  <p>This section defines a mapping from JSON data to XDM maps and arrays. Two functions are available
+                     to support this mapping: <code>fn:parse-json</code> and <code>fn:serialize</code> (with options
+                     selecting JSON as the output method).
+                     The <code>fn:parse-json</code> function will accept any JSON text as input, and converts it
+                     to XDM data values. The <code>fn:serialize</code> function (with JSON as the output method) will accept any XDM
+                     value produced using <code>fn:parse-json</code> and convert it back to the original JSON text
+                     (subject to insignificant variations such as reordering the properties in a JSON object). </p>
+                  
+                  <note><p>The conversion is lossless if recommended JSON good practice is followed. Information may however be lost if
+                     (a) JSON numbers are not exactly representable as double-precision floating point, or (b) duplicate key
+                     values appear within a JSON object.</p></note>
+                  
+                  <p>The representation of JSON data produced by the <code>fn:parse-json</code> function
+                     has been chosen with ease of manipulation as a design aim. For example, a simple JSON object
+                     such as <code>{"Sun":1, "Mon":2, "Tue":3, ...}</code> produces a simple map, so if the result
+                     of parsing is held in <code>$weekdays</code>, the number for a given weekday can be extracted
+                     using an expression such as <code>$weekdays?Tue</code>. Similarly, a simple array such as
+                     <code>["Sun", "Mon", "Tue", ...]</code> produces an array that can be addressed as, for example,
+                     <code>$weekdays(3)</code>. A more deeply nested structure can be addressed in a similar way:
+                     for example if the JSON text is an array of person objects, each of which has a property named
+                     <code>phones</code> which is an array of strings containing phone numbers, then the first phone number of
+                     each person in the data can be addressed as <code>$data?phones(1)</code>.</p>
+               </div3>
+               
+               
+               <div3 id="json-to-xml-mapping">
+                  <head>XML Representation of JSON</head>
+                  
+                  
+                  <p>This section defines a mapping from JSON data to XML (specifically, to XDM element and attribute nodes). A
+                     function <code>fn:json-to-xml</code> is provided to take a JSON string as input and convert it
+                     to the XML representation, and a second function <code>fn:xml-to-json</code> performs the reverse operation.</p>
+                  
+                  <p>The XML representation is designed to be capable of representing any valid JSON text including
+                     one that uses characters which are not valid in XML. The transformation is normally lossless: that is,
+                     distinct JSON texts convert to distinct XML representations. When converting JSON to XML, options are provided
+                     to reject unsupported characters, to replace them with a substitute character, or to leave them in
+                     backslash-escaped form.</p>
+                  
+                  <note><p>The conversion is lossless if recommended JSON good practice is followed. Information may however be lost if
+                     (a) JSON numbers are not exactly representable as double-precision floating point, or (b) duplicate key
+                     values appear within a JSON object.</p></note>
+                  
+                  <p>The following example demonstrates the correspondence of a JSON text and the corresponding XML
+                     representation. </p>
+                  
+                  <example>
+                     <head>A JSON Text and its XML Representation</head>
+                     <p>Consider the following JSON text:</p>
+                     <eg><![CDATA[
+{
+    "desc"    : "Distances between several cities, in kilometers.",
+    "updated" : "2014-02-04T18:50:45",
+    "uptodate": true,
+    "author"  : null,
+    "cities"  : {
+        "Brussels": [
+                      {"to": "London",    "distance": 322},
+                      {"to": "Paris",     "distance": 265},
+                      {"to": "Amsterdam", "distance": 173}
+                    ],
+        "London": [
+                      {"to": "Brussels",  "distance": 322},
+                      {"to": "Paris",     "distance": 344},
+                      {"to": "Amsterdam", "distance": 358}
+                  ],
+        "Paris": [
+                      {"to": "Brussels",  "distance": 265},
+                      {"to": "London",    "distance": 344},
+                      {"to": "Amsterdam", "distance": 431}
+                 ],
+        "Amsterdam": [
+                      {"to": "Brussels",  "distance": 173},
+                      {"to": "London",    "distance": 358},
+                      {"to": "Paris",     "distance": 431}
+                     ]
+     }
+}]]></eg>
+                     <p>The XML representation of this text is as follows. Whitespace is included in the XML representation for purposes of illustration,
+                        but it will not necessarily be present in the output of the
+                        <function>json-to-xml</function> function.</p>
+                     <eg><![CDATA[
+  <map xmlns="http://www.w3.org/2005/xpath-functions">
+    <string key='desc'>Distances between several cities, in kilometers.</string>
+    <string key='updated'>2014-02-04T18:50:45</string>
+    <boolean key="uptodate">true</boolean>
+    <null key="author"/>
+    <map key='cities'>
+      <array key="Brussels">
+        <map>
+            <string key="to">London</string>
+            <number key="distance">322</number>
+        </map>
+        <map>
+            <string key="to">Paris</string>
+            <number key="distance">265</number>
+        </map>
+        <map>
+            <string key="to">Amsterdam</string>
+            <number key="distance">173</number>
+        </map>
+      </array>
+      <array key="London">
+        <map>
+            <string key="to">Brussels</string>
+            <number key="distance">322</number>
+        </map>
+        <map>
+            <string key="to">Paris</string>
+            <number key="distance">344</number>
+        </map>
+        <map>
+            <string key="to">Amsterdam</string>
+            <number key="distance">358</number>
+        </map>
+      </array>
+      <array key="Paris">
+        <map>
+            <string key="to">Brussels</string>
+            <number key="distance">265</number>
+        </map>
+        <map>
+            <string key="to">London</string>
+            <number key="distance">344</number>
+        </map>
+        <map>
+            <string key="to">Amsterdam</string>
+            <number key="distance">431</number>
+        </map>
+      </array>
+      <array key="Amsterdam">
+        <map>
+            <string key="to">Brussels</string>
+            <number key="distance">173</number>
+        </map>
+        <map>
+            <string key="to">London</string>
+            <number key="distance">358</number>
+        </map>
+        <map>
+            <string key="to">Paris</string>
+            <number key="distance">431</number>
+        </map>
+      </array>
+    </map>
+  </map>]]></eg>
+                  </example>
+                  
+                  <p>An XSD 1.0 schema for the XML representation is provided in <specref ref="schema-for-json"/>.
+                     It is not necessary to import this schema into the static context unless the stylesheet or query
+                     makes explicit reference to the components defined in the schema. If the stylesheet or query does import a schema
+                     for the namespace <code>http://www.w3.org/2005/xpath-functions</code>, then:</p>
+                  
+                  <olist>
+                     <item><p>Unless the host language specifies otherwise, the processor (if it is schema-aware)
+                        <rfc2119>must</rfc2119> recognize an import declaration for
+                        this namespace, whether or not a schema location is supplied.</p></item>
+                     <item><p>If a schema location is provided, then the schema document at that location <rfc2119>must</rfc2119>
+                        be equivalent to the schema document at <specref ref="schema-for-json"/>; the effect if it is not equivalent is
+                        <termref def="implementation-dependent"/></p></item>
+                  </olist>
+                  
+                  <p>The rules governing the mapping from JSON to XML are as follows. In these rules, the phrase
+                     “an element named N” is to be interpreted as meaning “an element node whose local name is N and whose
+                     namespace URI is <code>http://www.w3.org/2005/xpath-functions</code>”.</p>
+                  
+                  <olist>
+                     <item><p>The JSON value <code>null</code> is represented by an element named <code>null</code>, with empty content.</p></item>
+                     <item><p>The JSON values <code>true</code> and <code>false</code> are represented by an element named <code>boolean</code>,
+                        with content conforming to the type <code>xs:boolean</code>. When the element is created by the
+                        <code>fn:json-to-xml</code> function, the string value of the element will be <code>true</code> or <code>false</code>.
+                        The <code>fn:xml-to-json</code> function also recognizes other strings that validate as <code>xs:boolean</code>,
+                        for example <code>1</code> and <code>0</code>. Leading and trailing whitespace is accepted.
+                     </p></item>
+                     <item><p>A JSON number is represented by an element named <code>number</code>,
+                        with content conforming to the type <code>xs:double</code>, with the additional restriction that the value
+                        must not be positive or negative infinity, nor <code>NaN</code>. The
+                        <code>fn:json-to-xml</code> function creates an element whose string value is lexically the same as the JSON representation
+                        of the number. The <code>fn:xml-to-json</code> function generates a JSON representation that is the result of casting the
+                        (typed or untyped) value of the node to <code>xs:double</code> and then casting the result to <code>xs:string</code>.
+                        Leading and trailing whitespace is accepted.
+                        Since JSON does not impose limits on the range or precision
+                        of numbers, these rules mean that conversion from JSON to XML will always succeed, and will retain full precision
+                        in the lexical representation unless the data model implementation is one that reconstructs the string value from
+                        the typed value. In the reverse direction, conversion from XML to JSON may fail if the value is infinity or <code>NaN</code>,
+                        or if the string value is such that casting to <code>xs:double</code> produces positive or negative infinity.
+                     </p>
+                     </item>
+                     <item><p>A JSON string is represented by an element named <code>string</code>, with
+                        content conforming to the type <code>xs:string</code>. The <code>string</code> element has two
+                        alternative representations: escaped form, and unescaped form.</p></item>
+                     <item><p>A JSON array is represented by an element named <code>array</code>. The content is a sequence of
+                        child elements representing the members of the array in order, each such element being the representation
+                        of the array member obtained by applying these rules recursively.</p></item>
+                     <item><p>A JSON object is represented by an element named <code>map</code>. The content is a sequence
+                        of child elements each of which represents one of the name/value pairs in the object. The representation of the
+                        name/value pair <var>N:V</var> is obtained by taking the element that represents the value <var>V</var> (by applying these
+                        rules recursively) and adding an attribute with name <code>key</code> (in no namespace), whose
+                        value is <var>N</var> as an instance of <code>xs:string</code>. The functions <code>fn:json-to-xml</code> and
+                        <code>fn:xml-to-json</code> both retain the order of entries, subject to rules about how duplicate keys are handled. The
+                        key may be represented in escaped or unescaped form.</p></item>
+                     
+                  </olist>
+                  
+                  <p>The attribute <code>escaped="true"</code> may be specified on a <code>string</code> element to indicate
+                     that the string value contains backslash-escaped characters that are to be interpreted according to the JSON
+                     rules. The attribute <code>escaped-key="true"</code> may be specified on any element with a <code>key</code> attribute to indicate
+                     that the key contains backslash-escaped characters that are to be interpreted according to the JSON
+                     rules. Both attributes have the default value <code>false</code>, signifying that the relevant value is in unescaped form.
+                     In unescaped form, the backslash character has no special significance (it represents itself).</p>
+                  
+                  <p>The JSON grammar for <code>number</code> is a subset of the lexical space of
+                     the XSD type <code>xs:double</code>. The mapping from JSON <code>number</code> values to <code>xs:double</code>
+                     values is defined by the XPath rules for casting from <code>xs:string</code> to <code>xs:double</code>. Note that
+                     these rules will never generate an error for out-of-range values; instead very large or very small values will be
+                     converted to <code>+INF</code> or <code>-INF</code>. Since JSON does not impose limits on the range or precision
+                     of numbers, the conversion is not guaranteed to retain full precision.</p>
+                  
+                  <p>Although the order of entries in a JSON object is generally considered to have no significance, the functions
+                     <code>json-to-xml</code> and <code>json-to-xml</code> both retain order.</p>
+                  
+                  <p>The XDM representation of a JSON value may either be untyped (all elements annotated as <code>xs:untyped</code>, attributes
+                     as <code>xs:untypedAtomic</code>), or it may be typed. If it is typed, then it <rfc2119>must</rfc2119> have the type
+                     annotations obtained by validating the untyped representation against the schema given in <specref ref="schema-for-json"/>.
+                     If it is untyped, then it <rfc2119>must</rfc2119> be an XDM instance such that validation against this schema would succeed;
+                     with the proviso that all attributes other than those in no namespace or in namespace <code>http://www.w3.org/2005/xpath-functions</code>
+                     are ignored, including attributes such as <code>xsi:type</code> and <code>xsi:nil</code> that would normally influence the process
+                     of schema validation.</p>
+                  
+                  <p>The namespace prefix associated with the namespace <code>http://www.w3.org/2005/xpath-functions</code> (if any) is immaterial.
+                     The effect of the <code>fn:xml-to-json</code> function does not depend on the choice of prefix, and the prefix (if any) generated by the
+                     <code>fn:json-to-xml</code> function is <termref def="implementation-dependent">implementation-dependent</termref>.</p>
+               </div3>
+            
+            
+            
+            <div3 id="func-parse-json">
+               <head><?function fn:parse-json?></head>
+            </div3>
+            <div3 id="func-json-doc">
+               <head><?function fn:json-doc?></head>
+            </div3>
+            <div3 id="func-json-to-xml">
+               <head><?function fn:json-to-xml?></head>
+            </div3>
+            <div3 id="func-xml-to-json">
+               <head><?function fn:xml-to-json?></head>
+            </div3>
+            <div3 id="func-json" diff="add" at="A">
+               <head><?function fn:json?></head>
+            </div3>
+         </div2>
+         <div2 id="csv-functions">
+            <head>Functions on CSV Data</head>
+            <p>This section describes functions that parse CSV data.</p>
+            <?local-function-index?>
+            <p>The structured representation of a parsed CSV is described by the
+               <code>parsed-csv-structure-record</code>, see <specref ref="csv-to-xdm-mapping"/>.</p>
+            
+  
 
             <p>Comma separated values (CSV) refers to a wide variety of plain-text tabular data with
                fields and records separated by standard character delimiters. CSV has developed
@@ -7310,8 +7296,35 @@ return <table>
                   ]]></eg>
                </div4>
             </div3>
+     
+
+            <div3 id="func-parse-csv">
+               <head><?function fn:parse-csv?></head>
+            </div3>
+            <div3 id="func-csv-to-xml">
+               <head><?function fn:csv-to-xml?></head>
+            </div3>
+            <div3 id="func-csv-to-simple-rows">
+               <head><?function fn:csv-to-simple-rows?></head>
+            </div3>
          </div2>
-      </div1>
+
+         <div2 id="ixml-functions">
+            <head>Functions on Invisible XML</head>
+            <p>This section describes functions that support
+            <bibref ref="invisible-xml"/> parsing.</p>
+            <p>Invisible XML defines a BNF-like language for specifying grammars, together with 
+            a mapping from sentences in that grammar to an XML representation. By defining an
+            Invisible XML grammar, a great variety of non-XML data formats can be manipulated
+            as if they were XML. The function <code>fn:invisible-xml</code> takes a grammar
+            as input, and returns a function which can be used for parsing data instances
+            and converting them to XML node trees.</p>
+            <div3 id="func-invisible-xml">
+               <head><?function fn:invisible-xml?></head>
+            </div3>
+         </div2>
+
+          </div1>
       <div1 id="context">
          <head>Context functions</head>
          <p>The following functions are defined to obtain information from the 


### PR DESCRIPTION
This PR reorganizes the subsections of F+O chapter 15 (the XML/HTML/JSON/CSV/IXML chapter). There is no change to content apart from a couple of introductory sentences. I'm planning to do some fine-grained work on the content in due course, but to make that easier to review it seems best to do the top-level reorganisation first. I'm therefore hoping that this PR will go through quickly "on the nod" so I can use it as a baseline for the detail changes.