### PR TITLE
1029 Make argument of fn:void optional

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14216,7 +14216,7 @@ return contains-subsequence(
    <fos:function name="void" prefix="fn">
       <fos:signatures>
          <fos:proto name="void" return-type="empty-sequence()">
-            <fos:arg name="input" type="item()*"/>
+            <fos:arg name="input" type="item()*" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -14251,11 +14251,17 @@ return contains-subsequence(
             <fos:test>
                <fos:expression>array:get(array { 1, 2, 3 }, 4, void#1)</fos:expression>
                <fos:result>()</fos:result>
-               <fos:postamble>Without the third argument, an error would be raised</fos:postamble>
+               <fos:postamble>Without the third argument, an error would be raised.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>for $f in (identity#1, void#1) return $f(123)</fos:expression>
                <fos:result>123</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $mapping := () 
+    return for-each(1 to 10, $mapping otherwise void#0)</eg></fos:expression>
+               <fos:result>()</fos:result>
+               <fos:postamble>Indicates that if no mapping is supplied, all items are dropped.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>


### PR DESCRIPTION
Allows the use of `fn:void#0` when required.

Fix #1029