### PR TITLE
99 fn:equal() function to compare sequences and arrays

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -3902,7 +3902,7 @@ return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
                <fos:expression><eg>compare(
   'Strasse',
   'Straße',
-  collation(map{'lang':'de', 'strength':'primary'})
+  'http://www.w3.org/2013/collation/UCA?lang=de;strength=primary'
 )</eg></fos:expression>
                <fos:result>0</fos:result>
                <fos:postamble>The specified collation equates <quote>ss</quote> and the German
@@ -19860,7 +19860,7 @@ else +1</eg>
          </fos:example>
          <fos:example>
             <p>To sort a set of strings <code>$in</code> using Swedish collation:</p>
-            <eg>let $SWEDISH := collation(map{'lang':'se'})
+            <eg>let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
 return sort($in, $SWEDISH)</eg>
          </fos:example>
          <fos:example>
@@ -19874,7 +19874,7 @@ return sort($in, $SWEDISH)</eg>
                and then by decreasing salary:
             </p>
             <eg>sort($employees, 
-               collation(map{'lang':'se'}),
+  "http://www.w3.org/2013/collation/UCA?lang=se",
   (fn { name/last }, fn { xs:decimal(salary) }), 
   ("ascending", "descending"))</eg>
          </fos:example>
@@ -22197,133 +22197,7 @@ map {
       </fos:history>
    </fos:function>
 
-   <fos:function name="collation" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="collation" return-type="xs:anyURI">
-            <fos:arg name="options" type="map(*)"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Constructs a collation URI with requested properties</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The function is supplied with a map defining the properties required of 
-            the collation, and returns a collation URI with these properties.</p>
-         
-         
-         <p>In the case where the requested properties correspond to the properties
-            defined for the Unicode Collation Algorithm (see <specref ref="uca-collations"/>),
-            the returned URI will conform to the specification of UCA collation URIs 
-            as described in that section. In other cases it will return an 
-            implementation-dependent URI.</p>
-         
-         <p>The following options are defined. 
-            The <termref def="option-parameter-conventions">option parameter conventions</termref> 
-            apply.</p>
-         
-         <fos:options>
-            <fos:option key="fallback">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>true()</fos:default>
-            </fos:option>
-            <fos:option key="lang">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>xs:language</fos:type>
-               <fos:default>default-language()</fos:default>
-            </fos:option>
-            <fos:option key="version">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>()</fos:default>
-            </fos:option>
-            <fos:option key="strength">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>enum("primary", "secondary", "tertiary",
-               "quaternary", "identical", "1", "2", "3", "4", "5")</fos:type>
-               <fos:default>()</fos:default>
-            </fos:option>
-            <fos:option key="maxVariable">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>enum("space", "punct", "symbol",
-                  "currency")</fos:type>
-               <fos:default>"punct"</fos:default>
-            </fos:option>
-            <fos:option key="alternate">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>enum("non-ignorable", "shifted", "blanked",
-                  "currency")</fos:type>
-               <fos:default>"non-ignorable"</fos:default>
-            </fos:option>
-            <fos:option key="backwards">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false()</fos:default>
-            </fos:option>
-            <fos:option key="normalization">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false()</fos:default>
-            </fos:option>
-            <fos:option key="caseLevel">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false()</fos:default>
-            </fos:option>
-            <fos:option key="caseFirst">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>enum("upper","lower")</fos:type>
-               <fos:default>"lower"</fos:default>
-            </fos:option>
-            <fos:option key="numeric">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false()</fos:default>
-            </fos:option>
-            <fos:option key="reorder">
-               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>""</fos:default>
-            </fos:option>
-            
-         </fos:options>
-         
-         
-         <p>If no suitable collation is available, the function raises an error,
-         rather than returning a URI that fails when subsequently used.</p>
-         <p>There is no guarantee that the returned collation URI is usable
-         if used within a different execution scope.</p>
-         
-      </fos:rules>
-      <fos:errors>
-         <p>An error is raised <errorref class="CH" code="0002"/> 
-            if no collation is available with the required properties. </p>
-      </fos:errors>
 
-      <fos:examples role="wide">
-         <fos:example>
-            <fos:test>
-               <fos:expression>collation(map{'lang':'de'})</fos:expression>
-               <fos:result>"http://www.w3.org/2013/collation/UCA?lang=de"</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression>collation(map{'lang':'de', 'strength':'primary'})</fos:expression>
-               <fos:result>"http://www.w3.org/2013/collation/UCA?lang=de;strength=primary"</fos:result>
-            </fos:test>
-            
-         </fos:example>
-         <fos:example>
-            <p>The expression <code>collation(map{'lang':default-language()})</code>
-               returns a collation suitable for the default language in the
-               dynamic context.</p>
-         </fos:example>
-      </fos:examples>
-   </fos:function>
 
    <fos:function name="collation-key" prefix="fn">
       <fos:signatures>
@@ -22418,7 +22292,7 @@ map {
       </fos:notes>
       <fos:examples>
          <fos:variable name="C" id="v-collation-key-C"
-            select="collation(map{'strength':'primary'})"/>
+            select="'http://www.w3.org/2013/collation/UCA?strength=primary'"/>
          <fos:example>
             <fos:test use="v-collation-key-C">
                <fos:expression><eg>map:merge(
@@ -26767,7 +26641,7 @@ return deep-equal(
          <fos:example>
             <p>To sort an array of strings <code>$in</code> using Swedish collation:</p>
             <eg>
-               let $SWEDISH := collation(map{'lang':'se'})
+               let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
                return array:sort($in, $SWEDISH)
             </eg>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14189,6 +14189,162 @@ return contains-subsequence(
          <fos:version version="4.0">New in 4.0. Accepted 2022-11-01</fos:version>
       </fos:history>
    </fos:function>
+   
+   <fos:function name="equal" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="equal" return-type="xs:boolean">
+            <fos:arg name="value1" type="item()*" />
+            <fos:arg name="value2" type="item()*" />
+            <fos:arg name="compare" type="(function(item(), item(), xs:integer) as xs:boolean)?" default="()"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties arity="2">
+         <fos:property>deterministic</fos:property>
+         <fos:property dependency="collations implicit-timezone">context-dependent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:properties arity="3">
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Determines whether two values are equal, based on item-by-item comparison.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>Informally, the two input sequences are compared item-by-item using
+            the supplied comparison function; the function returns true only if the
+            two values are the same length and their items are pairwise equal.</p>
+ 
+         
+         <p>More formally, the function returns true if and only if (a) <code>count($value1) eq count($value2)</code>
+         and (b) <code>every $i in 1 to count($value1) satisfies op:item-compare($value1[$i], $value2[$i], $i)</code>,
+         where the function <code>op:item-compare($v1, $v2, $pos)</code> is defined as follows, taking the rules
+            in order:</p>
+         
+         <olist>
+            <item>
+               <p>If both items are arrays, return true if and only if both the following conditions
+                  are satisfied:</p>
+               <olist>
+                  <item><p><code>array:size($v1) eq array:size($v2)</code></p></item>
+                  <item><p><code>every(array:for-each-pair($v1, $v2), equal(?, ?, $compare))</code></p></item>
+               </olist>
+            </item>
+            <item>
+               <p>If both items are maps, return true if and only if both the following conditions are satisfied:</p>
+               <olist>
+                  <item><p><code>map:size($v1) eq map:size($v2)</code></p></item>
+                  <item><p><code>every $k in map:keys($v1) satisfies equal($v1($k), $v2($k), $compare)</code></p></item>
+               </olist>
+            </item>
+            <item><p>If both items are function items other than maps or arrays, return true
+               if and only if the function items are identical as defined in 
+               <xspecref spec="DM40" ref="function-items"/>.</p>
+            </item>
+            
+            <item><p>If both items are nodes, then:</p>
+               <ulist>
+                  <item><p>If the third argument (<code>$compare</code>) is supplied and non-empty,
+                     return the result of <code>$compare($v1, $v2, $pos)</code>.</p></item>
+                  <item><p>Otherwise return the result of <code>$v1 is $v2</code>.</p></item>
+               </ulist>
+            </item>
+ 
+            <item>
+               <p>If both items are atomic values, then:</p>
+               <ulist>
+                  <item><p>If the third argument (<code>$compare</code>) is supplied and non-empty,
+                     return the result of <code>$compare($v1, $v2, $pos)</code>.</p></item>
+                  <item><p>Otherwise return the result of <code>fn:atomic-equal($v1, $v2)</code>.</p></item>
+               </ulist>
+            </item>
+            
+            <item><p>Otherwise, return false.</p></item>
+         </olist>
+        
+         
+      </fos:rules>
+      <fos:errors>
+         <p>The function raises an error if and only if the caller-supplied <code>$compare</code>
+         function raises an error.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>When the <code>$compare</code> argument is defaulted, the function is context-free, 
+            error-free, and transitive.</p>
+         <p>The caller-supplied <code>$compare</code> function is called only to process
+            atomic values and nodes; it is never called to process arrays, maps, or other
+            function items.</p>
+         <p>If the caller-supplied <code>$compare</code> function uses the third (position)
+         argument, this will always be the 1-based position of an item within its immediately
+         containing sequence; the position of that sequence within a containing map or array
+         is not available.</p>
+      </fos:notes>
+      
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>equal((), ())</fos:expression>
+               <fos:result>true</fos:result>
+            </fos:test>    
+            <fos:test>
+               <fos:expression>equal((1,2,3), (1,2,4))</fos:expression>
+               <fos:result>false</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal((1,2,3), (1,2,3,4))</fos:expression>
+               <fos:result>false</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal([1,2,3], [1,2,3])</fos:expression>
+               <fos:result>true</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal([1,2,3], [1,2,3,4])</fos:expression>
+               <fos:result>false</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal([1,2,3], (1,2,3))</fos:expression>
+               <fos:result>false</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal(map{1:"x",2:"y"}, map{2:"y",1:"x"})</fos:expression>
+               <fos:result>true</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal(//x, //x)</fos:expression>
+               <fos:result>true</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal(fn:count#1, fn:count#1)</fos:expression>
+               <fos:result>true</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>equal(1.223344e0, 1.223345e0, 
+        fn($v1, $v2){round($v1, 4) eq round($v2, 4)}</eg></fos:expression>
+               <fos:result>true</fos:result>
+               <fos:postamble>The values are equal to four decimal places.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal([1, xs:double('NaN')], [1, xs:double('NaN")], op('eq'))</fos:expression>
+               <fos:result>false</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>equal(("Anne", "Bob", "Cathy"), ("A", "B", "C"), starts-with#2)</fos:expression>
+               <fos:result>true</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>equal(("A", 1, "B", 2), ("A", 5, "B", 7), 
+        fn($v1, $v2, $pos){$v1 eq $v2 or $pos mod 2 = 0})</eg></fos:expression>
+               <fos:result>true</fos:result>
+               <fos:postamble>Items in even-numbered positions are allowed to differ.</fos:postamble>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:history>
+         <fos:version version="4.0">New in 4.0</fos:version>
+      </fos:history>
+   </fos:function>
 
    <fos:function name="unordered" prefix="fn">
       <fos:signatures>
@@ -25144,7 +25300,7 @@ else $fallback($position)</eg>
          <fos:version version="4.0">Functionality unchanged in 4.0, but the specification has been formalized</fos:version>
       </fos:history>
    </fos:function>
-
+   
    <fos:function name="join" prefix="array">
       <fos:signatures>
          <fos:proto name="join" return-type="array(*)">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -3902,7 +3902,7 @@ return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
                <fos:expression><eg>compare(
   'Strasse',
   'Straße',
-  'http://www.w3.org/2013/collation/UCA?lang=de;strength=primary'
+  collation(map{'lang':'de', 'strength':'primary'})
 )</eg></fos:expression>
                <fos:result>0</fos:result>
                <fos:postamble>The specified collation equates <quote>ss</quote> and the German
@@ -19860,7 +19860,7 @@ else +1</eg>
          </fos:example>
          <fos:example>
             <p>To sort a set of strings <code>$in</code> using Swedish collation:</p>
-            <eg>let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
+            <eg>let $SWEDISH := collation(map{'lang':'se'})
 return sort($in, $SWEDISH)</eg>
          </fos:example>
          <fos:example>
@@ -19874,7 +19874,7 @@ return sort($in, $SWEDISH)</eg>
                and then by decreasing salary:
             </p>
             <eg>sort($employees, 
-  "http://www.w3.org/2013/collation/UCA?lang=se",
+               collation(map{'lang':'se'}),
   (fn { name/last }, fn { xs:decimal(salary) }), 
   ("ascending", "descending"))</eg>
          </fos:example>
@@ -22197,7 +22197,133 @@ map {
       </fos:history>
    </fos:function>
 
+   <fos:function name="collation" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="collation" return-type="xs:anyURI">
+            <fos:arg name="options" type="map(*)"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Constructs a collation URI with requested properties</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function is supplied with a map defining the properties required of 
+            the collation, and returns a collation URI with these properties.</p>
+         
+         
+         <p>In the case where the requested properties correspond to the properties
+            defined for the Unicode Collation Algorithm (see <specref ref="uca-collations"/>),
+            the returned URI will conform to the specification of UCA collation URIs 
+            as described in that section. In other cases it will return an 
+            implementation-dependent URI.</p>
+         
+         <p>The following options are defined. 
+            The <termref def="option-parameter-conventions">option parameter conventions</termref> 
+            apply.</p>
+         
+         <fos:options>
+            <fos:option key="fallback">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>true()</fos:default>
+            </fos:option>
+            <fos:option key="lang">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>xs:language</fos:type>
+               <fos:default>default-language()</fos:default>
+            </fos:option>
+            <fos:option key="version">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="strength">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>enum("primary", "secondary", "tertiary",
+               "quaternary", "identical", "1", "2", "3", "4", "5")</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="maxVariable">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>enum("space", "punct", "symbol",
+                  "currency")</fos:type>
+               <fos:default>"punct"</fos:default>
+            </fos:option>
+            <fos:option key="alternate">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>enum("non-ignorable", "shifted", "blanked",
+                  "currency")</fos:type>
+               <fos:default>"non-ignorable"</fos:default>
+            </fos:option>
+            <fos:option key="backwards">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false()</fos:default>
+            </fos:option>
+            <fos:option key="normalization">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false()</fos:default>
+            </fos:option>
+            <fos:option key="caseLevel">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false()</fos:default>
+            </fos:option>
+            <fos:option key="caseFirst">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>enum("upper","lower")</fos:type>
+               <fos:default>"lower"</fos:default>
+            </fos:option>
+            <fos:option key="numeric">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false()</fos:default>
+            </fos:option>
+            <fos:option key="reorder">
+               <fos:meaning>See <specref ref="uca-collations"/>.</fos:meaning>
+               <fos:type>xs:string</fos:type>
+               <fos:default>""</fos:default>
+            </fos:option>
+            
+         </fos:options>
+         
+         
+         <p>If no suitable collation is available, the function raises an error,
+         rather than returning a URI that fails when subsequently used.</p>
+         <p>There is no guarantee that the returned collation URI is usable
+         if used within a different execution scope.</p>
+         
+      </fos:rules>
+      <fos:errors>
+         <p>An error is raised <errorref class="CH" code="0002"/> 
+            if no collation is available with the required properties. </p>
+      </fos:errors>
 
+      <fos:examples role="wide">
+         <fos:example>
+            <fos:test>
+               <fos:expression>collation(map{'lang':'de'})</fos:expression>
+               <fos:result>"http://www.w3.org/2013/collation/UCA?lang=de"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>collation(map{'lang':'de', 'strength':'primary'})</fos:expression>
+               <fos:result>"http://www.w3.org/2013/collation/UCA?lang=de;strength=primary"</fos:result>
+            </fos:test>
+            
+         </fos:example>
+         <fos:example>
+            <p>The expression <code>collation(map{'lang':default-language()})</code>
+               returns a collation suitable for the default language in the
+               dynamic context.</p>
+         </fos:example>
+      </fos:examples>
+   </fos:function>
 
    <fos:function name="collation-key" prefix="fn">
       <fos:signatures>
@@ -22292,7 +22418,7 @@ map {
       </fos:notes>
       <fos:examples>
          <fos:variable name="C" id="v-collation-key-C"
-            select="'http://www.w3.org/2013/collation/UCA?strength=primary'"/>
+            select="collation(map{'strength':'primary'})"/>
          <fos:example>
             <fos:test use="v-collation-key-C">
                <fos:expression><eg>map:merge(
@@ -26641,7 +26767,7 @@ return deep-equal(
          <fos:example>
             <p>To sort an array of strings <code>$in</code> using Swedish collation:</p>
             <eg>
-               let $SWEDISH := "http://www.w3.org/2013/collation/UCA?lang=se"
+               let $SWEDISH := collation(map{'lang':'se'})
                return array:sort($in, $SWEDISH)
             </eg>
          </fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -2617,11 +2617,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                   </tbody>
                </table>
                
-               <note><p>This list excludes parameters that are inconvenient to express in a URI, 
-                  or that are applicable only to substring matching.</p></note>
-               
-               <p>UCA collation URIs can be conveniently generated using the
-                  <code>fn:collation</code> function.</p>
+               <note><p>This list excludes parameters that are inconvenient to express in a URI, or that are applicable only to substring matching.</p></note>
             </div3>
             <div3 id="html-ascii-case-insensitive-collation" diff="chg" at="issue668">
                <head>The HTML ASCII Case-Insensitive Collation</head>
@@ -2708,9 +2704,6 @@ string conversion of the number as obtained above, and the appropriate <var>suff
             </div3>
             <div3 id="func-codepoint-equal">
                <head><?function fn:codepoint-equal?></head>
-            </div3>
-            <div3 id="func-collation">
-               <head><?function fn:collation?></head>
             </div3>
             <div3 id="func-collation-key">
                <head><?function fn:collation-key?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -2617,7 +2617,11 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                   </tbody>
                </table>
                
-               <note><p>This list excludes parameters that are inconvenient to express in a URI, or that are applicable only to substring matching.</p></note>
+               <note><p>This list excludes parameters that are inconvenient to express in a URI, 
+                  or that are applicable only to substring matching.</p></note>
+               
+               <p>UCA collation URIs can be conveniently generated using the
+                  <code>fn:collation</code> function.</p>
             </div3>
             <div3 id="html-ascii-case-insensitive-collation" diff="chg" at="issue668">
                <head>The HTML ASCII Case-Insensitive Collation</head>
@@ -2704,6 +2708,9 @@ string conversion of the number as obtained above, and the appropriate <var>suff
             </div3>
             <div3 id="func-codepoint-equal">
                <head><?function fn:codepoint-equal?></head>
+            </div3>
+            <div3 id="func-collation">
+               <head><?function fn:collation?></head>
             </div3>
             <div3 id="func-collation-key">
                <head><?function fn:collation-key?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5527,18 +5527,21 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-atomic-equal">
                <head><?function fn:atomic-equal?></head>
             </div3>
-            <div3 id="func-deep-equal">
-               <head><?function fn:deep-equal?></head>
-            </div3>
             <div3 id="func-compare">
                <head><?function fn:compare?></head>
+            </div3>
+            <div3 id="func-deep-equal">
+               <head><?function fn:deep-equal?></head>
             </div3>
             <div3 id="func-distinct-values">
                <head><?function fn:distinct-values?></head>
             </div3>  
             <div3 id="func-duplicate-values">
                <head><?function fn:duplicate-values?></head>
-            </div3>  
+            </div3>
+            <div3 id="func-equal">
+               <head><?function fn:equal?></head>
+            </div3>
             <div3 id="func-index-of">
                <head><?function fn:index-of?></head>
             </div3>


### PR DESCRIPTION
Fix issue #99 

Introduces a function fn:equal() that compares two arbitrary values (sequences, maps, arrays, etc), with a callback for comparing "leaf" items in the structure.