### PR TITLE
Updated as agreed 2024-02-06. 

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27752,21 +27752,18 @@ return every($dl/*, fn($elem, $pos) {
             <item><p>A backslash-escape sequence from the set <code>\n</code> (newline, <code>x0A</code>), 
                <code>\r</code> (carriage return, <code>x0D</code>),
                or <code>\t</code> (tab, <code>x09</code>).</p></item>
-            <item><p>A decimal codepoint value in the form <code>#[0-9]+</code>, for example
-            <code>fn:char("#10")</code> represents a newline character. Leading zeroes are optional.</p></item>
-            <item><p>A hexadecimal codepoint value in the form <code>#x[0-9a-fA-F]+</code>, for example
-               <code>fn:char("#x0A")</code> represents a newline character. Leading zeroes are optional, and the
-            letters A-F may be in either upper or lower case.</p></item>
+            
             
          </olist>
          <p diff="chg" at="2023-06-12">The result must consist of
          <termref def="dt-permitted-character">permitted characters</termref>.
-         For example <code>fn:char("#xDEAD")</code> is invalid because it is in the surrogate range.</p>
+         For example <code>fn:char(0xDEAD)</code> is invalid because it is in the surrogate range.</p>
       </fos:rules>
       <fos:errors>
          <p>The function fails with a dynamic error <errorref
                class="CH" code="0005"/> if <code>$value</code> is not a valid
-            representation of a valid character or sequence of characters.
+            representation of a <termref def="dt-permitted-character"/> 
+            or sequence of permitted characters.
          </p>
       </fos:errors>
       <fos:notes>
@@ -27802,19 +27799,11 @@ return every($dl/*, fn($elem, $pos) {
                <fos:postamble>The character <emph>tab</emph></fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>char("#32")</fos:expression>
-               <fos:result>" "</fos:result>
-            </fos:test>
-            <fos:test>
                <fos:expression>char(0x20)</fos:expression>
                <fos:result>" "</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>char("#x20")</fos:expression>
-               <fos:result>" "</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>char("#x1D1CA")</fos:expression>
+               <fos:expression>char(0x1D1CA)</fos:expression>
                <fos:result>"&#x1D1CA;"</fos:result>
                <fos:postamble>The character MUSICAL SYMBOL TEMPUS IMPERFECTUM CUM PROLATIONE PERFECTA</fos:postamble>
             </fos:test>


### PR DESCRIPTION
The forms char('#32`) and char('#x20') are dropped.