### PR TITLE
949 Partial Function Applications: Allow return of function name

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1275,7 +1275,7 @@ identity, equality, or otherwise, and</phrase> have no serialization.
   </item>
   <item>
     <p diff="add" at="2023-05-25">
-      <term>identity</term>: an abstract property that can be used to test whether
+      <term>identity</term>: An abstract property that can be used to test whether
       two variables refer to the same function or to different functions. This property
       is exposed only for this purpose.
     </p>
@@ -1344,7 +1344,7 @@ will create functions in the data model with zero annotations.
   </item>
   <item>
     <p diff="chg" at="2023-03-11">
-      <term>captured context</term>: this includes a static and dynamic context for evaluation
+      <term>captured context</term>: This includes a static and dynamic context for evaluation
       of the function body, as described in <xspecref spec="XP40" ref="context"/>. In particular
       it includes a set of <term>nonlocal variable bindings</term>
       (a mapping from <code>xs:QName</code> to <code>item()*</code>),

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8806,11 +8806,11 @@ At evaluation time, the value of a variable reference is the value to which the 
 
                   <item>
                      <p>
-                          The <termref def="dt-function-item"/> <var>F</var> to be called
+                          The <termref def="dt-function-item"/> <var>FI</var> to be called
                           is obtained by evaluating the base expression of the function call.
                               If this yields a sequence consisting of a single function item
                               whose arity matches the number of arguments in the <code>ArgumentList</code>,
-                              let <var>F</var> denote that function item.
+                              let <var>FI</var> denote that function item.
                               Otherwise, a type error is raised
                               <errorref
                                  class="TY" code="0004"/>.
@@ -8832,7 +8832,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                   <item>
                      <p>
                           Each argument value is converted
-                          to the corresponding parameter type in <var>F</var>’s signature
+                          to the corresponding parameter type in <var>FI</var>’s signature
                           by applying the <termref def="dt-coercion-rules">coercion rules</termref>, resulting in a
                         <term>converted argument value</term>
                      </p>
@@ -8841,23 +8841,23 @@ At evaluation time, the value of a variable reference is the value to which the 
                   
                   
                   <item>
-                     <p>If <var>F</var> is a map, it is evaluated as described in <specref
+                     <p>If <var>FI</var> is a map, it is evaluated as described in <specref
                            ref="id-map-lookup"/>.</p>
                   </item>
                   
                   <item>
-                     <p>If <var>F</var> is an array, it is evaluated as described in <specref
+                     <p>If <var>FI</var> is an array, it is evaluated as described in <specref
                         ref="id-array-lookup"/>.</p>
                   </item>
 
                               <item>
                                  
                                  <p>
-                                  If <var>F</var>’s <phrase diff="chg" at="2023-03-11">body</phrase> is 
+                                  If <var>FI</var>’s <phrase diff="chg" at="2023-03-11">body</phrase> is 
                                   
                                   an &language; expression
                                   
-                                    (for example, if <var>F</var> is
+                                    (for example, if <var>FI</var> is
                                     <phrase
                                        role="xquery">a <termref def="dt-udf"
                                           >user-defined function</termref> or</phrase>
@@ -8875,7 +8875,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                  <olist>
                                     <item>
                                        <p>
-                                          <var>F</var>’s <phrase diff="chg" at="2023-03-11">body</phrase> 
+                                          <var>FI</var>’s <phrase diff="chg" at="2023-03-11">body</phrase> 
                                       is evaluated.
                                       
                                         The static context for this evaluation
@@ -8931,7 +8931,7 @@ At evaluation time, the value of a variable reference is the value to which the 
 
                                           <item>
                                              <p>
-                                          <var>F</var>’s nonlocal variable bindings
+                                          <var>FI</var>’s nonlocal variable bindings
                                           are also added to the <termref
                                                   def="dt-variable-values"
                                                 >variable values</termref>.
@@ -8948,7 +8948,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                     <item>
                                        <p>
                                       The value returned by evaluating the function body
-                                      is then converted to the declared return type of <var>F</var>
+                                      is then converted to the declared return type of <var>FI</var>
                                       by applying the
                                       <termref
                                              def="dt-coercion-rules"
@@ -8960,7 +8960,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                                       As with argument values,
                                       the value returned by a function
                                       retains its <termref def="dt-dynamic-type"/>,
-                                      which may be a <termref def="dt-subtype"/> of the declared return type of <var>F</var>.
+                                      which may be a <termref def="dt-subtype"/> of the declared return type of <var>FI</var>.
                                       For example, a function that has
                                       a declared return type of <code>xs:decimal</code>
                                       may in fact return a value of dynamic type <code>xs:integer</code>.
@@ -9006,10 +9006,9 @@ return $vat(doc('wares.xml')/shop/article)
 
                               <item>
                                  <p>                                  
-                                  If <var>F</var>’s implementation is
-                                  
+                                  If the implementation of <var>FI</var> is
                                   not an &language; expression
-                                  (for example, <var>F</var> is
+                                  (for example, <var>FI</var> is
                                   a <termref
                                        def="dt-system-function">system function</termref>
                                     <phrase role="xquery">or an <termref def="dt-external-function"
@@ -9065,7 +9064,7 @@ return $vat(doc('wares.xml')/shop/article)
                
                <olist>
                   <item>
-                     <p>The <termref def="dt-function-definition"/> <var>F</var> to be partially applied
+                     <p>The <termref def="dt-function-definition"/> <var>FD</var> to be partially applied
                         is determined in the same way as for a static function call without placeholders, 
                         as described in <specref ref="id-function-calls"/>.
                         For this purpose an <code>ArgumentPlaceholder</code> contributes to the count of
@@ -9074,7 +9073,7 @@ return $vat(doc('wares.xml')/shop/article)
                   
                   
                   <item>
-                     <p>The parameters of <var>F</var> are classified into three categories:</p>
+                     <p>The parameters of <var>FD</var> are classified into three categories:</p>
                      <ulist>
                         <item><p>Parameters that map to a placeholder, referred to as <term>placeholder parameters</term>.</p></item>
                         <item><p>Parameters for which an explicit value is given in the function call (either
@@ -9120,9 +9119,11 @@ return $vat(doc('wares.xml')/shop/article)
                      </p>
                      <ulist>
                         <item>
-                           <p>
-                              <term>name</term>:
-                              Absent.
+                           <p><term>name</term>: The name of <var>FD</var> if all parameters map
+                              to placeholders, that is, if the partial function application is
+                              equivalent to the corresponding <termref
+                                 def="dt-named-function-ref">named function reference</termref>.
+                              Otherwise, the name is absent.
                            </p>
                         </item>
                         <item><p diff="add" at="2023-05-25"><term>identity</term>: A new function
@@ -9135,7 +9136,7 @@ return $vat(doc('wares.xml')/shop/article)
                         <item>
                            <p>
                               <term>parameter names</term>:
-                              The names of the parameters of <var>F</var>
+                              The names of the parameters of <var>FD</var>
                               that have been identified as placeholder parameters,
                               retaining the order in which the placeholders appear in the
                               function call.
@@ -9149,11 +9150,11 @@ return $vat(doc('wares.xml')/shop/article)
                         <item>
                            <p>
                               <term>signature</term>: The parameters in the returned function
-                              are the parameters of <var>F</var>
+                              are the parameters of <var>FD</var>
                               that have been identified as placeholder parameters,
                               retaining the order in which the placeholders appear in the
                               function call. The result type of the returned function
-                              is the same as the result type of <var>F</var>.</p>
+                              is the same as the result type of <var>FD</var>.</p>
                               
                               <p>An implementation which can determine a more specific signature (for example, 
                               through use of type analysis) is permitted to do so.
@@ -9161,7 +9162,7 @@ return $vat(doc('wares.xml')/shop/article)
                         </item>
                         
                         <item>
-                           <p><term>body</term>: The body of <var>F</var>.</p>
+                           <p><term>body</term>: The body of <var>FD</var>.</p>
                         </item>
                         
                         <item>
@@ -9196,7 +9197,7 @@ return $sum-of-squares(1 to 3)]]></eg>
 
                <olist>
                   <item>
-                     <p>The <termref def="dt-function-item"/> <var>F</var> to be partially applied is 
+                     <p>The <termref def="dt-function-item"/> <var>FI</var> to be partially applied is 
                         determined in the same way as for a 
                         dynamic function call without placeholders, as described in <specref ref="id-dynamic-function-invocation"/>.
                         For this purpose an <code>ArgumentPlaceholder</code> contributes to the count of
@@ -9204,7 +9205,7 @@ return $sum-of-squares(1 to 3)]]></eg>
                   </item>
                   
                   <item>
-                     <p>The parameters of <var>F</var> are classified into two categories:</p>
+                     <p>The parameters of <var>FI</var> are classified into two categories:</p>
                      <ulist>
                         <item><p>Parameters that map to a placeholder, referred to as <term>placeholder parameters</term>.</p></item>
                         <item><p>Parameters for which an explicit value is given in the function call, 
@@ -9262,12 +9263,12 @@ return $sum-of-squares(1 to 3)]]></eg>
                                 </p>
                               </item>
                               <item>
-                                 <p><term>arity</term>: the number of placeholders in the function call.</p>
+                                 <p><term>arity</term>: The number of placeholders in the function call.</p>
                               </item>
                               <item>
                                  <p>
                                     <term>parameter names</term>:
-                                  The names of parameters in <var>F</var> that have
+                                  The names of parameters in <var>FI</var> that have
                                     been identified as placeholder parameters, in order.
                                 </p>
                                  <note><p>In a dynamic partial function application, argument keywords
@@ -9277,7 +9278,7 @@ return $sum-of-squares(1 to 3)]]></eg>
                               <item>
                                  <p>
                                     <term>signature</term>:
-                                  The signature of <var>F</var>,
+                                  The signature of <var>FI</var>,
                                   removing the types of supplied parameters.
 				  
 				                      An implementation which can determine a more specific signature (for example, 
@@ -9286,14 +9287,14 @@ return $sum-of-squares(1 to 3)]]></eg>
                               </item>
 
                               <item>
-                                 <p><term>body</term>: The body of <var>F</var>.
+                                 <p><term>body</term>: The body of <var>FI</var>.
                                 </p>
                               </item>
 
                               <item>
                                  <p>
                                     <term>captured context</term>: the
-                                    captured context of <var>F</var>, augmented,
+                                    captured context of <var>FI</var>, augmented,
                                   for each supplied parameter, with
                                   a binding of the converted argument value
                                   to the corresponding parameter name.
@@ -9321,7 +9322,7 @@ return $paf(1 to 5)
                
                
                
-               <p>Partial function application never returns a map or an array.  If <code>$F</code> is a map or an array, then <code>$F(?)</code> is 
+               <p>Partial function application never returns a map or an array.  If <code>$f</code> is a map or an array, then <code>$f(?)</code> is 
                   a partial function application that returns a function, but the function it returns is neither a map nor an array.</p>
                <example>
                   <head>Partial Application of a Map</head>
@@ -9413,8 +9414,10 @@ return $a("A")]]></eg>
                obtained from <var>FD</var>
                as follows:
                <ulist>
-                  <item><p>The name of <var>FI</var> is the name of <var>FD</var>.</p></item>
-                  <item><p diff="add" at="2023-05-25">The identity of <var>FI</var> is as follows:</p>
+                  <item>
+                     <p><term>name</term>: The name of <var>FD</var>.</p>
+                  </item>
+                  <item><p diff="add" at="2023-05-25"><term>identity</term>:</p>
                      <ulist>
                         <item><p>If <var>FD</var> is <termref def="dt-context-dependent"/> for the given arity, then a new function
                         identity distinct from the identity of any other function item.</p>
@@ -9444,16 +9447,27 @@ return $a("A")]]></eg>
                      </ulist>
                      <note><p>See also <specref ref="id-function-identity"/>.</p></note>
                   </item>
-                  <item><p>The parameter names of <var>FI</var> are the first <var>A</var> parameter names of <var>FD</var>,
-                  where <var>A</var> is the required arity.</p></item>
-                  <item><p>The signature of <var>FI</var> is formed from the required types of the 
-                     first <var>A</var> parameters of <var>FD</var>, and the function result type of <var>FD</var>.</p></item>
-                  <item><p>The implementation of <var>FI</var> is the implementation of <var>FD</var>.</p></item>
-                  <item><p diff="chg" at="2023-03-12">The captured context of <var>FI</var> comprises the static and dynamic context of
-                     the named function reference, augmented with bindings of the names of parameters of <var>FD</var>
-                  beyond the <var>A</var>'th parameter, to their respective default values.</p>
-                     <note diff="chg" at="2023-03-12"><p>In practice it is necessary to retain only the parts of the context that the function
-                  actually depends on (if any).</p></note></item>
+                  <item>
+                     <p><term>arity</term>: As specified in the named function reference.</p>
+                  </item>
+                  <item>
+                     <p><term>parameter names</term>: The first <var>A</var> parameter names of
+                        <var>FD</var>, where <var>A</var> is the required arity.</p></item>
+                  <item>
+                     <p><term>signature</term>: Formed from the required types of the  first
+                        <var>A</var> parameters of <var>FD</var>, and the function result type of
+                        <var>FD</var>.</p></item>
+                  <item>
+                     <p><term>body</term>: The body of <var>FD</var>.</p>
+                  </item>
+                  <item>
+                     <p diff="chg" at="2023-03-12"><term>captured context</term>: Comprises the
+                        static and dynamic context of the named function reference, augmented with
+                        bindings of the names of parameters of <var>FD</var> beyond the
+                        <var>A</var>’th parameter, to their respective default values.</p>
+                     <note diff="chg" at="2023-03-12"><p>In practice, it is necessary to retain
+                        only the parts of the context that the function actually depends on
+                        (if any).</p></note></item>
                </ulist>
             </p>
             
@@ -9462,7 +9476,7 @@ return $a("A")]]></eg>
             returns a function item whose three parameters correspond to the first three parameters
             of <code>fn:format-date</code>; the remaining two arguments will take their default values.
                To obtain an arity-3 function that binds to arguments 1, 2, and 5 of <code>fn:format-date</code>,
-            use the partial function application <code>format-date(?, ?, place:?)</code>.</p></note>
+            use the partial function application <code>format-date(?, ?, place:=?)</code>.</p></note>
 
             <p diff="del" at="2023-03-12">
             Furthermore, if the function returned by the evaluation of


### PR DESCRIPTION
Issue: #949. The major change is the rule for the `name` property of partial function applications for static function calls.

In addition, I have unified the presentation of the different function item expressions.

Affects test cases like `xqhof40` (which need to be fixed with or without this PR).