### PR TITLE
919 Use EBV in boolean callbacks

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18599,7 +18599,7 @@ return $action($item, $pos)
       <fos:signatures>
          <fos:proto name="filter" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="predicate" type="function(item(), xs:integer) as xs:boolean" usage="inspection"/>
+            <fos:arg name="predicate" type="function(item(), xs:integer) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -18623,20 +18623,23 @@ return $item
       </fos:rules>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error
-            occurs if the supplied <code>$predicate</code> function returns anything other than a single
-               <code>xs:boolean</code> item; there is no conversion to an effective boolean
+            <errorref class="RG" code="0006"/> 
+            occurs if the result of the supplied <code>$predicate</code> function has no effective boolean
             value.</p>
+         
       </fos:errors>
       <fos:notes>
          <p>If <code>$predicate</code> is an arity-1 function,
             the function call <code>fn:filter($input, $predicate)</code> has a very similar effect to the
             expression <code>$input[$predicate(.)]</code>. There are some differences, however. In the case of
-               <code>fn:filter</code>, the function <code>$F</code> is required to return a boolean;
-            there is no special treatment for numeric predicate values, and no conversion to an
-            effective boolean value. Also, with a filter expression <code>$input[$predicate(.)]</code>,
+               <code>fn:filter</code>, the the effective boolean value of the result of
+            function <code>$F</code> is always used;
+            there is no special treatment for numeric predicate values. 
+            Also, with a filter expression <code>$input[$predicate(.)]</code>,
             the focus within the predicate is different from that outside; this means that the use of a
             context-sensitive function such as <code>fn:lang#1</code> will give different results in
             the two cases.</p>
+         <p>In version 3.1 and earlier, the function was required to return a boolean value.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -18653,6 +18656,18 @@ return $item
          </fos:example>
          <fos:example>
             <fos:test>
+               <fos:expression>filter("cat", "dog", " ", "mouse", normalize-space#1)</fos:expression>
+               <fos:result>("cat", "dog", "mouse")</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>filter(parse-xml(, lang("en", ?))</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
                <fos:expression><eg>let $sequence := (1, 1, 2, 3, 4, 4, 5)
 return filter(
   $sequence,
@@ -18663,7 +18678,8 @@ return filter(
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Changed in 4.0: Positional parameter added to predicate function.</fos:version>
+         <fos:version version="4.0">Changed in 4.0: Positional parameter added to predicate function; 
+            effective boolean value of predicate result is now used.</fos:version>
       </fos:history>
    </fos:function>
    <fos:function name="fold-left" prefix="fn">
@@ -19324,7 +19340,7 @@ chain((1, 2, 3, 4), $product3)
       <fos:signatures>
          <fos:proto name="while-do" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="function(item()*, xs:integer) as xs:boolean" example="false#0"/>
+            <fos:arg name="predicate" type="function(item()*, xs:integer) as item()*" example="false#0"/>
             <fos:arg name="action" type="function(item()*, xs:integer) as item()*"/>
          </fos:proto>
       </fos:signatures>
@@ -19345,7 +19361,8 @@ chain((1, 2, 3, 4), $product3)
                <p><code>$pos</code> is initially set to <code>1</code>.</p>
             </item>
             <item>
-               <p><code>$predicate($input, $pos)</code> is evaluated. If the result is
+               <p><code>$predicate($input, $pos)</code> is evaluated. If the 
+                  effective boolean value of the result is
                   <code>false</code>, the function returns the value of <code>$input</code>.</p>
             </item>
             <item>
@@ -19369,7 +19386,7 @@ declare %private function while-do-helper(
 
 declare function while-do(
   $input     as item()*,
-  $predicate as function(item()*, xs:integer) as xs:boolean,
+  $predicate as function(item()*, xs:integer) as item()*,
   $action    as function(item()*, xs:integer) as item()*
 ) as item()* {
   while-do-helper($input, $predicate, $action, 1)
@@ -19473,7 +19490,7 @@ return $result?numbers
          <fos:proto name="do-until" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="action" type="function(item()*, xs:integer) as item()*"/>
-            <fos:arg name="predicate" type="function(item()*, xs:integer) as xs:boolean"/>
+            <fos:arg name="predicate" type="function(item()*, xs:integer) as item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -19497,9 +19514,10 @@ return $result?numbers
                   is used as a new <code>$input</code>.</p>
             </item>
             <item>
-               <p><code>$predicate($input, $pos)</code> is evaluated. If the result is
+               <p><code>$predicate($input, $pos)</code> is evaluated. If the 
+                  effective boolean value of the result is
                   <code>true</code>, the function returns the value of <code>$input</code>.
-                  Otherwise , the process repeats from step 2 with <code>$pos</code> incremented by
+                  Otherwise, the process repeats from step 2 with <code>$pos</code> incremented by
                   <code>1</code>.</p>
             </item>
          </olist>
@@ -19508,7 +19526,7 @@ return $result?numbers
 declare %private function do-until-helper(
   $input     as item()*,
   $action    as function(item()*, xs:integer) as item()*,
-  $predicate as function(item()*, xs:integer) as xs:boolean,
+  $predicate as function(item()*, xs:integer) as item()*,
   $pos       as xs:integer
 ) as item()* {
   let $result := $action($input, $pos)
@@ -19522,7 +19540,7 @@ declare %private function do-until-helper(
 declare function do-until(
   $input     as item()*,
   $action    as function(item()*, xs:integer) as item()*,
-  $predicate as function(item()*, xs:integer) as xs:boolean
+  $predicate as function(item()*, xs:integer) as item()*
 ) as item()* {
   do-until-helper($input, $action, $predicate, 1)
 };]]></eg>
@@ -21818,7 +21836,7 @@ return <box>{
       <fos:signatures>
          <fos:proto name="filter" return-type="map(*)">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
-            <fos:arg name="predicate" type="function(xs:anyAtomicType, item()*) as map(*)"
+            <fos:arg name="predicate" type="function(xs:anyAtomicType, item()*) as item(*)"
                usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -21834,7 +21852,8 @@ return <box>{
          <p>The function <code>map:filter</code> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map; the result is a new map containing those entries for which
-            the function returns <code>true</code>.</p>
+            the effective boolean value of the result of the <code>$predicate</code> 
+            function is <code>true</code>.</p>
 
          <p>The function supplied as <code>$predicate</code> takes two arguments. It is called
             supplying the key of the map entry as the first argument, and the associated value as
@@ -21862,13 +21881,26 @@ return <box>{
 )</eg></fos:expression>
                <fos:result><eg>map{1:"Sunday", 7:"Saturday"}</eg></fos:result>
             </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:filter(
+                  map {1: 1, 2: 2, 3: 10, 4: 4 },
+                  function($k, $v) { $k ne $v }
+                  )</eg></fos:expression>
+               <fos:result><eg>map{3: 10}</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:filter(
+                  map {1:"a", 2:"b", 3:"", 4:"   "},
+                  function($k, $v) { normalize-space($v) }
+                  )</eg></fos:expression>
+               <fos:result><eg>map{1:"a", 2:"b"}</eg></fos:result>
+            </fos:test>
 
          </fos:example>
 
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0.
-            Discussed 2022-09-20; decided to defer acceptance pending ideas for alignment with <code>array:filter</code>.</fos:version>
+         <fos:version version="4.0">Accepted for 4.0.</fos:version>
       </fos:history>
    </fos:function>
 
@@ -25292,7 +25324,7 @@ array:index-of(
       <fos:signatures>
          <fos:proto name="index-where" return-type="xs:integer*">
             <fos:arg name="array" type="array(*)"/>
-            <fos:arg name="predicate" type="function(item()*, xs:integer) as xs:boolean"/>
+            <fos:arg name="predicate" type="function(item()*, xs:integer) as item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25306,10 +25338,11 @@ array:index-of(
       <fos:rules>
          
          <p>The result of the function is a sequence of integers, in monotonic ascending order, representing
-            the 1-based positions in the input array of those members for which the supplied predicate function
-            returns <code>true</code>.</p>
+            the 1-based positions in the input array of those members for which the effective boolean
+            value of the result of the supplied predicate function is <code>true</code>.</p>
          <p>More formally, the function returns the result of the expression:</p>
-         <eg>index-of($input => array:for-each($predicate) => array:values(), true())</eg>
+         <eg>let $ebv := fn($it, $pos){boolean($predicate($it, $pos))} 
+return index-of($input => array:for-each($ebv) => array:values(), true())</eg>
       </fos:rules>
       
       <fos:examples>
@@ -25344,6 +25377,13 @@ array:index-of(
   function($m) { count($m) = 3 }
 )</eg></fos:expression>
                <fos:result>(1, 2)</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>array:index-where(
+                  [(""), ("", "x"), (), ("", "")],
+                  string-join#1
+                  )</eg></fos:expression>
+               <fos:result>2</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[array:index-where(
@@ -25891,7 +25931,7 @@ return [ $action($member, $pos) ]
       <fos:signatures>
          <fos:proto name="filter" return-type="array(*)">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
-            <fos:arg name="predicate" type="function(item()*, xs:integer) as xs:boolean" usage="inspection"/>
+            <fos:arg name="predicate" type="function(item()*, xs:integer) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25902,11 +25942,11 @@ return [ $action($member, $pos) ]
       </fos:properties>
       <fos:summary>
          <p>Returns an array containing those members of the <code>$array</code> for which 
-            <code>$predicate</code> returns <code>true</code>.</p>
+            <code>$predicate</code> is <code>true</code>.</p>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function returns an array containing those members of the input
-         array that satisfy the supplied predicate.</p>
+         array for which the effective boolean value of the result of the supplied predicate is true.</p>
          <p>More formally, the function returns the result of the expression:</p>
          <eg><![CDATA[
 array:of-members(
@@ -25916,9 +25956,10 @@ array:of-members(
 )]]></eg>
       </fos:rules>
       <fos:errors>
-         <p>As a consequence of the function signature and the function calling rules, a type error occurs if the supplied
-            function <code>$function</code> returns anything other than a single <code>xs:boolean</code> item; there is no conversion 
-            to an effective boolean value.</p>
+         <p>As a consequence of the function signature and the function calling rules, a type error
+            <errorref class="RG" code="0006"/> 
+            occurs if the result of the supplied <code>$predicate</code> function has no effective boolean
+            value.</p>
       </fos:errors>
       <fos:examples>
          <fos:example>
@@ -25937,8 +25978,12 @@ array:of-members(
                <fos:result>["the cat", "on the mat"]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:filter(["A", "B", "", 0, 1], boolean#1)</fos:expression>
+               <fos:expression>array:filter(["A", (), "B", "", 0, 1], boolean#1)</fos:expression>
                <fos:result>["A", "B", 1]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>array:filter(["A", "B", "", " "], normalize-space#1)</fos:expression>
+               <fos:result>["A", "B"]</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -25954,7 +25999,8 @@ return array:filter(
       </fos:examples>
       <fos:history>
          <fos:version version="3.1">First introduced in 3.1.</fos:version>
-         <fos:version version="4.0">Changed in 4.0: Positional parameter added to predicate function; the specification has been formalized.</fos:version>
+         <fos:version version="4.0">Changed in 4.0: Positional parameter added to predicate function; 
+            the specification has been formalized; the effective boolean value of the predicate is used.</fos:version>
       </fos:history>
    </fos:function>
 
@@ -27779,7 +27825,7 @@ r:random-sequence(200);
       <fos:signatures>
          <fos:proto name="every" return-type="xs:boolean">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="(function(item(), xs:integer) as xs:boolean)?"
+            <fos:arg name="predicate" type="(function(item(), xs:integer) as item()*)?"
                default="fn:identity#1" example="fn:boolean#1"/>
          </fos:proto>
       </fos:signatures>
@@ -27797,15 +27843,16 @@ r:random-sequence(200);
 every $boolean in (
   for $item at $pos in $input
   return $predicate($item, $pos)
-) satisfies $boolean = true()
+) satisfies boolean($boolean)
 ]]></eg>
 
       </fos:rules>
       <fos:notes>
          <p>If the second argument is omitted or an empty sequence, the first argument must be
             a sequence of <code>xs:boolean</code> values.</p>
-         <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for which the predicate
-            returns <code>false</code>; it is not required to evaluate the predicate for every item.</p>
+         <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for 
+            which the effective boolean value of the predicate is <code>false</code>; 
+            it is not required to evaluate the predicate for every item.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -27824,6 +27871,14 @@ every $boolean in (
             <fos:test>
                <fos:expression>every((1, 3, 7), function { . mod 2 = 1 })</fos:expression>
                <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>every(1 to 10)</fos:expression>
+               <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>every(0 to 10)</fos:expression>
+               <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>every(-5 to +5, function { . ge 0 })</fos:expression>
@@ -27848,6 +27903,10 @@ every $boolean in (
             <fos:test>
                <fos:expression>every(1 to 5, fn($num, $pos) { $num = $pos })</fos:expression>
                <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>every(("a", "b", ""), normalize-space#1)</fos:expression>
+               <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[
@@ -28169,7 +28228,7 @@ function($item) {
       <fos:signatures>
          <fos:proto name="index-where" return-type="xs:integer*">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="function(item(), xs:integer) as xs:boolean"/>
+            <fos:arg name="predicate" type="function(item(), xs:integer) as item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -28183,8 +28242,9 @@ function($item) {
       <fos:rules>
 
          <p>The result of the function is a sequence of integers, in monotonic ascending order, representing
-            the 1-based positions in the input sequence of those items for which the supplied predicate function
-            returns <code>true</code>.</p>
+            the 1-based positions in the input sequence of those items for which the 
+            effective boolean value of the result of calling the supplied predicate function
+            is <code>true</code>.</p>
          <p>More formally, the function is equivalent to the following expression in XQuery:</p>
          <eg>
 for $item at $pos in $input
@@ -28214,6 +28274,12 @@ return $pos</eg>
   contains(?, "r")
 )</eg></fos:expression>
                <fos:result>(1, 2, 3, 4, 9, 10, 11, 12)</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[index-where(
+  parse-xml("<doc><a/><b/><b/></doc>")/doc/*, 
+  fn{self::b})]]></eg></fos:expression>
+               <fos:result>(2, 3)</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[index-where(
@@ -28478,7 +28544,9 @@ return $it
          <fos:version version="4.0">New in 4.0. See issue 1002</fos:version>
       </fos:history>
 
+
    </fos:function>
+
    <!--<fos:function name="subsequence-starting-where">
       <fos:signatures>
          <fos:proto name="subsequence-starting-where" return-type="item()*">
@@ -28544,7 +28612,9 @@ head(index-where($input, $predicate)) ! subsequence($input, .)
       </fos:history>
 
 
-   </fos:function>-->
+
+   </fos:function>
+-->
 
    <!--<fos:function name="subsequence-ending-where">
       <fos:signatures>
@@ -28750,7 +28820,7 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
       <fos:signatures>
          <fos:proto name="some" return-type="xs:boolean">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="(function(item(), xs:integer) as xs:boolean)?"
+            <fos:arg name="predicate" type="(function(item(), xs:integer) as item()*)?"
                default="fn:identity#1" example="fn:boolean#1"/>
          </fos:proto>
       </fos:signatures>
@@ -28768,14 +28838,15 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
 some $boolean in (
   for $item at $pos in $input
   return $predicate($item, $pos)
-) satisfies $boolean = true()
+) satisfies boolean($boolean)
 ]]></eg>
       </fos:rules>
       <fos:notes>
          <p>If the second argument is omitted or an empty sequence, the first argument must be
-            a sequence of <code>xs:boolean</code> values.</p>
-         <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for which the predicate
-         returns <code>true</code>; it is not required to evaluate the predicate for every item.</p>
+            a sequence of items each having an effective boolean value.</p>
+         <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for 
+            which the effective boolean value of the result of calling the predicate
+         is <code>true</code>; it is not required to evaluate the predicate for every item.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -28790,6 +28861,10 @@ some $boolean in (
             <fos:test>
                <fos:expression>some((), boolean#1)</fos:expression>
                <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>some((0, 1, 2, 3))</fos:expression>
+               <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>some((1, 3, 7), function {. mod 2 = 1 })</fos:expression>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -6804,7 +6804,7 @@ Tak, tak, tak! - da kommen sie.
          <p>Computes the effective boolean value of the sequence <code>$input</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function computes the effective boolean value of a sequence, defined according to
+         <p>The function computes the <termref def="dt-effective-boolean-value"/> of a sequence, defined according to
             the following rules. See also <xspecref
                spec="XP31" ref="id-ebv"/>.</p>
          <ulist>
@@ -6834,6 +6834,11 @@ Tak, tak, tak! - da kommen sie.
                   returns <code>true</code>.</p>
             </item>
          </ulist>
+         <p><termdef id="dt-effective-boolean-value" term="effective boolean value">The <term>effective boolean value</term>
+            of a value <var>V</var> is defined to be the result of applying the <code>fn:boolean</code>
+            function to <var>V</var>.</termdef></p>
+         
+
       </fos:rules>
       <fos:errors>
          <p>In all cases other than those listed above, <code>fn:boolean</code> raises a type error <errorref
@@ -6892,11 +6897,15 @@ Tak, tak, tak! - da kommen sie.
                <code>false</code>, or <code>false</code> if it is <code>true</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The value of <code>$input</code> is first reduced to an effective boolean value by
+         <p>The value of <code>$input</code> is first reduced to an <termref def="dt-effective-boolean-value"/> by
             applying the <code>fn:boolean()</code> function. The function returns <code>true</code>
             if the effective boolean value is <code>false</code>, or <code>false</code> if the
             effective boolean value is <code>true</code>. </p>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> if the argument
+            has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -12414,8 +12423,9 @@ let $newi := $o/tool</eg>
             <code>$input</code> matches <code>$search</code>, then the function returns the empty
             sequence.</p>
          <p>No error occurs if non-comparable values are encountered. So when comparing two atomic
-            values, the effective boolean value of <code>fn:index-of($a, $b)</code> is <code>true</code> if
-               <code>$a</code> and <code>$b</code> are equal, <code>false</code> if they are not equal or not
+            values <code>$a</code> and <code>$b</code>, the <termref def="dt-effective-boolean-value"/> of
+            <code>fn:index-of($a, $b)</code> is <code>true</code> (<code>xs:integer(1))</code> if
+               <code>$a</code> and <code>$b</code> are equal, <code>false</code> (empty sequence) if they are not equal or not
             comparable.</p>
       </fos:notes>
       <fos:examples>
@@ -13452,8 +13462,8 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       <fos:signatures>
          <fos:proto name="subsequence-where" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="transmission"/>
-            <fos:arg name="from" type="(function(item(), xs:integer) as xs:boolean)?" default="true#0"/>
-            <fos:arg name="to" type="(function(item(), xs:integer) as xs:boolean)?" default="false#0"/>
+            <fos:arg name="from" type="(function(item(), xs:integer) as item()*)?" default="true#0"/>
+            <fos:arg name="to" type="(function(item(), xs:integer) as item()*)?" default="false#0"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -13487,6 +13497,10 @@ return slice($input, $start, $end)</eg>
          
          
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> if either callback function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>The result includes both the item that matches the <code>$from</code> condition
          and the item that matches the <code>$to</code> condition. To select a subsequence that
@@ -13502,6 +13516,9 @@ return slice($input, $start, $end)</eg>
          relative to the start position. If this is needed, the function can be combined with others:
          for example, to select a subsequence of four items starting with <code>"Barbara"</code>,
          use <code>$input => subsequence-where(fn{. eq "Barbara"}) => slice(end:=4)</code>.</p>
+         
+         <p>The predicate functions are not required to return <code>xs:boolean</code> values;
+         the <termref def="dt-effective-boolean-value"/> of the result is used.</p>
          
          <p>If the requirement is to select all elements stopping before the first <code>h2</code>
             element if it exists, or up to the end of the sequence otherwise, the simplest
@@ -13828,7 +13845,7 @@ return slice($input, $start, $end)</eg>
          <fos:proto name="starts-with-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
-            <fos:arg name="compare" type="(function(item(), item()) as xs:boolean)?" default="fn:deep-equal#2"/>
+            <fos:arg name="compare" type="(function(item(), item()) as item()*)?" default="fn:deep-equal#2"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -13852,10 +13869,16 @@ return slice($input, $start, $end)</eg>
 count($input) ge count($subsequence) and
 every(for-each-pair($input, $subsequence, $compare))]]></eg>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> if the <code>$compare</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
             of equality comparison. The result is well-defined, for example, even if <code>$compare</code> is not transitive
          or not symmetric.</p>
+         <p>The <code>$compare</code> function is not required to return an <code>xs:boolean</code> value:
+            the <termref def="dt-effective-boolean-value"/> of the result is used.</p>
       </fos:notes>
 
       <fos:examples>
@@ -13932,6 +13955,16 @@ return starts-with-subsequence(
                <fos:result>true()</fos:result>
                <fos:postamble>True because the first three items in the input sequence end with <code>"a"</code>.</fos:postamble>
             </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[starts-with-subsequence(
+                  parse-xml("<doc><h1/><h1/><p/><p/></doc>")/doc/*,
+                  1 to 2,
+                  fn{self::h1}
+              )]]></eg></fos:expression>
+               <fos:result>true()</fos:result>
+               <fos:postamble>True because the first two items in the input sequence are <code>h1</code>
+                  elements: note that the <termref def="dt-effective-boolean-value"/> of the function result is used.</fos:postamble>
+            </fos:test>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -13944,7 +13977,7 @@ return starts-with-subsequence(
          <fos:proto name="ends-with-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
-            <fos:arg name="compare" type="(function(item(), item()) as xs:boolean)?" default="fn:deep-equal#2"/>
+            <fos:arg name="compare" type="(function(item(), item()) as item()*)?" default="fn:deep-equal#2"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -13966,10 +13999,16 @@ return starts-with-subsequence(
          <p>More formally, the function returns the value of the expression:</p>
          <eg><![CDATA[starts-with-subsequence(reverse($input), reverse($subsequence), $compare)]]></eg>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> if the <code>$compare</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
             of equality comparison. The result is well-defined, for example, even if <code>$compare</code> is not transitive
             or not symmetric.</p>
+         <p>The <code>$compare</code> function is not required to return an <code>xs:boolean</code> value:
+            the <termref def="dt-effective-boolean-value"/> of the result is used.</p>
       </fos:notes>
       
       <fos:examples>
@@ -14058,7 +14097,7 @@ return ends-with-subsequence(
          <fos:proto name="contains-subsequence" return-type="xs:boolean">
             <fos:arg name="input" type="item()*" usage="transmission"/>
             <fos:arg name="subsequence" type="item()*" usage="transmission"/>
-            <fos:arg name="compare" type="(function(item(), item()) as xs:boolean)?" default="fn:deep-equal#2"/>
+            <fos:arg name="compare" type="(function(item(), item()) as item()*)?" default="fn:deep-equal#2"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -14085,10 +14124,16 @@ some $i in 0 to count($input) - count($subsequence) satisfies (
 )
 ]]></eg>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> if the <code>$compare</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
             of equality comparison. The result is well-defined, for example, even if <code>$compare</code> is not transitive
             or not symmetric.</p>
+         <p>The <code>$compare</code> function is not required to return an <code>xs:boolean</code> value:
+         the <termref def="dt-effective-boolean-value"/> of the result is used.</p>
       </fos:notes>
       
       <fos:examples>
@@ -14168,6 +14213,15 @@ return contains-subsequence(
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>True because there is a run of 4 consecutive items ending in <code>"a"</code>.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[contains-subsequence(
+    parse-xml("<doc><p/><p/><hr/><hr/><p/></doc>")//*, 
+    1 to 2,
+    fn{self::hr})]]></eg></fos:expression>
+               <fos:result>true()</fos:result>
+               <fos:postamble>The effective boolean value of the comparison result is used; the result
+               is true because there is a run of two consecutive <code>hr</code> elements.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -18622,17 +18676,15 @@ return $item
 
       </fos:rules>
       <fos:errors>
-         <p>As a consequence of the function signature and the function calling rules, a type error
-            <errorref class="RG" code="0006"/> 
-            occurs if the result of the supplied <code>$predicate</code> function has no effective boolean
-            value.</p>
-         
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
       </fos:errors>
       <fos:notes>
          <p>If <code>$predicate</code> is an arity-1 function,
             the function call <code>fn:filter($input, $predicate)</code> has a very similar effect to the
             expression <code>$input[$predicate(.)]</code>. There are some differences, however. In the case of
-               <code>fn:filter</code>, the the effective boolean value of the result of
+               <code>fn:filter</code>, the the <termref def="dt-effective-boolean-value"/> of the result of
             function <code>$F</code> is always used;
             there is no special treatment for numeric predicate values. 
             Also, with a filter expression <code>$input[$predicate(.)]</code>,
@@ -19362,7 +19414,7 @@ chain((1, 2, 3, 4), $product3)
             </item>
             <item>
                <p><code>$predicate($input, $pos)</code> is evaluated. If the 
-                  effective boolean value of the result is
+                  <termref def="dt-effective-boolean-value"/> of the result is
                   <code>false</code>, the function returns the value of <code>$input</code>.</p>
             </item>
             <item>
@@ -19392,6 +19444,11 @@ declare function while-do(
   while-do-helper($input, $predicate, $action, 1)
 };]]></eg>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>While-do loops are very common in procedural programming languages, and this function
             provides a way to write functionally clean and interruptible iterations without
@@ -19515,7 +19572,7 @@ return $result?numbers
             </item>
             <item>
                <p><code>$predicate($input, $pos)</code> is evaluated. If the 
-                  effective boolean value of the result is
+                  <termref def="dt-effective-boolean-value"/> of the result is
                   <code>true</code>, the function returns the value of <code>$input</code>.
                   Otherwise, the process repeats from step 2 with <code>$pos</code> incremented by
                   <code>1</code>.</p>
@@ -19545,6 +19602,11 @@ declare function do-until(
   do-until-helper($input, $action, $predicate, 1)
 };]]></eg>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>Do-until loops are very common in procedural programming languages, and this function
             provides a way to write functionally clean and interruptible iterations without
@@ -21022,7 +21084,7 @@ map:for-each($map, fn($key, $value) { $key })
       <fos:signatures>
          <fos:proto name="keys-where" return-type="xs:anyAtomicType*">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
-            <fos:arg name="predicate" type="(function(xs:anyAtomicType, item()*) as xs:boolean)"/>
+            <fos:arg name="predicate" type="(function(xs:anyAtomicType, item()*) as item()*)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -21038,7 +21100,8 @@ map:for-each($map, fn($key, $value) { $key })
             <termref def="dt-map">map</termref> as its <code>$map</code> argument. The
             <code>$predicate</code> function takes the key and the value of the corresponding
             map entry as an argument, and the result is a sequence containing the keys of those
-            entries for which the predicate function returns <code>true</code> in <termref
+            entries for which the <termref def="dt-effective-boolean-value"/> of the result of the predicate 
+            function is <code>true</code>. The results are in <termref
                def="implementation-dependent">implementation-dependent</termref> order.</p>
          <p>More formally, the function returns the value of the expression:</p>
          <eg><![CDATA[
@@ -21052,6 +21115,11 @@ map:for-each($map, fn($key, $value) {
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -21092,6 +21160,18 @@ return map:keys-where($birthdays, fn($name, $date) {
 })
                </eg></fos:expression>
                <fos:result>"Joel"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[
+let $abbreviations := map {
+    "US": <country>United States</country>,
+    "UK": <country>United Kingdom</country>,
+    "FL": <state>Florida</state>,
+    "WY": <state>Wyoming</state>}
+return map:keys-where($abbreviations, fn($key, $value) {$value[self::country]})
+               ]]></eg></fos:expression>
+               <fos:result allow-permutation="true">"US", "UK</fos:result>
+               <fos:postamble>The effective boolean value of the predicate function is used.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -21852,13 +21932,18 @@ return <box>{
          <p>The function <code>map:filter</code> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map; the result is a new map containing those entries for which
-            the effective boolean value of the result of the <code>$predicate</code> 
+            the <termref def="dt-effective-boolean-value"/> of the result of the <code>$predicate</code> 
             function is <code>true</code>.</p>
 
          <p>The function supplied as <code>$predicate</code> takes two arguments. It is called
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -25344,6 +25429,11 @@ array:index-of(
          <eg>let $ebv := fn($it, $pos){boolean($predicate($it, $pos))} 
 return index-of($input => array:for-each($ebv) => array:values(), true())</eg>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       
       <fos:examples>
          <fos:example>
@@ -25946,7 +26036,7 @@ return [ $action($member, $pos) ]
       </fos:summary>
       <fos:rules>
          <p>Informally, the function returns an array containing those members of the input
-         array for which the effective boolean value of the result of the supplied predicate is true.</p>
+         array for which the <termref def="dt-effective-boolean-value"/> of the result of the supplied predicate is true.</p>
          <p>More formally, the function returns the result of the expression:</p>
          <eg><![CDATA[
 array:of-members(
@@ -25956,10 +26046,9 @@ array:of-members(
 )]]></eg>
       </fos:rules>
       <fos:errors>
-         <p>As a consequence of the function signature and the function calling rules, a type error
-            <errorref class="RG" code="0006"/> 
-            occurs if the result of the supplied <code>$predicate</code> function has no effective boolean
-            value.</p>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
       </fos:errors>
       <fos:examples>
          <fos:example>
@@ -27843,15 +27932,20 @@ r:random-sequence(200);
 every $boolean in (
   for $item at $pos in $input
   return $predicate($item, $pos)
-) satisfies boolean($boolean)
+) satisfies $boolean
 ]]></eg>
 
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>If the second argument is omitted or an empty sequence, the first argument must be
             a sequence of <code>xs:boolean</code> values.</p>
          <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for 
-            which the effective boolean value of the predicate is <code>false</code>; 
+            which the <termref def="dt-effective-boolean-value"/> of the predicate is <code>false</code>; 
             it is not required to evaluate the predicate for every item.</p>
       </fos:notes>
       <fos:examples>
@@ -28243,7 +28337,7 @@ function($item) {
 
          <p>The result of the function is a sequence of integers, in monotonic ascending order, representing
             the 1-based positions in the input sequence of those items for which the 
-            effective boolean value of the result of calling the supplied predicate function
+            <termref def="dt-effective-boolean-value"/> of the result of calling the supplied predicate function
             is <code>true</code>.</p>
          <p>More formally, the function is equivalent to the following expression in XQuery:</p>
          <eg>
@@ -28251,6 +28345,11 @@ for $item at $pos in $input
 where $predicate($item, $pos)
 return $pos</eg>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
 
       <fos:examples>
          <fos:example>
@@ -28486,8 +28585,13 @@ return $it
 ]]></eg>
          <p>That is, it returns all items in the sequence prior to the first one where the result of
          calling the supplied <code>$predicate</code> function, with the current item and its position
-         as arguments, has an effective boolean value of <code>false</code>.</p>
+         as arguments, has an <termref def="dt-effective-boolean-value"/> of <code>false</code>.</p>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       
 
       <fos:examples>
@@ -28838,14 +28942,19 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
 some $boolean in (
   for $item at $pos in $input
   return $predicate($item, $pos)
-) satisfies boolean($boolean)
+) satisfies $boolean
 ]]></eg>
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$predicate</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>If the second argument is omitted or an empty sequence, the first argument must be
-            a sequence of items each having an effective boolean value.</p>
+            a sequence of items each having an <termref def="dt-effective-boolean-value"/>.</p>
          <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for 
-            which the effective boolean value of the result of calling the predicate
+            which the <termref def="dt-effective-boolean-value"/> of the result of calling the predicate
          is <code>true</code>; it is not required to evaluate the predicate for every item.</p>
       </fos:notes>
       <fos:examples>
@@ -30057,7 +30166,7 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:signatures>
          <fos:proto name="partition" return-type="array(item())*">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="split-when" type="function(item()*, item(), xs:integer) as xs:boolean"/>
+            <fos:arg name="split-when" type="function(item()*, item(), xs:integer) as item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -30077,7 +30186,7 @@ path with an explicit <code>file:</code> scheme.</p>
             position in the input sequence.</p>
          <p>Each partition is a sequence of items; the function result wraps each partition as an array, and returns
             the sequence of arrays.</p>
-         <p>If the <code>$split-when</code> function returns <code>true</code>, the current partition is wrapped as an array and added to the result,
+         <p>If the <termref def="dt-effective-boolean-value"/> of the result of the <code>$split-when</code> function is <code>true</code>, the current partition is wrapped as an array and added to the result,
             and a new current partition is created, initially containing the item <var>J</var> only. If the <code>$split-when</code> 
             function returns <code>false</code>, the item <var>J</var> is added to the current partition.</p>
          <p>More formally, the function returns the result of the expression:</p>
@@ -30088,12 +30197,17 @@ path with an explicit <code>file:</code> scheme.</p>
 })   
          </eg>  
       </fos:rules>
+      <fos:errors>
+         <p>A type error is raised <errorref class="RG" code="0006"/> 
+            if the <code>$split-when</code> function returns
+            a result that has no <termref def="dt-effective-boolean-value"/>.</p>
+      </fos:errors>
       <fos:notes>
          <p>The function enables a variety of positional grouping problems to be solved. For example:</p>
          <ulist>
             <item><p><code>partition($input, function($a, $b) { count($a) eq 3 }</code>
                partitions a sequence into fixed size groups of length 3.</p></item>
-            <item><p><code>partition($input, function($a, $b) { boolean($b/self::h1) }</code>
+            <item><p><code>partition($input, function($a, $b) { $b/self::h1 }</code>
                starts a new group whenever an <code>h1</code> element is encountered.</p></item>
             <item><p><code>partition($input, function($a, $b) { $b lt foot($a) }</code>
                starts a new group whenever an item is encountered whose value is less than
@@ -30154,6 +30268,13 @@ path with an explicit <code>file:</code> scheme.</p>
   fn($all, $next, $p) { $p mod 2 = 1 }
 )</eg></fos:expression>
                <fos:result>["a", "b"], ["c", "d"], ["e"]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[partition(
+                  (<h1/>,<p/>,<p/>,<h1/>,<p/>),
+                  fn($partition, $next){$next[self::h1]}
+                  )]]></eg></fos:expression>
+               <fos:result><![CDATA[[<h1/>,<p/>,<p/>], [<h1/>,<p/>]]]></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1005,7 +1005,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   if its result depends on the <xtermref ref="dt-focus" spec="XP31">focus</xtermref>
                   (that is, the context item, position, or size) 
                   <phrase diff="add" at="2023-03-12">of the caller</phrase>.</termdef></p>
-               <p><termdef id="dt-focus-independent" term="focus-dependent">A function that
+               <p><termdef id="dt-focus-independent" term="focus-independent">A function that
                   is not <termref def="dt-focus-dependent">focus-dependent</termref> is called
                   <term>focus-independent</term>.</termdef></p>
 
@@ -11601,6 +11601,11 @@ ISBN 0 521 77752 6.</bibl>
             <?doc schema-for-csv.xsd?>
          </div2>
       </div1>
+      
+      <inform-div1 id="id-glossary">
+         <head>Glossary</head>
+         <?glossary?>
+      </inform-div1>
 
       <inform-div1 id="other-functions">
          <head>Other Functions</head>


### PR DESCRIPTION
Changes functions with a $predicate callback function to use the effective boolean value of the result, mainly to allow things like `index-where(*, fn{self::x})`.

Fix #919