### PR TITLE
1013 [XSLT] Clarify effect of accumulator capture on non-element nodes

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -26659,11 +26659,15 @@ the same group, and the-->
                
                <p>The <code>capture</code> attribute is intended primarily for use with streamable accumulators, but
                   in the interests of consistency, it has the same effect both for streamable and non-streamable
-                  accumulators. If an accumulator rule with <code>phase="end"</code> specifies <code>capture="yes"</code>,
-                  then the rule is evaluated not with the matched node as the context item, but rather with a snapshot
+                  accumulators. If an accumulator rule with <code>phase="end"</code> and <code>capture="yes"</code>
+                  matches an element node,
+                  then the rule is evaluated not with the matched element node as the context item, but rather with a snapshot
                   copy of the matched node. The snapshot copy is made following the rules of the <function>snapshot</function>
                   function, with one exception: no accumulator values are copied into the snapshot tree (which would otherwise
                   happen: see <specref ref="copying-accumulators"/>).</p>
+               
+               <p diff="add" at="issue1013">If a rule with <code>capture="yes"</code> matches a node other than an element, the attribute
+               has no effect.</p>
                
                <note><p>The principal effect of specifying <code>capture="yes"</code> is to relax
                   the rules for streamability. With this option, the <code>phase="end"</code> accumulator rule


### PR DESCRIPTION
Adds a sentence saying that when an accumulator rule with capture="yes" matches a non-element node, the capture attribute has no effect.

Fix #1013