### PR TITLE
888, 963: Error handling for unsatisfied context dependencies

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -132,8 +132,8 @@
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/>.</p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/>.</p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -231,8 +231,8 @@
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -291,12 +291,13 @@
 
       </fos:rules>
       <fos:errors>
+
          <p>The following errors may be raised when <code>$value</code> is omitted:</p>
          <ulist>
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
+                  type error <xerrorref spec="XP"
                      class="DY" code="0002" type="dynamic"/>.</p>
             </item>
             <item>
@@ -404,7 +405,7 @@
                /> if an item in
             the sequence <code>$input</code> is a function item other than
                an array. </p>
-         <p>A dynamic error is raised <xerrorref spec="XP" class="DY" code="0002" type="dynamic"/>
+         <p>A type error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"/>
             if <code>$input</code> is omitted and the context value is
                <xtermref ref="dt-absent" spec="DM40">absent</xtermref>.</p>
       </fos:errors>
@@ -504,8 +505,8 @@
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -552,8 +553,8 @@
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -4388,7 +4389,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       </fos:rules>
       <fos:errors>
          <p>If <code>$value</code> is not specified and the context value is <xtermref ref="dt-absent"
-               spec="DM40">absent</xtermref>, a dynamic error is raised: <xerrorref spec="XP"
+               spec="DM40">absent</xtermref>, a type error is raised: <xerrorref spec="XP"
                class="DY" code="0002" type="dynamic"/>.</p>
          <p>As a consequence of the rules given above, a type error is raised 
            <xerrorref spec="XP" class="TY" code="0004" type="type"/> if the context value
@@ -4470,9 +4471,10 @@ return normalize-unicode(concat($v1, $v2))</eg>
             (calculated using <code>fn:string</code>) of the context value (<code>.</code>). </p>
       </fos:rules>
       <fos:errors>
+
          <p>If no argument is supplied and the context value is
-            <xtermref ref="dt-absent" spec="DM40">absent</xtermref>, a dynamic error is raised
-            <xerrorref spec="XP" class="DY" code="0002" type="dynamic"/>.</p>
+            <xtermref ref="dt-absent" spec="DM40">absent</xtermref>, a type error is raised
+            <xerrorref spec="XP" class="DY" code="0002" type="type"/>.</p>
          <p>As a consequence of the rules given above, a type error is raised 
            <xerrorref spec="XP" class="TY" code="0004" type="type"/> if the context value
             cannot be atomized, or if the result of atomizing the context value is a sequence
@@ -11463,8 +11465,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -11563,8 +11565,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -11657,8 +11659,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -11742,7 +11744,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             fails, the <code>xs:double</code> value <code>NaN</code> is returned.</p>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised <xerrorref spec="XP" class="DY" code="0002" type="dynamic"
+         <p>A type error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"
                />
             if <code>$value</code> is omitted and the context value is <xtermref
                ref="dt-absent" spec="DM40">absent</xtermref>.</p>
@@ -11868,8 +11870,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -12012,8 +12014,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -12119,8 +12121,8 @@ Himmlische, dein Heiligtum.</p>}]]>
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -12217,8 +12219,8 @@ let $newi := $o/tool</eg>
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -15812,8 +15814,8 @@ else $c[1] + sum(subsequence($c, 2))</eg>
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -15989,9 +15991,10 @@ else $c[1] + sum(subsequence($c, 2))</eg>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
          <ulist>
             <item>
+
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
-                     >absent</xtermref>, dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                     >absent</xtermref>, type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -16146,8 +16149,8 @@ else $c[1] + sum(subsequence($c, 2))</eg>
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -17038,8 +17041,8 @@ else $c[1] + sum(subsequence($c, 2))</eg>
             <item>
                <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
                      >absent</xtermref>,
-                  dynamic error <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/></p>
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/></p>
             </item>
             <item>
                <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
@@ -18014,7 +18017,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
                ref="id-xp-evaluation-context-components"/>.)</p>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"
+         <p>A type error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"
                /> if
             the context value is <xtermref ref="dt-absent" spec="DM40"
                >absent</xtermref>.</p>
@@ -18038,7 +18041,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
                ref="id-xp-evaluation-context-components"/>.)</p>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"
+         <p>A type error is raised <xerrorref spec="XP" class="DY" code="0002" type="type"
                /> if
             the context <phrase>size</phrase> is <xtermref ref="dt-absent"
                spec="DM40">absent</xtermref>.</p>
@@ -18321,7 +18324,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
          <p diff="add" at="2023-12-12">An error is raised if the identified function depends on
             components of the static or dynamic context that are not present, or that have
             unsuitable values. For example <xerrorref spec="XP"
-               class="DY" code="0002" type="dynamic"/> is raised for the call
+               class="DY" code="0002" type="type"/> is raised for the call
             <code>function-lookup(xs:QName("fn:name"), 0)</code>
             if the context value is absent, and <errorref class="DC" code="0001" type="dynamic"
             /> is raised for the call <code>function-lookup(xs:QName("fn:id"), 1)</code> if the

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -11,12 +11,16 @@
             /></phrase>.</p>
       </error>
 
-      <error spec="XP" code="0002" class="DY" type="dynamic">
-         <p>It is a <termref def="dt-dynamic-error">dynamic error</termref> if evaluation of an
+      <error spec="XP" code="0002" class="DY" type="type">
+         <p>It is a <termref def="dt-type-error">type error</termref> if evaluation of an
             expression relies on some part of the <termref def="dt-dynamic-context">dynamic
-               context</termref> that <phrase diff="del">has not been assigned a
-               value</phrase><phrase diff="add">is <xtermref spec="DM40" ref="dt-absent"
-            /></phrase>.</p>
+               context</termref> that is <xtermref spec="DM40" ref="dt-absent"/>.</p>
+         <note><p>In version 4.0 this has been reclassified as a type error rather than
+         a dynamic error. This change allows a processor to report the error during static
+         analysis where possible; for example if the body of a user-defined
+         function is written as <code>fn($x){@code}</code>.
+         The error code is prefixed <code>XPDY</code> rather than <code>XPTY</code>
+         for backwards compatibility reasons.</p></note>
       </error>
 
       <error spec="XP" code="0003" class="ST" type="static">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1142,12 +1142,18 @@ items that would result from calling the <code>fn:collection</code> function wit
                <termdef id="dt-dynamic-context" term="dynamic context"
                      >The <term>dynamic
 context</term> of an expression is defined as information that is needed for the dynamic evaluation of an expression.</termdef> If
-evaluation of an expression relies on some part of the <termref
-                  def="dt-dynamic-context">dynamic context</termref> that 
-is <xtermref spec="DM40"
-                  ref="dt-absent"/>, a <termref def="dt-dynamic-error"
-                  >dynamic
-error</termref> is raised <errorref class="DY" code="0002"/>.</p>
+evaluation of an expression relies on some part of the <termref def="dt-dynamic-context"/> that 
+is <xtermref spec="DM40" ref="dt-absent"/>, a <termref def="dt-type-error"/> 
+               is raised <errorref class="DY" code="0002"/>.</p>
+            
+            <note><p>In previous versions of the specification, this was classified as a
+            <termref def="dt-dynamic-error"/>. The change allows the error to be raised during
+            static analysis when possible; for example a function written as
+            <code>fn($x){@code}</code> can now be reported as an error whether or not
+            the function is actually evaluated. The actual error code remains unchanged
+            for backwards compatibility reasons.</p>
+            <p>There are other cases where static detection of the error is not possible.</p>
+            </note>
             <p>The individual
 components of the <termref def="dt-dynamic-context"
                   >dynamic
@@ -8031,8 +8037,7 @@ At evaluation time, the value of a variable reference is the value to which the 
             
             <p>If the <termref def="dt-context-value"/> is <xtermref spec="DM40"
                   ref="dt-absent"/>, a context value reference raises a <termref
-                  def="dt-dynamic-error">dynamic error</termref>
-               <errorref class="DY" code="0002"/>.</p>
+                  def="dt-type-error"/> <errorref class="DY" code="0002"/>.</p>
             
             <note><p>Being absent is not the same thing as being empty.</p></note>
          </div3>
@@ -9020,7 +9025,7 @@ return $f(5)]]></eg>
                                  </example>
                                  <example>
                                     <head>Using the Context Value in an Anonymous Function</head>
-                                    <p>The following example will raise a dynamic error <errorref
+                                    <p>The following example will raise a <termref def="dt-type-error"/> <errorref
                                           class="DY" code="0002"/>:</p>
                                     <eg role="parse-test"><![CDATA[
 let $vat := function() { @vat + @price }
@@ -9133,7 +9138,8 @@ return $vat(doc('wares.xml')/shop/article)
                   </item>
                   <item>
                      <p>Explicitly supplied parameters and defaulted parameters are evaluated and 
-                        converted to the required type using the rules for a static function call.</p>
+                        converted to the required type using the rules for a static function call.
+                        This may result in an error being raised.</p>
                      
                      <p diff="add" at="2023-12-12">A type error is raised if any of the explicitly supplied or defaulted
                         parameters, after applying the
@@ -9143,10 +9149,22 @@ return $vat(doc('wares.xml')/shop/article)
                      <p diff="add" at="2023-12-12">In addition, a dynamic error <rfc2119>may</rfc2119> 
                         be raised if any of the explicitly supplied or defaulted parameters does not match other constraints on the
                         value of that parameter (for example, if the value supplied for a parameter expecting
-                        a regular expression is not a valid regular expression).</p>
+                        a regular expression is not a valid regular expression); or if the processor is
+                        able to establish that evaluation of the resulting function will fail
+                        for any other reason (for example, if an error is raised while evaluating 
+                        a subexpression in the function
+                        body that depends only on explicitly supplied and defaulted parameters).</p>
                      
-                     <p diff="add" at="2023-12-12">In both cases the error code is the same as for a static
-                        function call supplying the same invalid value.</p>
+                     <p diff="add" at="2023-12-12">In all cases the error code is the same as for a static
+                        function call supplying the same invalid value(s).</p>
+                     
+                     <p diff="add" at="2024-02-02">In the particular case where all the supplied arguments
+                     are placeholders, the error behavior <rfc2119>should</rfc2119> be the same as
+                     for an equivalent <termref def="dt-named-function-ref"/>: for example, <code>fn:id#1</code>
+                     fails if there is no context node, and <code>fn:id(?)</code> <rfc2119>should</rfc2119>
+                     fail likewise.</p>
+                     
+                     
                      
 
                   </item>
@@ -9272,7 +9290,11 @@ return $sum-of-squares(1 to 3)]]></eg>
                      <p diff="add" at="2023-12-12">In addition, a dynamic error <rfc2119>may</rfc2119> 
                      be raised if any of the supplied parameters does not match other constraints on the
                      value of that parameter (for example, if the value supplied for a parameter expecting
-                     a regular expression is not a valid regular expression).</p>
+                     a regular expression is not a valid regular expression); or if the processor is
+                     able to establish that evaluation of the resulting function will fail
+                     for any other reason (for example, if an error is raised while evaluating 
+                     a subexpression in the function
+                     body that depends only on explicitly supplied parameters).</p>
                      
                      <p diff="add" at="2023-12-12">In both cases the error code is the same as for a dynamic
                      function call supplying the same invalid value.</p>
@@ -9435,9 +9457,9 @@ return $a("A")]]></eg>
             
 
                <p diff="add" at="2023-12-12">An error is raised if the identified function depends on components of the static or dynamic
-                  context that are not present, or that have unsuitable values. For example <xerrorref spec="XP"
-                     class="DY" code="0002" type="dynamic"/> is raised for the expression <code>fn:name#0</code>
-                  if the context item is absent, and <errorref class="DC" code="0001" type="dynamic"
+                  context that are not present, or that have unsuitable values. For example <errorref 
+                     class="DY" code="0002" type="type"/> is raised for the expression <code>fn:name#0</code>
+                  if the context item is absent, and <xerrorref spec="FO" class="DC" code="0001" type="dynamic"
                   /> is raised for the call <code>fn:id#1</code> if the context item is not a node
                   in a tree that is rooted at a document node. The error that is raised is the same as the error that would
                   be raised by the corresponding function if called with the same static and dynamic context.</p>
@@ -19802,8 +19824,8 @@ matching</termref>; otherwise it returns <code>false</code>. For example:</p>
                   <p>This example returns <code>true</code> if the context value is a
                      single element node or <code>false</code> if the context value is defined 
                      but is not a single element node. If the context value is <xtermref
-                        spec="DM40" ref="dt-absent"/>, a <termref def="dt-dynamic-error"
-                        >dynamic error</termref> is raised <errorref class="DY" code="0002"/>.</p>
+                        spec="DM40" ref="dt-absent"/>, a <termref def="dt-type-error"/>
+                        is raised <errorref class="DY" code="0002"/>.</p>
                </item>
             </ulist>
             

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -9957,8 +9957,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      called, the focus within the body of the function is initially <termref def="dt-absent">absent</termref>.</p>
                   <p>When the focus is <termref def="dt-absent">absent</termref>, evaluation of any
                         <termref def="dt-expression">expression</termref> that references the
-                     context item, context position, or context size results in a <termref def="dt-dynamic-error">
-                        dynamic error</termref>
+                     context item, context position, or context size results in a <termref def="dt-type-error"/>
                      <xerrorref spec="XP40" class="DY" code="0002"/></p>
                   <p>The description above gives an outline of the way the <termref def="dt-focus">focus</termref> works. Detailed rules for the effect of each instruction
                      are given separately with the description of that instruction. In the absence
@@ -19023,8 +19022,8 @@ and <code>version="1.0"</code> otherwise.</p>
 
                <p>Within the sequence constructor, the <termref def="dt-focus">focus</termref> is
                   initially <termref def="dt-absent">absent</termref>; this means that any attempt
-                  to reference the context item, context position, or context size is a <termref def="dt-dynamic-error">
-                     dynamic error</termref>. (See <xerrorref spec="XP40" class="DY" code="0002"/>.)</p>
+                  to reference the context item, context position, or context size is a 
+                  <termref def="dt-type-error"/>. (See <xerrorref spec="XP40" class="DY" code="0002"/>.)</p>
 
                <p>It is not possible within the body of the <termref def="dt-stylesheet-function">stylesheet function</termref> to access the values of local variables that
                   were in scope in the place where the function call was written. Global variables,


### PR DESCRIPTION
Fix #963 by providing more detail on the expected error handling for partial function application.

Fix #888 by making XPDY0002 a type error rather than a dynamic error.