### PR TITLE
QT4CG-066-xx Add note regarding absence of drop-while / skip-while

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28423,6 +28423,13 @@ return $it
          as arguments, has an effective boolean value of <code>false</code>.</p>
       </fos:rules>
       
+      <fos:notes>
+         <p>There is no analogous <code>drop-while</code> or <code>skip-while</code> function,
+         as found in some functional programming languages. The effect of 
+            <code>drop-while($input, $predicate)</code> can be achieved by calling
+         <code>fn:subsequence-where($input, fn{not($predicate(.))})</code>.</p>
+      </fos:notes>
+      
 
       <fos:examples>
 


### PR DESCRIPTION
In response to comments noted in the minutes of meeting 066, and made in writing against PR #1008, add a note justifying the absence of drop-while or skip-while functions.