### PR TITLE
989 (partial) Allow char() to take integer argument

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27278,7 +27278,7 @@ return every($dl/*, fn($elem, $pos) {
    <fos:function name="char" prefix="fn">
       <fos:signatures>
          <fos:proto name="char" return-type="xs:string">
-            <fos:arg name="value" type="xs:string"/>
+            <fos:arg name="value" type="union(xs:string, xs:positiveInteger)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -27287,13 +27287,15 @@ return every($dl/*, fn($elem, $pos) {
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns a string containing a named character or glyph.</p>
+         <p>Returns a string containing a particular character or glyph.</p>
       </fos:summary>
       <fos:rules>
          <p>The function returns a string, generally containing a single <termref
                def="character">character</termref> or glyph, identified by <code>$value</code>.</p>
          <p>The supplied value of <code>$value</code> must be one of the following:</p>
          <olist>
+            <item><p>A Unicode codepoint, supplied as an integer. For example <code>fn:char(9)</code>
+            returns the tab character.</p></item>
             <item><p>An HTML5 character reference name (often referred to as an entity name) as defined
                at <loc href="https://html.spec.whatwg.org/multipage/named-characters.html">https://html.spec.whatwg.org/multipage/named-characters.html</loc>. The name is
                written with no leading ampersand and no trailing semicolon.
@@ -27348,12 +27350,21 @@ return every($dl/*, fn($elem, $pos) {
                <fos:result>"&#xF0;"</fos:result>
             </fos:test>
             <fos:test>
+               <fos:expression>char(9)</fos:expression>
+               <fos:result>codepoints-to-string(9)</fos:result>
+               <fos:postamble>The character <emph>tab</emph></fos:postamble>
+            </fos:test>
+            <fos:test>
                <fos:expression>char("\t")</fos:expression>
                <fos:result>codepoints-to-string(9)</fos:result>
                <fos:postamble>The character <emph>tab</emph></fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>char("#32")</fos:expression>
+               <fos:result>" "</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>char(0x20)</fos:expression>
                <fos:result>" "</fos:result>
             </fos:test>
             <fos:test>


### PR DESCRIPTION
Addresses the use case in issue #989. (But leave the issue open for now).

Discussion point: should we drop the options `char("#32")` and `char("#x20")` as they now seem redundant?