### PR TITLE
1039 Add notes referring to fn:collation-key

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -18703,6 +18703,18 @@ return (
 &lt;/category&gt;</eg>
                </item>
             </ulist>
+            <note>
+               <p>If a collation name is specified, it must be supplied as a literal string; it cannot
+                  be computed dynamically. A workaround in such cases is to use
+                   the <code>fn:collation-key</code> function. For example:</p>
+               
+               <eg role="parse-test">for $p in $products
+group by collation-key($p/description, $collation)
+return $product/@code</eg>
+               
+               <p>Note however that the <code>fn:collation-key</code> function might not work
+                  for all collations.</p>
+            </note>
          </div3>
          <div3 id="id-order-by-clause">
             <head>Order By Clause</head>
@@ -18995,21 +19007,34 @@ return $e/name]]></eg>
                </item>
             </ulist>
             <note>
-               <p>
-An alternative way of sorting is available from XQuery 3.1 using the <code>fn:sort</code> function. In previous versions of the language, a set of books might be sorted into alphabetic order by title using the FLWOR expression:</p>
-
+               <p>If a collation name is specified, it must be supplied as a literal string; it cannot
+                  be computed dynamically. Two possible workarounds are to use the <code>fn:sort</code> function
+               or the <code>fn:collation-key</code> function.</p>
+               <p>Using <code>fn:sort</code> the expression</p>
                <eg role="parse-test">for $b in $books/book[price &lt; 100]
 order by $b/title
 return $b</eg>
 
-               <p>In XQuery 3.1 the same effect can be achieved using the expression:</p>
+               <p>can be replaced with the following, which uses a dynamically-chosen collation:</p>
 
                <eg role="parse-test">
 sort(
   $books/book[price &lt; 100],
+  $collation,
   function($book) { $book/title }
 )
 </eg>
+               
+               <p>Alternatively, it is possible to compute collation keys using a dynamically-chosen
+               collation, and sort on the values of the collation keys:</p>
+               
+               <eg role="parse-test">for $b in $books/book[price &lt; 100]
+order by collation-key($b/title, $collation)
+return $b</eg>
+               
+               <p>Note however that the <code>fn:collation-key</code> function might not work
+               for all collations.</p>
+               
             </note>
 
 


### PR DESCRIPTION
Fix #1039

Rather than adding a new feature to the language, we add notes to "order by" and "group by" explaining how the requirement can be met using the fn:collation-key() function.