### PR TITLE
Fix some incorrect examples in the F&O spec

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -178,7 +178,7 @@
                <fos:result>fn:QName("http://example.com/ns", "ex:p")</fos:result>
             </fos:test>
             <fos:test use="v-node-name-e" spec="XQuery">
-               <fos:expression>node-name($e//processing-instruction[1])</fos:expression>
+               <fos:expression>node-name($e//processing-instruction()[1])</fos:expression>
                <fos:result>fn:QName("", "pi")</fos:result>
             </fos:test>
             <fos:test use="v-node-name-e" spec="XQuery">
@@ -190,7 +190,7 @@
                <fos:result>fn:QName("", "id")</fos:result>
             </fos:test>
             <fos:test use="v-node-name-e" spec="XQuery">
-               <fos:expression>node-name($e//*[@id='alpha']/@xml:id</fos:expression>
+               <fos:expression>node-name($e//*[@id='alpha']/@xml:id)</fos:expression>
                <fos:result>fn:QName("http://www.w3.org/XML/1998/namespace", "xml:id")</fos:result>
             </fos:test>
          </fos:example>
@@ -7144,7 +7144,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test>
                <fos:expression><eg>seconds(86400)</eg></fos:expression>
-               <fos:result>xs:dayTimeDuration('PT1D')</fos:result>
+               <fos:result>xs:dayTimeDuration('P1D')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -11502,7 +11502,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>"ex:p"</fos:result>
             </fos:test>
             <fos:test use="v-name-e" spec="XQuery">
-               <fos:expression>name($e//processing-instruction[1])</fos:expression>
+               <fos:expression>name($e//processing-instruction()[1])</fos:expression>
                <fos:result>"pi"</fos:result>
             </fos:test>
             <fos:test use="v-name-e" spec="XQuery">
@@ -11514,7 +11514,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>"id"</fos:result>
             </fos:test>
             <fos:test use="v-name-e" spec="XQuery">
-               <fos:expression>name($e//*[@id='alpha']/@xml:id</fos:expression>
+               <fos:expression>name($e//*[@id='alpha']/@xml:id)</fos:expression>
                <fos:result>"xml:id"</fos:result>
             </fos:test>
          </fos:example>
@@ -11595,19 +11595,19 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>"p"</fos:result>
             </fos:test>
             <fos:test use="v-local-name-e" spec="XQuery">
-               <fos:expression>local-name($e//processing-instruction[1])</fos:expression>
+               <fos:expression>local-name($e//processing-instruction()[1])</fos:expression>
                <fos:result>"pi"</fos:result>
             </fos:test>
             <fos:test use="v-local-name-e" spec="XQuery">
-               <fos:expression>local-name($e//*[@id='alpha]/text())</fos:expression>
+               <fos:expression>local-name($e//*[@id='alpha']/text())</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
             <fos:test use="v-local-name-e" spec="XQuery">
-               <fos:expression>local-name($e//*[@id='alpha]/@id)</fos:expression>
+               <fos:expression>local-name($e//*[@id='alpha']/@id)</fos:expression>
                <fos:result>"id"</fos:result>
             </fos:test>
             <fos:test use="v-local-name-e" spec="XQuery">
-               <fos:expression>local-name($e//*[@id='alpha]/@xml:id</fos:expression>
+               <fos:expression>local-name($e//*[@id='alpha']/@xml:id)</fos:expression>
                <fos:result>"id"</fos:result>
             </fos:test>
          </fos:example>
@@ -11688,7 +11688,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>"http://example.com/ns"</fos:result>
             </fos:test>
             <fos:test use="v-namespace-uri-e" spec="XQuery">
-               <fos:expression>namespace-uri($e//processing-instruction[1])</fos:expression>
+               <fos:expression>namespace-uri($e//processing-instruction()[1])</fos:expression>
                <fos:result>""</fos:result>
             </fos:test>
             <fos:test use="v-namespace-uri-e" spec="XQuery">
@@ -11700,7 +11700,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                <fos:result>""</fos:result>
             </fos:test>
             <fos:test use="v-namespace-uri-e" spec="XQuery">
-               <fos:expression>namespace-uri($e//*[@id='alpha']/@xml:id</fos:expression>
+               <fos:expression>namespace-uri($e//*[@id='alpha']/@xml:id)</fos:expression>
                <fos:result>"http://www.w3.org/XML/1998/namespace"</fos:result>
             </fos:test>
          </fos:example>
@@ -12684,7 +12684,7 @@ return exists($break)
          <fos:example>
             <fos:test>
                <fos:expression>distinct-values((1, 2.0, 3, 2))</fos:expression>
-               <fos:result>(1, 3, 2.0)</fos:result>
+               <fos:result>(1, 2.0, 3)</fos:result>
                <fos:postamble>Assuming ordering mode is <code>ordered</code>.</fos:postamble>
             </fos:test>
          </fos:example>
@@ -24496,9 +24496,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                
                <note><p>Conflicts between property names can arise because the XDM model allows keys of different types,
                   for example the <code>xs:date</code> value <code>2020-12-31</code> and the string value 
-                  <code>"2020-12-31"</code> can co-exist. The map <code>map{xs:duration('PT1D'):20, "PT1D":30}</code>
-                  is converted to the JSON string <code>{"PT1D":20,"PT1D(1)":30}</code> or 
-                  <code>{"PT1D":30,"PT1D(1)":20}</code>, depending on the (unpredictable) order in which the
+                  <code>"2020-12-31"</code> can co-exist. The map <code>map{xs:duration('P1D'):20, "P1D":30}</code>
+                  is converted to the JSON string <code>{"P1D":20,"P1D(1)":30}</code> or 
+                  <code>{"P1D":30,"P1D(1)":20}</code>, depending on the (unpredictable) order in which the
                entries in the map are processed.</p></note>
                <note><p>Because the order of entries in a map is unpredictable, the order in which the
                properties are listed in the JSON output is also unpredictable.</p></note>


### PR DESCRIPTION
No issue raised; the errors are revealed by the generated QT4 tests.