### PR TITLE
Minor edits (examples, rules)

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -160,7 +160,7 @@
          <fos:variable name="e" id="v-node-name-e"><![CDATA[<doc>
   <p id="alpha" xml:id="beta">One</p>
   <p id="gamma" xmlns="http://example.com/ns">Two</p>
-  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</ex:p>
   <?pi 3.14159?>
 </doc>}]]>
          </fos:variable>
@@ -11189,7 +11189,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:variable name="e" id="v-name-e"><![CDATA[<doc>
   <p id="alpha" xml:id="beta">One</p>
   <p id="gamma" xmlns="http://example.com/ns">Two</p>
-  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</ex:p>
   <?pi 3.14159?>
 </doc>}]]>
          </fos:variable>
@@ -11282,7 +11282,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:variable name="e" id="v-local-name-e"><![CDATA[<doc>
   <p id="alpha" xml:id="beta">One</p>
   <p id="gamma" xmlns="http://example.com/ns">Two</p>
-  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</ex:p>
   <?pi 3.14159?>
 </doc>}]]>
          </fos:variable>
@@ -11375,7 +11375,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:variable name="e" id="v-namespace-uri-e"><![CDATA[<doc>
   <p id="alpha" xml:id="beta">One</p>
   <p id="gamma" xmlns="http://example.com/ns">Two</p>
-  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</ex:p>
   <?pi 3.14159?>
 </doc>}]]>
          </fos:variable>
@@ -11959,7 +11959,7 @@ let $newi := $o/tool</eg>
   <p/>
   <p> </p>
   <?pi 3.14159?>
-</doc>}]]>
+</doc>]]>
          </fos:variable>
          <fos:example>
             <fos:test use="v-has-children-e" spec="XQuery">
@@ -14534,7 +14534,7 @@ declare function equal-strings(
                <fos:expression><eg>deep-equal(
   (1, 2, 3, 4),
   (1, 4, 3, 2),
-  map { 'ordered': false() }
+  options := map { 'ordered': false() }
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -14544,7 +14544,7 @@ declare function equal-strings(
                <fos:expression><eg>deep-equal(
   (1, 1, 2, 3),
   (1, 2, 3, 3),
-  map { 'ordered': false() }
+  options := map { 'ordered': false() }
 )</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
@@ -19383,8 +19383,8 @@ declare function transitive-closure (
             <fos:test use="transitive-closure-data" spec="XQuery">
                <fos:expression><eg>transitive-closure(
   $data, 
-  function { child::* })/@id
-)/string()</eg></fos:expression>
+  function { child::* }
+)/@id ! string()</eg></fos:expression>
                <fos:result>("0", "1", "2", "3", "4", "5", "6", "7","8")</fos:result>
             </fos:test>
          </fos:example>
@@ -20478,7 +20478,7 @@ return map:keys($birthdays, function($date) {
                ref="properties-of-functions"
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
-         <p>The effect of the function is equivalent to <code>map:for-each($map, fn($k, $v) { $v })</code>.</p>
+         <p>The effect of the function is equivalent to <code>$map?*</code>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -24543,7 +24543,7 @@ else $fallback($position)</eg>
             the 1-based positions in the input array of those members for which the supplied predicate function
             returns <code>true</code>.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>index-of(array:for-each($input, $predicate)?*, true())</eg>
+         <eg>index-of($input => array:for-each($predicate) => array:values(), true())</eg>
       </fos:rules>
       
       <fos:examples>
@@ -25842,7 +25842,7 @@ declare function flatten(
   $input as item()*
 ) as item()* {
   for $item in $input
-  return if ($item instance of array(*)) then flatten($item?*) else $item
+  return if ($item instance of array(*)) then flatten(array:values($item)) else $item
 };]]></eg>
       </fos:rules>
       <fos:notes>
@@ -29416,16 +29416,20 @@ month = '0', d | '1', ['0'|'1'|'2'] .
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $p := invisible-xml("S=A. A='a'.")
-return $p("b")</eg></fos:expression>
-               <fos:result>A “failed” XML document.</fos:result>
+               <fos:expression><eg>let $parser := invisible-xml("S=A. A='a'.")
+let $result := $parser("b")
+return $result/*/@*:state = 'failed'</eg></fos:expression>
+               <fos:result>true()</fos:result>
+               <fos:postamble>The returned document contains information about the error in the parsed string.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $p := invisible-xml("S=A. A='a'.",
-                        map { "fail-on-error": true() })
-return $p("b")</eg></fos:expression>
+               <fos:expression><eg><![CDATA[
+let $parser := invisible-xml("S=A. A='a'.", map { "fail-on-error": true() })
+let $result := $parser("b")
+return $result
+]]></eg></fos:expression>
                <fos:error-result error-code="FOIX0002"/>
             </fos:test>
          </fos:example>


### PR DESCRIPTION
* Examples were fixed.
* The equivalent expression for `map:values` was changed to `$map?*`.