### PR TITLE
1036 Rephrase the rules for number-parser with liberal JSON

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24297,10 +24297,14 @@ return
                      supplying a function that casts to <code>union(xs:decimal, xs:double)</code> will treat
                      the value as <code>xs:decimal</code> if there is no exponent, or as <code>xs:double</code>
                      otherwise. Supplying the value <code>fn:identity#1</code> causes the value to be retained
-                     unchanged as an <code>xs:untypedAtomic</code>. Before calling the supplied <code>number-parser</code>,
-                     the value is first checked to ensure that it conforms to the JSON grammar (for example,
-                     a leading plus sign and redundant leading zeroes are not allowed); these checks are disabled
-                     if the <code>liberal</code> option is set to <code>true</code>.
+                     unchanged as an <code>xs:untypedAtomic</code>. 
+                     
+                     If the <code>liberal</code> option is <code>false</code> (the default), then
+                     the supplied <code>number-parser</code> is called if and only if the value conforms 
+                     to the JSON grammar for numbers (for example,
+                     a leading plus sign and redundant leading zeroes are not allowed). If the <code>liberal</code>
+                     option is <code>true</code> then it is also called if the value conforms to an
+                     <termref def="implementation-defined"/> extension of this grammar.
                   </fos:value>
                </fos:values>
             </fos:option>


### PR DESCRIPTION
Rephrasing as suggested in the issue.

Fix #1036