### PR TITLE
1060 Formatting XPath/XQuery

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30757,13 +30757,13 @@ return $result
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>pin([ "a", "b", "c" ])?1 => label()?parent => array:foot()</fos:expression>
+               <fos:expression>pin([ "a", "b", "c" ])?1 ! label(.)?parent ! array:foot(.)</fos:expression>
                <fos:result>"c"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>pin([ "a", "b", "c", "d" ]) => array:remove(2)?* =!> label()?key </fos:expression>
+               <fos:expression>pin([ "a", "b", "c", "d" ]) ! array:remove(., 2)?* ! label(.)?key</fos:expression>
                <fos:result>1, 3, 4</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17996,12 +17996,12 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             <p>The expression <code>parse-html(())</code> returns <code>()</code>.</p>
             <p>The expression <code>parse-html("&lt;p>Hello&lt;/p>")</code> returns an XDM
                document node for a HTML document with a single paragraph within the body element.</p>
-            <p>The expression <code>parse-html("&lt;p>Hi&lt;/p>", method:=&quot;html&quot;)</code>
+            <p>The expression <code>parse-html("&lt;p>Hi&lt;/p>", method := &quot;html&quot;)</code>
                is equivalent to <code>parse-html("&lt;p>Hi&lt;/p>")</code>.</p>
-            <p>The expression <code>parse-html($html, method:=&quot;tidy&quot;)</code> could use
+            <p>The expression <code>parse-html($html, method := &quot;tidy&quot;)</code> could use
                the <emph>tidy</emph> application or library to parse <code>$html</code> if supported
                by the implementation. Otherwise an <errorref class="DC" code="0012"/> error is raised.</p>
-            <p>The expression <code>parse-html($html, method:=&quot;tagsoup&quot;, nons:=true())</code>
+            <p>The expression <code>parse-html($html, method := &quot;tagsoup&quot;, nons := true())</code>
                could use the <emph>tagsoup</emph> application to parse <code>$html</code> if supported
                by the implementation, passing the <code>--nons</code> argument to the application.</p>
             <p>[TODO: The examples depend on keyword arguments.]</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -330,7 +330,7 @@
                <fos:error-result error-code="XPTY0004"/>
             </fos:test>
             <fos:test>
-               <fos:expression>string([[1, 2], [3, 4]])</fos:expression>
+               <fos:expression>string([ [ 1, 2 ], [ 3, 4 ] ])</fos:expression>
                <fos:error-result error-code="FOTY0014"/>
             </fos:test>
             <fos:test>
@@ -425,7 +425,7 @@
                <fos:result>123, 456</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>data([[1,2],[3,4]])</fos:expression>
+               <fos:expression>data([ [ 1, 2 ], [ 3, 4 ] ])</fos:expression>
                <fos:result>1, 2, 3, 4</fos:result>
             </fos:test>
          </fos:example>
@@ -4836,7 +4836,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       <fos:signatures>
          <fos:proto name="hash" return-type="xs:hexBinary?">
             <fos:arg name="value" type="union(xs:string, xs:hexBinary, xs:base64Binary)?"/>
-            <fos:arg name="options" type="map(*)?" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" default="map { }"/>
             <!--<fos:arg name="algorithm" type="xs:string?" default="'MD5'"/>-->
          </fos:proto>
       </fos:signatures>
@@ -4940,14 +4940,14 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hash("ABC", map{"algorithm": "SHA-1"}) 
+               <fos:expression>hash("ABC", map { "algorithm": "SHA-1" }) 
 => string()</fos:expression>
                <fos:result>"3C01BDBB26F358BAB27F267924AA2C9A03FCFDB8"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>hash("ABC", map{"algorithm": "sha-256"})
+               <fos:expression>hash("ABC", map { "algorithm": "sha-256" })
 => string()</fos:expression>
                <fos:result>"B5D4045C3F466FA91FE2CC6ABE79232A1A57CDF104F7A26E716E0A1E2789DF78"</fos:result>
             </fos:test>
@@ -4961,7 +4961,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test use="v-hash-doc">
-               <fos:expression>hash(serialize($doc), map{"algorithm": "sha-1"}) 
+               <fos:expression>hash(serialize($doc), map { "algorithm": "sha-1" }) 
 => xs:base64Binary()                  
 => string()</fos:expression>
                <fos:result>"nJuRPrG2JU9HN86Ufv0W8W6Rb51u5cEQKiAC5I1MiL0="</fos:result>
@@ -4969,7 +4969,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:example>
          <fos:example>
             <fos:test use="v-hash-salt">
-               <fos:expression>hash("password123" || $salt, map{"algorithm": "SHA-256"}) 
+               <fos:expression>hash("password123" || $salt, map { "algorithm": "SHA-256" }) 
 => string()</fos:expression>
                <fos:result>"9C9B913EB1B6254F4737CE947EFD16F16E916F9D6EE5C1102A2002E48D4C88BD"</fos:result>
             </fos:test>
@@ -11299,8 +11299,8 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <fos:example>
             <fos:test use="v-in-scope-namespaces-e" spec="XQuery">
                <fos:expression>in-scope-namespaces($e)</fos:expression>
-               <fos:result>map{"": "http://example.org/one", "z": "http://example.org/two",
-                  "xml": "http://www.w3.org/XML/1998/namespace"}</fos:result>
+               <fos:result>map { "": "http://example.org/one", "z": "http://example.org/two",
+                  "xml": "http://www.w3.org/XML/1998/namespace" }</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -12008,7 +12008,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
                   <item>
                      <p>If the namespace node has no name (that is, it represents the default
                         namespace):
-                           <code>namespace::*[Q{http://www.w3.org/2005/xpath-functions}local-name()=""]</code></p>
+                           <code>namespace::*[Q{http://www.w3.org/2005/xpath-functions}local-name() = ""]</code></p>
                   </item>
                </olist>
             </item>
@@ -12145,8 +12145,8 @@ Himmlische, dein Heiligtum.</p>}]]>
          </fos:example>
          <fos:example>
             <eg xml:space="preserve">let $i := &lt;tool&gt;wrench&lt;/tool&gt;
-let $o := &lt;order&gt; {$i} &lt;quantity&gt;5&lt;/quantity&gt; &lt;/order&gt;
-let $odoc := document {$o}
+let $o := &lt;order&gt; { $i } &lt;quantity&gt;5&lt;/quantity&gt; &lt;/order&gt;
+let $odoc := document { $o }
 let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
@@ -12465,7 +12465,7 @@ let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>index-of([1, [5, 6], [6, 7]], 6)</fos:expression>
+               <fos:expression>index-of([ 1, [ 5, 6 ], [ 6, 7 ] ], 6)</fos:expression>
                <fos:result>(3, 4)</fos:result>
                <fos:postamble>The array is atomized to a sequence of five integers</fos:postamble>
             </fos:test>
@@ -12518,7 +12518,7 @@ let $newi := $o/tool</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>empty(map{})</fos:expression>
+               <fos:expression>empty(map { })</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -12577,7 +12577,7 @@ return empty($break)
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>exists(map{})</fos:expression>
+               <fos:expression>exists(map { })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -12764,7 +12764,7 @@ return exists($break)
       <fos:notes>
          <p>The effect of the function is equivalent to the following XSLT expression:</p>
          <eg><![CDATA[
-<xsl:for-each-group select="$values" group-by="." collation="{$collation}">
+<xsl:for-each-group select="$values" group-by="." collation="{ $collation }">
   <xsl:sequence select="current-group()[2]"/>
 </xsl:for-each>
 ]]></eg>
@@ -13043,8 +13043,8 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>head([1,2,3])</fos:expression>
-               <fos:result>[1,2,3]</fos:result>
+               <fos:expression>head([ 1, 2, 3 ])</fos:expression>
+               <fos:result>[ 1, 2, 3 ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -13098,7 +13098,7 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>tail([1,2,3])</fos:expression>
+               <fos:expression>tail([ 1, 2, 3 ])</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -13153,7 +13153,7 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>trunk([1,2,3])</fos:expression>
+               <fos:expression>trunk([ 1, 2, 3 ])</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
@@ -13367,15 +13367,15 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>reverse([1,2,3])</fos:expression>
-               <fos:result>[1,2,3]</fos:result>
+               <fos:expression>reverse([ 1, 2, 3 ])</fos:expression>
+               <fos:result>[ 1, 2, 3 ]</fos:result>
                <fos:postamble>The input is a sequence containing a single item (the array)</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>reverse(([1,2,3],[4,5,6]))</fos:expression>
-               <fos:result>([4,5,6],[1,2,3])</fos:result>
+               <fos:expression>reverse(([ 1, 2, 3 ], [ 4, 5, 6 ]))</fos:expression>
+               <fos:result>([ 4, 5, 6 ], [ 1, 2, 3 ])</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -13508,18 +13508,18 @@ return slice($input, $start, $end)</eg>
          <code>$input</code> sequence, but there is no mechanism to select an end position
          relative to the start position. If this is needed, the function can be combined with others:
          for example, to select a subsequence of four items starting with <code>"Barbara"</code>,
-         use <code>$input => subsequence-where(fn{. eq "Barbara"}) => slice(end:=4)</code>.</p>
+         use <code>$input => subsequence-where(fn {. eq "Barbara" }) => slice(end := 4)</code>.</p>
          
          <p>If the requirement is to select all elements stopping before the first <code>h2</code>
             element if it exists, or up to the end of the sequence otherwise, the simplest
          solution is perhaps to write:</p> 
-            <eg>slice($input, end:=index-where($input, fn{boolean(self::h2)})[1])</eg>
+            <eg>slice($input, end:=index-where($input, fn { boolean(self::h2) })[1])</eg>
       </fos:notes>
 
       
       <fos:examples role="wide">
          <fos:variable name="seq" id="v-subseq-seq"><![CDATA[("Anna", "Barbara", "Catherine", "Delia", 
-               "Eliza", "Freda", "Gertrude", "Hilda")]]></fos:variable>
+  "Eliza", "Freda", "Gertrude", "Hilda")]]></fos:variable>
          <fos:example>
             <fos:test use="v-subseq-seq">
                <fos:expression>subsequence-where($seq, starts-with(?, "E"))</fos:expression>
@@ -13528,13 +13528,13 @@ return slice($input, $start, $end)</eg>
          </fos:example>
          <fos:example>
             <fos:test use="v-subseq-seq">
-               <fos:expression>subsequence-where($seq, to:=starts-with(?, "D"))</fos:expression>
+               <fos:expression>subsequence-where($seq, to := starts-with(?, "D"))</fos:expression>
                <fos:result>("Anna", "Barbara", "Catherine", "Delia")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-subseq-seq">
-               <fos:expression>subsequence-where($seq, to:=starts-with(?, "D")) => trunk()</fos:expression>
+               <fos:expression>subsequence-where($seq, to := starts-with(?, "D")) => trunk()</fos:expression>
                <fos:result>("Anna", "Barbara", "Catherine")</fos:result>
             </fos:test>
          </fos:example>
@@ -13546,7 +13546,7 @@ return slice($input, $start, $end)</eg>
          </fos:example>
          <fos:example>
             <fos:test use="v-subseq-seq">
-               <fos:expression>subsequence-where($seq, starts-with(?, "D"), fn{string-length(.) gt 5})</fos:expression>
+               <fos:expression>subsequence-where($seq, starts-with(?, "D"), fn { string-length(.) gt 5 })</fos:expression>
                <fos:result>("Delia", "Eliza", "Freda", "Gertrude")</fos:result>
             </fos:test>
          </fos:example>
@@ -13566,19 +13566,24 @@ return slice($input, $start, $end)</eg>
             <fos:test use="v-subseq-seq">
                <fos:expression>subsequence-where($seq)</fos:expression>
                <fos:result>("Anna", "Barbara", "Catherine", "Delia", "Eliza", 
-      "Freda", "Gertrude", "Hilda")</fos:result>
+ "Freda", "Gertrude", "Hilda")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-subseq-seq">
-               <fos:expression>subsequence-where($seq, fn($it, $pos){ends-with($it, "a") and $pos gt 5})</fos:expression>
+               <fos:expression><eg>subsequence-where(
+  $seq,
+  fn($it, $pos) { ends-with($it, "a") and $pos gt 5 }
+)</eg></fos:expression>
                <fos:result>("Freda", "Gertrude", "Hilda")</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test use="v-subseq-seq">
-               <fos:expression>subsequence-where($seq, 
-                  to := fn($it, $pos){ends-with($it, "a") and $pos ge 5})</fos:expression>
+               <fos:expression><eg>subsequence-where(
+  $seq, 
+  to := fn($it, $pos) { ends-with($it, "a") and $pos ge 5 }
+)</eg></fos:expression>
                <fos:result>("Anna", "Barbara", "Catherine", "Delia", "Eliza")</fos:result>
             </fos:test>
          </fos:example>
@@ -14351,7 +14356,7 @@ return contains-subsequence(
             <fos:arg name="input1" type="item()*" usage="absorption"/>
             <fos:arg name="input2" type="item()*" usage="absorption"/>
             <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
-            <fos:arg name="options" type="map(*)?" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="2">
@@ -14989,13 +14994,13 @@ declare function equal-strings(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>deep-equal([1, 2, 3], [1, 2, 3])</fos:expression>
+               <fos:expression>deep-equal([ 1, 2, 3], [ 1, 2, 3 ])</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>deep-equal((1, 2, 3), [1, 2, 3])</fos:expression>
+               <fos:expression>deep-equal((1, 2, 3), [ 1, 2, 3 ])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -15075,7 +15080,7 @@ declare function equal-strings(
                <fos:expression><eg><![CDATA[deep-equal(
   parse-xml("<a><b/><c/></a>"),
   parse-xml("<a><c/><b/></a>"),
-  options := map {'unordered-elements': xs:QName('a') }
+  options := map { 'unordered-elements': xs:QName('a') }
 )]]></eg></fos:expression>
                <fos:result>true()</fos:result>
                <fos:postamble>The <code>unordered-elements</code> option means that the ordering of the children
@@ -15172,7 +15177,7 @@ declare function equal-strings(
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>count([1,2,3])</fos:expression>
+               <fos:expression>count([ 1, 2, 3 ])</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>        
@@ -15359,13 +15364,13 @@ declare function equal-strings(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>max((3,2,1))</fos:expression>
+               <fos:expression>max((3, 2, 1))</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>max([3,2,1])</fos:expression>
+               <fos:expression>max([ 3, 2, 1 ])</fos:expression>
                <fos:result>3</fos:result>
                <fos:postamble>Arrays are atomized</fos:postamble>
             </fos:test>
@@ -15502,13 +15507,13 @@ declare function equal-strings(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>min((3,4,5))</fos:expression>
+               <fos:expression>min((3, 4, 5))</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>min([3,4,5])</fos:expression>
+               <fos:expression>min([ 3, 4, 5 ])</fos:expression>
                <fos:result>3</fos:result>
                <fos:postamble>Arrays are atomized</fos:postamble>
             </fos:test>
@@ -15668,14 +15673,14 @@ else $c[1] + sum(subsequence($c, 2))</eg>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>sum([1, 2, 3])</fos:expression>
+               <fos:expression>sum([ 1, 2, 3 ])</fos:expression>
                <fos:result>6</fos:result>
                <fos:postamble>Atomizing an array returns the sequence obtained by atomizing its members.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>sum([[1, 2], [3, 4]])</fos:expression>
+               <fos:expression>sum([ [ 1, 2 ], [ 3, 4 ] ])</fos:expression>
                <fos:result>10</fos:result>
                <fos:postamble>Atomizing an array returns the sequence obtained by atomizing its members.</fos:postamble>
             </fos:test>
@@ -15799,8 +15804,8 @@ else $c[1] + sum(subsequence($c, 2))</eg>
                            <code>xs:NCName</code>), it is ignored. Formally, the candidate
                            <code>IDREF</code> values are the strings in the sequence given by the
                         expression:</p>
-                     <eg xml:space="preserve">for $s in $values return 
-    tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
+                     <eg xml:space="preserve">for $s in $values
+return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 
                   </item>
                </ulist>
@@ -15980,8 +15985,8 @@ else $c[1] + sum(subsequence($c, 2))</eg>
                            <code>xs:NCName</code>), it is ignored. Formally, the candidate
                            <code>IDREF</code> values are the strings in the sequence given by the
                         expression:</p>
-                     <eg xml:space="preserve">for $s in $arg return 
-   tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
+                     <eg xml:space="preserve">for $s in $arg
+return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   </item>
                </ulist>
             </item>
@@ -17095,7 +17100,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
                using the expression <code>fn:exists($N intersect $S)</code> may be expensive; there
                may then be performance benefits in creating a map:</p>
             <p>
-               <code>let $SMap := map:merge($S!map{fn:generate-id(.) : .})</code>
+               <code>let $SMap := map:merge($S ! map { fn:generate-id(.) : . })</code>
             </p>
             <p>and then testing for membership of the node-set using:</p>
             <p>
@@ -17337,7 +17342,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
       <fos:signatures>
          <fos:proto name="serialize" return-type="xs:string">
             <fos:arg name="input" type="item()*" usage="absorption"/>
-            <fos:arg name="options" type="item()?" usage="absorption" default="()" example="map{}"/>
+            <fos:arg name="options" type="item()?" usage="absorption" default="()" example="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17686,7 +17691,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
                   </td>
                   <td>See Note 3</td>
                   <td>
-                     <code>map{}</code>
+                     <code>map { }</code>
                   </td>
                </tr>
                <tr>
@@ -17805,7 +17810,7 @@ else $c[1] + sum(subsequence($c, 2))</eg>
          </fos:example>
          <fos:example>
             <p>The following call would also produce the output shown (though the second argument could equally well be supplied
-               as an empty map (<code>map{}</code>), since both parameters are given their default values):</p>
+               as an empty map (<code>map { }</code>), since both parameters are given their default values):</p>
          </fos:example>
          <fos:example>
             <fos:test use="v-serialize-data" spec="XQuery">
@@ -17817,8 +17822,8 @@ else $c[1] + sum(subsequence($c, 2))</eg>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>The expression <code>fn:serialize(map{"a":"AB", "b": "BC"}, map{"method":"adaptive"})</code> returns <code>"map{"a":"AB","b":"BC"}"</code></p>
-            <p>The expression <code>fn:serialize(array{"a",3, attribute test {"true"}}, map{"method":"adaptive"})</code> returns <code>"["a",3,test="true"]"</code></p>
+            <p>The expression <code>fn:serialize(map { "a": "AB", "b": "BC" }, map { "method": "adaptive" })</code> returns <code>"map{"a":"AB","b":"BC"}"</code></p>
+            <p>The expression <code>fn:serialize(array { "a", 3, attribute test { "true" } }, map { "method": "adaptive" })</code> returns <code>"["a",3,test="true"]"</code></p>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -17827,9 +17832,9 @@ else $c[1] + sum(subsequence($c, 2))</eg>
          <fos:proto name="parse-html" return-type="document-node(element(*:html))?">
             <fos:arg name="html" type="union(xs:string, xs:hexBinary, xs:base64Binary)?"/>
             <fos:arg name="options" type-ref="parse-html-options"
-                     default="map{
-                                 &quot;method&quot;:&quot;html&quot;,
-                                 &quot;html-version&quot;:&quot;5&quot;
+                     default="map {
+                                 &quot;method&quot;: &quot;html&quot;,
+                                 &quot;html-version&quot;: &quot;5&quot;
                               }"/>
          </fos:proto>
       </fos:signatures>
@@ -17875,13 +17880,13 @@ else $c[1] + sum(subsequence($c, 2))</eg>
             <item>
                <p>Tokenizing the byte stream according to the HTML parsing algorithm determined by the
                   <code>method</code> and <code>html-version</code> keys of <code>$options</code> (see below).
-                  For <code>{"method": "html", "html-version": "LS"}</code> this will be equivalent to
+                  For <code>{ "method": "html", "html-version": "LS" }</code> this will be equivalent to
                   <bibref ref="html5"/> section 13.2.5, <emph>Tokenization</emph>.</p>
             </item><item>
                <p>Constructing a <code>HTMLDocument</code> object for HTML documents, or an
                   <code>XMLDocument</code> for XML/XHTML documents according to the <code>method</code>'s
-                  tree construction algorithm from the tokens. For <code>{"method": "html",
-                  "html-version": "LS"}</code> this will be equivalent to <bibref ref="html5"/> section 13.2.6,
+                  tree construction algorithm from the tokens. For <code>{ "method": "html",
+                  "html-version": "LS" }</code> this will be equivalent to <bibref ref="html5"/> section 13.2.6,
                   <emph>Tree construction</emph>.</p>
             </item><item>
                <p>Building an XDM representation of the <code>HTMLDocument</code> or <code>XMLDocument</code>
@@ -18648,7 +18653,7 @@ return $item
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>filter(1 to 10, function($a) {$a mod 2 = 0})</fos:expression>
+               <fos:expression>filter(1 to 10, function($a) { $a mod 2 = 0 })</fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
          </fos:example>
@@ -18823,7 +18828,7 @@ declare function fold-left(
   map { },
   function($map, $n) { map:put($map, $n, $n * 2) }
 )</eg></fos:expression>
-               <fos:result>map{1:2, 2:4, 3:6, 4:8, 5:10}</fos:result>
+               <fos:result>map { 1: 2, 2: 4, 3: 6, 4: 8, 5: 10 }</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -19015,9 +19020,9 @@ return fold-right($input, (),
 <![CDATA[let $chain := (
 let $apply := function($x, $f)  {
   fn:apply($f,
-    if(function-arity($f) eq 1) then [$x]
+    if(function-arity($f) eq 1) then [ $x ]
     else if($x instance of array(*)) then $x 
-    else array{$x}
+    else array { $x }
   )
 }
 return function($input as item()*, $functions as function(*)*) as item()* {
@@ -19080,51 +19085,47 @@ return function($input as item()*, $functions as function(*)*) as item()* {
             In the following examples it is assumed that these definitions are in scope:
             <eg><![CDATA[(: The functions below: $incr, $times, $doubleAll, and $range, etc... 
    are needed only for the following examples :)
-let $incr := function($x) {op("+")($x, ?)},
-    $times := function($y) {op("*")($y,  ?)},
-    $doubleAll := function($nums as xs:numeric*) {$nums ! op("*")(., 2)},
-    $appendAll := function($strings as xs:string*, $addage as xs:string) 
-                {$strings ! concat#2(., $addage)},
-    $makeUpperAll := function($strings as xs:string*) {$strings ! upper-case(.)},
-    $countAll := function($ar as array(*)) 
-                {for $i in 1 to array:size($ar) return count($ar($i))},
-    $product3 := function($x, $y, $z) {  $x * $y * $z},
-    $range := function($n as xs:integer) {1 to $n}
-    ]]></eg>
+let $incr := function($x) { op("+")($x, ?) },
+    $times := function($y) { op("*")($y,  ?) },
+    $doubleAll := function($nums as xs:numeric*) { $nums ! op("*")(., 2) },
+    $appendAll := function($strings as xs:string*, $addage as xs:string) {
+      $strings ! concat#2(., $addage)
+    },
+    $makeUpperAll := function($strings as xs:string*) { $strings ! upper-case(.) },
+    $countAll := function($ar as array(*)) {
+      for $i in 1 to array:size($ar) return count($ar($i))
+    },
+    $product3 := function($x, $y, $z) {  $x * $y * $z },
+    $range := function($n as xs:integer) {1 to $n }
+]]></eg>
          </p>
       </fos:notes>
             <fos:examples>
-                <fos:variable name="incr" id="chain-variable-incr"><![CDATA[
-                function($x) {op("+")($x, ?)}
-                ]]></fos:variable>
-                <fos:variable name="doubleAll" id="chain-variable-doubleAll"><![CDATA[
-                function($nums as xs:numeric*) {$nums ! op("*")(., 2)}
-                ]]></fos:variable>
-                <fos:variable name="times" id="chain-variable-times"><![CDATA[
-                function($y) {op("*")($y,  ?)}
-                ]]></fos:variable>
-                <fos:variable name="appendAll" id="chain-variable-appendAll"><![CDATA[
-                function($strings as xs:string*, $addage as xs:string) 
-                {$strings ! concat#2(., $addage)}
-                ]]></fos:variable>
-                <fos:variable name="makeUpperAll" id="chain-variable-makeUpperAll"><![CDATA[
-                function($strings as xs:string*) {$strings ! upper-case(.)}
-                ]]></fos:variable>
-                <fos:variable name="countAll" id="chain-variable-countAll"><![CDATA[
-                function($ar as array(*)) 
-                {for $i in 1 to array:size($ar) return count($ar($i))}
-                ]]></fos:variable>
-                <fos:variable name="product3" id="chain-variable-product3"><![CDATA[
-                function($x, $y, $z) {  $x * $y * $z}
-                ]]></fos:variable>
-                <fos:variable name="range" id="chain-variable-range"><![CDATA[
-                function($n as xs:integer) {1 to $n}
-                ]]></fos:variable>
+                <fos:variable name="incr" id="chain-variable-incr"
+                ><![CDATA[function($x) { op("+")($x, ?) }]]></fos:variable>
+                <fos:variable name="doubleAll" id="chain-variable-doubleAll"
+                ><![CDATA[function($nums as xs:numeric*) { $nums ! op("*")(., 2) }]]></fos:variable>
+                <fos:variable name="times" id="chain-variable-times"
+                ><![CDATA[function($y) { op("*")($y,  ?) }]]></fos:variable>
+                <fos:variable name="appendAll" id="chain-variable-appendAll"
+                ><![CDATA[function($strings as xs:string*, $addage as xs:string) {
+  $strings ! concat#2(., $addage)
+}]]></fos:variable>
+                <fos:variable name="makeUpperAll" id="chain-variable-makeUpperAll"
+                ><![CDATA[function($strings as xs:string*) { $strings ! upper-case(.) }]]></fos:variable>
+                <fos:variable name="countAll" id="chain-variable-countAll"
+                ><![CDATA[function($ar as array(*)) {
+  for $i in 1 to array:size($ar) return count($ar($i))
+}]]></fos:variable>
+                <fos:variable name="product3" id="chain-variable-product3"
+                ><![CDATA[function($x, $y, $z) { $x * $y * $z }]]></fos:variable>
+                <fos:variable name="range" id="chain-variable-range"
+                ><![CDATA[function($n as xs:integer) { 1 to $n }]]></fos:variable>
                 <fos:example>
                    <fos:test use="chain-variable-incr chain-variable-doubleAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain( (2, 3), ($doubleAll, op("+"), $incr(3)))
+chain((2, 3), ($doubleAll, op("+"), $incr(3)))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>13</fos:result>
@@ -19134,7 +19135,7 @@ chain( (2, 3), ($doubleAll, op("+"), $incr(3)))
                     <fos:test use="chain-variable-incr chain-variable-doubleAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain( (2, 3), ($doubleAll, sum#1, $incr(3)))
+chain((2, 3), ($doubleAll, sum#1, $incr(3)))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>13</fos:result>
@@ -19144,7 +19145,7 @@ chain( (2, 3), ($doubleAll, sum#1, $incr(3)))
                     <fos:test use="chain-variable-incr">
                         <fos:expression>
                             <eg><![CDATA[
-chain( (2, 3), (op("+"), $incr(3)))
+chain((2, 3), (op("+"), $incr(3)))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>8</fos:result>
@@ -19154,7 +19155,7 @@ chain( (2, 3), (op("+"), $incr(3)))
                     <fos:test use="chain-variable-incr">
                         <fos:expression>
                             <eg><![CDATA[
-chain( (2, 3), (sum#1, $incr(3)))
+chain((2, 3), (sum#1, $incr(3)))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>8</fos:result>
@@ -19164,7 +19165,7 @@ chain( (2, 3), (sum#1, $incr(3)))
                     <fos:test use="chain-variable-incr">
                         <fos:expression>
                             <eg><![CDATA[
-chain( [1, (), 2, 3], (array:size#1, $incr(3)) )
+chain([ 1, (), 2, 3 ], (array:size#1, $incr(3)))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>7</fos:result>
@@ -19174,7 +19175,7 @@ chain( [1, (), 2, 3], (array:size#1, $incr(3)) )
                     <fos:test use="chain-variable-incr">
                         <fos:expression>
                             <eg><![CDATA[
-chain( (1, 2, 3), (count#1, $incr(3)) )
+chain((1, 2, 3), (count#1, $incr(3)))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>6</fos:result>
@@ -19184,7 +19185,7 @@ chain( (1, 2, 3), (count#1, $incr(3)) )
                     <fos:test use="chain-variable-incr">
                         <fos:expression>
                             <eg><![CDATA[
-chain( [1, 2, 3], (count#1, $incr(3)) )
+chain([ 1, 2, 3 ], (count#1, $incr(3)))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>4</fos:result>
@@ -19194,7 +19195,7 @@ chain( [1, 2, 3], (count#1, $incr(3)) )
                     <fos:test use="chain-variable-range chain-variable-doubleAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain( 5, ($range, $doubleAll, sum#1) )
+chain(5, ($range, $doubleAll, sum#1))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>30</fos:result>
@@ -19204,7 +19205,7 @@ chain( 5, ($range, $doubleAll, sum#1) )
                     <fos:test use="chain-variable-range chain-variable-doubleAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain( 2, ($range, $doubleAll, op("*")) )
+chain(2, ($range, $doubleAll, op("*")))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>8</fos:result>
@@ -19214,7 +19215,7 @@ chain( 2, ($range, $doubleAll, op("*")) )
                     <fos:test use="chain-variable-countAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain( [(1,2,3), ()], ($countAll, op("+")) )
+chain([(1,2,3), ()], ($countAll, op("+")))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>3</fos:result>
@@ -19224,7 +19225,7 @@ chain( [(1,2,3), ()], ($countAll, op("+")) )
                     <fos:test use="chain-variable-countAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain( [(1,2,3), (), (5, 6)], ($countAll, sum#1) )
+chain([(1,2,3), (), (5, 6)], ($countAll, sum#1))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>5</fos:result>
@@ -19234,7 +19235,7 @@ chain( [(1,2,3), (), (5, 6)], ($countAll, sum#1) )
                     <fos:test use="chain-variable-countAll chain-variable-product3">
                         <fos:expression>
                             <eg><![CDATA[
-chain( [(1,2,3), (), (5, 6)], ($countAll, $product3) )
+chain([(1,2,3), (), (5, 6)], ($countAll, $product3))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>0</fos:result>
@@ -19244,7 +19245,7 @@ chain( [(1,2,3), (), (5, 6)], ($countAll, $product3) )
                     <fos:test>
                         <fos:expression>
                             <eg><![CDATA[
-chain( "abra cadabra", (tokenize#2(?, " "), string-join#2(?, "+")) )
+chain("abra cadabra", (tokenize#2(?, " "), string-join#2(?, "+")))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>"abra+cadabra"</fos:result>
@@ -19254,13 +19255,12 @@ chain( "abra cadabra", (tokenize#2(?, " "), string-join#2(?, "+")) )
                     <fos:test use="chain-variable-appendAll chain-variable-makeUpperAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain( "The cat sat on the mat", 
-       ( tokenize#2(?, " "), 
-         $appendAll(?, "."), 
-         $makeUpperAll, 
-         string-join#2(?, " ") 
-        ) 
-     )]]></eg>
+chain("The cat sat on the mat", (
+  tokenize#2(?, " "), 
+  $appendAll(?, "."), 
+  $makeUpperAll, 
+  string-join#2(?, " ") 
+) )]]></eg>
                             </fos:expression>
                         <fos:result>"THE. CAT. SAT. ON. THE. MAT."</fos:result>
                     </fos:test>
@@ -19269,14 +19269,18 @@ chain( "The cat sat on the mat",
                     <fos:test>
                         <fos:expression>
                             <eg><![CDATA[
-chain( (
-         chain( ("A    long   message   ", "   long "), 
-                (head#1, normalize-space#1, normalize-unicode#1) ),
-         chain( ("A    long   message   ", "   long "),  
-                (tail#1, normalize-space#1, normalize-unicode#1) )
-       ),
-      (contains#2)
-    )]]></eg>
+chain((
+  chain(
+    ("A    long   message   ", "   long "), 
+    (head#1, normalize-space#1, normalize-unicode#1)
+  ),
+  chain(
+    ("A    long   message   ", "   long "),  
+    (tail#1, normalize-space#1, normalize-unicode#1)
+  )
+  ),
+  contains#2
+)]]></eg>
                             </fos:expression>
                         <fos:result>true()</fos:result>
                     </fos:test>
@@ -19285,7 +19289,7 @@ chain( (
                   <fos:test>
                     <fos:expression>
                        <eg><![CDATA[
-chain( (), true#0)
+chain((), true#0)
     ]]></eg>
                     </fos:expression>
                     <fos:result>true()</fos:result>                   
@@ -19622,7 +19626,7 @@ return $action($input1[$pos], $input2[$pos], $pos)
          </fos:example>
          <!--<fos:example>
             <fos:test>
-               <fos:expression><![CDATA[for-each-pair(function($a, $b) { <e a="{$a}" b="{$b}"/> }, (1 to 3), ("x", "y", "z"))]]></fos:expression>
+               <fos:expression><![CDATA[for-each-pair(function($a, $b) { <e a="{ $a }" b="{ $b }"/> }, (1 to 3), ("x", "y", "z"))]]></fos:expression>
                <fos:result as="element()*"><![CDATA[(<e a="1" b="x"/>, <e a="2" b="y"/>, <e a="3" b="z"/>)]]></fos:result>
                <fos:postamble>This example uses XQuery syntax</fos:postamble>
             </fos:test>
@@ -19854,16 +19858,18 @@ return sort($in, $SWEDISH)</eg>
             <p>To sort a sequence of employees by last name as the major sort key and first name as the minor sort key,
                using the default collation:
             </p>
-            <eg>sort($employees, (), fn{name ! (last, first)})</eg>
+            <eg>sort($employees, (), fn { name ! (last, first) })</eg>
          </fos:example>
          <fos:example>
             <p>To sort a sequence of employees first by increasing last name (using Swedish collation order)
                and then by decreasing salary:
             </p>
-            <eg>sort($employees, 
+            <eg>sort(
+  $employees, 
   "http://www.w3.org/2013/collation/UCA?lang=se",
   (fn { name/last }, fn { xs:decimal(salary) }), 
-  ("ascending", "descending"))</eg>
+  ("ascending", "descending")
+)</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -20050,26 +20056,26 @@ declare function transitive-closure (
             <code>$node | transitive-closure($node, $step)</code>.</p>
       </fos:notes>
       <fos:examples>
-         <fos:variable name="data" id="transitive-closure-data"><![CDATA[document{<doc>
-   <person id="0"/>
-   <person id="1" manager="0"/>
-   <person id="2" manager="0"/>
-   <person id="3" manager="2"/>
-   <person id="4" manager="2"/>
-   <person id="5" manager="1"/>
-   <person id="6" manager="3"/>
-   <person id="7" manager="6"/>
-   <person id="8" manager="6"/>
-</doc>}]]>
+         <fos:variable name="data" id="transitive-closure-data"><![CDATA[document { <doc>
+  <person id="0"/>
+  <person id="1" manager="0"/>
+  <person id="2" manager="0"/>
+  <person id="3" manager="2"/>
+  <person id="4" manager="2"/>
+  <person id="5" manager="1"/>
+  <person id="6" manager="3"/>
+  <person id="7" manager="6"/>
+  <person id="8" manager="6"/>
+</doc> }]]>
          </fos:variable>
          <fos:variable name="direct-reports" id="transitive-closure-reports"><![CDATA[function($p as element(person)) as element(person)* {
-  $p/../person[@manager=$p/@id]
+  $p/../person[@manager = $p/@id]
 }]]>
          </fos:variable>          
          <fos:example>
             <fos:test use="transitive-closure-data transitive-closure-reports" spec="XQuery">
                <fos:expression><eg>transitive-closure(
-  $data//person[@id="2"],
+  $data//person[@id = "2"],
   $direct-reports
 )/string(@id)</eg></fos:expression>
                <fos:result>("3", "4", "6", "7", "8")</fos:result>
@@ -20129,12 +20135,12 @@ declare function transitive-closure (
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>apply(concat#3, ["a", "b", "c"])</fos:expression>
+               <fos:expression>apply(concat#3, [ "a", "b", "c" ])</fos:expression>
                <fos:result>"abc"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-            <p>The expression <code>apply($f, array:subarray(["a", "b", "c", "d", "e", "f"], 1, function-arity($f)))</code> 
+            <p>The expression <code>apply($f, array:subarray([ "a", "b", "c", "d", "e", "f" ], 1, function-arity($f)))</code> 
                calls the supplied function <code>$f</code> supplying the number of arguments required by its arity.</p>
          </fos:example>
       </fos:examples>
@@ -20522,7 +20528,7 @@ declare function transitive-closure (
       <fos:signatures>
          <fos:proto name="merge" return-type="map(*)">
             <fos:arg name="maps" type="map(*)*" usage="inspection"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -20732,10 +20738,10 @@ return fold-left($MAPS, map { },
          each map in implementation-dependent order.</p>
 
             <p>The use of <code>fn:random-number-generator</code> represents one possible conformant
-         implementation for <code>"duplicates":"use-any"</code>, but it is not the only conformant
+         implementation for <code>"duplicates": "use-any"</code>, but it is not the only conformant
          implementation and is not intended to be a realistic implementation. The purpose of this
          option is to allow the implementation to use whatever strategy is most efficient; for example,
-         if the input maps are processed in parallel, then specifying <code>"duplicates":"use-any"</code>
+         if the input maps are processed in parallel, then specifying <code>"duplicates": "use-any"</code>
          means that the implementation does not need to keep track of the original order of the sequence of input
          maps.</p>
 
@@ -20764,11 +20770,11 @@ return fold-left($MAPS, map { },
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-merge-week"
-            select="map{0:&quot;Sonntag&quot;, 1:&quot;Montag&quot;, 2:&quot;Dienstag&quot;,&#xa;     3:&quot;Mittwoch&quot;, 4:&quot;Donnerstag&quot;, 5:&quot;Freitag&quot;, 6:&quot;Samstag&quot;}"/>
+            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test>
                <fos:expression>map:merge(())</fos:expression>
-               <fos:result>map{}</fos:result>
+               <fos:result>map { }</fos:result>
                <fos:postamble>Returns an empty map</fos:postamble>
             </fos:test>
             <fos:test>
@@ -20776,15 +20782,15 @@ return fold-left($MAPS, map { },
   map:entry(0, "no"),
   map:entry(1, "yes")
 ))</eg></fos:expression>
-               <fos:result>map{0:"no", 1:"yes"}</fos:result>
+               <fos:result>map { 0: "no", 1: "yes" }</fos:result>
                <fos:postamble>Returns a map with two entries</fos:postamble>
             </fos:test>
             <fos:test use="v-map-merge-week">
                <fos:expression><eg>map:merge(
   ($week, map { 7: "Unbekannt" })
 )</eg></fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Samstag", 7:"Unbekannt"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag", 6: "Samstag", 7: "Unbekannt" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the <phrase>returned map 
                   contains</phrase> all the entries from <code>$week</code>, supplemented with an additional
                   entry.</fos:postamble>
@@ -20794,8 +20800,8 @@ return fold-left($MAPS, map { },
   ($week, map { 6: "Sonnabend" }),
   map { "duplicates": "use-last" }
 )</eg></fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Sonnabend"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
+                  4: "Donnerstag", 5: "Freitag", 6: "Sonnabend" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
                   new entry. Both input maps contain an entry with the key <code>6</code>; the
@@ -20807,8 +20813,8 @@ return fold-left($MAPS, map { },
   ($week, map { 6: "Sonnabend" }),
   map { "duplicates": "use-first" }
 )</eg></fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Samstag"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag", 6: "Samstag" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
                   new entry. Both input maps contain an entry with the key <code>6</code>; the
@@ -20820,8 +20826,8 @@ return fold-left($MAPS, map { },
   ($week, map { 6: "Sonnabend" }),
   map { "duplicates": "combine" }
 )</eg></fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:("Samstag", "Sonnabend")}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5:"Freitag", 6:("Samstag", "Sonnabend") }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
                   new entry. Both input maps contain an entry with the key <code>6</code>; the
@@ -20839,7 +20845,7 @@ return fold-left($MAPS, map { },
             <fos:arg name="input" 
                      type="record(key as xs:anyAtomicType, value as item()*)*" 
                      usage="inspection"
-                     example="map{'key':'n','value':false()},map{'key':'y','value':true()}"/>
+                     example="map { 'key':'n','value':false() }, map { 'key':'y','value':true() }"/>
             <fos:arg name="combine" type="function(item()*, item()*) as item()*" usage="inspection" default="fn:op(',')"/>
          </fos:proto>
       </fos:signatures>
@@ -20884,11 +20890,11 @@ return fold-left($MAPS, map { },
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-of-week"
-            select="map { 0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;,&#xa;     3: &quot;Mittwoch&quot;, 4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6 :&quot;Samstag&quot; }"/>
+            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test>
                <fos:expression>map:of-pairs(())</fos:expression>
-               <fos:result>map{}</fos:result>
+               <fos:result>map { }</fos:result>
                <fos:postamble>Returns an empty map</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
@@ -20896,7 +20902,7 @@ return fold-left($MAPS, map { },
                <fos:result><eg>map { 0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 
       2: &quot;Dienstag&quot;, 3: &quot;Mittwoch&quot;, 
       4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 
-      6 :&quot;Samstag&quot; }</eg></fos:result>
+      6: &quot;Samstag&quot; }</eg></fos:result>
                <fos:postamble>The function <code>map:of-pairs</code> is the inverse of
                   <code>map:pairs</code>.</fos:postamble>
             </fos:test>
@@ -20905,7 +20911,7 @@ return fold-left($MAPS, map { },
   map { "key": 0, "value": "no" },
   map { "key": 1, "value": "yes" }
 ))]]></eg></fos:expression>
-               <fos:result>map{0:"no", 1:"yes"}</fos:result>
+               <fos:result>map { 0:"no", 1:"yes" }</fos:result>
                <fos:postamble>Returns a map with two entries</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
@@ -20913,8 +20919,8 @@ return fold-left($MAPS, map { },
   map:pairs($week),
   map { "key": 7, "value": "Unbekannt" }
 ))</eg></fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Samstag", 7:"Unbekannt"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag", 6: "Samstag", 7: "Unbekannt" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map 
                   contains all the entries from <code>$week</code>, supplemented with an additional
                   entry.</fos:postamble>
@@ -20924,8 +20930,8 @@ return fold-left($MAPS, map { },
   map:pairs($week),
   map { "key": 6, "value": "Sonnabend" }
 ))</eg></fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:("Samstag", "Sonnabend")}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag", 6: ("Samstag", "Sonnabend") }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
                   new entry. Both input maps contain an entry with the key <code>6</code>; the
@@ -20937,8 +20943,8 @@ return fold-left($MAPS, map { },
    map { "key": 6, "value": "Sonnabend" }),
   function($old, $new)  { $new }
 )</eg></fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Sonnabend"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag", 6: "Sonnabend" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
                   new entry. Both input maps contain an entry with the key <code>6</code>; the
@@ -20949,10 +20955,10 @@ return fold-left($MAPS, map { },
                <fos:expression><eg>map:of-pairs(
   (map:pairs($week),
    map { "key": 6, "value": "Sonnabend" }),
-  function($old, $new) { `{$old}|{$new}` }
+  function($old, $new) { `{ $old }|{ $new }` }
 )</eg></fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Samstag|Sonnabend"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag", 6: "Samstag|Sonnabend" }</fos:result>
                <fos:postamble>In the result map, the value for key <code>6</code> is obtained by concatenating the values
                   from the two input maps, with a separator character.</fos:postamble>
             </fos:test>
@@ -20998,7 +21004,7 @@ map:for-each($map, fn($key, $value) { $key })
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:keys(map { 1: "yes", 2:" no" })</fos:expression>
+               <fos:expression>map:keys(map { 1: "yes", 2: "no" })</fos:expression>
                <fos:result allow-permutation="true">(1, 2)</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                      >implementation-dependent</termref> order.</fos:postamble>
@@ -21117,7 +21123,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:values(
-  map{ 1: "yes", 2: "no" }
+  map { 1: "yes", 2: "no" }
 )</eg></fos:expression>
                <fos:result allow-permutation="true">("yes", "no")</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
@@ -21175,7 +21181,7 @@ return map:keys-where($birthdays, fn($name, $date) {
                <fos:expression><eg>map:entries(
   map { 1: "yes", 2: "no" }
 )</eg></fos:expression>
-               <fos:result allow-permutation="true">(map{1:"yes"}, map{2:"no"})</fos:result>
+               <fos:result allow-permutation="true">(map { 1: "yes" }, map { 2: "no" })</fos:result>
                <fos:postamble>The result sequence is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
@@ -21221,7 +21227,7 @@ return map:keys-where($birthdays, fn($name, $date) {
                <fos:expression><eg>map:pairs(
   map { 1: "yes", 2: "no" }
 )</eg></fos:expression>
-               <fos:result allow-permutation="true">(map{"key":1, "value":"yes"}, map{"key":2, "value":"no"})</fos:result>
+               <fos:result allow-permutation="true">(map { "key": 1, "value": "yes" }, map { "key": 2, "value": "no" })</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
@@ -21252,7 +21258,7 @@ return map:keys-where($birthdays, fn($name, $date) {
 
       <fos:examples>
          <fos:variable name="week" id="v-map-contains-week"
-            select="map{0:&quot;Sonntag&quot;, 1:&quot;Montag&quot;, 2:&quot;Dienstag&quot;,&#xa;     3:&quot;Mittwoch&quot;, 4:&quot;Donnerstag&quot;, 5:&quot;Freitag&quot;, 6:&quot;Samstag&quot;}"/>
+            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test use="v-map-contains-week">
                <fos:expression>map:contains($week, 2)</fos:expression>
@@ -21263,15 +21269,15 @@ return map:keys-where($birthdays, fn($name, $date) {
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:contains(map{}, "xyz")</fos:expression>
+               <fos:expression>map:contains(map { }, "xyz")</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:contains(map{"xyz":23}, "xyz")</fos:expression>
+               <fos:expression>map:contains(map { "xyz": 23 }, "xyz")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:contains(map{"abc":23, "xyz":()}, "xyz")</fos:expression>
+               <fos:expression>map:contains(map { "abc": 23, "xyz": () }, "xyz")</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
@@ -21299,7 +21305,7 @@ return map:keys-where($birthdays, fn($name, $date) {
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:empty(map {})</fos:expression>
+               <fos:expression>map:empty(map { })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
@@ -21355,7 +21361,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             key was found.</p></item>
             <item><p>It might raise a dynamic error, by means of a call on <code>fn:error</code>.</p></item>
             <item><p>It might compute a result algorithmically. For example, if the map holds a table of
-            abbreviations, such as <code>map{'CA':'Canada', 'UK':'United Kingdom', 'US':'United States'}</code>,
+            abbreviations, such as <code>map { 'CA': 'Canada', 'UK': 'United Kingdom', 'US': 'United States' }</code>,
             then specifying <code>fallback := fn:identity#1</code> has the effect that the key value is returned
             unchanged if it is not found in the map.</p></item>
          </ulist>
@@ -21371,7 +21377,7 @@ return map:keys-where($birthdays, fn($name, $date) {
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-get-week"
-            select="map{0:&quot;Sonntag&quot;, 1:&quot;Montag&quot;, 2:&quot;Dienstag&quot;,&#xa;     3:&quot;Mittwoch&quot;, 4:&quot;Donnerstag&quot;, 5:&quot;Freitag&quot;, 6:&quot;Samstag&quot;}"/>
+            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test use="v-map-get-week">
                <fos:expression>map:get($week, 4)</fos:expression>
@@ -21465,7 +21471,7 @@ return map:keys-where($birthdays, fn($name, $date) {
       </fos:notes>
       <fos:examples>
          <fos:variable name="responses" id="v-map-find-responses"
-            select="[map{0:'no', 1:'yes'}, map{0:'non', 1:'oui'}, &#xa;                  map{0:'nein', 1:('ja', 'doch')}]"/>
+            select="[ map { 0: 'no', 1: 'yes' }, map { 0: 'non', 1: 'oui' }, &#xa;                  map { 0: 'nein', 1: ('ja', 'doch') } ]"/>
          <fos:example>
             <fos:test use="v-map-find-responses">
                <fos:expression>map:find($responses, 0)</fos:expression>
@@ -21482,11 +21488,11 @@ return map:keys-where($birthdays, fn($name, $date) {
 
          </fos:example>
          <fos:variable name="inventory" id="v-map-find-inventory"
-            select='map{"name":"car", "id":"QZ123", &#xa;      "parts": [map{"name":"engine", "id":"YW678", "parts":[]}]}'/>
+            select='map { "name": "car", "id": "QZ123", &#xa;      "parts": [ map { "name": "engine", "id": "YW678", "parts": [] } ] }'/>
          <fos:example>
             <fos:test use="v-map-find-inventory">
                <fos:expression>map:find($inventory, "parts")</fos:expression>
-               <fos:result>[[map{"name":"engine", "id":"YW678", "parts":[]}], []]</fos:result>
+               <fos:result>[ [ map { "name": "engine", "id": "YW678", "parts": [] } ], [] ] </fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -21550,17 +21556,17 @@ return map:keys-where($birthdays, fn($name, $date) {
 
       <fos:examples>
          <fos:variable name="week" id="v-map-put-week"
-            select="map{0:&quot;Sonntag&quot;, 1:&quot;Montag&quot;, 2:&quot;Dienstag&quot;,&#xa;       3:&quot;Mittwoch&quot;, 4:&quot;Donnerstag&quot;, 5:&quot;Freitag&quot;, 6:&quot;Samstag&quot;}"/>
+            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test use="v-map-put-week">
                <fos:expression>map:put($week, 6, "Sonnabend")</fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Sonnabend"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag", 6: "Sonnabend" }</fos:result>
             </fos:test>
             <fos:test use="v-map-put-week">
                <fos:expression>map:put($week, -1, "Unbekannt")</fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Samstag", -1:"Unbekannt"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag", 6: "Samstag", -1: "Unbekannt" }</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -21594,31 +21600,31 @@ return map:keys-where($birthdays, fn($name, $date) {
       </fos:rules>
       <fos:notes>
          <p>The function call <code>map:entry(K, V)</code> produces the same result as the
-         expression <code>map{K : V}</code>.</p>
+         expression <code>map { K : V }</code>.</p>
          <p>The function <code>map:entry</code> is intended primarily for use in conjunction with
             the function <code>map:merge</code>. For example, a map containing seven entries may be
             constructed like this:</p>
 
          <eg><![CDATA[
 map:merge((
-   map:entry("Su", "Sunday"),
-   map:entry("Mo", "Monday"),
-   map:entry("Tu", "Tuesday"),
-   map:entry("We", "Wednesday"),
-   map:entry("Th", "Thursday"),
-   map:entry("Fr", "Friday"),
-   map:entry("Sa", "Saturday")
-   ))]]></eg>
+  map:entry("Su", "Sunday"),
+  map:entry("Mo", "Monday"),
+  map:entry("Tu", "Tuesday"),
+  map:entry("We", "Wednesday"),
+  map:entry("Th", "Thursday"),
+  map:entry("Fr", "Friday"),
+  map:entry("Sa", "Saturday")
+))]]></eg>
          <p>The <code>map:merge</code> function can be used to construct
             a map with a variable number of entries, for example:</p>
          <eg><![CDATA[
-map:merge(for $b in //book return map:entry($b/isbn, $b))]]></eg>
+map:merge(//book ! map:entry(isbn, .))]]></eg>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression>map:entry("M", "Monday")</fos:expression>
-               <fos:result>map{"M":"Monday"}</fos:result>
+               <fos:result>map { "M": "Monday" }</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -21712,26 +21718,27 @@ map:merge(
 
       <fos:examples>
          <fos:variable name="week" id="v-map-remove-week"
-            select="map{0:&quot;Sonntag&quot;, 1:&quot;Montag&quot;, 2:&quot;Dienstag&quot;,&#xa;       3:&quot;Mittwoch&quot;, 4:&quot;Donnerstag&quot;, 5:&quot;Freitag&quot;, 6:&quot;Samstag&quot;}"/>
+            select="map {&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot; Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
          <fos:example>
             <fos:test use="v-map-remove-week">
                <fos:expression>map:remove($week, 4)</fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 5:"Freitag",
-                  6:"Samstag"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
+                  5: "Freitag", 6: "Samstag" }</fos:result>
             </fos:test>
             <fos:test use="v-map-remove-week">
                <fos:expression>map:remove($week, 23)</fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag",
-                  5:"Freitag", 6:"Samstag"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
+                  4: "Donnerstag", 5: "Freitag", 6: "Samstag" }</fos:result>
             </fos:test>
             <fos:test use="v-map-remove-week">
                <fos:expression>map:remove($week, (0, 6 to 7))</fos:expression>
-               <fos:result>map{1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag", 5:"Freitag"}</fos:result>
+               <fos:result>map { 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
+                  5: "Freitag" }</fos:result>
             </fos:test>
             <fos:test use="v-map-remove-week">
                <fos:expression>map:remove($week, ())</fos:expression>
-               <fos:result>map{0:"Sonntag", 1:"Montag", 2:"Dienstag", 3:"Mittwoch", 4:"Donnerstag", 5:"Freitag",
-                  6:"Samstag"}</fos:result>
+               <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
+                  4: "Donnerstag", 5: "Freitag", 6: "Samstag" }</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -21799,7 +21806,7 @@ map:merge(
     function($k, $v) { map:entry($k, $v + 1) }
   )
 )</eg></fos:expression>
-               <fos:result>map{"a":2, "b":3}</fos:result>
+               <fos:result>map { "a": 2, "b": 3 }</fos:result>
                <fos:postamble>This function call returns a map with the same keys as the input map,
                   with the value of each entry increased by one.</fos:postamble>
             </fos:test>
@@ -21810,7 +21817,7 @@ map:merge(
                   element node:</p>
 
             <eg><![CDATA[
-let $dimensions := map{'height': 3, 'width': 4, 'depth': 5};
+let $dimensions := map { 'height': 3, 'width': 4, 'depth': 5 }
 return <box>{
   map:for-each($dimensions, function($k, $v) { attribute { $k } { $v } })
 }</box>]]></eg>
@@ -21851,23 +21858,19 @@ return <box>{
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:filter(
-  map { 1: "Sunday", 2: "Monday", 
-        3: "Tuesday", 4:"Wednesday",
-        5: "Thursday", 6: "Friday", 
-        7: "Saturday" },
+  map { 1: "Sunday", 2: "Monday", 3: "Tuesday", 4: "Wednesday",
+        5: "Thursday", 6: "Friday", 7: "Saturday" },
   function($k, $v) { $k = (1, 7) }
 )</eg></fos:expression>
-               <fos:result><eg>map{1:"Sunday", 7:"Saturday"}</eg></fos:result>
+               <fos:result><eg>map { 1: "Sunday", 7: "Saturday" }</eg></fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:filter(
-  map { 1: "Sunday", 2: "Monday", 
-        3: "Tuesday", 4: "Wednesday",
-        5: "Thursday", 6:"Friday", 
-        7:"Saturday" },
+  map { 1: "Sunday", 2: "Monday", 3: "Tuesday", 4: "Wednesday",
+        5: "Thursday", 6: "Friday", 7: "Saturday" },
   function($k, $v) { $v = ("Saturday", "Sunday") }
 )</eg></fos:expression>
-               <fos:result><eg>map{1:"Sunday", 7:"Saturday"}</eg></fos:result>
+               <fos:result><eg>map { 1: "Sunday", 7: "Saturday" }</eg></fos:result>
             </fos:test>
 
          </fos:example>
@@ -21916,11 +21919,11 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:replace(map{1:"alpha", 2:"beta"}, 1, upper-case#1)</fos:expression>
+               <fos:expression>map:replace(map { 1: "alpha", 2: "beta" }, 1, upper-case#1)</fos:expression>
                <fos:result>map { 1: "ALPHA", 2: "beta" }</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:replace(map{1:"alpha", 2:"beta"}, 3, upper-case#1)</fos:expression>
+               <fos:expression>map:replace(map { 1: "alpha", 2: "beta" }, 3, upper-case#1)</fos:expression>
                <fos:result>map { 1: "alpha", 2: "beta" 3: "" }</fos:result>
             </fos:test>
             <fos:test>
@@ -21933,7 +21936,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
     })
   }
 )</eg></fos:expression>
-               <fos:result>map{"a":2, "b":1, "c":1}</fos:result>
+               <fos:result>map { "a": 2, "b": 1, "c": 1 }</fos:result>
             </fos:test>
          </fos:example>
 
@@ -21977,14 +21980,14 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
   map { 1: true(), 2: false() },
   function($k, $v) { not($v) }
 )</eg></fos:expression>
-               <fos:result>map{1:false(), 2:true()}</fos:result>
+               <fos:result>map { 1: false(), 2: true() }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:substitute(
   map { 1: "yes", 2: "no" },
   function($k, $v) { $v || ' (' || $k || ')' }
 )</eg></fos:expression>
-               <fos:result>map{1:"yes (1)", 2:"no (2)"}</fos:result>
+               <fos:result>map { 1: "yes (1)", 2: "no (2)" }</fos:result>
             </fos:test>
          </fos:example>
 
@@ -22055,11 +22058,11 @@ fold-left($input, map { }, fn($map, $item) {
          <fos:example>
             <fos:test>
                <fos:expression>map:build((), string#1)</fos:expression>
-               <fos:result>map{}</fos:result>
+               <fos:result>map { }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>map:build(1 to 10, function { . mod 3 })</fos:expression>
-               <fos:result>map{0: (3, 6, 9), 1: (1, 4, 7, 10), 2: (2, 5, 8)}</fos:result>
+               <fos:result>map { 0: (3, 6, 9), 1: (1, 4, 7, 10), 2: (2, 5, 8) }</fos:result>
                <fos:postamble>Returns a map with one entry for each distinct value of <code>. mod 3</code>. The
                   function to compute the value is the identity function, and duplicates are combined by
                   sequence concatenation.</fos:postamble>
@@ -22069,29 +22072,35 @@ fold-left($input, map { }, fn($map, $item) {
   1 to 5,
   value := format-integer(?, "w")
 )</eg></fos:expression>
-               <fos:result>map{1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}</fos:result>
+               <fos:result>map { 1: "one", 2: "two", 3: "three", 4: "four", 5: "five" }</fos:result>
                <fos:postamble>Returns a map with five entries. The function to compute the key is an identity function, the
                   function to compute the value invokes <code>fn:format-integer</code>.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:build(
-  ("January", "February", "March", "April",
-   "May", "June", "July", "August", "September",
-   "October", "November", "December"),
+  ("January", "February", "March", "April", "May", "June",
+   "July", "August", "September", "October", "November", "December"),
   substring(?, 1, 1)
 )</eg></fos:expression>
-               <fos:result>map{"A": ("April", "August"), "D": ("December"), "F": ("February"), "J": ("January", "June", "July"), 
-                  "M": ("March", "May"), "N": ("November"), "O": ("October"), "S": ("September")}</fos:result>
+               <fos:result>map {
+  "A": ("April", "August"),
+  "D": ("December"),
+  "F": ("February"),
+  "J": ("January", "June", "July"),
+  "M": ("March", "May"),
+  "N": ("November"),
+  "O": ("October"),
+  "S": ("September")
+}</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:build(
-  ("apple", "apricot", "banana",
-   "blueberry", "cherry"), 
+  ("apple", "apricot", "banana", "blueberry", "cherry"), 
   substring(?, 1, 1),
   string-length#1,
   op("+")
 )</eg></fos:expression>
-               <fos:result>map{"a": 12, "b": 15, "c": 6}</fos:result>
+               <fos:result>map { "a": 12, "b": 15, "c": 6 }</fos:result>
                <fos:postamble>Constructs a map where the key is the first character of an input item, and where the corresponding value
                   is the total string-length of the items starting with that character.</fos:postamble>
             </fos:test>
@@ -22106,14 +22115,14 @@ return map:build($titles/title, fn($title) { $title/ix })
 ]]></eg></fos:expression>
                <fos:result><eg><![CDATA[
 map {
-   "Java": (
-     <title>A Beginner's Guide to <ix>Java</ix></title>,
-     <title>Using <ix>XML</ix> with <ix>Java</ix></title>
-   ),
-   "XML": (
-     <title>Learning <ix>XML</ix></title>,
-     <title>Using <ix>XML</ix> with <ix>Java</ix></title>
-   )
+  "Java": (
+    <title>A Beginner's Guide to <ix>Java</ix></title>,
+    <title>Using <ix>XML</ix> with <ix>Java</ix></title>
+  ),
+  "XML": (
+    <title>Learning <ix>XML</ix></title>,
+    <title>Using <ix>XML</ix> with <ix>Java</ix></title>
+  )
 }]]></eg></fos:result>
             </fos:test>
             
@@ -22169,11 +22178,11 @@ map {
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:size(map{})</fos:expression>
+               <fos:expression>map:size(map { })</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>map:size(map{"true":1, "false":0})</fos:expression>
+               <fos:expression>map:size(map { "true": 1, "false": 0 })</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
          </fos:example>
@@ -22309,8 +22318,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             <p>As the above examples illustrate, it is important that when the
                   <code>collation-key</code> function is used to add entries to a map, then it must
                also be used when retrieving entries from the map. This process can be made less
-               error-prone by encapsulating the map within a function: <code>function($k)
-                  {$M(collation-key($k, $collation)}</code>.</p>
+               error-prone by encapsulating the map within a function:
+               <code>function($k) { $M(collation-key($k, $collation) }</code>.</p>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -22319,7 +22328,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="json-to-xml" return-type="document-node()?">
             <fos:arg name="value" type="xs:string?" example="'[22,23]'"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -22618,7 +22627,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <fos:test>
                <fos:expression><eg>json-to-xml(
-  '{"x": 1, "y": [3,4,5]}',
+  '{ "x": 1, "y": [ 3, 4, 5 ] }',
   map { "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
@@ -22641,7 +22650,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
             <fos:test>
                <fos:expression><eg>json-to-xml(
-  '{"x": "\\", "y": "\u0025"}',
+  '{ "x": "\\", "y": "\u0025" }',
   map { "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
@@ -22652,7 +22661,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             </fos:test>
             <fos:test>
                <fos:expression><eg>json-to-xml(
-  '{"x": "\\", "y": "\u0025"}',
+  '{ "x": "\\", "y": "\u0025" }',
   map { 'escape': true(), "validate": false() }
 )</eg></fos:expression>
                <fos:result normalize-space="true" ignore-prefixes="true"><![CDATA[
@@ -22699,7 +22708,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="xml-to-json" return-type="xs:string?">
             <fos:arg name="node" type="node()?" usage="absorption" example="()"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23011,11 +23020,11 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:examples>
          <fos:example>
             <p>The input <code><![CDATA[<array xmlns="http://www.w3.org/2005/xpath-functions"><number>1</number><string>is</string><boolean>1</boolean></array>]]></code>
-         produces the result <code>[1,"is",true]</code>.</p>
+         produces the result <code>[ 1, "is", true ]</code>.</p>
          </fos:example>
          <fos:example>
             <p>The input <code><![CDATA[<map xmlns="http://www.w3.org/2005/xpath-functions"><number key="Sunday">1</number><number key="Monday">2</number></map>]]></code>
-            produces the result <code>{"Sunday":1,"Monday":2}</code>.</p>
+            produces the result <code>{ "Sunday": 1, "Monday": 2}</code>.</p>
          </fos:example>
       </fos:examples>
    </fos:function>
@@ -23024,7 +23033,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       <fos:signatures>
          <fos:proto name="parse-csv" return-type-ref="parsed-csv-structure-record">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23337,75 +23346,89 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <fos:example>
             <p>Default delimiters, no column headers:</p>
             <fos:test use="csv-display">
-               <fos:expression><eg>let $input := string-join((
-   "name,city",
-   "Bob,Berlin",
-   "Alice,Aachen"), char('\n'))
+               <fos:expression><eg>let $input := string-join(
+  ("name,city", "Bob,Berlin", "Alice,Aachen"),
+  char('\n')
+)
 let $result := parse-csv($input)
-return ($result => $display(),
-        $result?get(1,2),
-        $result?get(2,2))</eg></fos:expression>
-               <fos:result><eg>map{
-   "columns": (),
-   "column-index": map{},
-   "rows": (["name", "city"], ["Bob", "Berlin"], ["Alice", "Aachen"]),
-   "get": "(: function :)"
-}, "city", "Berlin"</eg></fos:result>
+return (
+  $result => $display(),
+  $result?get(1,2),
+  $result?get(2,2)
+)</eg></fos:expression>
+               <fos:result><eg>map {
+  "columns": (),
+  "column-index": map { },
+  "rows": ([ "name", "city" ], [ "Bob", "Berlin" ], [ "Alice", "Aachen" ]),
+  "get": "(: function :)"
+},
+"city",
+"Berlin"</eg></fos:result>
             </fos:test>
-            
 
             <p>Default delimiters, column headers:</p>
-            
             <fos:test use="csv-display">
-               <fos:expression><eg>let $input := string-join((
-   "name,city",
-   "Bob,Berlin",
-   "Alice,Aachen"), char('\n'))
-let $result := parse-csv($input, map {"header": true()})
-return ($result => $display(),
-        $result?get(1,"name"),
-        $result?get(2,"city"))</eg></fos:expression>
-<fos:result><eg>map{
-   "columns": ("name", "city"),
-   "column-index": map {"name": 1, "city": 2 },
-   "rows": (["Bob", "Berlin"], ["Alice", "Aachen"]),
-   "get": "(: function :)"
-}, "Bob", "Aachen"</eg></fos:result>
+               <fos:expression><eg>let $input := string-join(
+  ("name,city", "Bob,Berlin", "Alice,Aachen"),
+  char('\n')
+)
+let $result := parse-csv($input, map { "header": true() })
+return (
+  $result => $display(),
+  $result?get(1,"name"),
+  $result?get(2,"city")
+)</eg></fos:expression>
+<fos:result><eg>map {
+  "columns": ("name", "city"),
+  "column-index": map { "name": 1, "city": 2 },
+  "rows": ([ "Bob", "Berlin" ], [ "Alice", "Aachen" ]),
+  "get": "(: function :)"
+},
+"Bob",
+"Aachen"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Custom delimiters, no column headers:</p>
             <fos:test use="csv-display">
-               <fos:expression><eg>let $options := map { "row-delimiter": "§", 
-          "field-delimiter": ";", 
-          "quote-character": "|" }
+               <fos:expression><eg>let $options := map {
+  "row-delimiter": "§", 
+  "field-delimiter": ";", 
+  "quote-character": "|"
+}
 let $input := "|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|"
 let $result := parse-csv($csv, $options)
-return ($result => $display(),
-        $result?get(3, 1))</eg></fos:expression>
-               <fos:result><eg>map{
-   "columns": (),
-   "column-index": map {},
-   "rows": (["name", "city"], ["Bob", "Berlin"], ["Alice", "Aachen"]),
-   "get": "(: function :)"
-}, "Alice"</eg></fos:result>
+return (
+  $result => $display(),
+  $result?get(3, 1)
+)</eg></fos:expression>
+               <fos:result><eg>map {
+  "columns": (),
+  "column-index": map { },
+  "rows": ([ "name", "city" ], [ "Bob", "Berlin" ], [ "Alice", "Aachen" ]),
+  "get": "(: function :)"
+},
+"Alice"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Supplied column names:</p>
             <fos:test use="csv-display">
                <fos:expression><eg>let $headers := ("Person", "Location")
-let $options := map {"header": $headers, "row-delimiter": ";"}
+let $options := map { "header": $headers, "row-delimiter": ";" }
 let $input := "Alice,Aachen;Bob,Berlin;"
 let $parsed-csv := parse-csv($input, $options)
-return ($parsed-csv => $display(), 
-        $parsed-csv?get(2, "Location"))</eg></fos:expression>
-               <fos:result><eg>map{
-   "columns": ("Person", "Location"),
-   "column-index": map {"Person": 1, "Location": 2},
-   "rows": (["Alice", "Aachen"], ["Bob", "Berlin"]),
-   "get": "(: function :)"                  
-   }, "Berlin"</eg></fos:result>
+return (
+  $parsed-csv => $display(), 
+  $parsed-csv?get(2, "Location")
+)</eg></fos:expression>
+               <fos:result><eg>map {
+  "columns": ("Person", "Location"),
+  "column-index": map {"Person": 1, "Location": 2},
+  "rows": ([ "Alice", "Aachen" ], [ "Bob", "Berlin" ]),
+  "get": "(: function :)"                  
+},
+"Berlin"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -23415,44 +23438,57 @@ return ($parsed-csv => $display(),
    "date,name,city,amount,currency,original amount,note",
    "2023-07-19,Bob,Berlin,10.00,USD,13.99",
    "2023-07-20,Alice,Aachen,15.00",
-   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
+   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"
+), char('\n'))
 let $options := map { 
-   "header": true(), 
-   "select-columns": (2,1,4) }
+  "header": true(), 
+  "select-columns": (2,1,4)
+}
 let $result := parse-csv($input, $options)
-return ($result => $display(),
-        $result?get(2, "city"))</eg></fos:expression>
-               <fos:result><eg>map{
-   "columns": ("name", "date", "amount"),
-   "column-index": map {"name": 1, "date": 2, "amount": 3},
-   "rows": (["Bob", "2023-07-19", "10.00"], 
-            ["Alice", "2023-07-20", "15.00"], 
-            ["Charlie", "2023-07-20", "15.00"]),
-   "get": "(: function :)"                  
-}, "Aachen"</eg></fos:result>
+return (
+  $result => $display(),
+  $result?get(2, "city")
+)</eg></fos:expression>
+               <fos:result><eg>map {
+  "columns": ("name", "date", "amount"),
+  "column-index": map { "name": 1, "date": 2, "amount": 3 },
+  "rows": (
+    [ "Bob", "2023-07-19", "10.00" ],
+    [ "Alice", "2023-07-20", "15.00" ],
+    [ "Charlie", "2023-07-20", "15.00" ]
+  ),
+  "get": "(: function :)"                  
+},
+"Aachen"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Filtering columns, with supplied column map</p>
             <fos:test use="csv-display">
                <fos:expression><eg>let $input := string-join((
-   "2023-07-19,Bob,Berlin,10.00,USD,13.99",
-   "2023-07-20,Alice,Aachen,15.00",
-   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
+  "2023-07-19,Bob,Berlin,10.00,USD,13.99",
+  "2023-07-20,Alice,Aachen,15.00",
+  "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"
+), char('\n'))
 let $options := map { 
-   "header": map { "Person": 1, "Amount": 3 }, 
-   "select-columns": (2,1,4) }
+  "header": map { "Person": 1, "Amount": 3 }, 
+  "select-columns": (2, 1, 4)
+}
 let $result := parse-csv($input, $options)
-return ($result => $display(),
-        $result?get(2, "Person"),
-        $result?get(2, "Amount"))</eg></fos:expression>
+return (
+  $result => $display(),
+  $result?get(2, "Person"),
+  $result?get(2, "Amount")
+)</eg></fos:expression>
                
-               <fos:result><eg>map{
-   "columns": ("Person", "", "Amount"),
-   "column-index": map {"Person": 1, "Amount": 3},
-   "rows": (["Alice", "Aachen"], ["Bob", "Berlin"]),
-   "get": "(: function :)"                  
-}, "Alice", "15.00"</eg></fos:result>
+               <fos:result><eg>map {
+  "columns": ("Person", "", "Amount"),
+  "column-index": map { "Person": 1, "Amount": 3 },
+  "rows": ([ "Alice", "Aachen" ], [ "Bob", "Berlin" ]),
+  "get": "(: function :)"                  
+},
+"Alice",
+"15.00"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -23462,23 +23498,30 @@ return ($result => $display(),
   "date,      name,     amount,    currency,   original amount",               
   "2023-07-19,Bob,      10.00,     USD,        13.99",
   "2023-07-20,Alice,    15.00",
-  "2023-07-20,Charlie,  15.00,     GBP,        11.99,             extra data"), 
-  char('\n'))
-let $options := map {"header": false(), 
-                     "select-columns":1 to 5, 
-                     "trim-whitespace":true()}
+  "2023-07-20,Charlie,  15.00,     GBP,        11.99,             extra data"
+), char('\n'))
+let $options := map {
+  "header": false(), 
+  "select-columns": 1 to 5, 
+  "trim-whitespace":true()
+}
 let $result := parse-csv($input, $options)
-return ($result => $display(),
-        $result?get(4,3))</eg></fos:expression>
-               <fos:result><eg>map{
+return (
+  $result => $display(),
+  $result?get(4,3)
+)</eg></fos:expression>
+               <fos:result><eg>map {
   "columns": (),
-  "column-index": map {},
-  "rows": (["date","name","amount","currency","original amount"],
-           ["2023-07-19","Bob","10.00","USD","13.99"],
-           ["2023-07-20","Alice","15.00","",""],
-           ["2023-07-20","Charlie","15.00","GBP","11.99"]),
+  "column-index": map { },
+  "rows": (
+    [ "date", "name", "amount", "currency", "original amount" ],
+    [ "2023-07-19", "Bob", "10.00", "USD", "13.99" ],
+    [ "2023-07-20", "Alice", "15.00", "", "" ],
+    [ "2023-07-20", "Charlie", "15.00", "GBP", "11.99" ]
+  ),
   "get": "(: function :)"                  
-}, "15:00"</eg></fos:result>
+},
+"15:00"</eg></fos:result>
                
             </fos:test>
          </fos:example>
@@ -23489,19 +23532,26 @@ return ($result => $display(),
   "date,name,city,amount,currency,original amount,note",               
   "2023-07-19,Bob,Berlin,10.00,USD,13.99",
   "2023-07-20,Alice,Aachen,15.00",
-  "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"), char('\n'))
-let $options := map{"header": true(), "select-columns": 1 to 6}
+  "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"
+), char('\n'))
+let $options := map { "header": true(), "select-columns": 1 to 6 }
 let $result := parse-csv($input, $options)
-return ($result => $display(),
-        $result?get(3,"original amount"))</eg></fos:expression>
-               <fos:result><eg>map{
-   "columns": ("date","name","city","amount","currency","original amount"),
-   "column-index": map {"date":1, "name":2, "city":3, 
-                          "amount":4, "currency":5, "original amount":6},
-   "rows": (["2023-07-19","Bob","Berlin","10.00","USD","13.99"],
-            ["2023-07-20","Alice","Aachen","15.00","",""],
-            ["2023-07-20","Charlie","Celle","15.00","GBP","11.99"]),
-   "get": "(: function :)"                  
+return (
+  $result => $display(),
+  $result?get(3,"original amount")
+)</eg></fos:expression>
+               <fos:result><eg>map {
+  "columns": ("date", "name", "city", "amount", "currency", "original amount"),
+  "column-index": map {
+    "date": 1, "name": 2, "city": 3, "amount": 4,
+    "currency": 5, "original amount": 6
+  },
+  "rows": (
+    [ "2023-07-19", "Bob", "Berlin", "10.00", "USD", "13.99"],
+    [ "2023-07-20", "Alice", "Aachen", "15.00", "", ""],
+    [ "2023-07-20", "Charlie", "Celle", "15.00", "GBP", "11.99"]
+  ),
+  "get": "(: function :)"                  
 }, "11.99"</eg></fos:result>
             </fos:test>
          </fos:example>
@@ -23512,7 +23562,7 @@ return ($result => $display(),
       <fos:signatures>
          <fos:proto name="csv-to-arrays" return-type="array(xs:string)*">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23659,52 +23709,53 @@ return ($result => $display(),
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(" ", map{'trim-whitespace':true()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(" ", map { 'trim-whitespace': true() })</eg></fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(" ", map{'trim-whitespace':false()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(" ", map { 'trim-whitespace': false() })</eg></fos:expression>
                <fos:result>[" "]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, map{'trim-whitespace':true()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, map { 'trim-whitespace': true() })</eg></fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, map{'trim-whitespace':false()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(` {char('\n')}`, map { 'trim-whitespace': false() })</eg></fos:expression>
                <fos:result>[" "]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map{'trim-whitespace':true()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map { 'trim-whitespace': true() })</eg></fos:expression>
                <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map{'trim-whitespace':false()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(`{char('\n')} `, map { 'trim-whitespace': false() })</eg></fos:expression>
                <fos:result>[], [" "]</fos:result>
             </fos:test>
             <p>Using newline separators:</p>
             <fos:test>
                <fos:expression><eg>csv-to-arrays(
-   `name,city{char('\n')}`||
-   `Bob,Berlin{char('\n')}`||
-   `Alice,Aachen{char('\n')}`)</eg></fos:expression>
+  `name,city{ char('\n') }`||
+  `Bob,Berlin{ char('\n') }`||
+  `Alice,Aachen{ char('\n') }`)</eg></fos:expression>
                <fos:result><eg>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
+  [ "name", "city" ],
+  [ "Bob", "Berlin" ],
+  [ "Alice", "Aachen" ]
 )</eg></fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>let $CRLF := `{char('\r')}{char('\n')}`
 return csv-to-arrays(
-  `name,city{$CRLF)}`||
-  `Bob,Berlin{$CRLF)}`||
-  `Alice,Aachen{$CRLF)}`, 
-  map{"normalize-newlines":true()})</eg></fos:expression>
+  `name,city{ $CRLF }` ||
+  `Bob,Berlin{ $CRLF }` ||
+  `Alice,Aachen{ $CRLF }`, 
+  map { "normalize-newlines": true() }
+)</eg></fos:expression>
                <fos:result><eg>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
+  [ "name", "city" ],
+  [ "Bob", "Berlin" ],
+  [ "Alice", "Aachen" ]
 )</eg></fos:result>
             </fos:test>
 
@@ -23712,62 +23763,73 @@ return csv-to-arrays(
          <fos:example>
             <p>Quote handling:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(string-join(
-   `"name","city"`,
-   `"Bob","Berlin"`,
-   `"Alice","Aachen"`), char('\n\))</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(
+  string-join(
+    (`"name","city"`, `"Bob","Berlin"`, `"Alice","Aachen"`),
+    char('\n\)
+  )
+)</eg></fos:expression>
                <fos:result><eg>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
+  [ "name", "city" ],
+  [ "Bob", "Berlin" ],
+  [ "Alice", "Aachen" ]
 )</eg></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays(`"name","city"{char('\n')}`||
-             `"Bob ""The Exemplar"" Mustermann","Berlin"{char('\n')}`)</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(
+  `"name","city"{ char('\n') }` ||
+  `"Bob ""The Exemplar"" Mustermann","Berlin"{ char('\n') }`
+)</eg></fos:expression>
                <fos:result><eg>(
-   ["name", "city"],
-   ['Bob "The Exemplar" Mustermann', "Berlin"]
+  [ "name", "city" ],
+  [ 'Bob "The Exemplar" Mustermann', "Berlin" ]
 )</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Non-default record- and field-delimiters:</p>
             <fos:test>
-               <fos:expression><eg>csv-to-arrays("name;city§Bob;Berlin§Alice;Aachen", 
-              map{"row-delimiter": "§", "field-delimiter": ";"})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(
+  "name;city§Bob;Berlin§Alice;Aachen", 
+  map { "row-delimiter": "§", "field-delimiter": ";" }
+)</eg></fos:expression>
                <fos:result><eg>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
+  [ "name", "city" ],
+  [ "Bob", "Berlin" ],
+  [ "Alice", "Aachen" ]
 )</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Non-default quote character:</p>
             <fos:test use="escaped-crlf-3">
-               <fos:expression><eg>csv-to-arrays(string-join(
-   "|name|,|city|",
-   "|Bob|,|Berlin|"), char('\n')), 
-              map{"quote-character": "|"})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(
+  string-join(
+    ("|name|,|city|", "|Bob|,|Berlin|"),
+    char('\n')
+  ), 
+  map { "quote-character": "|" }
+)</eg></fos:expression>
                <fos:result><eg>(
-   ["name", "city"],
-   ["Bob", "Berlin"]
+  [ "name", "city" ],
+  [ "Bob", "Berlin" ]
 )</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Trimming whitespace in fields:</p>
             <fos:test use="escaped-crlf-3">
-               <fos:expression><eg>csv-to-arrays(string-join(
-    "name  ,city    ",
-    "Bob   ,Berlin  ",
-    "Alice ,Aachen  "), char('\n')), 
-              map{"trim-whitespace": true()})</eg></fos:expression>
+               <fos:expression><eg>csv-to-arrays(
+  string-join(
+    ("name  ,city    ", "Bob   ,Berlin  ", "Alice ,Aachen  "),
+    char('\n')
+  ),
+  map { "trim-whitespace": true() }
+)</eg></fos:expression>
                <fos:result><eg>(
-   ["name", "city"],
-   ["Bob", "Berlin"],
-   ["Alice", "Aachen"]
+  [ "name", "city" ],
+  [ "Bob", "Berlin" ],
+  [ "Alice", "Aachen" ]
 )</eg></fos:result>
             </fos:test>
          </fos:example>
@@ -23778,7 +23840,7 @@ return csv-to-arrays(
       <fos:signatures>
          <fos:proto name="csv-to-xml" return-type="element(fn:csv)?">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24141,7 +24203,7 @@ return
       <fos:signatures>
          <fos:proto name="parse-json" return-type="item()?">
             <fos:arg name="value" type="xs:string?" example="'[22,23]'"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24361,16 +24423,16 @@ return
                   pairs in the JSON object. The key is always of type <code>xs:string</code>; the
                   associated value may be of any type, and is the result of converting the JSON
                   value by recursive application of these rules. For example, the JSON text
-                     <code>{"x":2, "y":5}</code> is transformed to the value
-                     <code>map{"x":2, "y":5}</code>.</p>
+                     <code>{ "x": 2, "y": 5 }</code> is transformed to the value
+                     <code>map { "x": 2, "y": 5 }</code>.</p>
                <p>If duplicate keys are encountered in a JSON <emph>object</emph>, they are handled
                   as determined by the <code>duplicates</code> option defined above.</p>
             </item>
             <item>
                <p>A JSON <emph>array</emph> is transformed to an array whose members are the result of converting
                   the corresponding member of the array by recursive application of these rules. For
-                  example, the JSON text <code>["a", "b", null]</code> is transformed (by default) to the value
-                     <code>["a", "b", ()]</code>.</p>
+                  example, the JSON text <code>[ "a", "b", null ]</code> is transformed (by default) to the value
+                     <code>[ "a", "b", () ]</code>.</p>
             </item>
             <item>
                <p>A JSON <emph>string</emph> is converted to an <code>xs:string</code> value. 
@@ -24403,7 +24465,7 @@ return
 
          <p>A dynamic error <errorref class="JS" code="0003"
                /> occurs if the option
-            <code>"duplicates":"reject"</code> is present and the value of
+            <code>"duplicates": "reject"</code> is present and the value of
             <code>$value</code> contains a JSON object with duplicate keys.</p>
 
          <p>A dynamic error <errorref class="JS" code="0005"
@@ -24447,7 +24509,7 @@ return
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>parse-json('{"x":1, "y":[3,4,5]}')</fos:expression>
+               <fos:expression>parse-json('{ "x": 1, "y": [ 3, 4, 5 ] }')</fos:expression>
                <fos:result>map { "x": 1e0, "y": [ 3e0, 4e0, 5e0 ] }</fos:result>
             </fos:test>
             <fos:test>
@@ -24455,32 +24517,32 @@ return
                <fos:result>"abcd"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>parse-json('{"x":"\\", "y":"\u0025"}')</fos:expression>
+               <fos:expression>parse-json('{ "x": "\\", "y": "\u0025" }')</fos:expression>
                <fos:result>map { "x": "\", "y": "%" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
-  '{"x":"\\", "y":"\u0025"}',
+  '{ "x": "\\", "y": "\u0025" }',
   map { 'escape': true() }
 )</eg></fos:expression>
                <fos:result>map { "x": "\\", "y": "%" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
-  '{"x":"\\", "y":"\u0000"}'
+  '{ "x": "\\", "y": "\u0000" }'
 )</eg></fos:expression>
                <fos:result>map { "x": "\", "y": char(0xFFFD) }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
-  '{"x":"\\", "y":"\u0000"}',
+  '{ "x": "\\", "y": "\u0000" }',
   map { 'escape': true() }
 )</eg></fos:expression>
                <fos:result>map { "x": "\\", "y": "\u0000" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json(
-  '{"x":"\\", "y":"\u0000"}',
+  '{ "x": "\\", "y": "\u0000" }',
   map { 'fallback': function($s) { '[' || $s || ']' } }
 )</eg></fos:expression>
                <fos:result>map { "x": "\", "y": "[\u0000]" }</fos:result>
@@ -24500,7 +24562,7 @@ return
                <fos:result>[ true(), false(), true() ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>parse-json('["a", null, "b"]',
+               <fos:expression><eg>parse-json('[ "a", null, "b" ]',
   map { 'null': xs:QName("fn:null") }
 )</eg></fos:expression>
                <fos:result>[ "a", xs:QName("fn:null"), "b" ]</fos:result>
@@ -24513,7 +24575,7 @@ return
       <fos:signatures>
          <fos:proto name="json-doc" return-type="item()?">
             <fos:arg name="href" type="xs:string?" example="'JSONTestSuite/test_parsing/y_number.json'"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24577,7 +24639,7 @@ return
       <fos:signatures>
          <fos:proto name="json" return-type="xs:string">
             <fos:arg name="input" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection"  default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection"  default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24593,7 +24655,7 @@ return
          supplied input <code>$input</code>. The function is error-free (it accepts any input sequence
          whatsoever), but it is not lossless: there are cases when two different XDM values will
          have the same JSON representation. For example, the sequence <code>(1, 2)</code>
-            and the array <code>[1, 2]</code> are both output as <code>[1,2]</code>.</p>
+            and the array <code>[ 1, 2 ]</code> are both output as <code>[ 1, 2 ]</code>.</p>
          
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
          
@@ -24773,9 +24835,9 @@ return
                
                <note><p>Conflicts between property names can arise because the XDM model allows keys of different types,
                   for example the <code>xs:date</code> value <code>2020-12-31</code> and the string value 
-                  <code>"2020-12-31"</code> can co-exist. The map <code>map{xs:duration('PTD'):20, "P1D":30}</code>
-                  is converted to the JSON string <code>{"P1D":20,"P1D(1)":30}</code> or 
-                  <code>{"P1D":30,"P1D(1)":20}</code>, depending on the (unpredictable) order in which the
+                  <code>"2020-12-31"</code> can co-exist. The map <code>map { xs:duration('PTD'): 20, "P1D": 30 }</code>
+                  is converted to the JSON string <code>{ "P1D": 20, "P1D(1)": 30 }</code> or 
+                  <code>{ "P1D": 30, "P1D(1)": 20 }</code>, depending on the (unpredictable) order in which the
                entries in the map are processed.</p></note>
                <note><p>Because the order of entries in a map is unpredictable, the order in which the
                properties are listed in the JSON output is also unpredictable.</p></note>
@@ -24798,7 +24860,7 @@ return
                   <item><p><code>#arguments</code> whose value is an array
                   of strings, which identify the names and types of the function arguments,
                   in the format <code>$Q{uri}local as SequenceType</code>: for example 
-                     <code>["$x as double", "$y as string"]</code>. Namespace prefixes must not be used:
+                     <code>[ "$x as double", "$y as string" ]</code>. Namespace prefixes must not be used:
                      unprefixed element names and variable names are taken to be in no namespace, and unprefixed
                      type names are taken to be in the namespace <code>http://www.w3.org/2001/XMLSchema</code>.
                   </p></item>
@@ -24856,7 +24918,7 @@ return
                <fos:result>'true'</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>json(map{"a":1,"b":number('NaN'),"c":(1,2,3)})</fos:expression>
+               <fos:expression>json(map { "a": 1,"b": number('NaN'), "c": (1, 2, 3) })</fos:expression>
                <fos:result>'{"a":1,"b":"NaN","c":[1,2,3]}'</fos:result>
                <fos:postamble>(or some permutation thereof)</fos:postamble>
             </fos:test>
@@ -24910,19 +24972,19 @@ return
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:size(["a", "b", "c"])</fos:expression>
+               <fos:expression>array:size([ "a", "b", "c" ])</fos:expression>
                <fos:result>3</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:size(["a", ["b", "c"]])</fos:expression>
+               <fos:expression>array:size([ "a", [ "b", "c" ] ])</fos:expression>
                <fos:result>2</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:size([ ])</fos:expression>
+               <fos:expression>array:size([])</fos:expression>
                <fos:result>0</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:size([[ ]])</fos:expression>
+               <fos:expression>array:size([ [] ])</fos:expression>
                <fos:result>1</fos:result>
             </fos:test>
          </fos:example>
@@ -24956,7 +25018,7 @@ return
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:empty(["a", "b", "c"])</fos:expression>
+               <fos:expression>array:empty([ "a", "b", "c" ])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
@@ -24964,11 +25026,11 @@ return
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:empty([[]])</fos:expression>
+               <fos:expression>array:empty([ [] ])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:empty([()])</fos:expression>
+               <fos:expression>array:empty([ () ])</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
@@ -25018,15 +25080,15 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>["a", "b", "c"] => array:get(2)</fos:expression>
+               <fos:expression>[ "a", "b", "c" ] => array:get(2)</fos:expression>
                <fos:result>"b"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>["a", ["b", "c"]] => array:get(2)</fos:expression>
-               <fos:result>["b", "c"]</fos:result>
+               <fos:expression>[ "a", [ "b", "c" ] ] => array:get(2)</fos:expression>
+               <fos:result>[ "b", "c" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>["a"] => array:get(1, void#1)</fos:expression>
+               <fos:expression>[ "a" ] => array:get(1, void#1)</fos:expression>
                <fos:result>"a"</fos:result>
             </fos:test>
             <fos:test>
@@ -25070,16 +25132,16 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:put(["a", "b", "c"], 2, "d")</fos:expression>
-               <fos:result>["a", "d", "c"]</fos:result>
+               <fos:expression>array:put([ "a", "b", "c" ], 2, "d")</fos:expression>
+               <fos:result>[ "a", "d", "c" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:put(["a", "b", "c"], 2, ("d", "e"))</fos:expression>
-               <fos:result>["a", ("d", "e"), "c"]</fos:result>
+               <fos:expression>array:put([ "a", "b", "c" ], 2, ("d", "e"))</fos:expression>
+               <fos:result>[ "a", ("d", "e"), "c" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:put(["a"], 1, ["d", "e"])</fos:expression>
-               <fos:result>[["d", "e"]]</fos:result>
+               <fos:expression>array:put([ "a" ], 1, [ "d", "e" ])</fos:expression>
+               <fos:result>[ [ "d", "e" ] ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25128,12 +25190,12 @@ else $fallback($position)</eg>
                <fos:result>[10, 21, 12]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:replace(["a", "b", "c"], 2, concat(?, "x"))</fos:expression>
-               <fos:result>["a", "bx", "c"]</fos:result>
+               <fos:expression>array:replace([ "a", "b", "c" ], 2, concat(?, "x"))</fos:expression>
+               <fos:result>[ "a", "bx", "c" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:replace([("a", "b"), ("c", "d")], 2, reverse#1)</fos:expression>
-               <fos:result>[("a", "b"), ("d", "c")]</fos:result>
+               <fos:expression>array:replace([ ("a", "b"), ("c", "d") ], 2, reverse#1)</fos:expression>
+               <fos:result>[ ("a", "b"), ("d", "c") ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25163,22 +25225,22 @@ else $fallback($position)</eg>
             members in positions 1 to <code>array:size($array)</code> are the same as the members in the corresponding position
             of <code>$array</code>, and the member in position <code>array:size($array) + 1</code> is <code>$member</code>.</p>
          <p diff="chg" at="A">More formally, the result is the value of the expression
-            <code>array:of-members((array:members($array), map{'value':$member}))</code>.</p>
+            <code>array:of-members((array:members($array), map { 'value': $member }))</code>.</p>
 
       </fos:rules>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:append(["a", "b", "c"], "d")</fos:expression>
-               <fos:result>["a", "b", "c", "d"]</fos:result>
+               <fos:expression>array:append([ "a", "b", "c" ], "d")</fos:expression>
+               <fos:result>[ "a", "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:append(["a", "b", "c"], ("d", "e"))</fos:expression>
-               <fos:result>["a", "b", "c", ("d", "e")]</fos:result>
+               <fos:expression>array:append([ "a", "b", "c" ], ("d", "e"))</fos:expression>
+               <fos:result>[ "a", "b", "c", ("d", "e") ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:append(["a", "b", "c"], ["d", "e"])</fos:expression>
-               <fos:result>["a", "b", "c", ["d", "e"]]</fos:result>
+               <fos:expression>array:append([ "a", "b", "c" ], [ "d", "e" ])</fos:expression>
+               <fos:result>[ "a", "b", "c", [ "d", "e" ] ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25211,23 +25273,23 @@ else $fallback($position)</eg>
          <fos:example>
             <fos:test>
                <fos:expression>array:join(())</fos:expression>
-               <fos:result>[ ]</fos:result>
+               <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:join([1, 2, 3])</fos:expression>
-               <fos:result>[1, 2, 3]</fos:result>
+               <fos:expression>array:join([ 1, 2, 3 ])</fos:expression>
+               <fos:result>[ 1, 2, 3 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:join((["a", "b"], ["c", "d"]))</fos:expression>
-               <fos:result>["a", "b", "c", "d"]</fos:result>
+               <fos:expression>array:join(([ "a", "b" ], [ "c", "d" ]))</fos:expression>
+               <fos:result>[ "a", "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:join((["a", "b"], ["c", "d"], [ ]))</fos:expression>
-               <fos:result>["a", "b", "c", "d"]</fos:result>
+               <fos:expression>array:join(([ "a", "b" ],  [ "c", "d" ], []))</fos:expression>
+               <fos:result>[ "a", "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:join((["a", "b"], ["c", "d"], [["e", "f"]]))</fos:expression>
-               <fos:result>["a", "b", "c", "d", ["e", "f"]]</fos:result>
+               <fos:expression>array:join(([ "a", "b" ], [ "c", "d" ], [ [ "e", "f" ] ]))</fos:expression>
+               <fos:result>[ "a", "b", "c", "d", [ "e", "f" ] ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25289,32 +25351,32 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:subarray(["a", "b", "c", "d"], 2)</fos:expression>
-               <fos:result>["b", "c", "d"]</fos:result>
+               <fos:expression>array:subarray([ "a", "b", "c", "d" ], 2)</fos:expression>
+               <fos:result>[ "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:subarray(["a", "b", "c", "d"], 5)</fos:expression>
-               <fos:result>[ ]</fos:result>
+               <fos:expression>array:subarray([ "a", "b", "c", "d" ], 5)</fos:expression>
+               <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:subarray(["a", "b", "c", "d"], 2, 0)</fos:expression>
-               <fos:result>[ ]</fos:result>
+               <fos:expression>array:subarray([ "a", "b", "c", "d" ], 2, 0)</fos:expression>
+               <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:subarray(["a", "b", "c", "d"], 2, 1)</fos:expression>
-               <fos:result>["b"]</fos:result>
+               <fos:expression>array:subarray([ "a", "b", "c", "d" ], 2, 1)</fos:expression>
+               <fos:result>[ "b" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:subarray(["a", "b", "c", "d"], 2, 2)</fos:expression>
-               <fos:result>["b", "c"]</fos:result>
+               <fos:expression>array:subarray([ "a", "b", "c", "d" ], 2, 2)</fos:expression>
+               <fos:result>[ "b", "c" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:subarray(["a", "b", "c", "d"], 5, 0)</fos:expression>
-               <fos:result>[ ]</fos:result>
+               <fos:expression>array:subarray([ "a", "b", "c", "d" ], 5, 0)</fos:expression>
+               <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:subarray([ ], 1, 0)</fos:expression>
-               <fos:result>[ ]</fos:result>
+               <fos:expression>array:subarray([], 1, 0)</fos:expression>
+               <fos:result>[]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25392,7 +25454,7 @@ else $fallback($position)</eg>
             <fos:test>
                <fos:expression><eg>
 array:index-of(
-  ["a", ("b", "C"), "d"],
+  [ "a", ("b", "C"), "d" ],
   ("B", "c"),
   "http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"
 )
@@ -25444,7 +25506,7 @@ array:index-of(
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:index-where([0, (), 4, 9], boolean#1)</fos:expression>
+               <fos:expression>array:index-where([ 0, (), 4, 9 ], boolean#1)</fos:expression>
                <fos:result>(3, 4)</fos:result>
             </fos:test>
             <fos:test>
@@ -25517,31 +25579,31 @@ array:index-of(
          <fos:example>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := 4)</fos:expression>
-               <fos:result>["b", "c", "d"]</fos:result>
+               <fos:result>[ "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2)</fos:expression>
-               <fos:result>["b", "c", "d", "e"]</fos:result>
+               <fos:result>[ "b", "c", "d", "e" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, end := 2)</fos:expression>
-               <fos:result>["a", "b"]</fos:result>
+               <fos:result>[ "a", "b" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 3, end := 3)</fos:expression>
-               <fos:result>["c"]</fos:result>
+               <fos:result>[ "c" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 4, end := 3)</fos:expression>
-               <fos:result>["d", "c"]</fos:result>
+               <fos:result>[ "d", "c" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := 5, step := 2)</fos:expression>
-               <fos:result>["b", "d"]</fos:result>
+               <fos:result>[ "b", "d" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 5, end := 2, step := -2)</fos:expression>
-               <fos:result>["e", "c"]</fos:result>
+               <fos:result>[ "e", "c" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := 5, step := -2)</fos:expression>
@@ -25553,47 +25615,47 @@ array:index-of(
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in)</fos:expression>
-               <fos:result>["a", "b", "c", "d", "e"]</fos:result>
+               <fos:result>[ "a", "b", "c", "d", "e" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -1)</fos:expression>
-               <fos:result>["e"]</fos:result>
+               <fos:result>[ "e" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -3)</fos:expression>
-               <fos:result>["c", "d", "e"]</fos:result>
+               <fos:result>[ "c", "d", "e" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, end := -2)</fos:expression>
-               <fos:result>["a", "b", "c", "d"]</fos:result>
+               <fos:result>[ "a", "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := -2)</fos:expression>
-               <fos:result>["b", "c", "d"]</fos:result>
+               <fos:result>[ "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -2, end := 2)</fos:expression>
-               <fos:result>["d", "c", "b"]</fos:result>
+               <fos:result>[ "d", "c", "b" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -4, end := -2)</fos:expression>
-               <fos:result>["b", "c", "d"]</fos:result>
+               <fos:result>[ "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -2, end := -4)</fos:expression>
-               <fos:result>["d", "c", "b"]</fos:result>
+               <fos:result>[ "d", "c", "b" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -4, end := -2, step := 2)</fos:expression>
-               <fos:result>["b", "d"]</fos:result>
+               <fos:result>[ "b", "d" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := -2, end := -4, step := -2)</fos:expression>
-               <fos:result>["d", "b"]</fos:result>
+               <fos:result>[ "d", "b" ]</fos:result>
             </fos:test>
             <fos:test use="a-slice">
-               <fos:expression>array:slice(["a", "b", "c", "d"], 0)</fos:expression>
-               <fos:result>["a", "b", "c", "d"]</fos:result>
+               <fos:expression>array:slice([ "a", "b", "c", "d" ], 0)</fos:expression>
+               <fos:result>[ "a", "b", "c", "d" ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25636,24 +25698,24 @@ array:index-of(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:remove(["a", "b", "c", "d"], 1)</fos:expression>
-               <fos:result>["b", "c", "d"]</fos:result>
+               <fos:expression>array:remove([ "a", "b", "c", "d" ], 1)</fos:expression>
+               <fos:result>[ "b", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:remove(["a", "b", "c", "d"], 2)</fos:expression>
-               <fos:result>["a", "c", "d" ]</fos:result>
+               <fos:expression>array:remove([ "a", "b", "c", "d" ], 2)</fos:expression>
+               <fos:result>[ "a", "c", "d" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:remove(["a"], 1)</fos:expression>
-               <fos:result>[ ]</fos:result>
+               <fos:expression>array:remove([ "a" ], 1)</fos:expression>
+               <fos:result>[]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:remove(["a", "b", "c", "d"], 1 to 3)</fos:expression>
-               <fos:result>["d"]</fos:result>
+               <fos:expression>array:remove([ "a", "b", "c", "d" ], 1 to 3)</fos:expression>
+               <fos:result>[ "d" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:remove(["a", "b", "c", "d"], ())</fos:expression>
-               <fos:result>["a", "b", "c", "d"]</fos:result>
+               <fos:expression>array:remove([ "a", "b", "c", "d" ], ())</fos:expression>
+               <fos:result>[ "a", "b", "c", "d" ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25686,7 +25748,7 @@ array:index-of(
             then all members from <code>$array</code> whose position is greater than or equal to <code>$position</code>. 
             Positions are counted from 1.</p>
          <p>More formally, except in error cases, the result is the value of the expression
-            <code role="example">array:of-members(array:members($array) => fn:insert-before($position, map{'value':$member}))</code>.</p>
+            <code role="example">array:of-members(array:members($array) => fn:insert-before($position, map { 'value': $member }))</code>.</p>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
@@ -25701,27 +25763,27 @@ array:index-of(
          <fos:example>
             <fos:test>
                <fos:expression><eg>array:insert-before(
-  ["a", "b", "c", "d"],
+  [ "a", "b", "c", "d" ],
   3,
   ("x", "y")
 )</eg></fos:expression>
-               <fos:result>["a", "b", ("x", "y"), "c", "d"]</fos:result>
+               <fos:result>[ "a", "b", ("x", "y"), "c", "d" ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:insert-before(
-  ["a", "b", "c", "d"],
+  [ "a", "b", "c", "d" ],
   5,
   ("x", "y")
 )</eg></fos:expression>
-               <fos:result>["a", "b", "c", "d", ("x", "y")]</fos:result>
+               <fos:result>[ "a", "b", "c", "d", ("x", "y") ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:insert-before(
-  ["a", "b", "c", "d"],
+  [ "a", "b", "c", "d" ],
   3,
-  ["x", "y"]
+  [ "x", "y" ]
 )</eg></fos:expression>
-               <fos:result>["a", "b", ["x", "y"], "c", "d"]</fos:result>
+               <fos:result>[ "a", "b", [ "x", "y" ], "c", "d" ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25758,15 +25820,15 @@ array:index-of(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:head([5, 6, 7, 8])</fos:expression>
+               <fos:expression>array:head([ 5, 6, 7, 8 ])</fos:expression>
                <fos:result>5</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:head([["a", "b"], ["c", "d"]])</fos:expression>
-               <fos:result>["a", "b"]</fos:result>
+               <fos:expression>array:head([ [ "a", "b" ], [ "c", "d" ] ])</fos:expression>
+               <fos:result>[ "a", "b" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:head([("a", "b"), ("c", "d")])</fos:expression>
+               <fos:expression>array:head([ ("a", "b"), ("c", "d") ])</fos:expression>
                <fos:result>"a", "b"</fos:result>
             </fos:test>
          </fos:example>
@@ -25801,15 +25863,15 @@ array:index-of(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:foot([5, 6, 7, 8])</fos:expression>
+               <fos:expression>array:foot([ 5, 6, 7, 8 ])</fos:expression>
                <fos:result>8</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:foot([["a", "b"], ["c", "d"]])</fos:expression>
-               <fos:result>["c", "d"]</fos:result>
+               <fos:expression>array:foot([ [ "a", "b" ], [ "c", "d" ] ])</fos:expression>
+               <fos:result>[ "c", "d" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:foot([("a", "b"), ("c", "d")])</fos:expression>
+               <fos:expression>array:foot([ ("a", "b"), ("c", "d") ])</fos:expression>
                <fos:result>"c", "d"</fos:result>
             </fos:test>
          </fos:example>
@@ -25847,12 +25909,12 @@ array:index-of(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:tail([5, 6, 7, 8])</fos:expression>
-               <fos:result>[6, 7, 8]</fos:result>
+               <fos:expression>array:tail([ 5, 6, 7, 8 ])</fos:expression>
+               <fos:result>[ 6, 7, 8 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:tail([5])</fos:expression>
-               <fos:result>[ ]</fos:result>
+               <fos:expression>array:tail([ 5 ])</fos:expression>
+               <fos:result>[]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25890,12 +25952,12 @@ array:index-of(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:trunk([5, 6, 7, 8])</fos:expression>
-               <fos:result>[5, 6, 7]</fos:result>
+               <fos:expression>array:trunk([ 5, 6, 7, 8 ])</fos:expression>
+               <fos:result>[ 5, 6, 7 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:trunk([5])</fos:expression>
-               <fos:result>[ ]</fos:result>
+               <fos:expression>array:trunk([ 5 ])</fos:expression>
+               <fos:result>[]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -25925,16 +25987,16 @@ array:index-of(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:reverse(["a", "b", "c", "d"])</fos:expression>
-               <fos:result>["d", "c", "b", "a"]</fos:result>
+               <fos:expression>array:reverse([ "a", "b", "c", "d" ])</fos:expression>
+               <fos:result>[ "d", "c", "b", "a" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:reverse([("a", "b"), ("c", "d")])</fos:expression>
-               <fos:result>[("c", "d"), ("a", "b")]</fos:result>
+               <fos:expression>array:reverse([ ("a", "b"), ("c", "d") ])</fos:expression>
+               <fos:result>[ ("c", "d"), ("a", "b") ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:reverse([(1 to 5)])</fos:expression>
-               <fos:result>[(1, 2, 3, 4, 5)]</fos:result>
+               <fos:expression>array:reverse([ 1 to 5 ])</fos:expression>
+               <fos:result>[ (1, 2, 3, 4, 5) ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>array:reverse([])</fos:expression>
@@ -26003,7 +26065,7 @@ return [ $action($member, $pos) ]
   ['one', 'two', 'three'],
   fn($member, $pos) { $pos || '. ' || $member }
 )</eg></fos:expression>
-               <fos:result>["1. one", "2. two", "3. three"]</fos:result>
+               <fos:result>[ "1. one", "2. two", "3. three" ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -26049,31 +26111,31 @@ array:of-members(
          <fos:example>
             <fos:test>
                <fos:expression><eg>array:filter(
-  ["A", "B", 1, 2],
+  [ "A", "B", 1, 2 ],
   function($x) { $x instance of xs:integer }
 )</eg></fos:expression>
-               <fos:result>[1, 2]</fos:result>
+               <fos:result>[ 1, 2 ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:filter(
-  ["the cat", "sat", "on the mat"],
+  [ "the cat", "sat", "on the mat" ],
   function { count(tokenize(.)) > 1 }
 )</eg></fos:expression>
-               <fos:result>["the cat", "on the mat"]</fos:result>
+               <fos:result>[ "the cat", "on the mat" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:filter(["A", "B", "", 0, 1], boolean#1)</fos:expression>
-               <fos:result>["A", "B", 1]</fos:result>
+               <fos:expression>array:filter([ "A", "B", "", 0, 1 ], boolean#1)</fos:expression>
+               <fos:result>[ "A", "B", 1] </fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $array := [1, 1, 2, 3, 4, 4, 5]
+               <fos:expression><eg>let $array := [ 1, 1, 2, 3, 4, 4, 5 ]
 return array:filter(
   $array,
   fn($item, $pos) { $pos > 1 and $item = $array($pos - 1) }
 )</eg></fos:expression>
-               <fos:result>[1, 4]</fos:result>
+               <fos:result>[ 1, 4 ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -26232,7 +26294,7 @@ fold-right(
   [],
   function($x, $y) { [ $x, $y ] }
 )</eg></fos:expression>
-               <fos:result>[1, [2, [3, []]]]</fos:result>
+               <fos:result>[ 1, [ 2, [ 3, [] ] ] ]</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -26288,34 +26350,34 @@ return array:fold-right($input, (),
          <fos:example>
             <fos:test>
                <fos:expression><eg>array:for-each-pair(
-  ["A", "B", "C"],
-  [1, 2, 3],
+  [ "A", "B", "C" ],
+  [ 1, 2, 3 ],
   function($x, $y) { array { $x, $y }}
 )</eg></fos:expression>
-               <fos:result>[["A", 1], ["B", 2], ["C", 3]]</fos:result>
+               <fos:result>[ [ "A", 1 ], [ "B", 2 ], [ "C", 3 ] ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>let $array := ["A", "B", "C", "D"]
+               <fos:expression><eg>let $array := [ "A", "B", "C", "D" ]
 return array:for-each-pair(
   $array,
   array:tail($array),
   concat#2
 )</eg></fos:expression>
-               <fos:result>["AB", "BC", "CD"]</fos:result>
+               <fos:result>[ "AB", "BC", "CD" ]</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[
 array:for-each-pair(
-  [1, 8, 2],
-  [3, 4, 3],
+  [ 1, 8, 2 ],
+  [ 3, 4, 3 ],
   fn($member1, $member2, $pos) {
     $pos || ': ' || max(($member1, $member2))
   }
 )
 ]]></eg></fos:expression>
-               <fos:result>["1: 3", "2: 8", "3: 3"]</fos:result>
+               <fos:result>[ "1: 3", "2: 8", "3: 3" ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -26351,7 +26413,7 @@ array:for-each-pair(
       </fos:rules>
       <fos:notes>
          <p>The single-argument function <code>array:build($input)</code> is equivalent to the XPath
-         expression <code>array{$input}</code>, but it is useful to have this available as a function.</p>
+         expression <code>array { $input }</code>, but it is useful to have this available as a function.</p>
          <p>The two-argument form facilitates the construction of arrays whose members are arbitrary
          sequences.</p>
       </fos:notes>
@@ -26359,21 +26421,21 @@ array:for-each-pair(
          <fos:example>
             <fos:test>
                <fos:expression>array:build(1 to 5)</fos:expression>
-               <fos:result>[1, 2, 3, 4, 5]</fos:result>
+               <fos:result>[ 1, 2, 3, 4, 5 ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:build(
   1 to 5,
   function { 2 * . }
 )</eg></fos:expression>
-               <fos:result>[2, 4, 6, 8, 10]</fos:result>
+               <fos:result>[ 2, 4, 6, 8, 10 ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:build(
   1 to 5,
   function { 1 to . }
 )</eg></fos:expression>
-               <fos:result>[1, (1,2), (1,2,3), (1,2,3,4), (1,2,3,4,5)]</fos:result>
+               <fos:result>[ 1, (1, 2), (1, 2, 3), (1, 2, 3, 4), (1, 2, 3, 4, 5) ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:build(
@@ -26387,7 +26449,7 @@ array:for-each-pair(
   1 to 5,
   function { array { 1 to . } }
 )</eg></fos:expression>
-               <fos:result>[[1], [1,2], [1,2,3], [1,2,3,4], [1,2,3,4,5]]</fos:result>
+               <fos:result>[ [ 1 ], [ 1, 2 ], [ 1, 2, 3 ], [ 1, 2, 3, 4 ], [ 1, 2, 3, 4, 5 ] ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -26551,15 +26613,15 @@ return deep-equal(
             </fos:test>
             <fos:test>
                <fos:expression>array:of-members(map { 'value': (1 to 5) })</fos:expression>
-               <fos:result>[(1, 2, 3, 4, 5)]</fos:result>
+               <fos:result>[ (1, 2, 3, 4, 5) ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>array:of-members((1 to 5) ! map { 'value': . })</fos:expression>
-               <fos:result>[1, 2, 3, 4, 5]</fos:result>
+               <fos:result>[ 1, 2, 3, 4, 5 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:of-members((1 to 5) ! map { 'value': (., .*.) })</fos:expression>
-               <fos:result>[(1,1), (2,4), (3,9), (4,16), (5,25)]</fos:result>
+               <fos:expression>array:of-members((1 to 5) ! map { 'value': (., . * .) })</fos:expression>
+               <fos:result>[ (1, 1), (2, 4), (3, 9), (4, 16), (5, 25)]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -26658,27 +26720,29 @@ return deep-equal(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:sort([1, 4, 6, 5, 3])</fos:expression>
-               <fos:result>[1, 3, 4, 5, 6]</fos:result>
+               <fos:expression>array:sort([ 1, 4, 6, 5, 3 ])</fos:expression>
+               <fos:result>[ 1, 3, 4, 5, 6 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:sort([1, 4, 4e0, 6, 5, 3], orders := "descending")</fos:expression>
-               <fos:result>[6, 5, 4, 4e0, 3, 1]</fos:result>
+               <fos:expression>array:sort([ 1, 4, 4e0, 6, 5, 3 ], orders := "descending")</fos:expression>
+               <fos:result>[ 6, 5, 4, 4e0, 3, 1 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:sort([1, -2, 5, 10, -10, 10, 8], (), abs#1)</fos:expression>
-               <fos:result>[1, -2, 5, 8, 10, -10, 10]</fos:result>
+               <fos:expression>array:sort([ 1, -2, 5, 10, -10, 10, 8 ], (), abs#1)</fos:expression>
+               <fos:result>[ 1, -2, 5, 8, 10, -10, 10 ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:sort([[2, "i"], [1, "e"], [2, "g"], [1, "f"]])</fos:expression>
-               <fos:result>[[1, "e"], [1, "f"], [2, "g"], [2, "i"]]</fos:result>
+               <fos:expression>array:sort([ [ 2, "i" ], [ 1, "e" ], [ 2, "g" ], [ 1, "f" ] ])</fos:expression>
+               <fos:result>[ [ 1, "e" ], [ 1, "f" ], [ 2, "g" ], [ 2, "i" ] ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>array:sort([[2, "i"], [1, "e"], [2, "g"], [1, "f"]], 
-     (), 
-     (array:get(?, 1), array:get(?, 2)),
-     ("ascending", "descending"))</eg></fos:expression>
-               <fos:result>[[1, "f"], [1, "e"], [2, "i"], [2, "g"]]</fos:result>
+               <fos:expression><eg>array:sort(
+  [ [ 2, "i" ], [ 1, "e" ], [ 2, "g" ], [ 1, "f" ] ], 
+  (), 
+  (array:get(?, 1), array:get(?, 2)),
+  ("ascending", "descending")
+)</eg></fos:expression>
+               <fos:result>[ [ 1, "f" ], [ 1, "e" ], [ 2, "i" ], [ 2, "g" ]]</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -26692,7 +26756,7 @@ return deep-equal(
             <p>To sort an array of maps representing employees, using last name as the major sort key and first name as the minor sort key,
                with the default collation:
             </p>
-            <eg>array:sort($employees, (), function($emp) {$emp?name?last, $emp?name?first})</eg>
+            <eg>array:sort($employees, (), function($emp) { $emp?name?last, $emp?name?first })</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
@@ -26743,15 +26807,15 @@ declare function flatten(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:flatten([1, 4, 6, 5, 3])</fos:expression>
+               <fos:expression>array:flatten([ 1, 4, 6, 5, 3 ])</fos:expression>
                <fos:result>(1, 4, 6, 5, 3)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:flatten(([1, 2, 5], [[10, 11], 12], [], 13))</fos:expression>
+               <fos:expression>array:flatten(([ 1, 2, 5 ], [ [ 10, 11 ], 12 ], [], 13))</fos:expression>
                <fos:result>(1, 2, 5, 10, 11, 12, 13)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:flatten([(1,0), (1,1), (0,1), (0,0)])</fos:expression>
+               <fos:expression>array:flatten([ (1, 0), (1, 1), (0, 1), (0, 0) ])</fos:expression>
                <fos:result>(1, 0, 1, 1, 0, 1, 0, 0)</fos:result>
             </fos:test>
          </fos:example>
@@ -26799,7 +26863,7 @@ declare function flatten(
       <fos:signatures>
          <fos:proto name="load-xquery-module" return-type-ref="load-xquery-module-record">
             <fos:arg name="module-uri" type="xs:string"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -27523,7 +27587,7 @@ declare function flatten(
                         its default), following the same rules as when one <code>xsl:output</code>
                         declaration overrides another with lower import precedence.</p></item>
                      <item><p>When a parameter is supplied and the corresponding value is an empty
-                        sequence (for example, <code>map{"standalone":()}</code>), any value
+                        sequence (for example, <code>map { "standalone": () }</code>), any value
                         specified in the unnamed <code>xsl:output</code> declaration is overridden
                         by the default value. </p></item>
                      <item><p>When a parameter is not supplied in <code>serialization-params</code> (that
@@ -27630,7 +27694,7 @@ declare function flatten(
                      >implementation-defined</termref>. Implementations
                 <rfc2119>should</rfc2119> ignore options whose names are in an unrecognized
             namespace. Default is an empty map.</fos:meaning>
-               <fos:type>map{xs:QName, item()*}</fos:type>
+               <fos:type>map { xs:QName, item()* }</fos:type>
                <fos:default>Empty map</fos:default>
             </fos:option>
 
@@ -28566,7 +28630,7 @@ return $it
          <p>There is no analogous <code>drop-while</code> or <code>skip-while</code> function,
          as found in some functional programming languages. The effect of 
             <code>drop-while($input, $predicate)</code> can be achieved by calling
-         <code>fn:subsequence-where($input, fn{not($predicate(.))})</code>.</p>
+         <code>fn:subsequence-where($input, fn { not($predicate(.)) })</code>.</p>
       </fos:notes>
       
 
@@ -28574,11 +28638,11 @@ return $it
 
          <fos:example>
             <fos:test>
-               <fos:expression>take-while(10 to 20, fn{. le 12})</fos:expression>
+               <fos:expression>take-while(10 to 20, fn {. le 12 })</fos:expression>
                <fos:result>(10, 11, 12)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>take-while(10 to 20, fn{. lt 100})</fos:expression>
+               <fos:expression>take-while(10 to 20, fn {. lt 100 })</fos:expression>
                <fos:result>(10 to 20)</fos:result>
             </fos:test>
             <fos:test>
@@ -28611,7 +28675,7 @@ return $it
             <fos:test>
                <fos:expression><eg>take-while(
   characters("ABCD-123"), 
-  fn($ch, $pos) { $pos lt 4 and $ch ne '-'}
+  fn($ch, $pos) { $pos lt 4 and $ch ne '-' }
 ) => string-join()
 </eg></fos:expression>
                <fos:result>"ABC"</fos:result>
@@ -29195,7 +29259,7 @@ some $boolean in (
       <fos:signatures>
          <fos:proto name="parse-uri" return-type-ref="uri-structure-record">
             <fos:arg name="uri" type="xs:string"/>
-            <fos:arg name="options" type="map(*)?" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -29975,7 +30039,7 @@ path with an explicit <code>file:</code> scheme.</p>
                "port": (),
                "path": "/specifications/index.html"
                }'/>
-            <fos:arg name="options" type="map(*)?" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -30203,7 +30267,7 @@ path with an explicit <code>file:</code> scheme.</p>
     substring(head($partition),1,1) ne substring($next,1,1)
   }
 )</eg></fos:expression>
-               <fos:result>(["Anita", "Anne"], ["Barbara"], ["Catherine", "Christine"])</fos:result>
+               <fos:result>([ "Anita", "Anne" ], [ "Barbara" ], [ "Catherine", "Christine" ])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
@@ -30212,7 +30276,7 @@ path with an explicit <code>file:</code> scheme.</p>
     count($partition) eq 2
   }
 )</eg></fos:expression>
-               <fos:result>([1, 2], [3, 4], [5, 6], [7])</fos:result>
+               <fos:result>([ 1, 2 ], [ 3, 4 ], [ 5, 6 ], [ 7 ])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
@@ -30221,7 +30285,7 @@ path with an explicit <code>file:</code> scheme.</p>
     sum($partition) ge 5
   }
 )</eg></fos:expression>
-               <fos:result>([1, 4], [6], [3, 1, 1])</fos:result>
+               <fos:result>([ 1, 4 ], [ 6 ], [ 3, 1, 1 ])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
@@ -30230,21 +30294,21 @@ path with an explicit <code>file:</code> scheme.</p>
     sum(($partition, $next) ! string-length()) gt 10
   }
 )</eg></fos:expression>
-               <fos:result>(["In", "the"], ["beginning"], ["was", "the", "word"])</fos:result>
+               <fos:result>([ "In", "the" ], [ "beginning" ], [ "was", "the", "word" ])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
   (1, 2, 3, 6, 7, 9, 10),
   function($partition, $next) { $next != foot($partition) + 1 }
 )</eg></fos:expression>
-               <fos:result>([1, 2, 3], [6, 7], [9, 10])</fos:result>
+               <fos:result>([ 1, 2, 3 ], [ 6, 7 ], [ 9, 10 ])</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>partition(
   ('a', 'b', 'c', 'd', 'e'),
   fn($all, $next, $p) { $p mod 2 = 1 }
 )</eg></fos:expression>
-               <fos:result>["a", "b"], ["c", "d"], ["e"]</fos:result>
+               <fos:result>[ "a", "b" ], [ "c", "d" ], [ "e" ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -30322,13 +30386,13 @@ $scan-left := function($input as item()*,
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 10, 0, op('+'))</eg></fos:expression>
-               <fos:result>[0], [1], [3], [6], [10], [15], [21], [28], [36], [45], [55]</fos:result>
+               <fos:result>[ 0 ], [ 1 ], [ 3 ], [ 6 ], [ 10 ], [ 15 ], [ 21 ], [ 28 ], [ 36 ], [ 45 ], [ 55 ]</fos:result>
             </fos:test>
          </fos:example>         
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 3, 0, op('-'))</eg></fos:expression>
-               <fos:result>[0], [-1], [-3], [-6]</fos:result>
+               <fos:result>[ 0 ], [ -1 ], [ -3 ], [ -6 ]</fos:result>
             </fos:test>
          </fos:example>      
          <fos:example>
@@ -30337,16 +30401,16 @@ $scan-left := function($input as item()*,
             the sequence of sequences (intermediate results) would not be possible to express as a single sequence
             without losing completely the intermediate results.</p>
             <fos:test>
-               <fos:expression><eg>let $double := fn($x){2 * $x}
-  return scan-left(1 to 5, (), fn($seq, $it){$seq , $double($it)})</eg></fos:expression>
-               <fos:result>[()], [2], [(2,4)], [(2,4,6)], [(2,4,6,8)], [(2,4,6,8,10)]</fos:result>
+               <fos:expression><eg>let $double := fn($x) { 2 * $x }
+return scan-left(1 to 5, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:expression>
+               <fos:result>[ () ], [ 2 ], [ (2, 4) ], [ (2, 4, 6) ], [ (2, 4, 6, 8) ], [ (2, 4, 6, 8, 10) ]</fos:result>
             </fos:test>
          </fos:example>  
          <fos:example>
             <p> Produce the factorials of all numbers from 0 to 10</p>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 10, 1, op('*'))</eg></fos:expression>
-               <fos:result>[1], [1], [2], [6], [24], [120], [720], [5040], [40320], [362880], [3628800]</fos:result>
+               <fos:result>[ 1 ], [ 1 ], [ 2 ], [ 6 ], [ 24 ], [ 120 ], [ 720 ], [ 5040 ], [ 40320 ], [ 362880 ], [ 3628800 ]</fos:result>
             </fos:test>
          </fos:example>           
       </fos:examples>          
@@ -30441,7 +30505,7 @@ return
       <fos:signatures>
          <fos:proto name="invisible-xml" return-type="function(xs:string) as item()">
             <fos:arg name="grammar" type="item()?" default="()"/>
-            <fos:arg name="options" type="map(*)?" default="map{}"/>
+            <fos:arg name="options" type="map(*)?" default="map { }"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -30702,22 +30766,23 @@ return $result
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>pin(["a","b","c"])?1 => label()?parent => array:foot()</fos:expression>
+               <fos:expression>pin([ "a", "b", "c" ])?1 => label()?parent => array:foot()</fos:expression>
                <fos:result>"c"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>pin(["a","b","c","d"]) => array:remove(2)?* =!> label()?key </fos:expression>
+               <fos:expression>pin([ "a", "b", "c", "d" ]) => array:remove(2)?* =!> label()?key </fos:expression>
                <fos:result>1, 3, 4</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>let $data := map{
-         "fr":map{"capital":"Paris", "languages":["French"]}, 
-         "de":map{"capital":"Berlin", "languages":["German"]}
-       } return pin($data)??languages[.='German']!label()?path()[1]</eg></fos:expression>
+               <fos:expression><eg>let $data := map {
+  "fr": map { "capital": "Paris", "languages": [ "French" ] }, 
+  "de": map { "capital": "Berlin", "languages": [ "German" ] }
+}
+return pin($data)??languages[. = 'German'] ! label()?path()[1]</eg></fos:expression>
                <fos:result>"de"</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1418,7 +1418,7 @@
             be an instance of <code>xs:integer</code>.</p>
          <p>If the second argument is omitted or an empty sequence,
             the function produces the same result as the two-argument version with
-            <code>$precision=0</code> (that is, it rounds to a whole number).</p>
+            <code>$precision = 0</code> (that is, it rounds to a whole number).</p>
          <p>When <code>$value</code> is of type <code>xs:float</code> and <code>xs:double</code>:</p>
          <olist>
             <item>
@@ -1527,7 +1527,7 @@
             be an instance of <code>xs:integer</code>.</p>
          <p diff="chg" at="2023-01-17"> If the second argument is omitted or an empty sequence,
             the function produces the same result as the two-argument version with
-            <code>$precision=0</code>.</p>
+            <code>$precision = 0</code>.</p>
          <p>For arguments of type <code>xs:float</code> and <code>xs:double</code>:</p>
          <olist>
             <item>
@@ -25512,7 +25512,7 @@ array:index-of(
             <fos:test>
                <fos:expression><eg>array:index-where(
   array { 1 to 10 },
-  function {. mod 2 = 0 }
+  function { . mod 2 = 0 }
 )</eg></fos:expression>
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
@@ -28012,7 +28012,7 @@ every $boolean in (
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>every((1=1, 2=2, 3=4))</fos:expression>
+               <fos:expression>every((1 = 1, 2 = 2, 3 = 4))</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
@@ -29009,7 +29009,7 @@ some $boolean in (
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some((1=1, 2=2, 3=4))</fos:expression>
+               <fos:expression>some((1 = 1, 2 = 2, 3 = 4))</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
@@ -29017,11 +29017,11 @@ some $boolean in (
                <fos:result>false()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some((1, 3, 7), function {. mod 2 = 1 })</fos:expression>
+               <fos:expression>some((1, 3, 7), function { . mod 2 = 1 })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>some(-5 to +5, function {. ge 0 })</fos:expression>
+               <fos:expression>some(-5 to +5, function { . ge 0 })</fos:expression>
                <fos:result>true()</fos:result>
             </fos:test>
             <fos:test>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13486,7 +13486,7 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          
          <eg>let $start := index-where($input, $from)[1] 
               otherwise (count($input) + 1)
-let $end :=   index-where($input, $to)[. ge $start][1] 
+let   $end := index-where($input, $to)[. ge $start][1] 
               otherwise (count($input) + 1)
 return slice($input, $start, $end)</eg>
          
@@ -18838,7 +18838,7 @@ let $input := (11 to 21, 21 to 31)
 let $search := 21
 return fold-left($input, (),
   fn($result, $curr, $pos) {
-    $result, if($curr = $search) { $pos }
+    $result, if ($curr = $search) { $pos }
   }
 )
 </eg></fos:expression>
@@ -19018,16 +19018,16 @@ return fold-right($input, (),
             <p>More formally, the function is equivalent to the following implementation in XPath:</p>
             <eg>
 <![CDATA[let $chain := (
-let $apply := function($x, $f)  {
-  fn:apply($f,
-    if(function-arity($f) eq 1) then [ $x ]
-    else if($x instance of array(*)) then $x 
-    else array { $x }
-  )
-}
-return function($input as item()*, $functions as function(*)*) as item()* {
-  fold-left($functions, $input, $apply)
-}           
+  let $apply := function($x, $f)  {
+    fn:apply($f,
+      if (function-arity($f) eq 1) then [ $x ]
+      else if ($x instance of array(*)) then $x 
+      else array { $x }
+    )
+  }
+  return function($input as item()*, $functions as function(*)*) as item()* {
+    fold-left($functions, $input, $apply)
+  }           
 )]]>
             </eg>
         </fos:rules>
@@ -19909,7 +19909,7 @@ return sort($in, $SWEDISH)</eg>
          </ulist>
          <p>Users are responsible for supplying transitive comparators; otherwise, the result
             might not be correctly sorted. An example for a non-transitive and thus unsuitable
-            comparator is <code>fn($a, $b) { if($a mod 2 = 1) then 1 else -1 }</code>,
+            comparator is <code>fn($a, $b) { if ($a mod 2 = 1) then 1 else -1 }</code>,
             as it considers odd numbers to be greater than even numbers.</p>
          <p>Sorting is <emph>stable</emph>, which means that the relative order of the input items
             is maintained.</p>
@@ -19925,7 +19925,7 @@ declare function sort-with(
   ) else (
     let $head := head($input), $sorted-tail := sort-with(tail($input), $comparators)
     let $diff := fold-left($comparators, 0, fn($df, $cmp) {
-      if($df != 0) then $df else $cmp($head, head($sorted-tail))
+      if ($df != 0) then $df else $cmp($head, head($sorted-tail))
     })
     return if ($diff <= 0) then (
       $head, $sorted-tail
@@ -20023,7 +20023,7 @@ return sort-with($persons/person, (
   let $nextStep := $nodes/$step(.)
   let $newNodes := $nextStep except $nodes
   return if (exists($newNodes))
-         then $nodes | tc-inclusive($newNodes, $step)
+         then $nodes union tc-inclusive($newNodes, $step)
          else $nodes
 };
 declare function transitive-closure (
@@ -20939,8 +20939,7 @@ return fold-left($MAPS, map { },
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs(
-  (map:pairs($week),
-   map { "key": 6, "value": "Sonnabend" }),
+  (map:pairs($week), map { "key": 6, "value": "Sonnabend" }),
   function($old, $new)  { $new }
 )</eg></fos:expression>
                <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
@@ -20953,8 +20952,7 @@ return fold-left($MAPS, map { },
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs(
-  (map:pairs($week),
-   map { "key": 6, "value": "Sonnabend" }),
+  (map:pairs($week), map { "key": 6, "value": "Sonnabend" }),
   function($old, $new) { `{ $old }|{ $new }` }
 )</eg></fos:expression>
                <fos:result>map { 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch", 4: "Donnerstag",
@@ -21038,7 +21036,7 @@ map:for-each($map, fn($key, $value) { $key })
          <p>More formally, the function returns the value of the expression:</p>
          <eg><![CDATA[
 map:for-each($map, fn($key, $value) {
-  if($predicate($key, $value)) { $key }
+  if ($predicate($key, $value)) { $key }
 })
 ]]></eg>
          <p>The function is <term>nondeterministic with respect to ordering</term>
@@ -26217,7 +26215,7 @@ let $input := array { 11 to 21, 21 to 31 }
 let $search := 21
 return array:fold-left($input, (),
   fn($result, $curr, $pos) {
-    $result, if($curr = $search) { $pos }
+    $result, if ($curr = $search) { $pos }
   }
 )
 </eg></fos:expression>
@@ -26304,7 +26302,7 @@ let $input := array { 11 to 21, 21 to 31 }
 let $search := 21
 return array:fold-right($input, (),
   fn($curr, $result, $pos) {
-    $result, if($curr = $search) { $pos }
+    $result, if ($curr = $search) { $pos }
   }
 )</eg></fos:expression>
                <fos:result>(12, 11)</fos:result>
@@ -30344,7 +30342,7 @@ let $scan-left-inner := function(
   $self   as function(*)
 ) as array(*)* {
   let $result := [$zero]
-  return if(empty($input)) then (
+  return if (empty($input)) then (
     $result
   ) else (
     $result, $self(tail($input), $action($zero, head($input)), $action, $self)
@@ -30439,7 +30437,7 @@ let $scan-right-inner := function(
   $zero   as item()*,
   $action as function(item()*, item()) as item()*, $self as function(*)
 ) as array(*)* {
-  if(empty($input)) then (
+  if (empty($input)) then (
     [ $zero ]
   ) else (
     let $rightResult := $self(tail($input), $zero, $action, $self)

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17159,11 +17159,11 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </fos:test>
             <fos:test>
                <fos:expression>array:of-members((parcel(1 to 3), parcel(10 to 13))</fos:expression>
-               <fos:result>[(1, 2, 3), (10, 11, 12, 13)]</fos:result>
+               <fos:result>[ (1, 2, 3), (10, 11, 12, 13) ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>array:of-members(tokenize("A long hot summer") ! parcel((position(), .)))</fos:expression>
-               <fos:result>[(1,"A"), (2,"long"), (3,"hot"), (4,"summer")]</fos:result>
+               <fos:result>[ (1, "A"), (2, "long"), (3, "hot"), (4, "summer") ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -19215,7 +19215,7 @@ chain(2, ($range, $doubleAll, op("*")))
                     <fos:test use="chain-variable-countAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain([(1,2,3), ()], ($countAll, op("+")))
+chain([ (1,2,3), () ], ($countAll, op("+")))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>3</fos:result>
@@ -19225,7 +19225,7 @@ chain([(1,2,3), ()], ($countAll, op("+")))
                     <fos:test use="chain-variable-countAll">
                         <fos:expression>
                             <eg><![CDATA[
-chain([(1,2,3), (), (5, 6)], ($countAll, sum#1))
+chain([ (1,2,3), (), (5, 6) ], ($countAll, sum#1))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>5</fos:result>
@@ -19235,7 +19235,7 @@ chain([(1,2,3), (), (5, 6)], ($countAll, sum#1))
                     <fos:test use="chain-variable-countAll chain-variable-product3">
                         <fos:expression>
                             <eg><![CDATA[
-chain([(1,2,3), (), (5, 6)], ($countAll, $product3))
+chain([ (1,2,3), (), (5, 6) ], ($countAll, $product3))
                                 ]]></eg>
                             </fos:expression>
                         <fos:result>0</fos:result>
@@ -19260,7 +19260,7 @@ chain("The cat sat on the mat", (
   $appendAll(?, "."), 
   $makeUpperAll, 
   string-join#2(?, " ") 
-) )]]></eg>
+))]]></eg>
                             </fos:expression>
                         <fos:result>"THE. CAT. SAT. ON. THE. MAT."</fos:result>
                     </fos:test>
@@ -21475,11 +21475,11 @@ return map:keys-where($birthdays, fn($name, $date) {
          <fos:example>
             <fos:test use="v-map-find-responses">
                <fos:expression>map:find($responses, 0)</fos:expression>
-               <fos:result>['no', 'non', 'nein']</fos:result>
+               <fos:result>[ 'no', 'non', 'nein' ]</fos:result>
             </fos:test>
             <fos:test use="v-map-find-responses">
                <fos:expression>map:find($responses, 1)</fos:expression>
-               <fos:result>['yes', 'oui', ('ja', 'doch')]</fos:result>
+               <fos:result>[ 'yes', 'oui', ('ja', 'doch') ]</fos:result>
             </fos:test>
             <fos:test use="v-map-find-responses">
                <fos:expression>map:find($responses, 2)</fos:expression>
@@ -25186,8 +25186,8 @@ else $fallback($position)</eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>array:replace([10, 11, 12], 2, function { . + 10 })</fos:expression>
-               <fos:result>[10, 21, 12]</fos:result>
+               <fos:expression>array:replace([ 10, 11, 12 ], 2, function { . + 10 })</fos:expression>
+               <fos:result>[ 10, 21, 12 ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression>array:replace([ "a", "b", "c" ], 2, concat(?, "x"))</fos:expression>
@@ -25527,7 +25527,7 @@ array:index-of(
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:index-where(
-  [(1, 2, 3), (4, 5, 6), (7, 8)],
+  [ (1, 2, 3), (4, 5, 6), (7, 8) ],
   function($m) { count($m) = 3 }
 )</eg></fos:expression>
                <fos:result>(1, 2)</fos:result>
@@ -25575,7 +25575,7 @@ array:index-of(
       </fos:notes>
       
       <fos:examples>
-         <fos:variable name="in" id="a-slice" as="xs:string*" select="['a', 'b', 'c', 'd', 'e']"/>
+         <fos:variable name="in" id="a-slice" as="xs:string*" select="[ 'a', 'b', 'c', 'd', 'e' ]"/>
          <fos:example>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := 4)</fos:expression>
@@ -26051,18 +26051,18 @@ return [ $action($member, $pos) ]
   [ "the cat", "sat", "on the mat" ],
   tokenize#1
 )</eg></fos:expression>
-               <fos:result>[("the", "cat"), "sat", ("on", "the", "mat")]</fos:result>
+               <fos:result>[ ("the", "cat"), "sat", ("on", "the", "mat") ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:for-each(
   [ [ "the", "cat" ], [ "sat" ], [ "on", "the", "mat" ] ],
   array:flatten#1
 )</eg></fos:expression>
-               <fos:result>[("the", "cat"), "sat", ("on", "the", "mat")]</fos:result>
+               <fos:result>[ ("the", "cat"), "sat", ("on", "the", "mat") ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:for-each(
-  ['one', 'two', 'three'],
+  [ 'one', 'two', 'three' ],
   fn($member, $pos) { $pos || '. ' || $member }
 )</eg></fos:expression>
                <fos:result>[ "1. one", "2. two", "3. three" ]</fos:result>
@@ -26442,7 +26442,7 @@ array:for-each-pair(
   ("red", "green", "blue"),
   characters#1
 )</eg></fos:expression>
-               <fos:result>[("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e")]</fos:result>
+               <fos:result>[ ("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e") ]</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>array:build(
@@ -26492,11 +26492,11 @@ array:for-each-pair(
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>array:members([1 to 5])?value</fos:expression>
+               <fos:expression>array:members([ 1 to 5 ])?value</fos:expression>
                <fos:result>(1, 2, 3, 4, 5)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>array:members([(1,1), (2,4), (3,9), (4,16), (5,25)])
+               <fos:expression><eg>array:members([ (1,1), (2,4), (3,9), (4,16), (5,25) ])
 ! sum(?value)</eg></fos:expression>
                <fos:result>(2, 6, 12, 20, 30)</fos:result>
             </fos:test>
@@ -30337,32 +30337,27 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:rules>
          <p>The function is equivalent to the following implementation in XPath (return clause added in comments for completeness):</p>
          <eg><![CDATA[
-let $scan-left-inner := function($input as item()*, 
-                                 $zero as item()*, 
-                                 $action as function(item()*, item()) as item()*,
-                                 $self as function(*)
-                               ) as array(*)*                               
-{
+let $scan-left-inner := function(
+  $input  as item()*, 
+  $zero   as item()*, 
+  $action as function(item()*, item()) as item()*,
+  $self   as function(*)
+) as array(*)* {
   let $result := [$zero]
-   return
-     if(empty($input)) then $result
-       else
-         (
-           $result, $self(tail($input), $action($zero, head($input)), $action, $self)  
-         )
-},
-
-$scan-left := function($input as item()*, 
-                       $zero as item()*, 
-                       $action as function(item()*, item()) as item()*
-                     ) as array(*)*  
-{
+  return if(empty($input)) then (
+    $result
+  ) else (
+    $result, $self(tail($input), $action($zero, head($input)), $action, $self)
+  )
+}
+let $scan-left := function(
+  $input  as item()*, 
+  $zero   as item()*, 
+  $action as function(item()*, item()) as item()*
+) as array(*)*  {
   $scan-left-inner($input, $zero, $action, $scan-left-inner)
 }
-(:
-  return
-    $scan-left(1 to 10, 0, op('+'))  
-:)    
+(: return $scan-left(1 to 10, 0, op('+'))  :)    
 ]]></eg>         
       </fos:rules>
       <fos:errors>
@@ -30439,30 +30434,26 @@ return scan-left(1 to 5, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:ex
       <fos:rules>
          <p>The function is equivalent to the following implementation in XPath (return clause in comments added for completeness):</p>
          <eg><![CDATA[
-let  $scan-right-inner := function($input as item()*,
-                          $zero as item()*,
-                          $action as function(item()*, item()) as item()*,                          
-                          $self as function(*)
-                         ) as array(*)*
-{
-    if(empty($input)) then [$zero] 
-      else
-        let $rightResult := $self(tail($input), $zero, $action, $self)
-         return
-            ([$action(head($input), head($rightResult))], $rightResult)
-},
-
-$scan-right := function($input as item()*,
-                        $zero as item()*,
-                        $f as function(item()*, item()) as item()*
-                       ) as array(*)*
-{
+let $scan-right-inner := function(
+  $input  as item()*,
+  $zero   as item()*,
+  $action as function(item()*, item()) as item()*, $self as function(*)
+) as array(*)* {
+  if(empty($input)) then (
+    [ $zero ]
+  ) else (
+    let $rightResult := $self(tail($input), $zero, $action, $self)
+    return ([ $action(head($input), head($rightResult)) ], $rightResult)
+  )
+}
+let $scan-right := function(
+  $input as item()*,
+  $zero  as item()*,
+  $f     as function(item()*, item()) as item()*
+) as array(*)* {
   $scan-right-inner($input, $zero, $f, $scan-right-inner)
 }        
-(:
-return
-  $scan-right(1 to 10, 0, op('+'))  
-:)  
+(: return $scan-right(1 to 10, 0, op('+')) :)  
 ]]></eg>         
       </fos:rules>
       <fos:errors>
@@ -30486,13 +30477,13 @@ return
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-right(1 to 10, 0, op('+'))</eg></fos:expression>
-               <fos:result>[55], [54], [52], [49], [45], [40], [34], [27], [19], [10], [0]</fos:result>
+               <fos:result>[ 55 ], [ 54 ], [ 52 ], [ 49 ], [ 45 ], [ 40 ], [ 34 ], [ 27 ], [ 19 ], [ 10 ], [ 0 ]</fos:result>
             </fos:test>
          </fos:example>         
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-right(1 to 3, 0, op('-'))</eg></fos:expression>
-               <fos:result>[2], [-1], [3], [0]</fos:result>
+               <fos:result>[ 2 ], [ -1 ], [ 3 ], [ 0 ]</fos:result>
             </fos:test>
          </fos:example>         
       </fos:examples>      

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4935,7 +4935,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
             <fos:test>
                <fos:expression>hash("") 
 => string()</fos:expression>
-               <fos:result>"D41D8CD98F00B204E9800998ECF8427Eo"</fos:result>
+               <fos:result>"D41D8CD98F00B204E9800998ECF8427E"</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -4964,7 +4964,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression>hash(serialize($doc), map { "algorithm": "sha-1" }) 
 => xs:base64Binary()                  
 => string()</fos:expression>
-               <fos:result>"nJuRPrG2JU9HN86Ufv0W8W6Rb51u5cEQKiAC5I1MiL0="</fos:result>
+               <fos:result>"8PzN28NtxQv5RlxQ5/w6DcnrpEU="</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -660,7 +660,7 @@ for transition to Proposed Recommendation. </p>'>
             the function is evaluated. Maps are a new datatype introduced in XPath 3.1.</p>
             <p>For example, the function <code>fn:xml-to-json</code> has an options parameter
             allowing specification of whether the output is to be indented. A call might be written:</p>
-            <eg><![CDATA[xml-to-json($input, map{'indent':true()})]]></eg>
+            <eg><![CDATA[xml-to-json($input, map { 'indent': true() })]]></eg>
             <p><termdef id="option-parameter-conventions" term="option parameter conventions">Functions
             that take an options parameter adopt common conventions on how the
             options are used. These are referred to as the <term>option parameter conventions</term>. These
@@ -6692,10 +6692,10 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   
                   <p>The representation of JSON data produced by the <code>fn:parse-json</code> function
                      has been chosen with ease of manipulation as a design aim. For example, a simple JSON object
-                     such as <code>{"Sun":1, "Mon":2, "Tue":3, ...}</code> produces a simple map, so if the result
+                     such as <code>{ "Sun": 1, "Mon": 2, "Tue": 3, ... }</code> produces a simple map, so if the result
                      of parsing is held in <code>$weekdays</code>, the number for a given weekday can be extracted
                      using an expression such as <code>$weekdays?Tue</code>. Similarly, a simple array such as
-                     <code>["Sun", "Mon", "Tue", ...]</code> produces an array that can be addressed as, for example,
+                     <code>[ "Sun", "Mon", "Tue", ... ]</code> produces an array that can be addressed as, for example,
                      <code>$weekdays(3)</code>. A more deeply nested structure can be addressed in a similar way:
                      for example if the JSON text is an array of person objects, each of which has a property named
                      <code>phones</code> which is an array of strings containing phone numbers, then the first phone number of
@@ -6729,32 +6729,32 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <p>Consider the following JSON text:</p>
                      <eg><![CDATA[
 {
-    "desc"    : "Distances between several cities, in kilometers.",
-    "updated" : "2014-02-04T18:50:45",
-    "uptodate": true,
-    "author"  : null,
-    "cities"  : {
-        "Brussels": [
-                      {"to": "London",    "distance": 322},
-                      {"to": "Paris",     "distance": 265},
-                      {"to": "Amsterdam", "distance": 173}
-                    ],
-        "London": [
-                      {"to": "Brussels",  "distance": 322},
-                      {"to": "Paris",     "distance": 344},
-                      {"to": "Amsterdam", "distance": 358}
-                  ],
-        "Paris": [
-                      {"to": "Brussels",  "distance": 265},
-                      {"to": "London",    "distance": 344},
-                      {"to": "Amsterdam", "distance": 431}
-                 ],
-        "Amsterdam": [
-                      {"to": "Brussels",  "distance": 173},
-                      {"to": "London",    "distance": 358},
-                      {"to": "Paris",     "distance": 431}
-                     ]
-     }
+  "desc"    : "Distances between several cities, in kilometers.",
+  "updated" : "2014-02-04T18:50:45",
+  "uptodate": true,
+  "author"  : null,
+  "cities"  : {
+    "Brussels": [
+      { "to": "London",    "distance": 322 },
+      { "to": "Paris",     "distance": 265 },
+      { "to": "Amsterdam", "distance": 173 }
+    ],
+    "London": [
+      { "to": "Brussels",  "distance": 322 },
+      { "to": "Paris",     "distance": 344 },
+      { "to": "Amsterdam", "distance": 358 }
+    ],
+    "Paris": [
+      { "to": "Brussels",  "distance": 265 },
+      { "to": "London",    "distance": 344 },
+      { "to": "Amsterdam", "distance": 431 }
+   ],
+    "Amsterdam": [
+      { "to": "Brussels",  "distance": 173 },
+      { "to": "London",    "distance": 358 },
+      { "to": "Paris",     "distance": 431 }
+     ]
+   }
 }]]></eg>
                      <p>The XML representation of this text is as follows. Whitespace is included in the XML representation for purposes of illustration,
                         but it will not necessarily be present in the output of the
@@ -7635,14 +7635,14 @@ return <table>
                <p>It is possible to decompose any map into a sequence of <termref def="dt-singleton-map">singleton maps</termref>,
                   and to construct a map from a sequence of singleton maps.</p>
                <p>For example the map
-               <code>map{"x":1, "y":2}</code> can be decomposed to the sequence <code>(map{"x":1}, map{"y":2})</code>.</p></item>
+               <code>map { "x": 1, "y": 2 }</code> can be decomposed to the sequence <code>(map { "x": 1 }, map { "y": 2 })</code>.</p></item>
             
             <item><p><termdef id="dt-key-value-pair-map" term="key-value pair map">A <term>key-value pair map</term> is a map containing two
             entries, one (with the key <code>"key"</code>) containing the key part of a key value pair, the other (with the key <code>"value"</code>)
             containing the value part of a key value pair.</termdef></p>
                <p>For example
-                  the map <code>map{"x":1, "y":2}</code> can be decomposed as 
-                  <code>(map{"key":"x", "value":1}, map{"key":"y", "value":2})</code></p>
+                  the map <code>map { "x": 1, "y": 2 }</code> can be decomposed as 
+                  <code>(map { "key": "x", "value": 1 }, map { "key": "y", "value": 2 })</code></p>
                <p>A <termref def="dt-key-value-pair-map"/> is an instance of the type 
                   <code>record(key as xs:anyAtomicType, value as item()*)</code>.</p> </item>
          </olist>
@@ -8610,9 +8610,10 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
               <p>then there will be a function definition equivalent to:</p>
               
               <eg>declare function my:location (
-        $latitude as xs:double,
-        $longitude as xs:double) as my:location {
-    map{'latitude':$latitude, 'longitude':$longitude}
+  $latitude as xs:double,
+  $longitude as xs:double
+) as my:location {
+  map { 'latitude': $latitude, 'longitude': $longitude }
 }</eg>
               <p>Equivalently using XSLT syntax, if there is a named item type with the
               XSLT definition:</p>
@@ -8690,7 +8691,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
     $middle as xs:string?,
     $last as xs:string,
     $suffix as xs:string? := ()) as p:person {
-        let $m := map{},
+        let $m := map { },
             $m := if (exists($arg1)) then map:put($m, "1st-title", $arg1) else $m,
             $m := if (exists($arg2)) then map:put($m, "2nd-title", $arg2) else $m,
             $m := map:put($m, "first", $first),

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1625,7 +1625,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       as <code>fn</code>.</p></item>
       <item><p>New abbreviated syntax is introduced (<termref def="dt-focus-function"/>) 
         for simple inline functions taking a single argument. 
-        An example is <code>fn{../@code}</code></p></item>
+        An example is <code>fn { ../@code }</code></p></item>
       <item><p>The arrow operator <code>=></code> is now complemented by a “mapping arrow” operator <code>=!></code>
         which applies a the supplied function to each item in the input sequence independently.</p></item>
       <item><p>The “function conversion rules” are now renamed “coercion rules”.</p></item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5681,12 +5681,12 @@ declare function t:flatten($tree as t:tree) as item()* {
                   </item>
                   <item>
                      <p>
-                        <code>[(1,2),(3,4)] instance of array(xs:integer)</code> returns <code>false()</code>
+                        <code>[ (1, 2), (3, 4) ] instance of array(xs:integer)</code> returns <code>false()</code>
                      </p>
                   </item>
                   <item>
                      <p>
-                        <code>[(1,2),(3,4)] instance of array(xs:integer+)</code> returns <code>true()</code>
+                        <code>[ (1, 2), (3, 4) ] instance of array(xs:integer+)</code> returns <code>true()</code>
                      </p>
                   </item>
                </ulist>
@@ -15977,7 +15977,7 @@ map {
                   </item>
                   <item>
                      <p>
-                        <code>[ (), (27, 17, 0)]</code> creates an array with two members: <code>()</code> and the sequence <code>(27, 17, 0)</code>.</p>
+                        <code>[ (), (27, 17, 0) ]</code> creates an array with two members: <code>()</code> and the sequence <code>(27, 17, 0)</code>.</p>
                   </item>
                   <item>
                      <p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1152,7 +1152,7 @@ is <xtermref spec="DM40" ref="dt-absent"/>, a <termref def="dt-type-error"/>
             <note><p>In previous versions of the specification, this was classified as a
             <termref def="dt-dynamic-error"/>. The change allows the error to be raised during
             static analysis when possible; for example a function written as
-            <code>fn($x){@code}</code> can now be reported as an error whether or not
+            <code>fn($x) { @code }</code> can now be reported as an error whether or not
             the function is actually evaluated. The actual error code remains unchanged
             for backwards compatibility reasons.</p>
             <p>There are other cases where static detection of the error is not possible.</p>
@@ -1989,7 +1989,7 @@ is <code>xs:anyAtomicType</code>.</p>
                   and that no element of this type can have an attribute named <code>@sallary</code> (sic), then
                   a type error may be reported if the expression <code>$emp/@sallary</code> is encountered.</p>
                   <note><p>A static error <rfc2119>must not</rfc2119> be reported simply because a predicate
-                  will always return <code>false</code>: the expression <code>a[name()='b']</code> will always return
+                  will always return <code>false</code>: the expression <code>a[name() = 'b']</code> will always return
                   an empty sequence, but it is not an error.</p></note>
                   </item>  
                   
@@ -2926,12 +2926,12 @@ would raise an error because it has an <code>id</code> child whose value is not 
             
             <note>
                <p>These rules do not constrain the order of evaluation of subexpressions. For example, given an expression
-                  such as <code>//person[@first="Winston"][@last="Churchill"]</code>, or equivalently
-                  <code>//person[@first="Winston" and @last="Churchill"]</code>, an implementation might use an index on the value of
+                  such as <code>//person[@first = "Winston"][@last = "Churchill"]</code>, or equivalently
+                  <code>//person[@first = "Winston" and @last = "Churchill"]</code>, an implementation might use an index on the value of
                   <code>@last</code> to select items that satisfy the second condition, and then filter these
                   items on the value of the first condition. Alternatively, it might evaluate both predicates in parallel.
                   Or it might interpose an additional redundant condition: 
-                  <code>//person[string-length(@first)+string-length(@last)=16][@first="Winston"][@last="Churchill"]</code>.
+                  <code>//person[string-length(@first) + string-length(@last) = 16][@first = "Winston"][@last = "Churchill"]</code>.
                   But implementations must ensure that
                   such rewrites do not result in dynamic errors being reported that would not occur if the predicates
                   were evaluated in order as written.</p>
@@ -3152,7 +3152,7 @@ its <termref def="dt-typed-value"
                <item>
                   <p>If the item is an array <code>$a</code>, atomization is defined as <code>$a?* ! fn:data(.)</code>, which is equivalent to atomizing the members of the array.</p>
                   <note>
-                     <p>This definition recursively atomizes members that are arrays. Hence, the result of atomizing the array <code>[ [1, 2, 3], [4, 5, 6] ]</code> is the sequence <code>(1, 2, 3, 4, 5, 6)</code>.</p>
+                     <p>This definition recursively atomizes members that are arrays. Hence, the result of atomizing the array <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ] ]</code> is the sequence <code>(1, 2, 3, 4, 5, 6)</code>.</p>
                   </note>
                </item>
 
@@ -4683,7 +4683,7 @@ type annotation.</p>
 
                   <item diff="add" at="A">
                      <p><code role="parse-test"
-                           >element(Q{"http://www.w3.org/2000/svg"}*)</code> matches any element node whose name is in the SVG namespace.</p>
+                           >element(Q{http://www.w3.org/2000/svg}*)</code> matches any element node whose name is in the SVG namespace.</p>
                   </item>
 
                   <item diff="add" at="A">
@@ -4967,7 +4967,7 @@ regardless of its name or type annotation.</p>
 
                   <item diff="add" at="A">
                      <p><code role="parse-test"
-                           >element(Q{"http://www.w3.org/2000/svg"}*)</code> matches any attribute node whose name is in the SVG namespace.</p>
+                           >element(Q{http://www.w3.org/2000/svg}*)</code> matches any attribute node whose name is in the SVG namespace.</p>
                   </item>
 
                   <item diff="add" at="A">
@@ -5248,7 +5248,7 @@ name.</p>
                <p>Examples:</p>
 
                <p>Given a map <code>$M</code> whose keys are integers and whose
-  results are strings, such as <code>map{0:"no", 1:"yes"}</code>,
+  results are strings, such as <code>map { 0: "no", 1: "yes" }</code>,
   consider the results of the following expressions:
   </p>
 
@@ -5582,7 +5582,7 @@ name.</p>
                
                <p>Instances of recursive record types can be constructed and interrogated in the normal way.
                For example a list of length 3 can be constructed as:</p>
-               <p><eg>map{"value":1, "next":map{"value":2, "next":map{"value":3}}}</eg></p>
+               <p><eg>map { "value": 1, "next": map { "value": 2, "next": map { "value": 3 } } }</eg></p>
                <p>and the third value in the map can be retrieved as <code>$list?next?next?value</code>.
                In practice, recursive data structures are usually manipulated using recursive functions.</p>
                
@@ -7057,8 +7057,8 @@ declare function t:flatten($tree as t:tree) as item()* {
                      </olist>
 
                      <note><p>For example, if the required type is
-                     <code>record(longitude as xs:double, latitude as xs:double)</code> and the supplied value is <code>map{"longitude": 0, "latitude":53.2}</code>,
-                        then the map is converted to <code>map{"longitude": 0.0e0, "latitude": 53.2e0}</code>.</p></note>
+                     <code>record(longitude as xs:double, latitude as xs:double)</code> and the supplied value is <code>map { "longitude": 0, "latitude": 53.2 }</code>,
+                        then the map is converted to <code>map { "longitude": 0.0e0, "latitude": 53.2e0 }</code>.</p></note>
                   </item>
 
                   <item>
@@ -7124,7 +7124,7 @@ declare function t:flatten($tree as t:tree) as item()* {
                      are instances of both types are one or more of the following:</p>
                      <ulist>
                         <item><p>The empty sequence, <code>()</code>.</p></item>
-                        <item><p>The empty map, <code>map{}</code>.</p></item>
+                        <item><p>The empty map, <code>map { }</code>.</p></item>
                         <item><p>The empty array, <code>[]</code>.</p></item>
                      </ulist>
                      
@@ -7152,7 +7152,7 @@ declare function t:flatten($tree as t:tree) as item()* {
                   <item><p><code>round(timezone-from-time($now))</code>. The result of <code>fn:timezone-from-time</code>
                   is of type <code>xs:dayTimeDuration?</code>, which is substantively disjoint with the required type
                   of <code>fn:round</code>, namely <code>xs:numeric?</code>.</p></item>
-                  <item><p><code>function($x as xs:integer) as array(xs:string) { array{1 to $x} }</code>. The type
+                  <item><p><code>function($x as xs:integer) as array(xs:string) { array { 1 to $x } }</code>. The type
                   of the function body is <code>array(xs:integer)</code>, which is substantively disjoint with the
                   required type <code>array(xs:string)</code>: the function can succeed only in the exceptional case
                   where the function body delivers an empty array.</p></item>
@@ -7299,15 +7299,15 @@ declare function t:flatten($tree as t:tree) as item()* {
       For instance, consider the following query:
       <eg
                      role="parse-test"><![CDATA[
-declare function local:filter($s as item()*, 
-                              $p as function(xs:string) as xs:boolean) as item()*
-{
+declare function local:filter(
+  $s as item()*, 
+  $p as function(xs:string) as xs:boolean
+) as item()* {
   $s[$p(.)]
 };
 
 let $f := function($a) { starts-with($a, "E") }
-return
-  local:filter(("Ethel", "Enid", "Gertrude"), $f)
+return local:filter(("Ethel", "Enid", "Gertrude"), $f)
       ]]></eg>
                </p>
 
@@ -7386,8 +7386,8 @@ let $m := map {
   "Friday" : true(),
   "Saturday" : false(),
   "Sunday" : false()
-},
-$days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+}
+let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 return filter($days,$m)
       ]]></eg>
 
@@ -7437,16 +7437,16 @@ return filter($days,$m)
 
                <eg role="parse-test"><![CDATA[
 let $m := map {
-   "Monday" : true(),
-   "Tuesday" : false(),
-   "Wednesday" : true(),
-   "Thursday" : false(),
-   "Friday" : true(),
-   "Saturday" : false(),
-   "Sunday" : false()
+  "Monday"   : true(),
+  "Tuesday"  : false(),
+  "Wednesday": true(),
+  "Thursday" : false(),
+  "Friday"   : true(),
+  "Saturday" : false(),
+  "Sunday"   : false()
 }
 let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-return filter($days,$m)
+return filter($days, $m)
       ]]></eg>
 
                <p>The result of the expression is the sequence <code>("Monday", "Wednesday", "Friday")</code>
@@ -7457,16 +7457,15 @@ return filter($days,$m)
                   <p>For example, consider this case:</p>
                   <eg
                      role="parse-test"><![CDATA[
-declare function local:filter($s as item()*, 
-                              $p as function(xs:string) as xs:boolean) 
-                              as item()*
-{
+declare function local:filter(
+  $s as item()*, 
+  $p as function(xs:string) as xs:boolean
+) as item()* {
   $s[$p(.)]
 };
 
 let $f := function($a) { $a mod 2 = 0 }
-return
-  local:filter(1 to 10, $f)
+return local:filter(1 to 10, $f)
       ]]></eg>
                   
                   <p>Here the supplied function <code>$f</code> is an instance of the required type,
@@ -7483,8 +7482,7 @@ return
                   local variable bindings (for example <code>let</code> clauses). Previously
                   the following would execute without error:</p>
                   
-                  <eg role="xquery"><![CDATA[let $f as function(xs:integer) as item()* 
-        := function($x){$x+1}
+                  <eg role="xquery"><![CDATA[let $f as function(xs:integer) as item()* := function($x) { $x + 1 }
 return $f(12.3)]]></eg>
                   
                   <p role="xquery">With XQuery 4.0, as a consequence of function coercion,
@@ -8335,8 +8333,8 @@ At evaluation time, the value of a variable reference is the value to which the 
                      that is numerically equal to the position of the item in the input sequence.</p></note>
                   
                   <note><p>The truth value of a numeric predicate does not depend on the order
-                  of the numbers in <var>V</var>. The predicates <code>[1, 2, 3]</code>
-                  and <code>[3, 2, 1]</code> have exactly the same effect. The items in 
+                  of the numbers in <var>V</var>. The predicates <code>[ 1, 2, 3 ]</code>
+                  and <code>[ 3, 2, 1 ]</code> have exactly the same effect. The items in 
                   the result of a filter expression always retain the ordering of the input
                   sequence.</p></note>
                   
@@ -9442,7 +9440,7 @@ return $paf(1 to 5)
                <example>
                   <head>Partial Application of a Map</head>
                   <p>The following partial function application converts a map to an equivalent function that is not a map.</p>
-                  <eg role="parse-test"><![CDATA[let $a := map {"A": 1, "B": 2}(?)
+                  <eg role="parse-test"><![CDATA[let $a := map { "A": 1, "B": 2 }(?)
 return $a("A")]]></eg>
                </example>
                   
@@ -9632,7 +9630,7 @@ return $a("A")]]></eg>
             a dynamic function call always supplies the arguments positionally. Although the base function
             referred to may be variadic, the result of evaluating the function reference is a function that
             has fixed arity. In effect, the result of evaluating <code>my:func#3</code> is the
-            same as the result of evaluating the inline function expression <code>function($x, $y, $z){my:func($x, $y, $z)}</code>,
+            same as the result of evaluating the inline function expression <code>function($x, $y, $z) { my:func($x, $y, $z) }</code>,
             except that the returned function has a name (it retains the name <code>my:func</code>).</p></note>
 
          </div4>
@@ -9680,16 +9678,16 @@ return $a("A")]]></eg>
                <p>The syntax allows the names and types of the function argument to be declared, along
            with the type of the result:</p>
 
-               <eg>function($x as xs:integer, $y as xs:integer) as xs:integer {$x + $y}</eg>
+               <eg>function($x as xs:integer, $y as xs:integer) as xs:integer { $x + $y }</eg>
 
                <p>The types can be omitted<phrase diff="add" at="2023-07-04">, and the keyword can be abbreviated</phrase>:</p>
 
-               <eg>fn($x, $y) {$x + $y}</eg>
+               <eg>fn($x, $y) { $x + $y }</eg>
                
                
             
  
-            <p diff="add" at="A">A zero-arity function can be written as, for example, <code>fn(){current-date()}</code>.</p>
+            <p diff="add" at="A">A zero-arity function can be written as, for example, <code>fn() { current-date() }</code>.</p>
 
 
          
@@ -9817,16 +9815,14 @@ return $a("A")]]></eg>
                   <item>
                      <p>This example creates and invokes a function that captures the value of a local variable in its scope:
                         <eg role="parse-test"
-                           ><![CDATA[let $incrementors := 
-   for $x in 1 to 10
-   return function($y) as xs:integer { $x + $y }
+                           ><![CDATA[let $incrementors := (
+  for $x in 1 to 10
+  return function($y) as xs:integer { $x + $y }
+)
 return $incrementors[2](4)]]></eg>
                      </p>
                      <p>The result of this expression is <code>6</code></p>
                   </item>
-                  
-                  
-   
                </ulist>    
          
          </div4>
@@ -9839,13 +9835,13 @@ return $incrementors[2](4)]]></eg>
                the function body, which returns a result of type <code>item()*</code>.</termdef></p>
                <p>Here are some examples of focus functions:</p>
                <ulist>
-                  <item><p><code>fn{@age}</code> - a function that expects a node as its argument, and returns
+                  <item><p><code>fn { @age }</code> - a function that expects a node as its argument, and returns
                   the <code>@age</code> attribute of that node.</p></item>
-                  <item><p><code>fn{.+1}</code> - a function that expects a number as its argument, and returns
+                  <item><p><code>fn { . + 1 }</code> - a function that expects a number as its argument, and returns
                   that number plus one.</p></item>
-                  <item><p><code>function{`${.}`}</code> - a function that expects a string as its argument, and prepends
+                  <item><p><code>function { `${ . }` }</code> - a function that expects a string as its argument, and prepends
                      a <code>"$"</code> character.</p></item>
-                  <item><p><code>function{head(.)+foot(.)}</code> - a function that expects a sequence of numbers
+                  <item><p><code>function { head(.) + foot(.) }</code> - a function that expects a sequence of numbers
                      as its argument, and returns the sum of the first and last items in the sequence.</p></item>
                </ulist>
                <p>Focus functions are often useful as arguments to simple higher-order functions such as <code>fn:sort</code>.
@@ -9855,8 +9851,8 @@ return $incrementors[2](4)]]></eg>
                   and <termref def="dt-mapping-arrow-operator"/>.
                For example, <code>$s => tokenize() =!> fn { `"{.}"` }()</code> first tokenizes the string <code>$s</code>,
                then wraps each token in double quotation marks.</p>
-               <p>The expression <code>function{EXPR}</code> (or <code>fn{EXPR}</code>) is a syntactic shorthand for the expression
-               <code>function($Z as item()*) as item()* {$Z!(EXPR)}</code>, where <code>$Z</code> is a variable name that is
+               <p>The expression <code>function { EXPR }</code> (or <code>fn { EXPR }</code>) is a syntactic shorthand for the expression
+               <code>function($Z as item()*) as item()* { $Z ! (EXPR) }</code>, where <code>$Z</code> is a variable name that is
                otherwise unused. Note that the function body (<code>EXPR</code>) is evaluated with a <termref def="dt-fixed-focus"/>: 
                   the context position and context size will always be 1 (one).</p>
                <ednote><date>2023-09-14</date><edtext>TODO: The above no longer works. We don't currently have any construct (other than this one) that sets
@@ -11354,10 +11350,10 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
                <item>
                   <p>The attribute axis <code>attribute::</code> can be
     abbreviated by <code>@</code>. For example, a path expression <code
-                        role="parse-test">para[@type="warning"]</code> is short
+                        role="parse-test">para[@type = "warning"]</code> is short
     for <code
                         role="parse-test"
-                        >child::para[attribute::type="warning"]</code> and
+                        >child::para[attribute::type = "warning"]</code> and
     so selects <code>para</code> children with a <code>type</code> attribute with value
     equal to <code>warning</code>.</p>
                </item>
@@ -11581,7 +11577,7 @@ the <code>lang</code> attribute of the parent of the context node.</p>
                <item>
                   <p>
                      <code role="parse-test"
-                        >para[@type="warning"]</code> selects all <code>para</code> children of the context node that have a <code>type</code> attribute with value <code>warning</code>.
+                        >para[@type = "warning"]</code> selects all <code>para</code> children of the context node that have a <code>type</code> attribute with value <code>warning</code>.
                   </p>
                </item>
 
@@ -11589,7 +11585,7 @@ the <code>lang</code> attribute of the parent of the context node.</p>
                <item>
                   <p>
                      <code role="parse-test"
-                        >para[@type="warning"][5]</code> selects the fifth <code>para</code> child of the context node that has a <code>type</code> attribute with value <code>warning</code>.
+                        >para[@type = "warning"][5]</code> selects the fifth <code>para</code> child of the context node that has a <code>type</code> attribute with value <code>warning</code>.
                   </p>
                </item>
 
@@ -11597,7 +11593,7 @@ the <code>lang</code> attribute of the parent of the context node.</p>
                <item>
                   <p>
                      <code role="parse-test"
-                        >para[5][@type="warning"]</code> selects the fifth <code>para</code> child of the context node if that child has a <code>type</code> attribute with value <code>warning</code>.
+                        >para[5][@type = "warning"]</code> selects the fifth <code>para</code> child of the context node if that child has a <code>type</code> attribute with value <code>warning</code>.
                   </p>
                </item>
 
@@ -11605,7 +11601,7 @@ the <code>lang</code> attribute of the parent of the context node.</p>
                <item>
                   <p>
                      <code role="parse-test"
-                        >chapter[title="Introduction"]</code> selects the <code>chapter</code> children of the context node that have one
+                        >chapter[title = "Introduction"]</code> selects the <code>chapter</code> children of the context node that have one
 or more <code>title</code> children whose <termref
                         def="dt-typed-value"
                         >typed value</termref> is equal to the string <code>Introduction</code>.
@@ -11784,10 +11780,10 @@ every integer between the two operands, in increasing order. </p>
                <eg role="parse-test">$input[position() = 1 to 4]</eg>
                <!--<p>This example selects the first four items from an input sequence, in reverse order:</p>
                <eg role="parse-test">slice($input, 1 to 4 by -1)</eg>
-               <p>This example returns the array <code>["b", "c"]</code>:</p>
-               <eg role="parse-test">array:slice(["a", "b", "c", "d"], 2 to 3)</eg>
-               <p>This example returns the array <code>["d", "b"]</code>:</p>
-               <eg role="parse-test">array:slice(["a", "b", "c", "d"], 1 to 4 by -2)</eg>
+               <p>This example returns the array <code>[ "b", "c" ]</code>:</p>
+               <eg role="parse-test">array:slice([ "a", "b", "c", "d" ], 2 to 3)</eg>
+               <p>This example returns the array <code>[ "d", "b" ]</code>:</p>
+               <eg role="parse-test">array:slice([ "a", "b", "c", "d" ], 1 to 4 by -2)</eg>
                <p>This example tests whether <code>$x</code> is an even number in the range 100 to 200:</p>
                <eg role="parse-test">$x = (100 to 200 by 2)</eg>-->
                <p>This example returns the sequence <code>(0, 0.1, 0.2, 0.3, 0.5)</code>:</p>
@@ -12229,11 +12225,11 @@ course to the use of parentheses. Therefore, the following two examples have dif
             <p>For example:</p>
             <eg role="parse-test"><![CDATA[let $greeting := "Hello",
     $planet := "Mars"
-return `{$greeting}, {$planet}!`]]></eg>
+return `{ $greeting }, { $planet }!`]]></eg>
             <p>returns <code>"Hello, Mars!"</code>.</p>
             <p>The expression:</p>
             <eg role="parse-test"><![CDATA[let $longMonths := (1, 3, 5, 7, 8, 10, 12)
-return `The months with 31 days are: {$longMonths}.`]]></eg>
+return `The months with 31 days are: { $longMonths }.`]]></eg>
             <p>returns <code>"The months with 31 days are: 1 3 5 7 8 10 12."</code>.</p>
             
             <note>
@@ -12249,7 +12245,7 @@ return `The months with 31 days are: {$longMonths}.`]]></eg>
                are interchangeable. This means that back-ticks can sometimes be a useful way of delimiting a string
                that contains both single and double quotes: <code>`He said: "I didn't."`</code>.</p>
                <p>It is sometimes useful to use string templates in conjunction with the <code>fn:char</code> function
-                  to build strings containing special characters, for example <code>`Chapter{fn:char("nbsp")}{$chapNr}`</code>.</p>
+                  to build strings containing special characters, for example <code>`Chapter{ fn:char("nbsp") }{ $chapNr }`</code>.</p>
             </note>
             
             <note>
@@ -12334,7 +12330,7 @@ return `The months with 31 days are: {$longMonths}.`]]></eg>
             
             <p>For instance, the following expression:</p>
             <eg role="parse-test"><![CDATA[for $s in ("one", "two", "red", "blue")
-return ``[`{$s}` fish]``
+return ``[`{ $s }` fish]``
 ]]></eg>
             <p>evaluates to the sequence  <code>("one fish", "two fish", "red fish", "blue fish")</code>.</p>
             
@@ -12367,11 +12363,11 @@ return ``[`{$s}` fish]``
             
             <eg><![CDATA[declare function local:prize-message($a) as xs:string
 {
-``[Hello `{$a?name}`
-You have just won `{$a?value}` dollars!
+``[Hello `{ $a?name }`
+You have just won `{ $a?value }` dollars!
 `{ 
    if ($a?in_ca) 
-   then ``[Well, `{$a?taxed_value}` dollars, after taxes.]``
+   then ``[Well, `{ $a?taxed_value }` dollars, after taxes.]``
    else ""
 }`]``
 };]]></eg>
@@ -12387,11 +12383,11 @@ Well, 6000 dollars, after taxes.]]></eg>
             <eg><![CDATA[declare function local:prize-message($a) as xs:string
 {
 ``[<div>
-  <h1>Hello `{$a?name}`</h1>
-  <p>You have just won `{$a?value}` dollars!</p>
+  <h1>Hello `{ $a?name }`</h1>
+  <p>You have just won `{ $a?value }` dollars!</p>
     `{ 
       if ($a?in_ca) 
-      then ``[  <p>Well, `{$a?taxed_value}` dollars, after taxes.</p> ]``
+      then ``[  <p>Well, `{ $a?taxed_value }` dollars, after taxes.</p> ]``
       else ""
     }`
 </div>]``
@@ -12877,7 +12873,7 @@ is <code>false</code>. See <bibref
                   <p>The following comparison is true only if the left and right sides each
 evaluate to exactly the same single node:</p>
                   <eg role="parse-test"
-                     ><![CDATA[/books/book[isbn="1558604820"] is /books/book[call="QA76.9 C3845"]]]></eg>
+                     ><![CDATA[/books/book[isbn = "1558604820"] is /books/book[call = "QA76.9 C3845"]]]></eg>
                </item>
 
                <item role="xquery">
@@ -12891,7 +12887,7 @@ evaluate to exactly the same single node:</p>
                   <p>The following comparison is true only if the node identified by the left
 side occurs before the node identified by the right side in document order:</p>
                   <eg role="parse-test"
-                     >/transactions/purchase[parcel="28-451"] &lt;&lt; /transactions/sale[parcel="33-870"]</eg>
+                     >/transactions/purchase[parcel = "28-451"] &lt;&lt; /transactions/sale[parcel = "33-870"]</eg>
                </item>
             </ulist>
          </div3>
@@ -13354,7 +13350,7 @@ character (that is, the pair <code>"{{"</code> represents the
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test"
-                        >&lt;shoe size="As big as {$hat/@size}"/&gt;</eg>
+                        >&lt;shoe size="As big as { $hat/@size }"/&gt;</eg>
                      <p>The string value of the <code>size</code> attribute is the
 string <code>"As big as "</code>, concatenated with the string value of the
 node denoted by the expression
@@ -13559,7 +13555,7 @@ attribute is processed as follows:</p>
 
                   <item>
                      <p>In this element constructor, namespace declaration attributes are used to bind the namespace prefixes <code>metric</code> and <code>english</code>:</p>
-                     <eg role="parse-test"><![CDATA[<box xmlns:metric = "http://example.org/metric/units"
+                     <eg role="parse-test"><![CDATA[<box xmlns:metric="http://example.org/metric/units"
      xmlns:english = "http://example.org/english/units">
   <height> <metric:meters>3</metric:meters> </height>
   <width> <english:feet>6</english:feet> </width>
@@ -13933,25 +13929,25 @@ raised <errorref class="TY"
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test">&lt;a&gt;{1}&lt;/a&gt;</eg>
+                     <eg role="parse-test">&lt;a&gt;{ 1 }&lt;/a&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value <code>"1"</code>.</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test">&lt;a&gt;{1, 2, 3}&lt;/a&gt;</eg>
+                     <eg role="parse-test">&lt;a&gt;{ 1, 2, 3 }&lt;/a&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value <code>"1 2 3"</code>.</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test">&lt;c&gt;{1}{2}{3}&lt;/c&gt;</eg>
+                     <eg role="parse-test">&lt;c&gt;{ 1 }{ 2 }{ 3 }&lt;/c&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value <code>"123"</code>.</p>
                   </item>
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test">&lt;b&gt;{1, "2", "3"}&lt;/b&gt;</eg>
+                     <eg role="parse-test">&lt;b&gt;{ 1, "2", "3" }&lt;/b&gt;</eg>
                      <p>The constructed element node has one child, a text node containing the value <code>"1 2 3"</code>.</p>
                   </item>
 
@@ -13971,7 +13967,7 @@ raised <errorref class="TY"
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test"
-                        >&lt;fact&gt;I saw &lt;howmany&gt;{5 + 3}&lt;/howmany&gt; cats.&lt;/fact&gt;</eg>
+                        >&lt;fact&gt;I saw &lt;howmany&gt;{ 5 + 3 }&lt;/howmany&gt; cats.&lt;/fact&gt;</eg>
                      <p>The constructed element node has three children: a text node containing
                         <code>"I saw </code> ", a child element node named <code>howmany</code>,
                         and a text node containing <code>" cats."</code>. The child element node
@@ -14021,8 +14017,8 @@ end of the content, or by a <nt
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test">&lt;cat&gt;
-   &lt;breed&gt;{$b}&lt;/breed&gt;
-   &lt;color&gt;{$c}&lt;/color&gt;
+   &lt;breed&gt;{ $b }&lt;/breed&gt;
+   &lt;color&gt;{ $c }&lt;/color&gt;
 &lt;/cat&gt;</eg>
                      <p>The constructed
    <code>cat</code> element node has two child element nodes named
@@ -14034,7 +14030,7 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test">&lt;a&gt;  {"abc"}  &lt;/a&gt;</eg>
+                     <eg role="parse-test">&lt;a&gt; { "abc" } &lt;/a&gt;</eg>
                      <p>If
    boundary-space policy is <code>strip</code>, this example is equivalent to <code
                            role="parse-test"
@@ -14047,7 +14043,7 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test">&lt;a&gt; z {"abc"}&lt;/a&gt;</eg>
+                     <eg role="parse-test">&lt;a&gt; z { "abc" }&lt;/a&gt;</eg>
                      <p>Since the
    whitespace surrounding the <code>z</code> is not boundary
    whitespace, it is always preserved. This example is equivalent to
@@ -14057,7 +14053,7 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test">&lt;a&gt;&amp;#x20;{"abc"}&lt;/a&gt;</eg>
+                     <eg role="parse-test">&lt;a&gt;&amp;#x20;{ "abc" }&lt;/a&gt;</eg>
                      <p>This
    example is equivalent to <code role="parse-test"
                            >&lt;a&gt;&nbsp;abc&lt;/a&gt;</code>, regardless
@@ -14068,7 +14064,7 @@ end of the content, or by a <nt
 
                   <item>
                      <p>Example:</p>
-                     <eg role="parse-test">&lt;a&gt;{"  "}&lt;/a&gt;</eg>
+                     <eg role="parse-test">&lt;a&gt;{ "  " }&lt;/a&gt;</eg>
                      <p>This example constructs an element containing two space characters,
    regardless of the boundary-space policy, because whitespace inside an enclosed expression is never considered to be boundary whitespace.</p>
                   </item>
@@ -14166,11 +14162,11 @@ same result as the first example in <specref
                   ref="id-element-constructor"/>:</p>
 
             <eg role="parse-test"><![CDATA[element book {
-   attribute isbn {"isbn-0060229357" },
-   element title { "Harold and the Purple Crayon"},
+   attribute isbn { "isbn-0060229357" },
+   element title { "Harold and the Purple Crayon" },
    element author {
       element first { "Crockett" },
-      element last {"Johnson" }
+      element last { "Johnson" }
    }
 }]]></eg>
 
@@ -14422,8 +14418,8 @@ if the EQName is a  <termref
    element with the same name and attributes as <code>$e</code> and
    with numeric content equal to twice the value of
    <code>$e</code>:</p>
-               <eg role="parse-test"><![CDATA[element {node-name($e)}
-   {$e/@*, 2 * data($e)}]]></eg>
+               <eg role="parse-test"><![CDATA[element { node-name($e) }
+  { $e/@*, 2 * data($e) }]]></eg>
                <p>In this example, if <code>$e</code> is
    bound by the expression <code>let $e := &lt;length
    units="inches"&gt;{5}&lt;/length&gt;</code>, then the result of the
@@ -14460,8 +14456,8 @@ if the EQName is a  <termref
 expression generates the content and attributes:</p>
                <eg role="parse-test"><![CDATA[
   element
-    {$dict/entry[@word=name($e)]/variant[@xml:lang="it"]}
-    {$e/@*, $e/node()}]]></eg>
+    { $dict/entry[@word = name($e)]/variant[@xml:lang = "it"] }
+    { $e/@*, $e/node() }]]></eg>
                <p>The result of this expression is as follows:</p>
                <eg role="parse-test"
                   ><![CDATA[<indirizzo>123 Roosevelt Ave. Flushing, NY 11368</indirizzo>]]></eg>
@@ -14901,7 +14897,7 @@ attribute
                   <p>It is possible for a text node constructor to construct a text node containing a zero-length string. However, if used in the content of a constructed element or document node, such a text node will be deleted or merged with another text node.</p>
                </note>
                <p>The following example illustrates a text node constructor:</p>
-               <eg role="parse-test"><![CDATA[text {"Hello"}]]></eg>
+               <eg role="parse-test"><![CDATA[text { "Hello" }]]></eg>
             </div4>
 
             <div4 id="id-computed-pis">
@@ -14996,7 +14992,7 @@ attribute
                <p>The following example illustrates a computed processing instruction constructor:</p>
                <eg role="parse-test"><![CDATA[let $target := "audio-output",
     $content := "beep"
-return processing-instruction {$target} {$content}]]></eg>
+return processing-instruction { $target } { $content }]]></eg>
                <p>The processing instruction node constructed by this example might be serialized as follows:</p>
                <eg>&lt;?audio-output beep?&gt;</eg>
             </div4>
@@ -15189,21 +15185,21 @@ return comment {concat($homebase, ", we have a problem.")}]]></eg>
 
                   <item>
                      <p>A computed namespace constructor with a prefix:</p>
-                     <eg role="parse-test"><![CDATA[namespace a {"http://a.example.com" }]]></eg>
+                     <eg role="parse-test"><![CDATA[namespace a { "http://a.example.com" }]]></eg>
                   </item>
 
 
                   <item>
                      <p>A computed namespace constructor with a prefix expression:</p>
                      <eg role="parse-test"
-                        ><![CDATA[namespace {"a"} {"http://a.example.com" }]]></eg>
+                        ><![CDATA[namespace { "a" } { "http://a.example.com" }]]></eg>
                   </item>
 
 
                   <item>
                      <p>A computed namespace constructor with an empty prefix:</p>
                      <eg role="parse-test"
-                        ><![CDATA[namespace { "" } {"http://a.example.com" }]]></eg>
+                        ><![CDATA[namespace { "" } { "http://a.example.com" }]]></eg>
                   </item>
                </ulist>
 
@@ -15211,8 +15207,8 @@ return comment {concat($homebase, ", we have a problem.")}]]></eg>
 in-scope namespaces of elements created with element constructors:</p>
                <eg role="parse-test"><![CDATA[
 <age xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"> {
-  namespace xs {"http://www.w3.org/2001/XMLSchema"},
-  attribute xsi:type {"xs:integer"},
+  namespace xs { "http://www.w3.org/2001/XMLSchema" },
+  attribute xsi:type { "xs:integer" },
   23
 }</age>
 ]]></eg>
@@ -15352,7 +15348,7 @@ creating a default namespace for that element using a computed namespace constru
                />. 
 For instance, the following computed constructor raises an error because the element’s name is not in a namespace, but a default namespace is defined.</p>
 
-            <eg role="parse-test"><![CDATA[element e { namespace {''} {'u'} }]]></eg>
+            <eg role="parse-test"><![CDATA[element e { namespace { '' } { 'u' } }]]></eg>
 
             <p>The following query illustrates the in-scope namespaces of a constructed element:</p>
 
@@ -15548,7 +15544,7 @@ return g($x, $y)</phrase>
          </eg>
 
          <p diff="add" at="A">The following example illustrates processing of an array.</p>
-         <eg diff="add" at="A">for member $map in parse-json('[{"x":1, "y":2}, {"x":10, "y":20}]') return $map!(?x+?y)</eg>
+         <eg diff="add" at="A">for member $map in parse-json('[{ "x": 1, "y": 2 }, { "x": 10, "y": 20 }]') return $map ! (?x + ?y)</eg>
          <p diff="add" at="A">The result is the sequence <code>(3, 30)</code>.</p>
          
          <note>
@@ -16019,7 +16015,7 @@ map {
                   </item>
                   <item>
                      <p>
-                        <code>array{ $x, local:items(), &lt;tautology&gt;It is what it is.&lt;/tautology&gt; }</code> creates an array with the following members: the items to which <code>$x</code> is bound, followed by the items to which <code>local:items()</code> evaluates, followed by a tautology element.</p>
+                        <code>array { $x, local:items(), &lt;tautology&gt;It is what it is.&lt;/tautology&gt; }</code> creates an array with the following members: the items to which <code>$x</code> is bound, followed by the items to which <code>local:items()</code> evaluates, followed by a tautology element.</p>
                   </item>
                </ulist>
 
@@ -16056,11 +16052,11 @@ map {
                   </item>
                   <item>
                      <p>
-                        <code>[ [1, 2, 3], [4, 5, 6]](2)</code> evaluates to <code>[4, 5, 6]</code>.</p>
+                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ] ](2)</code> evaluates to <code>[ 4, 5, 6 ]</code>.</p>
                   </item>
                   <item>
                      <p>
-                        <code>[ [1, 2, 3], [4, 5, 6]](2)(2)</code> evaluates to <code>5</code>.</p>
+                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ] ](2)(2)</code> evaluates to <code>5</code>.</p>
                   </item>
                   <item>
                      <p>
@@ -16162,7 +16158,7 @@ map {
                         <eg diff="chg" at="2023-11-15"><![CDATA[
 for $k in 1 to array:size($V)
 let $m := array:get($V, $k)
-return if ($m instance of ST) {$m} 
+return if ($m instance of ST) { $m } 
 ]]></eg>
                         <p diff="add" at="2023-11-15">If no SequenceType is provided, it defaults to <code>item()*</code>.</p>
                         <note>
@@ -16200,7 +16196,7 @@ return if ($m instance of ST) {$m}
                            <p diff="chg" at="2023-11-15">If the <nt def="KeySpecifier"
                               >KeySpecifier</nt> is a wildcard (<code>*</code>) qualified by a SequenceType <var>ST</var>, 
                               the result is given by the following expression:</p>
-                           <eg diff="chg" at="2023-11-15"><![CDATA[map:for-each($V, function($k, $v){if ($v instance of ST) {$v}})]]></eg>
+                           <eg diff="chg" at="2023-11-15"><![CDATA[map:for-each($V, function($k, $v) { if ($v instance of ST) { $v } })]]></eg>
                            <p diff="add" at="2023-11-15">If no SequenceType is provided, it defaults to <code>item()*</code>.</p>
                            <note>
                               <p>The order of entries in <code>map:for-each</code> is implementation-dependent,
@@ -16233,19 +16229,19 @@ return if ($m instance of ST) {$m}
                   </item>
                   <item>
                      <p>
-                        <code>[4, 5, 6]?2</code> evaluates to <code>5</code>.</p>
+                        <code>[ 4, 5, 6 ]?2</code> evaluates to <code>5</code>.</p>
                   </item>
                   <item>
                      <p>
-                        <code>(map {"first": "Tom"}, map {"first": "Dick"}, map {"first": "Harry"})?first</code> evaluates to the sequence <code>("Tom", "Dick", "Harry")</code>.</p>
+                        <code>(map { "first": "Tom" }, map { "first": "Dick" }, map { "first": "Harry" })?first</code> evaluates to the sequence <code>("Tom", "Dick", "Harry")</code>.</p>
                   </item>
                   <item>
                      <p>
-                        <code>([1,2,3], [4,5,6])?2</code> evaluates to the sequence <code>(2, 5)</code>.</p>
+                        <code>([ 1, 2, 3 ], [ 4, 5, 6 ])?2</code> evaluates to the sequence <code>(2, 5)</code>.</p>
                   </item>
                   <item>
                      <p>
-                        <code>["a","b"]?3</code> raises a dynamic error <xerrorref spec="FO40"
+                        <code>[ "a", "b" ]?3</code> raises a dynamic error <xerrorref spec="FO40"
                            class="AY" code="0001"/>
                      </p>
                   </item>
@@ -16264,7 +16260,7 @@ return if ($m instance of ST) {$m}
                
                
                
-               <p>Unary lookup is most commonly used in predicates (for example, <code>$map[?name='Mike']</code>)
+               <p>Unary lookup is most commonly used in predicates (for example, <code>$map[?name = 'Mike']</code>)
                   or with the simple map operator (for example, <code>avg($maps ! (?price - ?discount))</code>).</p>
                
                <p>The unary lookup expression <code>?KS</code> is defined to be equivalent to the postfix lookup
@@ -16286,10 +16282,10 @@ return if ($m instance of ST) {$m}
                   <item>
                      <p>If the context item is the result of parsing the JSON input:</p>
                      <eg>{
-                        "name": "John Smith",
-                        "address": {"street": "18 Acacia Avenue", "postcode": "MK12 2EX"},
-                        "previous-address": {"street": "12 Seaview Road", "postcode": "EX8 9AA"}
-                        }</eg>
+  "name": "John Smith",
+  "address": { "street": "18 Acacia Avenue", "postcode": "MK12 2EX" },
+  "previous-address": { "street": "12 Seaview Road", "postcode": "EX8 9AA" }
+}</eg>
                      <p>then <code>?*::record(street, postcode)?postcode</code>
                         returns <code>("MK12 2EX", "EX8 9AA")</code> (or some permutation thereof).</p>
                      <note><p>Writing <code>?*?postcode</code> would raise a type error, because the result of the initial
@@ -16326,7 +16322,7 @@ return if ($m instance of ST) {$m}
                   </item>
                   <item>
                      <p>
-                        <code>([1,2,3], [1,2,5], [1,2])[?3 = 5]</code> raises an error because <code>?3</code> on one of the
+                        <code>([ 1, 2, 3 ], [ 1, 2, 5 ], [ 1, 2 ])[?3 = 5]</code> raises an error because <code>?3</code> on one of the
                         items in the sequence fails.</p>
                   </item>
                   <item>
@@ -16338,26 +16334,26 @@ return if ($m instance of ST) {$m}
                   </item>
                   <item>
                      <p>
-                        <code>[1, 2, 5, 7]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p>
+                        <code>[ 1, 2, 5, 7 ]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p>
                   </item>
                   <item>
                      <p>
-                        <code>[[1, 2, 3], [4, 5, 6]]?*</code> evaluates to <code>([1, 2, 3], [4, 5, 6])</code>
+                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ] ]?*</code> evaluates to <code>([ 1, 2, 3 ], [ 4, 5, 6 ])</code>
                      </p>
                   </item>
                   <item>
                      <p>
-                        <code>[[1, 2, 3], 4, 5]?*::array(*)</code> evaluates to <code>([1, 2, 3])</code>
+                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*::array(*)</code> evaluates to <code>([ 1, 2, 3 ])</code>
                      </p>
                   </item>
                   <item>
                      <p>
-                        <code>[[1, 2, 3], [4, 5, 6], 7]?*::array(*)?2</code> evaluates to <code>(2, 5)</code>
+                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], 7 ]?*::array(*)?2</code> evaluates to <code>(2, 5)</code>
                      </p>
                   </item>
                   <item>
                      <p>
-                        <code>[[1, 2, 3], 4, 5]?*::xs:integer</code> evaluates to <code>(4, 5)</code>
+                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*::xs:integer</code> evaluates to <code>(4, 5)</code>
                      </p>
                   </item>
                </ulist>
@@ -16412,22 +16408,22 @@ declare function recursive-content($item as item()) as map(*)* {
                
                <note>
                   <p>This is best explained by considering examples.</p>
-                  <p>Consider the expression <code>let $value := [map{"first":"John", "last":"Smith"}, map{"first":"Mary", "last":"Evans"}]</code>.</p>
+                  <p>Consider the expression <code>let $value := [ map { "first": "John", "last": "Smith" }, map { "first": "Mary", "last": "Evans" } ]</code>.</p>
                   <p>The recursive content of this array is the sequence of six singleton maps:</p>
                   <olist>
-                     <item><p><code>map{1: map{"first":"John", "last":"Smith"}}</code></p></item>
-                     <item><p><code>map{2: map{"first":"Mary", "last":"Evans"}}</code></p></item>
-                     <item><p><code>map{"first":"John"}</code></p></item>
-                     <item><p><code>map{"last":"Smith"}</code></p></item>
-                     <item><p><code>map{"first":"Mary"}</code></p></item>
-                     <item><p><code>map{"last":"Evans"}</code></p></item>
+                     <item><p><code>map { 1: map { "first": "John", "last": "Smith" } }</code></p></item>
+                     <item><p><code>map { 2: map { "first": "Mary", "last": "Evans" } }</code></p></item>
+                     <item><p><code>map { "first": "John" }</code></p></item>
+                     <item><p><code>map { "last": "Smith" }</code></p></item>
+                     <item><p><code>map { "first": "Mary" }</code></p></item>
+                     <item><p><code>map { "last": "Evans" }</code></p></item>
                   </olist>
                   <p>The expression <code>$value??*</code> returns the sequence 
-                     <code>map{"first":"John", "last":"Smith"}, map{"first":"Mary", "last":"Evans"},
+                     <code>map { "first": "John", "last": "Smith" }, map { "first": "Mary", "last": "Evans" },
                      "John", "Smith", "Mary", "Evans"</code>.</p>
                   <p>The expression <code>$value??first</code> returns the sequence <code>"John", "Mary"</code>.</p>
                   <p>The expression <code>$value??last</code> returns the sequence <code>"Smith", "Evans"</code>.</p>
-                  <p>The expression <code>$value??1</code> returns the sequence <code>map{"first":"John", "last":"Smith"}</code>.</p>
+                  <p>The expression <code>$value??1</code> returns the sequence <code>map { "first": "John", "last": "Smith" }</code>.</p>
                </note>
                <note>
                   <p>The effect of evaluating all shallow lookups on maps rather than arrays is that no error arises
@@ -16458,10 +16454,10 @@ declare function recursive-content($item as item()) as map(*)* {
                <note>
                   <p>An expression involving multiple deep lookup operators may return duplicates.
                      For example, the result of the expression 
-                     <code>[[["a"],["b"]],[["c"],["d"]]] ?? 1 ?? 1</code>
-                     is <code>(["a"], "a", "b", "a", "c")</code>. This is because the first <code>??</code> operator
+                     <code>[ [ [ "a" ], [ "b" ] ], [ [ "c" ], [ "d" ] ] ] ?? 1 ?? 1</code>
+                     is <code>([ "a" ], "a", "b", "a", "c")</code>. This is because the first <code>??</code> operator
                      selects members in position 1 at all three levels, that is it selects the arrays
-                     <code>[["a"],["b"]]</code>, <code>["a"]</code>, and <code>["c"]</code> as well
+                     <code>[ [ "a" ], [ "b" ] ]</code>, <code>[ "a" ]</code>, and <code>[ "c" ]</code> as well
                      as each of the four string values. The second <code>??</code> operator 
                   selects members in position 1 within each of these values, which results in the string
                   <code>"a"</code> being selected twice.</p>
@@ -16479,45 +16475,45 @@ declare function recursive-content($item as item()) as map(*)* {
                   function to the following input:</p>
                   <eg><![CDATA[
 {
-    "desc"    : "Distances between several cities, in kilometers.",
-    "updated" : "2014-02-04T18:50:45",
-    "uptodate": true,
-    "author"  : null,
-    "cities"  : {
-        "Brussels": [
-                      {"to": "London",    "distance": 322},
-                      {"to": "Paris",     "distance": 265},
-                      {"to": "Amsterdam", "distance": 173}
-                    ],
-        "London": [
-                      {"to": "Brussels",  "distance": 322},
-                      {"to": "Paris",     "distance": 344},
-                      {"to": "Amsterdam", "distance": 358}
-                  ],
-        "Paris": [
-                      {"to": "Brussels",  "distance": 265},
-                      {"to": "London",    "distance": 344},
-                      {"to": "Amsterdam", "distance": 431}
-                 ],
-        "Amsterdam": [
-                      {"to": "Brussels",  "distance": 173},
-                      {"to": "London",    "distance": 358},
-                      {"to": "Paris",     "distance": 431}
-                     ]
-     }
+  "desc"    : "Distances between several cities, in kilometers.",
+  "updated" : "2014-02-04T18:50:45",
+  "uptodate": true,
+  "author"  : null,
+  "cities"  : {
+    "Brussels": [
+      { "to": "London",    "distance": 322 },
+      { "to": "Paris",     "distance": 265 },
+      { "to": "Amsterdam", "distance": 173 }
+    ],
+    "London": [
+      { "to": "Brussels",  "distance": 322 },
+      { "to": "Paris",     "distance": 344 },
+      { "to": "Amsterdam", "distance": 358 }
+    ],
+    "Paris": [
+      { "to": "Brussels",  "distance": 265 },
+      { "to": "London",    "distance": 344 },
+      { "to": "Amsterdam", "distance": 431 }
+     ],
+    "Am sterdam": [
+      { "to": "Brussels",  "distance": 173 },
+      { "to": "London",    "distance": 358 },
+      { "to": "Paris",     "distance": 431 }
+    ]
+}
 }]]></eg>
                   
                   <p>Given two variables <code>$from</code> and <code>$to</code> containing the
                   names of two cities that are present in this table, the distance between the
                   two cities can be obtained with the expression:</p> 
                      
-                     <eg>$tree ??$from ??*::record(to, distance) [?to=$to] ?distance</eg>
+                     <eg>$tree ??$from ??*::record(to, distance) [?to = $to] ?distance</eg>
                   
                   <p>The names of all pairs of cities whose distance is represented in the data
                   can be obtained with the expression:</p>
                   
                   <eg>$tree ??$cities => 
-     map:for-each( fn($key, $val){$val ??to ! ($key || "-" || .)} )</eg>
+     map:for-each( fn($key, $val) { $val ??to ! ($key || "-" || .) } )</eg>
                   
                </example>
                <example>
@@ -16726,8 +16722,8 @@ declare function recursive-content($item as item()) as map(*)* {
                supplied map or array in which all items in the recursive content have been labeled.
             This is a useful model because it avoids the need to specify the effect of each individual
             function and operator on the structure. For example, the rule has the consequence that the result of
-            <code>pin([11,12,13,14]) => array:remove(3) => array:for-each(fn{label(.)?key})</code> is
-            <code>[1,2,4]</code>. In a practical implementation, however, it is likely that labels
+            <code>pin([ 11, 12, 13, 14 ]) => array:remove(3) => array:for-each(fn { label(.)?key })</code> is
+            <code>[ 1, 2, 4 ]</code>. In a practical implementation, however, it is likely that labels
             will be attached to items lazily, at the time they are retrieved. Such an implementation will need
             to recognize pinned maps and arrays and treat them specially when operations such as
             <code>array:get</code>, <code>array:remove</code>, <code>array:for-each</code>,
@@ -17314,7 +17310,7 @@ for member $y in $expr2]]></eg>
                
                <item diff="add" at="A">
                   <p>Initial clause:</p>
-                  <eg><![CDATA[for member $x in [1, 2, (5 to 10)]]></eg>
+                  <eg><![CDATA[for member $x in [ 1, 2, (5 to 10) ] ]]></eg>
                   <p>Output tuple stream:</p>
                   <eg><![CDATA[($x = (1))
 ($x = (2))
@@ -17503,12 +17499,12 @@ for member $y in $expr2]]></eg>
                   <eg><![CDATA[for member $y in [[$x+1, $x+2], [[$x+3, $x+4]] ]]></eg>
                   <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
                      >ordering mode</termref> is <code>ordered</code>):</p>
-                  <eg><![CDATA[($x = 1, $y = [2, 3])
-($x = 1, $y = [4, 5])
-($x = 2, $y = [3, 4])
-($x = 2, $y = [5, 6])
-($x = 3, $y = [4, 5])
-($x = 3, $y = [6, 7])
+                  <eg><![CDATA[($x = 1, $y = [ 2, 3 ])
+($x = 1, $y = [ 4, 5 ])
+($x = 2, $y = [ 3, 4 ])
+($x = 2, $y = [ 5, 6 ])
+($x = 3, $y = [ 4, 5 ])
+($x = 3, $y = [ 6, 7 ])
 ]]></eg>
                   
                </item>
@@ -18081,15 +18077,15 @@ return
                <eg role="parse-test">for $symbol in distinct-values(//symbol)
 let $closings := //closing[symbol = $symbol]
 for tumbling window $w in $closings
-   start $first next $second when $first/price &lt; $second/price
-   end $last next $beyond when $last/price &gt; $beyond/price
+  start $first next $second when $first/price &lt; $second/price
+  end $last next $beyond when $last/price &gt; $beyond/price
 return
-   &lt;run-up symbol="{$symbol}"&gt;
-      &lt;start-date&gt;{data($first/date)}&lt;/start-date&gt;
-      &lt;start-price&gt;{data($first/price)}&lt;/start-price&gt;
-      &lt;end-date&gt;{data($last/date)}&lt;/end-date&gt;
-      &lt;end-price&gt;{data($last/price)}&lt;/end-price&gt;
-   &lt;/run-up&gt;</eg>
+  &lt;run-up symbol="{ $symbol }"&gt;
+    &lt;start-date&gt;{ data($first/date) }&lt;/start-date&gt;
+    &lt;start-price&gt;{ data($first/price) }&lt;/start-price&gt;
+    &lt;end-date&gt;{ data($last/date) }&lt;/end-date&gt;
+    &lt;end-price&gt;{ data($last/price) }&lt;/end-price&gt;
+  &lt;/run-up&gt;</eg>
                <note>
                   <p>In the above example, the <code>for</code> and <code>let</code> clauses could be rewritten as follows:</p>
                   <eg><![CDATA[for $closings in //closing
@@ -18168,10 +18164,10 @@ group by $symbol]]></eg>
                      def="dt-positional-variable"
                      >positional variable</termref> to perform sampling on an input sequence. The query returns one value out of each one hundred input values.</p>
                   <eg role="parse-test">
-                     <phrase role="parse-test"
-                        >for $x at $i in $inputvalues
-                        where $i mod 100 = 0
-                        return $x</phrase>
+                     <phrase role="parse-test">
+for $x at $i in $inputvalues
+where $i mod 100 = 0
+return $x</phrase>
                   </eg>
                </item>
             </ulist>
@@ -18242,7 +18238,7 @@ return $x]]></eg>
             </note>
             
             <note><p>The expression <code>for $i in $input while $i le 3</code> differs
-               from the expression <code>subsequence-where($input, to:=fn{. gt 3})</code> in that
+               from the expression <code>subsequence-where($input, to := fn {. gt 3 })</code> in that
                the <code>while</code> expression drops the first item that is greater than 3,
                while the <code>subsequence-where</code> expression retains it.</p></note>
             
@@ -18310,21 +18306,21 @@ order by $p/sales descending
 count $rank
 while $rank &lt;= 3
 return
-   &lt;product rank="{$rank}"&gt;
-      {$p/name, $p/sales}
-   &lt;/product&gt;</eg>
+  &lt;product rank="{ $rank }"&gt;
+    { $p/name, $p/sales }
+  &lt;/product&gt;</eg>
                   <p>The result of this query has the following structure:</p>
                   <eg>&lt;product rank="1"&gt;
-   &lt;name&gt;Toaster&lt;/name&gt;
-   &lt;sales&gt;968&lt;/sales&gt;
+  &lt;name&gt;Toaster&lt;/name&gt;
+  &lt;sales&gt;968&lt;/sales&gt;
 &lt;/product&gt;
 &lt;product rank="2"&gt;
-   &lt;name&gt;Blender&lt;/name&gt;
-   &lt;sales&gt;520&lt;/sales&gt;
+  &lt;name&gt;Blender&lt;/name&gt;
+  &lt;sales&gt;520&lt;/sales&gt;
 &lt;/product&gt;
 &lt;product rank="3"&gt;
-   &lt;name&gt;Can Opener&lt;/name&gt;
-   &lt;sales&gt;475&lt;/sales&gt;
+  &lt;name&gt;Can Opener&lt;/name&gt;
+  &lt;sales&gt;475&lt;/sales&gt;
 &lt;/product&gt;</eg>
                </item>
             </ulist>
@@ -18494,16 +18490,14 @@ value. Consider the following query:</p>
 for $c in //customer
 where $c/salary > $x
 group by $d := $c/department
-return
-<department name="{$d}">
-   Number of employees earning more than ${$x} is {count($c)}
+return <department name="{ $d }">
+  Number of employees earning more than ${ $x } is { count($c) }
 </department>]]></eg>
 
                <p>If there are three qualifying customers in the sales department this
 evaluates to:</p>
 
                <eg><![CDATA[
-
 <department name="sales">
   Number of employees earning more than $64000 64000 64000 is 3
 </department>]]></eg>
@@ -18521,11 +18515,9 @@ for $c in //customer
 let $d := $c/department
 where $c/salary > $x
 group by $d
-return
- <department name="{$d}">
-  Number of employees earning more than ${distinct-values($x)} is {count($c)}
- </department>]]></eg>
-
+return <department name="{ $d }">
+  Number of employees earning more than ${ distinct-values($x) } is { count($c) }
+</department>]]></eg>
             </note>
 
             <note>
@@ -18607,7 +18599,7 @@ individual pre-grouping tuples.</p>
                   <eg role="parse-test">for $s in $sales
 let $storeno := $s/storeno
 group by $storeno
-return &lt;store number="{$storeno}" total-qty="{sum($s/qty)}"/&gt;</eg>
+return &lt;store number="{ $storeno }" total-qty="{ sum($s/qty) }"/&gt;</eg>
                   <p>The result of this query is a sequence of elements with the following structure:</p>
                   <eg>&lt;store number="S101" total-qty="1550" /&gt;
 &lt;store number="S102" total-qty="2125" /&gt;</eg>
@@ -18620,15 +18612,14 @@ return &lt;store number="{$storeno}" total-qty="{sum($s/qty)}"/&gt;</eg>
                         def="dt-grouping-variable">grouping variables</termref>:</p>
 
                   <eg role="parse-test">
-for $s in $sales,
-    $p in $products[itemno = $s/itemno]
+for $s in $sales
+for $p in $products[itemno = $s/itemno]
 let $revenue := $s/qty * $p/price
 group by $storeno := $s/storeno, 
-    $category := $p/category
-return
-    &lt;summary storeno="{$storeno}"
-              category="{$category}"
-              revenue="{sum($revenue)}"/>
+         $category := $p/category
+return &lt;summary storeno="{ $storeno }"
+                category="{ $category }"
+                revenue="{ sum($revenue) }"/>
 </eg>
 
 
@@ -18648,27 +18639,25 @@ return
 let $storeno := $s1/storeno
 group by $storeno
 order by $storeno
-return
-  &lt;store storeno="{$storeno}"&gt;
-    {for $s2 in $s1,
-         $p in $products[itemno = $s2/itemno]
-     let $category := $p/category,
-         $revenue := $s2/qty * $p/price
-     group by $category
-     let $group-revenue := sum($revenue)
-     where $group-revenue &gt; 10000
-     order by $group-revenue descending
-     return &lt;category name="{$category}" revenue="{$group-revenue}"/&gt;
-    }
-  &lt;/store&gt;
+return &lt;store storeno="{ $storeno }"&gt;{
+  for $s2 in $s1
+  for $p in $products[itemno = $s2/itemno]
+  let $category := $p/category
+  let $revenue := $s2/qty * $p/price
+  group by $category
+  let $group-revenue := sum($revenue)
+  where $group-revenue &gt; 10000
+  order by $group-revenue descending
+  return &lt;category name="{ $category }" revenue="{ $group-revenue }"/&gt;
+}&lt;/store&gt;
 </eg>
                   <p>The result of this example query has the following structure:</p>
                   <eg>&lt;store storeno="S101"&gt;
-   &lt;category name="Men's Wear" revenue="10185"/&gt;
+  &lt;category name="Men's Wear" revenue="10185"/&gt;
 &lt;/store&gt;
 &lt;store storeno="S102"&gt;
-   &lt;category name="Jewelry" revenue="30750"/&gt;
-   &lt;category name="Appliances" revenue="22650"/&gt;
+  &lt;category name="Jewelry" revenue="30750"/&gt;
+  &lt;category name="Appliances" revenue="22650"/&gt;
 &lt;/store&gt;</eg>
                </item>
 
@@ -18687,29 +18676,28 @@ of items in the post-grouping tuple.</p>
 for $p in $products[price &gt; $high-price]
 let $category := $p/category
 group by $category
-return
-   &lt;category name="{$category}"&gt;
-      {count($p)} products have price greater than {$high-price}.
-   &lt;/category&gt;</eg>
+return &lt;category name="{ $category }"&gt;{
+  count($p) || ' products have price greater than ' || $high-price || '.'
+}&lt;/category&gt;</eg>
                   <p>If three products in the “Men’s Wear” category have prices greater than 1000, the result of this query might look (in part) like this:</p>
                   <eg>&lt;category name="Men’s Wear"&gt;
-   3 products have price greater than 1000 1000 1000.
+  3 products have price greater than 1000 1000 1000.
 &lt;/category&gt;</eg>
                   <p>The repetition of "1000" in this query result is due to the fact that <code>$high-price</code> is not a <termref
                         def="dt-grouping-variable"
                         >grouping variable</termref>. One way to avoid this repetition is to move the binding of <code>$high-price</code> to an outer-level FLWOR expression, as follows:</p>
                   <eg role="parse-test">let $high-price := 1000
-return
-   for $p in $products[price &gt; $high-price]
-   let $category := $p/category
-   group by $category
-   return
-      &lt;category name="{$category}"&gt;
-         {count($p)} products have price greater than {$high-price}.
-      &lt;/category&gt;</eg>
+return (
+  for $p in $products[price &gt; $high-price]
+  let $category := $p/category
+  group by $category
+  return &lt;category name="{ $category }"&gt;{
+    count($p) || ' products have price greater than ' || $high-price || '.'
+  }&lt;/category&gt;  
+)</eg>
                   <p>The result of the revised query might contain the following element:</p>
                   <eg>&lt;category name="Men's Wear"&gt;
-   3 products have price greater than 1000.
+  3 products have price greater than 1000.
 &lt;/category&gt;</eg>
                </item>
             </ulist>
@@ -19017,7 +19005,7 @@ return $b</eg>
                <eg role="parse-test">
 sort(
   $books/book[price &lt; 100],
-  function($book){ $book/title }
+  function($book) { $book/title }
 )
 </eg>
             </note>
@@ -19060,10 +19048,9 @@ return
                      <eg role="parse-test">for $d in doc("depts.xml")//dept
 order by $d/deptno
 for $e in doc("emps.xml")//emp[deptno eq $d/deptno]
-return
-   &lt;assignment&gt;
-      {$d/deptno, $e/name}
-   &lt;/assignment&gt;</eg>
+return &lt;assignment&gt;{
+  $d/deptno, $e/name
+}&lt;/assignment&gt;</eg>
                      <p>The result of this query is a sequence of <code>assignment</code> elements, each containing a <code>deptno</code> element and a <code>name</code> element. The sequence will be ordered primarily by the <code>deptno</code> values because of the <code>order by</code> clause. If <termref
                            def="dt-ordering-mode"
                            >ordering mode</termref> is <code>ordered</code>, subsequences of <code>assignment</code> elements with equal <code>deptno</code> values will be ordered by the document order of their <code>name</code> elements within the <code>emps.xml</code> document; otherwise the ordering of these subsequences will be <termref
@@ -19153,13 +19140,10 @@ Also, within a <termref def="dt-path-expression"
                def="dt-document-order"
                >document order</termref> of <code>suppliers.xml</code>. However, this might not be the most efficient way to process the query if the ordering of the result is not important. An XQuery implementation might be able to process the query more efficiently by using an index to find the red parts, or by using <code>suppliers.xml</code> rather than <code>parts.xml</code> to control the primary ordering of the result. The <code>unordered</code> expression gives the query evaluator freedom to make these kinds of optimizations.</p>
          <eg role="parse-test"><![CDATA[unordered {
-  for $p in doc("parts.xml")/parts/part[color = "Red"],
-      $s in doc("suppliers.xml")/suppliers/supplier
+  for $p in doc("parts.xml")/parts/part[color = "Red"]
+  for $s in doc("suppliers.xml")/suppliers/supplier
   where $p/suppno = $s/suppno
-  return
-    <ps>
-       { $p/partno, $s/suppno }
-    </ps>
+  return <ps>{ $p/partno, $s/suppno }</ps>
 }]]></eg>
          <p>In addition to <code>ordered</code> and <code>unordered</code> expressions, XQuery provides a function named <code>fn:unordered</code> that operates on any sequence of items and returns the same sequence in an <termref
                def="dt-implementation-defined"
@@ -19559,10 +19543,10 @@ one <code>employee</code> element satisfies the given comparison expression:</p>
                <eg role="parse-test"><![CDATA[every $emp in /emps/employee satisfies
      some $sal in $emp/salary satisfies $sal/@current='true']]></eg>
                <note diff="add" at="A"><p>Like many quantified expressions, this can be simplified. This example can be written
-                  <code>every $emp in /emps/employee satisfies $emp/salary[@current='true']</code>, or even
-                  more concisely as <code>empty(/emps/employee[not(salary/@current='true')]</code>.</p>
+                  <code>every $emp in /emps/employee satisfies $emp/salary[@current = 'true']</code>, or even
+                  more concisely as <code>empty(/emps/employee[not(salary/@current = 'true')]</code>.</p>
                <p>Another alternative in &language; is to use the higher-order functions <code>fn:some</code> and <code>fn:every</code>.
-               This example can be written <code diff="chg" at="2023-04-25">fn:every(/emps/employee, function{salary/@current='true'})</code></p>
+               This example can be written <code diff="chg" at="2023-04-25">fn:every(/emps/employee, fn { salary/@current = 'true' })</code></p>
                </note>
             </item>
 
@@ -20413,7 +20397,7 @@ usa:zipcode?)</code>.</p>
                   <p>If <code>my:location</code> is a named item type that expands
                   to <code>record(latitude as xs:double, longitude as xs:double)</code>,
                   then the result of <code>my:location(50.52, -3.02)</code> is
-                  the map <code>map{'latitude':50.52e0, 'longitude':-3.02e0}</code>.</p>
+                  the map <code>map { 'latitude': 50.52e0, 'longitude': -3.02e0 }</code>.</p>
                </item>
             </ulist>
 
@@ -20724,14 +20708,14 @@ raised <errorref
          
          <p diff="add" at="A">The following example introduces an inline function to the pipeline:</p>
          <eg role="parse-test" diff="add" at="A"
-            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn($a){$a+1}() => sum()]]></eg>
+            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn($a) { $a + 1 }() => sum()]]></eg>
          
-         <p diff="add" at="A">This is equivalent to <code>sum((1 to 5) ! (math:sqrt(xs:double(.))+1))</code>.</p>
+         <p diff="add" at="A">This is equivalent to <code>sum((1 to 5) ! (math:sqrt(xs:double(.)) + 1))</code>.</p>
          
          <p diff="add" at="A">The same effect can be achieved using a <termref def="dt-focus-function"/>:</p>
          
          <eg role="parse-test" diff="add" at="A"
-            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn{.+1}() => sum()]]></eg>
+            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn { . + 1 }() => sum()]]></eg>
          
          <p>Where the value of an expression is a map containing functions, simulating the behavior
          of objects in object-oriented languages, then the <term>lookup arrow operator</term> <code>=?></code>
@@ -20837,9 +20821,9 @@ raised <errorref
          <p>For example, the expression</p>
          
          <eg>let $rectangle := map {
-   "width": 20,
-   "height": 12,
-   "area": fn($this){$this?width * $this?height}
+  "width": 20,
+  "height": 12,
+  "area": fn($this) { $this?width * $this?height }
 } 
 return $rectangle =?> area()</eg>
          
@@ -21253,7 +21237,7 @@ following expression, without actually changing the result.
 For example:</p>
                   <eg role="parse-test"><![CDATA[declare namespace exq = "http://example.org/XQueryImplementation";
    (# exq:use-index #)
-      { $bib/book/author[name='Berners-Lee'] }
+      { $bib/book/author[name = 'Berners-Lee'] }
 ]]></eg>
                   <p>An implementation that recognizes the <code>exq:use-index</code> pragma might use an
 index to evaluate the  expression that follows. An implementation that
@@ -21282,10 +21266,11 @@ evaluated in place of the following expression. In this case, the
 following expression itself (if it is present) provides a fallback for use by
 implementations that do not recognize the pragma. For example:</p>
                   <eg role="parse-test"><![CDATA[declare namespace exq = "http://example.org/XQueryImplementation";
-   for $x in
-      (# exq:distinct //city by @country #)
-      { //city[not(@country = preceding::city/@country)] }
-   return f:show-city($x)
+
+for $x in (# exq:distinct //city by @country #) {
+  //city[not(@country = preceding::city/@country)]
+}
+return f:show-city($x)
 ]]></eg>
                   <p>Here an implementation that recognizes the pragma will return the result of
 evaluating the proprietary syntax <code>exq:distinct //city by

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -9251,7 +9251,7 @@ return $vat(doc('wares.xml')/shop/article)
                               function call.
                            </p>
                            <note><p>A partial function application can be used to change the order
-                           of parameters, for example <code>fn:contains(substring:=?, value:=?)</code>
+                           of parameters, for example <code>fn:contains(substring := ?, value := ?)</code>
                            returns a function item that is equivalent to <code>fn:contains#2</code>,
                            but with the order of arguments reversed.</p></note>
                         </item>
@@ -9589,7 +9589,7 @@ return $a("A")]]></eg>
             returns a function item whose three parameters correspond to the first three parameters
             of <code>fn:format-date</code>; the remaining two arguments will take their default values.
                To obtain an arity-3 function that binds to arguments 1, 2, and 5 of <code>fn:format-date</code>,
-            use the partial function application <code>format-date(?, ?, place:=?)</code>.</p></note>
+            use the partial function application <code>format-date(?, ?, place := ?)</code>.</p></note>
 
             <p diff="del" at="2023-03-12">
             Furthermore, if the function returned by the evaluation of
@@ -20734,7 +20734,7 @@ raised <errorref
          
          <note diff="add" at="A"><p>The <code>ArgumentList</code> may include keyword arguments if the
             function is identified statically (that is, by name). For example,
-            the following is valid: <code>$xml => xml-to-json(indent:=true()) => parse-json(escape:=false())</code>.</p></note>
+            the following is valid: <code>$xml => xml-to-json(indent := true()) => parse-json(escape := false())</code>.</p></note>
          
          <p diff="add" at="A">The sequence arrow operator thus applies the supplied function to 
             the left-hand operand as a whole, while the mapping arrow operator applies the function to

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -2161,10 +2161,10 @@ not override serialization parameters specified in the query prolog.</p>
             <example role="xquery">
                <eg role="frag-prolog-parse-test"><![CDATA[
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
-declare option output:method   "xml";
+declare option output:method "xml";
 declare option output:encoding "iso-8859-1";
-declare option output:indent   "yes";
-declare option output:parameter-document "file:///home/me/serialization-parameters.xml";
+declare option output:indent "yes";
+declare option output:parameter-document "file:///home/serialization-parameters.xml";
 ]]></eg>
             </example>
 
@@ -2533,10 +2533,8 @@ error()
 
             <eg role="parse-test"><![CDATA[
 if (empty($arg))
-then
-  "cat" * 2
-else
-  0
+then "cat" * 2
+else 0
 ]]></eg>
 
 
@@ -4396,11 +4394,11 @@ the schema type named <code>us:address</code>.</p>
                            that permits only the value <code>"red"</code>. This is referred to
                            as a <term>singleton enumeration type</term>. It is equivalent to the XSD-defined type:</p>
                         <eg><![CDATA[
-               <xs:simpleType>
-                 <xs:restriction base="xs:string">
-                   <xs:enumeration value="red"/>
-                 </xs:restriction>
-               </xs:simpleType>]]></eg></item>
+<xs:simpleType>
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="red"/>
+  </xs:restriction>
+</xs:simpleType>]]></eg></item>
                         <item><p>Two singleton enumeration types are the same type if and only
                         if they have the same (single) enumerated value, as determined using the Unicode
                         codepoint collation.</p></item>
@@ -5598,11 +5596,11 @@ name.</p>
                   <head>A Binary Tree</head>
                   <p>A record used to represent a node in a binary tree might be represented (using XQuery syntax) as:</p>
                   <eg>declare item-type t:binary-tree 
-    as record(left? as t:binary-tree, value, right? as t:binary-tree)</eg>
+  as record(left? as t:binary-tree, value, right? as t:binary-tree)</eg>
                   <p>A function to walk this tree and enumerate all the values in depth-first order might be written 
                      (again using XQuery syntax) as:</p>
                   <eg><![CDATA[declare function t:values($tree as t:binary-tree?) as item()* {
-    $tree ! (t:values(?left), ?value, t:values(?right))   
+  $tree ! (t:values(?left), ?value, t:values(?right))   
 }]]></eg>
                </example>
                
@@ -5613,9 +5611,8 @@ name.</p>
                   <eg>declare item-type t:tree as record(value, children as t:tree*);</eg>
                   <p>A function to walk this tree and enumerate all the values in order might be written 
                      as:</p>
-                  <eg>               
-declare function t:flatten($tree as t:tree) as item()* {
-    $tree?value, $tree?children ! t:flatten(.))   
+                  <eg>declare function t:flatten($tree as t:tree) as item()* {
+  $tree?value, $tree?children ! t:flatten(.))   
 }</eg>
                </example>
                
@@ -7305,7 +7302,6 @@ declare function local:filter(
 ) as item()* {
   $s[$p(.)]
 };
-
 let $f := function($a) { starts-with($a, "E") }
 return local:filter(("Ethel", "Enid", "Gertrude"), $f)
       ]]></eg>
@@ -7382,13 +7378,11 @@ return local:filter(("Ethel", "Enid", "Gertrude"), $f)
                <eg role="parse-test"><![CDATA[
 let $m := map {
   "Monday" : true(),
-  "Wednesday" : true(),
-  "Friday" : true(),
-  "Saturday" : false(),
-  "Sunday" : false()
+  "Wednesday" : false(),
+  "Friday" : true()
 }
-let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
-return filter($days,$m)
+let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday")
+return filter($days, $m)
       ]]></eg>
 
                <p>
@@ -7437,19 +7431,15 @@ return filter($days,$m)
 
                <eg role="parse-test"><![CDATA[
 let $m := map {
-  "Monday"   : true(),
-  "Tuesday"  : false(),
-  "Wednesday": true(),
-  "Thursday" : false(),
-  "Friday"   : true(),
-  "Saturday" : false(),
-  "Sunday"   : false()
+  "Monday" : true(),
+  "Wednesday" : false(),
+  "Friday" : true()
 }
-let $days := ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+let $days := ("Monday", "Wednesday", "Friday")
 return filter($days, $m)
       ]]></eg>
 
-               <p>The result of the expression is the sequence <code>("Monday", "Wednesday", "Friday")</code>
+               <p>The result of the expression is the sequence <code>("Monday", "Friday")</code>
                </p>
                
                <note diff="add" at="issue1020">
@@ -10193,14 +10183,13 @@ return $incrementors[2](4)]]></eg>
                </olist>
 
                <note>
-                  <p>The semantics of the path operator can also be defined using the simple map operator (<code>!</code>) as follows (forming the union with an empty sequence <code>($R | ())</code> has the effect of eliminating duplicates and sorting nodes into document order):</p>
-                  <eg><![CDATA[E1/E2 ::= let $R := E1!E2
-  return
-    if (every $r in $R satisfies $r instance of node())
-    then ($R|())
-    else if (every $r in $R satisfies not($r instance of node()))
-    then $R
-    else error()]]></eg>
+                  <p>The semantics of the path operator can also be defined using the simple map operator (<code>!</code>) as follows (forming the union with an empty sequence <code>($R union ())</code> has the effect of eliminating duplicates and sorting nodes into document order):</p>
+                  <eg><![CDATA[let $R := E1 ! E2
+return if (every $r in $R satisfies $r instance of node())
+       then ($R union ())
+       else if (every $r in $R satisfies not($r instance of node()))
+       then $R
+       else error()]]></eg>
                   <p>For a table comparing the step operator to the map operator, see <specref ref="id-map-operator"/>.</p>
                </note>
     
@@ -12361,9 +12350,8 @@ return ``[`{ $s }` fish]``
             
             <p>This function creates a simple string.</p>
             
-            <eg><![CDATA[declare function local:prize-message($a) as xs:string
-{
-``[Hello `{ $a?name }`
+            <eg><![CDATA[declare function local:prize-message($a) as xs:string {
+  ``[Hello `{ $a?name }`
 You have just won `{ $a?value }` dollars!
 `{ 
    if ($a?in_ca) 
@@ -12380,9 +12368,8 @@ Well, 6000 dollars, after taxes.]]></eg>
             
             <p>This function creates a similar string in HTML syntax.</p>
             
-            <eg><![CDATA[declare function local:prize-message($a) as xs:string
-{
-``[<div>
+            <eg><![CDATA[declare function local:prize-message($a) as xs:string {
+  ``[<div>
   <h1>Hello `{ $a?name }`</h1>
   <p>You have just won `{ $a?value }` dollars!</p>
     `{ 
@@ -12404,9 +12391,8 @@ Well, 6000 dollars, after taxes.]]></eg>
             <p>This function creates a similar string in JSON syntax.</p>
             
             <eg><![CDATA[
-declare function local:prize-message($a) as xs:string
-{
-``[{ 
+declare function local:prize-message($a) as xs:string {
+  ``[{ 
   "name" : `{ $a?name }`
   "value" : `{ $a?value }`
   `{
@@ -13143,11 +13129,11 @@ encountered in finding the effective boolean value of its operand,
                      >A <term>direct element constructor</term> is a form of element constructor in which the name of the constructed element is a constant.</termdef> Direct element constructors are based on standard XML notation. For example, the following expression is a direct element constructor
 that creates a <code>book</code> element containing an attribute and some nested elements:</p>
             <eg role="parse-test"><![CDATA[<book isbn="isbn-0060229357">
-    <title>Harold and the Purple Crayon</title>
-    <author>
-        <first>Crockett</first>
-        <last>Johnson</last>
-    </author>
+  <title>Harold and the Purple Crayon</title>
+  <author>
+    <first>Crockett</first>
+    <last>Johnson</last>
+  </author>
 </book>]]></eg>
             <p>If the element name in a direct element constructor has a namespace prefix, the namespace prefix
                is resolved to a namespace URI using the <termref def="dt-static-namespaces"/>. 
@@ -13175,10 +13161,10 @@ used in the corresponding start tag, including its prefix or absence of a prefix
 are evaluated and replaced by their value, as illustrated by the following
 example:</p>
             <eg role="parse-test"><![CDATA[<example>
-   <p> Here is a query. </p>
-   <eg> $b/title </eg>
-   <p> Here is the result of the query. </p>
-   <eg>{ $b/title }</eg>
+  <p> Here is a query. </p>
+  <eg> $b/title </eg>
+  <p> Here is the result of the query. </p>
+  <eg>{ $b/title }</eg>
 </example>]]></eg>
             <p>The above query might generate the following result (whitespace has been added for readability to this result and other result examples in this document):</p>
             <eg role="parse-test"><![CDATA[
@@ -13982,11 +13968,11 @@ example, in the expression below, the end-tag
 <code>&lt;/title&gt;</code> and the start-tag <code>&lt;author&gt;</code> are separated by a newline character and four space
 characters:</p>
                <eg role="parse-test"><![CDATA[<book isbn="isbn-0060229357">
-    <title>Harold and the Purple Crayon</title>
-    <author>
-        <first>Crockett</first>
-        <last>Johnson</last>
-    </author>
+  <title>Harold and the Purple Crayon</title>
+  <author>
+    <first>Crockett</first>
+    <last>Johnson</last>
+  </author>
 </book>]]></eg>
                <p>
                   <termdef term="boundary whitespace" id="dt-boundary-whitespace">
@@ -14017,8 +14003,8 @@ end of the content, or by a <nt
                   <item>
                      <p>Example:</p>
                      <eg role="parse-test">&lt;cat&gt;
-   &lt;breed&gt;{ $b }&lt;/breed&gt;
-   &lt;color&gt;{ $c }&lt;/color&gt;
+  &lt;breed&gt;{ $b }&lt;/breed&gt;
+  &lt;color&gt;{ $c }&lt;/color&gt;
 &lt;/cat&gt;</eg>
                      <p>The constructed
    <code>cat</code> element node has two child element nodes named
@@ -14162,12 +14148,12 @@ same result as the first example in <specref
                   ref="id-element-constructor"/>:</p>
 
             <eg role="parse-test"><![CDATA[element book {
-   attribute isbn { "isbn-0060229357" },
-   element title { "Harold and the Purple Crayon" },
-   element author {
-      element first { "Crockett" },
-      element last { "Johnson" }
-   }
+  attribute isbn { "isbn-0060229357" },
+  element title { "Harold and the Purple Crayon" },
+  element author {
+    element first { "Crockett" },
+    element last { "Johnson" }
+  }
 }]]></eg>
 
             <div4 id="id-computedElements">
@@ -14418,8 +14404,7 @@ if the EQName is a  <termref
    element with the same name and attributes as <code>$e</code> and
    with numeric content equal to twice the value of
    <code>$e</code>:</p>
-               <eg role="parse-test"><![CDATA[element { node-name($e) }
-  { $e/@*, 2 * data($e) }]]></eg>
+               <eg role="parse-test"><![CDATA[element { node-name($e) } { $e/@*, 2 * data($e) }]]></eg>
                <p>In this example, if <code>$e</code> is
    bound by the expression <code>let $e := &lt;length
    units="inches"&gt;{5}&lt;/length&gt;</code>, then the result of the
@@ -14455,9 +14440,11 @@ if the EQName is a  <termref
                <p>Then the following expression generates a new element in which the name of <code>$e</code> has been translated into Italian and the content of <code>$e</code> (including its attributes, if any) has been preserved. The first enclosed expression after the <code>element</code> keyword generates the name of the element, and the second enclosed
 expression generates the content and attributes:</p>
                <eg role="parse-test"><![CDATA[
-  element
-    { $dict/entry[@word = name($e)]/variant[@xml:lang = "it"] }
-    { $e/@*, $e/node() }]]></eg>
+element {
+  $dict/entry[@word = name($e)]/variant[@xml:lang = "it"]
+} {
+  $e/@*, $e/node()
+}]]></eg>
                <p>The result of this expression is as follows:</p>
                <eg role="parse-test"
                   ><![CDATA[<indirizzo>123 Roosevelt Ave. Flushing, NY 11368</indirizzo>]]></eg>
@@ -14751,9 +14738,11 @@ attribute node.</p>
                      <p>Example:</p>
 
                      <eg role="parse-test">
-attribute
-   { if ($sex = "M") then "husband" else "wife" }
-   { &lt;a&gt;Hello&lt;/a&gt;, 1 to 3, &lt;b&gt;Goodbye&lt;/b&gt; }
+attribute {
+  if ($sex = "M") then "husband" else "wife"
+} {
+  &lt;a&gt;Hello&lt;/a&gt;, 1 to 3, &lt;b&gt;Goodbye&lt;/b&gt;
+}
 </eg>
 
                      <p>The name of the constructed attribute is
@@ -14783,12 +14772,11 @@ attribute
                <p>All document node constructors are computed constructors. The result of a document node constructor is a new document node, with its own node identity.</p>
                <p>A document node constructor is useful when the result of a query is to be a document in its own right. The following example illustrates a query that returns an XML document containing a root element named <code>author-list</code>:</p>
 
-               <eg role="parse-test">document
-  {
-      &lt;author-list&gt;
-         {doc("bib.xml")/bib/book/author}
-      &lt;/author-list&gt;
-  }</eg>
+               <eg role="parse-test">document {
+  &lt;author-list&gt;{
+    doc("bib.xml")/bib/book/author
+  }&lt;/author-list&gt;
+}</eg>
 
                <p>The <termref def="dt-content-expression"
                      >content expression</termref> of a document node constructor is processed in exactly the same way as an enclosed expression in the content of a <termref
@@ -14991,8 +14979,7 @@ attribute
                </olist>
                <p>The following example illustrates a computed processing instruction constructor:</p>
                <eg role="parse-test"><![CDATA[let $target := "audio-output",
-    $content := "beep"
-return processing-instruction { $target } { $content }]]></eg>
+return processing-instruction { $target } { "beep" }]]></eg>
                <p>The processing instruction node constructed by this example might be serialized as follows:</p>
                <eg>&lt;?audio-output beep?&gt;</eg>
             </div4>
@@ -15041,7 +15028,7 @@ return processing-instruction { $target } { $content }]]></eg>
                <p>The <code>parent</code> property of the constructed comment node is set to empty.</p>
                <p>The following example illustrates a computed comment constructor:</p>
                <eg role="parse-test"><![CDATA[let $homebase := "Houston"
-return comment {concat($homebase, ", we have a problem.")}]]></eg>
+return comment { concat($homebase, ", we have a problem.") }]]></eg>
                <p>The comment node constructed by this example might be serialized as follows:</p>
                <eg>&lt;!--Houston, we have a problem.--&gt;</eg>
             </div4>
@@ -15221,11 +15208,9 @@ known namespaces, the following expression results in a static error
 <errorref
                      class="ST" code="0081"/>.</p>
                <eg role="parse-test"><![CDATA[
-<a:form>
- {
+<a:form>{
   namespace a { "http://a.example.com" }
- }
-</a:form>
+}</a:form>
 ]]></eg>
 
 
@@ -15356,7 +15341,7 @@ For instance, the following computed constructor raises an error because the ele
 declare namespace q="http://example.com/ns/q";
 declare namespace f="http://example.com/ns/f";
 
-&lt;p:a q:b="{f:func(2)}" xmlns:r="http://example.com/ns/r"/&gt;
+&lt;p:a q:b="{ f:func(2) }" xmlns:r="http://example.com/ns/r"/&gt;
 </eg>
             <p>The <termref def="dt-in-scope-namespaces"
                   >in-scope namespaces</termref> of the resulting <code>p:a</code> element consists of the following namespace bindings:</p>
@@ -15830,26 +15815,26 @@ map {
 
                <eg id="map-book"><![CDATA[
 map {
-    "book": map {
-        "title": "Data on the Web",
-        "year": 2000,
-        "author": [
-            map {
-                "last": "Abiteboul",
-                "first": "Serge"
-            },
-            map {
-                "last": "Buneman",
-                "first": "Peter"
-            },
-            map {
-                "last": "Suciu",
-                "first": "Dan"
-            }
-        ],
-        "publisher": "Morgan Kaufmann Publishers",
-        "price": 39.95
-    }
+  "book": map {
+    "title": "Data on the Web",
+    "year": 2000,
+    "author": [
+      map {
+        "last": "Abiteboul",
+        "first": "Serge"
+      },
+      map {
+        "last": "Buneman",
+        "first": "Peter"
+      },
+      map {
+        "last": "Suciu",
+        "first": "Dan"
+      }
+    ],
+    "publisher": "Morgan Kaufmann Publishers",
+    "price": 39.95
+  }
 }
     ]]></eg>
 
@@ -16135,7 +16120,7 @@ map {
                      <item><p>If <code>KS</code> is a <code>ParenthesizedExpr</code>,
                         then it is evaluated to produce a value <code>$K</code>
                         and the result is:</p>
-                        <eg><![CDATA[for $k in data($K) return array:get($V, $k)]]></eg>
+                        <eg><![CDATA[data($K) ! array:get($V, .)]]></eg>
                         <note>
                            <p>The focus for evaluating the key specifier expression is the 
                               same as the focus for the <code>Lookup</code> expression itself.</p>
@@ -16173,7 +16158,7 @@ return if ($m instance of ST) { $m }
                         <item><p>If <code>KS</code> is a <code>ParenthesizedExpr</code>,
                            then it is evaluated to produce a value <code>$K</code>
                            and the result is:</p>
-                           <eg><![CDATA[for $k in data($K) return map:get($V, $k)]]></eg>
+                           <eg><![CDATA[data($K) ! map:get($V, .)]]></eg>
                            <note>
                               <p>The focus for evaluating the key specifier expression is the 
                                  same as the focus for the <code>Lookup</code> expression itself.</p>
@@ -16371,16 +16356,16 @@ return if ($m instance of ST) { $m }
                
                <p>First we define the <term>recursive content</term> of an item as follows:</p>
                
-               <eg><![CDATA[ declare function immediate-content($item as item()) as map(*)* {
-   if ($item instance of map(*)) {
-      map:entries($item)
-   } else if ($item instance of array(*)) {
-      for member $m at $p in $item
-      return map:entry($p, $m)
-   }
+               <eg><![CDATA[declare function immediate-content($item as item()) as map(*)* {
+  if ($item instance of map(*)) {
+    map:entries($item)
+  } else if ($item instance of array(*)) {
+    for member $m at $p in $item
+    return map:entry($p, $m)
+  }
 };    
 declare function recursive-content($item as item()) as map(*)* {
-   immediate-content($item) ! (., map:values(.) =!> recursive-content())
+  immediate-content($item) ! (., map:values(.) =!> recursive-content())
 };]]>
                </eg>
                
@@ -16396,10 +16381,10 @@ declare function recursive-content($item as item()) as map(*)* {
                <p>In addition we define the function <code>array-or-map</code> as follows:</p>
                
                <eg><![CDATA[declare function array-or-map($item as item()) {
-   typeswitch ($item) {
-      case array(*) | map(*) return $item
-      default return error(xs:QName("err:XPTY0004"))
-   }
+  typeswitch ($item) {
+    case array(*) | map(*) return $item
+    default return error(xs:QName("err:XPTY0004"))
+  }
 }]]></eg>
                
                <p>The result of the expression <code>E??KS</code>, where <code>E</code> is any expression
@@ -16523,36 +16508,35 @@ declare function recursive-content($item as item()) as map(*)* {
                   <p>The examples query the result of parsing the following JSON value, representing
                      a store whose stock consists of four books and a bicycle:</p>
                   <eg><![CDATA[{ "store": {
-       "book": [
-         { "category": "reference",
-           "author": "Nigel Rees",
-           "title": "Sayings of the Century",
-           "price": 8.95
-         },
-         { "category": "fiction",
-           "author": "Evelyn Waugh",
-           "title": "Sword of Honour",
-           "price": 12.99
-         },
-         { "category": "fiction",
-           "author": "Herman Melville",
-           "title": "Moby Dick",
-           "isbn": "0-553-21311-3",
-           "price": 8.99
-         },
-         { "category": "fiction",
-           "author": "J. R. R. Tolkien",
-           "title": "The Lord of the Rings",
-           "isbn": "0-395-19395-8",
-           "price": 22.99
-         }
-       ],
-       "bicycle": {
-         "color": "red",
-         "price": 399
-       }
-     }
-   }]]></eg>
+  "book": [
+    { "category": "reference",
+      "author": "Nigel Rees",
+      "title": "Sayings of the Century",
+      "price": 8.95
+    },
+    { "category": "fiction",
+      "author": "Evelyn Waugh",
+      "title": "Sword of Honour",
+      "price": 12.99
+    },
+    { "category": "fiction",
+      "author": "Herman Melville",
+      "title": "Moby Dick",
+      "isbn": "0-553-21311-3",
+      "price": 8.99
+    },
+    { "category": "fiction",
+      "author": "J. R. R. Tolkien",
+      "title": "The Lord of the Rings",
+      "isbn": "0-395-19395-8",
+      "price": 22.99
+    }
+  ],
+  "bicycle": {
+    "color": "red",
+    "price": 399
+  }
+} }]]></eg>
                   <p>The following table illustrates some queries on this data, expressed
                   both in JSONPath and in &language;.</p>
                   <table role="small" width="100%">
@@ -17699,8 +17683,8 @@ binds the window variable, but typically binds only a subset of the
 other variables.</p>
 
             <eg><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10)
-    start $s at $spos previous $sprev next $snext when true() 
-    end $e at $epos previous $eprev next $enext when true()]]></eg>
+  start $s at $spos previous $sprev next $snext when true() 
+  end   $e at $epos previous $eprev next $enext when true()]]></eg>
 
             <p>Windows are
 created by iterating over the items in the <termref
@@ -17754,7 +17738,7 @@ Typically, the <nt
                   def="dt-binding-sequence"
                >binding sequence</termref> that is larger than both the previous item and the following item:</p>
             <eg>start $s previous $sprev next $snext
-   when $s &gt; $sprev and $s &gt; $snext</eg>
+ when $s &gt; $sprev and $s &gt; $snext</eg>
             <p>The scoping rules for the variables bound by a <code>window</code> clause are as follows:</p>
             <ulist>
 
@@ -17824,8 +17808,8 @@ to the item before the next window’s starting item, or the end of the
                   <item>
                      <p>Show non-overlapping windows of three items.</p>
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s
-    only end at $e when $e - $s eq 2
+  start at $s
+  only end at $e when $e - $s eq 2
 return <window>{ $w }</window>]]></eg>
 
                      <p>Result:</p>
@@ -17839,8 +17823,8 @@ return <window>{ $w }</window>]]></eg>
                      <p>Show averages of non-overlapping three-item windows.</p>
                      <eg role="parse-test"><![CDATA[
 for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s
-    only end at $e when $e - $s eq 2
+  start at $s
+  only end at $e when $e - $s eq 2
 return avg($w)]]></eg>
 
                      <p>Result:</p>
@@ -17852,8 +17836,8 @@ return avg($w)]]></eg>
                   <item>
                      <p>Show first and last items in each window of three items.</p>
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start $first at $s
-    only end $last at $e when $e - $s eq 2
+  start $first at $s
+  only end $last at $e when $e - $s eq 2
 return <window>{ $first, $last }</window>]]></eg>
 
                      <p>Result:</p>
@@ -17866,8 +17850,8 @@ return <window>{ $first, $last }</window>]]></eg>
                   <item>
                      <p>Show non-overlapping windows of up to three items (illustrates <code>end</code> clause without the <code>only</code> keyword).</p>
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s
-    end at $e when $e - $s eq 2
+  start at $s
+  end at $e when $e - $s eq 2
 return <window>{ $w }</window>]]></eg>
 
                      <p>Result:</p>
@@ -17881,7 +17865,7 @@ return <window>{ $w }</window>]]></eg>
                   <item>
                      <p>Show non-overlapping windows of up to three items (illustrates use of <code>start</code> without explicit <code>end</code>).</p>
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s when $s mod 3 = 1
+  start at $s when $s mod 3 = 1
 return <window>{ $w }</window>]]></eg>
 
                      <p>Result:</p>
@@ -17896,7 +17880,7 @@ return <window>{ $w }</window>]]></eg>
                      <p>Show non-overlapping sequences starting with a number divisible by 3.</p>
 
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    start $first when $first mod 3 = 2
+  start $first when $first mod 3 = 2
 return <window>{ $w }</window>]]></eg>
 
                      <p>Result:</p>
@@ -17909,7 +17893,7 @@ return <window>{ $w }</window>]]></eg>
                      <p>Show non-overlapping sequences ending with a number divisible by 3.</p>
 
                      <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-    end $last when $last mod 3 = 0
+  end $last when $last mod 3 = 0
 return <window>{ $w }</window>]]></eg>
 
                      <p>Result (identical to the result of the previous query):</p>
@@ -17950,8 +17934,8 @@ item may be found in multiple windows drawn from the same <termref
                   <item>
                      <p>Show windows of three items.</p>
                      <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s
-    only end at $e when $e - $s eq 2
+  start at $s
+  only end at $e when $e - $s eq 2
 return <window>{ $w }</window>]]></eg>
 
                      <p>Result:</p>
@@ -17969,8 +17953,8 @@ return <window>{ $w }</window>]]></eg>
                      <p>Show moving averages of three items.</p>
 
                      <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s
-    only end at $e when $e - $s eq 2
+  start at $s
+  only end at $e when $e - $s eq 2
 return avg($w)]]></eg>
 
                      <p>Result:</p>
@@ -17983,8 +17967,8 @@ return avg($w)]]></eg>
                      <p>Show overlapping windows of up to three items (illustrates <code>end</code> clause without the <code>only</code> keyword).</p>
 
                      <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-    start at $s
-    end at $e when $e - $s eq 2
+  start at $s
+  end at $e when $e - $s eq 2
 return <window>{ $w }</window>]]></eg>
 
                      <p>Result:</p>
@@ -18039,24 +18023,24 @@ order in which their start items appear in the <termref
    start $first next $second when $first/price &lt; $second/price
    end $last next $beyond when $last/price &gt; $beyond/price
 return
-   &lt;run-up&gt;
-      &lt;start-date&gt;{data($first/date)}&lt;/start-date&gt;
-      &lt;start-price&gt;{data($first/price)}&lt;/start-price&gt;
-      &lt;end-date&gt;{data($last/date)}&lt;/end-date&gt;
-      &lt;end-price&gt;{data($last/price)}&lt;/end-price&gt;
-   &lt;/run-up&gt;</eg>
+  &lt;run-up&gt;
+    &lt;start-date&gt;{ data($first/date) }&lt;/start-date&gt;
+    &lt;start-price&gt;{ data($first/price) }&lt;/start-price&gt;
+    &lt;end-date&gt;{ data($last/date) }&lt;/end-date&gt;
+    &lt;end-price&gt;{ data($last/price) }&lt;/end-price&gt;
+  &lt;/run-up&gt;</eg>
                <p>For our sample input data, this <code>tumbling window</code> clause generates a tuple stream consisting of two tuples, each representing a window and containing five bound variables named <code>$w</code>, <code>$first</code>, <code>$second</code>, <code>$last</code>, and <code>$beyond</code>. The <code>return</code> clause is evaluated for each of these tuples, generating the following query result:</p>
                <eg>&lt;run-up&gt;
-   &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
-   &lt;start-price&gt;101&lt;/start-price&gt;
-   &lt;end-date&gt;2008-01-04&lt;/end-date&gt;
-   &lt;end-price&gt;103&lt;/end-price&gt;
+  &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
+  &lt;start-price&gt;101&lt;/start-price&gt;
+  &lt;end-date&gt;2008-01-04&lt;/end-date&gt;
+  &lt;end-price&gt;103&lt;/end-price&gt;
 &lt;/run-up&gt;
 &lt;run-up&gt;
-   &lt;start-date&gt;2008-01-05&lt;/start-date&gt;
-   &lt;start-price&gt;102&lt;/start-price&gt;
-   &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
-   &lt;end-price&gt;104&lt;/end-price&gt;
+  &lt;start-date&gt;2008-01-05&lt;/start-date&gt;
+  &lt;start-price&gt;102&lt;/start-price&gt;
+  &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
+  &lt;end-price&gt;104&lt;/end-price&gt;
 &lt;/run-up&gt;</eg>
                <p>The following example illustrates a <code>window</code> clause that is an intermediate clause in a FLWOR expression. In this example, the input data contains closing stock prices for several different companies, each identified by a three-letter symbol. We assume the following input data (again assuming that the type of the <code>price</code> element is <code>xs:decimal</code>):</p>
                <eg><![CDATA[<stocks>
@@ -18164,8 +18148,7 @@ group by $symbol]]></eg>
                      def="dt-positional-variable"
                      >positional variable</termref> to perform sampling on an input sequence. The query returns one value out of each one hundred input values.</p>
                   <eg role="parse-test">
-                     <phrase role="parse-test">
-for $x at $i in $inputvalues
+                     <phrase role="parse-test">for $x at $i in $input
 where $i mod 100 = 0
 return $x</phrase>
                   </eg>
@@ -18305,10 +18288,7 @@ and the number of bound variables in each tuple is unchanged.</p>
 order by $p/sales descending
 count $rank
 while $rank &lt;= 3
-return
-  &lt;product rank="{ $rank }"&gt;
-    { $p/name, $p/sales }
-  &lt;/product&gt;</eg>
+return &lt;product rank="{ $rank }"&gt;{ $p/name, $p/sales }&lt;/product&gt;</eg>
                   <p>The result of this query has the following structure:</p>
                   <eg>&lt;product rank="1"&gt;
   &lt;name&gt;Toaster&lt;/name&gt;
@@ -18583,15 +18563,15 @@ individual pre-grouping tuples.</p>
                <item>
                   <p>This example and the ones that follow are based on two separate sequences of elements, named <code>$sales</code> and <code>$products</code>. We assume that the variable <code>$sales</code> is bound to a sequence of elements with the following structure:</p>
                   <eg>&lt;sales&gt;
-   &lt;storeno&gt;S101&lt;/storeno&gt;
-   &lt;itemno&gt;P78395&lt;/itemno&gt;
-   &lt;qty&gt;125&lt;/qty&gt;
+  &lt;storeno&gt;S101&lt;/storeno&gt;
+  &lt;itemno&gt;P78395&lt;/itemno&gt;
+  &lt;qty&gt;125&lt;/qty&gt;
 &lt;/sales&gt;</eg>
                   <p>We also assume that the variable <code>$products</code> is bound to a sequence of  elements with the following structure:</p>
                   <eg>&lt;product&gt;
-   &lt;itemno&gt;P78395&lt;/itemno&gt;
-   &lt;price&gt;25.00&lt;/price&gt;
-   &lt;category&gt;Men's Wear&lt;/category&gt;
+  &lt;itemno&gt;P78395&lt;/itemno&gt;
+  &lt;price&gt;25.00&lt;/price&gt;
+  &lt;category&gt;Men's Wear&lt;/category&gt;
 &lt;/product&gt;</eg>
                   <p>The simplest kind of grouping query has a single <termref
                         def="dt-grouping-variable"
@@ -18972,7 +18952,7 @@ the following rules:</p>
                   <p>
                      <code>order by</code> clause:</p>
                   <eg><![CDATA[stable order by $make,
-   $value descending empty least]]></eg>
+  $value descending empty least]]></eg>
                   <p>Output tuple stream:</p>
                   <eg><![CDATA[($license = "RCM922", $make = "Dodge", $value = 11400)
 ($license = "KLM030", $make = "Dodge", $value = () )
@@ -19028,14 +19008,11 @@ sort(
 let $e := doc("emps.xml")//emp[deptno eq $d/deptno]
 where count($e) >= 10
 order by avg($e/salary) descending
-return
-   <big-dept>
-      {
-      $d/deptno,
-      <headcount>{count($e)}</headcount>,
-      <avgsal>{avg($e/salary)}</avgsal>
-      }
-   </big-dept>]]></eg>
+return <big-dept>{
+  $d/deptno,
+  <headcount>{count($e)}</headcount>,
+  <avgsal>{avg($e/salary)}</avgsal>
+}</big-dept>]]></eg>
             <notes>
                <ulist>
 
@@ -19063,13 +19040,13 @@ since FLWOR expressions have a higher precedence than the comma
 operator. For example, the following query raises an error because
 after the comma, <code>$j</code> is no longer within the FLWOR expression, and is an
 undefined variable:</p>
-                     <eg role="parse-test"><![CDATA[let $i := 5,
-    $j := 20 * $i
+                     <eg role="parse-test"><![CDATA[let $i := 5
+let $j := 20 * $i
 return $i, $j]]></eg>
                      <p>Parentheses can be used to bring <code>$j</code> into the <code>return</code> clause of the FLWOR expression, as the
 programmer probably intended:</p>
-                     <eg role="parse-test"><![CDATA[let $i := 5,
-    $j := 20 * $i
+                     <eg role="parse-test"><![CDATA[let $i := 5
+let $j := 20 * $i
 return ($i, $j)]]></eg>
                   </item>
                </ulist>
@@ -19403,10 +19380,10 @@ case, but not required to do so.</p>
 
          <eg role="parse-test" diff="chg" at="2023-07-01"><![CDATA[
 switch ($animal) {
-   case "Cow" return "Moo"
-   case "Cat" return "Meow"
-   case "Duck", "Goose" return "Quack"
-   default return "What's that odd noise?"
+  case "Cow" return "Moo"
+  case "Cat" return "Meow"
+  case "Duck", "Goose" return "Quack"
+  default return "What's that odd noise?"
 }]]></eg>
          
          <p diff="add" at="2023-07-01">The curly braces in a switch expression are optional. The above example can equally
@@ -19414,10 +19391,10 @@ switch ($animal) {
          
          <eg role="parse-test"><![CDATA[
 switch ($animal) 
-   case "Cow" return "Moo"
-   case "Cat" return "Meow"
-   case "Duck", "Goose" return "Quack"
-   default return "What's that odd noise?"
+  case "Cow" return "Moo"
+  case "Cat" return "Meow"
+  case "Duck", "Goose" return "Quack"
+  default return "What's that odd noise?"
 ]]></eg>
          
          <p diff="add" at="issue671">The following example illustrates a switch expression where the comparand is defaulted to
@@ -19425,10 +19402,10 @@ switch ($animal)
          
          <eg role="parse-test" diff="add" at="issue671"><![CDATA[
 switch {
-   case ($a le $b) return "lesser"
-   case ($a ge $b) return "greater"
-   case ($a eq $b) return "equal"
-   default return "not comparable"
+  case ($a le $b) return "lesser"
+  case ($a ge $b) return "greater"
+  case ($a eq $b) return "equal"
+  default return "not comparable"
 }]]></eg>
          
          <note diff="add" at="issue671"><p>The comparisons are performed using the <code>fn:deep-equal</code>
@@ -19534,14 +19511,15 @@ matching</termref>, a <termref
                <p>This expression is <code>true</code> if at least
 one <code>employee</code> element satisfies the given comparison expression:</p>
                <eg role="parse-test">some $emp in /emps/employee satisfies
-     ($emp/bonus &gt; 0.25 * $emp/salary)</eg>
+  ($emp/bonus &gt; 0.25 * $emp/salary)</eg>
             </item>
             
             <item>
                <p>This expression is <code>true</code> if every
                   <code>employee</code> element has at least one <code>salary</code> child with the attribute <code>current="true"</code>:</p>
-               <eg role="parse-test"><![CDATA[every $emp in /emps/employee satisfies
-     some $sal in $emp/salary satisfies $sal/@current='true']]></eg>
+               <eg role="parse-test"><![CDATA[every $emp in /emps/employee satisfies (
+  some $sal in $emp/salary satisfies $sal/@current = 'true'              
+)]]></eg>
                <note diff="add" at="A"><p>Like many quantified expressions, this can be simplified. This example can be written
                   <code>every $emp in /emps/employee satisfies $emp/salary[@current = 'true']</code>, or even
                   more concisely as <code>empty(/emps/employee[not(salary/@current = 'true')]</code>.</p>
@@ -19559,11 +19537,9 @@ expression over nine pairs of items, formed from the Cartesian
 product of the sequences <code>(1, 2, 3)</code> and <code>(2, 3, 4)</code>. 
                   The expression beginning with <code>some</code> evaluates to <code>true</code>, 
                   and the expression beginning with <code>every</code> evaluates to <code>false</code>.</p>
-               <eg role="parse-test"><![CDATA[some $x in (1, 2, 3), $y in (2, 3, 4)
-satisfies $x + $y = 4]]></eg>
+               <eg role="parse-test"><![CDATA[some $x in (1, 2, 3), $y in (2, 3, 4) satisfies $x + $y = 4]]></eg>
 
-               <eg role="parse-test"><![CDATA[every $x in (1, 2, 3), $y in (2, 3, 4)
-satisfies $x + $y = 4]]></eg>
+               <eg role="parse-test"><![CDATA[every $x in (1, 2, 3), $y in (2, 3, 4) satisfies $x + $y = 4]]></eg>
             </item>
 
             <item>
@@ -20065,35 +20041,33 @@ case</termref>, but not required to do so.</p>
 be used to process an expression in a way that depends on its <termref
                   def="dt-dynamic-type">dynamic type</termref>.</p>
             <eg role="parse-test" diff="chg" at="2023-07-01"><![CDATA[typeswitch($customer/billing-address) {
-   case $a as element(*, USAddress) return $a/state
-   case $a as element(*, CanadaAddress) return $a/province
-   case $a as element(*, JapanAddress) return $a/prefecture
-   default return "unknown"
+  case $a as element(*, USAddress) return $a/state
+  case $a as element(*, CanadaAddress) return $a/province
+  case $a as element(*, JapanAddress) return $a/prefecture
+  default return "unknown"
 }]]></eg>
             
             <p diff="add" at="2023-07-01">The curly braces in a <code>typeswitch</code> expression are optional. The
             above example can equally be written:</p>
             
             <eg role="parse-test"><![CDATA[typeswitch($customer/billing-address)
-   case $a as element(*, USAddress) return $a/state
-   case $a as element(*, CanadaAddress) return $a/province
-   case $a as element(*, JapanAddress) return $a/prefecture
-   default return "unknown"
+  case $a as element(*, USAddress) return $a/state
+  case $a as element(*, CanadaAddress) return $a/province
+  case $a as element(*, JapanAddress) return $a/prefecture
+  default return "unknown"
 ]]></eg>
 
             <p>The following example shows a union of sequence types in a single case:</p>
 
             <eg role="parse-test"><![CDATA[typeswitch($customer/billing-address) {
-   case $a as element(*, USAddress)
-            | element(*, AustraliaAddress)
-            | element(*, MexicoAddress)
-     return $a/state
-   case $a as element(*, CanadaAddress)
-     return $a/province
-   case $a as element(*, JapanAddress)
-     return $a/prefecture
-   default
-     return "unknown"
+  case $a as element(*, USAddress) | element(*, AustraliaAddress) | element(*, MexicoAddress)
+    return $a/state
+  case $a as element(*, CanadaAddress)
+    return $a/province
+  case $a as element(*, JapanAddress)
+    return $a/prefecture
+  default
+    return "unknown"
 }]]></eg>
 
          </div3>
@@ -20288,10 +20262,10 @@ the following example:</p>
 
             <eg role="parse-test"><![CDATA[
 if ($x castable as hatsize)
-   then $x cast as hatsize
-   else if ($x castable as IQ)
-   then $x cast as IQ
-   else $x cast as xs:string]]></eg>
+  then $x cast as hatsize
+  else if ($x castable as IQ)
+  then $x cast as IQ
+  else $x cast as xs:string]]></eg>
             
             <note diff="add" at="issue688">
                <p>The expression <code>$x castable as enum("red", "green", "blue")</code>
@@ -20694,7 +20668,11 @@ raised <errorref
             each item being the average of itself. The following example:</p>
          
          <eg role="parse-test"
-            ><![CDATA["The cat sat on the mat" => tokenize() =!> concat(".") =!> upper-case() => string-join(" ")]]></eg>
+            ><![CDATA["The cat sat on the mat"
+=> tokenize()
+=!> concat(".")
+=!> upper-case()
+=> string-join(" ")]]></eg>
          
          <p diff="add" at="A">returns <code>"THE. CAT. SAT. ON. THE. MAT."</code>. The first arrow
             could be written either as <code>=></code> or <code>=!></code> because the operand is a singleton; the next two
@@ -21236,8 +21214,9 @@ which extension expressions might be used.</p>
 following expression, without actually changing the result.
 For example:</p>
                   <eg role="parse-test"><![CDATA[declare namespace exq = "http://example.org/XQueryImplementation";
-   (# exq:use-index #)
-      { $bib/book/author[name = 'Berners-Lee'] }
+(# exq:use-index #) {
+  $bib/book/author[name = 'Berners-Lee']
+}
 ]]></eg>
                   <p>An implementation that recognizes the <code>exq:use-index</code> pragma might use an
 index to evaluate the  expression that follows. An implementation that

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1687,7 +1687,7 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       
      <p diff="add" at="2023-05-19">The default value for an optional parameter will often be supplied using a 
        simple literal or constant expression, for example
-     <code>$married as xs:boolean := false()</code> or <code>$options as map(*) := map{}</code>. However, to allow greater flexibility,
+     <code>$married as xs:boolean := false()</code> or <code>$options as map(*) := map { }</code>. However, to allow greater flexibility,
      the initial value can also be context-dependent. For example, <code>$node as node() := .</code> declares a parameter whose
      default value is the context value from the dynamic context of the caller, while <code>$collation as xs:string := default-collation()</code>
      declares a parameter whose default value is the default collation from the dynamic context of the caller.

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -86,9 +86,9 @@
       queries labeled with a different major version number. The processor may reject queries with the 
       same major version number and a greater minor version number than the processor recognizes.</p>
     
-      <note diff="add" at="2023-10-19"><p>The version numbers <code>“4.01”</code> and <code>“4.1”</code> are equivalent: 
-        both have a major number of 4 and a minor number of 1. Version <code>“4.10”</code> by the same reasoning
-        has a higher minor number than version <code>“4.2”</code>.</p></note>
+      <note diff="add" at="2023-10-19"><p>The version numbers <code>4.01</code> and <code>4.1</code> are equivalent: 
+        both have a major number of 4 and a minor number of 1. Version <code>4.10</code> by the same reasoning
+        has a higher minor number than version <code>4.2</code>.</p></note>
 
       <p>If a query is rejected because of a version mismatch with the processor, a static error  
       <errorref code="0031" class="ST"/> must be raised.</p>
@@ -458,10 +458,8 @@ declaration">A
       <p>The following query formats numbers using two different decimal format declarations:</p>
       
       <eg role="parse-test">
-declare decimal-format local:de 
-  decimal-separator = "," grouping-separator = "."; 
-declare decimal-format local:en 
-  decimal-separator = "." grouping-separator = ","; 
+declare decimal-format local:de decimal-separator = "," grouping-separator = "."; 
+declare decimal-format local:en decimal-separator = "." grouping-separator = ","; 
        
 let $numbers := (1234.567, 789, 1234567.765) 
 for $i in $numbers
@@ -647,7 +645,7 @@ return (
       location, and binding the prefix <code>soap</code> to the target namespace:</p>
 
     <eg role="frag-prolog-parse-test">import schema namespace soap="http://www.w3.org/2003/05/soap-envelope" 
-    at "http://www.w3.org/2003/05/soap-envelope/";</eg>
+  at "http://www.w3.org/2003/05/soap-envelope/";</eg>
     <p>The following example imports a schema by specifying only its target namespace, and makes it
       the <phrase diff="chg" at="A">default namespace for elements and types</phrase>:</p>
     <eg role="frag-prolog-parse-test">import schema default element namespace "http://example.org/abc";</eg>
@@ -759,20 +757,22 @@ return (
 
       <eg role="parse-test">(: Error - geometry:triangle is not defined :) 
 import module namespace geo = "http://example.org/geo-functions"; 
-declare variable $t as geometry:triangle := geo:make-triangle(); 
-$t</eg>
+declare variable $triangle as geometry:triangle := geo:make-triangle(); 
+$triangle</eg>
 
       <p>Without the type declaration for the variable, the variable declaration succeeds:</p>
 
       <eg role="parse-test">import module namespace geo = "http://example.org/geo-functions";
-declare variable $t := geo:make-triangle(); $t</eg>
+declare variable $triangle := geo:make-triangle();
+$triangle</eg>
 
       <p>Importing the schema that defines the type of the variable,
       the variable declaration succeeds:</p>
 
       <eg role="parse-test">import schema namespace geometry = "http://example.org/geo-schema-declarations"; 
 import module namespace geo = "http://example.org/geo-functions"; 
-declare variable $t as geometry:triangle := geo:make-triangle(); $t</eg>
+declare variable $triangle as geometry:triangle := geo:make-triangle();
+$triangle</eg>
     </example>
 
     <div3 id="id-module-handling-module-uris">
@@ -934,17 +934,17 @@ declare variable $t as geometry:triangle := geo:make-triangle(); $t</eg>
     <eg role="parse-test">
 <![CDATA[declare namespace xx = "http://example.org";
 
-let $i := <foo:bar xmlns:foo = "http://example.org">
-              <foo:bing> Lentils </foo:bing>
-          </foo:bar>
-return $i/xx:bing]]>
+let $node := <foo:bar xmlns:foo = "http://example.org">
+  <foo:bing> Lentils </foo:bing>
+</foo:bar>
+return $node/xx:bing]]>
     </eg>
     <p>Although the namespace prefixes <code>xx</code> and <code>foo</code> differ, both are bound
       to the namespace URI <code>http://example.org</code>. Since <code>xx:bing</code> and
         <code>foo:bing</code> have the same local name and the same namespace URI, they match. The
       output of the above query is as follows.</p>
     <eg role="parse-test">
-<![CDATA[<foo:bing xmlns:foo = "http://example.org"> Lentils </foo:bing>]]>
+<![CDATA[<foo:bing xmlns:foo="http://example.org"> Lentils </foo:bing>]]>
     </eg>
   </div2>
   <div2 id="id-default-namespace">
@@ -1449,8 +1449,7 @@ declare function local:f() { $b }; </eg>
     <ulist>
       <item>
         <p>Declare the type of the context value as a single element item with a required element name:</p>
-        <eg role="frag-prolog-parse-test">declare namespace env="http://www.w3.org/2003/05/soap-envelope"; 
-
+        <eg role="frag-prolog-parse-test">declare namespace env = "http://www.w3.org/2003/05/soap-envelope"; 
 declare context item as element(env:Envelope) external;</eg>
 
       </item>
@@ -1519,19 +1518,16 @@ declare context value as document-node()* := collection($uri); </eg>
       sequence of <code>dept</code> elements.</p>
     <example>
       <head>Using a function, prepare a summary of employees that are located in Denver.</head>
-        <eg role="parse-test">declare function local:summary($emps as element(employee)*) as element(dept)* 
-{ 
-   for $d in fn:distinct-values($emps/deptno) 
-   let $e := $emps[deptno = $d]
-   return 
-      &lt;dept&gt; 
-          &lt;deptno&gt;{$d}&lt;/deptno&gt; 
-          &lt;headcount&gt; {fn:count($e)} &lt;/headcount&gt; 
-          &lt;payroll&gt; {fn:sum($e/salary)} &lt;/payroll&gt; 
-      &lt;/dept&gt; 
+        <eg role="parse-test">declare function local:summary($emps as element(employee)*) as element(dept)* { 
+  for $no in distinct-values($emps/deptno) 
+  let $emp := $emps[deptno = $no]
+  return &lt;dept&gt; 
+    &lt;deptno&gt;{ $no }&lt;/deptno&gt; 
+    &lt;headcount&gt;{ count($emp) }&lt;/headcount&gt; 
+    &lt;payroll&gt;{ sum($emp/salary) }&lt;/payroll&gt; 
+  &lt;/dept&gt; 
 };
-          
-local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
+local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
     </example>
     
     <div3 id="id-user-defined-functions">
@@ -1746,9 +1742,8 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         function:</p>
       
       <eg role="frag-prolog-parse-test">declare 
-        %java:method("java.lang.StrictMath.copySign") 
-        function smath:copySign($magnitude, $sign) 
-        external;</eg>
+  %java:method("java.lang.StrictMath.copySign") 
+function smath:copySign($magnitude, $sign) external;</eg>
       
       
     </div3>
@@ -1798,16 +1793,14 @@ local:summary(fn:doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         <code>max</code>, which are in the default function namespace.</p>
  
         <eg role="parse-test">
-declare function local:depth($e as node()) as xs:integer
-{
-   (: A node with no children has depth 1 :)
-   (: Otherwise, add 1 to max depth of children :)
+declare function local:depth($e as node()) as xs:integer {
+  (: A node with no children has depth 1 :)
+  (: Otherwise, add 1 to max depth of children :)
 
-   if (fn:empty($e/*)) 
-   then 1
-   else fn:max(for $c in $e/* return local:depth($c)) + 1
+  if (empty($e/*)) 
+  then 1
+  else max(for $c in $e/* return local:depth($c)) + 1
 };
-
 local:depth(doc("partlist.xml"))
         </eg>
 
@@ -1967,9 +1960,8 @@ local:depth(doc("partlist.xml"))
       <item>
         <p>This option declaration might be used to associate a namespace used in function names
           with a Java class: </p>
-        <eg role="frag-prolog-parse-test">declare namespace smath =
-          "http://example.org/MathLibrary"; declare option exq:java-class "smath =
-          java.lang.StrictMath"; </eg>
+        <eg role="frag-prolog-parse-test">declare namespace smath = "http://example.org/MathLibrary";
+declare option exq:java-class "smath = java.lang.StrictMath"; </eg>
       </item>
     </ulist>
   </div2>

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -1426,7 +1426,7 @@
 
 <xsl:template match="bibref">
   <xsl:variable name="name" select="."/>
-  <xsl:apply-templates select="document('bib.xml')/key('bib',$name)"/>
+  <xsl:apply-templates select="document('bib.xml')/key('bib', $name)"/>
 </xsl:template>]]></eg>
                <note>
                   <p>This relies on the ability in XPath 2.0 to have a function call on the

--- a/specifications/xslt-40/src/xml-to-json.xsl
+++ b/specifications/xslt-40/src/xml-to-json.xsl
@@ -40,7 +40,7 @@
     <!-- Entry point: function to convert a supplied XML node to a JSON string -->
     <xsl:function name="j:xml-to-json" as="xs:string" visibility="public">
         <xsl:param name="input" as="node()"/>
-        <xsl:sequence select="j:xml-to-json($input, map{})"/>
+        <xsl:sequence select="j:xml-to-json($input, map { })"/>
     </xsl:function>
 
     <!-- Entry point: function to convert a supplied XML node to a JSON string, supplying options -->

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -816,7 +816,7 @@
                      <p>An optional <code>validation</code> attribute, whose value must be
                            <code>strict</code> or <code>lax</code>; the curly brackets indicate that
                         the value can be defined as an <termref def="dt-attribute-value-template">attribute value template</termref>, allowing a value such as
-                           <code>validation="{$val}"</code>, where the <termref def="dt-variable">variable</termref>
+                           <code>validation="{ $val }"</code>, where the <termref def="dt-variable">variable</termref>
                         <code>val</code> is evaluated to yield <code>"strict"</code> or
                            <code>"lax"</code> at run-time.</p>
                   </item>
@@ -3307,7 +3307,7 @@
                 as="map(xs:integer, xs:double)" visibility="public"&gt;
     &lt;xsl:param name="real" as="xs:double"/&gt;
     &lt;xsl:param name="imaginary" as="xs:double"/&gt;
-    &lt;xsl:sequence select="map{ 0:$real, 1:$imaginary }"/&gt;
+    &lt;xsl:sequence select="map { 0: $real, 1: $imaginary }"/&gt;
   &lt;/xsl:function&gt;
   
   &lt;xsl:function name="f:real" 
@@ -5404,7 +5404,7 @@
 &lt;xsl:variable name="v" as="xs:integer" visibility="public" select="3"/&gt;
 
 &lt;xsl:function name="f:factory" as="function(*)" visibility="final"&gt;
-  &lt;xsl:sequence select="function() {$v}"/&gt;
+  &lt;xsl:sequence select="function() { $v }"/&gt;
 &lt;/xsl:function&gt;  
                   </eg>
                      
@@ -8083,13 +8083,13 @@ and <code>version="1.0"</code> otherwise.</p>
                </ulist>
                
                <p>For example, an <elcode>xsl:include</elcode> element might be written:</p>
-               <eg role="xslt-declaration" xml:space="preserve">&lt;xsl:include _href="common{$VERSION}.xsl"/&gt;</eg>
+               <eg role="xslt-declaration" xml:space="preserve">&lt;xsl:include _href="common{ $VERSION }.xsl"/&gt;</eg>
                <p>allowing the stylesheet to include a specific version of a library module based on
                   the value of a <termref def="dt-static-parameter"/>.</p>
                <p>Similarly, a <termref def="dt-mode"/> might be declared like this:</p>
                <eg role="xslt-declaration" xml:space="preserve">&lt;xsl:param name="streamable" as="xs:boolean" 
                   required="yes" static="yes"/&gt;
-&lt;xsl:mode _streamable="{$streamable}" on-no-match="shallow-skip"/&gt;</eg>
+&lt;xsl:mode _streamable="{ $streamable }" on-no-match="shallow-skip"/&gt;</eg>
                <p>this allowing the streamability of the mode to be controlled using a <termref def="dt-static-parameter"/>
                   (Note: this example relies on the fact that the
                         <code>streamable</code> attribute accepts a boolean value, which means that
@@ -8143,7 +8143,7 @@ and <code>version="1.0"</code> otherwise.</p>
                           select="'http://example.com/ns/one'"/&gt;</eg>
                   <p>And this can then be used to set the default namespace for XPath
                      expressions:</p>
-                  <eg role="non-xml" xml:space="preserve">_xpath-default-namespace="{$NS}"</eg>
+                  <eg role="non-xml" xml:space="preserve">_xpath-default-namespace="{ $NS }"</eg>
                   <p>However, it is not possible to put this shadow attribute on the
                         <elcode>xsl:stylesheet</elcode> or <elcode>xsl:package</elcode> element of
                      the principal stylesheet module, because at that point the variable
@@ -8152,7 +8152,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      and an <elcode>xsl:include</elcode> of the stylesheet module containing the
                      real logic. The static stylesheet parameter will then be in scope on the
                         <elcode>xsl:stylesheet</elcode> element of the included stylesheet module,
-                     and the shadow attribute <code>_xpath-default-namespace="{$NS}"</code> can
+                     and the shadow attribute <code>_xpath-default-namespace="{ $NS }"</code> can
                      therefore appear on this <elcode>xsl:stylesheet</elcode> element.</p>
                </example>
 
@@ -8167,7 +8167,7 @@ and <code>version="1.0"</code> otherwise.</p>
            as="xs:string" select="'true()'"/&gt;
 &lt;xsl:function name="local:filter" as="xs:boolean"&gt;
    &lt;xsl:param name="e" as="element(employee)"/&gt;
-   &lt;xsl:sequence _select="$e/({$filter})"/&gt;
+   &lt;xsl:sequence _select="$e/({ $filter })"/&gt;
 &lt;/xsl:function&gt;
 &lt;xsl:template match="/"&gt;
    &lt;report&gt;
@@ -8916,7 +8916,7 @@ and <code>version="1.0"</code> otherwise.</p>
                revisit the same nodes later. There is also a special streamability rule for
                map constructor expressions (see <specref ref="maps-streaming"/>) that allows
                such an expression to make multiple downward selections in the streamed input
-               document: for example one can write <code>map{'authors':data(author), 'editors':data(editor)}</code>,
+               document: for example one can write <code>map { 'authors': data(author), 'editors': data(editor) }</code>,
                which gathers the values of these two elements, or sets of elements, from the input
                stream, regardless what order they appear in — even if they are interleaved.</p>
                
@@ -10717,12 +10717,12 @@ and <code>version="1.0"</code> otherwise.</p>
                   It matches values such as the string <code>"XSLT Transformations"</code>, the
                      <code>xs:anyURI</code> value
                      <code>http://www.w3.org/TR/XSLT</code>, the attribute node 
-                     <code>class="XSD XSLT XPath"</code>, and the singleton array <code>["XSLT 4.0"]</code>.</p>
+                     <code>class="XSD XSLT XPath"</code>, and the singleton array <code>[ "XSLT 4.0" ]</code>.</p>
                   
                   <note diff="add" at="2023-10-10"><p>
                      Evaluation of this example pattern may fail with a dynamic error if the item in question
                      has an atomized value that is not a string, or that is a sequence of strings: an example might
-                     be the array <code>["XSLT", 1999]</code>. It will also fail if the item cannot be atomized,
+                     be the array <code>[ "XSLT", 1999 ]</code>. It will also fail if the item cannot be atomized,
                      for example if it is a map. The rules in <specref ref="pattern-errors"/> cause these errors
                      to be masked: they simply result in the pattern being treated as non-matching.
                   </p></note>
@@ -11464,7 +11464,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <eg xml:space="preserve" role="xslt-declarations">&lt;xsl:variable name="image-dir" select="'/images'"/&gt;
 
 &lt;xsl:template match="photograph"&gt;
-  &lt;img src="{$image-dir}/{href}" width="{size/@width}"/&gt;
+  &lt;img src="{ $image-dir }/{ href }" width="{ size/@width }"/&gt;
 &lt;/xsl:template&gt;</eg>
                   <p>With this source</p>
                   <eg xml:space="preserve" role="xml">&lt;photograph&gt;
@@ -11555,7 +11555,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <eg role="xslt-instructions" xml:space="preserve">&lt;xsl:variable name="id" select="'A123'"/&gt;
 &lt;xsl:variable name="step" select="5"/&gt;
 &lt;xsl:message expand-text="yes"
-     &gt;Processing id={$id}, step={$step}&lt;/xsl:message&gt;
+     &gt;Processing id={ $id }, step={ $step }&lt;/xsl:message&gt;
 </eg>
                   <p>This will typically output the message text <code>Processing id=A123,
                         step=5</code>.</p>
@@ -11566,7 +11566,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <eg role="xslt-declaration xmlns:f='f'" xml:space="preserve">&lt;xsl:function name="f:sum" expand-text="yes" as="xs:integer"&gt;
 &lt;xsl:param name="x" as="xs:integer"/&gt;
 &lt;xsl:param name="y" as="xs:integer"/&gt;
-  {$x + $y}
+  { $x + $y }
 &lt;/xsl:function&gt;</eg>
                   <p>Note that although this is a very readable way of expressing the computation
                      performed by the function, the semantics are somewhat complex, and this could
@@ -12596,17 +12596,17 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>It takes the following JSON data as input:</p>
                <eg>[
   { "Title": "Computer Architecture",
-    "Authors": ["Enid Blyton"],
+    "Authors": [ "Enid Blyton"] ,
     "Category": "Computers",
     "Price": 42.60
   },
   { "Title": "Steppenwolf",
-    "Authors": ["Hermann Hesse"],
+    "Authors": [ "Hermann Hesse" ],
     "Category": "Fiction",
     "Price": 12.00
   },
   {  "Title": "How to Explore Outer Space with Binoculars",
-     "Authors": ["Bruce Betts", "Erica Colon"],
+     "Authors": [ "Bruce Betts", "Erica Colon" ],
      "Category": "Science",
      "Price": 10.40
   }
@@ -14041,8 +14041,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      produce a sequence of single-entry maps (each containing one key and one value), and then applying
                      templates to this sequence, using the current mode, and passing
                      on the values of all template parameters.</p></item>
-                  <item><p>If the map contains a single entry <code>map{<var>K</var> : <var>V/0</var>}</code>, then a new single entry
-                     map <code>map{<var>K</var> : <var>V/1</var>}</code> is constructed in which <var>V/1</var> is the
+                  <item><p>If the map contains a single entry <code>map { <var>K</var> : <var>V/0</var> }</code>, then a new single entry
+                     map <code>map { <var>K</var>: <var>V/1</var> }</code> is constructed in which <var>V/1</var> is the
                      result of applying templates to <var>V/0</var> (using the current mode, and passing
                      on the values of all template parameters).</p>
                      <note><p>This rule has the effect that if the input is a value record, the output will also
@@ -14089,35 +14089,35 @@ and <code>version="1.0"</code> otherwise.</p>
                      the function <function>parse-json</function>:</p>
                   
                   <eg>[
-   { "Title": "Computer Architecture",
-     "Authors": ["Enid Blyton", {"Note": "possibly misattributed"}],
-     "Category": "Computers",
-     "Price": 42.60
-   },
-   { "Title": "Steppenwolf",
-     "Authors": ["Hermann Hesse"],
-     "Category": "Fiction",
-     "Price": 12.00,
-     "Note": "out of print"
-   },
-   {  "Title": "How to Explore Outer Space with Binoculars",
-      "Authors": ["Bruce Betts", "Erica Colon"],
-      "Category": "Science",
-      "Price": 10.40
-   }
+  { "Title": "Computer Architecture",
+    "Authors": [ "Enid Blyton", { "Note": "possibly misattributed" } ],
+    "Category": "Computers",
+    "Price": 42.60
+  },
+  { "Title": "Steppenwolf",
+    "Authors": [ "Hermann Hesse" ],
+    "Category": "Fiction",
+    "Price": 12.00,
+    "Note": "out of print"
+  },
+  { "Title": "How to Explore Outer Space with Binoculars",
+    "Authors": [ "Bruce Betts", "Erica Colon" ],
+    "Category": "Science",
+    "Price": 10.40
+  }
 ]</eg>
                <p>The logic proceeds as follows:</p>
                   
                   <olist>
                      <item><p>The outermost array is processed by applying templates to a sequence of value records, 
                         the first being in the form:</p>
-                        <eg>map{"value": map:{"Title": ..., "Author": ..., ...}</eg>
+                        <eg>map { "value": map: { "Title": ..., "Author": ..., ... }</eg>
                      <p>The result of applying templates to these value records is expected to comprise a new sequence
                         of value records, which is used to construct the final output array.</p></item>
                      
                      <item><p>Each of the value records is processed using the rule for singleton maps. This rule
                         produces a new value record by applying templates to the value, that is, to a map of the form
-                        <code>map:{"Title": ..., "Author": ..., ...}</code> representing a book.</p></item>
+                        <code>map: { "Title": ..., "Author": ..., ... }</code> representing a book.</p></item>
                      
                      <item><p>Each of these books, being represented by a map with more than two entries, is processed by
                      a template rule that splits the map into its multiple entries, each represented as a singleton
@@ -14125,26 +14125,26 @@ and <code>version="1.0"</code> otherwise.</p>
                      <code>map{"Title": "Steppenwolf"}</code>.</p></item>
                      
                      <item><p>The default processing for a singleton map of the form 
-                        <code>map{"Title": "Steppenwolf"}</code> is to return the value unchanged.
+                        <code>map { "Title": "Steppenwolf" }</code> is to return the value unchanged.
                         This is achieved by applying templates to the string <code>"Steppenwolf"</code>;
                      the default template rule for strings returns the string unchanged.</p></item>
                      
-                     <item><p>When a singleton map in the form <code>map{"Note": "out of print"}</code> is encountered, no output
+                     <item><p>When a singleton map in the form <code>map { "Note": "out of print" }</code> is encountered, no output
                      is produced, meaning that entry in the parent map is effectively dropped. This is because there
                      is an explicit template rule with <code>match="record(Note)"</code> that matches such singleton maps.</p></item>
                      
-                     <item><p>When a singleton map in the form <code>"Authors": ["Bruce Betts", "Erica Colon"]</code> 
+                     <item><p>When a singleton map in the form <code>"Authors": [ "Bruce Betts", "Erica Colon" ]</code> 
                         is encountered, a new singleton map is produced; it has the same key (<code>"Authors"</code>),
-                        and a value obtained by applying templates to the array <code>["Bruce Betts", "Erica Colon"]</code>.
+                        and a value obtained by applying templates to the array <code>[ "Bruce Betts", "Erica Colon" ]</code>.
                         The default processing for an array, in which none of the constituents are matched by explicit
                         template rules, ends up delivering a copy of the array.</p></item>
                      
-                     <item><p>When the singleton map <code>"Authors": ["Enid Blyton", map{"Note": "possibly misattributed"}]</code>
+                     <item><p>When the singleton map <code>"Authors": [ "Enid Blyton", map { "Note": "possibly misattributed" } ]</code>
                         is encountered, the recursive processing results in templates being applied to the map
-                        <code>{"Note": "possibly misattributed"}</code>. This matches the template rule having
+                        <code>{ "Note": "possibly misattributed" }</code>. This matches the template rule having
                         <code>match="record(Note)"</code>, which returns no output, so the entry is effectively deleted.</p>
                         <note><p>The map entry is deleted, but the map itself remains, so the value becomes
-                           <code>"Authors": ["Enid Blyton", map:{}]</code>.</p></note>
+                           <code>"Authors": [ "Enid Blyton", map: {} ]</code>.</p></note>
                      
                      </item>
                   </olist>
@@ -14516,13 +14516,13 @@ and <code>version="1.0"</code> otherwise.</p>
             <p diff="del" at="2022-11-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
             are mutually exclusive: exactly one of these three attributes must be present.</p>
             <p diff="del" at="2022-11-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
-            <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
+            <code>select="array:for-each(EXPR, function($x) { map { 'value': $x })?*</code>. That is, it maps the
             elements of an input array to a sequence of items, each item being a map having a single entry, whose
             key is the string <code>value</code> and whose corresponding value is the relevant element of the
             array. Within the contained sequence constructor, the current array element can be referred to
             as <code>?value</code>.</p>
             <p diff="del" at="2022-11-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
-               <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
+               <code>select="map:for-each(EXPR, function($k, $v) { map { 'key': $k, 'value': $v })</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
@@ -14656,17 +14656,17 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>In this example the expression <code>$array?*</code> cannot be used on the inner arrays
                   because JSON nulls (which translate to an empty sequence in XDM) would be lost. Instead
                   the function <xfunction>array:members</xfunction> is used to create a sequence of
-                  value records: a non-null entry is represented by a value such as <code>map{'value':12.3}</code>,
-                  while a null entry would be <code>map{'value':()}</code>.</p>
+                  value records: a non-null entry is represented by a value such as <code>map { 'value': 12.3 }</code>,
+                  while a null entry would be <code>map { 'value': () }</code>.</p>
 
             </example>
             <example diff="add" at="2022-11-01">
                <head>Using <elcode>xsl:for-each</elcode> to process a map</head>
                <p>Consider a JSON document of the form:</p>
                <eg>{
-  "London": {"latitude": 51.5099, "longitude": -0.1181 },
-  "Paris":  {"latitude": 48.8647, "longitude": 2.3488 },
-  "Berlin": {"latitude": 52.5200, "longitude": 13.4049 }                  
+  "London": { "latitude": 51.5099, "longitude": -0.1181 },
+  "Paris":  { "latitude": 48.8647, "longitude": 2.3488 },
+  "Berlin": { "latitude": 52.5200, "longitude": 13.4049 }                  
 }</eg>
                <p>The following code processes this map to produce an XML representation of the same information. The
                   cities are sorted by name:</p>
@@ -14691,7 +14691,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <eg><![CDATA[
 <xsl:for-each select="6, 3, 9" separator="|">
    <xsl:sort select="."/>
-   <xsl:sequence select="., .+1"/>
+   <xsl:sequence select="., . + 1"/>
 </xsl:for-each>]]></eg>
             <p>produces a sequence comprising, in order: the integer 3, the integer 4, a text node with string value <code>"|"</code>,
                the integer 6, the integer 7, another text node with string value <code>"|"</code>,
@@ -14722,13 +14722,13 @@ and <code>version="1.0"</code> otherwise.</p>
             <p diff="del" at="2022-01-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
                are mutually exclusive: exactly one of these three attributes must be present.</p>
             <p diff="del" at="2022-01-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
-               <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
+               <code>select="array:for-each(EXPR, function($x) { map { 'value': $x })?*</code>. That is, it maps the
                elements of an input array to a sequence of items, each item being a map having a single entry, whose
                key is the string <code>value</code> and whose corresponding value is the relevant element of the
                array. Within the contained sequence constructor, the current array element can be referred to
                as <code>?value</code>.</p>
             <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
-               <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
+               <code>select="map:for-each(EXPR, function($k, $v) { map { 'key': $k, 'value': $v })</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
@@ -14988,8 +14988,8 @@ and <code>version="1.0"</code> otherwise.</p>
                     select="xs:date(@date)"/&gt;
       &lt;xsl:choose&gt;
         &lt;xsl:when test="empty($prevDate) or $thisDate eq $prevDate"&gt;
-          &lt;balance date="{$thisDate}" 
-                   value="{format-number($newBalance, '0.00')}"/&gt;
+          &lt;balance date="{ $thisDate }" 
+                   value="{ format-number($newBalance, '0.00') }"/&gt;
           &lt;xsl:next-iteration&gt;
             &lt;xsl:with-param name="balance" select="$newBalance"/&gt;
             &lt;xsl:with-param name="prevDate" select="$thisDate"/&gt;
@@ -15010,15 +15010,15 @@ and <code>version="1.0"</code> otherwise.</p>
       &lt;xsl:param name="balance" select="0.00" as="xs:decimal"/&gt;
       &lt;xsl:param name="prevDate" select="()" as="xs:date?"/&gt;
       &lt;xsl:on-completion&gt;
-        &lt;balance date="{$prevDate}" 
-                 value="{format-number($balance, '0.00')}"/&gt;
+        &lt;balance date="{ $prevDate }" 
+                 value="{ format-number($balance, '0.00') }"/&gt;
       &lt;/xsl:on-completion&gt;     
       &lt;xsl:variable name="newBalance" 
                     select="$balance + xs:decimal(@value)"/&gt;
       &lt;xsl:variable name="thisDate" select="xs:date(@date)"/&gt;
       &lt;xsl:if test="exists($prevDate) and $thisDate ne $prevDate"&gt;
-        &lt;balance date="{$prevDate}" 
-                 value="{format-number($balance, '0.00')}"/&gt;
+        &lt;balance date="{ $prevDate }" 
+                 value="{ format-number($balance, '0.00') }"/&gt;
       &lt;/xsl:if&gt;
       &lt;xsl:next-iteration&gt;
         &lt;xsl:with-param name="balance" select="$newBalance"/&gt;
@@ -15108,18 +15108,18 @@ and <code>version="1.0"</code> otherwise.</p>
                <head>Processing an array using <code>xsl:iterate</code></head>
                <p>Consider the following JSON document representing transactions in a bank account:</p>
                <eg>[
-   {"date":"2008-09-01", credit:12.00},
-   {"date":"2008-09-01", credit:8.00},
-   {"date":"2008-09-02", debit:2.00},
-   {"date":"2008-09-02", credit:12.00}
+  { "date": "2008-09-01", credit: 12.00 },
+  { "date": "2008-09-01", credit: 8.00 },
+  { "date": "2008-09-02", debit: 2.00 },
+  { "date": "2008-09-02", credit: 12.00 }
 ]</eg>
                <p>The following code converts this to an XML representation that includes a running balance:</p>
                <eg><![CDATA[<xsl:iterate select="json-doc('account.json') => array:members()">
    <xsl:param name="balance" as="xs:decimal" select="0"/>               
    <xsl:variable name="delta" select="?value?credit otherwise -?value?debit"/>               
-   <entry date="{?value?date}"
-          amount="{$delta}"
-          balance="{$balance + $delta}"/>
+   <entry date="{ ?value?date }"
+          amount="{ $delta }"
+          balance="{ $balance + $delta }"/>
    <xsl:next-iteration>
       <xsl:with-param name="balance" select="$balance + $delta"/>
    </xsl:next-iteration>   
@@ -15131,9 +15131,9 @@ and <code>version="1.0"</code> otherwise.</p>
                <eg><![CDATA[<xsl:iterate select="json-doc('account.json')?*">
    <xsl:param name="balance" as="xs:decimal" select="0"/>               
    <xsl:variable name="delta" select="?credit otherwise -?debit"/>               
-   <entry date="{?date}"
-          amount="{$delta}"
-          balance="{$balance + $delta}"/>
+   <entry date="{ ?date }"
+          amount="{ $delta }"
+          balance="{ $balance + $delta }"/>
    <xsl:next-iteration>
       <xsl:with-param name="balance" select="$balance + $delta"/>
    </xsl:next-iteration>   
@@ -15355,7 +15355,7 @@ and <code>version="1.0"</code> otherwise.</p>
           <xsl:otherwise select="'1'"/>
         </xsl:choose>
       </xsl:variable>  
-      <xsl:number format="{$format}"/>
+      <xsl:number format="{ $format }"/>
       <xsl:text>. </xsl:text>
     </fo:list-item-label>
     <fo:list-item-body>
@@ -15893,7 +15893,7 @@ and <code>version="1.0"</code> otherwise.</p>
       &lt;xsl:copy-of select="."/&gt;
     &lt;/xsl:source-document&gt;
     &lt;xsl:catch errors="*"&gt;
-       &lt;error code="{$err:code}" message="{$err:description}" file="in.xml"/&gt;
+       &lt;error code="{ $err:code }" message="{ $err:description }" file="in.xml"/&gt;
     &lt;/xsl:catch&gt;
   &lt;/xsl:try&gt;
 &lt;/xsl:result-document&gt;</eg>
@@ -17234,7 +17234,7 @@ and <code>version="1.0"</code> otherwise.</p>
                <eg xml:space="preserve" role="xslt-declaration xmlns:fo='fo'">&lt;xsl:param name="para-font-size" as="xs:string"&gt;12pt&lt;/xsl:param&gt;
 
 &lt;xsl:template match="para"&gt;
- &lt;fo:block font-size="{$para-font-size}"&gt;
+ &lt;fo:block font-size="{ $para-font-size }"&gt;
    &lt;xsl:apply-templates/&gt;
  &lt;/fo:block&gt;
 &lt;/xsl:template&gt;
@@ -17762,7 +17762,7 @@ and <code>version="1.0"</code> otherwise.</p>
   &lt;xsl:for-each select="1 to 5"&gt;
     &lt;xsl:variable name="x" select="$x+1"/&gt;
   &lt;/xsl:for-each&gt;
-  &lt;x value="{$x}"/&gt;
+  &lt;x value="{ $x }"/&gt;
 &lt;/xsl:template&gt;</eg>
             </example>
             <note>
@@ -18087,7 +18087,7 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <eg><![CDATA[<xsl:template name="log:message">
     <xsl:param name="message" as="xs:string"/>
-    <message>{$message}</message>
+    <message>{ $message }</message>
 </xsl:template>]]></eg>
                
                <p>a call on the template written as:</p>
@@ -18311,7 +18311,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <eg xml:space="preserve" role="xslt-declaration xmlns:fo='fo'">&lt;xsl:template name="numbered-block"&gt;
   &lt;xsl:param name="format"&gt;1. &lt;/xsl:param&gt;
   &lt;fo:block&gt;
-    &lt;xsl:number format="{$format}"/&gt;
+    &lt;xsl:number format="{ $format }"/&gt;
     &lt;xsl:apply-templates/&gt;
   &lt;/fo:block&gt;
 &lt;/xsl:template&gt;
@@ -18435,7 +18435,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      equations appear. It is possible to reflect this using a rule of the form:</p>
                   <eg xml:space="preserve" role="xslt-declaration">&lt;xsl:template match="equation"&gt;
   &lt;xsl:param name="equation-format" select="'(1)'" tunnel="yes"/&gt;
-  &lt;xsl:number level="any" format="{$equation-format}"/&gt;
+  &lt;xsl:number level="any" format="{ $equation-format }"/&gt;
 &lt;/xsl:template&gt;</eg>
                   <p>At any level of processing above this level, it is possible to determine how
                      the equations will be numbered, for example:</p>
@@ -18905,13 +18905,13 @@ and <code>version="1.0"</code> otherwise.</p>
                <p diff="add" at="2022-01-01">For example, the following <elcode>xsl:function</elcode> declaration
                declares a function, named <code>f:compare</code>, with an arity range of (2 to 3). 
                   The effect of calling <code>f:compare($a, $b)</code> is the same as the effect
-               of calling <code>f:compare($a, $b, map{"order":"ascending"})</code>.</p>
+               of calling <code>f:compare($a, $b, map { "order": "ascending" })</code>.</p>
                
                <eg><![CDATA[
 <xsl:function name="f:compare" as="xs:boolean">
   <xsl:param name="arg1" as="xs:double"/>
   <xsl:param name="arg2" as="xs:double"/>
-  <xsl:param name="options" as="map(*)" required="no" select="map{'order':'ascending'}"/>
+  <xsl:param name="options" as="map(*)" required="no" select="map { 'order': 'ascending' }"/>
   <xsl:if test="$options?order = 'descending'" then="$arg1 gt $arg2" else="$arg2 gt $arg1"/>
 </xsl:function>]]></eg>
 
@@ -18963,7 +18963,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   (one with <code>required="no"</code>) will often be supplied using a 
                   simple literal or constant expression, for example
                   <code>&lt;xsl:param name="married" as="xs:boolean" select="false()"/></code>,
-                  or <code>&lt;xsl:param name="options" as="map(*)" select="map{}"/></code>. 
+                  or <code>&lt;xsl:param name="options" as="map(*)" select="map { }"/></code>. 
                   However, to allow greater flexibility,
                   the default value can also be context-dependent. For example, 
                   <code>&lt;xsl:param name="node" as="node()" select="."/></code> declares a parameter whose
@@ -21738,8 +21738,8 @@ and <code>version="1.0"</code> otherwise.</p>
                be formatted, then the following transformation is applied to <var>$V</var>:</p>
 
             <eg role="non-xml" xml:space="preserve">
-for $i in 1 to count($V) return
-  if ($i le count($S))
+for $i in 1 to count($V)
+return if ($i le count($S))
   then $V[$i] + $S[$i] - 1
   else $V[$i] + $S[last()] - 1
 </eg>
@@ -23103,13 +23103,13 @@ for $i in 1 to count($V) return
             <p diff="del" at="2022-01-01">The attributes <code>select</code>, <code>array</code>, and <code>map</code>
                are mutually exclusive: exactly one of these three attributes must be present.</p>
             <p diff="del" at="2022-01-01">Specifying <code>array="EXPR"</code> is equivalent to specifying
-               <code>select="array:for-each(EXPR, function($x){map{'value':$x})?*</code>. That is, it maps the
+               <code>select="array:for-each(EXPR, function($x) { map { 'value': $x })?*</code>. That is, it maps the
                elements of an input array to a sequence of items, each item being a map having a single entry, whose
                key is the string <code>value</code> and whose corresponding value is the relevant element of the
                array. Within the contained sequence constructor, the current array element can be referred to
                as <code>?value</code>.</p>
             <p diff="del" at="2022-01-01">Specifying <code>map="EXPR"</code> is equivalent to specifying
-               <code>select="map:for-each(EXPR, function($k, $v){map{'key':$k, 'value':$v})</code>. That is, it maps the
+               <code>select="map:for-each(EXPR, function($k, $v) { map { 'key': $k, 'value': $v })</code>. That is, it maps the
                key-value entries of an input map to a sequence of items (in undefined order), each item being a map having 
                two entries, one entry holding the key, and the other holding the value. 
                Within the contained sequence constructor, the key and value of the current entry in the input map
@@ -23768,29 +23768,29 @@ the same group, and the-->
                <head>Grouping entries in a Map</head>
                <p>Consider a map with composite keys that might appear in a JSON document as:</p>
                <eg>{
-   "Africa/Abidjan": {"offset": "+00:00", "DST-offset": "+00:00" },
-   "Africa/Algiers": {"offset": "+01:00", "DST-offset": "+01:00" },
-   "Africa/Nairobi": {"offset": "+03:00", "DST-offset": "+03:00" },
-   "America/Anchorage": {"offset": "-09:00", "DST-offset": "-08:00" },
-   "America/Los_Angeles": {"offset": "-08:00", "DST-offset": "-07:00" },
-   "Asia/Dubai": {"offset": "+04:00", "DST-offset": "+04:00" },
-   "Asia/Kolkata": {"offset": "+05:30", "DST-offset": "+05:30" }                 
+   "Africa/Abidjan": { "offset": "+00:00", "DST-offset": "+00:00" },
+   "Africa/Algiers": { "offset": "+01:00", "DST-offset": "+01:00" },
+   "Africa/Nairobi": { "offset": "+03:00", "DST-offset": "+03:00" },
+   "America/Anchorage": { "offset": "-09:00", "DST-offset": "-08:00" },
+   "America/Los_Angeles": { "offset": "-08:00", "DST-offset": "-07:00" },
+   "Asia/Dubai": { "offset": "+04:00", "DST-offset": "+04:00" },
+   "Asia/Kolkata": { "offset": "+05:30", "DST-offset": "+05:30" }                 
 }</eg>
                <p>And suppose we wish to group this into a two-level map, thus:</p>
                <eg>{
-   "Africa": {
-       "Abidjan": {"offset": "+00:00", "DST-offset": "+00:00" },
-       "Algiers": {"offset": "+01:00", "DST-offset": "+01:00" },
-       "Nairobi": {"offset": "+03:00", "DST-offset": "+03:00" }
-   },    
-   "America": {
-       "Anchorage": {"offset": "-09:00", "DST-offset": "-08:00" },
-       "Los_Angeles": {"offset": "-08:00", "DST-offset": "-07:00" }
-   },    
-   "Asia": {
-       "Dubai": {"offset": "+04:00", "DST-offset": "+04:00" },
-       "Kolkata": {"offset": "+05:30", "DST-offset": "+05:30" }
-   }    
+  "Africa": {
+    "Abidjan": { "offset": "+00:00", "DST-offset": "+00:00" },
+    "Algiers": { "offset": "+01:00", "DST-offset": "+01:00" },
+    "Nairobi": { "offset": "+03:00", "DST-offset": "+03:00" }
+  },
+  "America": {
+    "Anchorage": { "offset": "-09:00", "DST-offset": "-08:00" },
+    "Los_Angeles": { "offset": "-08:00", "DST-offset": "-07:00" }
+  },
+  "Asia": {
+    "Dubai": { "offset": "+04:00", "DST-offset": "+04:00" },
+    "Kolkata": { "offset": "+05:30", "DST-offset": "+05:30" }
+  }
 }</eg>
                <p>This can be achieved as follows:</p>
                <eg><![CDATA[<xsl:map>
@@ -25932,9 +25932,9 @@ the same group, and the-->
                      are exempt from the usual rule that multiple downward selections are not allowed):</p>
                   
                   <eg xml:space="preserve" role="xslt-instruction">&lt;xsl:source-document streamable="yes" href="transactions.xml"&gt;
-  &lt;xsl:variable name="tally" select="map{ 'count': count(transactions/transaction), 
-                                          'max':   max(transactions/transaction/@value)}"/&gt;
-  &lt;value count="{$tally('count')}" max="{$tally('max')}"/&gt;
+  &lt;xsl:variable name="tally" select="map { 'count': count(transactions/transaction), 
+                                          'max': max(transactions/transaction/@value) }"/&gt;
+  &lt;value count="{ $tally('count') }" max="{ $tally('max') }"/&gt;
 &lt;/xsl:source-document&gt;</eg>
                   <p>Other options include the use of <elcode>xsl:fork</elcode>, or multiple <elcode>xsl:accumulator</elcode>
                   declarations, one for each value to be computed.</p>
@@ -25997,7 +25997,7 @@ the same group, and the-->
    &lt;xsl:source-document streamable="yes" href="book.xml"&gt;
       &lt;xsl:iterate select="book/chapter"&gt;
          &lt;xsl:param name="start-page" select="1"/&gt;
-         &lt;chapter title="{title}" start-page="{$start-page}"/&gt;
+         &lt;chapter title="{title}" start-page="{ $start-page }"/&gt;
          &lt;xsl:next-iteration&gt;
             &lt;xsl:with-param name="start-page" 
                             select="$start-page + @number-of-pages + 
@@ -26483,7 +26483,7 @@ the same group, and the-->
                <p><termdef id="dt-traversal-event" term="traversal-event">a <term>traversal
                         event</term> (shortened to <term>event</term> in this section) is a pair
                      comprising a phase (start or end) and a node.</termdef> It is modelled as a map
-                  with two entries: <code>map{"phase": p, "node": n}</code> where p is the string
+                  with two entries: <code>map { "phase": p, "node": n }</code> where p is the string
                      <code>"start"</code> or <code>"end"</code> and <code>n</code> is a node.</p>
                <p>The traversal of a tree contains two
                   traversal events for each node in the tree, other than attribute and namespace
@@ -26572,12 +26572,12 @@ the same group, and the-->
                   <item>
                      <p>Let <var>SB</var> be the subsequence of <var>T</var> starting at the first
                         event in <var>T</var> and ending with the start event for node <var>N</var>
-                        (that is, the event <code>map{ "phase":"start", "node":N }</code>).</p>
+                        (that is, the event <code>map { "phase": "start", "node": N }</code>).</p>
                   </item>
                   <item>
                      <p>Let <var>SA</var> be the subsequence of <var>T</var> starting at the first
                         event in <var>T</var>, and ending with the  end event
-                        for node <var>N</var> (that is, the event <code>map{ "phase":"end", "node":N
+                        for node <var>N</var> (that is, the event <code>map { "phase": "end", "node": N
                            }</code>).</p>
                   </item>
                   <item>
@@ -26697,8 +26697,8 @@ the same group, and the-->
                   <p>and the requirement is to generate a glossary that lists all the defined terms in the document, as an appendix.</p>
                   <p>This can be achieved by capturing all the defined terms in a map:</p>
                   <eg><![CDATA[<xsl:accumulator name="glossary-terms" 
-         as="map{xs:string, element(define)}" 
-         initial-value="map{}"
+         as="map { xs:string, element(define) }" 
+         initial-value="map { }"
          streamable="yes">
    <xsl:accumulator-rule match="define[@term]" 
            phase="end" 
@@ -27021,7 +27021,7 @@ the same group, and the-->
 
                   <eg role="xslt-declaration" xml:space="preserve">
  &lt;xsl:accumulator name="histogram" as="map(xs:string, xs:integer)"
-    initial-value="map{}"&gt;
+    initial-value="map { }"&gt;
     &lt;xsl:accumulator-rule match="book"&gt;
       &lt;xsl:choose&gt;
         &lt;xsl:when test="map:contains($value, @publisher)"&gt;
@@ -27760,7 +27760,7 @@ the same group, and the-->
                   </tr>
                   <tr>
                      <td rowspan="1" colspan="1">MapConstructor [,69]</td>
-                     <td rowspan="1" colspan="1"><code>map{"A":E, "B":F}</code></td>
+                     <td rowspan="1" colspan="1"><code>map { "A": E, "B": F }</code></td>
                      <td rowspan="1" colspan="1"><var>U{function(*)}</var></td>
                   </tr>
                   <tr>
@@ -27785,12 +27785,12 @@ the same group, and the-->
                   </tr>                 
                   <tr>
                      <td rowspan="1" colspan="1">SquareArrayConstructor [,74]</td>
-                     <td rowspan="1" colspan="1"><code>[X, Y, ...]</code></td>
+                     <td rowspan="1" colspan="1"><code>[ X, Y, ... ]</code></td>
                      <td rowspan="1" colspan="1"><var>U{function(*)}</var></td>
                   </tr>
                   <tr>
                      <td rowspan="1" colspan="1">CurlyArrayConstructor [,75]</td>
-                     <td rowspan="1" colspan="1"><code>array{X, Y, ...}</code></td>
+                     <td rowspan="1" colspan="1"><code>array {X, Y, ... }</code></td>
                      <td rowspan="1" colspan="1"><var>U{function(*)}</var></td>
                   </tr>
                </tbody>
@@ -31958,12 +31958,12 @@ the same group, and the-->
                      </tr>
                      <tr>
                         <td rowspan="1" colspan="1">SquareArrayConstructor [,74]</td>
-                        <td rowspan="1" colspan="1"><code>[N, N, ...]</code></td>
+                        <td rowspan="1" colspan="1"><code>[ N, N, ... ]</code></td>
                         <td rowspan="1" colspan="1"/>
                      </tr>
                      <tr>
                         <td rowspan="1" colspan="1">CurlyArrayConstructor [,75]</td>
-                        <td rowspan="1" colspan="1"><code>array{N, N, ...}</code></td>
+                        <td rowspan="1" colspan="1"><code>array { N, N, ... }</code></td>
                         <td rowspan="1" colspan="1"/>
                      </tr>
                   </tbody>
@@ -32965,8 +32965,8 @@ the same group, and the-->
                         <elcode>xsl:map-entry</elcode> instructions is then wrapped in an
                         <elcode>xsl:map</elcode> parent instruction.</p>
 
-                  <p>For example, the map constructor <code>map{'red':false(),
-                        'green':true()}</code> translates to the instruction:</p>
+                  <p>For example, the map constructor <code>map { 'red': false(),
+                        'green': true() }</code> translates to the instruction:</p>
                   <eg role="xslt-instruction" xml:space="preserve">
 &lt;xsl:map&gt;
   &lt;xsl:map-entry key="'red'" select="false()"/&gt;
@@ -33392,7 +33392,7 @@ the same group, and the-->
                      <code>$f</code>.</p>
 
                   <p>For example, given the call <code>fold-left(/*/transaction, 0, function($x as
-                        xs:decimal, $y as xs:decimal) as xs:decimal {$x+$y})</code>, the <termref def="dt-operand-usage"/> of the argument <code>/*/transaction</code> is
+                        xs:decimal, $y as xs:decimal) as xs:decimal { $x + $y })</code>, the <termref def="dt-operand-usage"/> of the argument <code>/*/transaction</code> is
                      determined by the declared type of <code>$y</code>, namely
                         <code>xs:decimal</code>. Since this is an atomic type, the <termref def="dt-type-determined-usage"/> is <termref def="dt-absorption"/>. Applying
                      this to the general streamability rules, the function call is <termref def="dt-grounded"/> and <termref def="dt-consuming"/>.</p>
@@ -35110,7 +35110,7 @@ the same group, and the-->
 
             <note>
                <p>So, given a map <code>$M</code> whose keys are integers and whose results are
-                  strings, such as <code>map{0:"no", 1:"yes"}</code>, the following relations hold,
+                  strings, such as <code>map { 0: "no", 1: "yes" }</code>, the following relations hold,
                   among others:</p>
                <ulist>
                   <item>
@@ -35392,39 +35392,39 @@ the same group, and the-->
                   </thead>
                   <tbody>
                      <tr>
-                        <td><code>function($a, $b){$a}</code></td>
+                        <td><code>function($a, $b) { $a }</code></td>
                         <td>The first of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>function($a, $b){$b}</code></td>
+                        <td><code>function($a, $b) { $b }</code></td>
                         <td>The last of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>function($a, $b){$a, $b}</code></td>
+                        <td><code>function($a, $b) { $a, $b }</code></td>
                         <td>The sequence-concatenation of the duplicate values is used. 
                            <phrase diff="add" at="2023-04-04">This could
                         also be expressed as <code>on-duplicates="op(',')"</code>.</phrase></td>
                      </tr>
                      <tr>
-                        <td><code>function($a, $b){max(($a, $b))}</code></td>
+                        <td><code>function($a, $b) { max(($a, $b)) }</code></td>
                         <td>The highest of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>function($a, $b){min(($a, $b))}</code></td>
+                        <td><code>function($a, $b) { min(($a, $b)) }</code></td>
                         <td>The lowest of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>function($a, $b){string-join(($a, $b), ', ')}</code></td>
+                        <td><code>function($a, $b) { string-join(($a, $b), ', ') }</code></td>
                         <td>The comma-separated string concatenation of the duplicate values is used.</td>
                      </tr>
                      <tr diff="add" at="2023-04-04">
-                        <td><code>function($a, $b){$a + $b)}</code></td>
+                        <td><code>function($a, $b) { $a + $b }</code></td>
                         <td>The sum of the duplicate values is used.
                            This could also be expressed as <code>on-duplicates="op('+')"</code>
                         </td>
                      </tr>
                      <tr>
-                        <td><code>function($a, $b){error()}</code></td>
+                        <td><code>function($a, $b) { error() }</code></td>
                         <td>Duplicates are rejected as an error (this is the default in the absence of a
                            callback function).</td>
                      </tr>
@@ -35441,10 +35441,10 @@ the same group, and the-->
    <event id="A23" value="2"/>
  </data>]]></eg>
                   <p>and constructs a map whose JSON representation is:</p>
-                  <eg><![CDATA[{"A23": [12, 2], "A24": [5], "A23": [9]}]]></eg>
+                  <eg><![CDATA[{ "A23": [ 12, 2 ], "A24": [ 5 ], "A23": [ 9 ] }]]></eg>
                   <p>The logic is:</p>
                   <eg><![CDATA[<xsl:template match="data">
-   <xsl:map on-duplicates="function($a, $b){array:join(($a, $b))}">
+   <xsl:map on-duplicates="function($a, $b) { array:join(($a, $b)) }">
      <xsl:for-each select="event">
         <xsl:map-entry key="@id" select="[xs:integer(@value)]"/>
      </xsl:for-each>
@@ -35569,7 +35569,7 @@ map {
                downward selections:</p>
 
             <eg role="non-xml" xml:space="preserve">
-let $m := map{'price':xs:decimal(price), 'discount':xs:decimal(discount)} 
+let $m := map { 'price': xs:decimal(price), 'discount': xs:decimal(discount) } 
 return ($m?price - $m?discount)</eg>
 
             <p>Analysis:</p>
@@ -35611,7 +35611,7 @@ return ($m?price - $m?discount)</eg>
   &lt;xsl:iterate select="*/employee"&gt;
     &lt;xsl:param name="highest-earners" 
                as="map(xs:string, element(employee))" 
-               select="map{}"/&gt;
+               select="map { }"/&gt;
     &lt;xsl:on-completion&gt;
       &lt;xsl:for-each select="map:keys($highest-earners)"&gt;
         &lt;department name="{.}"&gt;
@@ -35646,7 +35646,7 @@ return ($m?price - $m?discount)</eg>
 &lt;xsl:function name="i:complex" as="map(xs:int, xs:double)"&gt;
   &lt;xsl:param name="real" as="xs:double"/&gt;
   &lt;xsl:param name="imaginary" as="xs:double"/&gt;
-  &lt;xsl:sequence select="map{ $REAL : $real, $IMAG : $imaginary }"/&gt;
+  &lt;xsl:sequence select="map { $REAL: $real, $IMAG: $imaginary }"/&gt;
 &lt;/xsl:function&gt;
 
 &lt;xsl:function name="i:real" as="xs:double"&gt;
@@ -35690,7 +35690,7 @@ return ($m?price - $m?discount)</eg>
                <p>An index may be constructed as follows: </p>
                <eg role="xslt-declaration xmlns:map='http://www.w3.org/2005/xpath-functions/map" xml:space="preserve">
 &lt;xsl:variable name="isbn-index" as="map(xs:string, element(book))"
-    select="map:merge(for $b in //book return map{$b/isbn : $b})"/&gt;</eg>
+    select="map:merge(for $b in //book return map { $b/isbn: $b })"/&gt;</eg>
                <p>This index may then be used to retrieve the book for a given ISBN using either of
                   the expressions <code>map:get($isbn-index, "0470192747")</code> or
                      <code>$isbn-index("0470192747")</code>.</p>
@@ -35744,19 +35744,19 @@ return ($m?price - $m?discount)</eg>
                   formats. For example, with the first format the implementation might be:</p>
                <eg role="xslt-declaration" xml:space="preserve">
 &lt;xsl:variable name="flat-input-functions" as="map(xs:string, function(*))*"
-  select="map{
+  select="map {
             'orders-for-customer' : 
                  function($c as element(customer)) as element(order)* 
-                    {$c/../order[@customer=$c/@id]},
+                    { $c/../order[@customer = $c/@id] },
             'orders-for-product' : 
                  function($p as element(product)) as element(order)* 
-                    {$p/../order[@product=$p/@id]},
+                    { $p/../order[@product = $p/@id] },
             'customer-for-order' : 
                  function($o as element(order)) as element(customer) 
-                    {$o/../customer[@id=$o/@customer]},
+                    { $o/../customer[@id = $o/@customer] },
             'product-for-order' : 
                  function($o as element(order)) as element(product) 
-                    {$o/../product[@id=$o/@product]} }                    
+                    { $o/../product[@id = $o/@product] } }
          "/&gt;</eg>
                <p>Having established which input format is in use, the application can bind the
                   appropriate implementation of these functions to a variable such as
@@ -35780,7 +35780,7 @@ return ($m?price - $m?discount)</eg>
             <p diff="chg" at="2023-03-22">If the <code>use</code> attribute is omitted, the resulting
             array has one singleton member for each item returned by the <code>select</code> attribute or
             sequence constructor. For example <code>&lt;xsl:array select="1 to 5"/></code> returns
-            an array with five members: <code>[1, 2, 3, 4, 5]</code>.</p>
+            an array with five members: <code>[ 1, 2, 3, 4, 5 ]</code>.</p>
             <p diff="chg" at="2023-03-22">If the <code>use</code> attribute is present then it is evaluated
                once for each item in the sequence returned by the <code>select</code> attribute or
                sequence constructor, with a <termref def="dt-singleton-focus"/> based on that item,
@@ -35804,14 +35804,14 @@ return ($m?price - $m?discount)</eg>
                <head>Constructing an array whose members are single items</head>
                <p>The following example constructs an array by tokenizing a string:</p>
                <eg><![CDATA[<xsl:array select="tokenize('The cat sat on the mat')"/>]]></eg>
-               <p>The result is the array <code>["The", "cat", "sat", "on", "the", "mat"]</code>.</p>
+               <p>The result is the array <code>[ "The", "cat", "sat", "on", "the", "mat" ]</code>.</p>
                <p>The following example constructs an array containing items computed using nested instructions:</p>
                <eg><![CDATA[<xsl:array>
    <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
      <xsl:sequence select="string-join(current-group(), '-')"/>
    </xsl:for-each-group>
 </xsl:array>]]></eg>
-               <p>The result is the array <code>["0-1-2-3", "4-5-6-7", "8-9-10-11", "12-13-14-15", "16-17-18-19"]</code>.</p>
+               <p>The result is the array <code>[ "0-1-2-3", "4-5-6-7", "8-9-10-11", "12-13-14-15", "16-17-18-19" ]</code>.</p>
             </example>
             
             <example>
@@ -35854,8 +35854,8 @@ return ($m?price - $m?discount)</eg>
       <xsl:sort select="count(?value)"/>
    </xsl:perform-sort>
 </xsl:array>]]></eg>
-               <p>The following code inverts a nested array (such as <code>[[1,2,3], [4,5,6], [7,8,9]]</code>)
-               so the result is organized by columns rather than rows (<code>[[1,4,7], [2,5,8], [3,6,9]]</code>):</p>
+               <p>The following code inverts a nested array (such as <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]</code>)
+               so the result is organized by columns rather than rows (<code>[ [ 1, 4, 7 ], [ 2, 5, 8 ], [ 3, 6, 9 ] ]</code>):</p>
                <eg><![CDATA[<xsl:array>
    <xsl:for-each select="1 to array:size($input?1)">
       <xsl:variable name="index" select="."/>
@@ -35892,7 +35892,7 @@ return ($m?price - $m?discount)</eg>
             
             <example>
                <head>Processing an array of singleton items</head>
-               <p>Given an array <code>$in</code> containing <code>[1, 5, 6, 10]</code> the following example might output the sequence
+               <p>Given an array <code>$in</code> containing <code>[ 1, 5, 6, 10 ]</code> the following example might output the sequence
                <code>('i', 'v', 'vi', 'x')</code>:</p>
                <eg><![CDATA[
 <xsl:for-each-member select="$in">
@@ -35992,24 +35992,24 @@ return ($m?price - $m?discount)</eg>
   "author"  : null,
   "cities"  : {
     "Brussels": [
-      {"to": "London",    "distance": 322},
-      {"to": "Paris",     "distance": 265},
-      {"to": "Amsterdam", "distance": 173}
+      { "to": "London",    "distance": 322 },
+      { "to": "Paris",     "distance": 265 },
+      { "to": "Amsterdam", "distance": 173 }
     ],
     "London": [
-      {"to": "Brussels",  "distance": 322},
-      {"to": "Paris",     "distance": 344},
-      {"to": "Amsterdam", "distance": 358}
+      { "to": "Brussels",  "distance": 322 },
+      { "to": "Paris",     "distance": 344 },
+      { "to": "Amsterdam", "distance": 358 }
     ],
     "Paris": [
-      {"to": "Brussels",  "distance": 265},
-      {"to": "London",    "distance": 344},
-      {"to": "Amsterdam", "distance": 431}
+      { "to": "Brussels",  "distance": 265 },
+      { "to": "London",    "distance": 344 },
+      { "to": "Amsterdam", "distance": 431 }
     ],
     "Amsterdam": [
-      {"to": "Brussels",  "distance": 173},
-      {"to": "London",    "distance": 358},
-      {"to": "Paris",     "distance": 431}
+      { "to": "Brussels",  "distance": 173 },
+      { "to": "London",    "distance": 358 },
+      { "to": "Paris",     "distance": 431 }
     ]
   }
 }
@@ -36186,7 +36186,7 @@ return ($m?price - $m?discount)</eg>
                the function is evaluated. Maps are a new data type introduced in XSLT 3.0.</p>
             <p>For example, the function <code>fn:xml-to-json</code> has an options parameter
                allowing specification of whether the output is to be indented. A call might be written:</p>
-            <eg role="xpath" xml:space="preserve">xml-to-json($input, map{'indent':true()})</eg>
+            <eg role="xpath" xml:space="preserve">xml-to-json($input, map { 'indent': true() })</eg>
             <p><termdef id="option-parameter-conventions" term="option parameter conventions">Functions
                that take an options parameter adopt common conventions on how the
                options are used. These are referred to as the <term>option parameter conventions</term>. These
@@ -38960,7 +38960,7 @@ return ($m?price - $m?discount)</eg>
                <xnt spec="XP40" ref="prod-xpath40-ArgumentPlaceholder">ArgumentPlaceholder</xnt></p></error>.</p>
             
             <note><p>The effect is to disallow the three constructs used to create function-valued items: named function references
-            such as <code>round#1</code>, inline function expressions such as <code>function($x){$x+1}</code>, and
+            such as <code>round#1</code>, inline function expressions such as <code>function($x) { $x + 1 }</code>, and
             partial function application such as <code>starts-with(?, '#')</code>, along with sequence types
             such as <code>function(xs:integer) as xs:string</code> that serve no useful purpose in the absence of such items.</p> 
             

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35786,11 +35786,11 @@ return ($m?price - $m?discount)</eg>
                sequence constructor, with a <termref def="dt-singleton-focus"/> based on that item,
                to produce the value of the corresponding array member.</p>
             <p diff="chg" at="2023-03-22">For example, <code>&lt;xsl:array select="'red', 'green', 'blue'" use="characters(.)"/></code>
-               returns an array with three members: <code>[("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e")] </code>.</p>
+               returns an array with three members: <code>[ ("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e") ]</code>.</p>
             <p diff="chg" at="2023-03-22">A useful convention is to construct each array member as a <term>value record</term>
                (a singleton map whose single entry has the key <code>"value"</code>): 
                <code>&lt;xsl:array select="map:entry('value', 1 to 3), map:entry('value': 8 to 10)" use="?value"/></code>
-            returns an array with two members: <code>[(1,2,3), (8,9,10)]</code>. This is essentially equivalent to
+            returns an array with two members: <code>[ (1, 2, 3), (8, 9, 10) ]</code>. This is essentially equivalent to
             the effect of the <function>array:of-members</function> function.</p>
             <p>The <code>select</code> attribute and the contained sequence constructor are mutually
             exclusive: if the <code>select</code> attribute is present, then the only permitted child
@@ -35822,7 +35822,7 @@ return ($m?price - $m?discount)</eg>
      <xsl:map-entry key="'value'" select="current-group()"/>
    </xsl:for-each-group>
 </xsl:array>]]></eg>
-               <p>The result is the array <code>[(0,1,2,3), (4,5,6,7), (8,9,10,11), (12,13,14,15), (16,17,18,19)]</code>.</p>
+               <p>The result is the array <code>[ (0, 1, 2, 3), (4, 5, 6, 7), (8, 9, 10, 11), (12, 13, 14, 15), (16, 17, 18, 19) ]</code>.</p>
                <p>The technique used here is to capture each member sequence in a singleton map (known as a <term>value record</term>)
                with the conventional key <code>"value"</code>.</p> 
                <p>The following example delivers the same result in a different way:</p>
@@ -35912,7 +35912,7 @@ return ($m?price - $m?discount)</eg>
             </example>
             <example>
                <head>Processing an array of sequence-valued items</head>
-               <p>Given an array <code>$in</code> containing <code>[(1,2), (), (3,4,5)]</code>, the following example
+               <p>Given an array <code>$in</code> containing <code>[ (1, 2), (), (3, 4, 5) ]</code>, the following example
                outputs the sum of the integers in each member, that is, <code>(3, 0, 12)</code>.</p>
                <eg><![CDATA[
 <xsl:for-each-member select="$in" composite="yes">


### PR DESCRIPTION
Editorial; closes #1060.

This PR attempts to unify the presentation of XPath and XQuery code. It’s not complete, but it should definitely improve the status quo.

The chosen formatting and indentation rules can certainly be discussed. My major objective was consistency: I selected rules that were used frequently enough in the given documents.

Apart from the presentation stuff, this PR fixes various minor bugs in the rules and examples.