### PR TITLE
883-return-type-of-load-xquery-module

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -42,6 +42,13 @@
       </fos:record>
    </fos:type>
    
+   <fos:type id="load-xquery-module-record">
+      <fos:record extensible="true">
+         <fos:field name="variables" type="map(xs:QName, item()*)" required="true"/>
+         <fos:field name="functions" type="map(xs:QName, map(xs:integer, function(*)))" required="true"/>
+      </fos:record>
+   </fos:type>
+   
    <fos:type id="sort-key-record">
       <fos:record extensible="true">
          <fos:field name="key" type="function(item()) as xs:anyAtomicType*" required="true"/>
@@ -26754,7 +26761,7 @@ declare function flatten(
  
    <fos:function name="load-xquery-module" prefix="fn">
       <fos:signatures>
-         <fos:proto name="load-xquery-module" return-type="map(*)">
+         <fos:proto name="load-xquery-module" return-type-ref="load-xquery-module-record">
             <fos:arg name="module-uri" type="xs:string"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
          </fos:proto>
@@ -26834,6 +26841,9 @@ declare function flatten(
 
   
          <p>The result of the function is a map <var>R</var> with two entries:</p>
+         
+         <?type load-xquery-module-record?>
+         
          <olist>
             <item>
                <p>There is an entry whose key is the <code>xs:string</code> value <code>"variables"</code> and whose associated value


### PR DESCRIPTION
Use a record type for the return type of the function.

Fix #883