### PR TITLE
1024 Change precedence of 'otherwise' operator

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1525,16 +1525,16 @@ ErrorVal ::= "$" VarName
         </g:sequence>
       </g:postfix>
     </g:level>
+    <g:level>
+      <g:binary name="OtherwiseExpr" if="xpath40 xquery40 xslt40-patterns" condition="&gt; 1">
+        <g:string>otherwise</g:string>
+      </g:binary>
+    </g:level>
     <g:level if="xpath40 xquery40  xslt40-patterns">
       <g:binary name="StringConcatExpr" condition="&gt; 1">
         <g:string>||</g:string>
       </g:binary>
     </g:level>
-<!--    <g:level>
-      <g:binary name="ByExpr">
-        <g:string>by</g:string>
-      </g:binary>
-    </g:level>-->
     <g:level>
       <g:postfix name="RangeExpr" if="xpath40 xquery40 xslt40-patterns" prefix-seq-type="?" condition="&gt; 1">
         <g:sequence name="RangeExprOps">
@@ -1561,11 +1561,6 @@ ErrorVal ::= "$" VarName
           <g:string>idiv</g:string>
           <g:string>mod</g:string>
         </g:choice>
-      </g:binary>
-    </g:level>
-    <g:level>
-      <g:binary name="OtherwiseExpr" if="xpath40 xquery40 xslt40-patterns" condition="&gt; 1">
-        <g:string>otherwise</g:string>
       </g:binary>
     </g:level>
     <g:level>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -799,37 +799,37 @@
         <tr>
           <td>6</td>
           <td>
+            <nt def="OtherwiseExpr">otherwise</nt>
+          </td>
+          <td>either</td>
+        </tr>
+        <tr>
+          <td>7</td>
+          <td>
             <nt def="StringConcatExpr">||</nt>
           </td>
           <td>left-to-right</td>
         </tr>
         <tr>
-          <td>7</td>
+          <td>8</td>
           <td>
             <nt def="RangeExpr">to</nt>
           </td>
           <td>NA</td>
         </tr>
         <tr>
-          <td>8</td>
+          <td>9</td>
           <td>
             <nt def="AdditiveExpr">+, - (binary)</nt>
           </td>
           <td>left-to-right</td>
         </tr>
         <tr>
-          <td>9</td>
+          <td>10</td>
           <td>
             <nt def="MultiplicativeExpr">*, div, idiv, mod</nt>
           </td>
           <td>left-to-right</td>
-        </tr>
-        <tr>
-          <td>10</td>
-          <td>
-            <nt def="OtherwiseExpr">otherwise</nt>
-          </td>
-          <td>either</td>
         </tr>
         <tr>
           <td>11</td>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19240,12 +19240,13 @@ named <code>discounted</code>, independently of its value:</p>
          <note>
             <p>The operator is associative (even under error conditions): <code>A otherwise (B otherwise C)</code> returns
          the same result as <code>(A otherwise B) otherwise C</code>.</p>
+            <p>The <code>otherwise</code> operator binds more tightly than comparison operators such as
+            <code>=</code>, but less tightly than string concatenation (<code>||</code>) or arithemetic
+            operators. The expression <code>$a = @x otherwise @y + 1</code> parses as 
+               <code>$a = (@x otherwise (@y + 1))</code>.</p>
          </note>
 
-         <ednote><date>2022-12-20</date><edtext>This change
-         <loc href="https://qt4cg.org/meeting/minutes/2022/12-20.html#issue-170">was
-         approved</loc>
-         during QT4CG meeting 016 on 20 December, 2022</edtext></ednote>
+         
       </div2>
       <div2 id="id-switch" role="xquery">
          <head>Switch Expressions</head>


### PR DESCRIPTION
Changes the precedence of the `otherwise` operator so that `@price otherwise @cost * 2` now means `@price otherwise (@cost * 2)` rather than `(@price otherwise @cost) * 2`.

Fix #1024