### PR TITLE
1001 Fix incorrect operator precedence in subsequence-where

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13478,9 +13478,9 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          <p>More formally, the function returns the result of:</p>
          
          <eg>let $start := index-where($input, $from)[1] 
-              otherwise count($input) + 1
+              otherwise (count($input) + 1)
 let $end :=   index-where($input, $to)[. ge $start][1] 
-              otherwise count($input) + 1
+              otherwise (count($input) + 1)
 return slice($input, $start, $end)</eg>
          
  


### PR DESCRIPTION
Fixes the "equivalent expression" to subsequence-where. 

Fix issue #1001