### PR TITLE
1002 Add fn:take-while function (replacing subsequence-before)

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28255,11 +28255,11 @@ head(index-where($input, $predicate)) ! subsequence($input, . + 1)
 
    </fos:function>-->
 
-   <!--<fos:function name="subsequence-before">
+   <fos:function name="take-while">
       <fos:signatures>
-         <fos:proto name="subsequence-before" return-type="item()*">
+         <fos:proto name="take-while" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="function(item(), xs:integer) as xs:boolean"/>
+            <fos:arg name="predicate" type="function(item(), xs:integer) as item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -28268,67 +28268,76 @@ head(index-where($input, $predicate)) ! subsequence($input, . + 1)
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the items from the input sequence that precede the first item to match a supplied predicate.</p>
+         <p>Returns items from the input sequence prior to the first one that fails to match a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the result of the expression:</p>
+         <p>The function returns the result of the XQuery expression:</p>
          <eg><![CDATA[
-subsequence($input, 1, head(index-where($input, $predicate)))
+for $it at $pos in $input
+while $predicate($it, $pos)
+return $it
 ]]></eg>
+         <p>That is, it returns all items in the sequence prior to the first one where the result of
+         calling the supplied <code>$predicate</code> function, with the current item and its position
+         as arguments, has an effective boolean value of <code>false</code>.</p>
       </fos:rules>
-      <fos:notes>
-         <p>To retain the first matching item, use <code>fn:subsequence-ending-where</code>.</p>
-      </fos:notes>
       
 
       <fos:examples>
 
          <fos:example>
             <fos:test>
-               <fos:expression>subsequence-before(10 to 20, function { . gt 12 })</fos:expression>
+               <fos:expression>take-while(10 to 20, fn{. le 12})</fos:expression>
                <fos:result>(10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>subsequence-before(
-  ("January", "February", "March", "April", "May"),
-  starts-with(?, "A")
-)</eg></fos:expression>
-               <fos:result>("January", "February", "March")</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>subsequence-before(10 to 20, function { . gt 100 })</fos:expression>
+               <fos:expression>take-while(10 to 20, fn{. lt 100})</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>subsequence-before((), boolean#1)</fos:expression>
+               <fos:expression>take-while((), boolean#1)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/></doc>")//doc/*
-=> subsequence-before(function { boolean(self::img) })
-=!> name()]]></eg></fos:expression>
-               <fos:result>"p", "p", "h2"</fos:result>
+               <fos:expression>take-while(("A", "B", "C", " ", "E"), normalize-space#1)</fos:expression>
+               <fos:result>("A", "B", "C")</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg><![CDATA[parse-xml("<doc><p/><p/><h2/><img/><p/></doc>")/doc/*
+=> take-while(fn{self::p})
+=> count()]]></eg></fos:expression>
+               <fos:result>2</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[
 ("Aardvark", "Antelope", "Bison", "Buffalo", "Camel", "Dingo")
-=> subsequence-starting-where(starts-with(?, "B"))
-=> subsequence-before(starts-with(?, "D"))]]></eg></fos:expression>
-               <fos:result>"Bison", "Buffalo", "Camel"</fos:result>
+=> take-while(starts-with(?, "A"))]]></eg></fos:expression>
+               <fos:result>"Aardvark", "Antelope"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>subsequence-before(10 to 20, fn($num, $pos) { $num > 11 and $pos > 2 })</eg></fos:expression>
-               <fos:result>(10, 11)</fos:result>
+               <fos:expression><eg>take-while(10 to 20, fn($num, $pos) { $num lt 18 and $pos lt 4 })</eg></fos:expression>
+               <fos:result>(10, 11, 12, 13)</fos:result>
             </fos:test>
+            <fos:test>
+               <fos:expression><eg>take-while(characters("ABCD-123"), 
+   fn($ch, $pos) {$pos lt 4 and $ch ne '-'}) => string-join#1</eg></fos:expression>
+               <fos:result>"ABC"</fos:result>
+            </fos:test>  
+            <fos:test>
+               <fos:expression><eg>take-while("A", "a", "B", "b", "C", "D", "d"), 
+   fn($ch, $pos) {
+      matches($ch, if ($pos mod 2 eq 1) then "p{Lu}" else "p{Ll}")
+   }) </eg></fos:expression>
+               <fos:result>"A", "a", "B", "b", "C"</fos:result>
+            </fos:test>     
          </fos:example>
 
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">New in 4.0. Accepted 2022-10-25.</fos:version>
+         <fos:version version="4.0">New in 4.0. See issue 1002</fos:version>
       </fos:history>
 
    </fos:function>
--->
    <!--<fos:function name="subsequence-starting-where">
       <fos:signatures>
          <fos:proto name="subsequence-starting-where" return-type="item()*">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7487,10 +7487,6 @@ return <table>
             <div3 id="func-index-where" diff="add" at="A">
                <head><?function fn:index-where?></head>
             </div3>
- 
-            <div3 id="func-iterate-while">
-               <head><?function fn:iterate-while?></head>
-            </div3>
             <div3 id="func-lowest" diff="add" at="A">
                <head><?function fn:lowest?></head>
             </div3>
@@ -7511,6 +7507,9 @@ return <table>
             </div3>
             <div3 id="func-subsequence-where" diff="add" at="2024-01-10">
                <head><?function fn:subsequence-where?></head>
+            </div3>
+            <div3 id="func-take-while" diff="add" at="2024-02-07">
+               <head><?function fn:take-while?></head>
             </div3>
             <div3 id="func-transitive-closure">
                <head><?function fn:transitive-closure?></head>


### PR DESCRIPTION
Adds function `fn:take-while`, replacing/reinstating previously proposed `items-before()` and `subsequence-before()`.

Fix #1002