### PR TITLE
973 fn:parse-json, fn:json-to-xml: number-parser, fallback

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21969,7 +21969,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   option is present with the value <code>true</code>.
                </fos:meaning>
                <fos:type>(function(xs:untypedAtomic) as item()?)?</fos:type>
-               <fos:default>fn { char('#xFFFD') }</fos:default>
+               <fos:default>fn { char(0xFFFD) }</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function"
                         >
@@ -23665,7 +23665,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   option is present with the value <code>true</code>.
                </fos:meaning>
                <fos:type>(function(xs:untypedAtomic) as item()?)?</fos:type>
-               <fos:default>fn { char('#xFFFD') }</fos:default>
+               <fos:default>fn { char(0xFFFD) }</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function"
                         >

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21965,28 +21965,55 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   Provides a function which is called when the input contains an escape sequence 
                   that represents a character that is not valid in the version of XML
                   supported by the implementation. 
-                  
-                  It is an error to supply the <code>fallback</code> option if the <code>escape</code> option is present
-                  with the value <code>true</code>.
+                  It is an error to supply the <code>fallback</code> option if the <code>escape</code>
+                  option is present with the value <code>true</code>.
                </fos:meaning>
-               <fos:type>function(xs:string) as xs:string</fos:type>
-               <fos:default>The default is effectively the function <code>function($s) { "&amp;#xFFFD;" }</code>: that is,
-                  a function that replaces the escape sequence with the Unicode <code>REPLACEMENT CHARACTER</code>.</fos:default>
+               <fos:type>(function(xs:untypedAtomic) as item()?)?</fos:type>
+               <fos:default>fn { "&amp;#xFFFD;" }</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function"
                         >
-                     The function is called when the JSON input contains an escape sequence that is valid according to the JSON 
-                     grammar, but which does not represent a character that is valid in the version of XML supported
-                     by the processor. In the case of surrogates, the function is called once for any six-character escape sequence
-                     that is not properly paired with another surrogate. The string supplied 
-                     as the argument will always be a two- or six-character escape
-                     sequence, starting with a backslash, that conforms to the rules in the JSON grammar (as extended by the
-                     implementation if <code>liberal:true()</code> is specified): for example
-                     <code>\b</code> or <code>\uFFFF</code> or <code>\uDEAD</code>. The function is <emph>not</emph>
+                     The function is called when the JSON input contains an escape sequence
+                     that is valid according to the JSON grammar, but which does not represent a
+                     character that is valid in the version of XML supported by the processor.
+                     In the case of surrogates, it is called once for any six-character escape sequence
+                     that is not properly paired with another surrogate. The untyped atomic value
+                     supplied as the argument will always be a two- or six-character escape
+                     sequence, starting with a backslash, that conforms to the rules in the JSON grammar
+                     (as extended by the implementation if <code>liberal:true()</code> is specified):
+                     for example <code>\b</code> or <code>\uFFFF</code> or <code>\uDEAD</code>.
+                     <p>By default, the escape sequence is replaced with the Unicode
+                     <code>REPLACEMENT CHARACTER</code>. The function is <emph>not</emph>
                      called for an escape sequence that is invalid against the grammar (for example <code>\x0A</code>). 
-                     The function returns a string
-                     which is inserted into the result in place of the invalid character. The
-                     function also has the option of raising a dynamic error by calling <code>fn:error</code>.
+                     The string, which results from invoking <code>fn:string</code> on the result
+                     of the function, is inserted into the result in place of the invalid character. The
+                     function also has the option of raising a dynamic error by calling <code>fn:error</code>.</p>
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+
+            <fos:option key="number-parser" diff="add" at="A">
+               <fos:meaning>Determines how numeric values should be processed.</fos:meaning>
+               <fos:type>(function(xs:untypedAtomic) as item()?)?</fos:type>
+               <fos:default>xs:double#1</fos:default>
+               <fos:values>
+                  <fos:value value="User-supplied function">
+                     The supplied function is called to process the string value of any JSON number
+                     in the input. By default, numbers are processed by 
+                     converting to <code>xs:double</code> using the XPath casting rules.
+                     Supplying the value <code>xs:decimal#1</code> will instead convert to <code>xs:decimal</code>
+                     (which potentially retains more precision, but disallows exponential notation), while
+                     supplying a function that casts to <code>union(xs:decimal, xs:double)</code> will treat
+                     the value as <code>xs:decimal</code> if there is no exponent, or as <code>xs:double</code>
+                     otherwise. Supplying the value <code>fn:identity#1</code> causes the value to be retained
+                     unchanged as an <code>xs:untypedAtomic</code>. Before calling the supplied <code>number-parser</code>,
+                     the value is first checked to ensure that it conforms to the JSON grammar (for example,
+                     a leading plus sign and redundant leading zeroes are not allowed); these checks are disabled
+                     if the <code>liberal</code> option is set to <code>true</code>.
+                  </fos:value>
+                  <fos:value value="()">
+                     If no function is supplied, numbers are processed by casting the supplied value to
+                     <code>xs:double</code>.
                   </fos:value>
                </fos:values>
             </fos:option>
@@ -23573,6 +23600,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
+
             <fos:option key="duplicates">
                <fos:meaning>Determines the policy for handling duplicate keys in a JSON object.
                   To determine whether keys are duplicates, they are compared using the Unicode codepoint collation, after expanding escape
@@ -23631,39 +23659,45 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
+
             <fos:option key="fallback">
                <fos:meaning>
                   Provides a function which is called when the input contains an escape sequence 
                   that represents a character that is not valid in the version of XML
                   supported by the implementation. 
-                  
-                  It is an error to supply the <code>fallback</code> option if the <code>escape</code> option is present
-                  with the value <code>true</code>.
+                  It is an error to supply the <code>fallback</code> option if the <code>escape</code>
+                  option is present with the value <code>true</code>.
                </fos:meaning>
-               <fos:type>function(xs:string) as xs:string</fos:type>
-               <fos:default>The default is effectively the function <code>function($s) { "&amp;#xFFFD;" }</code>: that is,
-                  a function that replaces the escape sequence with the Unicode <code>REPLACEMENT CHARACTER</code>.</fos:default>
+               <fos:type>(function(xs:untypedAtomic) as item()?)?</fos:type>
+               <fos:default>fn { "&amp;#xFFFD;" }</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function"
                         >
-                     The function is called when the JSON input contains a special character (as defined under 
-                     the <code>escape</code> option) that is valid according to the JSON 
-                     grammar, whether the special character is represented in the input directly or as an escape sequence. 
-                     The function is called once for any surrogate
-                     that is not properly paired with another surrogate. The string supplied as the argument will always be a two- or six-character escape
-                     sequence, starting with a backslash, that conforms to the rules in the JSON grammar (as extended by the
-                     implementation if <code>liberal:true()</code> is specified): for example
-                     <code>\b</code> or <code>\uFFFF</code> or <code>\uDEAD</code>. The function is <emph>not</emph>
-                     called for an escape sequence that is invalid against the grammar (for example <code>\x0A</code>). The function returns a string
-                     which is inserted into the result in place of the invalid character. The
-                     function also has the option of raising a dynamic error by calling <code>fn:error</code>.
+                     The function is called when the JSON input contains a special character
+                     (as defined under the <code>escape</code> option) that is valid according to
+                     the JSON  grammar (whether the special character is represented in the input
+                     directly or as an escape sequence), but which does not represent a
+                     character that is valid in the version of XML supported by the processor.
+                     It is called once for any surrogate
+                     that is not properly paired with another surrogate. The untyped atomic value
+                     supplied as the argument will always be a two- or six-character escape
+                     sequence, starting with a backslash, that conforms to the rules in the JSON grammar
+                     (as extended by the implementation if <code>liberal:true()</code> is specified):
+                     for example <code>\b</code> or <code>\uFFFF</code> or <code>\uDEAD</code>.
+                     <p>By default, the escape sequence is replaced with the Unicode
+                     <code>REPLACEMENT CHARACTER</code>. The function is <emph>not</emph>
+                     called for an escape sequence that is invalid against the grammar (for example <code>\x0A</code>).
+                     The string, which results from invoking <code>fn:string</code> on the result
+                     of the function, is inserted into the result in place of the invalid character. The
+                     function also has the option of raising a dynamic error by calling <code>fn:error</code>.</p>
                   </fos:value>
                </fos:values>
             </fos:option>
+
             <fos:option key="number-parser" diff="add" at="A">
                <fos:meaning>Determines how numeric values should be processed.</fos:meaning>
-               <fos:type>(function(xs:string) as xs:anyAtomicType)?</fos:type>
-               <fos:default>()</fos:default>
+               <fos:type>(function(xs:untypedAtomic) as item()?)?</fos:type>
+               <fos:default>xs:double#1</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function">
                      The supplied function is called to process the string value of any JSON number
@@ -23674,7 +23708,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      supplying a function that casts to <code>union(xs:decimal, xs:double)</code> will treat
                      the value as <code>xs:decimal</code> if there is no exponent, or as <code>xs:double</code>
                      otherwise. Supplying the value <code>fn:identity#1</code> causes the value to be retained
-                     unchanged as an <code>xs:string</code>. Before calling the supplied <code>number-parser</code>,
+                     unchanged as an <code>xs:untypedAtomic</code>. Before calling the supplied <code>number-parser</code>,
                      the value is first checked to ensure that it conforms to the JSON grammar (for example,
                      a leading plus sign and redundant leading zeroes are not allowed); these checks are disabled
                      if the <code>liberal</code> option is set to <code>true</code>.

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22011,10 +22011,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      a leading plus sign and redundant leading zeroes are not allowed); these checks are disabled
                      if the <code>liberal</code> option is set to <code>true</code>.
                   </fos:value>
-                  <fos:value value="()">
-                     If no function is supplied, numbers are processed by casting the supplied value to
-                     <code>xs:double</code>.
-                  </fos:value>
                </fos:values>
             </fos:option>
          </fos:options>
@@ -23712,10 +23708,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      the value is first checked to ensure that it conforms to the JSON grammar (for example,
                      a leading plus sign and redundant leading zeroes are not allowed); these checks are disabled
                      if the <code>liberal</code> option is set to <code>true</code>.
-                  </fos:value>
-                  <fos:value value="()">
-                     If no function is supplied, numbers are processed by casting the supplied value to
-                     <code>xs:double</code>.
                   </fos:value>
                </fos:values>
             </fos:option>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21969,7 +21969,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   option is present with the value <code>true</code>.
                </fos:meaning>
                <fos:type>(function(xs:untypedAtomic) as item()?)?</fos:type>
-               <fos:default>fn { "&amp;#xFFFD;" }</fos:default>
+               <fos:default>fn { char('#xFFFD') }</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function"
                         >
@@ -23665,7 +23665,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   option is present with the value <code>true</code>.
                </fos:meaning>
                <fos:type>(function(xs:untypedAtomic) as item()?)?</fos:type>
-               <fos:default>fn { "&amp;#xFFFD;" }</fos:default>
+               <fos:default>fn { char('#xFFFD') }</fos:default>
                <fos:values>
                   <fos:value value="User-supplied function"
                         >


### PR DESCRIPTION
Issue: #973.

In addition, I fixed the description for the `fallback` option `fn:parse-json`, as it seemed incomplete to me: 

> The function is called when the JSON input contains a special character (as defined under the escape option) that is valid according to the JSON grammar, whether the special character is represented in the input directly or as an escape sequence. 
