### PR TITLE
1047 Default predicate for some#1 and every#1

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27902,7 +27902,7 @@ r:random-sequence(200);
          <fos:proto name="every" return-type="xs:boolean">
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="predicate" type="(function(item(), xs:integer) as xs:boolean)?"
-               default="fn:identity#1" example="fn:boolean#1"/>
+               default="fn:boolean#1" example="fn:boolean#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -27919,15 +27919,21 @@ r:random-sequence(200);
 every $boolean in (
   for $item at $pos in $input
   return $predicate($item, $pos)
-) satisfies $boolean = true()
+) satisfies $boolean
 ]]></eg>
 
       </fos:rules>
+      <fos:errors>
+         <p>An error is raised if the <code>$predicate</code> function raises an error. In particular,
+            when the default predicate <code>fn:boolean#1</code> is used, an error is raised if an
+            item has no effective boolean value.</p>
+      </fos:errors>
       <fos:notes>
-         <p>If the second argument is omitted or an empty sequence, the first argument must be
-            a sequence of <code>xs:boolean</code> values.</p>
+         <p>If the second argument is omitted or an empty sequence, the predicate defaults
+            to <code>fn:boolean#1</code>, which takes the effective boolean value of each item.</p>
          <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for which the predicate
-            returns <code>false</code>; it is not required to evaluate the predicate for every item.</p>
+            returns <code>false</code>; it is not required to evaluate the predicate for every item,
+            nor is it required to examine items sequentially from left to right.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -27966,6 +27972,11 @@ every $boolean in (
   =!> contains("r")
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>every((1, 2, number('NaN')))</fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>The effective boolean value of NaN is false.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>every(1 to 5, fn($num, $pos) { $num = $pos })</fos:expression>
@@ -28880,7 +28891,7 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
          <fos:proto name="some" return-type="xs:boolean">
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="predicate" type="(function(item(), xs:integer) as xs:boolean)?"
-               default="fn:identity#1" example="fn:boolean#1"/>
+               default="fn:boolean#1" example="fn:boolean#1"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -28897,14 +28908,20 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
 some $boolean in (
   for $item at $pos in $input
   return $predicate($item, $pos)
-) satisfies $boolean = true()
+) satisfies $boolean
 ]]></eg>
       </fos:rules>
+      <fos:errors>
+         <p>An error is raised if the <code>$predicate</code> function raises an error. In particular,
+         when the default predicate <code>fn:boolean#1</code> is used, an error is raised if an
+         item has no effective boolean value.</p>
+      </fos:errors>
       <fos:notes>
-         <p>If the second argument is omitted or an empty sequence, the first argument must be
-            a sequence of <code>xs:boolean</code> values.</p>
+         <p>If the second argument is omitted or an empty sequence, the predicate defaults
+            to <code>fn:boolean#1</code>, which takes the effective boolean value of each item.</p>
          <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for which the predicate
-         returns <code>true</code>; it is not required to evaluate the predicate for every item.</p>
+         returns <code>true</code>; it is not required to evaluate the predicate for every item,
+         nor is it required to examine items sequentially from left to right.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -28943,6 +28960,11 @@ some $boolean in (
   =!> contains("r")
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>some(("", 0, number('NaN')))</fos:expression>
+               <fos:result>false()</fos:result>
+               <fos:postamble>The effective boolean value in each case is false.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression>some(reverse(1 to 5), fn($num, $pos) { $num = $pos })</fos:expression>


### PR DESCRIPTION
Changes the default predicate for `fn:some#1` and `fn:every#1` to be `fn:boolean#1`, which takes the EBV of the items in the input sequence. The previous use of `fn:identity#1` caused some unexpected behaviour.