### PR TITLE
1050 Fix ItemType grammar ambiguity

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2703,7 +2703,6 @@ ErrorVal ::= "$" VarName
       <g:ref name="FunctionTest" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
       <g:ref name="MapTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ArrayTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
-      <g:ref name="AtomicOrUnionType"/>
       <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
@@ -2717,10 +2716,7 @@ ErrorVal ::= "$" VarName
       <g:string>)</g:string>   
   </g:production>
 
-  <g:production name="AtomicOrUnionType" if="xpath40 xquery40 xslt40-patterns">
-    <g:ref name="_QName_or_EQName" unfold="yes"/>
-  </g:production>
-
+ 
   <g:production name="KindTest" node-type="void">
     <g:choice break="true" name="KindTestChoice">
       <g:ref name="DocumentTest" />

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4228,7 +4228,6 @@ the schema type named <code>us:address</code>.</p>
                <prodrecap ref="MapTest"/>
                <prodrecap ref="RecordTest"/>
                <prodrecap ref="ArrayTest"/>
-               <prodrecap id="AtomicOrUnionType" ref="AtomicOrUnionType"/>
                <prodrecap ref="LocalUnionType"/>
                <prodrecap ref="EnumerationType"/>
             </scrap>
@@ -4239,7 +4238,7 @@ the schema type named <code>us:address</code>.</p>
             
             <p diff="add" at="A">An <termref def="dt-item-type-designator"/> written simply 
                as an <code>EQName</code>
-               (that is, a <code>NamedType</code>) is interpreted as follows:</p>
+               (that is, a <code>TypeName</code>) is interpreted as follows:</p>
             
             <olist diff="add" at="A">
                <item><p>If the name is written as a lexical QName, then it is expanded using the


### PR DESCRIPTION
Two alternatives in the grammar were both EQNames, distinguished semantically. This ambiguity in the grammar is now fixed (no living XPath expressions are harmed by this change).

Fix #1050