### PR TITLE
1052 Simplify the results of parse-csv

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -79,12 +79,14 @@
 
    <fos:type id="parsed-csv-structure-record">
       <fos:record extensible="false">
-         <fos:field name="columns" type="csv-columns-record" required="true"/>
-         <fos:field name="rows" type="csv-row-record*" required="true"/>
+         <fos:field name="column-names" type="xs:string*" required="true"/>
+         <fos:field name="column-numbers" type="map(xs:string, xs:integer)" required="true"/>
+         <fos:field name="rows" type="array(xs:string)*" required="true"/>
+         <fos:field name="field" required="true" type="function(xs:positiveInteger, union(xs:positiveInteger, xs:string)) as xs:string?"/>
       </fos:record>
    </fos:type>
 
-   <fos:type id="csv-columns-record">
+   <!--<fos:type id="csv-columns-record">
       <fos:record extensible="false">
          <fos:field name="names" type="map(xs:string, xs:integer)" required="true"/>
          <fos:field name="fields" required="true" type="xs:string*"/>
@@ -96,7 +98,7 @@
          <fos:field name="fields" type="xs:string*" required="true"/>
          <fos:field name="field" required="true" type="function(union(xs:integer, xs:string)) as xs:string?"/>
       </fos:record>
-   </fos:type>
+   </fos:type>-->
 
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
@@ -23047,14 +23049,13 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:properties>
       <fos:summary>
          <p>Parses CSV data supplied as a string, returning the results in the form of a
-            <code>parsed-csv-structure-record</code> record containing information about the
-            column structure of the data, as well as the data itself as a sequence of
-            <code>csv-row-record</code> records.</p>
+            record containing information about the
+            names in the header, as well as the data itself.</p>
       </fos:summary>
       <fos:rules>
          
          <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of 
-            an <code>xs:string</code> value. The function first parses this sequence using
+            an <code>xs:string</code> value. The function first parses this string using
             <code>fn:csv-to-arrays</code>, and then further processes the result. The initial
             parsing is exactly as defined for <code>fn:csv-to-arrays</code>, and can be controlled
             using the same options. Additional options are available to control the way in which
@@ -23085,9 +23086,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:default>","</fos:default>
             </fos:option>
             <fos:option key="row-delimiter">
-               <fos:meaning>The sequence of strings used to delimit rows within the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
+               <fos:meaning>A sequence of strings, any of which can be used to delimit rows within
+                  the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
                <fos:type>xs:string+</fos:type>
-               <fos:default>("&amp;#13;&amp;#10;", "&amp;#10;", "&amp;#13;")</fos:default>
+               <fos:default>(char(13)||char(10), char(10), char(13))</fos:default>
             </fos:option>
             <fos:option key="quote-character">
                <fos:meaning>The character used to quote fields within the CSV string. An instance of
@@ -23096,70 +23098,63 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:default>'"'</fos:default>
             </fos:option>
             <fos:option key="trim-whitespace">
-               <fos:meaning>Determines whether fields should have leading and trailing whitespace
-                  removed before being returned.</fos:meaning>
+               <fos:meaning>Determines whether leading and trailing whitespace
+                  is removed from the content of fields.</fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
                   <fos:value value="false">Fields will be returned with any leading or trailing
-                     whitespace intact. Implementations <rfc2119>must</rfc2119> preserve whitespace
-                     as it occurred in the CSV string.
+                     whitespace intact.
                   </fos:value>
                   <fos:value value="true">Fields will be returned with leading or trailing
-                     whitespace removed, and all non-leading or -trailing whitespace preserved.
+                     whitespace removed, and all other whitespace preserved.
                   </fos:value>
                </fos:values>
             </fos:option>
             <fos:option key="column-names">
                <fos:meaning>Determines whether the first row of the CSV should be treated as a list
-                  of column names and returned as a <code>csv-columns-record</code> in the
-                  <code>columns</code> entry of the returned map. Permitted values are a map of type
+                  of column names, or whether column names are being supplied by the caller. 
+                  Permitted values are a map of type
                   <code>map(xs:string, xs:integer)</code> or an <code>xs:boolean</code>.
                </fos:meaning>
                <fos:type>item()</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
-                  <fos:value value="true">A <code>csv-columns-record</code> is constructed using the
-                     first row of the CSV data and returned as the <code>header</code> entry of the
-                     <code>parsed-csv-structure-record</code>. The row’s fields are transformed
-                     into a map of the form <code>{ "Column name": column-number }</code> for the
-                     <code>names</code> entry of the <code>csv-columns-record</code>, and the
-                     fields of the row are returned as a sequence of strings
-                     (<code>xs:string*</code>) for the <code>fields</code> entry. 
-                     The first (header) row is excluded from the <code>rows</code>
-                     entry of the returned <code>parsed-csv-structure-record</code>.</fos:value>
-                  <fos:value value="false">The function returns an empty
-                     <code>csv-columns-record</code>, equivalent to the value <code>map {
-                     "names": map {}, "fields": () }</code>, in the <code>columns</code> entry of
-                     the returned <code>parsed-csv-structure-record</code>. The first row 
-                     is <emph>not</emph> excluded from the <code>rows</code>
-                     entry of the <code>parsed-csv-structure-record</code>.</fos:value>
-                  <fos:value value="map(xs:string, xs:integer)">A <code>csv-columns-record</code> is
-                     constructed using the supplied map and returned as the <code>header</code>
-                     entry of the <code>parsed-csv-structure-record</code>. The supplied map is used
-                     as the <code>names</code> entry, and a sequence of strings for the
-                     <code>fields</code> is constructed, filling in blank columns with the empty
-                     string, and the fields of the row are returned as the <code>fields</code>
-                     entry. The first row is <emph>not</emph> excluded from
-                     the <code>rows</code> entry of the <code>parsed-csv-structure-record</code>.
+                  <fos:value value="true">Column names are taken from the
+                     first row of the CSV data.</fos:value>
+                  <fos:value value="false">Column names are not available; all references
+                     to columns are by ordinal position.</fos:value>
+                  <fos:value value="map(xs:string, xs:integer)">The supplied map 
+                     gives a pairing from column names to column numbers. Note that
+                     if columns are filtered, the relevant column number is the position
+                     after any rearrangement.<!--is
+                     returned directly as the <code>column-numbers</code> entry in the result.
+                     The <code>column-names</code> entry is constructed from this map as
+                     the result of the expression <code>(1 to max(map:values($column-numbers))) !
+                     ($column-numbers(.) otherwise "")</code>. The first row 
+                     of the [arsed CSV content is <emph>not</emph> excluded from
+                     the <code>rows</code> entry of the result.-->
                   </fos:value>
                </fos:values>
             </fos:option>
             <fos:option key="filter-columns">
-               <fos:meaning>A sequence of integers indicating which fields to include and in which order. If this
-                  option is absent or empty, all fields are returned in their original
+               <fos:meaning>A sequence of integers indicating which columns to include and in which order. If this
+                  option is absent or empty, all columns are returned in their original
                   order, unless otherwise specified using the <code>number-of-columns</code>
                   option. An integer in the sequence is treated as the 1-based index of the column to include. In
                   the returned data, only fields from the specified columns are returned, and in
                   the order specified. If a particular row includes no field at the specified index,
-                  an empty field is included at the relevant position in the result. This option is mutually exclusive with the
+                  an empty field is included at the relevant position in the result. If an integer appears
+                  more than once then the result will include duplicated columns.
+                  This option is mutually exclusive with the
                   <code>number-of-columns</code> option. Specifying both options will cause an <errorref
                      class="CV" code="0006"/> error.</fos:meaning>
                <fos:type>xs:integer*</fos:type>
                <fos:default>()</fos:default>
             </fos:option>
             <fos:option key="number-of-columns">
-               <fos:meaning>Specifies how many columns to return. This option is mutually exclusive with the
+               <fos:meaning>Specifies how many columns to include in the result. 
+                  This option is mutually exclusive with the
                   <code>filter-columns</code> option. Specifying both options will cause an <errorref
                      class="CV" code="0006"/> error.</fos:meaning>
                <fos:type>union(enum("all", "first-row"), xs:integer)</fos:type>
@@ -23169,65 +23164,133 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      are returned, without being padded or truncated,
                      regardless of whether rows have varying numbers of fields, or of how many
                      fields they have.</fos:value>
-                  <fos:value value="'first-row'">The number of fields in the first row is counted,
+                  <fos:value value="'first-row'">The number of fields in the first row of 
+                     the input is counted (whether or not this is a header row),
                      and processing proceeds as if that integer had been supplied as the value for
                      this option.</fos:value>
                   <fos:value value="xs:integer">The number of columns is set to this value. Rows
                      with more fields than the supplied value are truncated by discarding the extra
-                     fields, as if calling <code>fn:subsequence(R, 1, I)</code>, given the row’s
-                     sequence of fields in <var>R</var>, and the supplied value in <var>I</var>. If
+                     fields, as if by calling <code>array:subarray(R, 1, N)</code>, given the row’s
+                     fields in array <var>R</var>, and the supplied value in <var>N</var>. If
                      a row has fewer fields than the supplied value it is padded by appending empty
-                     string values until it contains the specified number of fields.</fos:value>
+                     string values until it contains the specified number of fields. Setting
+                  <code>number-of-columns: <var>N</var></code> is equivalent to setting
+                  <code>filter-columns: 1 to <var>N</var></code>.</fos:value>
                </fos:values>
             </fos:option>
          </fos:options>
 
          <p>The result of the function is a <code>parsed-csv-structure-record</code>, a map with
-            string keys containing two entries, <code>columns</code>, and <code>rows</code>.</p>
-         <olist>
-            <item>
-               <p>The entry with key <code>"columns"</code> holds a <code>csv-columns-record</code>
-                  record. If column names have been extracted, or supplied, then the record will
-                  have a <code>names</code> entry whose value is a map of column-name to
-                  column-number, <code>map(xs:string, xs:integer)</code>. The record’s
-                  <code>fields</code> entry will contains the column names as a sequence of
-                  strings, <code>xs:string*</code>, replicating the row they were taken from.</p>
+            string-valued keys containing four entries: <code>column-names</code>, 
+            <code>column-numbers</code>, <code>rows</code>, and <code>field</code>.
+            The values of these entries are set as follows:</p>
+         <glist>
+            <gitem>
+               <label>column-names</label>
+               <def><p>This entry holds a sequence of strings containing column names.
+                  The content depends on the setting of the <code>column-names</code>
+                  entry in <code>$options</code>:</p>
+               
+                  <ulist>
+                     <item><p>If the option is <code>false()</code> (which is the default),
+                     then the value is an empty sequence.</p></item>
+                     <item><p>If the option is <code>true()</code>, then the entry
+                     contains strings taken from the first row of the data. The strings have
+                     leading and trailing whitespace trimmed, regardless of the value of the
+                     <code>trim-whitespace</code> option. The sequence
+                     of strings will potentially be truncated if the <code>number-of-columns</code>
+                     option is specified, and it will potentially be reordered if the
+                     <code>filter-columns</code> option is specified. Any strings that are
+                     zero-length or duplicated are retained <emph>as-is</emph>.</p>
+                    </item>
+                     <item><p>If the value of the option is a map (from column names to integers)
+                     then the value is constructed from the entries in this map. Specifically,
+                     if the supplied map is <code>$M</code>, then the sequence of names is
+                     obtained as the result of the expression:</p>
+                     <eg>let $inverse := 
+    $M => 
+    map:pairs() => 
+    map:build(key:=fn{?value}, value:=fn{?key}, combine:=fn:error#0)
+  return (1 to max(map:keys($inverse))) ! ($inverse(.) otherwise "")</eg>
+                     <p>For example, if the supplied value is <code>map{"a":1,"c":3}</code>
+                     then the sequence of names is <code>("a","","c")</code></p>
+                     <p>Column numbers are <emph>not</emph> adjusted based on the 
+                        <code>filter-columns</code> or <code>number-of-columns</code>
+                        options; the supplied map is expected to refer to column numbers
+                        in the result, not in the input.</p></item>
+                  </ulist></def>
+            </gitem>
+                  
+                  
+            
+          
+            <gitem>
+               <label>column-numbers</label>
+               <def><p>This entry holds a map from column names (as strings) to
+                  column positions (as 1-based integers).
+                  The content depends on the setting of the <code>column-names</code>
+                  entry in <code>$options</code>:</p>
+               
+               <ulist>
+                  <item><p>If the option is <code>false()</code> (which is the default),
+                     then the value is an empty map.</p></item>
+                  <item><p>If the option is <code>true()</code>, then the map
+                     contains entries based on the contents of the first row of the data. 
+                     The strings have
+                     leading and trailing whitespace trimmed, regardless of the value of the
+                     <code>trim-whitespace</code> option. Any string appearing in the header
+                     row that is non-zero-length and is not equal (using codepoint collation) to
+                     any previous string appearing in the header results in an entry
+                     pairing that string to its 1-based position in the header row.</p>
+                     <p>If the <code>filter-columns</code> or <code>number-of-columns</code>
+                     options is present then the entries are adjusted (or removed) to
+                     reflect their position in the adjusted data rows.</p>
+                     
+                    
+                  
+                  </item>
+                  <item><p>If the value of the option is a map (from column names to integers)
+                     then the supplied map is used unchanged.</p>
+                  </item>
+               </ulist></def>
+            </gitem>
+            <gitem>
+               <label>rows</label>
+            
+               <def><p>This entry is a sequence of arrays of strings, holding the parsed
+                  rows of the CSV data. The format is the same as the result of the
+                  <code>fn:csv-to-arrays</code> function, except that the first row
+                  is omitted in the case where the <code>column-names</code>
+                  option is set to <code>true</code>. If there are no data rows in the CSV, the
+                  value will be an empty sequence.</p></def>
+               
+            </gitem>
+            <gitem>
+               <label>field</label>
+               <def><p>This entry holds a function that takes two arguments: an integer
+                  row number (1-based), and a string or integer used to identify a column.
+                  Except in error cases (described below), 
+                  the function call <code>$csv?field($R, $C)</code>, where <code>$C</code>
+                  is an integer, returns the value of <code>$csv?rows[$R] => array:get($C, fn{""})</code>,
+                  and the function call <code>$csv?field($R, $K)</code>, where <code>$K</code>
+                  is a string, returns the value of <code>$csv?field($R, $csv?column-numbers($K))</code>.</p>
 
-               <p>If column names were not extracted or supplied, then the
-                  <code>csv-columns-record</code> will contain a <code>names</code> entry whose
-                  value is an empty map, and a <code>fields</code> entry whose value is the empty
-                  sequence.</p>
-            </item>
-            <item>
-               <p>The entry with key <code>"rows"</code> holds the records of the CSV as a sequence
-                  of row records, <code>csv-row-record*</code>. If there is no data in the CSV, this
-                  will be the empty sequence.</p>
-
-               <p>Each record in the <code>rows</code> sequence contains a <code>fields</code>
-                  entry, containing the row’s fields as a sequence of strings,
-                  <code>xs:string*</code>, and a <code>field</code> entry containing an arity-one
-                  function. The function takes a string or integer key <var>K</var> as input, and
-                  returns the field in <var>fields</var> that corresponds to the position
-                  <var>K</var>, if <var>K</var> is an <code>xs:integer</code>, or the position
-                  obtained by looking up <var>K</var> in the <code>names</code> map if <var>K</var>
-                  is an <code>xs:string</code>.</p>
-
-               <p>The properties of this function are as follows:</p>
+               <p>The properties of the function are as follows:</p>
                <ulist>
                   <item>
                      <p>name: absent</p>
                   </item>
                   <item>
-                     <p>parameter names: (<var>$key</var>)</p>
+                     <p>parameter names: (<var>$row</var>, <var>$col</var>)</p>
                   </item>
                   <item>
-                     <p>signature: <code>(union(xs:integer, xs:string)) => xs:string?</code></p>
+                     <p>signature: <code>(xs:integer, union(xs:integer, xs:string)) => xs:string?</code></p>
                   </item>
                   <item>
                      <p>non-local variable bindings: none</p>
                   </item>
                   <item>
-                     <p>implementation: implementation-dependent</p>
+                     <p>body: equivalent to the specification above</p>
                   </item>
                   <item>
                      <p>errors: A dynamic error <errorref class="CV" code="0004"/> occurs if the
@@ -23248,21 +23311,16 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
                      <p>When the argument is an integer, if the integer position is outside the
                         bounds of the sequence contained in the <code>fields</code> entry of this
-                        <code>csv-row-record</code> (i.e. is greater than the size of the
-                        sequence), then the function returns the zero-length
+                        <code>csv-row-record</code>, then the function returns the zero-length
                         string.</p>
                   </item>
-               </ulist>
-            </item>
-         </olist>
+               </ulist></def>
+            </gitem>
+         </glist>
 
-         <p>If column names were extracted from the first row of the CSV, when there are duplicate
-            column names, the result includes only the first occurrence
-            in the <code>names</code> entry of the <code>csv-columns-record</code>, ignoring
-            subsequent entries. Any fields in the first record whose value is the empty string
-            <rfc2119>must</rfc2119> also be omitted.</p>
+         
 
-         <p>If the <code>number-of-columns</code> options is set to <code>"first-row"</code> or an
+         <!--<p>If the <code>number-of-columns</code> options is set to <code>"first-row"</code> or an
             integer, or the <code>filter-columns</code> option is set, and the
             <code>column-names</code> option is set to <code>true()</code>, the filtering of
             columns is performed before the extraction of the first row and creation of the
@@ -23273,7 +23331,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <code>column-names</code> option is set to a <code>map(xs:string, xs:integer)</code>,
             then filtering of columns does not affect the creation of the
             <code>csv-columns-record</code>, and it is possible that the number of fields in the
-            rows is smaller than the number of fields in the <code>csv-columns-record</code>.</p>
+            rows is smaller than the number of fields in the <code>csv-columns-record</code>.</p>-->
       </fos:rules>
       <fos:errors>
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
@@ -23287,7 +23345,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>A dynamic error <errorref class="CV" code="0005"/> occurs if any column-index integers,
             such as the values in a map supplied to <code>column-names</code>, or as the value of
             <code>number-of-columns</code> or <code>filter-columns</code>, are negative or
-            zero.</p>
+            zero, or if any integer is mapped to more than one name.</p>
          <p>A dynamic error <errorref class="CV" code="0006"/> occurs if both the
             <code>number-of-columns</code> and <code>filter-columns</code> options are set in a
             call to <code>fn:parse-csv</code>.</p>
@@ -23298,177 +23356,191 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>For more discussion of the returned data, see <specref ref="csv-to-xdm-mapping"/>.</p>
       </fos:notes>
       <fos:examples>
-         <fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('\r')||char('\n')]]></fos:variable>
-         <fos:variable name="csv-string" id="csv-string">`name,city{$crlf}`||
+         <!--<fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('\r')||char('\n')]]></fos:variable>-->
+         <fos:variable name="display" id="csv-display">fn($result) {
+   (: tidy up the result for display (function items cannot be properly displayed) :)         
+   if ($result?field instance of function(xs:positiveInteger, 
+                                          union(xs:positiveInteger, xs:string)) 
+                                       as xs:string?)
+   then map:put($result, "field", "(: function :)")
+   else $result
+}</fos:variable>
+         <!--<fos:variable name="csv-string" id="csv-string">`name,city{$crlf}`||
             `Bob,Berlin{$crlf}`||
             `Alice,Aachen{$crlf}`</fos:variable>
          <fos:variable name="options" id="non-default-delims">map { "row-delimiter": "§", 
             "field-delimiter": ";", 
             "quote-character": "|" }</fos:variable>
          <fos:variable name="non-std-csv" id="non-standard-csv-string">`|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|`</fos:variable>
+         -->
          <fos:example>
-            <p>With defaults for delimiters and quotes, and default column extraction (false):</p>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>map:keys(parse-csv($csv-string))</eg></fos:expression>
-               <fos:result><eg>("columns", "rows")</eg></fos:result>
+            <p>Default delimiters, no column headers:</p>
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $crlf := char('\r')||char('\n')                  
+let $input := string-join((
+   "name,city",
+   "Bob,Berlin",
+   "Alice,Aachen"), $crlf)
+let $result := parse-csv($input)
+return ($result => $display(),
+        $result?field(1,2),
+        $result?field(2,2))</eg></fos:expression>
+               <fos:result><eg>map{
+   "column-names": (),
+   "column-numbers": map{},
+   "rows": (["name", "city"], ["Bob", "Berlin"], ["Alice", "Aachen"]),
+   "field": "(: function :)"
+}, "city", "Berlin"</eg></fos:result>
             </fos:test>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>parse-csv($csv-string)?columns</eg></fos:expression>
-               <fos:result><eg>map {
-  "names": map {},
-  "fields": ()
-}</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>count(parse-csv($csv-string)?rows)</eg></fos:expression>
-               <fos:result><eg>3</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>parse-csv($csv-string)?rows[1]?field("name")</eg></fos:expression>
-               <fos:error-result error-code="FOCV0004"/>
-            </fos:test>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>parse-csv($csv-string)?rows[1]?field(2)</eg></fos:expression>
-               <fos:result><eg>"city"</eg></fos:result>
-            </fos:test>
-            <p>With defaults for delimiters and quotes, and <code>columns: true()</code> set:</p>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>parse-csv($csv-string, map {"column-names": true()})?columns</eg></fos:expression>
-               <fos:result><eg>map {
-  "names": map { "name": 1, "city": 2 },
-  "fields": ("name", "city")
-}</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>count(parse-csv($csv-string, map {"column-names": true()})?rows)</eg></fos:expression>
-               <fos:result><eg>2</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>parse-csv($csv-string, map {"column-names": true()})?rows[1]?fields</eg></fos:expression>
-               <fos:result><eg>("Bob", "Berlin")</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>parse-csv($csv-string, map {"column-names": true()})?rows[1]?field("name")</eg></fos:expression>
-               <fos:result><eg>"Bob"</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string escaped-crlf-2">
-               <fos:expression><eg>parse-csv($csv-string, map {"column-names": true()})?rows[1]?field(2)</eg></fos:expression>
-               <fos:result><eg>"Berlin"</eg></fos:result>
+            
+
+            <p>Default delimiters, column headers:</p>
+            
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $crlf := char('\r')||char('\n')                  
+let $input := string-join((
+   "name,city",
+   "Bob,Berlin",
+   "Alice,Aachen"), $crlf)
+let $result := parse-csv($input, map {"column-names": true()})
+return ($result => $display(),
+        $result?field(1,"name"),
+        $result?field(2,"city"))</eg></fos:expression>
+<fos:result><eg>map{
+   "column-names": ("name", "city"),
+   "column-numbers": map {"name": 1, "city": 2 },
+   "rows": (["Bob", "Berlin"], ["Alice", "Aachen"]),
+   "field": "(: function :)"
+}, "Bob", "Aachen"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Non-default record- and field-delimiters, non-default quotes:</p>
-            <fos:test use="non-default-delims non-standard-csv-string">
-               <fos:expression><eg>parse-csv($non-std-csv, $options)?rows[3]?field(1)</eg></fos:expression>
-               <fos:result><eg>"Alice"</eg></fos:result>
+            <p>Custom delimiters, no column headers:</p>
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $options := map { "row-delimiter": "§", 
+          "field-delimiter": ";", 
+          "quote-character": "|" }
+let $input := "|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|"
+let $result := parse-csv($csv, $options)
+return ($result => $display(),
+        $result?field(3, 1))</eg></fos:expression>
+               <fos:result><eg>map{
+   "column-names": (),
+   "column-numbers": map {},
+   "rows": (["name", "city"], ["Bob", "Berlin"], ["Alice", "Aachen"]),
+   "field": "(: function :)"
+}, "Alice"</eg></fos:result>
             </fos:test>
          </fos:example>
-         <fos:variable name="csv-string" id="csv-string-no-headers">`Alice,Aachen{$crlf}Bob,Berlin{$crlf}`</fos:variable>
-         <fos:variable name="options" id="explicit-csv-column-opts">map { "column-names": map { "Person": 1, "Location": 2 } }</fos:variable>
          <fos:example>
-            <p>Specifying column names explicitly:</p>
-            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression><eg>map:keys(parse-csv($csv-string, $options))</eg></fos:expression>
-               <fos:result><eg>("columns", "rows")</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression><eg>parse-csv($csv-string, $options)?columns</eg></fos:expression>
-               <fos:result><eg>map {
-   "names": map { "Person": 1, "Location": 2 },
-   "fields": ("Person", "Location")
-}</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression><eg>count(parse-csv($csv-string, $options)?rows)</eg></fos:expression>
-               <fos:result><eg>2</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression><eg>parse-csv($csv-string, $options)?rows[1]?field(1)</eg></fos:expression>
-               <fos:result><eg>"Alice"</eg></fos:result>
-            </fos:test>
-            <fos:test use="csv-string-no-headers escaped-crlf-2 explicit-csv-column-opts">
-               <fos:expression><eg>parse-csv($csv-string, $options)?rows[2]?field("Location")</eg></fos:expression>
-               <fos:result><eg>"Berlin"</eg></fos:result>
+            <p>Supplied column names:</p>
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $headers := map { "Person": 1, "Location": 2 }
+let $options := map {"column-names": $headers, "row-delimiter": ";"}
+let $input := "Alice,Aachen;Bob,Berlin;"
+let $parsed-csv := parse-csv($input, $options)
+return ($parsed-csv => $display(), 
+        $parsed-csv?field(2, "Location"))</eg></fos:expression>
+               <fos:result><eg>map{
+   "column-names": ("Person", "Location"),
+   "column-numbers": map {"Person": 1, "Location": 2},
+   "rows": (["Alice", "Aachen"], ["Bob", "Berlin"]),
+   "field": "(: function :)"                  
+   }, "Berlin"</eg></fos:result>
             </fos:test>
          </fos:example>
-         <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string">concat(
-`date,name,city,amount,currency,original amount,note{$crlf}`,
-`2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}`,
-`2023-07-20,Alice,Aachen,15.00{$crlf}`,
-`2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie{$crlf}`)</fos:variable>
          <fos:example>
             <p>Filtering columns, with <code>column-names: true()</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression><eg>parse-csv($csv-uneven-cols, 
-          map { "column-names": true(), 
-                "filter-columns": (2,1,4) })
-  ?columns?fields</eg></fos:expression>
-               <fos:result><eg>("name","date","amount")</eg></fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression><eg>for $r in parse-csv($csv-uneven-cols, 
-          map { "column-names": true(), 
-                "filter-columns": (2,1,4) })?rows 
-return array { $r?fields }</eg></fos:expression>
-               <fos:result><eg>(
-   ["Bob","2023-07-19","10.00"],
-   ["Alice","2023-07-20","15.00"],
-   ["Charlie","2023-07-20","15.00"]
-)</eg></fos:result>
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $input := string-join((
+   "date,name,city,amount,currency,original amount,note",
+   "2023-07-19,Bob,Berlin,10.00,USD,13.99",
+   "2023-07-20,Alice,Aachen,15.00",
+   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
+let $options := map { 
+   "column-names": true(), 
+   "filter-columns": (2,1,4) }
+let $result := parse-csv($input, $options)
+return ($result => $display(),
+        $result?field(2, "city"))</eg></fos:expression>
+               <fos:result><eg>map{
+   "column-names": ("name", "date", "amount"),
+   "column-numbers": map {"name": 1, "date": 2, "amount": 3},
+   "rows": (["Bob", "2023-07-19", "10.00"], 
+            ["Alice", "2023-07-20", "15.00"], 
+            ["Charlie", "2023-07-20", "15.00"]),
+   "field": "(: function :)"                  
+}, "Aachen"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Filtering columns, with <code>column-names: map { ... }</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression><eg>parse-csv($csv-uneven-cols, 
-          map { "column-names": map { "Person": 1, "Amount": 3 }, 
-                "filter-columns": (2,1,4) })
-  ?columns</eg></fos:expression>
-               <fos:result><eg>map {
-   "names": map { "Person": 1, "Amount": 3 },
-   "fields": ("Person", "", "Amount")
-}</eg></fos:result>
+            <p>Filtering columns, with supplied column map</p>
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $input := string-join((
+   "2023-07-19,Bob,Berlin,10.00,USD,13.99",
+   "2023-07-20,Alice,Aachen,15.00",
+   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
+let $options := map { 
+   "column-names": map { "Person": 1, "Amount": 3 }, 
+   "filter-columns": (2,1,4) }
+let $result := parse-csv($input, $options)
+return ($result => $display(),
+        $result?field(2, "Person"),
+        $result?field(2, "Amount"))</eg></fos:expression>
+               
+               <fos:result><eg>map{
+   "column-names": ("Person", "", "Amount"),
+   "column-numbers": map {"Person": 1, "Amount": 3},
+   "rows": (["Alice", "Aachen"], ["Bob", "Berlin"]),
+   "field": "(: function :)"                  
+}, "Alice", "15.00"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Specifying the number of columns using <code>"first-row"</code> and <code>column-names: false()</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression><eg>for $r in parse-csv($csv-uneven-cols, 
-                  map { "number-of-columns": "first-row" })?rows 
-return array { $r?fields }</eg></fos:expression>
-               <fos:result><eg>(
-   ["date","name","city","amount","currency","original amount","note"],
-   ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
-   ["2023-07-20","Alice","Aachen","15.00","","",""],
-   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]
-)</eg></fos:result>
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $input := string-join((
+  "date,name,city,amount,currency,original amount,note",               
+  "2023-07-19,Bob,Berlin,10.00,USD,13.99",
+  "2023-07-20,Alice,Aachen,15.00",
+  "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
+let $options := map {"number-of-columns": "first-row"}
+let $result := parse-csv($input, $options)
+return ($result => $display(),
+        $result?field(4,7))</eg></fos:expression>
+               <fos:result><eg>map{
+  "column-names": (),
+  "column-numbers": map {},
+  "rows": (["date","name","city","amount","currency","original amount","note"],
+           ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
+           ["2023-07-20","Alice","Aachen","15.00","","",""],
+           ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]),
+  "field": "(: function :)"                  
+}, "cake"</eg></fos:result>
+               
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Specifying the number of columns with a number and <code>column-names: true()</code></p>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression><eg>parse-csv($csv-uneven-cols, 
-         map { "column-names": true(), "number-of-columns": 6 })
-  ?columns?fields</eg></fos:expression>
-               <fos:result><eg>map {
-   "names": map { "date": 1, "name": 2, "city": 3, 
-                  "amount": 4, "currency": 5, 
-                  "original amount": 6 },
-   "fields": ("date", "name", "city", 
-              "amount", "currency", 
-              "original amount")
-}</eg></fos:result>
-            </fos:test>
-            <fos:test use="escaped-crlf-2 uneven-cols-csv-string">
-               <fos:expression><eg>for $r in parse-csv($csv-uneven-cols, 
-                    map { "column-names": true(), 
-                          "number-of-columns": 6 })?rows 
-return array { $r?fields }</eg></fos:expression>
-               <fos:result><eg>(
-   ["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
-   ["2023-07-20","Alice","Aachen","15.00","",""],
-   ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]
-)</eg></fos:result>
+            <fos:test use="csv-display">
+               <fos:expression><eg>let $input := string-join((
+  "date,name,city,amount,currency,original amount,note",               
+  "2023-07-19,Bob,Berlin,10.00,USD,13.99",
+  "2023-07-20,Alice,Aachen,15.00",
+  "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
+let $options := map{"column-names": true(), "number-of-columns": 6}
+let $result := parse-csv($input, $options)
+return ($result => $display(),
+        $result?field(3,"original amount"))</eg></fos:expression>
+               <fos:result><eg>map{
+   "column-names": ("date","name","city","amount","currency","original amount"),
+   "column-numbers": map {"date":1, "name":2, "city":3, 
+                          "amount":4, "currency":5, "original amount":6},
+   "rows": (["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
+            ["2023-07-20","Alice","Aachen","15.00","","",""],
+            ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]),
+   "field": "(: function :)"                  
+}, "11.99"</eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23166,33 +23166,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
-            
-            <!--<fos:option key="number-of-columns">
-               <fos:meaning>Specifies how many columns to include in the result. 
-                  This option is mutually exclusive with the
-                  <code>filter-columns</code> option. Specifying both options will cause an <errorref
-                     class="CV" code="0006"/> error.</fos:meaning>
-               <fos:type>union(enum("all", "first-row"), xs:positiveInteger)</fos:type>
-               <fos:default>"all"</fos:default>
-               <fos:values>
-                  <fos:value value="'all'">All fields from all rows
-                     are returned, without being padded or truncated,
-                     regardless of whether rows have varying numbers of fields, or of how many
-                     fields they have.</fos:value>
-                  <fos:value value="'first-row'">The number of fields in the first row of 
-                     the input is counted (whether or not this is a header row),
-                     and processing proceeds as if that integer had been supplied as the value for
-                     this option.</fos:value>
-                  <fos:value value="xs:positiveInteger">The number of columns is set to this value. Rows
-                     with more fields than the supplied value are truncated by discarding the extra
-                     fields, as if by calling <code>array:subarray(R, 1, N)</code>, given the row’s
-                     fields in array <var>R</var>, and the supplied value in <var>N</var>. If
-                     a row has fewer fields than the supplied value it is padded by appending empty
-                     string values until it contains the specified number of fields. Setting
-                  <code>number-of-columns: <var>N</var></code> is equivalent to setting
-                  <code>filter-columns: 1 to <var>N</var></code>.</fos:value>
-               </fos:values>
-            </fos:option>-->
          </fos:options>
 
          <p>The result of the function is a <code>parsed-csv-structure-record</code>, a map with
@@ -23333,20 +23306,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </gitem>
          </glist>
 
-         
 
-         <!--<p>If the <code>number-of-columns</code> options is set to <code>"first-row"</code> or an
-            integer, or the <code>filter-columns</code> option is set, and the
-            <code>header</code> option is set to <code>true()</code>, the filtering of
-            columns is performed before the extraction of the first row and creation of the
-            <code>csv-columns-record</code>.</p>
-
-         <p>If the <code>number-of-columns</code> options is set to <code>"first-row"</code> or an
-            integer, or the <code>filter-columns</code> option is set, and the
-            <code>header</code> option is set to a <code>map(xs:string, xs:integer)</code>,
-            then filtering of columns does not affect the creation of the
-            <code>csv-columns-record</code>, and it is possible that the number of fields in the
-            rows is smaller than the number of fields in the <code>csv-columns-record</code>.</p>-->
       </fos:rules>
       <fos:errors>
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
@@ -23371,23 +23331,11 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>For more discussion of the returned data, see <specref ref="csv-to-xdm-mapping"/>.</p>
       </fos:notes>
       <fos:examples>
-         <!--<fos:variable name="crlf" id="escaped-crlf-2"><![CDATA[char('\r')||char('\n')]]></fos:variable>-->
          <fos:variable name="display" id="csv-display">fn($result) {
    (: tidy up the result for display (function items cannot be properly displayed) :)         
-   if ($result?field instance of function(xs:positiveInteger, 
-                                          union(xs:positiveInteger, xs:string)) 
-                                       as xs:string?)
-   then map:put($result, "get", "(: function :)")
-   else $result
+   map:put($result, "get", "(: function :)")
 }</fos:variable>
-         <!--<fos:variable name="csv-string" id="csv-string">`name,city{$crlf}`||
-            `Bob,Berlin{$crlf}`||
-            `Alice,Aachen{$crlf}`</fos:variable>
-         <fos:variable name="options" id="non-default-delims">map { "row-delimiter": "§", 
-            "field-delimiter": ";", 
-            "quote-character": "|" }</fos:variable>
-         <fos:variable name="non-std-csv" id="non-standard-csv-string">`|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|`</fos:variable>
-         -->
+
          <fos:example>
             <p>Default delimiters, no column headers:</p>
             <fos:test use="csv-display">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -5081,7 +5081,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <p>If <code>%</code> is followed by up to two characters that are not hexadecimal digits,
             these characters are replaced by octets <code>xEF</code>, <code>xBF</code>,
             and <code>xBD</code>, that is, the UTF-8 encoding of the Unicode replacement character
-            (<code>0xFFFD</code>). For example, the incomplete or invalid percent-encoded strings
+            (<code>U+FFFD</code>). For example, the incomplete or invalid percent-encoded strings
             <code>"%"</code>, <code>"%X"</code>, <code>"%AX"</code>, and <code>"%XA"</code> are all
             replaced with these octets. For the string <code>"%1X!"</code>, the octets <code>xEF</code>,
             <code>xBF</code>, <code>xBD</code>, and <code>x21</code> are returned.</p>
@@ -23076,7 +23076,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:meaning>The character used to delimit rows within
                   the CSV string. An instance of
                   <code>xs:string</code> whose length is exactly one.
-                  Defaults to a single newline character (<code>U+0010</code>).</fos:meaning>
+                  Defaults to a single newline character (<code>U+000A</code>).</fos:meaning>
                <fos:type>xs:string</fos:type>
                <fos:default>char('\n')</fos:default>
             </fos:option>
@@ -23088,57 +23088,86 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:option>
             <fos:option key="trim-whitespace">
                <fos:meaning>Determines whether leading and trailing whitespace
-                  is removed from the content of fields.</fos:meaning>
+                  is removed from the content of unquoted fields.</fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
-                  <fos:value value="false">Fields will be returned with any leading or trailing
+                  <fos:value value="false">Unquoted fields will be returned with any leading or trailing
                      whitespace intact.
                   </fos:value>
-                  <fos:value value="true">Fields will be returned with leading or trailing
+                  <fos:value value="true">Unquoted fields will be returned with leading or trailing
                      whitespace removed, and all other whitespace preserved.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="normalize-newlines">
+               <fos:meaning>Determines whether CR and CRLF character sequences
+                  are treated as equivalent to NL characters.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">No normalization takes place.
+                  </fos:value>
+                  <fos:value value="true">The character sequences CR (<code>U+000D</code>)
+                  and CRLF (<code>U+000D, U+000A</code>) are treated as equivalent to the
+                  character NL (<code>U+000A</code>), except when they appear within a quoted field. 
+                  The normalization is done prior to recognition of row delimiters, and happens
+                  whether or not NL is used as the row delimiter.
                   </fos:value>
                </fos:values>
             </fos:option>
             <fos:option key="header">
                <fos:meaning>Determines whether the first row of the CSV should be treated as a list
                   of column names, or whether column names are being supplied by the caller. 
-                  Permitted values are a map of type
-                  <code>map(xs:string, xs:integer)</code> or an <code>xs:boolean</code>.
+                  The value must either be a single boolean, or a sequence of one or more strings.
                </fos:meaning>
-               <fos:type>item()</fos:type>
+               <fos:type>item()*</fos:type>
                <fos:default>false</fos:default>
                <fos:values>
                   <fos:value value="true">Column names are taken from the
                      first row of the CSV data.</fos:value>
                   <fos:value value="false">Column names are not available; all references
                      to columns are by ordinal position.</fos:value>
-                  <fos:value value="map(xs:string, xs:positiveInteger)">The supplied map 
-                     gives a pairing from column names to column numbers. Note that
-                     if columns are filtered, the relevant column number is the position
-                     after any rearrangement.
+                  <fos:value value="xs:string+">Supplies explicit names for the columns. The <var>N</var>th
+                     name in the list applies to the <var>N</var>th column after any filtering or rearrangement.
+                     A zero-length string can be used when there is a column that requires no name.
                   </fos:value>
                </fos:values>
             </fos:option>
-            <fos:option key="filter-columns">
+            <fos:option key="select-columns">
                <fos:meaning>A sequence of integers indicating which columns to include and in which order. If this
                   option is absent or empty, all columns are returned in their original
-                  order, unless otherwise specified using the <code>number-of-columns</code>
-                  option. For example, the value <code>(1, 5, 4)</code> indicates that the output
+                  order. For example, the value <code>1 to 4</code> indicates that the output
+                  contains the first, second, third, and fourth columns from the input, in order,
+                  while <code>(1, 5, 4)</code> indicates that the output
                   contains three columns, taken from the first, fifth, and fourth columns of the input,
                   in that order. An integer in the sequence is treated as the 1-based 
-                  index of the column to include. In
-                  the returned data, only fields from the specified columns are returned, and in
-                  the order specified. If a particular row includes no field at the specified index,
+                  index of the column to include. Any other columns are dropped. 
+                  If a particular row includes no field at the specified index,
                   an empty field is included at the relevant position in the result. If an integer appears
                   more than once then the result will include duplicated columns.
-                  This option is mutually exclusive with the
-                  <code>number-of-columns</code> option. Specifying both options will cause an <errorref
-                     class="CV" code="0006"/> error.</fos:meaning>
+               </fos:meaning>
                <fos:type>xs:positiveInteger*</fos:type>
                <fos:default>()</fos:default>
             </fos:option>
-            <fos:option key="number-of-columns">
+            <fos:option key="trim-rows">
+               <fos:meaning>Determines whether all rows should be adjusted to
+                  contain the same number of fields. This option is ignored if
+                  <code>select-columns</code> is specified.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">No padding or trimming of rows takes place,
+                  unless requested using the <code>select-columns</code> option.</fos:value>
+                  <fos:value value="true">The number of fields in the first row (whether this
+                     be a header or a data row) determines the number of fields in every
+                     subsequent row; to achieve this, excess fields are removed, or
+                     additional zero-length fields are added.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            
+            <!--<fos:option key="number-of-columns">
                <fos:meaning>Specifies how many columns to include in the result. 
                   This option is mutually exclusive with the
                   <code>filter-columns</code> option. Specifying both options will cause an <errorref
@@ -23163,7 +23192,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   <code>number-of-columns: <var>N</var></code> is equivalent to setting
                   <code>filter-columns: 1 to <var>N</var></code>.</fos:value>
                </fos:values>
-            </fos:option>
+            </fos:option>-->
          </fos:options>
 
          <p>The result of the function is a <code>parsed-csv-structure-record</code>, a map with
@@ -23189,21 +23218,12 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <code>filter-columns</code> option is specified. Any strings that are
                      zero-length or duplicated are retained <emph>as-is</emph>.</p>
                     </item>
-                     <item><p>If the value of the option is a map (from column names to positive integers)
-                     then the value is constructed from the entries in this map. Specifically,
-                     if the supplied map is <code>$M</code>, then the sequence of names is
-                     obtained as the result of the expression:</p>
-                     <eg>let $inverse := 
-    $M => 
-    map:pairs() => 
-    map:build(key:=fn{?value}, value:=fn{?key}, combine:=fn:error#0)
-  return (1 to max(map:keys($inverse))) ! ($inverse(.) otherwise "")</eg>
-                     <p>For example, if the supplied value is <code>map{"a":1,"c":3}</code>
-                     then the sequence of names is <code>("a","","c")</code></p>
-                     <p>Supplied column numbers are <emph>not</emph> adjusted based on the 
-                        <code>filter-columns</code> or <code>number-of-columns</code>
-                        options; the supplied map is expected to refer to column positions
-                        in the result, not in the input.</p></item>
+                     <item><p>If the value of the <code>header</code> option is a sequence
+                     of strings, then the value is taken from the supplied sequence.</p>
+                     <p>The order of names is <emph>not</emph> adjusted based on the 
+                        <code>select-columns</code> 
+                        option; the supplied list of names is expected to refer to columns
+                        in the result, not to columns in the input.</p></item>
                   </ulist></def>
             </gitem>
                   
@@ -23228,15 +23248,24 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      row that is non-zero-length and is not equal (using codepoint collation) to
                      any previous string appearing in the header results in an entry
                      pairing that string to its 1-based position in the header row.</p>
-                     <p>If the <code>filter-columns</code> or <code>number-of-columns</code>
-                     options is present then the entries are adjusted (or removed) to
+                     <p>If the <code>select-columns</code> 
+                     option is present then the entries are adjusted (or removed) to
                      reflect their position in the adjusted data rows.</p>
                      
                     
                   
                   </item>
-                  <item><p>If the value of the option is a map (from column names to integers)
-                     then the supplied map is used unchanged.</p>
+                  <item><p>If the value of the <code>header</code> option is a 
+                     sequence of strings, then the map contains entries based on the supplied value.
+                     Any string appearing in the option value that is non-zero-length and 
+                     is not equal (using codepoint collation) to
+                     any previous string results in an entry
+                     pairing that string to its 1-based position in the sequence.
+                  </p>
+                     <p>The allocation of column numbers is <emph>not</emph> adjusted based on the 
+                        <code>select-columns</code> 
+                        option; the supplied list of names is expected to refer to columns
+                        in the result, not to columns in the input.</p>
                   </item>
                </ulist></def>
             </gitem>
@@ -23329,18 +23358,14 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             for more than one of the options
             <code>field-delimiter</code>, <code>row-delimiter</code>, and
             <code>quote-character</code>.</p>
-         <p>A dynamic error <errorref class="CV" code="0005"/> occurs if the map 
-            supplied in the <code>header</code> option maps any integer to
-            more than one name.</p>
-         <p>A dynamic error <errorref class="CV" code="0006"/> occurs if both the
-            <code>number-of-columns</code> and <code>filter-columns</code> options are set.</p>
+
       </fos:errors>
       <fos:notes>
-         <p>The default row delimiter is a single newline (U+0010) character. If the content
+         <p>The default row delimiter is a single newline (U+000A) character. If the content
          is read using the <code>unparsed-text</code> function, alternative line endings
          such as <code>CR</code> and <code>CRLF</code> will have been normalized to a single
-         newline. In other cases, this normalization can be achieved with a call on the
-         <code>fn:replace</code> function.</p>
+         newline. In other cases, this normalization can be achieved by setting the 
+         <code>normalize-newlines</code> option.</p>
          <p>All fields are returned as <code>xs:string</code> values.</p>
          <p>Quoted fields in the input are returned without the quotes.</p>
          <p>For more discussion of the returned data, see <specref ref="csv-to-xdm-mapping"/>.</p>
@@ -23423,7 +23448,7 @@ return ($result => $display(),
          <fos:example>
             <p>Supplied column names:</p>
             <fos:test use="csv-display">
-               <fos:expression><eg>let $headers := map { "Person": 1, "Location": 2 }
+               <fos:expression><eg>let $headers := ("Person", "Location")
 let $options := map {"header": $headers, "row-delimiter": ";"}
 let $input := "Alice,Aachen;Bob,Berlin;"
 let $parsed-csv := parse-csv($input, $options)
@@ -23447,7 +23472,7 @@ return ($parsed-csv => $display(),
    "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
 let $options := map { 
    "header": true(), 
-   "filter-columns": (2,1,4) }
+   "select-columns": (2,1,4) }
 let $result := parse-csv($input, $options)
 return ($result => $display(),
         $result?get(2, "city"))</eg></fos:expression>
@@ -23470,7 +23495,7 @@ return ($result => $display(),
    "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
 let $options := map { 
    "header": map { "Person": 1, "Amount": 3 }, 
-   "filter-columns": (2,1,4) }
+   "select-columns": (2,1,4) }
 let $result := parse-csv($input, $options)
 return ($result => $display(),
         $result?get(2, "Person"),
@@ -23494,7 +23519,7 @@ return ($result => $display(),
   "2023-07-20,Charlie,  15.00,     GBP,        11.99,             extra data"), 
   char('\n'))
 let $options := map {"header": false(), 
-                     "number-of-columns":5, 
+                     "select-columns":1 to 5, 
                      "trim-whitespace":true()}
 let $result := parse-csv($input, $options)
 return ($result => $display(),
@@ -23519,7 +23544,7 @@ return ($result => $display(),
   "2023-07-19,Bob,Berlin,10.00,USD,13.99",
   "2023-07-20,Alice,Aachen,15.00",
   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
-let $options := map{"header": true(), "number-of-columns": 6}
+let $options := map{"header": true(), "select-columns": 1 to 6}
 let $result := parse-csv($input, $options)
 return ($result => $display(),
         $result?get(3,"original amount"))</eg></fos:expression>
@@ -23587,7 +23612,7 @@ return ($result => $display(),
                <fos:meaning>The character used to delimit rows within
                   the CSV string. An instance of
                   <code>xs:string</code> whose length is exactly one.
-                  Defaults to a single newline character (<code>U+0010</code>).</fos:meaning>
+                  Defaults to a single newline character (<code>U+000A</code>).</fos:meaning>
                <fos:type>xs:string+</fos:type>
                <fos:default>char('\n')</fos:default>
             </fos:option>
@@ -23608,6 +23633,22 @@ return ($result => $display(),
                   </fos:value>
                   <fos:value value="true">Fields will be returned with leading or trailing
                      whitespace removed, and all other whitespace preserved.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="normalize-newlines">
+               <fos:meaning>Determines whether CR and CRLF character sequences
+                  are treated as equivalent to NL characters.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">No normalization takes place.
+                  </fos:value>
+                  <fos:value value="true">The character sequences CR (<code>U+000D</code>)
+                     and CRLF (<code>U+000D, U+000A</code>) are treated as equivalent to the
+                     character NL (<code>U+000A</code>), except when they appear within a quoted field. 
+                     The normalization is done prior to recognition of row delimiters, and happens
+                     whether or not NL is used as the row delimiter.
                   </fos:value>
                </fos:values>
             </fos:option>
@@ -23645,11 +23686,12 @@ return ($result => $display(),
             <code>quote-character</code>.</p>
       </fos:errors>
       <fos:notes>
-         <p>The default row delimiter is a single newline (U+0010) character. If the content
+         <p>The default row delimiter is a single newline (U+000A) character. If the content
             is read using the <code>unparsed-text</code> function, alternative line endings
             such as <code>CR</code> and <code>CRLF</code> will have been normalized to a single
-            newline. In other cases, this normalization can be achieved with a call on the
-            <code>fn:replace</code> function.</p>
+            newline. In other cases, this normalization can be achieved by setting the
+            option <code>normalize-newlines</code>. This option does not affect CR or CRLF
+            sequences occurring within quoted fields.</p>
          <p>All fields are returned as <code>xs:string</code> values.</p>
          <p>Quoted fields in the input are returned without the quotes.</p>
          <p>The first row is not treated specially.</p>
@@ -23694,12 +23736,25 @@ return ($result => $display(),
                <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map{'trim-whitespace':false()})</eg></fos:expression>
                <fos:result>[], [" "]</fos:result>
             </fos:test>
-            <p>Using the default record separators:</p>
+            <p>Using newline separators:</p>
             <fos:test>
                <fos:expression><eg>csv-to-arrays(
    `name,city{char('\n')}`||
    `Bob,Berlin{char('\n')}`||
    `Alice,Aachen{char('\n')}`)</eg></fos:expression>
+               <fos:result><eg>(
+   ["name", "city"],
+   ["Bob", "Berlin"],
+   ["Alice", "Aachen"]
+)</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>let $CRLF := `{char('\r')}{char('\n')}`
+return csv-to-arrays(
+  `name,city{$CRLF)}`||
+  `Bob,Berlin{$CRLF)}`||
+  `Alice,Aachen{$CRLF)}`, 
+  map{"normalize-newlines":true()})</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -23721,7 +23776,7 @@ return ($result => $display(),
    ["Alice", "Aachen"]
 )</eg></fos:result>
             </fos:test>
-            <fos:test use="escaped-crlf">
+            <fos:test>
                <fos:expression><eg>csv-to-arrays(`"name","city"{char('\n')}`||
              `"Bob ""The Exemplar"" Mustermann","Berlin"{char('\n')}`)</eg></fos:expression>
                <fos:result><eg>(
@@ -23877,7 +23932,7 @@ return
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>An empty CSV with column extraction:</p>
+            <p>An empty CSV with header extraction:</p>
             <fos:test>
                <fos:expression><eg>csv-to-xml("", map { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
@@ -23891,7 +23946,7 @@ return
          <fos:example>
             <p>An empty CSV with explicit column names:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-xml("", map { "header": map { "name": 1, "city": 3 } })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml("", map { "header": ("name", "", "city") })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23905,7 +23960,7 @@ return
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>With defaults for delimiters and quotes, and column extraction:</p>
+            <p>With defaults for delimiters and quotes, recognizing headers:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-string, map { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
@@ -23928,8 +23983,8 @@ return
 ]]></eg></fos:result>
             </fos:test>
          </fos:example>
-         <fos:example>
-            <p>With defaults for delimiters and quotes, and column extraction:</p>
+         <!--<fos:example>
+            <p>With defaults for delimiters and quotes, recognizing headers:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-string, map { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
@@ -23951,7 +24006,7 @@ return
 </csv>
 ]]></eg></fos:result>
             </fos:test>
-         </fos:example>
+         </fos:example>-->
          <fos:variable name="csv-uneven-cols" id="uneven-cols-csv-string-2">concat(
 `date,name,city,amount,currency,original amount,note{$crlf}`,
 `2023-07-19,Bob,Berlin,10.00,USD,13.99{$crlf}`,
@@ -23962,7 +24017,7 @@ return
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
            map { "header": true(), 
-                 "filter-columns": (2,1,4) })</eg></fos:expression>
+                 "select-columns": (2,1,4) })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23992,11 +24047,10 @@ return
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Specifying the number of columns, using "all" (the default)</p>
+            <p>Ragged rows</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "header": true(), 
-                 "number-of-columns": "all" })</eg></fos:expression>
+           map { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -24039,11 +24093,11 @@ return
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Specifying the number of columns using <code>"first-row"</code></p>
+            <p>Trimming rows to constant width</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
            map { "header": true(), 
-                 "number-of-columns": "first-row" })</eg></fos:expression>
+                 "trim-rows": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -24089,11 +24143,11 @@ return
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Specifying the number of columns with a number</p>
+            <p>Specifying a fixed number of columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
            map { "header": true(), 
-                 "number-of-columns": 6 })</eg></fos:expression>
+                 "select-columns": 1 to 6 })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -59,46 +59,33 @@
       </fos:record>
    </fos:type>
 
-   <!-- MP - FIXUP -->
+ <!--  <!-\- MP - FIXUP -\->
    <fos:type id="common-csv-options">
       <fos:record extensible="false">
          <fos:field name="row-delimiter" type="xs:string" required="false"/>
          <fos:field name="column-delimiter" type="xs:string" required="false"/>
          <fos:field name="quote-character" type="xs:string" required="false"/>
       </fos:record>
-   </fos:type>
+   </fos:type>-->
 
-   <fos:type id="csv-parsing-options">
+ <!--  <fos:type id="csv-parsing-options">
       <fos:record extensible="false">
          <fos:field name="row-delimiter" type="xs:string" required="false"/>
          <fos:field name="column-delimiter" type="xs:string" required="false"/>
          <fos:field name="quote-character" type="xs:string" required="false"/>
          <fos:field name="trim-whitespace" type="xs:boolean" required="false"/>
       </fos:record>
-   </fos:type>
+   </fos:type>-->
 
    <fos:type id="parsed-csv-structure-record">
       <fos:record extensible="false">
-         <fos:field name="column-names" type="xs:string*" required="true"/>
-         <fos:field name="column-numbers" type="map(xs:string, xs:integer)" required="true"/>
+         <fos:field name="columns" type="xs:string*" required="true"/>
+         <fos:field name="column-index" type="map(xs:string, xs:positiveInteger)" required="true"/>
          <fos:field name="rows" type="array(xs:string)*" required="true"/>
-         <fos:field name="field" required="true" type="function(xs:positiveInteger, union(xs:positiveInteger, xs:string)) as xs:string?"/>
+         <fos:field name="get" required="true" type="function(xs:positiveInteger, union(xs:positiveInteger, xs:string)) as xs:string?"/>
       </fos:record>
    </fos:type>
 
-   <!--<fos:type id="csv-columns-record">
-      <fos:record extensible="false">
-         <fos:field name="names" type="map(xs:string, xs:integer)" required="true"/>
-         <fos:field name="fields" required="true" type="xs:string*"/>
-      </fos:record>
-   </fos:type>
-
-   <fos:type id="csv-row-record">
-      <fos:record extensible="false">
-         <fos:field name="fields" type="xs:string*" required="true"/>
-         <fos:field name="field" required="true" type="function(union(xs:integer, xs:string)) as xs:string?"/>
-      </fos:record>
-   </fos:type>-->
 
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
@@ -23086,10 +23073,12 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:default>","</fos:default>
             </fos:option>
             <fos:option key="row-delimiter">
-               <fos:meaning>A sequence of strings, any of which can be used to delimit rows within
-                  the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
-               <fos:type>xs:string+</fos:type>
-               <fos:default>(char(13)||char(10), char(10), char(13))</fos:default>
+               <fos:meaning>The character used to delimit rows within
+                  the CSV string. An instance of
+                  <code>xs:string</code> whose length is exactly one.
+                  Defaults to a single newline character (<code>U+0010</code>).</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>char('\n')</fos:default>
             </fos:option>
             <fos:option key="quote-character">
                <fos:meaning>The character used to quote fields within the CSV string. An instance of
@@ -23111,7 +23100,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
-            <fos:option key="column-names">
+            <fos:option key="header">
                <fos:meaning>Determines whether the first row of the CSV should be treated as a list
                   of column names, or whether column names are being supplied by the caller. 
                   Permitted values are a map of type
@@ -23124,16 +23113,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      first row of the CSV data.</fos:value>
                   <fos:value value="false">Column names are not available; all references
                      to columns are by ordinal position.</fos:value>
-                  <fos:value value="map(xs:string, xs:integer)">The supplied map 
+                  <fos:value value="map(xs:string, xs:positiveInteger)">The supplied map 
                      gives a pairing from column names to column numbers. Note that
                      if columns are filtered, the relevant column number is the position
-                     after any rearrangement.<!--is
-                     returned directly as the <code>column-numbers</code> entry in the result.
-                     The <code>column-names</code> entry is constructed from this map as
-                     the result of the expression <code>(1 to max(map:values($column-numbers))) !
-                     ($column-numbers(.) otherwise "")</code>. The first row 
-                     of the [arsed CSV content is <emph>not</emph> excluded from
-                     the <code>rows</code> entry of the result.-->
+                     after any rearrangement.
                   </fos:value>
                </fos:values>
             </fos:option>
@@ -23141,7 +23124,10 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <fos:meaning>A sequence of integers indicating which columns to include and in which order. If this
                   option is absent or empty, all columns are returned in their original
                   order, unless otherwise specified using the <code>number-of-columns</code>
-                  option. An integer in the sequence is treated as the 1-based index of the column to include. In
+                  option. For example, the value <code>(1, 5, 4)</code> indicates that the output
+                  contains three columns, taken from the first, fifth, and fourth columns of the input,
+                  in that order. An integer in the sequence is treated as the 1-based 
+                  index of the column to include. In
                   the returned data, only fields from the specified columns are returned, and in
                   the order specified. If a particular row includes no field at the specified index,
                   an empty field is included at the relevant position in the result. If an integer appears
@@ -23149,7 +23135,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   This option is mutually exclusive with the
                   <code>number-of-columns</code> option. Specifying both options will cause an <errorref
                      class="CV" code="0006"/> error.</fos:meaning>
-               <fos:type>xs:integer*</fos:type>
+               <fos:type>xs:positiveInteger*</fos:type>
                <fos:default>()</fos:default>
             </fos:option>
             <fos:option key="number-of-columns">
@@ -23157,7 +23143,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   This option is mutually exclusive with the
                   <code>filter-columns</code> option. Specifying both options will cause an <errorref
                      class="CV" code="0006"/> error.</fos:meaning>
-               <fos:type>union(enum("all", "first-row"), xs:integer)</fos:type>
+               <fos:type>union(enum("all", "first-row"), xs:positiveInteger)</fos:type>
                <fos:default>"all"</fos:default>
                <fos:values>
                   <fos:value value="'all'">All fields from all rows
@@ -23168,7 +23154,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      the input is counted (whether or not this is a header row),
                      and processing proceeds as if that integer had been supplied as the value for
                      this option.</fos:value>
-                  <fos:value value="xs:integer">The number of columns is set to this value. Rows
+                  <fos:value value="xs:positiveInteger">The number of columns is set to this value. Rows
                      with more fields than the supplied value are truncated by discarding the extra
                      fields, as if by calling <code>array:subarray(R, 1, N)</code>, given the row’s
                      fields in array <var>R</var>, and the supplied value in <var>N</var>. If
@@ -23181,21 +23167,21 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          </fos:options>
 
          <p>The result of the function is a <code>parsed-csv-structure-record</code>, a map with
-            string-valued keys containing four entries: <code>column-names</code>, 
-            <code>column-numbers</code>, <code>rows</code>, and <code>field</code>.
+            string-valued keys containing four entries: <code>columns</code>, 
+            <code>column-index</code>, <code>rows</code>, and <code>get</code>.
             The values of these entries are set as follows:</p>
          <glist>
             <gitem>
-               <label>column-names</label>
+               <label>columns</label>
                <def><p>This entry holds a sequence of strings containing column names.
-                  The content depends on the setting of the <code>column-names</code>
+                  The content depends on the setting of the <code>header</code>
                   entry in <code>$options</code>:</p>
                
                   <ulist>
-                     <item><p>If the option is <code>false()</code> (which is the default),
+                     <item><p>With <code>"header":false()</code> (which is the default),
                      then the value is an empty sequence.</p></item>
-                     <item><p>If the option is <code>true()</code>, then the entry
-                     contains strings taken from the first row of the data. The strings have
+                     <item><p>With <code>"header":true()</code>, the value is a sequence
+                     of strings taken from the first row of the data. The strings have
                      leading and trailing whitespace trimmed, regardless of the value of the
                      <code>trim-whitespace</code> option. The sequence
                      of strings will potentially be truncated if the <code>number-of-columns</code>
@@ -23203,7 +23189,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <code>filter-columns</code> option is specified. Any strings that are
                      zero-length or duplicated are retained <emph>as-is</emph>.</p>
                     </item>
-                     <item><p>If the value of the option is a map (from column names to integers)
+                     <item><p>If the value of the option is a map (from column names to positive integers)
                      then the value is constructed from the entries in this map. Specifically,
                      if the supplied map is <code>$M</code>, then the sequence of names is
                      obtained as the result of the expression:</p>
@@ -23214,9 +23200,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
   return (1 to max(map:keys($inverse))) ! ($inverse(.) otherwise "")</eg>
                      <p>For example, if the supplied value is <code>map{"a":1,"c":3}</code>
                      then the sequence of names is <code>("a","","c")</code></p>
-                     <p>Column numbers are <emph>not</emph> adjusted based on the 
+                     <p>Supplied column numbers are <emph>not</emph> adjusted based on the 
                         <code>filter-columns</code> or <code>number-of-columns</code>
-                        options; the supplied map is expected to refer to column numbers
+                        options; the supplied map is expected to refer to column positions
                         in the result, not in the input.</p></item>
                   </ulist></def>
             </gitem>
@@ -23225,16 +23211,16 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             
           
             <gitem>
-               <label>column-numbers</label>
+               <label>column-index</label>
                <def><p>This entry holds a map from column names (as strings) to
-                  column positions (as 1-based integers).
-                  The content depends on the setting of the <code>column-names</code>
+                  column positions (as 1-based positive integers).
+                  The content depends on the setting of the <code>header</code>
                   entry in <code>$options</code>:</p>
                
                <ulist>
-                  <item><p>If the option is <code>false()</code> (which is the default),
-                     then the value is an empty map.</p></item>
-                  <item><p>If the option is <code>true()</code>, then the map
+                  <item><p>With <code>"header":false()</code> (which is the default),
+                     the value is an empty map.</p></item>
+                  <item><p>With <code>"header":true()</code>, the map
                      contains entries based on the contents of the first row of the data. 
                      The strings have
                      leading and trailing whitespace trimmed, regardless of the value of the
@@ -23260,20 +23246,20 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                <def><p>This entry is a sequence of arrays of strings, holding the parsed
                   rows of the CSV data. The format is the same as the result of the
                   <code>fn:csv-to-arrays</code> function, except that the first row
-                  is omitted in the case where the <code>column-names</code>
-                  option is set to <code>true</code>. If there are no data rows in the CSV, the
+                  is omitted in the case where the <code>header</code>
+                  option is <code>true</code>. If there are no data rows in the CSV, the
                   value will be an empty sequence.</p></def>
                
             </gitem>
             <gitem>
-               <label>field</label>
+               <label>get</label>
                <def><p>This entry holds a function that takes two arguments: an integer
                   row number (1-based), and a string or integer used to identify a column.
                   Except in error cases (described below), 
-                  the function call <code>$csv?field($R, $C)</code>, where <code>$C</code>
+                  the function call <code>$csv?get($R, $C)</code>, where <code>$C</code>
                   is an integer, returns the value of <code>$csv?rows[$R] => array:get($C, fn{""})</code>,
-                  and the function call <code>$csv?field($R, $K)</code>, where <code>$K</code>
-                  is a string, returns the value of <code>$csv?field($R, $csv?column-numbers($K))</code>.</p>
+                  and the function call <code>$csv?get($R, $K)</code>, where <code>$K</code>
+                  is a string, returns the value of <code>$csv?get($R, $csv?column-numbers($K))</code>.</p>
 
                <p>The properties of the function are as follows:</p>
                <ulist>
@@ -23284,7 +23270,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <p>parameter names: (<var>$row</var>, <var>$col</var>)</p>
                   </item>
                   <item>
-                     <p>signature: <code>(xs:integer, union(xs:integer, xs:string)) => xs:string?</code></p>
+                     <p>signature: <code>(xs:positiveInteger, union(xs:xs:positiveInteger, xs:string)) => xs:string?</code></p>
                   </item>
                   <item>
                      <p>non-local variable bindings: none</p>
@@ -23322,13 +23308,13 @@ return $M(collation-key("a", $C))</eg></fos:expression>
 
          <!--<p>If the <code>number-of-columns</code> options is set to <code>"first-row"</code> or an
             integer, or the <code>filter-columns</code> option is set, and the
-            <code>column-names</code> option is set to <code>true()</code>, the filtering of
+            <code>header</code> option is set to <code>true()</code>, the filtering of
             columns is performed before the extraction of the first row and creation of the
             <code>csv-columns-record</code>.</p>
 
          <p>If the <code>number-of-columns</code> options is set to <code>"first-row"</code> or an
             integer, or the <code>filter-columns</code> option is set, and the
-            <code>column-names</code> option is set to a <code>map(xs:string, xs:integer)</code>,
+            <code>header</code> option is set to a <code>map(xs:string, xs:integer)</code>,
             then filtering of columns does not affect the creation of the
             <code>csv-columns-record</code>, and it is possible that the number of fields in the
             rows is smaller than the number of fields in the <code>csv-columns-record</code>.</p>-->
@@ -23336,21 +23322,25 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:errors>
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
             <code>$csv</code> does not conform to the required grammar.</p>
-         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if one or more of the values
-            for <code>field-delimiter</code> or <code>quote-character</code> are specified and are
-            not a single character.</p>
-         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
-            <code>field-delimiter</code>, <code>row-delimiter</code>,
-            <code>quote-character</code> are equal.</p>
-         <p>A dynamic error <errorref class="CV" code="0005"/> occurs if any column-index integers,
-            such as the values in a map supplied to <code>column-names</code>, or as the value of
-            <code>number-of-columns</code> or <code>filter-columns</code>, are negative or
-            zero, or if any integer is mapped to more than one name.</p>
+         <p>A dynamic error <errorref class="CV" code="0002"/> occurs if any of the
+            options <code>field-delimiter</code>, <code>row-delimiter</code>, or <code>quote-character</code>
+            is not a single character.</p>
+         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if the same character is used
+            for more than one of the options
+            <code>field-delimiter</code>, <code>row-delimiter</code>, and
+            <code>quote-character</code>.</p>
+         <p>A dynamic error <errorref class="CV" code="0005"/> occurs if the map 
+            supplied in the <code>header</code> option maps any integer to
+            more than one name.</p>
          <p>A dynamic error <errorref class="CV" code="0006"/> occurs if both the
-            <code>number-of-columns</code> and <code>filter-columns</code> options are set in a
-            call to <code>fn:parse-csv</code>.</p>
+            <code>number-of-columns</code> and <code>filter-columns</code> options are set.</p>
       </fos:errors>
       <fos:notes>
+         <p>The default row delimiter is a single newline (U+0010) character. If the content
+         is read using the <code>unparsed-text</code> function, alternative line endings
+         such as <code>CR</code> and <code>CRLF</code> will have been normalized to a single
+         newline. In other cases, this normalization can be achieved with a call on the
+         <code>fn:replace</code> function.</p>
          <p>All fields are returned as <code>xs:string</code> values.</p>
          <p>Quoted fields in the input are returned without the quotes.</p>
          <p>For more discussion of the returned data, see <specref ref="csv-to-xdm-mapping"/>.</p>
@@ -23362,7 +23352,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
    if ($result?field instance of function(xs:positiveInteger, 
                                           union(xs:positiveInteger, xs:string)) 
                                        as xs:string?)
-   then map:put($result, "field", "(: function :)")
+   then map:put($result, "get", "(: function :)")
    else $result
 }</fos:variable>
          <!--<fos:variable name="csv-string" id="csv-string">`name,city{$crlf}`||
@@ -23376,20 +23366,19 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Default delimiters, no column headers:</p>
             <fos:test use="csv-display">
-               <fos:expression><eg>let $crlf := char('\r')||char('\n')                  
-let $input := string-join((
+               <fos:expression><eg>let $input := string-join((
    "name,city",
    "Bob,Berlin",
-   "Alice,Aachen"), $crlf)
+   "Alice,Aachen"), char('\n'))
 let $result := parse-csv($input)
 return ($result => $display(),
-        $result?field(1,2),
-        $result?field(2,2))</eg></fos:expression>
+        $result?get(1,2),
+        $result?get(2,2))</eg></fos:expression>
                <fos:result><eg>map{
-   "column-names": (),
-   "column-numbers": map{},
+   "columns": (),
+   "column-index": map{},
    "rows": (["name", "city"], ["Bob", "Berlin"], ["Alice", "Aachen"]),
-   "field": "(: function :)"
+   "get": "(: function :)"
 }, "city", "Berlin"</eg></fos:result>
             </fos:test>
             
@@ -23397,20 +23386,19 @@ return ($result => $display(),
             <p>Default delimiters, column headers:</p>
             
             <fos:test use="csv-display">
-               <fos:expression><eg>let $crlf := char('\r')||char('\n')                  
-let $input := string-join((
+               <fos:expression><eg>let $input := string-join((
    "name,city",
    "Bob,Berlin",
-   "Alice,Aachen"), $crlf)
-let $result := parse-csv($input, map {"column-names": true()})
+   "Alice,Aachen"), char('\n'))
+let $result := parse-csv($input, map {"header": true()})
 return ($result => $display(),
-        $result?field(1,"name"),
-        $result?field(2,"city"))</eg></fos:expression>
+        $result?get(1,"name"),
+        $result?get(2,"city"))</eg></fos:expression>
 <fos:result><eg>map{
-   "column-names": ("name", "city"),
-   "column-numbers": map {"name": 1, "city": 2 },
+   "columns": ("name", "city"),
+   "column-index": map {"name": 1, "city": 2 },
    "rows": (["Bob", "Berlin"], ["Alice", "Aachen"]),
-   "field": "(: function :)"
+   "get": "(: function :)"
 }, "Bob", "Aachen"</eg></fos:result>
             </fos:test>
          </fos:example>
@@ -23423,12 +23411,12 @@ return ($result => $display(),
 let $input := "|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|"
 let $result := parse-csv($csv, $options)
 return ($result => $display(),
-        $result?field(3, 1))</eg></fos:expression>
+        $result?get(3, 1))</eg></fos:expression>
                <fos:result><eg>map{
-   "column-names": (),
-   "column-numbers": map {},
+   "columns": (),
+   "column-index": map {},
    "rows": (["name", "city"], ["Bob", "Berlin"], ["Alice", "Aachen"]),
-   "field": "(: function :)"
+   "get": "(: function :)"
 }, "Alice"</eg></fos:result>
             </fos:test>
          </fos:example>
@@ -23436,21 +23424,21 @@ return ($result => $display(),
             <p>Supplied column names:</p>
             <fos:test use="csv-display">
                <fos:expression><eg>let $headers := map { "Person": 1, "Location": 2 }
-let $options := map {"column-names": $headers, "row-delimiter": ";"}
+let $options := map {"header": $headers, "row-delimiter": ";"}
 let $input := "Alice,Aachen;Bob,Berlin;"
 let $parsed-csv := parse-csv($input, $options)
 return ($parsed-csv => $display(), 
-        $parsed-csv?field(2, "Location"))</eg></fos:expression>
+        $parsed-csv?get(2, "Location"))</eg></fos:expression>
                <fos:result><eg>map{
-   "column-names": ("Person", "Location"),
-   "column-numbers": map {"Person": 1, "Location": 2},
+   "columns": ("Person", "Location"),
+   "column-index": map {"Person": 1, "Location": 2},
    "rows": (["Alice", "Aachen"], ["Bob", "Berlin"]),
-   "field": "(: function :)"                  
+   "get": "(: function :)"                  
    }, "Berlin"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Filtering columns, with <code>column-names: true()</code></p>
+            <p>Filtering columns, with ragged input and <code>header: true()</code></p>
             <fos:test use="csv-display">
                <fos:expression><eg>let $input := string-join((
    "date,name,city,amount,currency,original amount,note",
@@ -23458,18 +23446,18 @@ return ($parsed-csv => $display(),
    "2023-07-20,Alice,Aachen,15.00",
    "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
 let $options := map { 
-   "column-names": true(), 
+   "header": true(), 
    "filter-columns": (2,1,4) }
 let $result := parse-csv($input, $options)
 return ($result => $display(),
-        $result?field(2, "city"))</eg></fos:expression>
+        $result?get(2, "city"))</eg></fos:expression>
                <fos:result><eg>map{
-   "column-names": ("name", "date", "amount"),
-   "column-numbers": map {"name": 1, "date": 2, "amount": 3},
+   "columns": ("name", "date", "amount"),
+   "column-index": map {"name": 1, "date": 2, "amount": 3},
    "rows": (["Bob", "2023-07-19", "10.00"], 
             ["Alice", "2023-07-20", "15.00"], 
             ["Charlie", "2023-07-20", "15.00"]),
-   "field": "(: function :)"                  
+   "get": "(: function :)"                  
 }, "Aachen"</eg></fos:result>
             </fos:test>
          </fos:example>
@@ -23481,65 +23469,68 @@ return ($result => $display(),
    "2023-07-20,Alice,Aachen,15.00",
    "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
 let $options := map { 
-   "column-names": map { "Person": 1, "Amount": 3 }, 
+   "header": map { "Person": 1, "Amount": 3 }, 
    "filter-columns": (2,1,4) }
 let $result := parse-csv($input, $options)
 return ($result => $display(),
-        $result?field(2, "Person"),
-        $result?field(2, "Amount"))</eg></fos:expression>
+        $result?get(2, "Person"),
+        $result?get(2, "Amount"))</eg></fos:expression>
                
                <fos:result><eg>map{
-   "column-names": ("Person", "", "Amount"),
-   "column-numbers": map {"Person": 1, "Amount": 3},
+   "columns": ("Person", "", "Amount"),
+   "column-index": map {"Person": 1, "Amount": 3},
    "rows": (["Alice", "Aachen"], ["Bob", "Berlin"]),
-   "field": "(: function :)"                  
+   "get": "(: function :)"                  
 }, "Alice", "15.00"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Specifying the number of columns using <code>"first-row"</code> and <code>column-names: false()</code></p>
+            <p>Specifying the number of columns explicitly, with <code>header: false()</code></p>
             <fos:test use="csv-display">
                <fos:expression><eg>let $input := string-join((
-  "date,name,city,amount,currency,original amount,note",               
-  "2023-07-19,Bob,Berlin,10.00,USD,13.99",
-  "2023-07-20,Alice,Aachen,15.00",
-  "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
-let $options := map {"number-of-columns": "first-row"}
+  "date,      name,     amount,    currency,   original amount",               
+  "2023-07-19,Bob,      10.00,     USD,        13.99",
+  "2023-07-20,Alice,    15.00",
+  "2023-07-20,Charlie,  15.00,     GBP,        11.99,             extra data"), 
+  char('\n'))
+let $options := map {"header": false(), 
+                     "number-of-columns":5, 
+                     "trim-whitespace":true()}
 let $result := parse-csv($input, $options)
 return ($result => $display(),
-        $result?field(4,7))</eg></fos:expression>
+        $result?get(4,3))</eg></fos:expression>
                <fos:result><eg>map{
-  "column-names": (),
-  "column-numbers": map {},
-  "rows": (["date","name","city","amount","currency","original amount","note"],
-           ["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
-           ["2023-07-20","Alice","Aachen","15.00","","",""],
-           ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]),
-  "field": "(: function :)"                  
-}, "cake"</eg></fos:result>
+  "columns": (),
+  "column-index": map {},
+  "rows": (["date","name","amount","currency","original amount"],
+           ["2023-07-19","Bob","10.00","USD","13.99"],
+           ["2023-07-20","Alice","15.00","",""],
+           ["2023-07-20","Charlie","15.00","GBP","11.99"]),
+  "get": "(: function :)"                  
+}, "15:00"</eg></fos:result>
                
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>Specifying the number of columns with a number and <code>column-names: true()</code></p>
+            <p>Specifying the number of columns with a number and <code>header: true()</code></p>
             <fos:test use="csv-display">
                <fos:expression><eg>let $input := string-join((
   "date,name,city,amount,currency,original amount,note",               
   "2023-07-19,Bob,Berlin,10.00,USD,13.99",
   "2023-07-20,Alice,Aachen,15.00",
   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
-let $options := map{"column-names": true(), "number-of-columns": 6}
+let $options := map{"header": true(), "number-of-columns": 6}
 let $result := parse-csv($input, $options)
 return ($result => $display(),
-        $result?field(3,"original amount"))</eg></fos:expression>
+        $result?get(3,"original amount"))</eg></fos:expression>
                <fos:result><eg>map{
-   "column-names": ("date","name","city","amount","currency","original amount"),
-   "column-numbers": map {"date":1, "name":2, "city":3, 
+   "columns": ("date","name","city","amount","currency","original amount"),
+   "column-index": map {"date":1, "name":2, "city":3, 
                           "amount":4, "currency":5, "original amount":6},
-   "rows": (["2023-07-19","Bob","Berlin","10.00","USD","13.99",""],
-            ["2023-07-20","Alice","Aachen","15.00","","",""],
-            ["2023-07-20","Charlie","Celle","15.00","GBP","11.99","cake"]),
-   "field": "(: function :)"                  
+   "rows": (["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
+            ["2023-07-20","Alice","Aachen","15.00","",""],
+            ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]),
+   "get": "(: function :)"                  
 }, "11.99"</eg></fos:result>
             </fos:test>
          </fos:example>
@@ -23550,7 +23541,7 @@ return ($result => $display(),
       <fos:signatures>
          <fos:proto name="csv-to-arrays" return-type="array(xs:string)*">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" type-ref="csv-parsing-options" usage="inspection" default="map{}"/>
+            <fos:arg name="options" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23582,18 +23573,6 @@ return ($result => $display(),
 
          
 
-         
-         <!--<p>Implementations <rfc2119>must</rfc2119> treat any of CRLF, CR, or LF as a single line
-            separator, as with <code>fn:unparsed-text-lines</code>.</p>
-
-         <p>Fields are regarded as simple <code>xs:string</code> values. Implementations
-            <rfc2119>must</rfc2119> leave whitespace within a field untouched, without
-            normalizing or otherwise altering it, unless whitespace trimming is explicitly requested
-            by the user using the <code>trim-whitespace</code> option.</p>
-
-         <p>When whitespace trimming is requested, implementations <rfc2119>must</rfc2119> only
-            strip leading and trailing whitespace, this is not equivalent to calling
-            <code>fn:normalize-space()</code>.</p>-->
 
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
 
@@ -23605,10 +23584,12 @@ return ($result => $display(),
                <fos:default>","</fos:default>
             </fos:option>
             <fos:option key="row-delimiter">
-               <fos:meaning>A sequence of strings, any of which can be used to delimit rows within
-                  the CSV string. Defaults to CRLF/LF/CR.</fos:meaning>
+               <fos:meaning>The character used to delimit rows within
+                  the CSV string. An instance of
+                  <code>xs:string</code> whose length is exactly one.
+                  Defaults to a single newline character (<code>U+0010</code>).</fos:meaning>
                <fos:type>xs:string+</fos:type>
-               <fos:default>(char(13)||char(10), char(10), char(13))</fos:default>
+               <fos:default>char('\n')</fos:default>
             </fos:option>
             <fos:option key="quote-character">
                <fos:meaning>The character used to quote fields within the CSV string. An instance of
@@ -23656,22 +23637,25 @@ return ($result => $display(),
          <p>A dynamic error <errorref class="CV" code="0001"/> occurs if the value of
             <code>$csv</code> does not conform to the required grammar.</p>
          <p>A dynamic error <errorref class="CV" code="0002"/> occurs if the value of the
-            <code>field-delimiter</code> or <code>quote-character</code> option is
-            not a single character.</p>
-         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if any of the values for
+            <code>field-delimiter</code>, <code>row-delimiter</code>, or 
+            <code>quote-character</code> option is not a single character.</p>
+         <p>A dynamic error <errorref class="CV" code="0003"/> occurs if the same character
+            is used for more than one of the
             <code>field-delimiter</code>, <code>row-delimiter</code>, and
-            <code>quote-character</code> are equal under the Unicode codepoint collation.</p>
+            <code>quote-character</code>.</p>
       </fos:errors>
       <fos:notes>
+         <p>The default row delimiter is a single newline (U+0010) character. If the content
+            is read using the <code>unparsed-text</code> function, alternative line endings
+            such as <code>CR</code> and <code>CRLF</code> will have been normalized to a single
+            newline. In other cases, this normalization can be achieved with a call on the
+            <code>fn:replace</code> function.</p>
          <p>All fields are returned as <code>xs:string</code> values.</p>
          <p>Quoted fields in the input are returned without the quotes.</p>
          <p>The first row is not treated specially.</p>
          <p>For more discussion of the returned data, see <specref ref="basic-csv-to-xdm-mapping"/>.</p>
       </fos:notes>
       <fos:examples>
-         <fos:variable name="lf" id="escaped-lf"><![CDATA[char('\n')]]></fos:variable>
-         <fos:variable name="cr" id="escaped-cr"><![CDATA[char('\r')]]></fos:variable>
-         <fos:variable name="crlf" id="escaped-crlf"><![CDATA[char('\r')||char('\n')]]></fos:variable>
          <fos:example>
             <p>Handling trivial input:</p>
             <fos:test>
@@ -23683,7 +23667,7 @@ return ($result => $display(),
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays($crlf)</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(char('\n'))</eg></fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
@@ -23695,59 +23679,42 @@ return ($result => $display(),
                <fos:result>[" "]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(` {$crlf}`, map{'trim-whitespace':true()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, map{'trim-whitespace':true()})</eg></fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(` {$crlf}`, map{'trim-whitespace':false()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, map{'trim-whitespace':false()})</eg></fos:expression>
                <fos:result>[" "]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(`{$crlf} `, map{'trim-whitespace':true()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map{'trim-whitespace':true()})</eg></fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(`{$crlf} `, map{'trim-whitespace':false()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map{'trim-whitespace':false()})</eg></fos:expression>
                <fos:result>[], [" "]</fos:result>
             </fos:test>
-            <p>Handling any of the default record separators:</p>
-            <fos:test use="escaped-crlf">
-               <fos:expression><eg>csv-to-arrays(`name,city{$crlf}`||
-              `Bob,Berlin{$crlf}`||
-              `Alice,Aachen{$crlf}`)</eg></fos:expression>
+            <p>Using the default record separators:</p>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(
+   `name,city{char('\n')}`||
+   `Bob,Berlin{char('\n')}`||
+   `Alice,Aachen{char('\n')}`)</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
    ["Alice", "Aachen"]
 )</eg></fos:result>
             </fos:test>
-            <fos:test use="escaped-cr">
-               <fos:expression><eg>csv-to-arrays(`name,city{$cr}`||
-              `Bob,Berlin{$cr}`||
-              `Alice,Aachen{$cr}`)</eg></fos:expression>
-               <fos:result><eg>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
-)</eg></fos:result>
-            </fos:test>
-            <fos:test use="escaped-lf">
-               <fos:expression><eg>csv-to-arrays(`name,city{$lf}`||
-              `Bob,Berlin{$lf}`||
-              `Alice,Aachen{$lf}`)</eg></fos:expression>
-               <fos:result><eg>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
-)</eg></fos:result>
-            </fos:test>
+
          </fos:example>
          <fos:example>
             <p>Quote handling:</p>
-            <fos:test use="escaped-crlf">
-               <fos:expression><eg>csv-to-arrays(`"name","city"{$crlf}`||
-              `"Bob","Berlin"{$crlf}`||
-              `"Alice","Aachen"{$crlf}`)</eg></fos:expression>
+            <fos:test>
+               <fos:expression><eg>csv-to-arrays(string-join(
+   `"name","city"`,
+   `"Bob","Berlin"`,
+   `"Alice","Aachen"`), char('\n\))</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ["Bob", "Berlin"],
@@ -23755,8 +23722,8 @@ return ($result => $display(),
 )</eg></fos:result>
             </fos:test>
             <fos:test use="escaped-crlf">
-               <fos:expression><eg>csv-to-arrays(`"name","city"{$crlf}`||
-              `"Bob ""The Exemplar"" Mustermann","Berlin"{$crlf}`)</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`"name","city"{char('\n')}`||
+             `"Bob ""The Exemplar"" Mustermann","Berlin"{char('\n')}`)</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
    ['Bob "The Exemplar" Mustermann', "Berlin"]
@@ -23766,9 +23733,7 @@ return ($result => $display(),
          <fos:example>
             <p>Non-default record- and field-delimiters:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays("name;city§"||
-              "Bob;Berlin§"||
-              "Alice;Aachen", 
+               <fos:expression><eg>csv-to-arrays("name;city§Bob;Berlin§Alice;Aachen", 
               map{"row-delimiter": "§", "field-delimiter": ";"})</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
@@ -23780,8 +23745,9 @@ return ($result => $display(),
          <fos:example>
             <p>Non-default quote character:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression><eg>csv-to-arrays(`|name|,|city|{$crlf}`||
-              `|Bob|,|Berlin|{$crlf}`, 
+               <fos:expression><eg>csv-to-arrays(string-join(
+   "|name|,|city|",
+   "|Bob|,|Berlin|"), char('\n')), 
               map{"quote-character": "|"})</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
@@ -23792,9 +23758,10 @@ return ($result => $display(),
          <fos:example>
             <p>Trimming whitespace in fields:</p>
             <fos:test use="escaped-crlf">
-               <fos:expression xml:space="preserve"><eg>csv-to-arrays(`name  ,city  {$crlf}`||
-              `Bob   ,Berlin{$crlf}`||
-              `Alice ,Aachen{$crlf}`, 
+               <fos:expression><eg>csv-to-arrays(string-join(
+    "name  ,city    ",
+    "Bob   ,Berlin  ",
+    "Alice ,Aachen  "), char('\n')), 
               map{"trim-whitespace": true()})</eg></fos:expression>
                <fos:result><eg>(
    ["name", "city"],
@@ -23912,7 +23879,7 @@ return
          <fos:example>
             <p>An empty CSV with column extraction:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-xml("", map { "column-names": true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml("", map { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns/>
@@ -23924,7 +23891,7 @@ return
          <fos:example>
             <p>An empty CSV with explicit column names:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-xml("", map { "column-names": map { "name": 1, "city": 3 } })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml("", map { "header": map { "name": 1, "city": 3 } })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23940,7 +23907,7 @@ return
          <fos:example>
             <p>With defaults for delimiters and quotes, and column extraction:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression><eg>csv-to-xml($csv-string, map { "column-names": true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml($csv-string, map { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23964,7 +23931,7 @@ return
          <fos:example>
             <p>With defaults for delimiters and quotes, and column extraction:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression><eg>csv-to-xml($csv-string, map { "column-names": true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml($csv-string, map { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23994,7 +23961,7 @@ return
             <p>Filtering columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "column-names": true(), 
+           map { "header": true(), 
                  "filter-columns": (2,1,4) })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -24028,7 +23995,7 @@ return
             <p>Specifying the number of columns, using "all" (the default)</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "column-names": true(), 
+           map { "header": true(), 
                  "number-of-columns": "all" })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -24075,7 +24042,7 @@ return
             <p>Specifying the number of columns using <code>"first-row"</code></p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "column-names": true(), 
+           map { "header": true(), 
                  "number-of-columns": "first-row" })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -24125,7 +24092,7 @@ return
             <p>Specifying the number of columns with a number</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "column-names": true(), 
+           map { "header": true(), 
                  "number-of-columns": 6 })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23566,7 +23566,7 @@ return ($result => $display(),
       <fos:signatures>
          <fos:proto name="csv-to-arrays" return-type="array(xs:string)*">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23856,18 +23856,18 @@ return csv-to-arrays(
             (where <code>$options</code> is an empty map if the argument is not supplied):</p>
          
          <eg><![CDATA[let $parsedCSV := parse-csv($value, $options)
-let $colNames := $parsedCSV?columns?fields
+let $colNames := $parsedCSV?columns
 return
    <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
        if (exists($colNames)) {
          <columns> {$colNames ! <column>{.}</column>} </columns>
        },
        <rows> {
-         for $row in $parsedCSV?rows?row return
+         for $row in $parsedCSV?rows return
          <row> {
            for member $field at $col in $row return
            <field> {
-             if (exists($colnames[$col])) {
+             if ($colnames[$col]) {
                attribute column {$colnames[$col]}
              },
              $field

--- a/specifications/xpath-functions-40/src/schema-for-csv.xsd
+++ b/specifications/xpath-functions-40/src/schema-for-csv.xsd
@@ -45,7 +45,7 @@
 
     <xs:complexType name="rowType">
         <xs:sequence>
-            <xs:element ref="csv:field"/>
+            <xs:element ref="csv:field" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7158,13 +7158,30 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                   data supplied by the caller in the <code>options</code> parameter.</p>
                   
                   <p>The function returns a
-                  <code>parsed-csv-structure-record</code>. This has two parts:
-                  <code>columns</code> contains information about the column names, while
-                  <code>rows</code> contains the data in the non-header rows:</p>
+                  <code>parsed-csv-structure-record</code>:</p>
 
                <?type parsed-csv-structure-record ?>
+               
+               <p>The record has four parts, which are always present (though potentially empty):</p>
+                  
+               <ulist>
+                  <item><p><code>column-names</code> gives the list of column names, in order.</p></item>
+                  <item><p><code>column-numbers</code> is a map from column names to the 1-based integer
+                     position of the column.</p></item>
+                  <item><p><code>rows</code> gives the contents of the non-header rows 
+                     in the CSV data, as a sequence
+                     of arrays of <code>xs:string</code> values; each array represents one
+                     row of the CSV data. </p></item>
+                  <item><p><code>field</code> is a function providing ready access to a given
+                  field in a given row. The function has signature:</p>
+                     <eg>function($row as xs:integer, $column as union(xs:string, xs:integer)) as xs:string?</eg>
+                     <p>The function takes two arguments: the first is an integer giving the
+                        row number (1-based), the second identifies a column either by its name
+                        or by its 1-based position.</p></item>
+               </ulist>
+                  
 
-               <div4 id="csv-xdm-header">
+               <!--<div4 id="csv-xdm-header">
                   <head>The <code>columns</code> entry</head>
 
                   <p>The <code>columns</code> entry describes how the names of columns map to their
@@ -7178,18 +7195,18 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                      returns a <code>csv-columns-record</code> whose
                      <code>names</code> entry is an empty map, and whose <code>fields</code>
                      entry is the empty sequence.</p>
-               </div4>
+               </div4>-->
 
-               <div4 id="csv-xdm-rows">
+               <!--<div4 id="csv-xdm-rows">
                   <head>The <code>rows</code> entry</head>
 
                   <p>The <code>rows</code> entry returns the rows themselves. It is a sequence of
                      <code>csv-row</code> records. If the input CSV contains no rows, the function
                      returns a <code>rows</code> entry whose value is the
                      empty sequence.</p>
-               </div4>
+               </div4>-->
 
-               <div4 id="csv-xdm-row">
+               <!--<div4 id="csv-xdm-row">
                   <head>The <code>csv-row-record</code></head>
 
                   <?type csv-row-record ?>
@@ -7200,17 +7217,12 @@ Field 2A,Field 2B,Field 2C,Field 2D'
 
                   <p>The <code>field</code> entry contains a function, as described below:</p>
                </div4>
-
-               <div4 id="csv-xdm-field-function">
+-->
+               <!--<div4 id="csv-xdm-field-function">
                   <head>The <code>field</code> function</head>
 
-                  <p>The function returned in the <code>field</code> entry is an arity 1 (one)
-                     function which takes either a string or an integer as its argument
-                     <code>$key</code>, and returns a field from the <code>csv-row-record</code>’s
-                     <code>fields</code> sequence by either its 1-based column position (when passed an
-                     <code>xs:integer</code>) or column name (when passed an
-                     <code>xs:string</code>).</p>
-               </div4>
+                  
+               </div4>-->
             </div3>
             <div3 id="func-parse-csv">
                <head><?function fn:parse-csv?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6978,7 +6978,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
 
 
-            <div3 id="common-parsing-options">
+            <!--<div3 id="common-parsing-options">
                <head>Common parsing options</head>
 
                <p>All three functions: <code>fn:csv-to-arrays</code>, <code>fn:csv-to-xml</code>, and
@@ -6993,7 +6993,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
 
                <?type csv-parsing-options ?>
             </div3>
-
+-->
             <div3 id="csv-delimiters">
                <head>CSV delimiters</head>
                
@@ -7001,30 +7001,21 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   is raised if the same delimiter string is used in multiple roles 
                   <errorref class="CV" code="0003"/>.</p>
 
-
-               <div4 id="row-delimiters">
-                  <head>Row delimiters</head>
-
-                  <p>Rows in CSV are typically delimited with CRLF (<code>U+000D, U+000A</code>), 
-                     LF (<code>U+000A</code>), or CR (<code>U+000D</code>) line endings, although
-                     field quoting means that there is not always a one-to-one mapping between lines in a file
-                     and rows/records in the parsed CSV.</p>
-
-                  <p>The default row delimiter allows any of CRLF,
-                     LF, or CR. Valid values for the row
-                     delimiter are a single Unicode character, or one of CRLF, LF, or CR. An error
-                     is raised if the
-                     <code>row-delimiter</code> option is set to a multi-character string other
-                     than CRLF (<code>U+000D, U+000A</code>)  <errorref class="CV" code="0002"/>.</p>
-                  
+                  <p>Rows in CSV files are typically delimited with CRLF (<code>U+000D, U+000A</code>), 
+                     LF (<code>U+000A</code>), or CR (<code>U+000D</code>) line endings, 
+                     although RFC 4180 specifies CRLF. By contrast, the <code>fn:unparsed-text</code>
+                     function normalizes these line endings to LF (<code>U+000A</code>).
+                     The CSV parsing functions therefore use LF by default.</p>
+               
+                  <p>Note that row delimiters can appear within quoted fields; if line endings
+                     are normalized prior to parsing, this will affect line endings within
+                     quoted fields as well as those used as row separators. It is not possible
+                     to specify a multi-character row delimiter such as CRLF.</p>
+               
                   <p>The last row in the file may or may not be followed by a row delimiter.</p>
-              </div4>
-
-               <div4 id="column-delimiters">
-                  <head>Column/Field delimiters</head>
 
                   <p>Fields in CSV are frequently delimited with a comma. Other field
-                     delimiters are useful for
+                     delimiters are useful, for
                      example when numeric data uses comma as a decimal separator. The
                      chosen field delimiter is then often a semicolon (<code>U+003B</code>)
                      or tab (<code>U+0009</code>).</p>
@@ -7033,7 +7024,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      The value may be
                      any single Unicode character. An error is raised if the 
                      <code>column-delimiter</code> option is set to a multi-character string.</p>
-               </div4>
             </div3>
 
             <div3 id="csv-field-quoting">
@@ -7064,8 +7054,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>The quote character defaults to the Unicode quotation mark
                   <code>"</code> (<code>U+0022</code>).</p>
 
-               <div4 id="csv-field-quoting-column-delimiters">
-                  <head>Field quoting and column delimiters</head>
 
                   <p>No space is allowed between the column delimiter and a quote. An error is raised
                      <errorref class="CV" code="0001"/> if
@@ -7076,7 +7064,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
 
                   <eg>'"Field 1", "Field 2", "Field 3"'</eg>
 
-               </div4>
             </div3>
 
             <div3 id="basic-csv-to-xdm-mapping">
@@ -7165,14 +7152,14 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                <p>The record has four parts, which are always present (though potentially empty):</p>
                   
                <ulist>
-                  <item><p><code>column-names</code> gives the list of column names, in order.</p></item>
-                  <item><p><code>column-numbers</code> is a map from column names to the 1-based integer
+                  <item><p><code>columns</code> gives the list of column names, in order.</p></item>
+                  <item><p><code>column-index</code> is a map from column names to the 1-based integer
                      position of the column.</p></item>
                   <item><p><code>rows</code> gives the contents of the non-header rows 
                      in the CSV data, as a sequence
                      of arrays of <code>xs:string</code> values; each array represents one
                      row of the CSV data. </p></item>
-                  <item><p><code>field</code> is a function providing ready access to a given
+                  <item><p><code>get</code> is a function providing ready access to a given
                   field in a given row. The function has signature:</p>
                      <eg>function($row as xs:integer, $column as union(xs:string, xs:integer)) as xs:string?</eg>
                      <p>The function takes two arguments: the first is an integer giving the
@@ -7181,48 +7168,6 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                </ulist>
                   
 
-               <!--<div4 id="csv-xdm-header">
-                  <head>The <code>columns</code> entry</head>
-
-                  <p>The <code>columns</code> entry describes how the names of columns map to their
-                     integer positions. as well as
-                     providing the contents of the header row that was used to generate the column
-                     names.</p>
-
-                  <?type csv-columns-record ?>
-
-                  <p>If column names were not extracted, then the function
-                     returns a <code>csv-columns-record</code> whose
-                     <code>names</code> entry is an empty map, and whose <code>fields</code>
-                     entry is the empty sequence.</p>
-               </div4>-->
-
-               <!--<div4 id="csv-xdm-rows">
-                  <head>The <code>rows</code> entry</head>
-
-                  <p>The <code>rows</code> entry returns the rows themselves. It is a sequence of
-                     <code>csv-row</code> records. If the input CSV contains no rows, the function
-                     returns a <code>rows</code> entry whose value is the
-                     empty sequence.</p>
-               </div4>-->
-
-               <!--<div4 id="csv-xdm-row">
-                  <head>The <code>csv-row-record</code></head>
-
-                  <?type csv-row-record ?>
-
-                  <p>Each <code>csv-row-record</code> represents a single row. The
-                     <code>fields</code> entry is a sequence containing the fields as
-                     <code>xs:string</code> values.</p>
-
-                  <p>The <code>field</code> entry contains a function, as described below:</p>
-               </div4>
--->
-               <!--<div4 id="csv-xdm-field-function">
-                  <head>The <code>field</code> function</head>
-
-                  
-               </div4>-->
             </div3>
             <div3 id="func-parse-csv">
                <head><?function fn:parse-csv?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7005,12 +7005,14 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      LF (<code>U+000A</code>), or CR (<code>U+000D</code>) line endings, 
                      although RFC 4180 specifies CRLF. By contrast, the <code>fn:unparsed-text</code>
                      function normalizes these line endings to LF (<code>U+000A</code>).
-                     The CSV parsing functions therefore use LF by default.</p>
+                     The CSV parsing functions therefore use LF by default. An option is available
+                     to normalize line endings so that CR and CRLF are converted to NL (except
+                     when they appear in quote fields). This option is off by default, because
+                     line ending normalization will usually have been carried out earlier: for 
+                     example, the <code>fn:unparsed-text</code> function does it automatically.
+                  </p>
                
-                  <p>Note that row delimiters can appear within quoted fields; if line endings
-                     are normalized prior to parsing, this will affect line endings within
-                     quoted fields as well as those used as row separators. It is not possible
-                     to specify a multi-character row delimiter such as CRLF.</p>
+                 
                
                   <p>The last row in the file may or may not be followed by a row delimiter.</p>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11610,7 +11610,7 @@ ISBN 0 521 77752 6.</bibl>
          <div2 id="schema-for-csv">
             <head>Schema for the result of <code>fn:csv-to-xml</code></head>
             <p>This schema describes the output of the function <code>fn:csv-to-xml</code>.</p>
-            <p>The schema is reproduced below, and can also be found in <loc href="schema-for-json.xsd">schema-for-json.xsd</loc>:</p>
+            <p>The schema is reproduced below, and can also be found in <loc href="schema-for-csv.xsd">schema-for-csv.xsd</loc>:</p>
             <?doc schema-for-csv.xsd?>
          </div2>
       </div1>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11225,11 +11225,11 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="CV" code="0004" label="Argument supplied is not a known column name."
                type="dynamic">
-               <p>Raised by the function from the <code>field</code> entry of
+               <p>Raised by the function from the <code>get</code> entry of
                   <code>csv-columns-record</code>, if its <code>$key</code> argument is an
                   <code>xs:string</code> and is not one of the known column names.</p>
             </error>
-            <error class="CV" code="0005" label="Non-positive integer provided as column index."
+            <!--<error class="CV" code="0005" label="Non-positive integer provided as column index."
                type="dynamic">
                <p>Raised by <code>fn:parse-csv</code>, <code>fn:csv-to-xml</code>, and the function
                   from the <code>field</code> entry of <code>csv-columns-record</code>, if an
@@ -11243,7 +11243,7 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <code>fn:parse-csv</code> and <code>fn:csv-to-xml</code>, if both the
                   <code>number-of-columns</code> and <code>filter-columns</code> options are set:
                   they are mutually exclusive.</p>
-            </error>
+            </error>-->
             <error class="DC" code="0001" label="No context document." type="dynamic">
                <p>Raised by <code>fn:id</code>, <code>fn:idref</code>, and <code>fn:element-with-id</code>
                   if the node that identifies the tree to be searched is a node in a tree whose root is not

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -585,8 +585,11 @@
 	<xsl:template match="fos:history | fos:version"/>
 
 	<xsl:template match="processing-instruction('type')" expand-text="yes">
-		<xsl:variable name="target" select="$fosdoc//fos:type[@id = normalize-space(current())]"
-			as="element(fos:type)"/>
+		<xsl:variable name="target" select="$fosdoc//fos:type[@id = normalize-space(current())]"/>
+		<xsl:if test="count($target) ne 1">
+			<xsl:message expand-text="yes">Failed to locate record type {.}</xsl:message>
+		</xsl:if>
+		<xsl:variable name="verified-target" select="$target" as="element(fos:type)"/>
 		<xsl:variable name="record" select="$target/fos:record" as="element(fos:record)"/>
 		<xsl:apply-templates select="$record"/>
 	</xsl:template>


### PR DESCRIPTION
Changes parse-csv to deliver the results in a simpler format:

(a) the result structure is less deeply nested: one record with four entries
(b) the actual data is delivered as a sequence of arrays of strings, closely aligned with the result of `csv-to-arrays`

The rules in the spec have also been rearranged to reflect this, so the rules are now organised according to the values delivered for each of these four fields.

The examples in the spec are changed to reflect the new output format; in addition they have been editorially reorganized so each example is more self-contained, avoiding the need for extensive scrolling to find the values of variables referenced in each example.

Fix issue #1052