### PR TITLE
566-partial Fix colon issue in URI parsing

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29290,9 +29290,10 @@ some $boolean in (
          <ulist>
             <item>
          <p>If the scheme is not known or is known to be <code>file</code>
-         and the <emph>string</emph> matches <code>^/*(/[a-zA-Z]:.*)$</code>,
+         and the <emph>string</emph> matches <code>^/*(/[a-zA-Z][:|].*)$</code>,
          the <emph>authority</emph> is empty and the <emph>string</emph> is
-         the first match group.</p></item>
+         the first match group. If the second character in the <emph>string</emph> is <code>|</code>,
+            it is changed to <code>:</code>.</p></item>
          <item><p>Otherwise, if the <emph>string</emph>
          matches <code>^///*([^/]+)?(/.*)?$</code>, the <emph>authority</emph>
          is the first match group and the <emph>string</emph> is the second

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -29292,7 +29292,7 @@ some $boolean in (
          <p>If the scheme is not known or is known to be <code>file</code>
          and the <emph>string</emph> matches <code>^/*(/[a-zA-Z][:|].*)$</code>,
          the <emph>authority</emph> is empty and the <emph>string</emph> is
-         the first match group. If the second character in the <emph>string</emph> is <code>|</code>,
+         the first match group. If the third character in the <emph>string</emph> is <code>|</code>,
             it is changed to <code>:</code>.</p></item>
          <item><p>Otherwise, if the <emph>string</emph>
          matches <code>^///*([^/]+)?(/.*)?$</code>, the <emph>authority</emph>


### PR DESCRIPTION
In the course of reviewing the tests for `fn:parse-uri`, I discovered (or perhaps more correctly, @ChristianGruen discovered) that the rules for matching Windows drive letters are inconsistent. This PR fixes that inconsistency.