### PR TITLE
859 lookup syntax problems

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2089,10 +2089,6 @@ ErrorVal ::= "$" VarName
   
   <g:production name="LookupWildcard">
     <g:string process-value="yes">*</g:string>
-    <g:optional>
-      <g:string>::</g:string>
-      <g:ref name="SequenceType"/>
-    </g:optional>
   </g:production>
 
   <g:production name="ArrowStaticFunction">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16158,14 +16158,10 @@ processing with JSON processing.</p>
                      </item>
                      <item>
                         <p diff="chg" at="2023-11-15">If <code>KS</code> is a wildcard
-                           (<code>*</code>) qualified by a SequenceType <var>ST</var>, 
+                           (<code>*</code>), 
                            the result is given by the following expression:</p>
-                        <eg diff="chg" at="2023-11-15"><![CDATA[
-for $k in 1 to array:size($V)
-let $m := array:get($V, $k)
-return if ($m instance of ST) { $m } 
-]]></eg>
-                        <p diff="add" at="2023-11-15">If no SequenceType is provided, it defaults to <code>item()*</code>.</p>
+
+                        <eg diff="chg" at="2024-03-21"><![CDATA[array:values($V)]]></eg>
                         <note>
                            <p>Note that array items are returned in order.</p>
                         </note>
@@ -16199,11 +16195,11 @@ return if ($m instance of ST) { $m }
                         </item>
                         <item>
                            <p diff="chg" at="2023-11-15">If the <nt def="KeySpecifier"
-                              >KeySpecifier</nt> is a wildcard (<code>*</code>) qualified by a SequenceType <var>ST</var>, 
+                              >KeySpecifier</nt> is a wildcard (<code>*</code>), 
                               the result is given by the following expression:</p>
-                           <eg diff="chg" at="2023-11-15"><![CDATA[map:for-each($V, function($k, $v) { if ($v instance of ST) { $v } })]]></eg>
-                           <p diff="add" at="2023-11-15">If no SequenceType is provided, it defaults to <code>item()*</code>.</p>
-                           <note>
+
+                           <eg diff="chg" at="2023-11-15"><![CDATA[map:values($V)]]></eg>
+                          <note>
                               <p>The order of entries in <code>map:for-each</code> is implementation-dependent,
                                  so the order of values in the result sequence is also implementation-dependent.</p>
                            </note>
@@ -16287,11 +16283,13 @@ return if ($m instance of ST) { $m }
                   <item>
                      <p>If the context item is the result of parsing the JSON input:</p>
                      <eg>{
+
   "name": "John Smith",
   "address": { "street": "18 Acacia Avenue", "postcode": "MK12 2EX" },
   "previous-address": { "street": "12 Seaview Road", "postcode": "EX8 9AA" }
 }</eg>
-                     <p>then <code>?*::record(street, postcode)?postcode</code>
+
+                     <p>then <code>?*[. instance of record(street, postcode)]?postcode</code>
                         returns <code>("MK12 2EX", "EX8 9AA")</code> (or some permutation thereof).</p>
                      <note><p>Writing <code>?*?postcode</code> would raise a type error, because the result of the initial
                         step <code>?*</code> includes an item (the string <code>"John Smith"</code>) that is neither
@@ -16348,17 +16346,19 @@ return if ($m instance of ST) { $m }
                   </item>
                   <item>
                      <p>
-                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*::array(*)</code> evaluates to <code>([ 1, 2, 3 ])</code>
+
+                        <code>[ [1, 2, 3], 4, 5 ]?*[. instance of array(*)]</code> evaluates to <code>([1, 2, 3])</code>
+                        </p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], 7 ]?*[. instance of array(*)]?2</code> evaluates to <code>(2, 5)</code>
                      </p>
                   </item>
                   <item>
                      <p>
-                        <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], 7 ]?*::array(*)?2</code> evaluates to <code>(2, 5)</code>
-                     </p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*::xs:integer</code> evaluates to <code>(4, 5)</code>
+                        <code>[ [ 1, 2, 3 ], 4, 5 ]?*[. instance of xs:integer]</code> 
+                        evaluates to <code>(4, 5)</code>.
                      </p>
                   </item>
                </ulist>
@@ -16513,8 +16513,9 @@ declare function recursive-content($item as item()) as map(*)* {
                   names of two cities that are present in this table, the distance between the
                   two cities can be obtained with the expression:</p> 
                      
-                     <eg>$tree ??$from ??*::record(to, distance) [?to = $to] ?distance</eg>
-                  
+
+                     <eg>$tree ??$from ??*[. instance of record(to, distance)][?to=$to] ?distance</eg>
+                 
                   <p>The names of all pairs of cities whose distance is represented in the data
                   can be obtained with the expression:</p>
                   


### PR DESCRIPTION
Fix the syntax ambiguity identified in issue #859 by dropping the troublesome construct.

It is hoped something else will be introduced in its place.

Fix #859