### PR TITLE
960(partial) Recognize alternative representation of JSON null

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24072,6 +24072,27 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
+            
+            <fos:option key="null" diff="add" at="2024-02-19">
+               <fos:meaning>Determines how the JSON <code>null</code> value should be represented.</fos:meaning>
+               <fos:type>item()*</fos:type>
+               <fos:default>()</fos:default>
+               <fos:values>
+                  <fos:value value="Value">
+                     The supplied XDM value is used to represent the JSON <code>null</code> value.
+                     The default representation of <code>null</code> is an empty sequence, which works
+                     well in cases where setting a property of an object to <code>null</code> has the
+                     same meaning as omitting the property. It works less well in cases where <code>null</code>
+                     is used with some other meaning, because expressions such as the lookup operators
+                     <code>?</code> and <code>??</code> flatten the result to a single sequence of items,
+                     which means that any entries whose value is an empty sequence effectively disappear.
+                     The property can be set to any XDM value; a suggested value is the <code>xs:QName</code>
+                     value <code>fn:QName("http://www.w3.org/2005/xpath-functions", "null")</code>,
+                     which is recognized by the JSON serialization method as representing the JSON value
+                     <code>null</code>.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
 
             <fos:option key="number-parser" diff="add" at="A">
                <fos:meaning>Determines how numeric values should be processed.</fos:meaning>
@@ -24116,7 +24137,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <item>
                <p>A JSON <emph>array</emph> is transformed to an array whose members are the result of converting
                   the corresponding member of the array by recursive application of these rules. For
-                  example, the JSON text <code>["a", "b", null]</code> is transformed to the value
+                  example, the JSON text <code>["a", "b", null]</code> is transformed (by default) to the value
                      <code>["a", "b", ()]</code>.</p>
             </item>
             <item>
@@ -24134,7 +24155,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   converted to the corresponding <code>xs:boolean</code> values.</p>
             </item>
             <item>
-               <p>The JSON value <emph>null</emph> is converted to the empty sequence.</p>
+               <p diff="chg" at="2024-02-19">The JSON value <emph>null</emph> is converted 
+                  to the value given by the <code>null</code> option, which defaults to an 
+                  empty sequence.</p>
             </item>
          </olist>
 
@@ -24243,6 +24266,12 @@ return $M(collation-key("a", $C))</eg></fos:expression>
   map { 'number-parser': fn  { boolean(. >= 0) } }
 )</eg></fos:expression>
                <fos:result>[ true(), false(), true() ]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>parse-json('["a", null, "b"]',
+  map { 'null': xs:QName("fn:null") }
+)</eg></fos:expression>
+               <fos:result>[ "a", xs:QName("fn:null"), "b" ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -211,9 +211,9 @@ to certain types of input value.</p>
   
   <p diff="chg" at="2023-11-01"><termdef id="dt-input-tree" term="input tree">In general the output of the serializer
     will represent the items actually present in the input value, together with other items that are reachable
-    from these, for example (in the case of nodes) their descendants.</termdef> The complete set of items that
+    from these, for example (in the case of nodes) their descendants. The complete set of items that
     are represented in the output of the serializer is referred to (without loss of generality) as the 
-    <term>input tree</term>.</p> 
+    <term>input tree</term>.</termdef></p> 
 
 
 <div2 id="terminology"><head>Terminology</head>
@@ -314,7 +314,7 @@ A <termref def="dt-sequence">sequence</termref> is an ordered collection of zero
 
 <item>
 <p><termdef id="dt-function-item" term="function item">The term
-<term>function</term> is defined in
+<term>function item</term> is defined in
 <xspecref spec="DM40" ref="function-items"/>.</termdef></p>
 </item>
 
@@ -2147,7 +2147,7 @@ agents designed originally to handle HTML.</p>
   <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> is first subjected to
 <termref def="PREFIXNORMALIZATION">prefix normalization</termref>.</p>
 <p>
-<termdef term="PREFIXNORMALIZATION" id="PREFIXNORMALIZATION">During
+<termdef term="prefix normalization" id="PREFIXNORMALIZATION">During
   <term>prefix normalization</term>, any element node in the 
   <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> that is in one of the
 <termref def="xhtml-namespace">XHTML namespace</termref>, the
@@ -4301,6 +4301,11 @@ the mechanism described in <specref ref="serparams-in-xdm-instance"/>.</p>
     </tbody>
   </table>			
 </div1>
+  
+  <inform-div1 id="id-glossary"><head>Glossary</head>
+    <!-- This processing instruction automatically generates the glossary. -->
+    <?glossary?>
+  </inform-div1>
 
 <inform-div1 id="implementation-defined-or-dependent-features">
   <head>Checklist of Implementation-Defined and Implementation-Dependent Features</head>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3491,9 +3491,21 @@ is serialized to the JSON token <code>true</code>.</p></item>
   in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/>
 of type <code>xs:boolean</code> and value <code>false</code> is
 serialized to the JSON token <code>false</code>.</p></item>
+  
+  <item diff="add" at="2024-02-19">
+    <p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic value</xtermref> 
+      of type <code>xs:QName</code> in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/>
+     whose namespace part is <code>"http://www.w3.org/2005/xpath-functions"</code> 
+    and whose local part is <code>"null"</code> is
+    serialized to the JSON token <code>null</code>.</p>
+  <note><p>This rule is introduced in 4.0, along with an option in the <code>fn:parse-json</code>
+  function to allow a user-defined representation of the JSON value <code>null</code>. While
+  the default representation of <code>null</code> as an empty sequence is usable in many
+  circumstances, an explicit representation of <code>null</code> as a recognizable item can make
+  some operations on JSON-derived values easier.</p></note></item> 
 
-<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic
-  value</xtermref> in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> of any other type 
+<item><p>Any other <xtermref spec="XP40" ref="dt-atomic-value">atomic
+  value</xtermref> in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> 
 is serialized <termref def="to-a-json-string">to a JSON string</termref> by outputting the 
 result of applying the <code>fn:string</code> function to the item.</p></item>
 


### PR DESCRIPTION
Defines an option in parse-json and json-doc to define a representation for JSON null, defaulting to `()` as currently used. Selecting a different value may be useful because it bypasses the problem that the `?` and `??` operators flatten the results, causing `()` to be elided.

Suggests use of the QName `fn:null` as an alternative representation; and changes the JSON serialization method to recognize this QName as a representation of null.