### PR TITLE
1016 Editorial cleanup - csv-to-arrays

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23016,7 +23016,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
          <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
             sequence of <code>xs:string</code> values. The function parses this sequence using
-            <code>fn:csv-to-simple-rows</code>, and then processes its result to return an XDM value.</p>
+            <code>fn:csv-to-arrays</code>, and then processes its result to return an XDM value.</p>
 
          <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
             return a <code>parsed-csv-structure-record</code> whose <code>rows</code> entry is the empty sequence.</p>
@@ -23032,7 +23032,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
 
          <p>Handling of delimiters, and whitespace trimming, are handled using
-            <code>fn:csv-to-simple-rows</code>, and the options controlling their use are defined
+            <code>fn:csv-to-arrays</code>, and the options controlling their use are defined
             there.</p>
 
          <p>If the <code>column-names</code> option is true, implementations <rfc2119>must</rfc2119>
@@ -23413,9 +23413,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:examples>
    </fos:function>
 
-   <fos:function name="csv-to-simple-rows" prefix="fn">
+   <fos:function name="csv-to-arrays" prefix="fn">
       <fos:signatures>
-         <fos:proto name="csv-to-simple-rows" return-type="array(xs:string)*">
+         <fos:proto name="csv-to-arrays" return-type="array(xs:string)*">
             <fos:arg name="csv" type="xs:string?"/>
             <fos:arg name="options" type-ref="csv-parsing-options" usage="inspection" default="map{}"/>
          </fos:proto>
@@ -23426,26 +23426,28 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Parses CSV data supplied as a string, returning the results in the form of a sequence of arrays of strings.</p>
+         <p>Parses CSV data supplied as a string, returning the results in the form of a sequence
+            of arrays of strings.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the second argument is omitted or an empty sequence, the result is the same as
-            calling the two-argument form with an empty map as the value of the <code>$options</code>
-            argument.</p>
-
-         <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
-            sequence of <code>xs:string</code> values. The function parses this sequence to return
-            an XDM value.</p>
-
-         <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
-            return the empty sequence as the value of the <code>body</code> field of the returned
-            map.</p>
-
+         
+         <p>The <code>$csv</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of an
+            <code>xs:string</code> value. The function parses this string.</p>
+         
+         <p>If <code>$csv</code> is the empty sequence, the function returns an empty sequence.</p>
+         
          <p>The <code>$options</code> argument can be used to control the way in which the parsing
             takes place. The <termref
                def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
+         
+         <p>If the <code>$options</code> argument is omitted or an empty sequence, the result is the same as
+            calling the two-argument form with an empty map as the value of the <code>$options</code>
+            argument.</p>
 
-         <p>Implementations <rfc2119>must</rfc2119> treat any of CRLF, CR, or LF as a single line
+         
+
+         
+         <!--<p>Implementations <rfc2119>must</rfc2119> treat any of CRLF, CR, or LF as a single line
             separator, as with <code>fn:unparsed-text-lines</code>.</p>
 
          <p>Fields are regarded as simple <code>xs:string</code> values. Implementations
@@ -23455,7 +23457,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
          <p>When whitespace trimming is requested, implementations <rfc2119>must</rfc2119> only
             strip leading and trailing whitespace, this is not equivalent to calling
-            <code>fn:normalize-space()</code>.</p>
+            <code>fn:normalize-space()</code>.</p>-->
 
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
 
@@ -23467,9 +23469,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:default>","</fos:default>
             </fos:option>
             <fos:option key="row-delimiter">
-               <fos:meaning>The sequence of strings used to delimit rows within the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
+               <fos:meaning>A sequence of strings, any of which can be used to delimit rows within
+                  the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
                <fos:type>xs:string+</fos:type>
-               <fos:default>("&amp;#13;&amp;#10;", "&amp;#10;", "&amp;#13;")</fos:default>
+               <fos:default>(char(13)||char(10), char(10), char(13))</fos:default>
             </fos:option>
             <fos:option key="quote-character">
                <fos:meaning>The character used to quote fields within the CSV string. An instance of
@@ -23478,41 +23481,41 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:default>'"'</fos:default>
             </fos:option>
             <fos:option key="trim-whitespace">
-               <fos:meaning>Determines whether fields should have leading and trailing whitespace
-                  removed before being returned.</fos:meaning>
+               <fos:meaning>Determines whether leading and trailing whitespace
+                  is removed from the content of fields.</fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
                   <fos:value value="false">Fields will be returned with any leading or trailing
-                     whitespace intact. Implementations <rfc2119>must</rfc2119> preserve whitespace
-                     as it occurred in the CSV string.
+                     whitespace intact.
                   </fos:value>
                   <fos:value value="true">Fields will be returned with leading or trailing
-                     whitespace removed, and all non-leading or -trailing whitespace preserved.
+                     whitespace removed, and all other whitespace preserved.
                   </fos:value>
                </fos:values>
             </fos:option>
          </fos:options>
 
-         <p>The result of the function is a sequence of arrays-of-strings
+         <p>The result of the function is a sequence of arrays of strings, that is
             <code>array(xs:string)*</code>.</p>
          <p>A blank row is represented as an empty array.</p>
-         <p>An empty field is represented by the empty string.</p>
+         <p>An empty field is represented by the zero-length string.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
             <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
             fields.</p>
-         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
-            for <code>field-delimiter</code> or <code>quote-character</code> are specified and are
+         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if the value of the
+            <code>field-delimiter</code> or <code>quote-character</code> option is
             not a single character.</p>
          <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
-            <code>field-delimiter</code>, <code>row-delimiter</code>,
-            <code>quote-character</code> are equal.</p>
+            <code>field-delimiter</code>, <code>row-delimiter</code>, and
+            <code>quote-character</code> are equal under the Unicode codepoint collation.</p>
       </fos:errors>
       <fos:notes>
          <p>All fields are returned as <code>xs:string</code> values.</p>
          <p>Quoted fields in the input are returned without the quotes.</p>
+         <p>The first row is not treated specially.</p>
          <p>For more discussion of the returned data, see <specref ref="csv-to-xdm-mapping"/>.</p>
       </fos:notes>
       <fos:examples>
@@ -23522,78 +23525,78 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Handling any of the default record separators:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression>csv-to-simple-rows(`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`)</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>csv-to-arrays(`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`)</eg></fos:expression>
+               <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-cr">
-               <fos:expression>csv-to-simple-rows(`name,city{$cr}Bob,Berlin{$cr}Alice,Aachen{$cr}`)</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>csv-to-arrays(`name,city{$cr}Bob,Berlin{$cr}Alice,Aachen{$cr}`)</eg></fos:expression>
+               <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-lf">
-               <fos:expression>csv-to-simple-rows(`name,city{$lf}Bob,Berlin{$lf}Alice,Aachen{$lf}`)</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>csv-to-arrays(`name,city{$lf}Bob,Berlin{$lf}Alice,Aachen{$lf}`)</eg></fos:expression>
+               <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Quote handling:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression>csv-to-simple-rows(`"name","city"{$crlf}"Bob","Berlin"{$crlf}"Alice","Aachen"{$crlf}`)</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>csv-to-arrays(`"name","city"{$crlf}"Bob","Berlin"{$crlf}"Alice","Aachen"{$crlf}`)</eg></fos:expression>
+               <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-crlf">
-               <fos:expression>csv-to-simple-rows(`"name","city"{$crlf}"Bob ""The Exemplar"" Mustermann","Berlin"{$crlf}`)</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>csv-to-arrays(`"name","city"{$crlf}"Bob ""The Exemplar"" Mustermann","Berlin"{$crlf}`)</eg></fos:expression>
+               <fos:result><eg>(
    ["name", "city"],
    ['Bob "The Exemplar" Mustermann', "Berlin"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Non-default record- and field-delimiters:</p>
             <fos:test>
-               <fos:expression>csv-to-simple-rows("name;city§Bob;Berlin§Alice;Aachen", map{"row-delimiter": "§", "field-delimiter": ";"})</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>csv-to-arrays("name;city§Bob;Berlin§Alice;Aachen", map{"row-delimiter": "§", "field-delimiter": ";"})</eg></fos:expression>
+               <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Non-default quote character:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression>csv-to-simple-rows(`|name|,|city|{$crlf}|Bob|,|Berlin|{$crlf}`, map{"quote-character": "|"})</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>csv-to-arrays(`|name|,|city|{$crlf}|Bob|,|Berlin|{$crlf}`, map{"quote-character": "|"})</eg></fos:expression>
+               <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Trimming whitespace in fields:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression xml:space="preserve">csv-to-simple-rows(`name  ,city  {$crlf}Bob   ,Berlin{$crlf}Alice ,Aachen{$crlf}`, map{"trim-whitespace": true()})</fos:expression>
-               <fos:result>(
+               <fos:expression xml:space="preserve"><eg>csv-to-arrays(`name  ,city  {$crlf}Bob   ,Berlin{$crlf}Alice ,Aachen{$crlf}`, map{"trim-whitespace": true()})</eg></fos:expression>
+               <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -23622,7 +23625,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
          <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
             sequence of <code>xs:string</code> values. The function parses this sequence using
-            <code>fn:csv-to-simple-rows</code>, and then processes its result to return an XML document.</p>
+            <code>fn:csv-to-arrays</code>, and then processes its result to return an XML document.</p>
 
          <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
             return a <code><![CDATA[<fn:csv>]]></code> whose <code><![CDATA[<fn:rows>]]></code> element
@@ -23643,7 +23646,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
 
          <p>Handling of delimiters, and whitespace trimming, are handled using
-            <code>fn:csv-to-simple-rows</code>, and the options controlling their use are defined
+            <code>fn:csv-to-arrays</code>, and the options controlling their use are defined
             there.</p>
 
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23257,8 +23257,12 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:notes>
       <fos:examples>
          <fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('\r')||char('\n')]]></fos:variable>
-         <fos:variable name="csv-string" id="csv-string">`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`</fos:variable>
-         <fos:variable name="options" id="non-default-delims">map { "row-delimiter": "§", "field-delimiter": ";", "quote-character": "|" }</fos:variable>
+         <fos:variable name="csv-string" id="csv-string">`name,city{$crlf}`||
+            `Bob,Berlin{$crlf}`||
+            `Alice,Aachen{$crlf}`</fos:variable>
+         <fos:variable name="options" id="non-default-delims">map { "row-delimiter": "§", 
+            "field-delimiter": ";", 
+            "quote-character": "|" }</fos:variable>
          <fos:variable name="non-std-csv" id="non-standard-csv-string">`|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|`</fos:variable>
          <fos:example>
             <p>With defaults for delimiters and quotes, and default column extraction (false):</p>
@@ -23345,7 +23349,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:result><eg>"Berlin"</eg></fos:result>
             </fos:test>
          </fos:example>
-         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string">concat(`date,name,city,amount,currency,original amount,note{$crlf}`,
+         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string">concat(
+`date,name,city,amount,currency,original amount,note{$crlf}`,
 `2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}`,
 `2023-07-20,Alice,Aachen,15.00{$crlf}`,
 `2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`)</fos:variable>
@@ -23353,13 +23358,15 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <p>Filtering columns, with <code>column-names: true()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
                <fos:expression><eg>parse-csv($csv-uneven-cols, 
-         map { "column-names": true(), "filter-columns": (2,1,4) })
+          map { "column-names": true(), 
+                "filter-columns": (2,1,4) })
   ?columns?fields</eg></fos:expression>
                <fos:result><eg>("name","date","amount")</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
                <fos:expression><eg>for $r in parse-csv($csv-uneven-cols, 
-         map { "column-names": true(), "filter-columns": (2,1,4) })?rows 
+          map { "column-names": true(), 
+                "filter-columns": (2,1,4) })?rows 
 return array { $r?fields }</eg></fos:expression>
                <fos:result><eg>(
    ["Bob","2023-07-19","10.00"],
@@ -23372,7 +23379,8 @@ return array { $r?fields }</eg></fos:expression>
             <p>Filtering columns, with <code>column-names: map { ... }</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
                <fos:expression><eg>parse-csv($csv-uneven-cols, 
-         map { "column-names": map { "Person": 1, "Amount": 3 }, "filter-columns": (2,1,4) })
+          map { "column-names": map { "Person": 1, "Amount": 3 }, 
+                "filter-columns": (2,1,4) })
   ?columns</eg></fos:expression>
                <fos:result><eg>map {
    "names": map { "Person": 1, "Amount": 3 },
@@ -23404,12 +23412,15 @@ return array { $r?fields }</eg></fos:expression>
    "names": map { "date": 1, "name": 2, "city": 3, 
                   "amount": 4, "currency": 5, 
                   "original amount": 6 },
-   "fields": ("date","name","city","amount","currency","original amount")
+   "fields": ("date", "name", "city", 
+              "amount", "currency", 
+              "original amount")
 }</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
                <fos:expression><eg>for $r in parse-csv($csv-uneven-cols, 
-                  map { "column-names": true(), "number-of-columns": 6 })?rows 
+                    map { "column-names": true(), 
+                          "number-of-columns": 6 })?rows 
 return array { $r?fields }</eg></fos:expression>
                <fos:result><eg>(
    ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
@@ -23525,7 +23536,7 @@ return array { $r?fields }</eg></fos:expression>
          <p>All fields are returned as <code>xs:string</code> values.</p>
          <p>Quoted fields in the input are returned without the quotes.</p>
          <p>The first row is not treated specially.</p>
-         <p>For more discussion of the returned data, see <specref ref="csv-to-xdm-mapping"/>.</p>
+         <p>For more discussion of the returned data, see <specref ref="basic-csv-to-xdm-mapping"/>.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="lf" id="escaped-lf"><![CDATA[char('\n')]]></fos:variable>
@@ -23534,7 +23545,9 @@ return array { $r?fields }</eg></fos:expression>
          <fos:example>
             <p>Handling any of the default record separators:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression><eg>csv-to-arrays(`name,city{$crlf}Bob,Berlin{$crlf}Alice,Aachen{$crlf}`)</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`name,city{$crlf}`||
+              `Bob,Berlin{$crlf}`||
+              `Alice,Aachen{$crlf}`)</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -23542,7 +23555,9 @@ return array { $r?fields }</eg></fos:expression>
 )</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-cr">
-               <fos:expression><eg>csv-to-arrays(`name,city{$cr}Bob,Berlin{$cr}Alice,Aachen{$cr}`)</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`name,city{$cr}`||
+              `Bob,Berlin{$cr}`||
+              `Alice,Aachen{$cr}`)</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -23550,7 +23565,9 @@ return array { $r?fields }</eg></fos:expression>
 )</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-lf">
-               <fos:expression><eg>csv-to-arrays(`name,city{$lf}Bob,Berlin{$lf}Alice,Aachen{$lf}`)</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`name,city{$lf}`||
+              `Bob,Berlin{$lf}`||
+              `Alice,Aachen{$lf}`)</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -23561,7 +23578,9 @@ return array { $r?fields }</eg></fos:expression>
          <fos:example>
             <p>Quote handling:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression><eg>csv-to-arrays(`"name","city"{$crlf}"Bob","Berlin"{$crlf}"Alice","Aachen"{$crlf}`)</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`"name","city"{$crlf}`||
+              `"Bob","Berlin"{$crlf}`||
+              `"Alice","Aachen"{$crlf}`)</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -23569,7 +23588,8 @@ return array { $r?fields }</eg></fos:expression>
 )</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-crlf">
-               <fos:expression><eg>csv-to-arrays(`"name","city"{$crlf}"Bob ""The Exemplar"" Mustermann","Berlin"{$crlf}`)</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`"name","city"{$crlf}`||
+              `"Bob ""The Exemplar"" Mustermann","Berlin"{$crlf}`)</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ['Bob "The Exemplar" Mustermann', "Berlin"]
@@ -23579,7 +23599,10 @@ return array { $r?fields }</eg></fos:expression>
          <fos:example>
             <p>Non-default record- and field-delimiters:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays("name;city§Bob;Berlin§Alice;Aachen", map{"row-delimiter": "§", "field-delimiter": ";"})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays("name;city§"||
+              "Bob;Berlin§"||
+              "Alice;Aachen", 
+              map{"row-delimiter": "§", "field-delimiter": ";"})</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -23590,7 +23613,9 @@ return array { $r?fields }</eg></fos:expression>
          <fos:example>
             <p>Non-default quote character:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression><eg>csv-to-arrays(`|name|,|city|{$crlf}|Bob|,|Berlin|{$crlf}`, map{"quote-character": "|"})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`|name|,|city|{$crlf}`||
+              `|Bob|,|Berlin|{$crlf}`, 
+              map{"quote-character": "|"})</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"]
@@ -23600,7 +23625,10 @@ return array { $r?fields }</eg></fos:expression>
          <fos:example>
             <p>Trimming whitespace in fields:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression xml:space="preserve"><eg>csv-to-arrays(`name  ,city  {$crlf}Bob   ,Berlin{$crlf}Alice ,Aachen{$crlf}`, map{"trim-whitespace": true()})</eg></fos:expression>
+               <fos:expression xml:space="preserve"><eg>csv-to-arrays(`name  ,city  {$crlf}`||
+              `Bob   ,Berlin{$crlf}`||
+              `Alice ,Aachen{$crlf}`, 
+              map{"trim-whitespace": true()})</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -23900,7 +23928,8 @@ return
 ]]></eg></fos:result>
             </fos:test>
          </fos:example>
-         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string-2">concat(`date,name,city,amount,currency,original amount,note{$crlf}`,
+         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string-2">concat(
+`date,name,city,amount,currency,original amount,note{$crlf}`,
 `2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}`,
 `2023-07-20,Alice,Aachen,15.00{$crlf}`,
 `2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`)</fos:variable>
@@ -23908,7 +23937,8 @@ return
             <p>Filtering columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-                  map { "column-names": true(), "filter-columns": (2,1,4) })</eg></fos:expression>
+           map { "column-names": true(), 
+                 "filter-columns": (2,1,4) })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23941,7 +23971,8 @@ return
             <p>Specifying the number of columns, using "all" (the default)</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-                  map { "column-names": true(), "number-of-columns": "all" })</eg></fos:expression>
+           map { "column-names": true(), 
+                 "number-of-columns": "all" })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23987,7 +24018,8 @@ return
             <p>Specifying the number of columns using <code>"first-row"</code></p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-                  map { "column-names": true(), "number-of-columns": "first-row" })</eg></fos:expression>
+           map { "column-names": true(), 
+                 "number-of-columns": "first-row" })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -24035,7 +24067,9 @@ return
          <fos:example>
             <p>Specifying the number of columns with a number</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression><eg>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
+           map { "column-names": true(), 
+                 "number-of-columns": 6 })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23511,8 +23511,8 @@ return array { $r?fields }</eg></fos:expression>
          <p>An empty field is represented by a zero-length string.</p>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
-            <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
+         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if 
+            <code>$value</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
             fields.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if the value of the
             <code>field-delimiter</code> or <code>quote-character</code> option is
@@ -23628,31 +23628,86 @@ return array { $r?fields }</eg></fos:expression>
             <specref ref="csv-represent-as-xml"/>.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the second argument is omitted or an empty sequence, the result is the same as
-            calling the two-argument form with an empty map as the value of the <code>$options</code>
-            argument.</p>
+         
+         <p>The arguments have the same meaning, and are subject to the same constraints, as
+         the arguments of <code>fn:parse-csv</code>.</p>
+         
+         <p>The effect of the function is equivalent to the result of the following XQuery expression
+            (where <code>$options</code> is an empty map if the argument is not supplied):</p>
+         
+         <eg><![CDATA[let $parsedCSV := parse-csv($value, $options)
+let $colNames := $parsedCSV?columns?fields
+return
+   <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
+       if (exists($colNames)) {
+         <columns> {$colNames ! <column>{.}</column>} </columns>
+       },
+       <rows> {
+         for $row in $parsedCSV?rows?row return
+         <row> {
+           for member $field at $col in $row return
+           <field> {
+             if (exists($colnames[$col])) {
+               attribute column {$colnames[$col]}
+             },
+             $field
+           } </field>
+         } </row>
+       } </rows> 
+   } </csv>]]></eg>
+         
+         <p>The namespace prefix used in the names of elements (or its absence) is 
+            <termref def="implementation-dependent"/>.</p>
+         
+         <p>If the function is called twice with the same arguments, it is <termref
+            def="implementation-dependent"/> whether the two calls return the same element node
+            or distinct (but deep equal) element nodes. In this respect it is <termref
+               def="dt-nondeterministic">nondeterministic with respect to node identity</termref>.</p>
+         
+         <p>The base URI of the element nodes in the result is <termref
+            def="implementation-dependent"/>.</p>
+         
+         <p>A schema is defined for the structure of the returned element: see <specref
+            ref="schema-for-csv"/>.</p>
+         
+         <p>The result of the function will always be such that validation against this schema would succeed.
+            However, it is <termref
+               def="implementation-defined"/> whether the result is typed or untyped,
+            that is, whether the elements and attributes in the returned tree have type annotations that reflect
+            the result of validating against this schema.</p>
+         
+   <!--      <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of an
+            <code>xs:string</code> value. The function first parses this sequence using
+            <code>fn:csv-to-arrays</code>, and then performs further processing on the result to return a tree
+            rooted at an <code>fn:csv</code> element. The initial
+            parsing is exactly as defined for <code>fn:csv-to-arrays</code>, and can be controlled
+            using the same options. Additional options are available to control the way in which
+            header information and column names are handled.</p>
 
-         <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
-            sequence of <code>xs:string</code> values. The function parses this sequence using
-            <code>fn:csv-to-arrays</code>, and then processes its result to return an XML document.</p>
+         <p>If <code>$value</code> is the empty sequence, then the returned 
+            <code><![CDATA[<fn:csv>]]></code> element is as follows: </p>
+         
+         <olist>
+            <item><p>Its <code><![CDATA[<fn:rows>]]></code> child is present as an empty element.</p>
+            </item>
+            <item><p>If column name extraction has been
+               requested, but explicit column names have not been supplied, then its
+               <code><![CDATA[<fn:header>]]></code> child is present as an empty element.</p></item>
+            <item><p>If explicit column names have been
+               supplied, then the <code><![CDATA[<fn:header>]]></code>
+               element is present and contains the appropriate
+               <code><![CDATA[<fn:column>]]></code> elements.</p></item>
+         </olist>
 
-         <p>If <code>$value</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
-            return a <code><![CDATA[<fn:csv>]]></code> whose <code><![CDATA[<fn:rows>]]></code> element
-            is empty.</p>
 
-         <p>If <code>$value</code> is the empty sequence, but column name extraction has been
-            requested, but explicit column names have not been supplied, then the implementation
-            <rfc2119>must</rfc2119> return a <code><![CDATA[<fn:csv>]]></code> element whose
-            <code><![CDATA[<fn:header>]]></code> element is empty.</p>
-
-         <p>If <code>$value</code> is the empty sequence, but explicit column names have been
-            supplied, then the implementation <rfc2119>must</rfc2119> return a
-            <code><![CDATA[<fn:csv>]]></code> element whose <code><![CDATA[<fn:header>]]></code>
-            element contains the appropriate <code><![CDATA[<fn:column>]]></code> elements.</p>
 
          <p>The <code>$options</code> argument can be used to control the way in which the parsing
             takes place. The <termref
                def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
+         
+         <p>If the <code>$options</code> argument is omitted or is an empty sequence, the result is the same as
+            calling the two-argument form with an empty map as the value of the <code>$options</code>
+            argument.</p>
 
          <p>Handling of delimiters, and whitespace trimming, are handled using
             <code>fn:csv-to-arrays</code>, and the options controlling their use are defined
@@ -23696,33 +23751,34 @@ return array { $r?fields }</eg></fos:expression>
             </fos:option>
             <fos:option key="column-names">
                <fos:meaning>Determines whether the first row of the CSV should be treated as a list
-                  of column headers and returned as <code><![CDATA[<column>]]></code> elements in
-                  the <code><![CDATA[<header>]]></code> element. Permitted values are a map of type
+                  of column headers and returned as a sequence of <code><![CDATA[<fn:column>]]></code> 
+                  elements appearing as children of
+                  the <code><![CDATA[<fn:header>]]></code> element. The value must be either a map of type
                   <code>map(xs:string, xs:integer)</code> or an <code>xs:boolean</code>.
                </fos:meaning>
                <fos:type>item()</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
-                  <fos:value value="true">The <code><![CDATA[<header>]]></code> element is populated
-                     with <code><![CDATA[<column>]]></code> elements constructed using the values
+                  <fos:value value="true">The <code><![CDATA[<fn:header>]]></code> element is populated
+                     with <code><![CDATA[<fn:column>]]></code> elements constructed using the values
                      from the first row of the CSV data. Implmentations <rfc2119>must</rfc2119>
-                     exclude the first row from the <code><![CDATA[<rows>]]></code>
+                     exclude the first row from the <code><![CDATA[<fn:rows>]]></code>
                      element.</fos:value>
-                  <fos:value value="false">Implementations <rfc2119>must not</rfc2119> include a
-                     <code><![CDATA[<header>]]></code> element in the output.</fos:value>
+                  <fos:value value="false">No <code><![CDATA[<fn:header>]]></code> element 
+                     is included in the output.</fos:value>
                   <fos:value value="map(xs:string, xs:integer)">The supplied map is used to
-                     construct a sequence of <code><![CDATA[<column>]]></code> elements to populate
-                     the <code><![CDATA[<header>]]></code> element. The <code>xs:integer</code>
+                     construct a sequence of <code><![CDATA[<fn:column>]]></code> elements to populate
+                     the <code><![CDATA[<fn:header>]]></code> element. The <code>xs:integer</code>
                      denotes the column number, and the <code>xs:string</code> the column name. Gaps
                      in the integer sequence of column numbers are filled with empty
-                     <code><![CDATA[<column>]]></code> elements. Implementations <rfc2119>must
-                     not</rfc2119> exclude the first row from the <code><![CDATA[<rows>]]></code>
+                     <code><![CDATA[<fn:column>]]></code> elements. The first row from 
+                     the input is included in the <code><![CDATA[<fn:rows>]]></code>
                      element.</fos:value>
                </fos:values>
             </fos:option>
             <fos:option key="filter-columns">
                <fos:meaning>A sequence indicating which fields to return and in which order. If this
-                  option is missing or the empty sequence, all fields are returned in their natural
+                  option is missing or empty, all fields are returned in their original
                   order. Items in the sequence are treated as the index of the column to return. In
                   the returned data, only fields from the specified columnms are returned, and in
                   the order specified.</fos:meaning>
@@ -23749,18 +23805,10 @@ return array { $r?fields }</eg></fos:expression>
                      string values until it contains the specified number of fields.</fos:value>
                </fos:values>
             </fos:option>
-         </fos:options>
+         </fos:options>-->
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
-            <code>$value</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
-            fields.</p>
-         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
-            for <code>field-delimiter</code>, <code>row-delimiter</code>,
-            <code>quote-character</code> are specified and are not a single character.</p>
-         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
-            <code>field-delimiter</code>, <code>row-delimiter</code>,
-            <code>quote-character</code> are equal.</p>
+         <p>See <code>fn:parse-csv</code>.</p>
       </fos:errors>
       <fos:examples>
          <fos:variable name="crlf" id="escaped-crlf-3"><![CDATA[char('\r')||char('\n')]]></fos:variable>
@@ -23768,31 +23816,31 @@ return array { $r?fields }</eg></fos:expression>
          <fos:example>
             <p>An empty CSV with default column extraction (false):</p>
             <fos:test>
-               <fos:expression>csv-to-xml("")</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml("")</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <rows/>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>An empty CSV with column extraction:</p>
             <fos:test>
-               <fos:expression>csv-to-xml("", map { "column-names": true() })</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml("", map { "column-names": true() })</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns/>
    <rows/>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>An empty CSV with explicit column names:</p>
             <fos:test>
-               <fos:expression>csv-to-xml("", map { "column-names": map { "name": 1, "city": 3 } })</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml("", map { "column-names": map { "name": 1, "city": 3 } })</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
       <column>name</column>
@@ -23801,14 +23849,14 @@ return array { $r?fields }</eg></fos:expression>
    </columns>
    <rows/>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>With defaults for delimiters and quotes, and column extraction:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression>csv-to-xml($csv-string, map { "column-names": true() })</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml($csv-string, map { "column-names": true() })</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
       <column>name</column>
@@ -23825,14 +23873,14 @@ return array { $r?fields }</eg></fos:expression>
       </row>
    </rows>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>With defaults for delimiters and quotes, and column extraction:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression>csv-to-xml($csv-string, map { "column-names": true() })</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml($csv-string, map { "column-names": true() })</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
       <column>name</column>
@@ -23849,7 +23897,7 @@ return array { $r?fields }</eg></fos:expression>
       </row>
    </rows>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string-2">concat(`date,name,city,amount,currency,original amount,note{$crlf}`,
@@ -23859,8 +23907,9 @@ return array { $r?fields }</eg></fos:expression>
          <fos:example>
             <p>Filtering columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
+                  map { "column-names": true(), "filter-columns": (2,1,4) })</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
       <column>name</column>
@@ -23885,14 +23934,15 @@ return array { $r?fields }</eg></fos:expression>
       </row>
    </rows>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Specifying the number of columns, using "all" (the default)</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "all" })</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
+                  map { "column-names": true(), "number-of-columns": "all" })</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
       <column>date</column>
@@ -23930,14 +23980,15 @@ return array { $r?fields }</eg></fos:expression>
       </row>
    </rows>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Specifying the number of columns using <code>"first-row"</code></p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": "first-row" })</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
+                  map { "column-names": true(), "number-of-columns": "first-row" })</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
       <column>date</column>
@@ -23978,14 +24029,14 @@ return array { $r?fields }</eg></fos:expression>
       </row>
    </rows>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Specifying the number of columns with a number</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
-               <fos:expression>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })</fos:expression>
-               <fos:result><![CDATA[
+               <fos:expression><eg>csv-to-xml($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })</eg></fos:expression>
+               <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
       <column>date</column>
@@ -24022,7 +24073,7 @@ return array { $r?fields }</eg></fos:expression>
       </row>
    </rows>
 </csv>
-]]></fos:result>
+]]></eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23010,35 +23010,29 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <code>csv-row-record</code> records.</p>
       </fos:summary>
       <fos:rules>
-         <p>If the second argument is omitted or an empty sequence, the result is the same as
-            calling the two-argument form with an empty map as the value of the <code>$options</code>
-            argument.</p>
-
-         <p>The first argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
-            sequence of <code>xs:string</code> values. The function parses this sequence using
-            <code>fn:csv-to-arrays</code>, and then processes its result to return an XDM value.</p>
-
-         <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
-            return a <code>parsed-csv-structure-record</code> whose <code>rows</code> entry is the empty sequence.</p>
-
-         <p>If <code>$csv</code> is the empty sequence, but column name extraction has been
-            requested, or explicit column names have been supplied, then the
-            <code>parsed-csv-structure-record</code> returned by implementations
-            <rfc2119>must</rfc2119> have a <code>rows</code> entry whose value is the empty
-            sequence.</p>
-
+         
+         <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
+            sequence of <code>xs:string</code> values. The function first parses this sequence using
+            <code>fn:csv-to-arrays</code>, and then further processes the result. The initial
+            parsing is exactly as defined for <code>fn:csv-to-arrays</code>, and can be controlled
+            using the same options. Additional options are available to control the way in which
+            header information and column names are handled.</p>
+         
+         <p>If <code>$value</code> is the empty sequence, the function
+               returns a <code>parsed-csv-structure-record</code> whose 
+               <code>rows</code> entry is the empty sequence.</p>
+         
          <p>The <code>$options</code> argument can be used to control the way in which the parsing
             takes place. The <termref
                def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
+         
+         <p>If the <code>$options</code> argument is omitted or is an empty sequence, the result is the same as
+            calling the two-argument form with an empty map as the value of the <code>$options</code>
+            argument.</p>
 
-         <p>Handling of delimiters, and whitespace trimming, are handled using
-            <code>fn:csv-to-arrays</code>, and the options controlling their use are defined
-            there.</p>
+ 
 
-         <p>If the <code>column-names</code> option is true, implementations <rfc2119>must</rfc2119>
-            exclude the first record from the returned map’s <code>rows</code> key, and use it to
-            construct a <code>csv-columns-record</code> that is returned as the value of the
-            returned map’s <code>columns</code> key.</p>
+         
 
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
          <fos:options>
@@ -23089,31 +23083,31 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      into a map of the form <code>{ "Column name": column-number }</code> for the
                      <code>names</code> entry of the <code>csv-columns-record</code>, and the
                      fields of the row are returned as a sequence of strings
-                     (<code>xs:string*</code>) for the <code>fields</code> entry. Implmentations
-                     <rfc2119>must</rfc2119> exclude the first row from the <code>rows</code>
+                     (<code>xs:string*</code>) for the <code>fields</code> entry. 
+                     The first (header) row is excluded from the <code>rows</code>
                      entry of the returned <code>parsed-csv-structure-record</code>.</fos:value>
-                  <fos:value value="false">Implementations <rfc2119>must</rfc2119> return an empty
-                     <code>csv-columns-record</code>, equivalent to the literal map <code>map {
-                     names: map {}, fields: () }</code>, in the <code>columns</code> entry of
-                     the returned <code>parsed-csv-structure-record</code>. Implementations
-                     <rfc2119>must not</rfc2119> exclude the first row from the <code>rows</code>
+                  <fos:value value="false">The function returns an empty
+                     <code>csv-columns-record</code>, equivalent to the value <code>map {
+                     "names": map {}, "fields": () }</code>, in the <code>columns</code> entry of
+                     the returned <code>parsed-csv-structure-record</code>. The first row 
+                     is <emph>not</emph> excluded from the <code>rows</code>
                      entry of the <code>parsed-csv-structure-record</code>.</fos:value>
                   <fos:value value="map(xs:string, xs:integer)">A <code>csv-columns-record</code> is
                      constructed using the supplied map and returned as the <code>header</code>
                      entry of the <code>parsed-csv-structure-record</code>. The supplied map is used
                      as the <code>names</code> entry, and a sequence of strings for the
                      <code>fields</code> is constructed, filling in blank columns with the empty
-                     string. and the fields of the row are returned as the <code>fields</code>
-                     entry. Implementations <rfc2119>must not</rfc2119> exclude the first row from
+                     string, and the fields of the row are returned as the <code>fields</code>
+                     entry. The first row is <emph>not</emph> excluded from
                      the <code>rows</code> entry of the <code>parsed-csv-structure-record</code>.
                   </fos:value>
                </fos:values>
             </fos:option>
             <fos:option key="filter-columns">
                <fos:meaning>A sequence indicating which fields to return and in which order. If this
-                  option is missing or the empty sequence, all fields are returned in their natural
+                  option is absent or empty, all fields are returned in their original
                   order. Items in the sequence are treated as the index of the column to return. In
-                  the returned data, only fields from the specified columnms are returned, and in
+                  the returned data, only fields from the specified columns are returned, and in
                   the order specified. This option is mutually exclusive with the
                   <code>number-of-columns</code> option. Specifying both options will cause an <errorref
                      class="CV" code="0006"/> error.</fos:meaning>
@@ -23128,7 +23122,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:default>"all"</fos:default>
                <fos:values>
                   <fos:value value="'all'">All fields from all rows
-                     <rfc2119>must</rfc2119> be returned, without being padded or truncated,
+                     are returned, without being padded or truncated,
                      regardless of whether rows have varying numbers of fields, or of how many
                      fields they have.</fos:value>
                   <fos:value value="'first-row'">The number of fields in the first row is counted,
@@ -23136,7 +23130,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      this option.</fos:value>
                   <fos:value value="xs:integer">The number of columns is set to this value. Rows
                      with more fields than the supplied value are truncated by discarding the extra
-                     fields. as if calling <code>fn:subsequence(R, 1, I)</code>, given the row’s
+                     fields, as if calling <code>fn:subsequence(R, 1, I)</code>, given the row’s
                      sequence of fields in <var>R</var>, and the supplied value in <var>I</var>. If
                      a row has fewer fields than the supplied value it is padded by appending empty
                      string values until it contains the specified number of fields.</fos:value>
@@ -23269,58 +23263,58 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>With defaults for delimiters and quotes, and default column extraction (false):</p>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>map:keys(parse-csv($csv-string))</fos:expression>
-               <fos:result>("columns", "rows")</fos:result>
+               <fos:expression><eg>map:keys(parse-csv($csv-string))</eg></fos:expression>
+               <fos:result><eg>("columns", "rows")</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>parse-csv($csv-string)?columns</fos:expression>
-               <fos:result>map {
+               <fos:expression><eg>parse-csv($csv-string)?columns</eg></fos:expression>
+               <fos:result><eg>map {
   "names": map {},
   "fields": ()
-}</fos:result>
+}</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>count(parse-csv($csv-string)?rows)</fos:expression>
-               <fos:result>3</fos:result>
+               <fos:expression><eg>count(parse-csv($csv-string)?rows)</eg></fos:expression>
+               <fos:result><eg>3</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>parse-csv($csv-string)?rows[1]?field("name")</fos:expression>
+               <fos:expression><eg>parse-csv($csv-string)?rows[1]?field("name")</eg></fos:expression>
                <fos:error-result error-code="FOCV0004"/>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>parse-csv($csv-string)?rows[1]?field(2)</fos:expression>
-               <fos:result>"city"</fos:result>
+               <fos:expression><eg>parse-csv($csv-string)?rows[1]?field(2)</eg></fos:expression>
+               <fos:result><eg>"city"</eg></fos:result>
             </fos:test>
             <p>With defaults for delimiters and quotes, and <code>columns: true()</code> set:</p>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>parse-csv($csv-string, map {"column-names": true()})?columns</fos:expression>
-               <fos:result>map {
+               <fos:expression><eg>parse-csv($csv-string, map {"column-names": true()})?columns</eg></fos:expression>
+               <fos:result><eg>map {
   "names": map { "name": 1, "city": 2 },
   "fields": ("name", "city")
-}</fos:result>
+}</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>count(parse-csv($csv-string, map {"column-names": true()})?rows)</fos:expression>
-               <fos:result>2</fos:result>
+               <fos:expression><eg>count(parse-csv($csv-string, map {"column-names": true()})?rows)</eg></fos:expression>
+               <fos:result><eg>2</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>parse-csv($csv-string, map {"column-names": true()})?rows[1]?fields</fos:expression>
-               <fos:result>("Bob", "Berlin")</fos:result>
+               <fos:expression><eg>parse-csv($csv-string, map {"column-names": true()})?rows[1]?fields</eg></fos:expression>
+               <fos:result><eg>("Bob", "Berlin")</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>parse-csv($csv-string, map {"column-names": true()})?rows[1]?field("name")</fos:expression>
-               <fos:result>"Bob"</fos:result>
+               <fos:expression><eg>parse-csv($csv-string, map {"column-names": true()})?rows[1]?field("name")</eg></fos:expression>
+               <fos:result><eg>"Bob"</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression>parse-csv($csv-string, map {"column-names": true()})?rows[1]?field(2)</fos:expression>
-               <fos:result>"Berlin"</fos:result>
+               <fos:expression><eg>parse-csv($csv-string, map {"column-names": true()})?rows[1]?field(2)</eg></fos:expression>
+               <fos:result><eg>"Berlin"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Non-default record- and field-delimiters, non-default quotes:</p>
             <fos:test use="non-default-delims non-standard-csv-string">
-               <fos:expression>parse-csv($non-std-csv, $options)?rows[3]?field(1)</fos:expression>
-               <fos:result>"Alice"</fos:result>
+               <fos:expression><eg>parse-csv($non-std-csv, $options)?rows[3]?field(1)</eg></fos:expression>
+               <fos:result><eg>"Alice"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:variable name="csv-string" id="csv-string-no-headers">`Alice,Aachen{$crlf}Bob,Berlin{$crlf}`</fos:variable>
@@ -23328,27 +23322,27 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Specifying column names explicitly:</p>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>map:keys(parse-csv($csv-string, $options))</fos:expression>
-               <fos:result>("columns", "rows")</fos:result>
+               <fos:expression><eg>map:keys(parse-csv($csv-string, $options))</eg></fos:expression>
+               <fos:result><eg>("columns", "rows")</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>parse-csv($csv-string, $options)?columns</fos:expression>
-               <fos:result>map {
+               <fos:expression><eg>parse-csv($csv-string, $options)?columns</eg></fos:expression>
+               <fos:result><eg>map {
    "names": map { "Person": 1, "Location": 2 },
    "fields": ("Person", "Location")
-}</fos:result>
+}</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>count(parse-csv($csv-string, $options)?rows)</fos:expression>
-               <fos:result>2</fos:result>
+               <fos:expression><eg>count(parse-csv($csv-string, $options)?rows)</eg></fos:expression>
+               <fos:result><eg>2</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>parse-csv($csv-string, $options)?rows[1]?field(1)</fos:expression>
-               <fos:result>"Alice"</fos:result>
+               <fos:expression><eg>parse-csv($csv-string, $options)?rows[1]?field(1)</eg></fos:expression>
+               <fos:result><eg>"Alice"</eg></fos:result>
             </fos:test>
             <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression>parse-csv($csv-string, $options)?rows[2]?field("Location")</fos:expression>
-               <fos:result>"Berlin"</fos:result>
+               <fos:expression><eg>parse-csv($csv-string, $options)?rows[2]?field("Location")</eg></fos:expression>
+               <fos:result><eg>"Berlin"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string">concat(`date,name,city,amount,currency,original amount,note{$crlf}`,
@@ -23358,56 +23352,70 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Filtering columns, with <code>column-names: true()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>parse-csv($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })?columns?fields</fos:expression>
-               <fos:result>("name","date","amount")</fos:result>
+               <fos:expression><eg>parse-csv($csv-uneven-cols, 
+         map { "column-names": true(), "filter-columns": (2,1,4) })
+  ?columns?fields</eg></fos:expression>
+               <fos:result><eg>("name","date","amount")</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in parse-csv($csv-uneven-cols, map { "column-names": true(), "filter-columns": (2,1,4) })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>for $r in parse-csv($csv-uneven-cols, 
+         map { "column-names": true(), "filter-columns": (2,1,4) })?rows 
+return array { $r?fields }</eg></fos:expression>
+               <fos:result><eg>(
    ["Bob","2023-07-19","10.00"],
    ["Alice","2023-07-20","15.00"],
    ["Charlie","2023-07-20","15.00"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Filtering columns, with <code>column-names: map { ... }</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>parse-csv($csv-uneven-cols, map { "column-names": map { "Person": 1, "Amount": 3 }, "filter-columns": (2,1,4) })?columns</fos:expression>
-               <fos:result>map {
+               <fos:expression><eg>parse-csv($csv-uneven-cols, 
+         map { "column-names": map { "Person": 1, "Amount": 3 }, "filter-columns": (2,1,4) })
+  ?columns</eg></fos:expression>
+               <fos:result><eg>map {
    "names": map { "Person": 1, "Amount": 3 },
    "fields": ("Person", "", "Amount")
-}</fos:result>
+}</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Specifying the number of columns using <code>"first-row"</code> and <code>column-names: false()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in parse-csv($csv-uneven-cols, map { "number-of-columns": "first-row" })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>for $r in parse-csv($csv-uneven-cols, 
+                  map { "number-of-columns": "first-row" })?rows 
+return array { $r?fields }</eg></fos:expression>
+               <fos:result><eg>(
    ["date","name","city","amount","currency","original amount","note"],
    ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
    ["2023-07-20","Alice","Aachen","15.00","","",""],
    ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Specifying the number of columns with a number and <code>column-names: true()</code></p>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>parse-csv($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?columns?fields</fos:expression>
-               <fos:result>map {
-   "names": map { "date": 1, "name": 2, "city": 3, "amount": 4, "currency": 5, "original amount": 6 },
+               <fos:expression><eg>parse-csv($csv-uneven-cols, 
+         map { "column-names": true(), "number-of-columns": 6 })
+  ?columns?fields</eg></fos:expression>
+               <fos:result><eg>map {
+   "names": map { "date": 1, "name": 2, "city": 3, 
+                  "amount": 4, "currency": 5, 
+                  "original amount": 6 },
    "fields": ("date","name","city","amount","currency","original amount")
-}</fos:result>
+}</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression>for $r in parse-csv($csv-uneven-cols, map { "column-names": true(), "number-of-columns": 6 })?rows return array { $r?fields }</fos:expression>
-               <fos:result>(
+               <fos:expression><eg>for $r in parse-csv($csv-uneven-cols, 
+                  map { "column-names": true(), "number-of-columns": 6 })?rows 
+return array { $r?fields }</eg></fos:expression>
+               <fos:result><eg>(
    ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
    ["2023-07-20","Alice","Aachen","15.00","",""],
    ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
-)</fos:result>
+)</eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -23432,7 +23440,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:rules>
          
          <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of an
-            <code>xs:string</code> value. The function parses this string.</p>
+            <code>xs:string</code> value. The function parses this string.
+            The result of the function is a sequence of arrays of strings, that is
+            <code>array(xs:string)*</code>; each array represents one row of the CSV input.</p>
          
          <p>If <code>$value</code> is the empty sequence, the function returns an empty sequence.</p>
          
@@ -23496,10 +23506,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:option>
          </fos:options>
 
-         <p>The result of the function is a sequence of arrays of strings, that is
-            <code>array(xs:string)*</code>.</p>
+
          <p>A blank row is represented as an empty array.</p>
-         <p>An empty field is represented by the zero-length string.</p>
+         <p>An empty field is represented by a zero-length string.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22994,7 +22994,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
    <fos:function name="parse-csv" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record">
-            <fos:arg name="csv" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -23416,7 +23416,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
    <fos:function name="csv-to-arrays" prefix="fn">
       <fos:signatures>
          <fos:proto name="csv-to-arrays" return-type="array(xs:string)*">
-            <fos:arg name="csv" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="options" type-ref="csv-parsing-options" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -23605,7 +23605,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
    <fos:function name="csv-to-xml" prefix="fn">
       <fos:signatures>
          <fos:proto name="csv-to-xml" return-type="element(fn:csv)">
-            <fos:arg name="csv" type="xs:string?"/>
+            <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23431,10 +23431,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:summary>
       <fos:rules>
          
-         <p>The <code>$csv</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of an
+         <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of an
             <code>xs:string</code> value. The function parses this string.</p>
          
-         <p>If <code>$csv</code> is the empty sequence, the function returns an empty sequence.</p>
+         <p>If <code>$value</code> is the empty sequence, the function returns an empty sequence.</p>
          
          <p>The <code>$options</code> argument can be used to control the way in which the parsing
             takes place. The <termref
@@ -23627,16 +23627,16 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             sequence of <code>xs:string</code> values. The function parses this sequence using
             <code>fn:csv-to-arrays</code>, and then processes its result to return an XML document.</p>
 
-         <p>If <code>$csv</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
+         <p>If <code>$value</code> is the empty sequence, implementations <rfc2119>must</rfc2119>
             return a <code><![CDATA[<fn:csv>]]></code> whose <code><![CDATA[<fn:rows>]]></code> element
             is empty.</p>
 
-         <p>If <code>$csv</code> is the empty sequence, but column name extraction has been
+         <p>If <code>$value</code> is the empty sequence, but column name extraction has been
             requested, but explicit column names have not been supplied, then the implementation
             <rfc2119>must</rfc2119> return a <code><![CDATA[<fn:csv>]]></code> element whose
             <code><![CDATA[<fn:header>]]></code> element is empty.</p>
 
-         <p>If <code>$csv</code> is the empty sequence, but explicit column names have been
+         <p>If <code>$value</code> is the empty sequence, but explicit column names have been
             supplied, then the implementation <rfc2119>must</rfc2119> return a
             <code><![CDATA[<fn:csv>]]></code> element whose <code><![CDATA[<fn:header>]]></code>
             element contains the appropriate <code><![CDATA[<fn:column>]]></code> elements.</p>
@@ -23744,7 +23744,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
-            <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
+            <code>$value</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
             fields.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
             for <code>field-delimiter</code>, <code>row-delimiter</code>,

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7076,7 +7076,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
 
             <div3 id="basic-csv-to-xdm-mapping">
-               <head>Basic mapping of CSV to arrays</head>
+               <head>Basic parsing of CSV to arrays</head>
 
                <p>The result of <code>fn:csv-to-arrays</code> is a sequence of rows, where
                   each row is represented as an array of <code>xs:string</code> values.</p>
@@ -7144,25 +7144,34 @@ Field 2A,Field 2B,Field 2C,Field 2D'
             </div3>
 
             <div3 id="csv-to-xdm-mapping">
-               <head>Mapping CSV data to XDM in <code>fn:parse-csv</code></head>
+               <head>Enhanced parsing of CSV data to maps and arrays</head>
 
 
-               <p>The <code>fn:parse-csv</code> function returns a
-                  <code>parsed-csv-structure-record</code>:</p>
+               <p>While <code>fn:csv-to-arrays</code> simply delivers the CSV content
+                  as a sequence of arrays, the <code>fn:parse-csv</code> function goes a step
+                  further and enables access to the data using column names. The column
+                  names may be taken either from the first row of the CSV data, or from
+                  data supplied by the caller in the <code>options</code> parameter.</p>
+                  
+                  <p>The function returns a
+                  <code>parsed-csv-structure-record</code>. This has two parts:
+                  <code>columns</code> contains information about the column names, while
+                  <code>rows</code> contains the data in the non-header rows:</p>
 
                <?type parsed-csv-structure-record ?>
 
                <div4 id="csv-xdm-header">
                   <head>The <code>columns</code> entry</head>
 
-                  <p>The required <code>columns</code> entry describes how columns map to names, as well as
-                     providing all the fields in the header row that was used to generate the column
+                  <p>The <code>columns</code> entry describes how the names of columns map to their
+                     integer positions. as well as
+                     providing the contents of the header row that was used to generate the column
                      names.</p>
 
                   <?type csv-columns-record ?>
 
-                  <p>If column names were not extracted, then implementations
-                     <rfc2119>must</rfc2119> return a <code>csv-columns-record</code> whose
+                  <p>If column names were not extracted, then the function
+                     returns a <code>csv-columns-record</code> whose
                      <code>names</code> entry is an empty map, and whose <code>fields</code>
                      entry is the empty sequence.</p>
                </div4>
@@ -7171,8 +7180,8 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                   <head>The <code>rows</code> entry</head>
 
                   <p>The <code>rows</code> entry returns the rows themselves. It is a sequence of
-                     <code>csv-row</code> records. If the CSV was empty of rows, implementations
-                     <rfc2119>must</rfc2119> return a <code>rows</code> entry consisting of the
+                     <code>csv-row</code> records. If the input CSV contains no rows, the function
+                     returns a <code>rows</code> entry whose value is the
                      empty sequence.</p>
                </div4>
 
@@ -7181,9 +7190,9 @@ Field 2A,Field 2B,Field 2C,Field 2D'
 
                   <?type csv-row-record ?>
 
-                  <p>The <code>csv-row-record</code> represents a single row. The
+                  <p>Each <code>csv-row-record</code> represents a single row. The
                      <code>fields</code> entry is a sequence containing the fields as
-                     <code>xs:string</code>.</p>
+                     <code>xs:string</code> values.</p>
 
                   <p>The <code>field</code> entry contains a function, as described below:</p>
                </div4>
@@ -7194,7 +7203,7 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                   <p>The function returned in the <code>field</code> entry is an arity 1 (one)
                      function which takes either a string or an integer as its argument
                      <code>$key</code>, and returns a field from the <code>csv-row-record</code>’s
-                     <code>fields</code> sequence by either column position (when passed an
+                     <code>fields</code> sequence by either its 1-based column position (when passed an
                      <code>xs:integer</code>) or column name (when passed an
                      <code>xs:string</code>).</p>
                </div4>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6913,27 +6913,43 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <div2 id="csv-functions">
             <head>Functions on CSV Data</head>
             <p>This section describes functions that parse CSV data.</p>
-            <?local-function-index?>
-            <p>The structured representation of a parsed CSV is described by the
-               <code>parsed-csv-structure-record</code>, see <specref ref="csv-to-xdm-mapping"/>.</p>
             
   
 
-            <p>Comma separated values (CSV) refers to a wide variety of plain-text tabular data with
-               fields and records separated by standard character delimiters. CSV has developed
-               informally for decades, and this implementation refers to <bibref ref="rfc4180"/>,
-               which provides a standardized grammar. This section defines a mapping from <bibref ref="rfc4180"/>
+            <p><termdef id="dt-csv" term="CSV"> The term <term>comma separated values</term> or 
+               <term>CSV</term> refers to a wide variety of plain-text tabular data formats with
+               fields and records separated by standard character delimiters 
+               (often, but not invariably, commas).</termdef></p>
+            
+            <p>CSV has developed informally for decades, and many variations are found. 
+               This specification refers to <bibref ref="rfc4180"/>,
+               which provides a standardized grammar. This specification defines a 
+               mapping from <bibref ref="rfc4180"/>
                to constructs in the XDM model, and provides illustrative examples of how these
-               constructs can be used in conjunction with existing language features to provide rich
-               processing of CSV data.</p>
+               constructs can be combined with other language features to process CSV data.</p>
 
             <p>A CSV is a 2-dimensional tabular data structure consisting of multiple <term>rows</term> 
-               (also known as a <term>record</term>). Each
-               row contains multiple <term>fields</term>. Each field’s position in
-               the row is organized by <term>column</term>. Fields
-               across records are members of a column, identified by position and
-               possibly name. Column names can be
+               (also known as <term>records</term>). Each
+               row contains multiple <term>fields</term>. Fields occupying the same position in
+               successive rows constitute a <term>column</term>. Columns are identified by position and
+               optionally by name. Column names can be
                assigned within a CSV using an optional <term>header row</term>.</p>
+            
+            <?local-function-index?>
+            
+            <p>The most basic function for parsing CSV is <code>fn:csv-to-arrays</code>
+            which recognizes the delimiters for rows and fields and returns a sequence
+            of arrays each corresponding to one row. The fields within each array are
+            represented as instances of <code>xs:string</code>.</p>
+            
+            <p>The other two functions recognize column names, and make it easier to address
+            individual fields using these names. The <code>parse-csv</code> function
+            delivers this capability using XDM maps and functions, while <code>csv-to-xml</code>
+            function represents the information using XDM element nodes.</p>
+            
+            <!--<p>The structured representation of a parsed CSV is described by the
+               <code>parsed-csv-structure-record</code>, see <specref ref="csv-to-xdm-mapping"/>.</p>
+            
 
             <p>The rows and fields from this specification map directly to the record
                and field structures defined in <bibref ref="rfc4180"/>, which has no explicit structure to
@@ -6944,25 +6960,26 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                as with an array. Named columns allow fields to be retrieved by name, as with a
                map.</p>
 
-            <p>Fields are simple strings. A field that contains reserved characters (one of the
+            <p>The content of a field is a simple string. A field that contains reserved characters (one of the
                delimiters) must be quoted, and the quote character must be escaped if it occurs
                within a field. (See <specref ref="csv-field-quoting"/>.)</p>
 
             <p>The functions for processing CSV-formatted data are built on
-               <code>fn:csv-to-simple-rows</code>, which provides a simple representation of a parsed CSV
-               as a sequence of arrays-of-strings, <code>array(xs:string)*</code>, handling row and
-               column delimiters, and quoting.</p>
+               <code>fn:csv-to-arrays</code>, which provides a simple mapping of a parsed CSV
+               to a sequence of arrays of strings, that is <code>array(xs:string)*</code>.
+               The function handles row and column delimiters and quoting.</p>
 
             <p>The <code>fn:csv-to-xml</code> and <code>fn:parse-csv</code> functions provide more
-               sophisticated processing.</p>
+               sophisticated processing, for example identification of fields by names appearing
+               in a header row.</p>-->
 
 
             <div3 id="common-parsing-options">
                <head>Common parsing options</head>
 
-               <p>All three functions: <code>fn:csv-to-simple-rows</code>, <code>fn:csv-to-xml</code>, and
-                  <code>fn:parse-csv</code>, take options to control basic parsing, consisting
-                  of specifying the various delimiters. These core delimiter options are used by the
+               <p>All three functions: <code>fn:csv-to-arrays</code>, <code>fn:csv-to-xml</code>, and
+                  <code>fn:parse-csv</code>, take options to control parsing, in particular
+                  specifying the characters used as delimiters. These core delimiter options are used by the
                   functions that generate CSV data:</p>
 
                <?type common-csv-options ?>
@@ -6975,81 +6992,83 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
 
             <div3 id="csv-delimiters">
                <head>CSV delimiters</head>
+               
+               <p>The delimiters used for rows, columns, and quoting are configurable. An error
+                  is raised if the same delimiter string is used in multiple roles 
+                  <errorref class="CV" code="0003"/>.</p>
 
 
                <div4 id="row-delimiters">
                   <head>Row delimiters</head>
 
-                  <p>Rows in CSV are typically delimited with CRLF, LF, or CR line endings, although
-                     field quoting means that there is not always a one-to-one mapping between line
-                     and row in a file.</p>
+                  <p>Rows in CSV are typically delimited with CRLF (<code>U+000D, U+000A</code>), 
+                     LF (<code>U+000A</code>), or CR (<code>U+000D</code>) line endings, although
+                     field quoting means that there is not always a one-to-one mapping between lines in a file
+                     and rows/records in the parsed CSV.</p>
 
-                  <p>The row delimiter defaults to matching any of CRLF (<code><![CDATA[&#x0D;&#x0A;]]></code>),
-                     LF (<code><![CDATA[&#x0A;]]></code>), or CR (<code><![CDATA[&#x0D;]]></code>). Valid values for the row
-                     delimiter are a single Unicode character, or one of CRLF, LF, or CR, that has
-                     not been marked for use as the column delimiter. Implementations
-                     <rfc2119>must</rfc2119> raise <errorref class="CV" code="0002"/> if the
+                  <p>The default row delimiter allows any of CRLF,
+                     LF, or CR. Valid values for the row
+                     delimiter are a single Unicode character, or one of CRLF, LF, or CR. An error
+                     is raised if the
                      <code>row-delimiter</code> option is set to a multi-character string other
-                     than CRLF (<code><![CDATA[&#x0D;&#x0A;]]></code>), and <errorref class="CV" code="0003"/>
-                     if the same string has been set for row or column delimiter, or quote
-                     character.</p>
+                     than CRLF (<code>U+000D, U+000A</code>)  <errorref class="CV" code="0002"/>.</p>
+                  
+                  <p>The last row in the file may or may not be followed by a row delimiter.</p>
               </div4>
 
                <div4 id="column-delimiters">
                   <head>Column/Field delimiters</head>
 
-                  <p>Fields in CSV are typically delimited with a comma. Files with other field
-                     delimiters are common, especially when the comma has data significance, for
-                     example with the use of the decimal comma in much of the world (the
-                     delimiter then usually becomes the semicolon).</p>
+                  <p>Fields in CSV are frequently delimited with a comma. Other field
+                     delimiters are useful for
+                     example when numeric data uses comma as a decimal separator. The
+                     chosen field delimiter is then often a semicolon (<code>U+003B</code>)
+                     or tab (<code>U+0009</code>).</p>
 
-                  <p>The column delimiter defaults to the comma <code>","</code>. Valid values for
-                     the column delimiter are a single Unicode character that has not been marked
-                     for use as the row delimiter. Implementations <rfc2119>must</rfc2119> raise
-                     <errorref class="CV" code="0002"/> if the <code>column-delimiter</code>
-                     option is set to a multi-character string, and <errorref class="CV" code="0003"
-                     /> if the same string has been set for row or column delimiter, or quote
-                     character.</p>
+                  <p>The column delimiter defaults to the comma <code>","</code> (<code>U+002C</code>). 
+                     The value may be
+                     any single Unicode character. An error is raised if the 
+                     <code>column-delimiter</code> option is set to a multi-character string.</p>
                </div4>
             </div3>
 
             <div3 id="csv-field-quoting">
                <head>Field quoting</head>
 
-               <p>CSVs, per <bibref ref="rfc4180"/>, require that fields be wrapped with a quote character if they
-                  contain either the row or column delimiter. This is achieved by wrapping the field
-                  with the quote character:</p>
+               <p>CSVs, as specified in <bibref ref="rfc4180"/>, require that fields be wrapped with a quote character if they
+                  contain either the row or column delimiter. For example:</p>
 
-               <eg>"A single field, with a comma","another field containing CRLF
+               <eg>"A single field, containing a comma","another field containing CRLF
                   within it"</eg>
 
-               <p>If a field is to contain the quote character, it must be escaped by preceding it
-                  with itself, as with escaping double quotes in XPath (see <xspecref
-                     ref="id-literals" spec="XP40"/>). Implementations <rfc2119>must</rfc2119> raise
+               <p>If a field is to contain the quote character, the character must be escaped by doubling it, 
+                  as with escaping of quotes in XPath string literals (see <xspecref
+                     ref="id-literals" spec="XP40"/>). An error is raised
                   <errorref class="CV" code="0001"/> if a quote character appears within a field
-                  incorrectly escaped.</p>
+                  incorrectly escaped, for example:</p>
 
                <eg>incorrectly escaped " quote character</eg>
 
-               <p>The quotes surrounding quoted fields are not included in their content. The
-                  following input string, when parsed, would produce a sequence of strings, as shown
+               <p>The quotes surrounding quoted fields are not included in the result. The
+                  following input string, when parsed, produces a sequence of strings, as shown
                   below:</p>
 
                <eg>'"Field 1","Field 2","Field ""with quotes"" 3"'</eg>
 
                <eg>('Field 1', 'Field 2', 'Field "with quotes" 3')</eg>
 
-               <p>The quote character defaults to the double quote <code>"</code>.</p>
+               <p>The quote character defaults to the Unicode quotation mark
+                  <code>"</code> (<code>U+0022</code>).</p>
 
                <div4 id="csv-field-quoting-column-delimiters">
                   <head>Field quoting and column delimiters</head>
 
-                  <p>No space is allowed between the column delimiter and a quote. Implementations
-                     <rfc2119>must</rfc2119> raise <errorref class="CV" code="0001"/> if
+                  <p>No space is allowed between the column delimiter and a quote. An error is raised
+                     <errorref class="CV" code="0001"/> if
                      whitespace or other characters occur between a quote character and the nearest
                      column delimiter.</p>
 
-                  <p>The following example is illegal and parsing it should raise an error.</p>
+                  <p>The following example is therefore invalid and parsing it will raise an error.</p>
 
                   <eg>'"Field 1", "Field 2", "Field 3"'</eg>
 
@@ -7057,14 +7076,18 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             </div3>
 
             <div3 id="basic-csv-to-xdm-mapping">
-               <head>Basic mapping of CSV to XDM</head>
+               <head>Basic mapping of CSV to arrays</head>
 
-               <p>The basic output from <code>fn:csv-to-simple-rows</code> returns a sequence of rows, where
-                  each row is simply mapped to an array of <code>xs:string</code> values.</p>
+               <p>The result of <code>fn:csv-to-arrays</code> is a sequence of rows, where
+                  each row is represented as an array of <code>xs:string</code> values.</p>
 
-               <p>The first row of the CSV is returned as with all the other rows.
-                  <code>fn:csv-to-simple-rows</code> does not distinguish between a header row and data
+               <p>The first row of the CSV is returned in the same way as all the other rows.
+                  <code>fn:csv-to-arrays</code> does not distinguish between a header row and data
                   rows, and returns all of them.</p>
+
+<example>
+   <head>A CSV with fixed-width rows</head>
+   <p>For example, given the input:</p>
 
                <eg>
 'Column 1,Column 2,Column 3
@@ -7072,7 +7095,7 @@ Field 1A,Field 1B,Field 1C
 Field 2A,Field 2B,Field 2C'
                </eg>
 
-               <p>produces</p>
+               <p>the <code>fn:csv-to-arrays</code> function produces</p>
 
                <eg>
 (
@@ -7081,9 +7104,13 @@ Field 2A,Field 2B,Field 2C'
    ["Field 2A", "Field 2B", "Field 2C"]
 )
                </eg>
+   </example>
+               <example>
+                  <head>A CSV with variable-width rows</head>
+               
 
-               <p>There is an expectation that, in the general case, all rows in a given CSV will
-                  have the same number of columns, but there is no guarantee of this.</p>
+               <p>It is common practice for all rows in a CSV to
+                  have the same number of columns, but this is not required.</p>
 
                <eg>
 'Column 1,Column 2,Column 3
@@ -7104,11 +7131,16 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                <p><bibref ref="rfc4180"/> states that CSVs <rfc2119>should</rfc2119> contain the
                   same number of fields in each row, so that there are a uniform number of columns.
                   However, the reality is that CSVs can, and sometimes do, contain a variable number
-                  of fields in a row. As a result, implementations of this function <rfc2119>must
-                  not</rfc2119> truncate or pad the number of fields in each row for any reason.
+                  of fields in a row. As a result, this function does
+                  not truncate or pad the number of fields in each row for any reason.
                   The <code>fn:csv-to-xml</code> and <code>fn:parse-csv</code> functions provide
-                  facilities to deal with enforcing uniformity and an expected number of
+                  facilities to enforce uniformity and an expected number of
                   columns.</p>
+               </example>
+            </div3>
+            
+            <div3 id="func-csv-to-arrays">
+               <head><?function fn:csv-to-arrays?></head>
             </div3>
 
             <div3 id="csv-to-xdm-mapping">
@@ -7167,11 +7199,14 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                      <code>xs:string</code>).</p>
                </div4>
             </div3>
+            <div3 id="func-parse-csv">
+               <head><?function fn:parse-csv?></head>
+            </div3>
             <div3 id="csv-represent-as-xml">
                <head>Representing CSV data as XML</head>
 
-               <p>The <code>fn:csv-to-xml</code> function returns XML representing the CSV data.
-                  Following is a CSV text and its XML representation.</p>
+               <p>The <code>fn:csv-to-xml</code> function returns an XDM node tree representing the CSV data.
+                  Following is a CSV text and the XML serialization of the corresponding node tree.</p>
 
                <eg>Name,Date,Amount
 Alice,2023-07-14,1.23
@@ -7227,19 +7262,20 @@ Bob,2023-07-14,2.34
 </csv>
 ]]></eg>
 
-               <p>An XSD 1.0 schema for the XML representation is provided in <specref ref="schema-for-csv"/>.</p>
+               <p>An XSD 1.0 schema for the XML representation is provided in 
+                  <specref ref="schema-for-csv"/>.</p>
             </div3>
             <div3 id="illustrative-csv-examples">
                <head>Illustrative examples of processing CSV data</head>
 
 
-               <p>The following examples illustrate how an application can build more complex processing of the output of <code>fn:csv-to-simple-rows</code>.</p>
+               <p>The following examples illustrate how an application can build more complex processing of the output of <code>fn:csv-to-arrays</code>.</p>
 
-               <p>A variable, <code>$crlf</code> is assumed to be in scope containing the CR and LF characters</p>
+               <p>A variable, <code>$crlf</code> is assumed to be in scope representing the CRLF string:</p>
 
-               <eg>let $crlf := fn:char('x0D')||fn:char('x0A')</eg>
+               <eg>let $crlf := fn:char(0x0D)||fn:char(0x0A)</eg>
 
-               <div4 id="csv-to-html-table">
+               <example id="csv-to-html-table">
                   <head>Converting a CSV into an HTML-style table using <code>fn:parse-csv</code></head>
 
                   <p>Direct conversion is a matter of iterating across the records and fields to
@@ -7299,8 +7335,8 @@ return <table>
   </xsl:template>
 </xsl:stylesheet>
                   ]]></eg>
-               </div4>
-               <div4 id="csv-to-html-table-csv-to-xml">
+               </example>
+               <example id="csv-to-html-table-csv-to-xml">
                   <head>Converting a CSV into an HTML-style table using <code>fn:csv-to-xml</code></head>
 
                   <p>The <code>fn:csv-to-xml</code> function makes these kinds of
@@ -7369,19 +7405,15 @@ return <table>
   </xsl:template>
 </xsl:stylesheet>
                   ]]></eg>
-               </div4>
+               </example>
             </div3>
      
-
-            <div3 id="func-parse-csv">
-               <head><?function fn:parse-csv?></head>
-            </div3>
+            
+            
             <div3 id="func-csv-to-xml">
                <head><?function fn:csv-to-xml?></head>
             </div3>
-            <div3 id="func-csv-to-simple-rows">
-               <head><?function fn:csv-to-simple-rows?></head>
-            </div3>
+            
          </div2>
 
          <div2 id="ixml-functions">
@@ -11206,18 +11238,18 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="CV" code="0001" label="CSV field quoting error."
                type="dynamic">
-               <p>Raised by <code>fn:csv-to-simple-rows</code> if a syntax error in the quoting of one of the
+               <p>Raised by <code>fn:csv-to-arrays</code> if a syntax error in the quoting of one of the
                   fields in the input CSV is found.</p>
             </error>
             <error class="CV" code="0002" label="Illegal CSV delimiter error."
                type="dynamic">
-               <p>Raised by <code>fn:csv-to-simple-rows</code> if the <code>field-separator</code>,
+               <p>Raised by <code>fn:csv-to-arrays</code> if the <code>field-separator</code>,
                   <code>record-separator</code>, or <code>quote-character</code> option is set to
                   an illegal value.</p>
             </error>
             <error class="CV" code="0003" label="duplicate CSV delimiter error."
                type="dynamic">
-               <p>Raised by <code>fn:csv-to-simple-rows</code> if any of the delimiter characters have been
+               <p>Raised by <code>fn:csv-to-arrays</code> if any of the delimiter characters have been
                   set to the same value.</p>
             </error>
             <error class="CV" code="0004" label="Argument supplied is not a known column name."
@@ -11804,6 +11836,8 @@ ISBN 0 521 77752 6.</bibl>
               <item><p><code>fn:char</code></p></item>
               <item><p><code>fn:characters</code></p></item>
               <item><p><code>fn:contains-subsequence</code></p></item>
+              <item><p><code>fn:csv-to-xml</code></p></item>
+              <item><p><code>fn:csv-to-arrays</code></p></item>
               <item><p><code>fn:decode-from-uri</code></p></item>
               <item><p><code>fn:do-until</code></p></item>
               <item><p><code>fn:duplicate-values</code></p></item>
@@ -11823,6 +11857,7 @@ ISBN 0 521 77752 6.</bibl>
               <item><p><code>fn:lowest</code></p></item>
               <item><p><code>fn:message</code></p></item>
               <item><p><code>fn:op</code></p></item>
+              <item><p><code>fn:parse-csv</code></p></item>
               <item><p><code>fn:parse-html</code></p></item>
               <item><p><code>fn:parse-integer</code></p></item>
               <item><p><code>fn:parse-QName</code></p></item>
@@ -11871,9 +11906,6 @@ ISBN 0 521 77752 6.</bibl>
               <item><p><code>map:filter</code></p></item>
               <item><p><code>map:replace</code></p></item>
               <item><p><code>map:substitute</code></p></item>
-              <item><p><code>fn:parse-csv</code></p></item>
-              <item><p><code>fn:csv-to-xml</code></p></item>
-              <item><p><code>fn:csv-to-simple-rows</code></p></item>
               <item><p><code>array:replace</code></p></item>
            </ulist>
            

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7274,13 +7274,19 @@ Bob,2023-07-14,2.34
                <p>An XSD 1.0 schema for the XML representation is provided in 
                   <specref ref="schema-for-csv"/>.</p>
             </div3>
+            
+            
+            <div3 id="func-csv-to-xml">
+               <head><?function fn:csv-to-xml?></head>
+            </div3>
+            
             <div3 id="illustrative-csv-examples">
                <head>Illustrative examples of processing CSV data</head>
 
 
-               <p>The following examples illustrate how an application can build more complex processing of the output of <code>fn:csv-to-arrays</code>.</p>
+               <p>The following examples illustrate more complex applications making use of CSV parsing functions.</p>
 
-               <p>A variable, <code>$crlf</code> is assumed to be in scope representing the CRLF string:</p>
+               <p>A variable <code>$crlf</code> is assumed to be in scope representing the CRLF string:</p>
 
                <eg>let $crlf := fn:char(0x0D)||fn:char(0x0A)</eg>
 
@@ -7417,11 +7423,7 @@ return <table>
                </example>
             </div3>
      
-            
-            
-            <div3 id="func-csv-to-xml">
-               <head><?function fn:csv-to-xml?></head>
-            </div3>
+         
             
          </div2>
 


### PR DESCRIPTION
The changes here are almost entirely editorial, reordering material, removing duplication and changing some of the language for consistency with the rest of the spec. There is one substantive change - the function `csv-to-simple-rows` is renamed `csv-to-arrays`.

Fix #1016 