### PR TITLE
Correct the status of new language features

### DIFF
--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1600,7 +1600,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
   <div3 id="id-substantive-changes-since-3.1">
     <head>Substantive Changes</head>
   
-  <p>The following changes have been agreed by the working group:</p>
+  <p>The following changes have been made:</p>
     <olist>
       <item><p>The concept of the context item has been generalized, so it is now a context value. That is,
       it is no longer constrained to be a single item.</p></item>
@@ -1682,42 +1682,35 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       <item role="xquery"><p>The <termref def="dt-default-namespace-elements-and-types"/> can now be declared to be fixed
       for a query module, meaning it is unaffected by a namespace declaration appearing on a direct
       element constructor.</p></item>
+      
+      <item><p>The rules for reporting type errors during static analysis have been changed
+        so that a processor has more freedom to report errors in respect of constructs that
+        are evidently wrong, such as <code>@price/@value</code>, even though dynamic evaluation
+        is defined to return an empty sequence rather than an error.</p></item>
+      <item><p>Record types are added as a new kind of <code>ItemType</code>, constraining
+        the value space of maps.</p></item>
+      <item><p>Local union types are added as a new kind of <code>ItemType</code>, constraining
+        the value space of atomic values.</p></item>
+      <item><p>Enumeration types are added as a new kind of <code>ItemType</code>, constraining
+        the value space of strings.</p></item>
+      
+      
+      
+      
+      <item><p>The lookup operator <code>?</code> can now be followed by a string literal, for cases where
+        map keys are strings other than NCNames.</p></item>
+      
+      
+      <item><p>The rules for value comparisons when comparing values of different types (for example, decimal and double)
+        have changed to be transitive. A decimal value is no longer converted to double, instead the double is converted
+        to a decimal without loss of precision. This may affect compatibility in edge cases involving comparison of
+        values that are numerically very close.</p></item>
+      <item><p>A <code>for member</code> clause is added to FLWOR expressions to allow iteration over
+        an array.</p></item>
 
     </olist>
     
-    <p>The following changes are present in this draft, but are awaiting review and agreement:</p>
-  <olist>
-   
-    <item><p>A new <code>with</code> expression allows namespace bindings to be defined
-    within an expression (and to be redefined in nested expressions).</p></item>
     
-    <item><p>The rules for reporting type errors during static analysis have been changed
-    so that a processor has more freedom to report errors in respect of constructs that
-    are evidently wrong, such as <code>@price/@value</code>, even though dynamic evaluation
-    is defined to return an empty sequence rather than an error.</p></item>
-    <item><p>Record types are added as a new kind of <code>ItemType</code>, constraining
-      the value space of maps.</p></item>
-    <item><p>Local union types are added as a new kind of <code>ItemType</code>, constraining
-      the value space of atomic values.</p></item>
-    <item><p>Enumeration types are added as a new kind of <code>ItemType</code>, constraining
-      the value space of strings.</p></item>
-    
- 
-    
-    
-    <item><p>The lookup operator <code>?</code> can now be followed by a string literal, for cases where
-    map keys are strings other than NCNames.</p></item>
-    
-    
-    <item><p>The rules for value comparisons when comparing values of different types (for example, decimal and double)
-    have changed to be transitive. A decimal value is no longer converted to double, instead the double is converted
-    to a decimal without loss of precision. This may affect compatibility in edge cases involving comparison of
-    values that are numerically very close.</p></item>
-    <item><p>A <code>for member</code> clause is added to FLWOR expressions to allow iteration over
-    an array.</p></item>
-    
- 
-  </olist>
   </div3>
   <div3 id="id-editorial-changes-since-3.1">
     <head>Editorial Changes</head>


### PR DESCRIPTION
This PR corrects the status of certain language features that the change appendix in the spec incorrectly describes as having not been accepted by the WG., The features in question are:

> The rules for reporting type errors during static analysis have been changed
>     so that a processor has more freedom to report errors in respect of constructs that
>     are evidently wrong, such as `@price/@value`, even though dynamic evaluation
>     is defined to return an empty sequence rather than an error.

This change has in fact been discussed and accepted by the group.  See PRs #603 and #884.

>     Record types are added as a new kind of ItemType, constraining
>       the value space of maps.

Record types have become a fundamental feature of much of our work, with many additional capabilities relying on them. They became an official part of the spec with the closure of issue #172. 

>     Local union types are added as a new kind of ItemType, constraining
>       the value space of atomic values.

>    Enumeration types are added as a new kind of <code>ItemType</code>, constraining
      the value space of strings.

Local union types and enumeration types became an official part of the spec with the acceptance of PR #691
    
>  The lookup operator <code>?</code> can now be followed by a string literal, for cases where
>     map keys are strings other than NCNames.
>     

These changes were endorsed by acceptance of PR #926.
    

> The rules for value comparisons when comparing values of different types (for example, decimal and double)
>     have changed to be transitive. A decimal value is no longer converted to double, instead the double is converted
>     to a decimal without loss of precision. This may affect compatibility in edge cases involving comparison of
>     values that are numerically very close.

We still have open issues regarding comparison, conversion, and promotion of numeric values. See for example issue #986. So we may yet decide to roll back these changes. For practical purposes it's sensible to treat the current text as status quo, since so many individual changes have been made that unwinding can only be treated as a new issue. 

> A `for member` clause is added to FLWOR expressions to allow iteration over
>     an array.

The current specification of `for member` results from the acceptance of PR #752.
