### PR TITLE
Confirm status of provisional functions

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13833,7 +13833,7 @@ return slice($input, $start, $end)</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
+         <fos:version version="4.0">Accepted for 4.0.</fos:version>
       </fos:history>
    </fos:function>
    
@@ -21953,7 +21953,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       </fos:examples>
    </fos:function>
 
-   <fos:function name="substitute" prefix="map">
+   <!--<fos:function name="substitute" prefix="map">
       <fos:signatures>
          <fos:proto name="substitute" return-type="map(*)">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
@@ -22002,7 +22002,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
          </fos:example>
 
       </fos:examples>
-   </fos:function>
+   </fos:function>-->
 
    <fos:function name="build" prefix="map">
       <fos:signatures>
@@ -24530,7 +24530,7 @@ return
       </fos:notes>
    </fos:function>
    
-   <fos:function name="json" prefix="fn">
+   <!--<fos:function name="json" prefix="fn">
       <fos:signatures>
          <fos:proto name="json" return-type="xs:string">
             <fos:arg name="input" type="xs:string?"/>
@@ -24839,7 +24839,7 @@ return
          <fos:version version="4.0">Proposed for 4.0; not yet reviewed.</fos:version>
       </fos:history>
    </fos:function>
-
+-->
 
    <fos:function name="size" prefix="array">
       <fos:signatures>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6912,9 +6912,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-xml-to-json">
                <head><?function fn:xml-to-json?></head>
             </div3>
-            <div3 id="func-json" diff="add" at="A">
+            <!--<div3 id="func-json" diff="add" at="A">
                <head><?function fn:json?></head>
-            </div3>
+            </div3>-->
             <div3 id="func-pin" diff="add" at="A">
                <head><?function fn:pin?></head>
             </div3>
@@ -7794,9 +7794,9 @@ return <table>
             <div3 id="func-map-size">
                <head><?function map:size?></head>
             </div3>
-            <div3 id="func-map-substitute" diff="add" at="A">
+            <!--<div3 id="func-map-substitute" diff="add" at="A">
                <head><?function map:substitute?></head>
-            </div3>
+            </div3>-->
             <div3 id="func-map-values" diff="add" at="2023-04-19">
                <head><?function map:values?></head>
             </div3>
@@ -11891,6 +11891,7 @@ ISBN 0 521 77752 6.</bibl>
               <item><p><code>fn:slice</code></p></item>
               <item><p><code>fn:some</code></p></item>
               <item><p><code>fn:sort-with</code></p></item>
+              <item><p><code>fn:stack-trace</code></p></item>
               <item><p><code>fn:starts-with-subsequence</code></p></item>
               <item><p><code>fn:subsequence-where</code></p></item>
               <!--<item><p><code>fn:subsequence-before</code></p></item>
@@ -11908,6 +11909,7 @@ ISBN 0 521 77752 6.</bibl>
               <item><p><code>array:index-where</code></p></item>
               <item><p><code>array:members</code></p></item>
               <item><p><code>array:of-members</code></p></item>
+              <item><p><code>array:replace</code></p></item>
               <item><p><code>array:slice</code></p></item>
               <item><p><code>array:split</code></p></item>
               <item><p><code>array:trunk</code></p></item>
@@ -11915,21 +11917,16 @@ ISBN 0 521 77752 6.</bibl>
               <item><p><code>map:build</code></p></item>
               <item><p><code>map:empty</code></p></item>
               <item><p><code>map:entries</code></p></item>
+              <item><p><code>map:filter</code></p></item>
               <item><p><code>map:keys-where</code></p></item>
               <item><p><code>map:of-pairs</code></p></item>
               <item><p><code>map:pair</code></p></item>
               <item><p><code>map:pairs</code></p></item>
+              <item><p><code>map:replace</code></p></item>
               <item><p><code>map:values</code></p></item>
            </ulist>
 
-           <p>A number of functions are included in the draft specification but have not yet been reviewed or accepted:</p>
-           <ulist>
-              <item><p><code>fn:stack-trace</code></p></item>
-              <item><p><code>map:filter</code></p></item>
-              <item><p><code>map:replace</code></p></item>
-              <item><p><code>map:substitute</code></p></item>
-              <item><p><code>array:replace</code></p></item>
-           </ulist>
+           
            
 	     </div2>
 	     <div2 id="changes-to-existing-functions">
@@ -11950,27 +11947,24 @@ ISBN 0 521 77752 6.</bibl>
 	              a sequence in a single call.</p></item>
 	           <item><p>The <code>fn:replace</code> function has an additional optional argument
 	              allowing the replacement string to be computed from the matched input string.</p></item>
-	        </olist>
-	        <p>The following changes are present in this draft, but have not been agreed by the community group:</p>
-	        <olist>
-	           
 	           <item><p>The third argument of <code>fn:format-number</code> can now be supplied
 	              as an <code>xs:QName</code> instead of as a string that can be converted to a QName.
 	              Using a <code>xs:QName</code>, especially in the (rare) cases when the value is
 	              supplied dynamically, avoids the need to maintain the static namespace context
-	              at execution time.</p></item>
-	           
+	              at execution time. In addition an extra argument has been added to <code>fn:format-number</code>
+	           to allow the decimal format to be supplied explicitly.</p></item>
 	           <item><p>The function <code>fn:xml-to-json</code> accepts an additional option:
 	              <code>number-formatter</code> allows the user to control the formatting of numeric 
 	              values, for example by preventing the use of exponential notation for large integers.</p></item>
-	           
-	           <item><p>In the functions <code>fn:substring</code>, <code>fn:subsequence</code>,
+	           <item><p>In many functions including <code>fn:substring</code>, <code>fn:subsequence</code>,
 	              <code>fn:unparsed-text</code>, <code>fn:unparsed-text-available</code>, <code>fn:unparsed-text-lines</code>,
-	           and <code>array:subarray</code>, <code>fn:resolve-uri</code>, <code>fn:error</code>, and <code>fn:trace</code>,
+	              <code>array:subarray</code>, <code>fn:resolve-uri</code>, <code>fn:error</code>, and <code>fn:trace</code>,
 	              arguments that can be omitted can now also be set to an empty sequence;
-	           the effect of supplying an empty sequence is equivalent to the effect of not supplying the argument.</p></item>
+	              the effect of supplying an empty sequence is equivalent to the effect of not supplying the argument.</p></item>
+	           
 	           
 	        </olist>
+	        
 	     </div2>
 	     <div2 id="changes-to-casts-and-constructors">
 	        <head>Changes to Casts and Constructor Functions</head>


### PR DESCRIPTION
The purpose of this PR is to bring the current F&O draft specification into a state where it is confirmed as the current status quo accepted by the CG.

The following functions (mainly new, some amended) that have been present in the draft for some while, but with caveats about their status, are confirmed as part of the status quo:

- fn:slice
- fn:format-number
- fn:stack-trace
- map:filter
- map:replace
- array:replace

The following functions are dropped (for the time being):

- fn:json
- map:substitute

The actual PR essentially changes text that alludes to the status of these functions, it does not change the actual specifications.

The current state of qt4tests in relation to these functions is:

fn:slice - OK
fn:format-number - missing tests for recent changes
fn:stack-trace - no tests
map:filter - OK
map:replace - no tests
array:replace - no tests
fn:json - no tests
map:substitute - no tests