### PR TITLE
Build fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ task publish(dependsOn: ["publish-xpath-functions-40",
                          "publish-xslt-40",
                          "publish-datamodel-40",
                          "publish-xslt-xquery-serialization-40"]) {
-  inputs.files fileTree(dir: "${buildDir}/www")
+  inputs.dir "${buildDir}/www"
   outputs.file "${buildDir}/www/index.html"
 
   doLast {
@@ -184,9 +184,9 @@ task fo_merge(
   description: "Expand the FO sources into a single XML file",
   dependsOn: ["common_sources", "saxon_config"]
 ) {
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-functions-40/src")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-functions-40/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-functions-40/images")
+  inputs.dir "${projectDir}/specifications/xpath-functions-40/src"
+  inputs.dir "${projectDir}/specifications/xpath-functions-40/style"
+  inputs.dir "${projectDir}/specifications/xpath-functions-40/images"
   outputs.file "${buildDir}/expanded/xpath-functions-40/xpath-functions-40.xml"
 
   doLast {
@@ -205,7 +205,7 @@ task fo_xml(
   group: "Spec XML",
   description: "Create the XML version of the specification"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style/identity.xsl")
+  inputs.file "${projectDir}/style/identity.xsl"
   inputs.file fo_merge.outputs.getFiles().getSingleFile()
   outputs.file "${buildDir}/www/xpath-functions-40/xpath-functions-40.xml"
 
@@ -221,8 +221,8 @@ task fo_html(
   group: "Spec HTML",
   description: "Create the HTML and XHTML versions of the specification"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-functions-40/style")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xpath-functions-40/style"
   inputs.file fo_merge.outputs.getFiles().getSingleFile()
   outputs.file "${buildDir}/www/xpath-functions-40/Overview.xml"
   outputs.file "${buildDir}/www/xpath-functions-40/Overview.html"
@@ -244,8 +244,8 @@ task fo_html_diff(
   group: "Spec HTML (diff)",
   description: "Create the HTML and XHTML versions of the specification (with diff markup)"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-functions-40/style")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xpath-functions-40/style"
   inputs.file fo_merge.outputs.getFiles().getSingleFile()
   outputs.file "${buildDir}/www/xpath-functions-40/Overview-diff.xml"
   outputs.file "${buildDir}/www/xpath-functions-40/Overview-diff.html"
@@ -339,7 +339,7 @@ task xpath_keyword_tests(
 task grammar_40(
   dependsOn: ["saxon_config"]
 ) {
-  inputs.files fileTree(dir: "${projectDir}/specifications/grammar-40")
+  inputs.dir "${projectDir}/specifications/grammar-40"
   inputs.file "${projectDir}/style/grammar-identity.xsl"
   outputs.file "${buildDir}/grammar-40/xpath-grammar.xml"
 
@@ -372,10 +372,10 @@ task xslt_grammar(
   dependsOn: ["grammar_40", "saxon_config"],
   description: "Build the grammar files for XSLT 4.0"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/src")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/grammar-40")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xslt-40/src"
+  inputs.dir "${projectDir}/specifications/xslt-40/style"
+  inputs.dir "${projectDir}/specifications/grammar-40"
   outputs.file "${buildDir}/xslt-40/src/xslt-40-assembled.xml"
 
   doLast {
@@ -412,9 +412,9 @@ task xslt_grammar(
 task xslt_merge_catalog(
   dependsOn: ["xslt_grammar", "saxon_config"]
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/src")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/style")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xslt-40/src"
+  inputs.dir "${projectDir}/specifications/xslt-40/style"
   inputs.file xslt_grammar.outputs.getFiles().getSingleFile()
   outputs.file "${buildDir}/xslt-40/src/xslt-expanded.xml"
 
@@ -492,8 +492,8 @@ task xslt_make_svg(
   dependsOn: ["xslt_merge_catalog", "saxon_config"],
   description: "Create SVG images with GraphViz"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/style")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xslt-40/style"
   inputs.file xslt_merge_catalog.outputs.getFiles().getSingleFile()
   outputs.file "${buildDir}/xslt-40/img/fig1.svg"
 
@@ -526,8 +526,8 @@ task xslt_make_svg(
 task xslt_copy_svg(
   description: "Copy SVG images"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-40/style")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xslt-40/style"
   outputs.file "${buildDir}/xslt-40/img/fig1.svg"
 
   doLast {
@@ -652,7 +652,7 @@ task xslt_xml(
   dependsOn: ["xslt_merge_catalog", "saxon_config"],
   description: "Create the XML version of the specification"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style/identity.xsl")
+  inputs.file "${projectDir}/style/identity.xsl"
   inputs.file xslt_merge_catalog.outputs.getFiles().getSingleFile()
   outputs.file "${buildDir}/www/xslt-40/xslt-40.xml"
 
@@ -710,10 +710,10 @@ task shared_40(
     dependsOn: ["grammar_40", "saxon_config"],
     description: "Build the grammar files for the ${shortName} specification"
   ) {
-    inputs.files fileTree(dir: "${projectDir}/style")
-    inputs.files fileTree(dir: "${projectDir}/specifications/xquery-40/src")
-    inputs.files fileTree(dir: "${projectDir}/specifications/xquery-40/style")
-    inputs.files fileTree(dir: "${projectDir}/specifications/grammar-40")
+    inputs.dir "${projectDir}/style"
+    inputs.dir "${projectDir}/specifications/xquery-40/src"
+    inputs.dir "${projectDir}/specifications/xquery-40/style"
+    inputs.dir "${projectDir}/specifications/grammar-40"
     outputs.file "${buildDir}/xquery-40/tokens-${shortName}.xml"
     outputs.file "${buildDir}/xquery-40/temp-${shortName}-grammar.xml"
 
@@ -744,10 +744,10 @@ task shared_40(
     dependsOn: ["xquery_${shortName}_grammar", "saxon_config"],
     description: "Assemble the sources for the ${shortName} specification"
   ) {
-    inputs.files fileTree(dir: "${projectDir}/style")
-    inputs.files fileTree(dir: "${projectDir}/specifications/xquery-40/src")
-    inputs.files fileTree(dir: "${projectDir}/specifications/xquery-40/style")
-    inputs.files fileTree(dir: "${projectDir}/specifications/grammar-40")
+    inputs.dir "${projectDir}/style"
+    inputs.dir "${projectDir}/specifications/xquery-40/src"
+    inputs.dir "${projectDir}/specifications/xquery-40/style"
+    inputs.dir "${projectDir}/specifications/grammar-40"
     inputs.file "${buildDir}/xquery-40/tokens-${shortName}.xml"
     outputs.file "${buildDir}/xquery-40/src/${shortName}-assembled.xml"
 
@@ -782,9 +782,9 @@ task shared_40(
     dependsOn: ["xquery_assemble_${shortName}", "setup_crossref_indexes", "saxon_config"],
     description: "Create the HTML and XHTML versions of the ${shortName} specification"
   ) {
-    inputs.files fileTree(dir: "${projectDir}/style")
-    inputs.files fileTree(dir: "${projectDir}/specifications/xquery-40/src")
-    inputs.files fileTree(dir: "${projectDir}/specifications/xquery-40/style")
+    inputs.dir "${projectDir}/style"
+    inputs.dir "${projectDir}/specifications/xquery-40/src"
+    inputs.dir "${projectDir}/specifications/xquery-40/style"
     inputs.file "${buildDir}/xquery-40/src/${shortName}-assembled.xml"
     outputs.file "${buildDir}/www/xquery-40/${shortName}-40.html"
 
@@ -819,9 +819,9 @@ task shared_40(
     dependsOn: ["xquery_assemble_${shortName}", "saxon_config"],
     description: "Create the HTML and XHTML versions of the ${shortName} specification"
   ) {
-    inputs.files fileTree(dir: "${projectDir}/style")
-    inputs.files fileTree(dir: "${projectDir}/specifications/xquery-40/src")
-    inputs.files fileTree(dir: "${projectDir}/specifications/xquery-40/style")
+    inputs.dir "${projectDir}/style"
+    inputs.dir "${projectDir}/specifications/xquery-40/src"
+    inputs.dir "${projectDir}/specifications/xquery-40/style"
     inputs.file "${buildDir}/xquery-40/src/${shortName}-assembled.xml"
     outputs.file "${buildDir}/www/xquery-40/${shortName}-40.html"
 
@@ -913,8 +913,8 @@ task datamodel_40(
 task datamodel_merge(
   dependsOn: ["common_sources", "saxon_config"]
 ) {
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-datamodel-40/src")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-datamodel-40/style")
+  inputs.dir "${projectDir}/specifications/xpath-datamodel-40/src"
+  inputs.dir "${projectDir}/specifications/xpath-datamodel-40/style"
   outputs.files "${buildDir}/expanded/xpath-datamodel-40/xpath-datamodel.xml"
 
   doLast {
@@ -963,8 +963,8 @@ task datamodel_xml(
   description: "Create the XML version of the specification"
 ) {
   inputs.file datamodel_merge.outputs.getFiles().getSingleFile()
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-datamodel-40/style")
-  inputs.files fileTree(dir: "${projectDir}/style/identity.xsl")
+  inputs.dir "${projectDir}/specifications/xpath-datamodel-40/style"
+  inputs.file "${projectDir}/style/identity.xsl"
   outputs.file "${buildDir}/www/xpath-datamodel-40/xpath-datamodel-40.xml"
 
   doLast {
@@ -979,9 +979,9 @@ task datamodel_html(
   dependsOn: ["datamodel_xml", "setup_crossref_indexes", "saxon_config"],
   description: "Create the HTML and XHTML versions of the specification"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
+  inputs.dir "${projectDir}/style"
   inputs.files fileTree(dir: buildDir, include: "*.svg")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-datamodel-40/style")
+  inputs.dir "${projectDir}/specifications/xpath-datamodel-40/style"
   inputs.file datamodel_merge.outputs.getFiles().getSingleFile()
   outputs.file "${buildDir}/www/xpath-datamodel-40/Overview.xml"
   outputs.file "${buildDir}/www/xpath-datamodel-40/Overview.html"
@@ -1003,8 +1003,8 @@ task datamodel_html_diff(
   group: "Spec HTML (diff)",
   description: "Create the HTML and XHTML versions of the specification (with diff markup)"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xpath-datamodel-40/style")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xpath-datamodel-40/style"
   inputs.file datamodel_merge.outputs.getFiles().getSingleFile()
   outputs.file "${buildDir}/www/xpath-datamodel-40/Overview-diff.xml"
   outputs.file "${buildDir}/www/xpath-datamodel-40/Overview-diff.html"
@@ -1096,9 +1096,9 @@ task serialization_xml(
   description: "Create the XML version of the specification",
   dependsOn: ["saxon_config"]
 ) {
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-xquery-serialization-40/src")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-xquery-serialization-40/style")
-  inputs.files fileTree(dir: "${projectDir}/style/identity.xsl")
+  inputs.dir "${projectDir}/specifications/xslt-xquery-serialization-40/src"
+  inputs.dir "${projectDir}/specifications/xslt-xquery-serialization-40/style"
+  inputs.file "${projectDir}/style/identity.xsl"
   outputs.file "${buildDir}/www/xslt-xquery-serialization-40/xslt-xquery-serialization-40.xml"
 
   doLast {
@@ -1117,8 +1117,8 @@ task serialization_html(
   dependsOn: ["serialization_xml", "setup_crossref_indexes", "saxon_config"],
   description: "Create the HTML and XHTML versions of the specification"
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-xquery-serialization-40/style")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xslt-xquery-serialization-40/style"
   inputs.file serialization_src
   outputs.file "${buildDir}/www/xslt-xquery-serialization-40/Overview.xml"
   outputs.file "${buildDir}/www/xslt-xquery-serialization-40/Overview.html"
@@ -1140,8 +1140,8 @@ task serialization_html_diff(
   description: "Create the HTML and XHTML versions of the specification (with diff markup)",
   dependsOn: ["saxon_config"]
 ) {
-  inputs.files fileTree(dir: "${projectDir}/style")
-  inputs.files fileTree(dir: "${projectDir}/specifications/xslt-xquery-serialization-40/style")
+  inputs.dir "${projectDir}/style"
+  inputs.dir "${projectDir}/specifications/xslt-xquery-serialization-40/style"
   inputs.file serialization_src
   outputs.file "${buildDir}/www/xslt-xquery-serialization-40/Overview-diff.xml"
   outputs.file "${buildDir}/www/xslt-xquery-serialization-40/Overview-diff.html"

--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,6 @@ task fo_merge(
 ) {
   inputs.dir "${projectDir}/specifications/xpath-functions-40/src"
   inputs.dir "${projectDir}/specifications/xpath-functions-40/style"
-  inputs.dir "${projectDir}/specifications/xpath-functions-40/images"
   outputs.file "${buildDir}/expanded/xpath-functions-40/xpath-functions-40.xml"
 
   doLast {

--- a/schema/xsl-query.dtd
+++ b/schema/xsl-query.dtd
@@ -149,6 +149,9 @@
 
 <!-- Allow a 'code' element to contain a 'var' element for italicised code -->
 <!ELEMENT code (%tech.pcd.mix;|var|emph)*>
+<!ATTLIST code
+        nobreak        (true|false)    "false"
+>
 
 <!ATTLIST issue
         id              ID		#REQUIRED


### PR DESCRIPTION
I had a brain cramp when I wrote the `build.gradle` file for this repository. This PR fixes that.

It also adds a `nobreak` attribute to the `code` element. The intent, not yet implemented, is that you can say

```
<code nobreak="true">some long, but not unreasonably long expression</code>
```

and the stylesheet will prevent a line break in the middle of the expression.