### PR TITLE
150bis revised proposal for fn:ranks

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29973,8 +29973,7 @@ path with an explicit <code>file:</code> scheme.</p>
          in <code>$input</code>
          
          More formally, the function is equivalent to the following implementation in XPath (return clause added in comments for completeness):</p>
-         <eg><![CDATA[  
-let $ranks := function(
+         <eg><![CDATA[let $ranks := function(
                 $input as item()*,
                 $key as function(item()) as xs:anyAtomicType*,
                 $distinct-ranks as xs:boolean,

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29947,6 +29947,7 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:proto name="ranks" return-type="array(item())*"> 
             <fos:arg name="input" type="item()*" usage ="navigation"/>  
             <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
+            <fos:arg name="distinct-ranks" type="xs:boolean" usage="navigation" default="true()"/>
             <fos:arg name="collation-input" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
             <fos:arg name="collation-keys" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
          </fos:proto>        
@@ -29957,16 +29958,17 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:property>focus-independent</fos:property>
       </fos:properties>   
       <fos:summary>
-        <p>Sorts the distinct items of a supplied sequence based on the value of a sort key function, 
+        <p>Sorts the items of a supplied sequence based on the value of a sort key function, 
         grouping the results so that items with the same key appear together 
         as members of the same array, ordered by increasing key value.
         </p>
       </fos:summary>  
       <fos:rules>     
-         <p> The distinct items from <code>$input</code> are sorted 
+         <p> The items from <code>$input</code> are sorted 
          by the results of applying the <code>$key</code> function on each of them, 
          and then for each of the sorted key-values (in increasing sort-order) an array is produced,
-         containing all distinct <code>$input</code> items having that same key-value.
+         containing all <code>$input</code> items having that same key-value, that are distinct 
+         if <code>$distinct-ranks</code> is <code>true()</code>.
          Each such result-array contains its members ordered in the same way as they appear
          in <code>$input</code>
          
@@ -29975,16 +29977,22 @@ path with an explicit <code>file:</code> scheme.</p>
 let $ranks := function(
                 $input as item()*,
                 $key as function(item()) as xs:anyAtomicType*,
+                $distinct-ranks as xs:boolean,
                 $collation-input as xs:string?,
                 $collation-keys as xs:string?
-                ) as array(item())*,
-                
+                ) as array(item())*
  {
     for $v in sort(distinct-values($input ! $key(.), $collation-input),  $collation-keys)
-     return array{$input[compare($key(.), $v, $collation-keys) eq 0]}
+     return 
+        let $make-distinct := ( (distinct-values#2)[$distinct-ranks], fn($x, $y){$x} )[1],
+            $compare-keys := fn($k1, $k2, $collation-keys) 
+                             {deep-equal($k1, $k2, $collation-keys)}
+         return
+           array{$make-distinct($input[$compare-keys($key(.), $v, $collation-keys)],  
+                                                     $collation-input)}
  }
 (: 
-  return $ranks($input, $key, $collation-input, $collation-keys)
+  return $ranks($input, $key, $distinct-ranks, $collation-input, $collation-keys)
 :) 
 ]]></eg>         
       </fos:rules>
@@ -29995,6 +30003,11 @@ let $ranks := function(
                            when, respectively, the values of <code>$input</code> and <code>$key($inputValue)</code> are strings.
                            These collation arguments have default values, thus in most cases it would not be necessary
                            to specify collations on the function call.                           
+                        </p>
+                    </item>
+                    <item>
+                        <p>The argument <code>$distinct-ranks</code> has a default of <code>true()</code> and only
+                           needs to be specified if the caller wants ranks to contain any duplicate items.                        
                         </p>
                     </item>
                     <item>
@@ -30057,13 +30070,69 @@ let $Group := map{
    "fine": "Bra"
  }
  return
-   ranks(("good", "difficult", "great", "severe", "fine"), 
-         fn($word){$toSwedish($word)}, 
-         (), "http://www.w3.org/2013/collation/UCA?lang=se") ]]></eg>
+   ranks(("good", "difficult", "great", "severe", "fine", "good"), 
+         fn($word){$toSwedish($word)}, true(), default-collation(), 
+                   "http://www.w3.org/2013/collation/UCA?lang=se") ]]></eg>
                </fos:expression>
                <fos:result>["good","great","fine"], ["difficult","severe"]</fos:result>
             </fos:test>
          </fos:example>       
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[
+ $toSwedish := map{
+   "good" : "Bra",
+   "difficult" : "svår",
+   "great" : "Bra",
+   "severe": "svår",
+   "fine": "Bra"
+ }
+ return
+   ranks(("good", "difficult", "great", "severe", "fine", "good"), 
+         fn($word){$toSwedish($word)}, false(), default-collation(), 
+                   "http://www.w3.org/2013/collation/UCA?lang=se") ]]></eg>
+               </fos:expression>
+               <fos:result>["good","great","fine","good"], ["difficult","severe"]</fos:result>
+            </fos:test>
+         </fos:example> 
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[
+let $decompose := fn($s as xs:string)
+{
+  let $chars := string-to-codepoints($s) ! codepoints-to-string#1(.),
+      $freqs := fold-left($chars, map{},  
+                          fn($m as map(*), $c as xs:string) 
+                          {
+                            if(not($m($c))) then $m => map:put($c, 1)
+                              else $m => map:put($c, $m($c) +1)
+                          }
+                         )
+      return 
+        string-join((for $k in sort($freqs => map:keys()),
+                         $kv in $k || $freqs($k)
+                      return $kv),
+                      '')
+       
+}
+ return
+   ranks (("apple macintosh", "astronomer ", "angered", "brush", "dictionary", 
+           "dirty room", "editor ", "enraged", "eleven plus two",  
+           "indicatory", "laptop machines", "redo it", "dormitory ", "shrub", 
+           "moon starer", "twelve plus one"), 
+          fn($word){$decompose($word)} ) ]]></eg>               
+               </fos:expression>
+               <fos:result>["astronomer ","moon starer"], 
+["apple macintosh","laptop machines"],
+["editor ","redo it"],
+["dirty room","dormitory "],
+["eleven plus two","twelve plus one"],
+["dictionary","indicatory"],
+["angered","enraged"],
+["brush","shrub"]
+</fos:result>
+            </fos:test>            
+         </fos:example>        
       </fos:examples>       
       <fos:history>
          <fos:version version="4.0">Proposed for 4.0</fos:version>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29981,12 +29981,11 @@ path with an explicit <code>file:</code> scheme.</p>
                 $collation-keys as xs:string?
                 ) as array(item())*
  {
-    for $v in sort(distinct-values($input ! $key(.), $collation-keys),  $collation-keys)
-     return 
-        let $make-distinct := ( (distinct-values#2)[$distinct-ranks], fn($x, $y){$x} )[1],
-            $compare-keys := fn($k1, $k2, $collation-keys) 
-                             {deep-equal($k1, $k2, $collation-keys)}
-         return
+  let $make-distinct := ( (distinct-values#2)[$distinct-ranks], fn($x, $y){$x} )[1],
+      $compare-keys := fn($k1, $k2, $collation-keys) {deep-equal($k1, $k2, $collation-keys)}
+    return
+      for $v in sort(distinct-values($input ! $key(.), $collation-keys),  $collation-keys)
+        return
            array{$make-distinct($input[$compare-keys($key(.), $v, $collation-keys)],  
                                 $collation-input)}
  }

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29981,7 +29981,7 @@ let $ranks := function(
                 
  {
     for $v in sort(distinct-values($input ! $key(.), $collation-input),  $collation-keys)
-     return array{$input[compare($key(.), $v) eq 0]}
+     return array{$input[compare($key(.), $v, $collation-keys) eq 0]}
  }
 (: 
   return $ranks($input, $key, $collation-input, $collation-keys)

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29963,7 +29963,14 @@ path with an explicit <code>file:</code> scheme.</p>
         </p>
       </fos:summary>  
       <fos:rules>     
-         <p>The function is equivalent to the following implementation in XPath (return clause added in comments for completeness):</p>
+         <p> The distinct items from <code>$input</code> are sorted 
+         by the results of applying the <code>$key</code> function on each of them, 
+         and then for each of the sorted key-values (in increasing sort-order) an array is produced,
+         containing all distinct <code>$input</code> items having that same key-value.
+         Each such result-array contains its members ordered in the same way as they appear
+         in <code>$input</code>
+         
+         More formally, the function is equivalent to the following implementation in XPath (return clause added in comments for completeness):</p>
          <eg><![CDATA[  
 let $ranks := function(
                 $input as item()*,

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29993,7 +29993,7 @@ let $ranks := function(
                     <item>
                         <p>The arguments <code>$collation-input</code> and <code>$collation-keys</code> will be used in cases
                            when, respectively, the values of <code>$input</code> and <code>$key($inputValue)</code> are strings.
-                           These collation arguments have default values that, in most cases, will not require
+                           These collation arguments have default values, thus in most cases it would not be necessary
                            to specify collations on the function call.                           
                         </p>
                     </item>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29991,7 +29991,7 @@ let $ranks := function(
                         </p>
                     </item>
                     <item>
-                        <p>Note that each result is placed in a separate singleton array.
+                        <p>Note that each result is placed in a separate array.
                            This is necessary because we cannot represent a sequence of results, some or all of which are
                            a sequence - that is "sequence of sequences" as just a single sequence.
                         </p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30006,16 +30006,31 @@ let $ranks := function(
             </fos:test>
          </fos:example>       
          <fos:example>
-            <fos:test>
+         <fos:test>
                <fos:expression><eg>ranks((-2, -1, 0, 1, 2, 3), (), fn($n) {$n * $n})</eg></fos:expression>
                <fos:result>[0], [(-1, 1)], [(-2, 2)], [3]</fos:result>
             </fos:test>
+         </fos:example>      
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[
+let $Group := map{
+  "Argentina" : (2, 0, 1),
+  "Poland" : (1, 1, 1),
+  "Mexico" : (1, 1, 1),
+  "Saudi Arabia" : (1, 0, 2)
+}
+ return
+   reverse($ranks($Group => map:keys(), (), 
+                  fn($team){2 * $Group($team)[1] + $Group($team)[2]})) ]]></eg>
+               </fos:expression>
+               <fos:result>["Argentina"], [("Poland","Mexico")]. ["Saudi Arabia"]</fos:result>
+            </fos:test>
          </fos:example>       
-      </fos:examples>      
+      </fos:examples>       
       <fos:history>
          <fos:version version="4.0">Proposed for 4.0</fos:version>
       </fos:history>
-
    </fos:function>
 
    <fos:function name="scan-left" prefix="fn">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29957,7 +29957,7 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:property>focus-independent</fos:property>
       </fos:properties>   
       <fos:summary>
-        <p>Sorts a supplied sequence based on the value of a sort key function, 
+        <p>Sorts the distinct items of a supplied sequence based on the value of a sort key function, 
         grouping the results so that items with the same key appear together 
         as members of the same array, ordered by increasing key value.
         </p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29981,7 +29981,7 @@ let $ranks := function(
                 
  {
     for $v in sort(distinct-values($input ! $key(.), $collation-input),  $collation-keys)
-     return array{$input[$key(.) eq $v]}
+     return array{$input[compare($key(.), $v) eq 0]}
  }
 (: 
   return $ranks($input, $key, $collation-input, $collation-keys)

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29968,7 +29968,7 @@ path with an explicit <code>file:</code> scheme.</p>
          by the results of applying the <code>$key</code> function on each of them, 
          and then for each of the sorted key-values (in increasing sort-order) an array is produced,
          containing all <code>$input</code> items having that same key-value, that are distinct 
-         if <code>$distinct-ranks</code> is <code>true()</code>.
+         if the value of the <code>$distinct-ranks</code> argument is specified as <code>true()</code>.
          Each such result-array contains its members ordered in the same way as they appear
          in <code>$input</code>
          
@@ -29982,7 +29982,7 @@ let $ranks := function(
                 $collation-keys as xs:string?
                 ) as array(item())*
  {
-    for $v in sort(distinct-values($input ! $key(.), $collation-input),  $collation-keys)
+    for $v in sort(distinct-values($input ! $key(.), $collation-keys),  $collation-keys)
      return 
         let $make-distinct := ( (distinct-values#2)[$distinct-ranks], fn($x, $y){$x} )[1],
             $compare-keys := fn($k1, $k2, $collation-keys) 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19783,7 +19783,7 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
      return if ($rel eq 0)
             then op:lexicographic-compare(tail($a), tail($b), $C)
             else $rel</eg></item>
-                  <item><p>Here <code>op:simple-compare($k1, $k2)</code> is defined as follows:</p>
+                  <item><p>Here <code>op:simple-compare($k1, $k2, $C)</code> is defined as follows:</p>
                      <eg>if ($k1 instance of union(xs:string, xs:anyURI, xs:untypedAtomic)
     and $k2 instance of union(xs:string, xs:anyURI, xs:untypedAtomic))
 then compare($k1, $k2, $C)
@@ -30216,14 +30216,13 @@ path with an explicit <code>file:</code> scheme.</p>
       </fos:history>
    </fos:function>
    
-   <fos:function name="ranks" pefix="fn">
+   <fos:function name="ranks" prefix="fn">
        <fos:signatures>
          <fos:proto name="ranks" return-type="array(item())*"> 
-            <fos:arg name="input" type="item()*" usage ="navigation"/>  
-            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
-            <fos:arg name="distinct-ranks" type="xs:boolean" usage="navigation" default="true()"/>
-            <fos:arg name="collation-input" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
-            <fos:arg name="collation-keys" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="input" type="item()*" usage="navigation"/>
+            <fos:arg name="collations" type="xs:string*" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="keys" type="(function(item()) as xs:anyAtomicType*)*" usage="inspection" default="fn:data#1"/>
+            <fos:arg name="orders" type="enum('ascending', 'descending')*" usage="absorption" default="'ascending'"/>
          </fos:proto>        
        </fos:signatures> 
       <fos:properties>
@@ -30232,104 +30231,73 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:property>focus-independent</fos:property>
       </fos:properties>   
       <fos:summary>
-        <p>Sorts the items of a supplied sequence based on the value of a sort key function, 
+        <p>Sorts the items of a supplied sequence based on the value of one or more sort keys, 
         grouping the results so that items with the same key appear together 
         as members of the same array, ordered by increasing key value.
         </p>
       </fos:summary>  
-      <fos:rules>     
-         <p> The items from <code>$input</code> are sorted 
-         by the results of applying the <code>$key</code> function on each of them, 
-         and then for each of the sorted key-values (in increasing sort-order) an array is produced,
-         containing all <code>$input</code> items having that same key-value, that are distinct 
-         if the value of the <code>$distinct-ranks</code> argument is specified as <code>true()</code>.
-         Each such result-array contains its members ordered in the same way as they appear
-         in <code>$input</code>
+      <fos:rules>
+         <p>The effect of the function is equivalent to first sorting the input
+            sequence by applying the <code>fn:sort</code> function with the same
+            arguments, and then partitioning the result into a sequence of arrays
+            so that adjacent items with the same sort key go into the same array.</p>
          
-         More formally, the function is equivalent to the following implementation in XPath (return clause added in comments for completeness):</p>
-         <eg><![CDATA[let $ranks := function(
-                $input as item()*,
-                $key as function(item()) as xs:anyAtomicType*,
-                $distinct-ranks as xs:boolean,
-                $collation-input as xs:string?,
-                $collation-keys as xs:string?
-                ) as array(item())*
- {
-  let $make-distinct := ( (distinct-values#2)[$distinct-ranks], fn($x, $y){$x} )[1],
-      $compare-keys := fn($k1, $k2, $collation-keys) {deep-equal($k1, $k2, $collation-keys)}
-    return
-      for $v in sort(distinct-values($input ! $key(.), $collation-keys),  $collation-keys)
-        return
-           array{$make-distinct($input[$compare-keys($key(.), $v, $collation-keys)],  
-                                $collation-input)}
- }
-(: 
-  return $ranks($input, $key, $distinct-ranks, $collation-input, $collation-keys)
-:) 
-]]></eg>         
+         <p>That is, the result of the function is given by the expression:</p>
+         
+         <eg>sort($input, $collations, $keys, $orders) =>
+   partition(split-when := fn($group, $item) {
+      not(op:same-sort-keys(foot($group), 
+                            $item, 
+                            $collations, 
+                            $keys))})</eg>
+         
+         <p>where <code>op:same-sort-keys($item1, $item2, $collations, $keys)</code> is a function
+            that returns true if and only if the first two arguments have pairwise equal sort
+            key values as defined in the rules of the <code>fn:sort</code> function.</p>
+         
       </fos:rules>
-      <fos:notes>
-                <olist>
-                    <item><p>The arguments <code>$collation-input</code> and <code>$collation-keys</code> will be used in cases
-                           when, respectively, the values of <code>$input</code> and <code>$key($inputValue)</code> are strings.
-                           These collation arguments have default values, thus in most cases it would not be necessary
-                           to specify collations on the function call.                           
-                        </p></item>
-                    <item>
-                        <p>The argument <code>$distinct-ranks</code> has a default of <code>true()</code> and only
-                           needs to be specified if the caller wants ranks to contain any duplicate items.                        
-                        </p>
-                    </item>
-                    <item>
-                        <p>Note that each result is placed in a separate array.
-                           This is necessary because we cannot represent a sequence of results, some or all of which are
-                           a sequence - that is "sequence of sequences" as just a single sequence.
-                        </p>
-                    </item>
-                </olist>
-        </fos:notes>                 
+               
       <fos:errors>
-         <p>If the set of computed keys contains <code>xs:untypedAtomic</code> values that are not 
-            castable to <code>xs:double</code> then 
-            operation will fail with a dynamic error (<xerrorref
-               spec="FO" class="RG" code="0001"/>).
-         </p>
-         <p>If the set of computed keys contains values that are not comparable using 
-            the <code>lt</code> operator then the sort 
-            operation will fail with a type error (<xerrorref
-               spec="XP" class="TY" code="0004"/>).
-         </p>   
+         <p>The errors that may be raised are the same as for <code>fn:sort</code>.</p>
       </fos:errors>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>ranks((3, 2, 4), fn($n) {$n mod 2})</eg></fos:expression>
+               <fos:expression><eg>ranks(("red", "orange", "yellow", "green", "blue", "indigo", "violet"),
+   (), string-length#1)</eg></fos:expression>
+               <fos:result>["red"], ["blue"], ["green"], ["orange", "yellow", "indigo", "violet"]</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>ranks((3, 2, 4), (), fn($n) {$n mod 2})</eg></fos:expression>
                <fos:result>[2, 4], [3]</fos:result>
             </fos:test>
          </fos:example>       
          <fos:example>
          <fos:test>
-               <fos:expression><eg>ranks((-2, -1, 0, 1, 2, 3) fn($n) {$n * $n})</eg></fos:expression>
+               <fos:expression><eg>ranks((-2, -1, 0, 1, 2, 3), (), fn($n) {$n * $n})</eg></fos:expression>
                <fos:result>[0], [-1, 1], [-2, 2], [3]</fos:result>
             </fos:test>
          </fos:example>      
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[
-let $Group := map{
+let $group := map {
   "Argentina" : (2, 0, 1),
   "Poland" : (1, 1, 1),
   "Mexico" : (1, 1, 1),
   "Saudi Arabia" : (1, 0, 2)
 }
- return
-   reverse(ranks($Group => map:keys(), 
-                  fn($team){3 * $Group($team)[1] + $Group($team)[2]})) ]]></eg>
+return ranks(map:keys($group), 
+             (),
+             fn($team){3 * $group($team)[1] + $group($team)[2]}, 
+             "descending")) ]]></eg>
                </fos:expression>
-               <fos:result>["Argentina"], ["Poland","Mexico"], ["Saudi Arabia"]</fos:result>
+               <fos:result>["Argentina"], ["Poland", "Mexico"], ["Saudi Arabia"]</fos:result>
             </fos:test>
          </fos:example>       
-         <fos:example>
+ <!--        <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[
  $toSwedish := map{
@@ -30340,7 +30308,7 @@ let $Group := map{
    "fine": "Bra"
  }
  return
-   ranks(("good", "difficult", "great", "severe", "fine", "good"), 
+   ranks(("good", "difficult", "great", "severe", "fine", "good"), ()
          fn($word){$toSwedish($word)}, true(), default-collation(), 
                    "http://www.w3.org/2013/collation/UCA?lang=se") ]]></eg>
                </fos:expression>
@@ -30364,41 +30332,35 @@ let $Group := map{
                </fos:expression>
                <fos:result>["good","great","fine","good"], ["difficult","severe"]</fos:result>
             </fos:test>
-         </fos:example> 
+         </fos:example> -->
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[
-let $decompose := fn($s as xs:string)
-{
-  let $chars := string-to-codepoints($s) ! codepoints-to-string#1(.),
-      $freqs := fold-left($chars, map{},  
-                          fn($m as map(*), $c as xs:string) 
-                          {
-                            if(not($m($c))) then $m => map:put($c, 1)
-                              else $m => map:put($c, $m($c) +1)
-                          }
-                         )
-      return 
-        string-join((for $k in sort($freqs => map:keys()),
-                         $kv in $k || $freqs($k)
-                      return $kv),
-                      '')       
+let $decompose := fn($s as xs:string) {
+  let $chars := characters($s)[. ne ' '],
+      $frequencies := map:build($chars, value:=fn{1}, combine:=op('+'))
+                      => map:pairs()
+                      => sort((), fn{?key})
+  return string-join($frequencies ! (?key, ?value), '')      
 }
- return
-   ranks (("apple macintosh", "astronomer ", "angered", "brush", "dictionary", 
-           "dirty room", "editor ", "enraged", "eleven plus two",  
-           "indicatory", "laptop machines", "redo it", "dormitory ", "shrub", 
-           "moon starer", "twelve plus one"), 
-          fn($word){$decompose($word)} ) ]]></eg>               
+return
+   ranks (("apple macintosh", "astronomer", 
+             "angered", "brush", "dictionary", 
+             "dirty room", "editor", 
+             "enraged", "eleven plus two",  
+             "indicatory", "laptop machines", 
+             "redo it", "dormitory", "shrub", 
+             "moon starer", "twelve plus one"),
+          keys := $decompose} ) ]]></eg>               
                </fos:expression>
-               <fos:result>["astronomer ","moon starer"], 
-["apple macintosh","laptop machines"],
-["editor ","redo it"],
-["dirty room","dormitory "],
-["eleven plus two","twelve plus one"],
-["dictionary","indicatory"],
-["angered","enraged"],
-["brush","shrub"]
+               <fos:result>["astronomer", "moon starer"], 
+["apple macintosh", "laptop machines"],
+["editor", "redo it"],
+["dirty room", "dormitory"],
+["eleven plus two", "twelve plus one"],
+["dictionary", "indicatory"],
+["angered", "enraged"],
+["brush", "shrub"]
 </fos:result>
             </fos:test>            
          </fos:example>        

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30022,7 +30022,7 @@ let $Group := map{
 }
  return
    reverse($ranks($Group => map:keys(), (), 
-                  fn($team){2 * $Group($team)[1] + $Group($team)[2]})) ]]></eg>
+                  fn($team){3 * $Group($team)[1] + $Group($team)[2]})) ]]></eg>
                </fos:expression>
                <fos:result>["Argentina"], [("Poland","Mexico")]. ["Saudi Arabia"]</fos:result>
             </fos:test>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30008,7 +30008,7 @@ let $ranks := function(
          <fos:example>
             <fos:test>
                <fos:expression><eg>ranks((-2, -1, 0, 1, 2, 3), (), fn($n) {$n * $n})</eg></fos:expression>
-               <fos:result>[3], [(-2, 2)], [(-1, 1), [0]</fos:result>
+               <fos:result>[0], [(-1, 1)], [(-2, 2)], [3]</fos:result>
             </fos:test>
          </fos:example>       
       </fos:examples>      

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30021,7 +30021,7 @@ let $Group := map{
   "Saudi Arabia" : (1, 0, 2)
 }
  return
-   reverse($ranks($Group => map:keys(), (), 
+   reverse(ranks($Group => map:keys(), (), 
                   fn($team){3 * $Group($team)[1] + $Group($team)[2]})) ]]></eg>
                </fos:expression>
                <fos:result>["Argentina"], [("Poland","Mexico")], ["Saudi Arabia"]</fos:result>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29958,7 +29958,7 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:summary>
         <p>Sorts a supplied sequence based on the value of a sort key function, 
         grouping the results so that items with the same key appear together 
-        as members of the same array.
+        as members of the same array, ordered by increasing key value.
         </p>
       </fos:summary>  
       <fos:rules>     

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30050,9 +30050,11 @@ let $Group := map{
    "fine": "Bra"
  }
  return
-   ranks($toSwedish => map:keys(), fn($word){$toSwedish($word)}, (), "http://www.w3.org/2013/collation/UCA?lang=se") ]]></eg>
+   ranks(("good", "difficult", "great", "severe", "fine"), 
+         fn($word){$toSwedish($word)}, 
+         (), "http://www.w3.org/2013/collation/UCA?lang=se") ]]></eg>
                </fos:expression>
-               <fos:result>["great","fine","good"], ["severe","difficult"]</fos:result>
+               <fos:result>["good","great","fine"], ["difficult","severe"]</fos:result>
             </fos:test>
          </fos:example>       
       </fos:examples>       

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29946,8 +29946,9 @@ path with an explicit <code>file:</code> scheme.</p>
        <fos:signatures>
          <fos:proto name="ranks" return-type="array(item())*"> 
             <fos:arg name="input" type="item()*" usage ="navigation"/>  
-            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
             <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
+            <fos:arg name="collation-input" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="collation-keys" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
          </fos:proto>        
        </fos:signatures> 
       <fos:properties>
@@ -29966,19 +29967,29 @@ path with an explicit <code>file:</code> scheme.</p>
          <eg><![CDATA[  
 let $ranks := function(
                 $input as item()*,
-                $collation as xs:string?,
-                $key as function(item()) as xs:anyAtomicType*) as array(item()*)*
+                $key as function(item()) as xs:anyAtomicType*,
+                $collation-input as xs:string?,
+                $collation-keys as xs:string?
+                ) as array(item())*,
+                
  {
-    for $v in sort(distinct-values($input ! $key(.)),  $collation)
+    for $v in sort(distinct-values($input ! $key(.), $collation-input),  $collation-keys)
      return array{$input[$key(.) eq $v]}
  }
 (: 
-  return $ranks($input, $collation, $key)
+  return $ranks($input, $key, $collation-input, , $collation-keys)
 :) 
 ]]></eg>         
       </fos:rules>
       <fos:notes>
                 <olist>
+                    <item>
+                        <p>The arguments <code>$collation-input</code> and <code>$collation-keys</code> will be used in cases
+                           when, respectively, the values of <code>$input</code> and <code>$key($inputValue)</code> are strings.
+                           These collation arguments have default values that, in most cases, will not require
+                           to specify collations on the function call.                           
+                        </p>
+                    </item>
                     <item>
                         <p>Note that each result is placed in a separate singleton array.
                            This is necessary because we cannot represent a sequence of results, some or all of which are
@@ -30002,13 +30013,13 @@ let $ranks := function(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>ranks((3, 2, 4), (), fn($n) {$n mod 2})</eg></fos:expression>
+               <fos:expression><eg>ranks((3, 2, 4), fn($n) {$n mod 2})</eg></fos:expression>
                <fos:result>[2, 4], [3]</fos:result>
             </fos:test>
          </fos:example>       
          <fos:example>
          <fos:test>
-               <fos:expression><eg>ranks((-2, -1, 0, 1, 2, 3), (), fn($n) {$n * $n})</eg></fos:expression>
+               <fos:expression><eg>ranks((-2, -1, 0, 1, 2, 3) fn($n) {$n * $n})</eg></fos:expression>
                <fos:result>[0], [-1, 1], [-2, 2], [3]</fos:result>
             </fos:test>
          </fos:example>      
@@ -30022,7 +30033,7 @@ let $Group := map{
   "Saudi Arabia" : (1, 0, 2)
 }
  return
-   reverse(ranks($Group => map:keys(), (), 
+   reverse(ranks($Group => map:keys(), 
                   fn($team){3 * $Group($team)[1] + $Group($team)[2]})) ]]></eg>
                </fos:expression>
                <fos:result>["Argentina"], ["Poland","Mexico"], ["Saudi Arabia"]</fos:result>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30039,6 +30039,22 @@ let $Group := map{
                <fos:result>["Argentina"], ["Poland","Mexico"], ["Saudi Arabia"]</fos:result>
             </fos:test>
          </fos:example>       
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[
+ $toSwedish := map{
+   "good" : "Bra",
+   "difficult" : "svår",
+   "great" : "Bra",
+   "severe": "svår",
+   "fine": "Bra"
+ }
+ return
+   ranks($toSwedish => map:keys(), fn($word){$toSwedish($word)}, (), "http://www.w3.org/2013/collation/UCA?lang=se") ]]></eg>
+               </fos:expression>
+               <fos:result>["great","fine","good"], ["severe","difficult"]</fos:result>
+            </fos:test>
+         </fos:example>       
       </fos:examples>       
       <fos:history>
          <fos:version version="4.0">Proposed for 4.0</fos:version>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29989,7 +29989,7 @@ let $ranks := function(
                              {deep-equal($k1, $k2, $collation-keys)}
          return
            array{$make-distinct($input[$compare-keys($key(.), $v, $collation-keys)],  
-                                                     $collation-input)}
+                                $collation-input)}
  }
 (: 
   return $ranks($input, $key, $distinct-ranks, $collation-input, $collation-keys)
@@ -29998,13 +29998,11 @@ let $ranks := function(
       </fos:rules>
       <fos:notes>
                 <olist>
-                    <item>
-                        <p>The arguments <code>$collation-input</code> and <code>$collation-keys</code> will be used in cases
+                    <item><p>The arguments <code>$collation-input</code> and <code>$collation-keys</code> will be used in cases
                            when, respectively, the values of <code>$input</code> and <code>$key($inputValue)</code> are strings.
                            These collation arguments have default values, thus in most cases it would not be necessary
                            to specify collations on the function call.                           
-                        </p>
-                    </item>
+                        </p></item>
                     <item>
                         <p>The argument <code>$distinct-ranks</code> has a default of <code>true()</code> and only
                            needs to be specified if the caller wants ranks to contain any duplicate items.                        
@@ -30112,8 +30110,7 @@ let $decompose := fn($s as xs:string)
         string-join((for $k in sort($freqs => map:keys()),
                          $kv in $k || $freqs($k)
                       return $kv),
-                      '')
-       
+                      '')       
 }
  return
    ranks (("apple macintosh", "astronomer ", "angered", "brush", "dictionary", 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29941,6 +29941,82 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:version version="4.0">Proposed for 4.0</fos:version>
       </fos:history>
    </fos:function>
+   
+   <fos:function name="ranks" pefix="fn">
+       <fos:signatures>
+         <fos:proto name="ranks" return-type="array(item()*)*"> 
+            <fos:arg name="input" type="item()*" usage ="navigation"/>  
+            <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
+            <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
+         </fos:proto>        
+       </fos:signatures> 
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>   
+      <fos:summary>
+        <p>Produces an array containing all ranks from lowest to highest
+           when the input is projected using a given function.
+        </p>
+      </fos:summary>  
+      <fos:rules>     
+         <p>The function is equivalent to the following implementation in XPath (return clause added in comments for completeness):</p>
+         <eg><![CDATA[  
+let $ranks := function(
+                $input as item()*,
+                $collation as xs:string?,
+                $key as function(item()) as xs:anyAtomicType*) as array(item()*)*
+ {
+    for $v in sort(distinct-values($input ! $key(.)),  $collation)
+     return [$input[$key(.) eq $v]]
+ }
+(: 
+  return $ranks($input, $collation, $key)
+:) 
+]]></eg>         
+      </fos:rules>
+      <fos:notes>
+                <olist>
+                    <item>
+                        <p>Note that each result is placed in a separate singleton array.
+                           This is necessary because we cannot represent a sequence of results, some or all of which are
+                           a sequence - that is "sequence of sequences" as just a single sequence.
+                        </p>
+                    </item>
+                </olist>
+        </fos:notes>                 
+      <fos:errors>
+         <p>If the set of computed keys contains <code>xs:untypedAtomic</code> values that are not 
+            castable to <code>xs:double</code> then 
+            operation will fail with a dynamic error (<xerrorref
+               spec="FO" class="RG" code="0001"/>).
+         </p>
+         <p>If the set of computed keys contains values that are not comparable using 
+            the <code>lt</code> operator then the sort 
+            operation will fail with a type error (<xerrorref
+               spec="XP" class="TY" code="0004"/>).
+         </p>   
+      </fos:errors>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>ranks((3, 2, 4), (), fn($n) {$n mod 2})</eg></fos:expression>
+               <fos:result>[(2, 4)], [3]</fos:result>
+            </fos:test>
+         </fos:example>       
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>ranks((-2, -1, 0, 1, 2, 3), (), fn($n) {$n * $n})</eg></fos:expression>
+               <fos:result>[3], [(-2, 2)], [(-1, 1), [0]</fos:result>
+            </fos:test>
+         </fos:example>       
+      </fos:examples>      
+      <fos:history>
+         <fos:version version="4.0">Proposed for 4.0</fos:version>
+      </fos:history>
+
+   </fos:function>
 
    <fos:function name="scan-left" prefix="fn">
        <fos:signatures>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30351,7 +30351,7 @@ return
              "indicatory", "laptop machines", 
              "redo it", "dormitory", "shrub", 
              "moon starer", "twelve plus one"),
-          keys := $decompose} ) ]]></eg>               
+          keys := $decompose ) ]]></eg>               
                </fos:expression>
                <fos:result>["astronomer", "moon starer"], 
 ["apple macintosh", "laptop machines"],

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29944,7 +29944,7 @@ path with an explicit <code>file:</code> scheme.</p>
    
    <fos:function name="ranks" pefix="fn">
        <fos:signatures>
-         <fos:proto name="ranks" return-type="array(item()*)*"> 
+         <fos:proto name="ranks" return-type="array(item())*"> 
             <fos:arg name="input" type="item()*" usage ="navigation"/>  
             <fos:arg name="collation" type="xs:string?" usage="absorption" default="fn:default-collation()"/>
             <fos:arg name="key" type="function(item()) as xs:anyAtomicType*" usage="inspection" default="fn:data#1"/>
@@ -29956,8 +29956,9 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:property>focus-independent</fos:property>
       </fos:properties>   
       <fos:summary>
-        <p>Produces an array containing all ranks from lowest to highest
-           when the input is projected using a given function.
+        <p>Sorts a supplied sequence based on the value of a sort key function, 
+        grouping the results so that items with the same key appear together 
+        as members of the same array.
         </p>
       </fos:summary>  
       <fos:rules>     
@@ -29969,7 +29970,7 @@ let $ranks := function(
                 $key as function(item()) as xs:anyAtomicType*) as array(item()*)*
  {
     for $v in sort(distinct-values($input ! $key(.)),  $collation)
-     return [$input[$key(.) eq $v]]
+     return array{$input[$key(.) eq $v]}
  }
 (: 
   return $ranks($input, $collation, $key)
@@ -30002,13 +30003,13 @@ let $ranks := function(
          <fos:example>
             <fos:test>
                <fos:expression><eg>ranks((3, 2, 4), (), fn($n) {$n mod 2})</eg></fos:expression>
-               <fos:result>[(2, 4)], [3]</fos:result>
+               <fos:result>[2, 4], [3]</fos:result>
             </fos:test>
          </fos:example>       
          <fos:example>
          <fos:test>
                <fos:expression><eg>ranks((-2, -1, 0, 1, 2, 3), (), fn($n) {$n * $n})</eg></fos:expression>
-               <fos:result>[0], [(-1, 1)], [(-2, 2)], [3]</fos:result>
+               <fos:result>[0], [-1, 1], [-2, 2], [3]</fos:result>
             </fos:test>
          </fos:example>      
          <fos:example>
@@ -30024,7 +30025,7 @@ let $Group := map{
    reverse(ranks($Group => map:keys(), (), 
                   fn($team){3 * $Group($team)[1] + $Group($team)[2]})) ]]></eg>
                </fos:expression>
-               <fos:result>["Argentina"], [("Poland","Mexico")], ["Saudi Arabia"]</fos:result>
+               <fos:result>["Argentina"], ["Poland","Mexico"], ["Saudi Arabia"]</fos:result>
             </fos:test>
          </fos:example>       
       </fos:examples>       

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30024,7 +30024,7 @@ let $Group := map{
    reverse($ranks($Group => map:keys(), (), 
                   fn($team){3 * $Group($team)[1] + $Group($team)[2]})) ]]></eg>
                </fos:expression>
-               <fos:result>["Argentina"], [("Poland","Mexico")]. ["Saudi Arabia"]</fos:result>
+               <fos:result>["Argentina"], [("Poland","Mexico")], ["Saudi Arabia"]</fos:result>
             </fos:test>
          </fos:example>       
       </fos:examples>       

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29977,7 +29977,7 @@ let $ranks := function(
      return array{$input[$key(.) eq $v]}
  }
 (: 
-  return $ranks($input, $key, $collation-input, , $collation-keys)
+  return $ranks($input, $key, $collation-input, $collation-keys)
 :) 
 ]]></eg>         
       </fos:rules>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7497,6 +7497,9 @@ return <table>
             <div3 id="func-partition" diff="add" at="A">
                <head><?function fn:partition?></head>
             </div3>
+            <div3 id="func-ranks" diff="add" at="A">
+               <head><?function fn:ranks?></head>
+            </div3>
             <div3 id="func-scan-left" diff="add" at="A">
                <head><?function fn:scan-left?></head>
             </div3>
@@ -11675,6 +11678,7 @@ ISBN 0 521 77752 6.</bibl>
               <item><p><code>fn:parse-QName</code></p></item>
               <item><p><code>fn:parse-uri</code></p></item>
               <item><p><code>fn:partition</code></p></item>
+              <item><p><code>fn:ranks</code></p></item>
               <item><p><code>fn:replicate</code></p></item>
               <item><p><code>fn:slice</code></p></item>
               <item><p><code>fn:some</code></p></item>


### PR DESCRIPTION
This proposal is an amended/alternative proposal for the fn:ranks function, taking into account the work done on the original issue #150 and the PR #1027 and the comments raised. Acknowledgements to the original author for the idea and for a lot of good work on examples etc.

It amends the previous proposal as follows:

(a) the signature and the semantics are aligned with fn:sort. This adds some functionality (multiple sort keys, ascending/descending) and also removes some complexity (two different collations for comparing input items and result items)

(b) the style of exposition is changed editorially for consistency with other functions