### PR TITLE
911 Coercion to allow double to decimal etc

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6954,8 +6954,11 @@ declare function t:flatten($tree as t:tree) as item()* {
                                     </thead>
                                     <tbody>
                                        <tr><td><code>xs:decimal</code></td><td><code>xs:double</code></td></tr>
+                                       <tr><td><code>xs:double</code></td><td><code>xs:decimal</code></td></tr>
                                        <tr><td><code>xs:decimal</code></td><td><code>xs:float</code></td></tr>
+                                       <tr><td><code>xs:float</code></td><td><code>xs:decimal</code></td></tr>
                                        <tr><td><code>xs:float</code></td><td><code>xs:double</code></td></tr>
+                                       <tr><td><code>xs:double</code></td><td><code>xs:float</code></td></tr>
                                        <tr><td><code>xs:string</code></td><td><code>xs:anyURI</code></td></tr>
                                        <tr><td><code>xs:anyURI</code></td><td><code>xs:string</code></td></tr>
                                        <tr><td><code>xs:hexBinary</code></td><td><code>xs:base64Binary</code></td></tr>
@@ -6966,8 +6969,12 @@ declare function t:flatten($tree as t:tree) as item()* {
                                  
                                  <note><p>The item type in the <var>to</var> column must match <var>R</var>
                                     exactly; however, <var>A</var> may belong to a subtype of the type in the <var>from</var>
-                                    column. For example, an <code>xs:NCName</code> will be cast to type <code>xs:anyURI</code>,
-                                    but an <code>xs:anyURI</code> will not be cast to type <code>xs:NCName</code>.</p></note>
+                                    column.</p>
+                                    <p>For example, an <code>xs:NCName</code> will be cast to type <code>xs:anyURI</code>,
+                                    but an <code>xs:anyURI</code> will not be cast to type <code>xs:NCName</code>.</p>
+                                    <p>Similarly, an <code>xs:integer</code> will be cast to type <code>xs:double</code>,
+                                    but an <code>xs:double</code> will not be cast to type <code>xs:integer</code>.</p>
+                                 </note>
                                  
                               </item>
                               <item><p>If <var>R</var> is derived from some primitive atomic type <var>P</var>, 


### PR DESCRIPTION
Fix #911 The coercion rules are changed to allow implicit casts among numeric types, for example a double can be supplied where the required type is decimal. (The term "promotion" is now used only for operators, where the two operands must be converted to a common type.)

