### PR TITLE
QT4CG-066-01 Add note that whitespace and comments in regexen are lexical constructs

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3135,6 +3135,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                      <code>SingleCharEsc</code> is extended to allow the <code>#</code> character 
                      to be escaped.
                   </p>
+                  
                </div4>
             </div3>
                
@@ -3265,6 +3266,8 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                         <p> 
                            <code>fn:matches("hello world", "hello world", "x")</code> returns <code>false()</code>
                         </p>
+                        <note><p>Whitespace is treated as a lexical construct to be removed before the
+                        regular expression is parsed; it is therefore not explicit in the regular expression grammar.</p></note>
                      </item>
                      <item><p><code>q</code>: if present, all characters in the regular expression
                      are treated as representing themselves, not as metacharacters. In effect, every
@@ -3292,6 +3295,9 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                         character or by the end of the regular expression string.</p>
                         <p>For example:</p>
                         <p><code>fn:replace("03/24/2025", "(..#month#)/(..#day#)/(....#year#)", "$3-$1-$2", "c")</code></p>
+                        <note><p>Comments are treated as a lexical construct to be removed before the
+                           regular expression is parsed; they are therefore not explicit in the regular 
+                           expression grammar.</p></note>
                      </item>
                   </ulist>
                </div3>


### PR DESCRIPTION
Adds a note explaining why whitespace and comments are not explicit in the regex grammar; see action QT4CG-066-01