### PR TITLE
Fix broken idref to escaped-crlf in test generation

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23748,7 +23748,7 @@ return csv-to-arrays(
          </fos:example>
          <fos:example>
             <p>Non-default quote character:</p>
-            <fos:test use="escaped-crlf">
+            <fos:test use="escaped-crlf-3">
                <fos:expression><eg>csv-to-arrays(string-join(
    "|name|,|city|",
    "|Bob|,|Berlin|"), char('\n')), 
@@ -23761,7 +23761,7 @@ return csv-to-arrays(
          </fos:example>
          <fos:example>
             <p>Trimming whitespace in fields:</p>
-            <fos:test use="escaped-crlf">
+            <fos:test use="escaped-crlf-3">
                <fos:expression><eg>csv-to-arrays(string-join(
     "name  ,city    ",
     "Bob   ,Berlin  ",


### PR DESCRIPTION
It appears that `escaped-crlf-3` might have been intended. @michaelhkay ?