### PR TITLE
937 revised in light of CG feedback

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4807,10 +4807,15 @@ return normalize-unicode(concat($v1, $v2))</eg>
       </fos:examples>
    </fos:function>
    <fos:function name="hash" prefix="fn" at="2024-01-10" diff="add">
+      <!-- output: hexbinary to string cast for output -->
+      <!-- output: hexbinary preferred -->
+      <!-- provide options map: input, output -->
+      
       <fos:signatures>
-         <fos:proto name="hash" return-type="xs:string">
+         <fos:proto name="hash" return-type="xs:hexBinary?">
             <fos:arg name="value" type="union(xs:string, xs:hexBinary, xs:base64Binary)?"/>
-            <fos:arg name="algorithm" type="xs:string?" default="'md5'"/>
+            <fos:arg name="options" type="map(*)?" default="map{}"/>
+            <!--<fos:arg name="algorithm" type="xs:string?" default="'MD5'"/>-->
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="1">
@@ -4828,42 +4833,50 @@ return normalize-unicode(concat($v1, $v2))</eg>
             cyclic redundancy check function upon the input.</p>
       </fos:summary>
       <fos:rules>
+         <p>The <code>$options</code> argument, if present, defines additional parameters
+            controlling how the process is conducted. The <termref def="option-parameter-conventions"
+               >option parameter conventions</termref> apply.</p>
          <p>If the one-argument version of the function is used, the result is the same as calling
-            the two-argument version, with <code>$algorithm</code> set to "MD5". </p>
-         <p>The effective value of <code>$algorithm</code> is the value of the expression
-            <code>fn:upper-case(fn:normalize-space($algorithm))</code>. </p>
+            the two-argument version, with the default <code>$options</code> settings. </p>
+         <p> </p>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
          <p>If <code>$value</code> is an instance of <code>xs:string</code>, it is converted to a sequence
             of octets on the basis of UTF-8 encoding. If <code>$value</code> is an instance of
                <code>xs:base64Binary</code> or <code>xs:hexBinary</code>, it is converted to a sequence of
             octets. </p>
-         <p>The function returns an <code>xs:string</code> representation of the bytes returned by
-            passing <code>$value</code> as an octet sequence through the specified hash or checksum
-            function. The process is followed even if the input octet sequence is empty. </p>
-         <!-- To be discussed. -->
-         <p>Output is always lowercase.</p>
-         <p>Conforming implementations 
-            <rfc2119>must</rfc2119> support the following:</p>
-         <olist>
-            <item>
-               <p>
-                  <code>MD5</code> and the associated MD5 Message-Digest algorithm defined by
-                     <bibref ref="rfc6151"/> (update to <bibref ref="rfc1321"/>).</p>
-            </item>
-            <item>
-               <p><code>SHA-1</code>, defined by 
-                  <bibref ref="fips180-4"/>. </p>
-            </item>
-            <item>
-               <p><code>SHA-256</code>, defined by 
-                  <bibref ref="fips180-4"/>.</p>
-            </item>
-         </olist>
-         <p>Conforming implementations <rfc2119>may</rfc2119> support other checksum and
-                  hash functions with implementation-defined semantics.</p>
+         <p>The function returns as <code>xs:hexBinary</code> the octets returned by passing
+               <code>$value</code> as an octet sequence through the hash, checksum, or cyclical
+            redundancy check function specified by the options map. The process is followed even if
+            the input octet sequence is empty. </p>
+         <p>The entries that may appear in the <code>$options</code> map are as follows. The detailed rules
+            for the interpretation of each option appear later.</p>
+         
+         <fos:options>
+            <fos:option key="algorithm">
+               <fos:meaning>
+                  <p>Determines the algorithm to be used to calculate a checksum, hash, or cyclic
+                     redundancy check. The effective value is determined by first passing
+                     the value through <code>fn:upper-case(fn:normalize-space())</code>. </p>
+                  <p>Conforming implementations <rfc2119>must</rfc2119> support the following
+                     options and the functions referred to by them:</p>
+                  <ulist>
+                     <item><p><code>MD5</code>: the MD5 Message-Digest algorithm defined by <bibref
+                        ref="rfc6151"/> (update to <bibref ref="rfc1321"/>).</p></item>
+                     <item><p><code>SHA-1</code>: the <code>SHA-1</code> algorithm, defined by <bibref
+                        ref="fips180-4"/>. </p></item>
+                     <item><p><code>SHA-256</code>: the <code>SHA-256</code> algorithm, defined by <bibref
+                        ref="fips180-4"/>. </p></item>
+                  </ulist>
+                  <p>Conforming implementations <rfc2119>may</rfc2119> support other checksum and
+                           hash functions with implementation-defined semantics.</p>
+               </fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>MD5</fos:default>
+            </fos:option>
+         </fos:options>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised ([TODO: error code]) if the effective value of
+         <p>A dynamic error is raised ([TODO: error code]) if the effective value of the option
                <code>$algorithm</code> is not one of the values supported by the implementation.</p>
       </fos:errors>
       <fos:notes>
@@ -4873,42 +4886,45 @@ return normalize-unicode(concat($v1, $v2))</eg>
             relevant.</p>
          <p>Additional security practices, such as salting, may be applied as a preprocessing step,
             or <code>fn:hash()</code> can be incorporated into more complex functions.</p>
+         <p>In most cases, the <code>xs:hexBinary</code> output of the function will be sought in
+            string form. Because of serialization rules, casting to a string renders the hash in
+            uppercase, and the more customary lowercase requires further adjustment.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="doc" id="v-hash-doc"><![CDATA[<doc>abc</doc>]]></fos:variable>
          <fos:variable name="salt" id="v-hash-salt" select="&quot;D;%yL9TS:5PalS/d&quot;"/>
          <fos:example>
             <fos:test>
-               <fos:expression>hash("abc")</fos:expression>
-               <fos:result>"900150983cd24fb0d6963f7d28e17f72"</fos:result>
+               <fos:expression>hash("abc") => string()</fos:expression>
+               <fos:result>"900150983CD24FB0D6963F7D28E17F72"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>hash("ABC")</fos:expression>
+               <fos:expression>hash("ABC") => string() => lower-case()</fos:expression>
                <fos:result>"902fbdd2b1df0c4f70b4a5d23525e932"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>hash("")</fos:expression>
+               <fos:expression>hash("") => string() => lower-case()</fos:expression>
                <fos:result>"d41d8cd98f00b204e9800998ecf8427e"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>hash("ABC", "SHA-1")</fos:expression>
+               <fos:expression>hash("ABC", map{"algorithm": "SHA-1"}) => string() => lower-case()</fos:expression>
                <fos:result>"3c01bdbb26f358bab27f267924aa2c9a03fcfdb8"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>hash("ABC", "sha-256")</fos:expression>
+               <fos:expression>hash("ABC", map{"algorithm": "sha-256")} => string() => lower-case()</fos:expression>
                <fos:result>"b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78"</fos:result>
             </fos:test>
             <fos:test use="v-hash-doc">
-               <fos:expression>hash($doc)</fos:expression>
+               <fos:expression>hash($doc) => string() => lower-case()</fos:expression>
                <fos:result>"900150983cd24fb0d6963f7d28e17f72"</fos:result>
             </fos:test>
             <fos:test use="v-hash-doc">
-               <fos:expression>hash(serialize($doc), "sha-1")</fos:expression>
-               <fos:result>"f0fccddbc36dc50bf9465c50e7fc3a0dc9eba445"</fos:result>
+               <fos:expression>hash(serialize($doc), map{"algorithm": "sha-1"}) => xs:base64Binary() => string()</fos:expression>
+               <fos:result>"nJuRPrG2JU9HN86Ufv0W8W6Rb51u5cEQKiAC5I1MiL0="</fos:result>
             </fos:test>
             <fos:test use="v-hash-salt">
-               <fos:expression>hash("password123" || $salt, "SHA-256")</fos:expression>
-               <fos:result>"9c9b913eb1b6254f4737ce947efd16f16e916f9d6ee5c1102a2002e48d4c88bd"</fos:result>
+               <fos:expression>hash("password123" || $salt, map{"algorithm": "SHA-256"}) => string()</fos:expression>
+               <fos:result>"9C9B913EB1B6254F4737CE947EFD16F16E916F9D6EE5C1102A2002E48D4C88BD"</fos:result>
             </fos:test>
             <!--<fos:test>
                <fos:expression>hash("password123" || $salt, "sha-1234567")</fos:expression>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4807,10 +4807,6 @@ return normalize-unicode(concat($v1, $v2))</eg>
       </fos:examples>
    </fos:function>
    <fos:function name="hash" prefix="fn" at="2024-01-10" diff="add">
-      <!-- output: hexbinary to string cast for output -->
-      <!-- output: hexbinary preferred -->
-      <!-- provide options map: input, output -->
-      
       <fos:signatures>
          <fos:proto name="hash" return-type="xs:hexBinary?">
             <fos:arg name="value" type="union(xs:string, xs:hexBinary, xs:base64Binary)?"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4873,7 +4873,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised ([TODO: error code]) if the effective value of the option
-               <code>$algorithm</code> is not one of the values supported by the implementation.</p>
+               <code>algorithm</code> is not one of the values supported by the implementation.</p>
       </fos:errors>
       <fos:notes>
          <p>It is common for secure algorithms to be cryptographically broken, as has happened to
@@ -4884,42 +4884,67 @@ return normalize-unicode(concat($v1, $v2))</eg>
             or <code>fn:hash()</code> can be incorporated into more complex functions.</p>
          <p>In most cases, the <code>xs:hexBinary</code> output of the function will be sought in
             string form. Because of serialization rules, casting to a string renders the hash in
-            uppercase, and the more customary lowercase requires further adjustment.</p>
+            uppercase, and rendering in lowercase (as adopted by <bibref ref="rfc1321"/> and 
+            <bibref ref="fips180-4"/>) requires further adjustment.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="doc" id="v-hash-doc"><![CDATA[<doc>abc</doc>]]></fos:variable>
          <fos:variable name="salt" id="v-hash-salt" select="&quot;D;%yL9TS:5PalS/d&quot;"/>
          <fos:example>
             <fos:test>
-               <fos:expression>hash("abc") => string()</fos:expression>
+               <fos:expression>hash("abc") 
+=> string()</fos:expression>
                <fos:result>"900150983CD24FB0D6963F7D28E17F72"</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
             <fos:test>
-               <fos:expression>hash("ABC") => string() => lower-case()</fos:expression>
+               <fos:expression>hash("ABC") 
+=> string() 
+=> lower-case()</fos:expression>
                <fos:result>"902fbdd2b1df0c4f70b4a5d23525e932"</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
             <fos:test>
-               <fos:expression>hash("") => string() => lower-case()</fos:expression>
-               <fos:result>"d41d8cd98f00b204e9800998ecf8427e"</fos:result>
+               <fos:expression>hash("") 
+=> string()</fos:expression>
+               <fos:result>"D41D8CD98F00B204E9800998ECF8427Eo"</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
             <fos:test>
-               <fos:expression>hash("ABC", map{"algorithm": "SHA-1"}) => string() => lower-case()</fos:expression>
-               <fos:result>"3c01bdbb26f358bab27f267924aa2c9a03fcfdb8"</fos:result>
+               <fos:expression>hash("ABC", map{"algorithm": "SHA-1"}) 
+=> string()</fos:expression>
+               <fos:result>"3C01BDBB26F358BAB27F267924AA2C9A03FCFDB8"</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
             <fos:test>
-               <fos:expression>hash("ABC", map{"algorithm": "sha-256")} => string() => lower-case()</fos:expression>
-               <fos:result>"b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78"</fos:result>
+               <fos:expression>hash("ABC", map{"algorithm": "sha-256")} 
+=> string()</fos:expression>
+               <fos:result>"B5D4045C3F466FA91FE2CC6ABE79232A1A57CDF104F7A26E716E0A1E2789DF78"</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
             <fos:test use="v-hash-doc">
-               <fos:expression>hash($doc) => string() => lower-case()</fos:expression>
-               <fos:result>"900150983cd24fb0d6963f7d28e17f72"</fos:result>
+               <fos:expression>hash($doc) 
+=> string()</fos:expression>
+               <fos:result>"900150983CD24FB0D6963F7D28E17F72"</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
             <fos:test use="v-hash-doc">
-               <fos:expression>hash(serialize($doc), map{"algorithm": "sha-1"}) => xs:base64Binary() => string()</fos:expression>
+               <fos:expression>hash(serialize($doc), map{"algorithm": "sha-1"}) 
+=> xs:base64Binary()                  
+=> string()</fos:expression>
                <fos:result>"nJuRPrG2JU9HN86Ufv0W8W6Rb51u5cEQKiAC5I1MiL0="</fos:result>
             </fos:test>
+         </fos:example>
+         <fos:example>
             <fos:test use="v-hash-salt">
-               <fos:expression>hash("password123" || $salt, map{"algorithm": "SHA-256"}) => string()</fos:expression>
+               <fos:expression>hash("password123" || $salt, map{"algorithm": "SHA-256"}) 
+=> string()</fos:expression>
                <fos:result>"9C9B913EB1B6254F4737CE947EFD16F16E916F9D6EE5C1102A2002E48D4C88BD"</fos:result>
             </fos:test>
             <!--<fos:test>


### PR DESCRIPTION
This revises #937 (catalyzed by #779) in light CG discussion that approved the PR.

* Output is now `xs:hexBinary?`
* Second parameter `$algorithm` replaced with an option map. In the specs I avoided `fos:values/fos:value`, because this would disallow for case/space normalization, and it would effectively disallow any implement-defined algorithms not on the list of three algorithms, and trigger the dynamic error described in rule 6 in the [option parameter conventions](https://qt4cg.org/specifications/xpath-functions-40/Overview.html#option-parameter-conventions).
* Options map has only one option. It doesn't make sense to provide an option changing the kind of output.
* I think this is the first example of an options map where the `fos:meaning` has rich text (paragraphs, unordered lists). It builds and renders fine locally.
* Extra note on the output format.
* Examples are expressed as chained functions, to illustrate how to get the customary string values.