### PR TITLE
617 Define record constructors

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7927,10 +7927,28 @@ return <table>
             <head>Constructor functions</head>
            
            <p>
-              This section describes constructor functions corresponding to simple types defined in <bibref ref="xmlschema-2"/>. 
-              Constructor functions are used to convert a supplied value to a given type. They always take a single argument, 
-              and the name of the function is the same as the name of the target type.
-           </p>
+              Constructor functions are used to convert a supplied value to a given type,
+              and the name of the function is the same as the name of the target type. 
+              This section describes constructor functions corresponding to the following types:</p>
+           
+           <ulist>
+              <item><p>Simple types (atomic types, union types, and list types as
+                 defined in <bibref ref="xmlschema-2"/>), which are present in the
+                 static context either because they appear in the 
+                 <xtermref ref="dt-is-types" spec="XP40">in-scope schema types</xtermref>
+                 or because they appear as
+                 <xtermref spec="XP40" ref="dt-named-item-types">named item types</xtermref>.
+              </p>
+                 <p>These constructor functions always take a single argument.</p></item>
+              <item><p>Record tests defined as 
+                 <xtermref spec="XP40" ref="dt-named-item-types">named item types</xtermref>.</p>
+              <p>These take one argument for each named field of the record test.
+              Constructor functions for record types are defined in 
+                 <specref ref="id-constructors-for-record-tests"/>.
+              </p></item>
+           </ulist> 
+            
+
             
            <p>
               Constructor functions are defined for all user-defined named simple types, and for most built-in atomic, list, 
@@ -8442,7 +8460,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
            </div2>  
               
             <div2 id="constructor-functions-for-user-defined-types">
-                <head>Constructor functions for user-defined types</head>
+                <head>Constructor functions for user-defined atomic and union types</head>
                 <p>For every <phrase diff="add" at="issue687">named</phrase> 
                    user-defined simple type in the static context (See <xspecref spec="XP31"
                     ref="static_context"/>), there is a
@@ -8513,6 +8531,116 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                     to use a cast expression (<code>17 cast as hatsize</code>) or (if the host language allows it) 
                   to undeclare the default function namespace. </p></note>
             </div2>
+           
+           <div2 diff="add" at="issue617" id="id-constructors-for-record-tests">
+              <head>Constructor functions for named record tests</head>
+              
+              <p>For every named item type in the static context (See <xspecref spec="XP31"
+                    ref="static_context"/>) whose expansion is a record test, there is a
+                 constructor function whose name is the same as the name of the 
+                 type, and whose parameters correspond to the fields defined in the record test.</p>
+              
+              <p>For example, if there is a named item type with the XQuery definition:</p>
+              
+              <eg>declare item type my:location 
+    as record(latitude as xs:double, longitude as xs:double)</eg>
+              
+              <p>then there will be a function definition equivalent to:</p>
+              
+              <eg>declare function my:location (
+        $latitude as xs:double,
+        $longitude as xs:double) as my:location {
+    map{'latitude':$latitude, 'longitude':$longitude}
+}</eg>
+              <p>Equivalently using XSLT syntax, if there is a named item type with the
+              XSLT definition:</p>
+              
+              <eg><![CDATA[<xsl:item-type name="my:location"
+    as="record(latitude as xs:double, longitude as xs:double)"/>]]></eg>
+              
+              <p>then there will be a function definition equivalent to:</p>
+              
+              <eg><![CDATA[<xsl:function name="my:location" as="my:location">
+    <xsl:param name="latitude" as="xs:double"/>
+    <xsl:param name="longitude" as="xs:double"/>
+    <xsl:map>
+        <xsl:map-entry key="'latitude'" select="$latitude"/>
+        <xsl:map-entry key="'longitude'" select="$longitude"/>
+    </xsl:map>
+</xsl:function>]]></eg>
+              
+              <p>The rules defining the relationship of the function definition to the
+              record test are as follows:</p>
+              
+              <olist>
+                 <item><p>The name of the function is the same as the name of the
+                 named item type. A static error occurs if this clashes with the name and arity
+                 of other function definitions in the static context.</p></item>
+                 <item><p>For every named field in the record test, in order,
+                 there is is one parameter defined as follows:</p>
+                 <olist>
+                    <item><p>If the name of the field is an <code>NCName</code>, then
+                    the name of the parameter is the name of the field.</p></item>
+                    <item><p>Otherwise, the name of the parameter is <code>argNZ</code>,
+                    where <code>arg</code> is the literal string <code>"arg"</code>,
+                    <code>N</code> is the ordinal position of the field, counting from 1 (one),
+                    and <code>Z</code> is an implementation-defined suffix, added only when
+                    needed to make the parameter name unique.</p></item>
+                    <item><p>The declared type of the parameter is the same as the declared
+                    type of the field, but if the field is declared optional, then the
+                    occurrence indicator is adjusted to <code>?</code> or <code>*</code>
+                    if needed to make the empty sequence a valid value for the parameter.</p></item>
+                    <item><p>If the field is optional and if all subsequent fields are optional,
+                    then the parameter is declared as optional with a default value of <code>()</code>
+                    (the empty sequence). In all other cases the parameter is declared as required.</p></item>
+                 </olist>
+                 </item>
+                 <item><p>It is immaterial whether the record test is extensible; the constructor
+                 function cannot be used to create entries in the resulting map other than entries
+                 corresponding to named fields.</p></item>
+                 <item><p>The return type of the constructor function is the record test (with
+                 no occurrence indicator).</p></item>
+                 <item><p>The body of the function constructs a map having one entry for
+                 each mandatory field in the record test, and one entry for each optional field
+                 in the record test for which an actual value other than the empty sequence
+                 is supplied in the arguments of the function call. The key of the entry
+                 is the field name as an instance of <code>xs:string</code>, and the corresponding
+                 value is the value supplied in the arguments to the constructor function call,
+                 after applying the coercion rules.</p></item>
+              </olist>
+              
+              <example id="record-constructor-with-optional-fields">
+                 <head>Record constructor with optional fields</head>
+                 <p>Consider the record test (in XQuery syntax):</p>
+                 <eg>declare item type p:person as record(
+    "1st-title"? as xs:string,
+    "2nd-title"? as xs:string,
+    first as xs:string,
+    middle? as xs:string,
+    last as xs:string,
+    suffix? as xs:string,
+    *)</eg>
+                 <p>This will result in an implicit function declaration equivalent to:</p>
+                 <eg>declare function p:person (
+    $arg1 as xs:string?,
+    $arg2 as xs:string?,
+    $first as xs:string,
+    $middle as xs:string?,
+    $last as xs:string,
+    $suffix as xs:string? := ()) as p:person {
+        let $m := map{},
+            $m := if (exists($arg1)) then map:put($m, "1st-title", $arg1) else $m,
+            $m := if (exists($arg2)) then map:put($m, "2nd-title", $arg2) else $m,
+            $m := map:put($m, "first", $first),
+            $m := if (exists($middle)) then map:put($m, "middle", $middle) else $m,
+            $m := map:put($m, "last", $last),
+            $m := if (exists($suffix)) then map:put($m, "suffix", $suffix) else $m
+        return $m
+    };
+                 </eg>
+              </example>
+              
+           </div2>
         </div1>
       <div1 id="casting">
          <head>Casting</head>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19834,20 +19834,38 @@ if ($x castable as hatsize)
          <div3 id="id-constructor-functions">
             <head>Constructor Functions</head>
             <p>For every simple type in the <termref def="dt-is-types"
-                  >in-scope schema types</termref>  (except <code>xs:NOTATION</code> and <code>xs:anyAtomicType</code>, and <code>xs:anySimpleType</code>, which are not instantiable), a <term>constructor function</term> is implicitly defined. In each case, the name of the constructor function is the same as the name of its target type (including namespace). The signature of the constructor function for  a given type depends on the type that is being constructed, and can be found in  <xspecref
-
-                  spec="FO40" ref="constructor-functions"/>.
-               There is also a constructor function for every <termref def="dt-named-item-type"/> in the <termref def="dt-static-context"/>
-            that maps to a <termref def="dt-generalized-atomic-type"/>.</p> 
+                  >in-scope schema types</termref>  (except <code>xs:NOTATION</code> and 
+               <code>xs:anyAtomicType</code>, and <code>xs:anySimpleType</code>, which 
+               are not instantiable), a <term>constructor function</term> is implicitly defined. 
+               In each case, the name of the constructor function is the same as the name of 
+               its target type (including namespace). The signature of the constructor 
+               function for  a given type depends on the type that is being constructed, 
+               and can be found in <xspecref spec="FO40" ref="constructor-functions"/>.</p>
+            
+            
+               <p>There is also a constructor function for every <termref def="dt-named-item-type"/> 
+               in the <termref def="dt-static-context"/>
+            that expands either to a <termref def="dt-generalized-atomic-type"/> 
+            <phrase diff="add" at="issue617">or to
+            a <nt def="RecordTest">RecordTest</nt></phrase>.</p> 
             
                <p>All such constructor functions are classified as
                <termref def="dt-system-function">system functions</termref>.</p>
 
-
+            <note diff="add" at="issue617"><p>The constructor function is present in the static
+            context if and only if the corresponding type is present in the static context.</p>
+            <p>For XSLT, this means that a constructor function corresponding to an imported
+            schema type is private to the stylesheet package, and a constructor function
+            corresponding to an <code>xsl:item-type</code> declaration has the same visibility
+               as the <code>xsl:item-type</code> declaration.</p>
+               <p>For XQuery, this means that a constructor function corresponding to an imported
+                  schema type is private to the query module, and a constructor function
+                  corresponding to a named item type declaration is <code>%public</code>
+                  or <code>%private</code> according to the annotations on the item type declaration.</p></note>
 
             <p>
                <termdef term="constructor function" id="dt-constructor-function"
-                     >The <term>constructor function</term> for a given type is used to convert instances of other  simple types into the given type. 
+                     >The <term>constructor function</term> for a given simple type is used to convert instances of other  simple types into the given type. 
                   The semantics of the constructor function call <code>T($arg)</code> are defined to be equivalent to the expression <code
                      role="parse-test">(($arg) cast as T?)</code>.</termdef>
             </p>
@@ -19905,6 +19923,12 @@ usa:zipcode?)</code>.</p>
                      <code>union(xs:date, xs:time, xs:dateTime)</code>, then the result
                      of <code>my:chrono("12:00:00Z")</code> is the <code>xs:time</code>
                      value <code>12:00:00Z</code>.</p>
+               </item>
+               <item diff="add" at="issue617">
+                  <p>If <code>my:location</code> is a named item type that expands
+                  to <code>record(latitude as xs:double, longitude as xs:double)</code>,
+                  then the result of <code>my:location(50.52, -3.02)</code> is
+                  the map <code>map{'latitude':50.52e0, 'longitude':-3.02e0}</code>.</p>
                </item>
             </ulist>
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1926,7 +1926,11 @@ local:depth(doc("partlist.xml"))
     in public function and variable declarations are themselves public. This is likely
     to be especially true in the case of higher-order functions.</p></note>
     
-
+    <note>
+      <p>Declaring a named item type will in many cases implicitly create a constructor
+      function, having the same name as the type, for use when creating instances of the
+      type. For details see <specref ref="id-constructor-functions"/>.</p>
+    </note>
     
   </div2>
   

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11078,23 +11078,20 @@ and <code>version="1.0"</code> otherwise.</p>
             to be referenced by name throughout the stylesheet package.</p>
             <example id="e-item-type-complex">
                <p>The following example declares a named item type for complex numbers, and uses it in a variable
-               declaration and two function declarations.</p>
+                  declaration and a function declaration.</p>
                <eg><![CDATA[<xsl:item-type name="cx:complex" as="record(r as xs:double, i as xs:double)"/>
 
 <xsl:variable name="i" as="cx:complex" select="cx:number(0, 1)"/>
 
-<xsl:function name="cx:number" as="cx:complex">
-  <xsl:param name="r" as="xs:double"/>
-  <xsl:param name="i" as="xs:double"/>
-  <xsl:sequence select="map{'r':$r, 'i':$i}"/>
-</xsl:function>
-
 <xsl:function name="cx:add" as="cx:complex">
   <xsl:param name="x" as="cx:complex"/>
   <xsl:param name="y" as="cx:complex"/>
-  <xsl:sequence select="cx:number($x?r + $y?r, $x?i + $y?i)"/>
+  <xsl:sequence select="cx:complex($x?r + $y?r, $x?i + $y?i)"/>
 </xsl:function>
                   ]]></eg>
+               <p>Note how the item type declaration has implicitly declared a constructor function
+                  <code>cx:complex</code> that can be used to create instances of the item type;
+                  details of this mechanism are at <xspecref spec="XP40" ref="id-constructor-functions"/>.</p>
             </example>
             <p>Using named item types makes the stylesheet more readable, and improves potential for change: a change
             to the way complex numbers are implemented in this example is less likely to affect users of the function


### PR DESCRIPTION
Fix #617

Note that this is a first step. Noticeably we can't yet use these constructor functions to create records that have methods. It's nevertheless a big step forward.