### PR TITLE
1110-partial New error codes

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4898,7 +4898,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          </fos:options>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised ([TODO: error code]) if the effective value of the option
+         <p>A dynamic error is raised <errorref class="HA" code="0001"/> if the effective value of the option
                <code>algorithm</code> is not one of the values supported by the implementation.</p>
       </fos:errors>
       <fos:notes>
@@ -20178,7 +20178,8 @@ declare function transitive-closure (
          <p>For example, <code>op("+")</code> returns <code>function($x, $y) { $x + $y }</code>.</p>
       </fos:rules>
       <fos:errors>
-         <p>A dynamic error is raised if the supplied argument is not one of the supported operators ([TODO: error code]).
+         <p>A type error is raised <xerrorref spec="XP" class="TY" code="0004" type="type"/> if the
+            supplied argument is not one of the supported operators.
          </p>
       </fos:errors>
       <fos:notes>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11359,6 +11359,11 @@ ISBN 0 521 77752 6.</bibl>
 			   selects a component that is not present in a date, or if the picture string supplied to <code>fn:format-time</code> 
 			   selects a component that is not present in a time.</p>
             </error>
+
+            <error class="HA" code="0001" label="Invalid algorithm." type="dynamic">
+               <p>Raised by <code>fn:hash</code> if the effective value of the supplied
+               algorithm is not one of the values supported by the implementation.</p>
+            </error>
             
             <error class="JS" code="0001" label="JSON syntax error." type="dynamic">
                <p>Raised by functions such as <code>fn:json-doc</code>, <code>fn:parse-json</code> 


### PR DESCRIPTION
Issue: #1110.

* [fn:hash](https://qt4cg.org/specifications/xpath-functions-40/Overview-diff.html#func-hash): I added `FOHA0001` as error code.
* [fn:op](https://qt4cg.org/specifications/xpath-functions-40/Overview-diff.html#func-op): I used `XPTY0004` as error code, as the allowed operators could also be defined as string enumeration.
* [XQuery, Map Test](https://qt4cg.org/specifications/xquery-40/xquery-40-diff.html#id-map-test): Not included in this PR.
