### PR TITLE
1070 Bare Brace map constructor syntax

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2542,7 +2542,9 @@ ErrorVal ::= "$" VarName
   <!-- ] end Function Items -->
 
   <g:production name="MapConstructor" if="xpath40 xquery40">
-    <g:string>map</g:string>
+    <g:optional>
+      <g:string>map</g:string>
+    </g:optional>
     <g:ref name="Lbrace"/>
     <g:optional>
       <g:ref name="MapConstructorEntry"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -2343,7 +2343,7 @@
             </fos:test>
             <fos:test>
                <fos:expression><eg>
-format-number(1234567.8, '0.000,0', format := map {
+format-number(1234567.8, '0.000,0', format := {
    'grouping-separator': '.',
    'decimal-separator': ','
  })</eg></fos:expression>
@@ -2358,7 +2358,7 @@ format-number(1234567.8, '0.000,0', format := map {
             </fos:test>
             <fos:test>
                <fos:expression><eg>
-format-number(12345, '0,###^0', 'de', map {
+format-number(12345, '0,###^0', 'de', {
   'exponent-separator': '^'
 })</eg></fos:expression>
                <fos:result>"1,234^4"</fos:result>
@@ -4836,7 +4836,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:signatures>
          <fos:proto name="hash" return-type="xs:hexBinary?">
             <fos:arg name="value" type="union(xs:string, xs:hexBinary, xs:base64Binary)?"/>
-            <fos:arg name="options" type="map(*)?" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" default="{ }"/>
             <!--<fos:arg name="algorithm" type="xs:string?" default="'MD5'"/>-->
          </fos:proto>
       </fos:signatures>
@@ -4940,14 +4940,14 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hash("ABC", map { "algorithm": "SHA-1" }) 
+               <fos:expression>hash("ABC", { "algorithm": "SHA-1" }) 
 => string()</fos:expression>
                <fos:result>"3C01BDBB26F358BAB27F267924AA2C9A03FCFDB8"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hash("ABC", map { "algorithm": "sha-256" })
+               <fos:expression>hash("ABC", { "algorithm": "sha-256" })
 => string()</fos:expression>
                <fos:result>"B5D4045C3F466FA91FE2CC6ABE79232A1A57CDF104F7A26E716E0A1E2789DF78"</fos:result>
             </fos:test>
@@ -4961,7 +4961,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test use="v-hash-doc">
-               <fos:expression>hash(serialize($doc), map { "algorithm": "sha-1" }) 
+               <fos:expression>hash(serialize($doc), { "algorithm": "sha-1" }) 
 => xs:base64Binary()                  
 => string()</fos:expression>
                <fos:result>"8PzN28NtxQv5RlxQ5/w6DcnrpEU="</fos:result>
@@ -4969,7 +4969,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test use="v-hash-salt">
-               <fos:expression>hash("password123" || $salt, map { "algorithm": "SHA-256" }) 
+               <fos:expression>hash("password123" || $salt, { "algorithm": "SHA-256" }) 
 => string()</fos:expression>
                <fos:result>"9C9B913EB1B6254F4737CE947EFD16F16E916F9D6EE5C1102A2002E48D4C88BD"</fos:result>
             </fos:test>
@@ -6182,7 +6182,7 @@ Tak, tak, tak! - da kommen sie.
                <fos:expression><eg>replace(
   "LHR to LAX",
   "[A-Z]{3}",
-  action := map { 'LAX': 'Los Angeles', 'LHR': 'London' }
+  action := { 'LAX': 'Los Angeles', 'LHR': 'London' }
 )</eg></fos:expression>
                <fos:result>"London to Los Angeles"</fos:result>
             </fos:test>
@@ -11299,7 +11299,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test use="v-in-scope-namespaces-e" spec="XQuery">
                <fos:expression>in-scope-namespaces($e)</fos:expression>
-               <fos:result>map { "": "http://example.org/one", "z": "http://example.org/two",
+               <fos:result>{ "": "http://example.org/one", "z": "http://example.org/two",
                   "xml": "http://www.w3.org/XML/1998/namespace" }</fos:result>
             </fos:test>
          </fos:example>
@@ -12518,7 +12518,7 @@ let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>empty(map { })</fos:expression>
+               <fos:expression>empty({ })</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -12577,7 +12577,7 @@ return empty($break)
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>exists(map { })</fos:expression>
+               <fos:expression>exists({ })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -14356,7 +14356,7 @@ return contains-subsequence(
             <fos:arg name="input1" type="item()*" usage="absorption"/>
             <fos:arg name="input2" type="item()*" usage="absorption"/>
             <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
-            <fos:arg name="options" type="map(*)?" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -15007,8 +15007,8 @@ declare function equal-strings(
          <fos:example>
             <fos:test>
                <fos:expression><eg>deep-equal(
-  map { 1: 'a', 2: 'b' },
-  map { 2: 'b', 1: 'a' }
+  { 1: 'a', 2: 'b' },
+  { 2: 'b', 1: 'a' }
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -15018,7 +15018,7 @@ declare function equal-strings(
                <fos:expression><eg>deep-equal(
   (1, 2, 3, 4),
   (1, 4, 3, 2),
-  options := map { 'ordered': false() }
+  options := { 'ordered': false() }
 )</eg></fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
@@ -15028,7 +15028,7 @@ declare function equal-strings(
                <fos:expression><eg>deep-equal(
   (1, 1, 2, 3),
   (1, 2, 3, 3),
-  options := map { 'ordered': false() }
+  options := { 'ordered': false() }
 )</eg></fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
@@ -15048,7 +15048,7 @@ declare function equal-strings(
                <fos:expression><eg><![CDATA[deep-equal(
   parse-xml("<a xmlns='AA'/>"),
   parse-xml("<p:a xmlns:p='AA'/>"),
-  options := map { 'namespace-prefixes': true() }
+  options := { 'namespace-prefixes': true() }
 )]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>False because the namespace prefixes differ</fos:postamble>
@@ -15059,7 +15059,7 @@ declare function equal-strings(
                <fos:expression><eg><![CDATA[deep-equal(
   parse-xml("<a xmlns='AA'/>"),
   parse-xml("<p:a xmlns:p='AA'/>"),
-  options := map { 'in-scope-namespaces': true() }
+  options := { 'in-scope-namespaces': true() }
 )]]></eg></fos:expression>
                <fos:result>false()</fos:result>
                <fos:postamble>False because the in-scope namespace bindings differ</fos:postamble>
@@ -15080,7 +15080,7 @@ declare function equal-strings(
                <fos:expression><eg><![CDATA[deep-equal(
   parse-xml("<a><b/><c/></a>"),
   parse-xml("<a><c/><b/></a>"),
-  options := map { 'unordered-elements': xs:QName('a') }
+  options := { 'unordered-elements': xs:QName('a') }
 )]]></eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The <code>unordered-elements</code> option means that the ordering of the children
@@ -15103,7 +15103,7 @@ declare function equal-strings(
                <fos:expression><eg><![CDATA[deep-equal(
   parse-xml("<para style='bold'><span>x</span></para>"),
   parse-xml("<para style=' bold'> <span>x</span></para>"),
-  options := map { 'whitespace': 'normalize' }
+  options := { 'whitespace': 'normalize' }
 )]]></eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The <code>whitespace</code> option causes both the leading space
@@ -17100,7 +17100,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                using the expression <code>fn:exists($N intersect $S)</code> may be expensive; there
                may then be performance benefits in creating a map:</p>
             <p>
-               <code>let $SMap := map:merge($S ! map { fn:generate-id(.) : . })</code>
+               <code>let $SMap := map:merge($S ! { fn:generate-id(.) : . })</code>
             </p>
             <p>and then testing for membership of the node-set using:</p>
             <p>
@@ -17342,7 +17342,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="serialize" return-type="xs:string">
             <fos:arg name="input" type="item()*" usage="absorption"/>
-            <fos:arg name="options" type="item()?" usage="absorption" default="()" example="map { }"/>
+            <fos:arg name="options" type="item()?" usage="absorption" default="()" example="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17691,7 +17691,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   </td>
                   <td>See Note 3</td>
                   <td>
-                     <code>map { }</code>
+                     <code>{ }</code>
                   </td>
                </tr>
                <tr>
@@ -17810,20 +17810,20 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </fos:example>
          <fos:example>
             <p>The following call would also produce the output shown (though the second argument could equally well be supplied
-               as an empty map (<code>map { }</code>), since both parameters are given their default values):</p>
+               as an empty map (<code>{}</code>), since both parameters are given their default values):</p>
          </fos:example>
          <fos:example>
             <fos:test use="v-serialize-data" spec="XQuery">
                <fos:expression><eg><![CDATA[serialize(
   $data,
-  map { "method": "xml", "omit-xml-declaration": true() }
+  { "method": "xml", "omit-xml-declaration": true() }
 )]]></eg></fos:expression>
                <fos:result><![CDATA['<a b="3"/>']]></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>The expression <code>fn:serialize(map { "a": "AB", "b": "BC" }, map { "method": "adaptive" })</code> returns <code>"map{"a":"AB","b":"BC"}"</code></p>
-            <p>The expression <code>fn:serialize(array { "a", 3, attribute test { "true" } }, map { "method": "adaptive" })</code> returns <code>"["a",3,test="true"]"</code></p>
+            <p>The expression <code>fn:serialize({ "a": "AB", "b": "BC" }, { "method": "adaptive" })</code> returns <code>"map{"a":"AB","b":"BC"}"</code></p>
+            <p>The expression <code>fn:serialize(array { "a", 3, attribute test { "true" } }, { "method": "adaptive" })</code> returns <code>"["a",3,test="true"]"</code></p>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -17832,7 +17832,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <fos:proto name="parse-html" return-type="document-node(element(*:html))?">
             <fos:arg name="html" type="union(xs:string, xs:hexBinary, xs:base64Binary)?"/>
             <fos:arg name="options" type-ref="parse-html-options"
-                     default="map {
+                     default="{
                                  &quot;method&quot;: &quot;html&quot;,
                                  &quot;html-version&quot;: &quot;5&quot;
                               }"/>
@@ -18523,7 +18523,7 @@ return function-arity($initial)</eg></fos:expression>
                <fos:expression><eg>
 declare %private function local:inc($c) { $c + 1 };
 function-annotations(local:inc#1)</eg></fos:expression>
-               <fos:result>map { Q{http://www.w3.org/2012/xquery}private: () }</fos:result>
+               <fos:result>{ Q{http://www.w3.org/2012/xquery}private: () }</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -18539,7 +18539,7 @@ return map:keys($ann) || ': ' || string-join(map:values($ann), ', ')
          <fos:example>
             <fos:test>
                <fos:expression>function-annotations(true#0)</fos:expression>
-               <fos:result>map { }</fos:result>
+               <fos:result>{}</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -18825,10 +18825,10 @@ declare function fold-left(
             <fos:test>
                <fos:expression><eg>fold-left(
   1 to 5,
-  map { },
+  {},
   function($map, $n) { map:put($map, $n, $n * 2) }
 )</eg></fos:expression>
-               <fos:result>map { 1: 2, 2: 4, 3: 6, 4: 8, 5: 10 }</fos:result>
+               <fos:result>{ 1: 2, 2: 4, 3: 6, 4: 8, 5: 10 }</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -20528,7 +20528,7 @@ declare function transitive-closure (
       <fos:signatures>
          <fos:proto name="merge" return-type="map(*)">
             <fos:arg name="maps" type="map(*)*" usage="inspection"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -20708,7 +20708,7 @@ declare function transitive-closure (
 
          <eg><![CDATA[
 let $FOJS0003 := QName("http://www.w3.org/2005/xqt-errors", "FOJS0003")
-let $duplicates-handler := map {
+let $duplicates-handler := {
   "use-first": function($a, $b) { $a },
   "use-last":  function($a, $b) { $b },
   "combine":   function($a, $b) { $a, $b },
@@ -20722,7 +20722,7 @@ let $combine-maps := function($A as map(*), $B as map(*), $deduplicator as funct
     else map:put($z, $k, $B($k))
   })
 }
-return fold-left($MAPS, map { },
+return fold-left($MAPS, {},
   $combine-maps(?, ?, $duplicates-handler($OPTIONS?duplicates otherwise "use-first"))
 )]]></eg>
          <note>
@@ -20770,11 +20770,11 @@ return fold-left($MAPS, map { },
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-merge-week"
-            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
+            select="{&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test>
                <fos:expression>map:merge(())</fos:expression>
-               <fos:result>map { }</fos:result>
+               <fos:result>{}</fos:result>
                <fos:postamble>Returns an empty map</fos:postamble>
             </fos:test>
             <fos:test>
@@ -20782,14 +20782,14 @@ return fold-left($MAPS, map { },
   map:entry(0, "no"),
   map:entry(1, "yes")
 ))</eg></fos:expression>
-               <fos:result>map { 0: "no", 1: "yes" }</fos:result>
+               <fos:result>{ 0: "no", 1: "yes" }</fos:result>
                <fos:postamble>Returns a map with two entries</fos:postamble>
             </fos:test>
             <fos:test use="v-map-merge-week">
                <fos:expression><eg>map:merge(
-  ($week, map { 7: "Unbekannt" })
+  ($week, { 7: "Unbekannt" })
 )</eg></fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag", 6: "Samstag", 7: "Unbekannt" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the <phrase>returned map 
                   contains</phrase> all the entries from <code>$week</code>, supplemented with an additional
@@ -20797,10 +20797,10 @@ return fold-left($MAPS, map { },
             </fos:test>
             <fos:test use="v-map-merge-week">
                <fos:expression><eg>map:merge(
-  ($week, map { 6: "Sonnabend" }),
-  map { "duplicates": "use-last" }
+  ($week, { 6: "Sonnabend" }),
+  { "duplicates": "use-last" }
 )</eg></fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
                   4: "Donnerstag", 5: "Freitag", 6: "Sonnabend" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
@@ -20810,10 +20810,10 @@ return fold-left($MAPS, map { },
             </fos:test>
             <fos:test use="v-map-merge-week">
                <fos:expression><eg>map:merge(
-  ($week, map { 6: "Sonnabend" }),
-  map { "duplicates": "use-first" }
+  ($week, { 6: "Sonnabend" }),
+  { "duplicates": "use-first" }
 )</eg></fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag", 6: "Samstag" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
@@ -20823,10 +20823,10 @@ return fold-left($MAPS, map { },
             </fos:test>
             <fos:test use="v-map-merge-week">
                <fos:expression><eg>map:merge(
-  ($week, map { 6: "Sonnabend" }),
-  map { "duplicates": "combine" }
+  ($week, { 6: "Sonnabend" }),
+  { "duplicates": "combine" }
 )</eg></fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5:"Freitag", 6:("Samstag", "Sonnabend") }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
@@ -20845,7 +20845,7 @@ return fold-left($MAPS, map { },
             <fos:arg name="input" 
                      type="record(key as xs:anyAtomicType, value as item()*)*" 
                      usage="inspection"
-                     example="map { 'key':'n','value':false() }, map { 'key':'y','value':true() }"/>
+                     example="{ 'key':'n','value':false() }, { 'key':'y','value':true() }"/>
             <fos:arg name="combine" type="function(item()*, item()*) as item()*" usage="inspection" default="fn:op(',')"/>
          </fos:proto>
       </fos:signatures>
@@ -20890,16 +20890,16 @@ return fold-left($MAPS, map { },
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-of-week"
-            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
+            select="{&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test>
                <fos:expression>map:of-pairs(())</fos:expression>
-               <fos:result>map { }</fos:result>
+               <fos:result>{ }</fos:result>
                <fos:postamble>Returns an empty map</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression>map:of-pairs(map:pairs($week))</fos:expression>
-               <fos:result><eg>map { 0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 
+               <fos:result><eg>{ 0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 
       2: &quot;Dienstag&quot;, 3: &quot;Mittwoch&quot;, 
       4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 
       6: &quot;Samstag&quot; }</eg></fos:result>
@@ -20908,18 +20908,18 @@ return fold-left($MAPS, map { },
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[map:of-pairs((
-  map { "key": 0, "value": "no" },
-  map { "key": 1, "value": "yes" }
+  { "key": 0, "value": "no" },
+  { "key": 1, "value": "yes" }
 ))]]></eg></fos:expression>
-               <fos:result>map { 0:"no", 1:"yes" }</fos:result>
+               <fos:result>{ 0:"no", 1:"yes" }</fos:result>
                <fos:postamble>Returns a map with two entries</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs((
   map:pairs($week),
-  map { "key": 7, "value": "Unbekannt" }
+  { "key": 7, "value": "Unbekannt" }
 ))</eg></fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag", 6: "Samstag", 7: "Unbekannt" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map 
                   contains all the entries from <code>$week</code>, supplemented with an additional
@@ -20928,9 +20928,9 @@ return fold-left($MAPS, map { },
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs((
   map:pairs($week),
-  map { "key": 6, "value": "Sonnabend" }
+  { "key": 6, "value": "Sonnabend" }
 ))</eg></fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag", 6: ("Samstag", "Sonnabend") }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
@@ -20939,10 +20939,10 @@ return fold-left($MAPS, map { },
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs(
-  (map:pairs($week), map { "key": 6, "value": "Sonnabend" }),
+  (map:pairs($week), { "key": 6, "value": "Sonnabend" }),
   function($old, $new)  { $new }
 )</eg></fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag", 6: "Sonnabend" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
@@ -20952,10 +20952,10 @@ return fold-left($MAPS, map { },
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs(
-  (map:pairs($week), map { "key": 6, "value": "Sonnabend" }),
+  (map:pairs($week), { "key": 6, "value": "Sonnabend" }),
   function($old, $new) { `{ $old }|{ $new }` }
 )</eg></fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag", 6: "Samstag|Sonnabend" }</fos:result>
                <fos:postamble>In the result map, the value for key <code>6</code> is obtained by concatenating the values
                   from the two input maps, with a separator character.</fos:postamble>
@@ -21002,7 +21002,7 @@ map:for-each($map, fn($key, $value) { $key })
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:keys(map { 1: "yes", 2: "no" })</fos:expression>
+               <fos:expression>map:keys({ 1: "yes", 2: "no" })</fos:expression>
                <fos:result allow-permutation="true">(1, 2)</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                      >implementation-dependent</termref> order.</fos:postamble>
@@ -21049,7 +21049,7 @@ map:for-each($map, fn($key, $value) {
          <fos:example>
             <fos:test>
                <fos:expression><eg>
-let $numbers := map {
+let $numbers := {
   0: "zero",
   1: "one",
   2: "two",
@@ -21074,7 +21074,7 @@ return map:keys-where($square, fn($key, $value) { $value &gt; 5 and $value &lt; 
          <fos:example>
             <fos:test>
                <fos:expression><eg>
-let $birthdays := map {
+let $birthdays := {
   "Agnieszka": xs:date("1980-12-31"),
   "Jabulile": xs:date("2001-05-05"),
   "Joel": xs:date("1969-11-10"),
@@ -21121,7 +21121,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:values(
-  map { 1: "yes", 2: "no" }
+  { 1: "yes", 2: "no" }
 )</eg></fos:expression>
                <fos:result allow-permutation="true">("yes", "no")</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
@@ -21129,7 +21129,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:values(
-  map {
+  {
     1: ("red", "green"),
     2: ("blue", "yellow"),
     3:()
@@ -21171,15 +21171,15 @@ return map:keys-where($birthdays, fn($name, $date) {
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
          <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:for-each($map, fn($k, $v) { map { $k: $v } })</eg>
+         <eg>map:for-each($map, fn($k, $v) { { $k: $v } })</eg>
       </fos:rules>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:entries(
-  map { 1: "yes", 2: "no" }
+  { 1: "yes", 2: "no" }
 )</eg></fos:expression>
-               <fos:result allow-permutation="true">(map { 1: "yes" }, map { 2: "no" })</fos:result>
+               <fos:result allow-permutation="true">({ 1: "yes" }, { 2: "no" })</fos:result>
                <fos:postamble>The result sequence is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
@@ -21217,15 +21217,15 @@ return map:keys-where($birthdays, fn($name, $date) {
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
          <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:for-each($map, fn($k, $v) { map { "key": $k, "value": $v } })</eg>
+         <eg>map:for-each($map, fn($k, $v) { { "key": $k, "value": $v } })</eg>
       </fos:rules>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:pairs(
-  map { 1: "yes", 2: "no" }
+  { 1: "yes", 2: "no" }
 )</eg></fos:expression>
-               <fos:result allow-permutation="true">(map { "key": 1, "value": "yes" }, map { "key": 2, "value": "no" })</fos:result>
+               <fos:result allow-permutation="true">({ "key": 1, "value": "yes" }, { "key": 2, "value": "no" })</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
@@ -21256,7 +21256,7 @@ return map:keys-where($birthdays, fn($name, $date) {
 
       <fos:examples>
          <fos:variable name="week" id="v-map-contains-week"
-            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
+            select="{&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test use="v-map-contains-week">
                <fos:expression>map:contains($week, 2)</fos:expression>
@@ -21267,15 +21267,15 @@ return map:keys-where($birthdays, fn($name, $date) {
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:contains(map { }, "xyz")</fos:expression>
+               <fos:expression>map:contains({ }, "xyz")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:contains(map { "xyz": 23 }, "xyz")</fos:expression>
+               <fos:expression>map:contains({ "xyz": 23 }, "xyz")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:contains(map { "abc": 23, "xyz": () }, "xyz")</fos:expression>
+               <fos:expression>map:contains({ "abc": 23, "xyz": () }, "xyz")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -21303,11 +21303,11 @@ return map:keys-where($birthdays, fn($name, $date) {
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:empty(map { })</fos:expression>
+               <fos:expression>map:empty({ })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:empty(map { 1: () })</fos:expression>
+               <fos:expression>map:empty({ 1: () })</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -21359,7 +21359,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             key was found.</p></item>
             <item><p>It might raise a dynamic error, by means of a call on <code>fn:error</code>.</p></item>
             <item><p>It might compute a result algorithmically. For example, if the map holds a table of
-            abbreviations, such as <code>map { 'CA': 'Canada', 'UK': 'United Kingdom', 'US': 'United States' }</code>,
+            abbreviations, such as <code>{ 'CA': 'Canada', 'UK': 'United Kingdom', 'US': 'United States' }</code>,
             then specifying <code>fallback := fn:identity#1</code> has the effect that the key value is returned
             unchanged if it is not found in the map.</p></item>
          </ulist>
@@ -21375,7 +21375,7 @@ return map:keys-where($birthdays, fn($name, $date) {
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-get-week"
-            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
+            select="{&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test use="v-map-get-week">
                <fos:expression>map:get($week, 4)</fos:expression>
@@ -21394,7 +21394,7 @@ return map:keys-where($birthdays, fn($name, $date) {
                   present and the associated value is an empty sequence.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>map { 1: "single", 2: "double", 3: "triple" }
+               <fos:expression><eg>{ 1: "single", 2: "double", 3: "triple" }
 => map:get(10, function { . || "-fold" })</eg></fos:expression>
                <fos:result>"10-fold"</fos:result>
                <fos:postamble>The map holds special cases; the fallback function handles other cases.</fos:postamble>
@@ -21469,7 +21469,7 @@ return map:keys-where($birthdays, fn($name, $date) {
       </fos:notes>
       <fos:examples>
          <fos:variable name="responses" id="v-map-find-responses"
-            select="[ map { 0: 'no', 1: 'yes' }, map { 0: 'non', 1: 'oui' }, &#xa;                  map { 0: 'nein', 1: ('ja', 'doch') } ]"/>
+            select="[ { 0: 'no', 1: 'yes' }, { 0: 'non', 1: 'oui' }, &#xa;                  { 0: 'nein', 1: ('ja', 'doch') } ]"/>
          <fos:example>
             <fos:test use="v-map-find-responses">
                <fos:expression>map:find($responses, 0)</fos:expression>
@@ -21486,11 +21486,11 @@ return map:keys-where($birthdays, fn($name, $date) {
 
          </fos:example>
          <fos:variable name="inventory" id="v-map-find-inventory"
-            select='map { "name": "car", "id": "QZ123", &#xa;      "parts": [ map { "name": "engine", "id": "YW678", "parts": [] } ] }'/>
+            select='{ "name": "car", "id": "QZ123", &#xa;      "parts": [ { "name": "engine", "id": "YW678", "parts": [] } ] }'/>
          <fos:example>
             <fos:test use="v-map-find-inventory">
                <fos:expression>map:find($inventory, "parts")</fos:expression>
-               <fos:result>[ [ map { "name": "engine", "id": "YW678", "parts": [] } ], [] ] </fos:result>
+               <fos:result>[ [ { "name": "engine", "id": "YW678", "parts": [] } ], [] ] </fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -21554,16 +21554,16 @@ return map:keys-where($birthdays, fn($name, $date) {
 
       <fos:examples>
          <fos:variable name="week" id="v-map-put-week"
-            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
+            select="{&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test use="v-map-put-week">
                <fos:expression>map:put($week, 6, "Sonnabend")</fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag", 6: "Sonnabend" }</fos:result>
             </fos:test>
             <fos:test use="v-map-put-week">
                <fos:expression>map:put($week, -1, "Unbekannt")</fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag", 6: "Samstag", -1: "Unbekannt" }</fos:result>
             </fos:test>
          </fos:example>
@@ -21598,7 +21598,7 @@ return map:keys-where($birthdays, fn($name, $date) {
       </fos:rules>
       <fos:notes>
          <p>The function call <code>map:entry(K, V)</code> produces the same result as the
-         expression <code>map { K : V }</code>.</p>
+         expression <code>{ K : V }</code>.</p>
          <p>The function <code>map:entry</code> is intended primarily for use in conjunction with
             the function <code>map:merge</code>. For example, a map containing seven entries may be
             constructed like this:</p>
@@ -21622,7 +21622,7 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
          <fos:example>
             <fos:test>
                <fos:expression>map:entry("M", "Monday")</fos:expression>
-               <fos:result>map { "M": "Monday" }</fos:result>
+               <fos:result>{ "M": "Monday" }</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -21652,7 +21652,7 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
       </fos:rules>
       <fos:notes>
          <p>The function call <code>map:pair(K, V)</code> produces the same result as the
-         expression <code>map { "key": K, "value": V }</code>.</p>
+         expression <code>{ "key": K, "value": V }</code>.</p>
          <p>The function <code>map:pair</code> is intended primarily for use in conjunction with
             the function <code>map:of-pairs</code>. A map may be constructed like this:</p>
 
@@ -21674,7 +21674,7 @@ map:of-pairs((
          <fos:example>
             <fos:test>
                <fos:expression>map:pair("M", "Monday")</fos:expression>
-               <fos:result>map { "key": "M", "value": "Monday" }</fos:result>
+               <fos:result>{ "key": "M", "value": "Monday" }</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -21716,26 +21716,26 @@ map:merge(
 
       <fos:examples>
          <fos:variable name="week" id="v-map-remove-week"
-            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
+            select="{&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test use="v-map-remove-week">
                <fos:expression>map:remove($week, 4)</fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
                   5: "Freitag", 6: "Samstag" }</fos:result>
             </fos:test>
             <fos:test use="v-map-remove-week">
                <fos:expression>map:remove($week, 23)</fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
                   4: "Donnerstag", 5: "Freitag", 6: "Samstag" }</fos:result>
             </fos:test>
             <fos:test use="v-map-remove-week">
                <fos:expression>map:remove($week, (0, 6 to 7))</fos:expression>
-               <fos:result>map { 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+               <fos:result>{ 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
                   5: "Freitag" }</fos:result>
             </fos:test>
             <fos:test use="v-map-remove-week">
                <fos:expression>map:remove($week, ())</fos:expression>
-               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
+               <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
                   4: "Donnerstag", 5: "Freitag", 6: "Samstag" }</fos:result>
             </fos:test>
          </fos:example>
@@ -21779,7 +21779,7 @@ map:merge(
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:for-each(
-  map { 1: "yes", 2: "no" },
+  { 1: "yes", 2: "no" },
   function($k, $v) { $k }
 )</eg></fos:expression>
                <fos:result allow-permutation="true">(1,2)</fos:result>
@@ -21789,7 +21789,7 @@ map:merge(
             <fos:test>
                <fos:expression><eg>distinct-values(
   map:for-each(
-    map { 1: "yes", 2: "no" },
+    { 1: "yes", 2: "no" },
     function($k, $v) { $v }
   )
 )</eg></fos:expression>
@@ -21800,11 +21800,11 @@ map:merge(
             <fos:test>
                <fos:expression><eg>map:merge(
   map:for-each(
-    map { "a": 1, "b": 2 },
+    { "a": 1, "b": 2 },
     function($k, $v) { map:entry($k, $v + 1) }
   )
 )</eg></fos:expression>
-               <fos:result>map { "a": 2, "b": 3 }</fos:result>
+               <fos:result>{ "a": 2, "b": 3 }</fos:result>
                <fos:postamble>This function call returns a map with the same keys as the input map,
                   with the value of each entry increased by one.</fos:postamble>
             </fos:test>
@@ -21815,7 +21815,7 @@ map:merge(
                   element node:</p>
 
             <eg><![CDATA[
-let $dimensions := map { 'height': 3, 'width': 4, 'depth': 5 }
+let $dimensions := { 'height': 3, 'width': 4, 'depth': 5 }
 return <box>{
   map:for-each($dimensions, function($k, $v) { attribute { $k } { $v } })
 }</box>]]></eg>
@@ -21856,19 +21856,19 @@ return <box>{
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:filter(
-  map { 1: "Sunday", 2: "Monday", 3: "Tuesday", 4: "Wednesday",
-        5: "Thursday", 6: "Friday", 7: "Saturday" },
+  { 1: "Sunday", 2: "Monday", 3: "Tuesday", 4: "Wednesday",
+    5: "Thursday", 6: "Friday", 7: "Saturday" },
   function($k, $v) { $k = (1, 7) }
 )</eg></fos:expression>
-               <fos:result><eg>map { 1: "Sunday", 7: "Saturday" }</eg></fos:result>
+               <fos:result><eg>{ 1: "Sunday", 7: "Saturday" }</eg></fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:filter(
-  map { 1: "Sunday", 2: "Monday", 3: "Tuesday", 4: "Wednesday",
-        5: "Thursday", 6: "Friday", 7: "Saturday" },
+  { 1: "Sunday", 2: "Monday", 3: "Tuesday", 4: "Wednesday",
+    5: "Thursday", 6: "Friday", 7: "Saturday" },
   function($k, $v) { $v = ("Saturday", "Sunday") }
 )</eg></fos:expression>
-               <fos:result><eg>map { 1: "Sunday", 7: "Saturday" }</eg></fos:result>
+               <fos:result><eg>{ 1: "Sunday", 7: "Saturday" }</eg></fos:result>
             </fos:test>
 
          </fos:example>
@@ -21917,24 +21917,24 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:replace(map { 1: "alpha", 2: "beta" }, 1, upper-case#1)</fos:expression>
-               <fos:result>map { 1: "ALPHA", 2: "beta" }</fos:result>
+               <fos:expression>map:replace({ 1: "alpha", 2: "beta" }, 1, upper-case#1)</fos:expression>
+               <fos:result>{ 1: "ALPHA", 2: "beta" }</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:replace(map { 1: "alpha", 2: "beta" }, 3, upper-case#1)</fos:expression>
-               <fos:result>map { 1: "alpha", 2: "beta" 3: "" }</fos:result>
+               <fos:expression>map:replace({ 1: "alpha", 2: "beta" }, 3, upper-case#1)</fos:expression>
+               <fos:result>{ 1: "alpha", 2: "beta" 3: "" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>fold-left(
   ("a", "b", "c", "a"),
-  map { },
+  { },
   function($map, $key) {
     map:replace($map, $key, function($val) {
       ($val otherwise 0) + 1
     })
   }
 )</eg></fos:expression>
-               <fos:result>map { "a": 2, "b": 1, "c": 1 }</fos:result>
+               <fos:result>{ "a": 2, "b": 1, "c": 1 }</fos:result>
             </fos:test>
          </fos:example>
 
@@ -21975,17 +21975,17 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:substitute(
-  map { 1: true(), 2: false() },
+  { 1: true(), 2: false() },
   function($k, $v) { not($v) }
 )</eg></fos:expression>
-               <fos:result>map { 1: false(), 2: true() }</fos:result>
+               <fos:result>{ 1: false(), 2: true() }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:substitute(
-  map { 1: "yes", 2: "no" },
+  { 1: "yes", 2: "no" },
   function($k, $v) { $v || ' (' || $k || ')' }
 )</eg></fos:expression>
-               <fos:result>map { 1: "yes (1)", 2: "no (2)" }</fos:result>
+               <fos:result>{ 1: "yes (1)", 2: "no (2)" }</fos:result>
             </fos:test>
          </fos:example>
 
@@ -22024,7 +22024,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </ulist>
          <p>More formally, the function returns the value of the expression:</p>
          <eg>
-fold-left($input, map { }, fn($map, $item) {
+fold-left($input, { }, fn($map, $item) {
   let $v := $value($item)
   return fold-left($key($item), $map, fn($m, $k) {
     if (map:contains($m, $k)) then (
@@ -22056,11 +22056,11 @@ fold-left($input, map { }, fn($map, $item) {
          <fos:example>
             <fos:test>
                <fos:expression>map:build((), string#1)</fos:expression>
-               <fos:result>map { }</fos:result>
+               <fos:result>{ }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>map:build(1 to 10, function { . mod 3 })</fos:expression>
-               <fos:result>map { 0: (3, 6, 9), 1: (1, 4, 7, 10), 2: (2, 5, 8) }</fos:result>
+               <fos:result>{ 0: (3, 6, 9), 1: (1, 4, 7, 10), 2: (2, 5, 8) }</fos:result>
                <fos:postamble>Returns a map with one entry for each distinct value of <code>. mod 3</code>. The
                   function to compute the value is the identity function, and duplicates are combined by
                   sequence concatenation.</fos:postamble>
@@ -22070,7 +22070,7 @@ fold-left($input, map { }, fn($map, $item) {
   1 to 5,
   value := format-integer(?, "w")
 )</eg></fos:expression>
-               <fos:result>map { 1: "one", 2: "two", 3: "three", 4: "four", 5: "five" }</fos:result>
+               <fos:result>{ 1: "one", 2: "two", 3: "three", 4: "four", 5: "five" }</fos:result>
                <fos:postamble>Returns a map with five entries. The function to compute the key is an identity function, the
                   function to compute the value invokes <code>fn:format-integer</code>.</fos:postamble>
             </fos:test>
@@ -22080,7 +22080,7 @@ fold-left($input, map { }, fn($map, $item) {
    "July", "August", "September", "October", "November", "December"),
   substring(?, 1, 1)
 )</eg></fos:expression>
-               <fos:result>map {
+               <fos:result>{
   "A": ("April", "August"),
   "D": ("December"),
   "F": ("February"),
@@ -22098,7 +22098,7 @@ fold-left($input, map { }, fn($map, $item) {
   string-length#1,
   op("+")
 )</eg></fos:expression>
-               <fos:result>map { "a": 12, "b": 15, "c": 6 }</fos:result>
+               <fos:result>{ "a": 12, "b": 15, "c": 6 }</fos:result>
                <fos:postamble>Constructs a map where the key is the first character of an input item, and where the corresponding value
                   is the total string-length of the items starting with that character.</fos:postamble>
             </fos:test>
@@ -22112,7 +22112,7 @@ let $titles := <titles>
 return map:build($titles/title, fn($title) { $title/ix })
 ]]></eg></fos:expression>
                <fos:result><eg><![CDATA[
-map {
+{
   "Java": (
     <title>A Beginner's Guide to <ix>Java</ix></title>,
     <title>Using <ix>XML</ix> with <ix>Java</ix></title>
@@ -22176,11 +22176,11 @@ map {
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:size(map { })</fos:expression>
+               <fos:expression>map:size({ })</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:size(map { "true": 1, "false": 0 })</fos:expression>
+               <fos:expression>map:size({ "true": 1, "false": 0 })</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
          </fos:example>
@@ -22290,9 +22290,9 @@ map {
          <fos:example>
             <fos:test use="v-collation-key-C">
                <fos:expression><eg>map:merge(
-  (map { collation-key("A", $C): 1 },
-   map { collation-key("a", $C): 2 }),
-  map { "duplicates": "use-last" }
+  ({ collation-key("A", $C): 1 },
+   { collation-key("a", $C): 2 }),
+  { "duplicates": "use-last" }
 )(collation-key("A", $C))</eg></fos:expression>
                <fos:result>2</fos:result>
                <fos:postamble>Given that the keys of the two entries are equal under the rules of
@@ -22302,7 +22302,7 @@ map {
          </fos:example>
          <fos:example>
             <fos:test use="v-collation-key-C">
-               <fos:expression><eg>let $M := map {
+               <fos:expression><eg>let $M := {
   collation-key("A", $C): 1,
   collation-key("B", $C): 2
 }
@@ -22326,7 +22326,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="json-to-xml" return-type="document-node()?">
             <fos:arg name="value" type="xs:string?" example="'[22,23]'"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -22626,7 +22626,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test>
                <fos:expression><eg>json-to-xml(
   '{ "x": 1, "y": [ 3, 4, 5 ] }',
-  map { "validate": false() }
+  { "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
@@ -22641,7 +22641,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test>
                <fos:expression><eg>json-to-xml(
   '"abcd"',
-  map { 'liberal': false() }
+  { 'liberal': false() }
 )</eg></fos:expression>
                <fos:result ignore-prefixes="true"
                   ><![CDATA[<string xmlns="http://www.w3.org/2005/xpath-functions">abcd</string>]]></fos:result>
@@ -22649,7 +22649,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test>
                <fos:expression><eg>json-to-xml(
   '{ "x": "\\", "y": "\u0025" }',
-  map { "validate": false() }
+  { "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
@@ -22660,7 +22660,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <fos:test>
                <fos:expression><eg>json-to-xml(
   '{ "x": "\\", "y": "\u0025" }',
-  map { 'escape': true(), "validate": false() }
+  { 'escape': true(), "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
 <map xmlns="http://www.w3.org/2005/xpath-functions">
@@ -22677,11 +22677,11 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <eg><![CDATA[
  let 
    $jsonstr := unparsed-text('http://example.com/endpoint'),
-   $options := map {
+   $options := {
      'liberal': true(),
      'fallback': function($char as xs:string) as xs:string {
        let 
-         $c0chars := map {
+         $c0chars := {
            '\u0000':'[NUL]',
            '\u0001':'[SOH]',
            '\u0002':'[STX]',
@@ -22706,7 +22706,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="xml-to-json" return-type="xs:string?">
             <fos:arg name="node" type="node()?" usage="absorption" example="()"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23031,7 +23031,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23354,9 +23354,9 @@ return (
   $result?get(1,2),
   $result?get(2,2)
 )</eg></fos:expression>
-               <fos:result><eg>map {
+               <fos:result><eg>{
   "columns": (),
-  "column-index": map { },
+  "column-index": { },
   "rows": ([ "name", "city" ], [ "Bob", "Berlin" ], [ "Alice", "Aachen" ]),
   "get": "(: function :)"
 },
@@ -23370,15 +23370,15 @@ return (
   ("name,city", "Bob,Berlin", "Alice,Aachen"),
   char('\n')
 )
-let $result := parse-csv($input, map { "header": true() })
+let $result := parse-csv($input, { "header": true() })
 return (
   $result => $display(),
   $result?get(1,"name"),
   $result?get(2,"city")
 )</eg></fos:expression>
-<fos:result><eg>map {
+<fos:result><eg>{
   "columns": ("name", "city"),
-  "column-index": map { "name": 1, "city": 2 },
+  "column-index": { "name": 1, "city": 2 },
   "rows": ([ "Bob", "Berlin" ], [ "Alice", "Aachen" ]),
   "get": "(: function :)"
 },
@@ -23389,7 +23389,7 @@ return (
          <fos:example>
             <p>Custom delimiters, no column headers:</p>
             <fos:test use="csv-display">
-               <fos:expression><eg>let $options := map {
+               <fos:expression><eg>let $options := {
   "row-delimiter": "§", 
   "field-delimiter": ";", 
   "quote-character": "|"
@@ -23400,9 +23400,9 @@ return (
   $result => $display(),
   $result?get(3, 1)
 )</eg></fos:expression>
-               <fos:result><eg>map {
+               <fos:result><eg>{
   "columns": (),
-  "column-index": map { },
+  "column-index": { },
   "rows": ([ "name", "city" ], [ "Bob", "Berlin" ], [ "Alice", "Aachen" ]),
   "get": "(: function :)"
 },
@@ -23413,16 +23413,16 @@ return (
             <p>Supplied column names:</p>
             <fos:test use="csv-display">
                <fos:expression><eg>let $headers := ("Person", "Location")
-let $options := map { "header": $headers, "row-delimiter": ";" }
+let $options := { "header": $headers, "row-delimiter": ";" }
 let $input := "Alice,Aachen;Bob,Berlin;"
 let $parsed-csv := parse-csv($input, $options)
 return (
   $parsed-csv => $display(), 
   $parsed-csv?get(2, "Location")
 )</eg></fos:expression>
-               <fos:result><eg>map {
+               <fos:result><eg>{
   "columns": ("Person", "Location"),
-  "column-index": map {"Person": 1, "Location": 2},
+  "column-index": {"Person": 1, "Location": 2},
   "rows": ([ "Alice", "Aachen" ], [ "Bob", "Berlin" ]),
   "get": "(: function :)"                  
 },
@@ -23438,7 +23438,7 @@ return (
    "2023-07-20,Alice,Aachen,15.00",
    "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"
 ), char('\n'))
-let $options := map { 
+let $options := { 
   "header": true(), 
   "select-columns": (2,1,4)
 }
@@ -23447,9 +23447,9 @@ return (
   $result => $display(),
   $result?get(2, "city")
 )</eg></fos:expression>
-               <fos:result><eg>map {
+               <fos:result><eg>{
   "columns": ("name", "date", "amount"),
-  "column-index": map { "name": 1, "date": 2, "amount": 3 },
+  "column-index": { "name": 1, "date": 2, "amount": 3 },
   "rows": (
     [ "Bob", "2023-07-19", "10.00" ],
     [ "Alice", "2023-07-20", "15.00" ],
@@ -23468,8 +23468,8 @@ return (
   "2023-07-20,Alice,Aachen,15.00",
   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"
 ), char('\n'))
-let $options := map { 
-  "header": map { "Person": 1, "Amount": 3 }, 
+let $options := { 
+  "header": { "Person": 1, "Amount": 3 }, 
   "select-columns": (2, 1, 4)
 }
 let $result := parse-csv($input, $options)
@@ -23479,9 +23479,9 @@ return (
   $result?get(2, "Amount")
 )</eg></fos:expression>
                
-               <fos:result><eg>map {
+               <fos:result><eg>{
   "columns": ("Person", "", "Amount"),
-  "column-index": map { "Person": 1, "Amount": 3 },
+  "column-index": { "Person": 1, "Amount": 3 },
   "rows": ([ "Alice", "Aachen" ], [ "Bob", "Berlin" ]),
   "get": "(: function :)"                  
 },
@@ -23498,7 +23498,7 @@ return (
   "2023-07-20,Alice,    15.00",
   "2023-07-20,Charlie,  15.00,     GBP,        11.99,             extra data"
 ), char('\n'))
-let $options := map {
+let $options := {
   "header": false(), 
   "select-columns": 1 to 5, 
   "trim-whitespace":true()
@@ -23508,9 +23508,9 @@ return (
   $result => $display(),
   $result?get(4,3)
 )</eg></fos:expression>
-               <fos:result><eg>map {
+               <fos:result><eg>{
   "columns": (),
-  "column-index": map { },
+  "column-index": { },
   "rows": (
     [ "date", "name", "amount", "currency", "original amount" ],
     [ "2023-07-19", "Bob", "10.00", "USD", "13.99" ],
@@ -23532,15 +23532,15 @@ return (
   "2023-07-20,Alice,Aachen,15.00",
   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"
 ), char('\n'))
-let $options := map { "header": true(), "select-columns": 1 to 6 }
+let $options := { "header": true(), "select-columns": 1 to 6 }
 let $result := parse-csv($input, $options)
 return (
   $result => $display(),
   $result?get(3,"original amount")
 )</eg></fos:expression>
-               <fos:result><eg>map {
+               <fos:result><eg>{
   "columns": ("date", "name", "city", "amount", "currency", "original amount"),
-  "column-index": map {
+  "column-index": {
     "date": 1, "name": 2, "city": 3, "amount": 4,
     "currency": 5, "original amount": 6
   },
@@ -23560,7 +23560,7 @@ return (
       <fos:signatures>
          <fos:proto name="csv-to-arrays" return-type="array(xs:string)*">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23707,27 +23707,27 @@ return (
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(" ", map { 'trim-whitespace': true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(" ", { 'trim-whitespace': true() })</eg></fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(" ", map { 'trim-whitespace': false() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(" ", { 'trim-whitespace': false() })</eg></fos:expression>
                <fos:result>[" "]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, map { 'trim-whitespace': true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, { 'trim-whitespace': true() })</eg></fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, map { 'trim-whitespace': false() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, { 'trim-whitespace': false() })</eg></fos:expression>
                <fos:result>[" "]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map { 'trim-whitespace': true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, { 'trim-whitespace': true() })</eg></fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map { 'trim-whitespace': false() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, { 'trim-whitespace': false() })</eg></fos:expression>
                <fos:result>[], [" "]</fos:result>
             </fos:test>
             <p>Using newline separators:</p>
@@ -23748,7 +23748,7 @@ return csv-to-arrays(
   `name,city{ $CRLF }` ||
   `Bob,Berlin{ $CRLF }` ||
   `Alice,Aachen{ $CRLF }`, 
-  map { "normalize-newlines": true() }
+  { "normalize-newlines": true() }
 )</eg></fos:expression>
                <fos:result><eg>(
   [ "name", "city" ],
@@ -23789,7 +23789,7 @@ return csv-to-arrays(
             <fos:test>
                <fos:expression><eg>csv-to-arrays(
   "name;city§Bob;Berlin§Alice;Aachen", 
-  map { "row-delimiter": "§", "field-delimiter": ";" }
+  { "row-delimiter": "§", "field-delimiter": ";" }
 )</eg></fos:expression>
                <fos:result><eg>(
   [ "name", "city" ],
@@ -23806,7 +23806,7 @@ return csv-to-arrays(
     ("|name|,|city|", "|Bob|,|Berlin|"),
     char('\n')
   ), 
-  map { "quote-character": "|" }
+  { "quote-character": "|" }
 )</eg></fos:expression>
                <fos:result><eg>(
   [ "name", "city" ],
@@ -23822,7 +23822,7 @@ return csv-to-arrays(
     ("name  ,city    ", "Bob   ,Berlin  ", "Alice ,Aachen  "),
     char('\n')
   ),
-  map { "trim-whitespace": true() }
+  { "trim-whitespace": true() }
 )</eg></fos:expression>
                <fos:result><eg>(
   [ "name", "city" ],
@@ -23838,7 +23838,7 @@ return csv-to-arrays(
       <fos:signatures>
          <fos:proto name="csv-to-xml" return-type="element(fn:csv)?">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23940,7 +23940,7 @@ return
          <fos:example>
             <p>An empty CSV with header extraction:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-xml("", map { "header": true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml("", { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns/>
@@ -23952,7 +23952,7 @@ return
          <fos:example>
             <p>An empty CSV with explicit column names:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-xml("", map { "header": ("name", "", "city") })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml("", { "header": ("name", "", "city") })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23968,7 +23968,7 @@ return
          <fos:example>
             <p>With defaults for delimiters and quotes, recognizing headers:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression><eg>csv-to-xml($csv-string, map { "header": true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml($csv-string, { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -23992,7 +23992,7 @@ return
          <!--<fos:example>
             <p>With defaults for delimiters and quotes, recognizing headers:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression><eg>csv-to-xml($csv-string, map { "header": true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml($csv-string, { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -24022,7 +24022,7 @@ return
             <p>Filtering columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "header": true(), 
+           { "header": true(), 
                  "select-columns": (2,1,4) })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -24056,7 +24056,7 @@ return
             <p>Ragged rows</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "header": true() })</eg></fos:expression>
+           { "header": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
    <columns>
@@ -24102,7 +24102,7 @@ return
             <p>Trimming rows to constant width</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "header": true(), 
+           { "header": true(), 
                  "trim-rows": true() })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -24152,7 +24152,7 @@ return
             <p>Specifying a fixed number of columns</p>
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml($csv-uneven-cols, 
-           map { "header": true(), 
+           { "header": true(), 
                  "select-columns": 1 to 6 })</eg></fos:expression>
                <fos:result><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -24201,7 +24201,7 @@ return
       <fos:signatures>
          <fos:proto name="parse-json" return-type="item()?">
             <fos:arg name="value" type="xs:string?" example="'[22,23]'"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24422,7 +24422,7 @@ return
                   associated value may be of any type, and is the result of converting the JSON
                   value by recursive application of these rules. For example, the JSON text
                      <code>{ "x": 2, "y": 5 }</code> is transformed to the value
-                     <code>map { "x": 2, "y": 5 }</code>.</p>
+                     <code>{ "x": 2, "y": 5 }</code>.</p>
                <p>If duplicate keys are encountered in a JSON <emph>object</emph>, they are handled
                   as determined by the <code>duplicates</code> option defined above.</p>
             </item>
@@ -24508,7 +24508,7 @@ return
          <fos:example>
             <fos:test>
                <fos:expression>parse-json('{ "x": 1, "y": [ 3, 4, 5 ] }')</fos:expression>
-               <fos:result>map { "x": 1e0, "y": [ 3e0, 4e0, 5e0 ] }</fos:result>
+               <fos:result>{ "x": 1e0, "y": [ 3e0, 4e0, 5e0 ] }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>parse-json('"abcd"')</fos:expression>
@@ -24516,52 +24516,52 @@ return
             </fos:test>
             <fos:test>
                <fos:expression>parse-json('{ "x": "\\", "y": "\u0025" }')</fos:expression>
-               <fos:result>map { "x": "\", "y": "%" }</fos:result>
+               <fos:result>{ "x": "\", "y": "%" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
   '{ "x": "\\", "y": "\u0025" }',
-  map { 'escape': true() }
+  { 'escape': true() }
 )</eg></fos:expression>
-               <fos:result>map { "x": "\\", "y": "%" }</fos:result>
+               <fos:result>{ "x": "\\", "y": "%" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
   '{ "x": "\\", "y": "\u0000" }'
 )</eg></fos:expression>
-               <fos:result>map { "x": "\", "y": char(0xFFFD) }</fos:result>
+               <fos:result>{ "x": "\", "y": char(0xFFFD) }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
   '{ "x": "\\", "y": "\u0000" }',
-  map { 'escape': true() }
+  { 'escape': true() }
 )</eg></fos:expression>
-               <fos:result>map { "x": "\\", "y": "\u0000" }</fos:result>
+               <fos:result>{ "x": "\\", "y": "\u0000" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
   '{ "x": "\\", "y": "\u0000" }',
-  map { 'fallback': function($s) { '[' || $s || ']' } }
+  { 'fallback': function($s) { '[' || $s || ']' } }
 )</eg></fos:expression>
-               <fos:result>map { "x": "\", "y": "[\u0000]" }</fos:result>
+               <fos:result>{ "x": "\", "y": "[\u0000]" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
   "1984.2",
-  map { 'number-parser': fn { xs:integer(round(.)) } }
+  { 'number-parser': fn { xs:integer(round(.)) } }
 )</eg></fos:expression>
                <fos:result>1984</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
   '[ 1, -1, 2 ]',
-  map { 'number-parser': fn  { boolean(. >= 0) } }
+  { 'number-parser': fn  { boolean(. >= 0) } }
 )</eg></fos:expression>
                <fos:result>[ true(), false(), true() ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json('[ "a", null, "b" ]',
-  map { 'null': xs:QName("fn:null") }
+  { 'null': xs:QName("fn:null") }
 )</eg></fos:expression>
                <fos:result>[ "a", xs:QName("fn:null"), "b" ]</fos:result>
             </fos:test>
@@ -24573,7 +24573,7 @@ return
       <fos:signatures>
          <fos:proto name="json-doc" return-type="item()?">
             <fos:arg name="href" type="xs:string?" example="'JSONTestSuite/test_parsing/y_number.json'"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24637,7 +24637,7 @@ return
       <fos:signatures>
          <fos:proto name="json" return-type="xs:string">
             <fos:arg name="input" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection"  default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection"  default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24833,7 +24833,7 @@ return
                
                <note><p>Conflicts between property names can arise because the XDM model allows keys of different types,
                   for example the <code>xs:date</code> value <code>2020-12-31</code> and the string value 
-                  <code>"2020-12-31"</code> can co-exist. The map <code>map { xs:duration('PTD'): 20, "P1D": 30 }</code>
+                  <code>"2020-12-31"</code> can co-exist. The map <code>{ xs:duration('PTD'): 20, "P1D": 30 }</code>
                   is converted to the JSON string <code>{ "P1D": 20, "P1D(1)": 30 }</code> or 
                   <code>{ "P1D": 30, "P1D(1)": 20 }</code>, depending on the (unpredictable) order in which the
                entries in the map are processed.</p></note>
@@ -24916,7 +24916,7 @@ return
                <fos:result>'true'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json(map { "a": 1,"b": number('NaN'), "c": (1, 2, 3) })</fos:expression>
+               <fos:expression>json({ "a": 1,"b": number('NaN'), "c": (1, 2, 3) })</fos:expression>
                <fos:result>'{"a":1,"b":"NaN","c":[1,2,3]}'</fos:result>
                <fos:postamble>(or some permutation thereof)</fos:postamble>
             </fos:test>
@@ -25223,7 +25223,7 @@ else $fallback($position)</eg>
             members in positions 1 to <code>array:size($array)</code> are the same as the members in the corresponding position
             of <code>$array</code>, and the member in position <code>array:size($array) + 1</code> is <code>$member</code>.</p>
          <p diff="chg" at="A">More formally, the result is the value of the expression
-            <code>array:of-members((array:members($array), map { 'value': $member }))</code>.</p>
+            <code>array:of-members((array:members($array), { 'value': $member }))</code>.</p>
 
       </fos:rules>
       <fos:examples>
@@ -25746,7 +25746,7 @@ array:index-of(
             then all members from <code>$array</code> whose position is greater than or equal to <code>$position</code>. 
             Positions are counted from 1.</p>
          <p>More formally, except in error cases, the result is the value of the expression
-            <code role="example">array:of-members(array:members($array) => fn:insert-before($position, map { 'value': $member }))</code>.</p>
+            <code role="example">array:of-members(array:members($array) => fn:insert-before($position, { 'value': $member }))</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
@@ -26407,7 +26407,7 @@ array:for-each-pair(
          <p>Informally, <code>array:build#2</code> applies the supplied function to each item 
             in the input sequence, and the resulting sequence becomes one member of the returned array.</p>
          <p>More formally, <code>array:build#2</code> returns the result of the expression:</p>
-         <eg>array:of-members($input ! map { 'value': $action(.) })</eg>
+         <eg>array:of-members($input ! { 'value': $action(.) })</eg>
       </fos:rules>
       <fos:notes>
          <p>The single-argument function <code>array:build($input)</code> is equivalent to the XPath
@@ -26610,15 +26610,15 @@ return deep-equal(
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members(map { 'value': (1 to 5) })</fos:expression>
+               <fos:expression>array:of-members({ 'value': (1 to 5) })</fos:expression>
                <fos:result>[ (1, 2, 3, 4, 5) ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members((1 to 5) ! map { 'value': . })</fos:expression>
+               <fos:expression>array:of-members((1 to 5) ! { 'value': . })</fos:expression>
                <fos:result>[ 1, 2, 3, 4, 5 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members((1 to 5) ! map { 'value': (., . * .) })</fos:expression>
+               <fos:expression>array:of-members((1 to 5) ! { 'value': (., . * .) })</fos:expression>
                <fos:result>[ (1, 1), (2, 4), (3, 9), (4, 16), (5, 25)]</fos:result>
             </fos:test>
          </fos:example>
@@ -26861,7 +26861,7 @@ declare function flatten(
       <fos:signatures>
          <fos:proto name="load-xquery-module" return-type-ref="load-xquery-module-record">
             <fos:arg name="module-uri" type="xs:string"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -27585,7 +27585,7 @@ declare function flatten(
                         its default), following the same rules as when one <code>xsl:output</code>
                         declaration overrides another with lower import precedence.</p></item>
                      <item><p>When a parameter is supplied and the corresponding value is an empty
-                        sequence (for example, <code>map { "standalone": () }</code>), any value
+                        sequence (for example, <code>{ "standalone": () }</code>), any value
                         specified in the unnamed <code>xsl:output</code> declaration is overridden
                         by the default value. </p></item>
                      <item><p>When a parameter is not supplied in <code>serialization-params</code> (that
@@ -27692,7 +27692,7 @@ declare function flatten(
                      >implementation-defined</termref>. Implementations
                 <rfc2119>should</rfc2119> ignore options whose names are in an unrecognized
             namespace. Default is an empty map.</fos:meaning>
-               <fos:type>map { xs:QName, item()* }</fos:type>
+               <fos:type>{ xs:QName, item()* }</fos:type>
                <fos:default>Empty map</fos:default>
             </fos:option>
 
@@ -27803,7 +27803,7 @@ declare function flatten(
                to examine the result:</p>
             <eg><![CDATA[
 let $result := transform(
-  map {
+  {
     "stylesheet-location" : "render.xsl",
     "source-node"    : doc('test.xml')
   })
@@ -28333,7 +28333,7 @@ function($item) {
                <fos:expression><eg>highest(
   ("red", "green", "blue"),
   (),
-  map {
+  {
     "red"  : xs:hexBinary('FF0000'),
     "green": xs:hexBinary('008000'),
     "blue" : xs:hexBinary('0000FF')
@@ -28931,7 +28931,7 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
                <fos:expression><eg>lowest(
   ("red", "green", "blue"),
   (),
-  map {
+  {
     "red"  : xs:hexBinary('FF0000'),
     "green": xs:hexBinary('008000'),
     "blue" : xs:hexBinary('0000FF')
@@ -29257,7 +29257,7 @@ some $boolean in (
       <fos:signatures>
          <fos:proto name="parse-uri" return-type-ref="uri-structure-record">
             <fos:arg name="uri" type="xs:string"/>
-            <fos:arg name="options" type="map(*)?" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -29589,7 +29589,7 @@ some $boolean in (
       <fos:expression><eg>parse-uri(
   "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri"
 )</eg></fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri",
   "scheme": "http",
   "hierarchical": true(),
@@ -29604,7 +29604,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("http://www.ietf.org/rfc/rfc2396.txt")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "http://www.ietf.org/rfc/rfc2396.txt",
   "scheme": "http",
   "hierarchical": true(),
@@ -29618,7 +29618,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("https://example.com/path/to/file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "https://example.com/path/to/file",
   "scheme": "https",
   "hierarchical": true(),
@@ -29634,7 +29634,7 @@ some $boolean in (
       <fos:expression><eg>parse-uri(
   `https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`
 )</eg></fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": `https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`,
   "scheme": "https",
   "hierarchical": true(),
@@ -29643,7 +29643,7 @@ some $boolean in (
   "port": "8080",
   "path": "/path",
   "query": `s=%22hello world%22&amp;sort=relevance`,
-  "query-parameters": map {
+  "query-parameters": {
     "s": '"hello world"',
     "sort": "relevance"
   },
@@ -29654,7 +29654,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("https://user@example.com/path/to/file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "https://user@example.com/path/to/file",
   "scheme": "https",
   "hierarchical": true(),
@@ -29669,7 +29669,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
   "scheme": "ftp",
   "hierarchical": true(),
@@ -29683,7 +29683,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:////uncname/path/to/file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "file:////uncname/path/to/file",
   "scheme": "file",
   "hierarchical": true(),
@@ -29698,7 +29698,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:///c:/path/to/file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "file:///c:/path/to/file",
   "scheme": "file",
   "hierarchical": true(),
@@ -29711,7 +29711,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:/C:/Program%20Files/test.jar")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "file:/C:/Program%20Files/test.jar",
   "scheme": "file",
   "hierarchical": true(),
@@ -29724,7 +29724,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:\\c:\path\to\file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "file:\\c:\path\to\file",
   "scheme": "file",
   "hierarchical": true(),
@@ -29737,7 +29737,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("file:\c:\path\to\file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "file:\c:\path\to\file",
   "scheme": "file",
   "hierarchical": true(),
@@ -29750,7 +29750,7 @@ some $boolean in (
   <fos:example>
     <fos:test>
       <fos:expression>parse-uri("c:\path\to\file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "c:\path\to\file",
   "scheme": "file",
   "hierarchical": true(),
@@ -29764,7 +29764,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("/path/to/file")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "/path/to/file",
   "hierarchical": true(),
   "path": "/path/to/file",
@@ -29777,7 +29777,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("#testing")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
  "uri": "#testing",
  "fragment": "testing"
 }</eg></fos:result>
@@ -29787,10 +29787,10 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("?q=1")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "?q=1",
   "query": "q=1",
-  "query-parameters": map {
+  "query-parameters": {
     "q": "1"
   }
 }</eg></fos:result>
@@ -29800,7 +29800,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("ldap://[2001:db8::7]/c=GB?objectClass?one")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "ldap://[2001:db8::7]/c=GB?objectClass?one",
   "scheme": "ldap",
   "hierarchical": true(),
@@ -29808,7 +29808,7 @@ some $boolean in (
   "host": "[2001:db8::7]",
   "path": "/c=GB",
   "query": "objectClass?one",
-  "query-parameters": map {
+  "query-parameters": {
     "": "objectClass?one"
   },
   "path-segments": ("", "c=GB")
@@ -29819,7 +29819,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("mailto:John.Doe@example.com")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "mailto:John.Doe@example.com",
   "scheme": "mailto",
   "hierarchical": false(),
@@ -29832,7 +29832,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("news:comp.infosystems.www.servers.unix")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "news:comp.infosystems.www.servers.unix",
   "scheme": "news",
   "hierarchical": false(),
@@ -29845,7 +29845,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("tel:+1-816-555-1212")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "tel:+1-816-555-1212",
   "scheme": "tel",
   "hierarchical": false(),
@@ -29858,7 +29858,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("telnet://192.0.2.16:80/")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "telnet://192.0.2.16:80/",
   "scheme": "telnet",
   "hierarchical": true(),
@@ -29876,7 +29876,7 @@ some $boolean in (
   "urn:oasis:names:specification:docbook:dtd:xml:4.1.2"
 )</eg></fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
   "scheme": "urn",
   "hierarchical": false(),
@@ -29889,7 +29889,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("tag:textalign.net,2015:ns")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "tag:textalign.net,2015:ns",
   "scheme": "tag",
   "hierarchical": false(),
@@ -29903,7 +29903,7 @@ some $boolean in (
     <fos:test>
       <fos:expression>parse-uri("tag:jan@example.com,1999-01-31:my-uri")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "tag:jan@example.com,1999-01-31:my-uri",
   "scheme": "tag",
   "hierarchical": false(),
@@ -29921,7 +29921,7 @@ specifically aware of the <code>jar:</code> scheme.</p>
   "jar:file:/C:/Program%20Files/test.jar!/foo/bar"
 )</eg></fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
   "scheme": "jar",
   "hierarchical": false(),
@@ -29938,7 +29938,7 @@ description of <code>fn:resolve-uri</code>.</p>
     <fos:test>
       <fos:expression>parse-uri("http://www.example.org/Dürst")</fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "http://www.example.org/Dürst",
   "scheme": "http",
   "hierarchical": true(),
@@ -29955,10 +29955,10 @@ description of <code>fn:resolve-uri</code>.</p>
     <fos:test>
       <fos:expression><eg>parse-uri(
   "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
-  map { "query-separator": ";" }
+  { "query-separator": ";" }
 )</eg></fos:expression>
       <fos:result>
-<eg>map {
+<eg>{
   "uri": "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
   "scheme": "https",
   "hierarchical": true(),
@@ -29967,7 +29967,7 @@ description of <code>fn:resolve-uri</code>.</p>
   "port": "8080",
   "path": "/path",
   "query": "s=%22hello world%22;sort=relevance",
-  "query-parameters": map {
+  "query-parameters": {
     "s": '"hello world"',
     "sort": "relevance"
   },
@@ -29980,7 +29980,7 @@ description of <code>fn:resolve-uri</code>.</p>
     <fos:test>
       <fos:expression><eg>parse-uri(
   "https://example.com:8080/path?s=%22hello world%22;;sort=relevance",
-  map { "query-separator": ";;" }
+  { "query-separator": ";;" }
 )</eg></fos:expression>
       <fos:error-result error-code="FOXX0000"/>
     </fos:test>
@@ -29990,7 +29990,7 @@ description of <code>fn:resolve-uri</code>.</p>
 path.</p>
     <fos:test>
       <fos:expression>parse-uri("c|/path/to/file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "c|/path/to/file",
   "scheme": "file",
   "hierarchical": true(),
@@ -30005,7 +30005,7 @@ path.</p>
 path with an explicit <code>file:</code> scheme.</p>
     <fos:test>
       <fos:expression>parse-uri("file://c|/path/to/file")</fos:expression>
-      <fos:result><eg>map {
+      <fos:result><eg>{
   "uri": "file://c|/path/to/file",
   "scheme": "file",
   "hierarchical": true(),
@@ -30032,13 +30032,13 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:signatures>
          <fos:proto name="build-uri" return-type="xs:string">
             <fos:arg name="parts" type-ref="uri-structure-record"
-               example='map {
+               example='{
                "scheme": "https",
                "host": "qt4cg.org",
                "port": (),
                "path": "/specifications/index.html"
                }'/>
-            <fos:arg name="options" type="map(*)?" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -30184,7 +30184,7 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:examples role="wide">
          <fos:example>
             <fos:test>
-               <fos:expression><eg>build-uri(map {
+               <fos:expression><eg>build-uri({
     "scheme": "https",
     "host": "qt4cg.org",
     "port": (),
@@ -30495,7 +30495,7 @@ let $scan-right := function(
       <fos:signatures>
          <fos:proto name="invisible-xml" return-type="function(xs:string) as item()">
             <fos:arg name="grammar" type="item()?" default="()"/>
-            <fos:arg name="options" type="map(*)?" default="map { }"/>
+            <fos:arg name="options" type="map(*)?" default="{ }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -30601,7 +30601,7 @@ return $result/*/@*:state = 'failed'</eg></fos:expression>
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[
-let $parser := invisible-xml("S=A. A='a'.", map { "fail-on-error": true() })
+let $parser := invisible-xml("S=A. A='a'.", { "fail-on-error": true() })
 let $result := $parser("b")
 return $result
 ]]></eg></fos:expression>
@@ -30768,9 +30768,9 @@ return $result
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $data := map {
-  "fr": map { "capital": "Paris", "languages": [ "French" ] }, 
-  "de": map { "capital": "Berlin", "languages": [ "German" ] }
+               <fos:expression><eg>let $data := {
+  "fr": { "capital": "Paris", "languages": [ "French" ] }, 
+  "de": { "capital": "Berlin", "languages": [ "German" ] }
 }
 return pin($data)??languages[. = 'German'] ! label()?path()[1]</eg></fos:expression>
                <fos:result>"de"</fos:result>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -660,7 +660,7 @@ for transition to Proposed Recommendation. </p>'>
             the function is evaluated. Maps are a new datatype introduced in XPath 3.1.</p>
             <p>For example, the function <code>fn:xml-to-json</code> has an options parameter
             allowing specification of whether the output is to be indented. A call might be written:</p>
-            <eg><![CDATA[xml-to-json($input, map { 'indent': true() })]]></eg>
+            <eg><![CDATA[xml-to-json($input, { 'indent': true() })]]></eg>
             <p><termdef id="option-parameter-conventions" term="option parameter conventions">Functions
             that take an options parameter adopt common conventions on how the
             options are used. These are referred to as the <term>option parameter conventions</term>. These
@@ -7636,14 +7636,14 @@ return <table>
                <p>It is possible to decompose any map into a sequence of <termref def="dt-singleton-map">singleton maps</termref>,
                   and to construct a map from a sequence of singleton maps.</p>
                <p>For example the map
-               <code>map { "x": 1, "y": 2 }</code> can be decomposed to the sequence <code>(map { "x": 1 }, map { "y": 2 })</code>.</p></item>
+               <code>{ "x": 1, "y": 2 }</code> can be decomposed to the sequence <code>({ "x": 1 }, { "y": 2 })</code>.</p></item>
             
             <item><p><termdef id="dt-key-value-pair-map" term="key-value pair map">A <term>key-value pair map</term> is a map containing two
             entries, one (with the key <code>"key"</code>) containing the key part of a key value pair, the other (with the key <code>"value"</code>)
             containing the value part of a key value pair.</termdef></p>
                <p>For example
-                  the map <code>map { "x": 1, "y": 2 }</code> can be decomposed as 
-                  <code>(map { "key": "x", "value": 1 }, map { "key": "y", "value": 2 })</code></p>
+                  the map <code>{ "x": 1, "y": 2 }</code> can be decomposed as 
+                  <code>({ "key": "x", "value": 1 }, { "key": "y", "value": 2 })</code></p>
                <p>A <termref def="dt-key-value-pair-map"/> is an instance of the type 
                   <code>record(key as xs:anyAtomicType, value as item()*)</code>.</p> </item>
          </olist>
@@ -7966,12 +7966,12 @@ return <table>
                  <item><p><code>array { $sequence }</code> constructs an array whose members
                     are the items in <code>$sequence</code>. Every member of this array will
                     be a singleton item. This can be defined as
-                    <code>array:of-members($sequence ! map { 'value': . })</code>.</p></item>
+                    <code>array:of-members($sequence ! { 'value': . })</code>.</p></item>
                  <item><p><code>[E1, E2, E3, ..., En]</code> constructs an array in which
                     <code>E1</code> is the first member, <code>E2</code> is the second member,
                     and so on. The result is equivalent to the expression
-                    <code>array:of-members((map { 'value': E1 }, map { 'value': E2 },
-                      map { 'value': E3 }, ... map { 'value': En })). </code></p></item>
+                    <code>array:of-members(({ 'value': E1 }, { 'value': E2 },
+                      { 'value': E3 }, ... { 'value': En })). </code></p></item>
                  <item><p>The lookup expression <code>$array?*</code> is equivalent to 
                     <code>array:members($array) ! ?value</code>.</p></item>
                  <item><p>The lookup expression <code>$array?$N</code>, where <code>$N</code>
@@ -8614,7 +8614,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
   $latitude as xs:double,
   $longitude as xs:double
 ) as my:location {
-  map { 'latitude': $latitude, 'longitude': $longitude }
+  { 'latitude': $latitude, 'longitude': $longitude }
 }</eg>
               <p>Equivalently using XSLT syntax, if there is a named item type with the
               XSLT definition:</p>
@@ -8692,7 +8692,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
     $middle as xs:string?,
     $last as xs:string,
     $suffix as xs:string? := ()) as p:person {
-        let $m := map { },
+        let $m := { },
             $m := if (exists($arg1)) then map:put($m, "1st-title", $arg1) else $m,
             $m := if (exists($arg2)) then map:put($m, "2nd-title", $arg2) else $m,
             $m := map:put($m, "first", $first),

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1614,6 +1614,8 @@ specification since the publication of XPath 3.1 Recommendation.</p>
         value of <code>A</code>, unless it is an empty sequence, in which case it returns the value of <code>B</code>.</p></item>
       <item><p>Alternative syntax for conditional expressions is available: <code>if (condition) {X} else {Y}</code>,
       with the <code>else</code> part being optional.</p></item>
+      <item><p>In map constructors, the keyword <code>map</code> is now optional, so 
+        <code>map { 0: false(), 1: true() }</code> can now be written <code>{ 0: false(), 1: true() }</code>.</p></item>
       <item><p>The syntax <code>for $x in X for $y in Y return Z</code> is now accepted in XPath as well as in XQuery.</p></item>
       <item><p>The <code>NodeTest</code> in an <code>AxisStep</code> now allows alternatives: 
         <code>ancestor::(section|appendix)</code>.</p></item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5246,7 +5246,7 @@ name.</p>
                <p>Examples:</p>
 
                <p>Given a map <code>$M</code> whose keys are integers and whose
-  results are strings, such as <code>map { 0: "no", 1: "yes" }</code>,
+  results are strings, such as <code>{ 0: "no", 1: "yes" }</code>,
   consider the results of the following expressions:
   </p>
 
@@ -5580,7 +5580,7 @@ name.</p>
                
                <p>Instances of recursive record types can be constructed and interrogated in the normal way.
                For example a list of length 3 can be constructed as:</p>
-               <p><eg>map { "value": 1, "next": map { "value": 2, "next": map { "value": 3 } } }</eg></p>
+               <p><eg>{ "value": 1, "next": { "value": 2, "next": { "value": 3 } } }</eg></p>
                <p>and the third value in the map can be retrieved as <code>$list?next?next?value</code>.
                In practice, recursive data structures are usually manipulated using recursive functions.</p>
                
@@ -7054,8 +7054,8 @@ name.</p>
                      </olist>
 
                      <note><p>For example, if the required type is
-                     <code>record(longitude as xs:double, latitude as xs:double)</code> and the supplied value is <code>map { "longitude": 0, "latitude": 53.2 }</code>,
-                        then the map is converted to <code>map { "longitude": 0.0e0, "latitude": 53.2e0 }</code>.</p></note>
+                     <code>record(longitude as xs:double, latitude as xs:double)</code> and the supplied value is <code>{ "longitude": 0, "latitude": 53.2 }</code>,
+                        then the map is converted to <code>{ "longitude": 0.0e0, "latitude": 53.2e0 }</code>.</p></note>
                   </item>
 
                   <item>
@@ -7121,7 +7121,7 @@ name.</p>
                      are instances of both types are one or more of the following:</p>
                      <ulist>
                         <item><p>The empty sequence, <code>()</code>.</p></item>
-                        <item><p>The empty map, <code>map { }</code>.</p></item>
+                        <item><p>The empty map, <code>{}</code>.</p></item>
                         <item><p>The empty array, <code>[]</code>.</p></item>
                      </ulist>
                      
@@ -7376,7 +7376,7 @@ return local:filter(("Ethel", "Enid", "Gertrude"), $f)
       </p>
 
                <eg role="parse-test"><![CDATA[
-let $m := map {
+let $m := {
   "Monday" : true(),
   "Wednesday" : false(),
   "Friday" : true()
@@ -7430,10 +7430,11 @@ return filter($days, $m)
       </p>
 
                <eg role="parse-test"><![CDATA[
-let $m := map {
-  "Monday" : true(),
-  "Wednesday" : false(),
-  "Friday" : true()
+
+let $m := {
+   "Monday" : true(),
+   "Wednesday" : false(),
+   "Friday" : true(),
 }
 let $days := ("Monday", "Wednesday", "Friday")
 return filter($days, $m)
@@ -9430,7 +9431,7 @@ return $paf(1 to 5)
                <example>
                   <head>Partial Application of a Map</head>
                   <p>The following partial function application converts a map to an equivalent function that is not a map.</p>
-                  <eg role="parse-test"><![CDATA[let $a := map { "A": 1, "B": 2 }(?)
+                  <eg role="parse-test"><![CDATA[let $a := { "A": 1, "B": 2 }(?)
 return $a("A")]]></eg>
                </example>
                   
@@ -12341,7 +12342,7 @@ return ``[`{ $s }` fish]``
                ref="Moustache"
             />, a JavaScript template library. Each function takes a map, containing values like these:</p>
             
-            <eg><![CDATA[map {
+            <eg><![CDATA[{
   "name": "Chris",
   "value": 10000,
   "taxed_value": 10000 - (10000 * 0.4),
@@ -15698,6 +15699,17 @@ processing with JSON processing.</p>
                   <prodrecap id="MapKeyExpr" ref="MapKeyExpr"/>
                   <prodrecap id="MapValueExpr" ref="MapValueExpr"/>
                </scrap>
+               
+               <note>
+                  <p>The keyword <code>map</code> was required in earlier versions
+                  of the language; in &language; it becomes optional.</p>
+                  <p>In some contexts it may be necessary to separate two adjacent
+                  left brace (<code>{</code>) or right brace (<code>}</code>) characters
+                  with whitespace to avoid the doubled brace being interpreted as an
+                  escaped single brace. This situation rarely arises in practice.</p>
+                  <p>Although the <code>map</code> keyword is redundant in 4.0,
+                  its use may improve readability in some situations.</p>
+               </note>
 
 
                <note>
@@ -15709,20 +15721,20 @@ processing with JSON processing.</p>
     </p>
 
                   <p>
-    For instance, consider the expression <code>map{a:b}</code>.
+    For instance, consider the expression <code>{a:b}</code>.
     Although it matches the EBNF for MapConstructor
     (with <code>a</code> matching MapKeyExpr and <code>b</code> matching MapValueExpr),
     the "longest possible match" rule requires that <code>a:b</code> be parsed as a QName,
     which results in a syntax error.
-    Changing the expression to <code>map{a :b}</code> or <code>map{a: b}</code>
+    Changing the expression to <code>{a :b}</code> or <code>{a: b}</code>
     will prevent this, resulting in the intended parse.
     </p>
 
                   <p>Similarly, consider these three expressions:</p>
                   <eg><![CDATA[
-    map{a:b:c}
-    map{a:*:c}
-    map{*:b:c}]]></eg>
+    {a:b:c}
+    {a:*:c}
+    {*:b:c}]]></eg>
                   <p>
     In each case, the expression matches the EBNF in two different ways,
     but the “longest possible match” rule forces the parse in which
@@ -15799,7 +15811,7 @@ processing with JSON processing.</p>
 
                <p>The following expression constructs a map with seven entries:</p>
                <eg id="map-weekdays"><![CDATA[
-map {
+{
   "Su" : "Sunday",
   "Mo" : "Monday",
   "Tu" : "Tuesday",
@@ -15814,20 +15826,21 @@ map {
                <p>Maps can nest, and can contain any XDM value. Here is an example of a nested map with values that can be string values, numeric values, or arrays:</p>
 
                <eg id="map-book"><![CDATA[
-map {
-  "book": map {
+
+{
+  "book": {
     "title": "Data on the Web",
     "year": 2000,
     "author": [
-      map {
+      {
         "last": "Abiteboul",
         "first": "Serge"
       },
-      map {
+      {
         "last": "Buneman",
         "first": "Peter"
       },
-      map {
+      {
         "last": "Suciu",
         "first": "Dan"
       }
@@ -15837,6 +15850,13 @@ map {
   }
 }
     ]]></eg>
+               
+               <note><p>The syntax deliberately mimics JSON, but there are a few differences.
+               JSON constructs that are not accepted in &language; map
+               constructors include the keywords <code>true</code>, <code>false</code>,
+               and <code>null</code>, and backslash-escaped characters such as <code>"\n"</code>
+               in string literals. In an &language; map constructor, of course, any literal 
+               value can be replaced with an expression.</p></note>
 
 
             </div4>
@@ -16006,7 +16026,7 @@ map {
 
                <note>
                   <p>&language; does not provide explicit support for sparse arrays. Use integer-valued maps to represent sparse arrays, 
-                     for example: <code>map { 27 : -1, 153 : 17 } </code>.</p>
+                     for example: <code>{ 27 : -1, 153 : 17 }</code>.</p>
                </note>
 
             </div4>
@@ -16204,12 +16224,12 @@ return if ($m instance of ST) { $m }
                <ulist>
                   <item>
                      <p>
-                        <code>map { "first" : "Jenna", "last" : "Scott" }?first</code> evaluates to <code>"Jenna"</code>
+                        <code>{ "first" : "Jenna", "last" : "Scott" }?first</code> evaluates to <code>"Jenna"</code>
                      </p>
                   </item>
                   <item diff="add" at="A">
                      <p>
-                        <code>map { "first name" : "Jenna", "last name" : "Scott" }?"first name"</code> evaluates to <code>"Jenna"</code>
+                        <code>{ "first name" : "Jenna", "last name" : "Scott" }?"first name"</code> evaluates to <code>"Jenna"</code>
                      </p>
                   </item>
                   <item>
@@ -16218,7 +16238,7 @@ return if ($m instance of ST) { $m }
                   </item>
                   <item>
                      <p>
-                        <code>(map { "first": "Tom" }, map { "first": "Dick" }, map { "first": "Harry" })?first</code> evaluates to the sequence <code>("Tom", "Dick", "Harry")</code>.</p>
+                        <code>({ "first": "Tom" }, { "first": "Dick" }, { "first": "Harry" })?first</code> evaluates to the sequence <code>("Tom", "Dick", "Harry")</code>.</p>
                   </item>
                   <item>
                      <p>
@@ -16393,22 +16413,23 @@ declare function recursive-content($item as item()) as map(*)* {
                
                <note>
                   <p>This is best explained by considering examples.</p>
-                  <p>Consider the expression <code>let $value := [ map { "first": "John", "last": "Smith" }, map { "first": "Mary", "last": "Evans" } ]</code>.</p>
+
+                  <p>Consider the expression <code>let $value := [ { "first": "John", "last": "Smith" }, { "first": "Mary", "last": "Evans" } ]</code>.</p>
                   <p>The recursive content of this array is the sequence of six singleton maps:</p>
                   <olist>
-                     <item><p><code>map { 1: map { "first": "John", "last": "Smith" } }</code></p></item>
-                     <item><p><code>map { 2: map { "first": "Mary", "last": "Evans" } }</code></p></item>
-                     <item><p><code>map { "first": "John" }</code></p></item>
-                     <item><p><code>map { "last": "Smith" }</code></p></item>
-                     <item><p><code>map { "first": "Mary" }</code></p></item>
-                     <item><p><code>map { "last": "Evans" }</code></p></item>
+                     <item><p><code>{ 1: { "first": "John", "last": "Smith" } }</code></p></item>
+                     <item><p><code>{ 2: { "first": "Mary", "last": "Evans" } }</code></p></item>
+                     <item><p><code>{ "first": "John" }</code></p></item>
+                     <item><p><code>{ "last": "Smith" }</code></p></item>
+                     <item><p><code>{ "first": "Mary" }</code></p></item>
+                     <item><p><code>{ "last": "Evans" }</code></p></item>
                   </olist>
                   <p>The expression <code>$value??*</code> returns the sequence 
-                     <code>map { "first": "John", "last": "Smith" }, map { "first": "Mary", "last": "Evans" },
+                     <code>{ "first": "John", "last": "Smith" }, { "first": "Mary", "last": "Evans" },
                      "John", "Smith", "Mary", "Evans"</code>.</p>
                   <p>The expression <code>$value??first</code> returns the sequence <code>"John", "Mary"</code>.</p>
                   <p>The expression <code>$value??last</code> returns the sequence <code>"Smith", "Evans"</code>.</p>
-                  <p>The expression <code>$value??1</code> returns the sequence <code>map { "first": "John", "last": "Smith" }</code>.</p>
+                  <p>The expression <code>$value??1</code> returns the sequence <code>{ "first": "John", "last": "Smith" }</code>.</p>
                </note>
                <note>
                   <p>The effect of evaluating all shallow lookups on maps rather than arrays is that no error arises
@@ -19849,7 +19870,7 @@ local:thrice(try { "oops" } catch * { 3 } )
                <eg role="parse-test"><![CDATA[try {
   1 + <empty/>
 } catch * {
-  serialize($err:map, map { 'method': 'adaptive' })
+  serialize($err:map, {'method':'adaptive'})
 }]]></eg>
             </item>
 
@@ -20371,7 +20392,7 @@ usa:zipcode?)</code>.</p>
                   <p>If <code>my:location</code> is a named item type that expands
                   to <code>record(latitude as xs:double, longitude as xs:double)</code>,
                   then the result of <code>my:location(50.52, -3.02)</code> is
-                  the map <code>map { 'latitude': 50.52e0, 'longitude': -3.02e0 }</code>.</p>
+                  the map <code>{ 'latitude': 50.52e0, 'longitude': -3.02e0 }</code>.</p>
                </item>
             </ulist>
 
@@ -20798,7 +20819,7 @@ raised <errorref
          
          <p>For example, the expression</p>
          
-         <eg>let $rectangle := map {
+         <eg>let $rectangle := {
   "width": 20,
   "height": 12,
   "area": fn($this) { $this?width * $this?height }

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -3307,7 +3307,7 @@
                 as="map(xs:integer, xs:double)" visibility="public"&gt;
     &lt;xsl:param name="real" as="xs:double"/&gt;
     &lt;xsl:param name="imaginary" as="xs:double"/&gt;
-    &lt;xsl:sequence select="map { 0: $real, 1: $imaginary }"/&gt;
+    &lt;xsl:sequence select="{ 0: $real, 1: $imaginary }"/&gt;
   &lt;/xsl:function&gt;
   
   &lt;xsl:function name="f:real" 
@@ -8916,7 +8916,7 @@ and <code>version="1.0"</code> otherwise.</p>
                revisit the same nodes later. There is also a special streamability rule for
                map constructor expressions (see <specref ref="maps-streaming"/>) that allows
                such an expression to make multiple downward selections in the streamed input
-               document: for example one can write <code>map { 'authors': data(author), 'editors': data(editor) }</code>,
+               document: for example one can write <code>{ 'authors': data(author), 'editors': data(editor) }</code>,
                which gathers the values of these two elements, or sets of elements, from the input
                stream, regardless what order they appear in — even if they are interleaved.</p>
                
@@ -14041,8 +14041,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      produce a sequence of single-entry maps (each containing one key and one value), and then applying
                      templates to this sequence, using the current mode, and passing
                      on the values of all template parameters.</p></item>
-                  <item><p>If the map contains a single entry <code>map { <var>K</var> : <var>V/0</var> }</code>, then a new single entry
-                     map <code>map { <var>K</var>: <var>V/1</var> }</code> is constructed in which <var>V/1</var> is the
+                  <item><p>If the map contains a single entry <code>{ <var>K</var> : <var>V/0</var> }</code>, then a new single entry
+                     map <code>{ <var>K</var>: <var>V/1</var> }</code> is constructed in which <var>V/1</var> is the
                      result of applying templates to <var>V/0</var> (using the current mode, and passing
                      on the values of all template parameters).</p>
                      <note><p>This rule has the effect that if the input is a value record, the output will also
@@ -14111,7 +14111,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <olist>
                      <item><p>The outermost array is processed by applying templates to a sequence of value records, 
                         the first being in the form:</p>
-                        <eg>map { "value": map: { "Title": ..., "Author": ..., ... }</eg>
+                        <eg>{ "value": map: { "Title": ..., "Author": ..., ... }</eg>
                      <p>The result of applying templates to these value records is expected to comprise a new sequence
                         of value records, which is used to construct the final output array.</p></item>
                      
@@ -14122,14 +14122,14 @@ and <code>version="1.0"</code> otherwise.</p>
                      <item><p>Each of these books, being represented by a map with more than two entries, is processed by
                      a template rule that splits the map into its multiple entries, each represented as a singleton
                      map (a map with one key and one value). One of these singleton maps, for example, would be
-                     <code>map{"Title": "Steppenwolf"}</code>.</p></item>
+                     <code>{"Title": "Steppenwolf"}</code>.</p></item>
                      
                      <item><p>The default processing for a singleton map of the form 
-                        <code>map { "Title": "Steppenwolf" }</code> is to return the value unchanged.
+                        <code>{ "Title": "Steppenwolf" }</code> is to return the value unchanged.
                         This is achieved by applying templates to the string <code>"Steppenwolf"</code>;
                      the default template rule for strings returns the string unchanged.</p></item>
                      
-                     <item><p>When a singleton map in the form <code>map { "Note": "out of print" }</code> is encountered, no output
+                     <item><p>When a singleton map in the form <code>{ "Note": "out of print" }</code> is encountered, no output
                      is produced, meaning that entry in the parent map is effectively dropped. This is because there
                      is an explicit template rule with <code>match="record(Note)"</code> that matches such singleton maps.</p></item>
                      
@@ -14139,7 +14139,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         The default processing for an array, in which none of the constituents are matched by explicit
                         template rules, ends up delivering a copy of the array.</p></item>
                      
-                     <item><p>When the singleton map <code>"Authors": [ "Enid Blyton", map { "Note": "possibly misattributed" } ]</code>
+                     <item><p>When the singleton map <code>"Authors": [ "Enid Blyton", { "Note": "possibly misattributed" } ]</code>
                         is encountered, the recursive processing results in templates being applied to the map
                         <code>{ "Note": "possibly misattributed" }</code>. This matches the template rule having
                         <code>match="record(Note)"</code>, which returns no output, so the entry is effectively deleted.</p>
@@ -14516,13 +14516,13 @@ and <code>version="1.0"</code> otherwise.</p>
             <p diff="del" at="2022-11-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
             are mutually exclusive: exactly one of these three attributes must be present.</p>
             <p diff="del" at="2022-11-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
-            <code>select="array:for-each(EXPR, function($x) { map { 'value': $x })?*</code>. That is, it maps the
+            <code>select="array:for-each(EXPR, function($x) { { 'value': $x } })?*</code>. That is, it maps the
             elements of an input array to a sequence of items, each item being a map having a single entry, whose
             key is the string <code>value</code> and whose corresponding value is the relevant element of the
             array. Within the contained sequence constructor, the current array element can be referred to
             as <code>?value</code>.</p>
             <p diff="del" at="2022-11-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
-               <code>select="map:for-each(EXPR, function($k, $v) { map { 'key': $k, 'value': $v })</code>. That is, it maps the
+               <code>select="map:for-each(EXPR, function($k, $v) { { 'key': $k, 'value': $v } })</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
@@ -14656,8 +14656,8 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>In this example the expression <code>$array?*</code> cannot be used on the inner arrays
                   because JSON nulls (which translate to an empty sequence in XDM) would be lost. Instead
                   the function <xfunction>array:members</xfunction> is used to create a sequence of
-                  value records: a non-null entry is represented by a value such as <code>map { 'value': 12.3 }</code>,
-                  while a null entry would be <code>map { 'value': () }</code>.</p>
+                  value records: a non-null entry is represented by a value such as <code>{ 'value': 12.3 }</code>,
+                  while a null entry would be <code>{ 'value': () }</code>.</p>
 
             </example>
             <example diff="add" at="2022-11-01">
@@ -14722,13 +14722,13 @@ and <code>version="1.0"</code> otherwise.</p>
             <p diff="del" at="2022-01-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
                are mutually exclusive: exactly one of these three attributes must be present.</p>
             <p diff="del" at="2022-01-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
-               <code>select="array:for-each(EXPR, function($x) { map { 'value': $x })?*</code>. That is, it maps the
+               <code>select="array:for-each(EXPR, function($x) { { 'value': $x } })?*</code>. That is, it maps the
                elements of an input array to a sequence of items, each item being a map having a single entry, whose
                key is the string <code>value</code> and whose corresponding value is the relevant element of the
                array. Within the contained sequence constructor, the current array element can be referred to
                as <code>?value</code>.</p>
             <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
-               <code>select="map:for-each(EXPR, function($k, $v) { map { 'key': $k, 'value': $v })</code>. That is, it maps the
+               <code>select="map:for-each(EXPR, function($k, $v) { { 'key': $k, 'value': $v } })</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
@@ -18905,13 +18905,13 @@ and <code>version="1.0"</code> otherwise.</p>
                <p diff="add" at="2022-01-01">For example, the following <elcode>xsl:function</elcode> declaration
                declares a function, named <code>f:compare</code>, with an arity range of (2 to 3). 
                   The effect of calling <code>f:compare($a, $b)</code> is the same as the effect
-               of calling <code>f:compare($a, $b, map { "order": "ascending" })</code>.</p>
+               of calling <code>f:compare($a, $b, { "order": "ascending" })</code>.</p>
                
                <eg><![CDATA[
 <xsl:function name="f:compare" as="xs:boolean">
   <xsl:param name="arg1" as="xs:double"/>
   <xsl:param name="arg2" as="xs:double"/>
-  <xsl:param name="options" as="map(*)" required="no" select="map { 'order': 'ascending' }"/>
+  <xsl:param name="options" as="map(*)" required="no" select="{ 'order': 'ascending' }"/>
   <xsl:if test="$options?order = 'descending'" then="$arg1 gt $arg2" else="$arg2 gt $arg1"/>
 </xsl:function>]]></eg>
 
@@ -18963,7 +18963,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   (one with <code>required="no"</code>) will often be supplied using a 
                   simple literal or constant expression, for example
                   <code>&lt;xsl:param name="married" as="xs:boolean" select="false()"/></code>,
-                  or <code>&lt;xsl:param name="options" as="map(*)" select="map { }"/></code>. 
+                  or <code>&lt;xsl:param name="options" as="map(*)" select="{ }"/></code>. 
                   However, to allow greater flexibility,
                   the default value can also be context-dependent. For example, 
                   <code>&lt;xsl:param name="node" as="node()" select="."/></code> declares a parameter whose
@@ -23103,13 +23103,13 @@ return if ($i le count($S))
             <p diff="del" at="2022-01-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
                are mutually exclusive: exactly one of these three attributes must be present.</p>
             <p diff="del" at="2022-01-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
-               <code>select="array:for-each(EXPR, function($x) { map { 'value': $x })?*</code>. That is, it maps the
+               <code>select="array:for-each(EXPR, function($x) { { 'value': $x } })?*</code>. That is, it maps the
                elements of an input array to a sequence of items, each item being a map having a single entry, whose
                key is the string <code>value</code> and whose corresponding value is the relevant element of the
                array. Within the contained sequence constructor, the current array element can be referred to
                as <code>?value</code>.</p>
             <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
-               <code>select="map:for-each(EXPR, function($k, $v) { map { 'key': $k, 'value': $v })</code>. That is, it maps the
+               <code>select="map:for-each(EXPR, function($k, $v) { { 'key': $k, 'value': $v } })</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
@@ -25932,7 +25932,7 @@ the same group, and the-->
                      are exempt from the usual rule that multiple downward selections are not allowed):</p>
                   
                   <eg xml:space="preserve" role="xslt-instruction">&lt;xsl:source-document streamable="yes" href="transactions.xml"&gt;
-  &lt;xsl:variable name="tally" select="map { 'count': count(transactions/transaction), 
+  &lt;xsl:variable name="tally" select="{ 'count': count(transactions/transaction), 
                                           'max': max(transactions/transaction/@value) }"/&gt;
   &lt;value count="{ $tally('count') }" max="{ $tally('max') }"/&gt;
 &lt;/xsl:source-document&gt;</eg>
@@ -26483,7 +26483,7 @@ the same group, and the-->
                <p><termdef id="dt-traversal-event" term="traversal-event">a <term>traversal
                         event</term> (shortened to <term>event</term> in this section) is a pair
                      comprising a phase (start or end) and a node.</termdef> It is modelled as a map
-                  with two entries: <code>map { "phase": p, "node": n }</code> where p is the string
+                  with two entries: <code>{ "phase": p, "node": n }</code> where p is the string
                      <code>"start"</code> or <code>"end"</code> and <code>n</code> is a node.</p>
                <p>The traversal of a tree contains two
                   traversal events for each node in the tree, other than attribute and namespace
@@ -26572,12 +26572,12 @@ the same group, and the-->
                   <item>
                      <p>Let <var>SB</var> be the subsequence of <var>T</var> starting at the first
                         event in <var>T</var> and ending with the start event for node <var>N</var>
-                        (that is, the event <code>map { "phase": "start", "node": N }</code>).</p>
+                        (that is, the event <code>{ "phase": "start", "node": N }</code>).</p>
                   </item>
                   <item>
                      <p>Let <var>SA</var> be the subsequence of <var>T</var> starting at the first
                         event in <var>T</var>, and ending with the  end event
-                        for node <var>N</var> (that is, the event <code>map { "phase": "end", "node": N
+                        for node <var>N</var> (that is, the event <code>{ "phase": "end", "node": N
                            }</code>).</p>
                   </item>
                   <item>
@@ -26697,8 +26697,8 @@ the same group, and the-->
                   <p>and the requirement is to generate a glossary that lists all the defined terms in the document, as an appendix.</p>
                   <p>This can be achieved by capturing all the defined terms in a map:</p>
                   <eg><![CDATA[<xsl:accumulator name="glossary-terms" 
-         as="map { xs:string, element(define) }" 
-         initial-value="map { }"
+         as="{ xs:string, element(define) }" 
+         initial-value="{ }"
          streamable="yes">
    <xsl:accumulator-rule match="define[@term]" 
            phase="end" 
@@ -27021,7 +27021,7 @@ the same group, and the-->
 
                   <eg role="xslt-declaration" xml:space="preserve">
  &lt;xsl:accumulator name="histogram" as="map(xs:string, xs:integer)"
-    initial-value="map { }"&gt;
+    initial-value="{ }"&gt;
     &lt;xsl:accumulator-rule match="book"&gt;
       &lt;xsl:choose&gt;
         &lt;xsl:when test="map:contains($value, @publisher)"&gt;
@@ -27760,7 +27760,7 @@ the same group, and the-->
                   </tr>
                   <tr>
                      <td rowspan="1" colspan="1">MapConstructor [,69]</td>
-                     <td rowspan="1" colspan="1"><code>map { "A": E, "B": F }</code></td>
+                     <td rowspan="1" colspan="1"><code>{ "A": E, "B": F }</code></td>
                      <td rowspan="1" colspan="1"><var>U{function(*)}</var></td>
                   </tr>
                   <tr>
@@ -32965,7 +32965,7 @@ the same group, and the-->
                         <elcode>xsl:map-entry</elcode> instructions is then wrapped in an
                         <elcode>xsl:map</elcode> parent instruction.</p>
 
-                  <p>For example, the map constructor <code>map { 'red': false(),
+                  <p>For example, the map constructor <code>{ 'red': false(),
                         'green': true() }</code> translates to the instruction:</p>
                   <eg role="xslt-instruction" xml:space="preserve">
 &lt;xsl:map&gt;
@@ -35110,7 +35110,7 @@ the same group, and the-->
 
             <note>
                <p>So, given a map <code>$M</code> whose keys are integers and whose results are
-                  strings, such as <code>map { 0: "no", 1: "yes" }</code>, the following relations hold,
+                  strings, such as <code>{ 0: "no", 1: "yes" }</code>, the following relations hold,
                   among others:</p>
                <ulist>
                   <item>
@@ -35514,7 +35514,7 @@ the same group, and the-->
                a dynamic error occurs <errorref spec="XT" class="DE" code="3365"/>.</p>
             <p>For example, the following expression constructs a map with seven entries:</p>
             <eg role="non-xml" xml:space="preserve">
-map {
+{
   "Su" : "Sunday",
   "Mo" : "Monday",
   "Tu" : "Tuesday",
@@ -35569,7 +35569,7 @@ map {
                downward selections:</p>
 
             <eg role="non-xml" xml:space="preserve">
-let $m := map { 'price': xs:decimal(price), 'discount': xs:decimal(discount) } 
+let $m := { 'price': xs:decimal(price), 'discount': xs:decimal(discount) } 
 return ($m?price - $m?discount)</eg>
 
             <p>Analysis:</p>
@@ -35611,7 +35611,7 @@ return ($m?price - $m?discount)</eg>
   &lt;xsl:iterate select="*/employee"&gt;
     &lt;xsl:param name="highest-earners" 
                as="map(xs:string, element(employee))" 
-               select="map { }"/&gt;
+               select="{ }"/&gt;
     &lt;xsl:on-completion&gt;
       &lt;xsl:for-each select="map:keys($highest-earners)"&gt;
         &lt;department name="{.}"&gt;
@@ -35646,7 +35646,7 @@ return ($m?price - $m?discount)</eg>
 &lt;xsl:function name="i:complex" as="map(xs:int, xs:double)"&gt;
   &lt;xsl:param name="real" as="xs:double"/&gt;
   &lt;xsl:param name="imaginary" as="xs:double"/&gt;
-  &lt;xsl:sequence select="map { $REAL: $real, $IMAG: $imaginary }"/&gt;
+  &lt;xsl:sequence select="{ $REAL: $real, $IMAG: $imaginary }"/&gt;
 &lt;/xsl:function&gt;
 
 &lt;xsl:function name="i:real" as="xs:double"&gt;
@@ -35690,7 +35690,7 @@ return ($m?price - $m?discount)</eg>
                <p>An index may be constructed as follows: </p>
                <eg role="xslt-declaration xmlns:map='http://www.w3.org/2005/xpath-functions/map" xml:space="preserve">
 &lt;xsl:variable name="isbn-index" as="map(xs:string, element(book))"
-    select="map:merge(for $b in //book return map { $b/isbn: $b })"/&gt;</eg>
+    select="map:merge(for $b in //book return { $b/isbn: $b })"/&gt;</eg>
                <p>This index may then be used to retrieve the book for a given ISBN using either of
                   the expressions <code>map:get($isbn-index, "0470192747")</code> or
                      <code>$isbn-index("0470192747")</code>.</p>
@@ -35744,7 +35744,7 @@ return ($m?price - $m?discount)</eg>
                   formats. For example, with the first format the implementation might be:</p>
                <eg role="xslt-declaration" xml:space="preserve">
 &lt;xsl:variable name="flat-input-functions" as="map(xs:string, function(*))*"
-  select="map {
+  select="{
             'orders-for-customer' : 
                  function($c as element(customer)) as element(order)* 
                     { $c/../order[@customer = $c/@id] },
@@ -36186,7 +36186,7 @@ return ($m?price - $m?discount)</eg>
                the function is evaluated. Maps are a new data type introduced in XSLT 3.0.</p>
             <p>For example, the function <code>fn:xml-to-json</code> has an options parameter
                allowing specification of whether the output is to be indented. A call might be written:</p>
-            <eg role="xpath" xml:space="preserve">xml-to-json($input, map { 'indent': true() })</eg>
+            <eg role="xpath" xml:space="preserve">xml-to-json($input, { 'indent': true() })</eg>
             <p><termdef id="option-parameter-conventions" term="option parameter conventions">Functions
                that take an options parameter adopt common conventions on how the
                options are used. These are referred to as the <term>option parameter conventions</term>. These


### PR DESCRIPTION
Makes the keyword "map" in map constructors optional.

Fix #1070