### PR TITLE
1043 Clarification of CSV edge cases

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23036,14 +23036,14 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:summary>
       <fos:rules>
          
-         <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of a
-            sequence of <code>xs:string</code> values. The function first parses this sequence using
+         <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of 
+            an <code>xs:string</code> value. The function first parses this sequence using
             <code>fn:csv-to-arrays</code>, and then further processes the result. The initial
             parsing is exactly as defined for <code>fn:csv-to-arrays</code>, and can be controlled
             using the same options. Additional options are available to control the way in which
             header information and column names are handled.</p>
          
-         <p>If <code>$value</code> is the empty sequence, the function
+         <p>If <code>$value</code> is the empty sequence or a zero-length string, the function
                returns a <code>parsed-csv-structure-record</code> whose 
                <code>rows</code> entry is the empty sequence.</p>
          
@@ -23129,11 +23129,13 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                </fos:values>
             </fos:option>
             <fos:option key="filter-columns">
-               <fos:meaning>A sequence indicating which fields to return and in which order. If this
+               <fos:meaning>A sequence of integers indicating which fields to include and in which order. If this
                   option is absent or empty, all fields are returned in their original
-                  order. Items in the sequence are treated as the index of the column to return. In
+                  order, unless otherwise specified using the <code>number-of-columns</code>
+                  option. An integer in the sequence is treated as the 1-based index of the column to include. In
                   the returned data, only fields from the specified columns are returned, and in
-                  the order specified. This option is mutually exclusive with the
+                  the order specified. If a particular row includes no field at the specified index,
+                  an empty field is included at the relevant position in the result. This option is mutually exclusive with the
                   <code>number-of-columns</code> option. Specifying both options will cause an <errorref
                      class="CV" code="0006"/> error.</fos:meaning>
                <fos:type>xs:integer*</fos:type>
@@ -23225,13 +23227,12 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                         was returned as part of.</p>
 
                      <p>When the argument is a string, if the string is missing from the keys
-                        of the <code>names</code> map , then implementations <rfc2119>must</rfc2119>
-                        raise an <errorref class="CV" code="0004"/>.</p>
+                        of the <code>names</code> map, then an error is raised <errorref class="CV" code="0004"/>.</p>
 
                      <p>When the argument is an integer, if the integer position is outside the
                         bounds of the sequence contained in the <code>fields</code> entry of this
                         <code>csv-row-record</code> (i.e. is greater than the size of the
-                        sequence), then implementations <rfc2119>must</rfc2119> return the empty
+                        sequence), then the function returns the zero-length
                         string.</p>
                   </item>
                </ulist>
@@ -23239,7 +23240,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          </olist>
 
          <p>If column names were extracted from the first row of the CSV, when there are duplicate
-            column names, implementations <rfc2119>must</rfc2119> include only the first occurrence
+            column names, the result includes only the first occurrence
             in the <code>names</code> entry of the <code>csv-columns-record</code>, ignoring
             subsequent entries. Any fields in the first record whose value is the empty string
             <rfc2119>must</rfc2119> also be omitted.</p>
@@ -23259,8 +23260,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
-            <code>$csv</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
-            fields.</p>
+            <code>$csv</code> does not conform to the required grammar.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
             for <code>field-delimiter</code> or <code>quote-character</code> are specified and are
             not a single character.</p>
@@ -23480,7 +23480,8 @@ return array { $r?fields }</eg></fos:expression>
             The result of the function is a sequence of arrays of strings, that is
             <code>array(xs:string)*</code>; each array represents one row of the CSV input.</p>
          
-         <p>If <code>$value</code> is the empty sequence, the function returns an empty sequence.</p>
+         <p>If <code>$value</code> is the empty sequence or a zero-length string, the 
+            function returns an empty sequence.</p>
          
          <p>The <code>$options</code> argument can be used to control the way in which the parsing
             takes place. The <termref
@@ -23542,14 +23543,29 @@ return array { $r?fields }</eg></fos:expression>
             </fos:option>
          </fos:options>
 
-
-         <p>A blank row is represented as an empty array.</p>
-         <p>An empty field is represented by a zero-length string.</p>
+         <p>An empty field is represented by a zero-length string. An empty field is deemed to exist
+         when a field delimiter immediately follows either another field delimiter, or
+         a row delimiter, or the start of <code>$value</code>; or when a row delimiter or the
+         end of <code>$value</code> immediately follows a field delimiter.</p>
+         
+         <p>A blank row is represented as an empty array (not as an
+            array containing a single empty field). A blank row is deemed to exist when a
+            row delimiter immediately follows either another row delimiter or the start of <code>$value</code>,
+         after trimming of whitespace if the <code>trim-whitespace</code> option is <code>true</code>.
+         No blank row occurs after the final row delimiter.</p>
+         
+         <p>If <code>$value</code> is a zero-length string, the CSV is considered to
+         contain no rows; while if <code>$value</code> consists of a single row delimiter,
+         it is considered to contain a single blank row. The presence or
+         absence of a final row delimiter generally has no effect on the result,
+         except in the situation described in the previous paragraph where it causes a
+         blank row to exist.</p>
+         
+         
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if 
-            <code>$value</code> does not conform to the <bibref ref="rfc4180"/> grammar for quoted
-            fields.</p>
+         <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
+            <code>$csv</code> does not conform to the required grammar.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if the value of the
             <code>field-delimiter</code> or <code>quote-character</code> option is
             not a single character.</p>
@@ -23568,6 +23584,43 @@ return array { $r?fields }</eg></fos:expression>
          <fos:variable name="cr" id="escaped-cr"><![CDATA[char('\r')]]></fos:variable>
          <fos:variable name="crlf" id="escaped-crlf"><![CDATA[char('\r')||char('\n')]]></fos:variable>
          <fos:example>
+            <p>Handling trivial input:</p>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(())</eg></fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays("")</eg></fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays($crlf)</eg></fos:expression>
+               <fos:result>[]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(" ", map{'trim-whitespace':true()})</eg></fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(" ", map{'trim-whitespace':false()})</eg></fos:expression>
+               <fos:result>[" "]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(` {$crlf}`, map{'trim-whitespace':true()})</eg></fos:expression>
+               <fos:result>[]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(` {$crlf}`, map{'trim-whitespace':false()})</eg></fos:expression>
+               <fos:result>[" "]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(`{$crlf} `, map{'trim-whitespace':true()})</eg></fos:expression>
+               <fos:result>[]</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(`{$crlf} `, map{'trim-whitespace':false()})</eg></fos:expression>
+               <fos:result>[], [" "]</fos:result>
+            </fos:test>
             <p>Handling any of the default record separators:</p>
             <fos:test use="escaped-crlf">
                <fos:expression><eg>csv-to-arrays(`name,city{$crlf}`||
@@ -23666,7 +23719,7 @@ return array { $r?fields }</eg></fos:expression>
 
    <fos:function name="csv-to-xml" prefix="fn">
       <fos:signatures>
-         <fos:proto name="csv-to-xml" return-type="element(fn:csv)">
+         <fos:proto name="csv-to-xml" return-type="element(fn:csv)?">
             <fos:arg name="value" type="xs:string?"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
          </fos:proto>
@@ -23685,7 +23738,10 @@ return array { $r?fields }</eg></fos:expression>
          <p>The arguments have the same meaning, and are subject to the same constraints, as
          the arguments of <code>fn:parse-csv</code>.</p>
          
-         <p>The effect of the function is equivalent to the result of the following XQuery expression
+         <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
+         
+         <p>In other cases, the effect of the function is equivalent to the result of the 
+            following XQuery expression
             (where <code>$options</code> is an empty map if the argument is not supplied):</p>
          
          <eg><![CDATA[let $parsedCSV := parse-csv($value, $options)
@@ -23729,136 +23785,9 @@ return
             that is, whether the elements and attributes in the returned tree have type annotations that reflect
             the result of validating against this schema.</p>
          
-   <!--      <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of an
-            <code>xs:string</code> value. The function first parses this sequence using
-            <code>fn:csv-to-arrays</code>, and then performs further processing on the result to return a tree
-            rooted at an <code>fn:csv</code> element. The initial
-            parsing is exactly as defined for <code>fn:csv-to-arrays</code>, and can be controlled
-            using the same options. Additional options are available to control the way in which
-            header information and column names are handled.</p>
-
-         <p>If <code>$value</code> is the empty sequence, then the returned 
-            <code><![CDATA[<fn:csv>]]></code> element is as follows: </p>
+         <p>The returned element node has no parent node.</p>
          
-         <olist>
-            <item><p>Its <code><![CDATA[<fn:rows>]]></code> child is present as an empty element.</p>
-            </item>
-            <item><p>If column name extraction has been
-               requested, but explicit column names have not been supplied, then its
-               <code><![CDATA[<fn:header>]]></code> child is present as an empty element.</p></item>
-            <item><p>If explicit column names have been
-               supplied, then the <code><![CDATA[<fn:header>]]></code>
-               element is present and contains the appropriate
-               <code><![CDATA[<fn:column>]]></code> elements.</p></item>
-         </olist>
-
-
-
-         <p>The <code>$options</code> argument can be used to control the way in which the parsing
-            takes place. The <termref
-               def="option-parameter-conventions">option parameter conventions</termref> apply.</p>
-         
-         <p>If the <code>$options</code> argument is omitted or is an empty sequence, the result is the same as
-            calling the two-argument form with an empty map as the value of the <code>$options</code>
-            argument.</p>
-
-         <p>Handling of delimiters, and whitespace trimming, are handled using
-            <code>fn:csv-to-arrays</code>, and the options controlling their use are defined
-            there.</p>
-
-         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
-
-         <fos:options>
-            <fos:option key="field-delimiter">
-               <fos:meaning>The character used to delimit fields within a record. An instance of
-                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>","</fos:default>
-            </fos:option>
-            <fos:option key="row-delimiter">
-               <fos:meaning>The characters used to delimit rows within the CSV string, if the
-                  default use of line separator as record separator is to be overridden.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>()</fos:default>
-            </fos:option>
-            <fos:option key="quote-character">
-               <fos:meaning>The character used to quote fields within the CSV string. An instance of
-                  <code>xs:string</code> whose length is exactly one.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>'"'</fos:default>
-            </fos:option>
-            <fos:option key="trim-whitespace">
-               <fos:meaning>Determines whether fields should have leading and trailing whitespace
-                  removed before being returned.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false</fos:default>
-               <fos:values>
-                  <fos:value value="false">Fields will be returned with any leading or trailing
-                     whitespace intact. Implementations <rfc2119>must</rfc2119> preserve whitespace
-                     as it occurred in the CSV string.
-                  </fos:value>
-                  <fos:value value="true">Fields will be returned with leading or trailing
-                     whitespace removed, and all non-leading or -trailing whitespace preserved.
-                  </fos:value>
-               </fos:values>
-            </fos:option>
-            <fos:option key="column-names">
-               <fos:meaning>Determines whether the first row of the CSV should be treated as a list
-                  of column headers and returned as a sequence of <code><![CDATA[<fn:column>]]></code> 
-                  elements appearing as children of
-                  the <code><![CDATA[<fn:header>]]></code> element. The value must be either a map of type
-                  <code>map(xs:string, xs:integer)</code> or an <code>xs:boolean</code>.
-               </fos:meaning>
-               <fos:type>item()</fos:type>
-               <fos:default>false</fos:default>
-               <fos:values>
-                  <fos:value value="true">The <code><![CDATA[<fn:header>]]></code> element is populated
-                     with <code><![CDATA[<fn:column>]]></code> elements constructed using the values
-                     from the first row of the CSV data. Implmentations <rfc2119>must</rfc2119>
-                     exclude the first row from the <code><![CDATA[<fn:rows>]]></code>
-                     element.</fos:value>
-                  <fos:value value="false">No <code><![CDATA[<fn:header>]]></code> element 
-                     is included in the output.</fos:value>
-                  <fos:value value="map(xs:string, xs:integer)">The supplied map is used to
-                     construct a sequence of <code><![CDATA[<fn:column>]]></code> elements to populate
-                     the <code><![CDATA[<fn:header>]]></code> element. The <code>xs:integer</code>
-                     denotes the column number, and the <code>xs:string</code> the column name. Gaps
-                     in the integer sequence of column numbers are filled with empty
-                     <code><![CDATA[<fn:column>]]></code> elements. The first row from 
-                     the input is included in the <code><![CDATA[<fn:rows>]]></code>
-                     element.</fos:value>
-               </fos:values>
-            </fos:option>
-            <fos:option key="filter-columns">
-               <fos:meaning>A sequence indicating which fields to return and in which order. If this
-                  option is missing or empty, all fields are returned in their original
-                  order. Items in the sequence are treated as the index of the column to return. In
-                  the returned data, only fields from the specified columnms are returned, and in
-                  the order specified.</fos:meaning>
-               <fos:type>xs:integer*</fos:type>
-               <fos:default>()</fos:default>
-            </fos:option>
-            <fos:option key="number-of-columns">
-               <fos:meaning>Specifies how many columns to return.</fos:meaning>
-               <fos:type>union(enum("all", "first-row"), xs:integer)</fos:type>
-               <fos:default>"all"</fos:default>
-               <fos:values>
-                  <fos:value value="'all'">All fields from all rows
-                     <rfc2119>must</rfc2119> be returned, without being padded or truncated,
-                     regardless of whether rows have varying numbers of fields, or of how many
-                     fields they have.</fos:value>
-                  <fos:value value="'first-row'">The number of fields in the first row is counted,
-                     and processing proceeds as if that integer had been supplied as the value for
-                     this option.</fos:value>
-                  <fos:value value="xs:integer">The number of columns is set to this value. Rows
-                     with more fields than the supplied value are truncated by discarding the extra
-                     fields. as if calling <code>fn:subsequence(R, 1, I)</code>, given the row’s
-                     sequence of fields in <var>R</var>, and the supplied value in <var>I</var>. If
-                     a row has fewer fields than the supplied value it is padded by appending empty
-                     string values until it contains the specified number of fields.</fos:value>
-               </fos:values>
-            </fos:option>
-         </fos:options>-->
+ 
       </fos:rules>
       <fos:errors>
          <p>See <code>fn:parse-csv</code>.</p>
@@ -23869,10 +23798,24 @@ return
          <fos:example>
             <p>An empty CSV with default column extraction (false):</p>
             <fos:test>
+               <fos:expression><eg>csv-to-xml(())</eg></fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+            <fos:test>
                <fos:expression><eg>csv-to-xml("")</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <rows/>
+</csv>
+]]></eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>csv-to-xml(char('\n'))</eg></fos:expression>
+               <fos:result><eg><![CDATA[
+<csv xmlns="http://www.w3.org/2005/xpath-functions">
+   <rows>
+      <row/>
+   </rows>
 </csv>
 ]]></eg></fos:result>
             </fos:test>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6933,19 +6933,35 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                fields and records separated by standard character delimiters 
                (often, but not invariably, commas).</termdef></p>
             
-            <p>CSV has developed informally for decades, and many variations are found. 
-               This specification refers to <bibref ref="rfc4180"/>,
-               which provides a standardized grammar. This specification defines a 
-               mapping from <bibref ref="rfc4180"/>
-               to constructs in the XDM model, and provides illustrative examples of how these
-               constructs can be combined with other language features to process CSV data.</p>
-
             <p>A CSV is a 2-dimensional tabular data structure consisting of multiple <term>rows</term> 
                (also known as <term>records</term>). Each
                row contains multiple <term>fields</term>. Fields occupying the same position in
                successive rows constitute a <term>column</term>. Columns are identified by position and
                optionally by name. Column names can be
                assigned within a CSV using an optional <term>header row</term>.</p>
+            
+            <p>CSV has developed informally for decades, and many variations are found. 
+               This specification refers to <bibref ref="rfc4180"/>,
+               which provides a standardized grammar. This specification extends the
+               grammar defined in <bibref ref="rfc4180"/> as follows:</p>
+            
+            <ulist>
+               <item><p>This specification uses the term <term>row</term> where RFC 4180 uses
+               <term>record</term>.</p></item>
+               <item><p>Row delimiters other than <code>CRLF</code> are recognized.</p></item>
+               <item><p>Field delimiters other than comma (<code>","</code>) are recognized.</p></item>
+               <item><p>Quote characters other than the double quotation mark (<code>'"'</code>)
+               are recognized.</p></item>
+               <item><p>Non-ASCII characters are recognized.</p></item>
+            </ulist>
+            
+            
+            <p>This specification defines a 
+               mapping from this extended grammar
+               to constructs in the XDM model, and provides illustrative examples of how these
+               constructs can be combined with other language features to process CSV data.</p>
+
+            
             
             <?local-function-index?>
             
@@ -6959,31 +6975,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             delivers this capability using XDM maps and functions, while <code>csv-to-xml</code>
             function represents the information using XDM element nodes.</p>
             
-            <!--<p>The structured representation of a parsed CSV is described by the
-               <code>parsed-csv-structure-record</code>, see <specref ref="csv-to-xdm-mapping"/>.</p>
             
-
-            <p>The rows and fields from this specification map directly to the record
-               and field structures defined in <bibref ref="rfc4180"/>, which has no explicit structure to
-               represent columns.</p>
-
-            <p>A row can be thought of as analogous to both a sequence of fields and a map of fields
-               (when columns are named). Fields are ordered left-to-right and thus have a position,
-               as with an array. Named columns allow fields to be retrieved by name, as with a
-               map.</p>
-
-            <p>The content of a field is a simple string. A field that contains reserved characters (one of the
-               delimiters) must be quoted, and the quote character must be escaped if it occurs
-               within a field. (See <specref ref="csv-field-quoting"/>.)</p>
-
-            <p>The functions for processing CSV-formatted data are built on
-               <code>fn:csv-to-arrays</code>, which provides a simple mapping of a parsed CSV
-               to a sequence of arrays of strings, that is <code>array(xs:string)*</code>.
-               The function handles row and column delimiters and quoting.</p>
-
-            <p>The <code>fn:csv-to-xml</code> and <code>fn:parse-csv</code> functions provide more
-               sophisticated processing, for example identification of fields by names appearing
-               in a header row.</p>-->
 
 
             <div3 id="common-parsing-options">
@@ -11261,19 +11253,18 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="CV" code="0001" label="CSV field quoting error."
                type="dynamic">
-               <p>Raised by <code>fn:csv-to-arrays</code> if a syntax error in the quoting of one of the
-                  fields in the input CSV is found.</p>
+               <p>Raised when parsing CSV input if a syntax error in the input CSV is found.</p>
             </error>
-            <error class="CV" code="0002" label="Illegal CSV delimiter error."
+            <error class="CV" code="0002" label="Invalid CSV delimiter error."
                type="dynamic">
-               <p>Raised by <code>fn:csv-to-arrays</code> if the <code>field-separator</code>,
+               <p>Raised when parsing CSV input if the <code>field-separator</code>,
                   <code>record-separator</code>, or <code>quote-character</code> option is set to
-                  an illegal value.</p>
+                  an invalid value.</p>
             </error>
-            <error class="CV" code="0003" label="duplicate CSV delimiter error."
+            <error class="CV" code="0003" label="Duplicate CSV delimiter error."
                type="dynamic">
-               <p>Raised by <code>fn:csv-to-arrays</code> if any of the delimiter characters have been
-                  set to the same value.</p>
+               <p>Raised when parsing CSV input if the same delimiter character is assigned
+                  to more than one role.</p>
             </error>
             <error class="CV" code="0004" label="Argument supplied is not a known column name."
                type="dynamic">
@@ -11281,7 +11272,7 @@ ISBN 0 521 77752 6.</bibl>
                   <code>csv-columns-record</code>, if its <code>$key</code> argument is an
                   <code>xs:string</code> and is not one of the known column names.</p>
             </error>
-            <error class="CV" code="0005" label="zero or negative integer provided as column index."
+            <error class="CV" code="0005" label="Non-positive integer provided as column index."
                type="dynamic">
                <p>Raised by <code>fn:parse-csv</code>, <code>fn:csv-to-xml</code>, and the function
                   from the <code>field</code> entry of <code>csv-columns-record</code>, if an


### PR DESCRIPTION
Gives a more precise definition of blank rows and empty fields, and generally adds detail on how edge cases should be handled.

Fix #1043.