### PR TITLE
1038 take-while predicate no longer uses EBV

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28400,7 +28400,7 @@ head(index-where($input, $predicate)) ! subsequence($input, . + 1)
       <fos:signatures>
          <fos:proto name="take-while" return-type="item()*">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="predicate" type="function(item(), xs:integer) as item()*"/>
+            <fos:arg name="predicate" type="function(item(), xs:integer) as xs:boolean"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -28420,7 +28420,7 @@ return $it
 ]]></eg>
          <p>That is, it returns all items in the sequence prior to the first one where the result of
          calling the supplied <code>$predicate</code> function, with the current item and its position
-         as arguments, has an effective boolean value of <code>false</code>.</p>
+         as arguments, returns the value <code>false</code>.</p>
       </fos:rules>
       
 
@@ -28440,7 +28440,8 @@ return $it
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>take-while(("A", "B", "C", " ", "E"), normalize-space#1)</fos:expression>
+               <fos:expression><eg>take-while(("A", "B", "C", " ", "E"), 
+   fn{boolean(normalize-space()))</eg></fos:expression>
                <fos:result>("A", "B", "C")</fos:result>
             </fos:test>
             <fos:test>


### PR DESCRIPTION
See issue #1038, which pointed out compatibility problems with using EBV for callback predicates, as proposed in issue #919.

In specifying `fn:take-while` we anticipated acceptance of the proposal to use EBV for predicate callbacks; now that we have decided not to make that change, this PR brings `take-while` into alignment with other functions using a predicate callback. 