### PR TITLE
1116 Add options param to unparsed-text

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17085,13 +17085,13 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <fos:values>
                   <fos:value value="false">No normalization of line endings takes place.
                   </fos:value>
-                  <fos:value value="true">The character sequences CR (<code>U+000D</code>)
-                     and CRLF (<code>U+000D, U+000A</code>) are converted to the
-                     character NL (<code>U+000A</code>).
+                  <fos:value value="true">The character <char>U+000D</char>
+                     and the character pair (<char>U+000D</char>, <char>U+000A</char>) are converted to the
+                     single character <char>U+000A</char>.
                   </fos:value>
                </fos:values>
             </fos:option>
-            <fos:option key="deterministic">
+            <!--<fos:option key="deterministic">
                <fos:meaning>Determines whether multiple calls on the function
                   specifying the same arguments are required to return
                   the same result.</fos:meaning>
@@ -17105,7 +17105,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                      return the same result.
                   </fos:value>
                </fos:values>
-            </fos:option>
+            </fos:option>-->
          </fos:options>
                 
          <p>The mapping of URIs to the string representation of a resource is the mapping defined in
@@ -17153,13 +17153,13 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p>The result of the function is a string containing the string representation of the
             resource retrieved using the URI, decoded according to the specified encoding.</p>
          
-         <p>Two or more calls on <code>fn:unparsed-text</code>, <code>fn:unparsed-text-lines</code>,
+         <!--<p>Two or more calls on <code>fn:unparsed-text</code>, <code>fn:unparsed-text-lines</code>,
          or <code>fn:unparsed-text-available</code> within the same <termref def="execution-scope"/>
             specifying equivalent URIs must return consistent results if all the calls 
             specify (or default to) <code>deterministic</code> = <code>true</code>.
             For this purpose URIs are equivalent if they resolve to the same absolute URI
             when resolved. If the <code>deterministic</code> option is set to <code>false</code>
-            there is no requirement that the results be consistent.</p>
+            there is no requirement that the results be consistent.</p>-->
          
       </fos:rules>
       <fos:errors>
@@ -17311,12 +17311,12 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </eg>
  
          <p>The result is thus a sequence of strings containing the text of the resource retrieved
-            using the URI, each string representing one line of text. The line endings <code>x0D</code> 
-            and <code>0x0D, 0x0A</code> are treated as equivalent <code>xOA</code>.
-            Newline characters <code>xOA</code> are not
+            using the URI, each string representing one line of text. The line endings <char>U+000D</char> 
+            and (<char>U+000D</char>, <char>U+000A</char>) are treated as equivalent to <char>U+000A</char>.
+            Line ending characters are not
             included in the returned strings. If there are two adjacent newline sequences, a
             zero-length string will be returned to represent the empty line; but if the external
-            resource ends with a newline character, the result will be as if this final
+            resource ends with a newline sequence, the result will be as if this final
             line ending were not present.</p>
       </fos:rules>
       <fos:errors>
@@ -17362,7 +17362,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             identified by the absolute URI may change over time, even within the same execution
             scope, which means that a call on <code>fn:unparsed-text-available</code> that returns true
             may be followed by a call on <code>fn:unparsed-text</code> that fails, or vice versa.</p>
-         <!--<p>The functions <code>fn:unparsed-text</code> and
+         <p>The functions <code>fn:unparsed-text</code> and
                <code>fn:unparsed-text-available</code> have the same requirement for
                <termref
                def="dt-deterministic"
@@ -17373,7 +17373,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             transformation <rfc2119>must</rfc2119> return the same results each time; moreover, the
             results of a call on <code>fn:unparsed-text-available</code>
             <rfc2119>must</rfc2119> be consistent with the results of a subsequent call on
-               <code>unparsed-text</code> with the same arguments.</p>-->
+               <code>unparsed-text</code> with the same arguments.</p>
       </fos:rules>
       <fos:notes>
          <p>This function was introduced before XQuery and XSLT allowed errors to be caught;
@@ -17397,7 +17397,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:notes>
       <fos:history>
          <fos:version version="4.0">Changed in 4.0: the options parameter is added.</fos:version>
-      </fos:history>|
+      </fos:history>
 
    </fos:function>
    <fos:function name="environment-variable" prefix="fn">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17045,11 +17045,11 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="unparsed-text" return-type="xs:string?">
             <fos:arg name="href" type="xs:string?"/>
-            <fos:arg name="encoding" type="xs:string?" default="()"/>
+            <fos:arg name="options" type="item()?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>deterministic</fos:property>
+         <fos:property>nondeterministic</fos:property>
          <fos:property dependency="static-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -17063,6 +17063,51 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <rfc2119>must</rfc2119> identify a resource for which a string representation is
             available. If the URI is a relative URI reference, then it is resolved relative to the
             <term>static base URI</term> property from the static context.</p>
+         <p>The <code>$options</code> argument, for backwards compatibility reasons, may be supplied
+         either as a map, or as a string. Supplying a value <code>$S</code> that is not a map
+            is equivalent to supplying the map <code>map{"encoding":$S}</code>.
+            After that substitution, the <termref def="option-parameter-conventions"/> apply.</p>
+         
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         
+         <fos:options>
+            <fos:option key="encoding">
+               <fos:meaning>Defines the encoding of the resource, as described below.
+               </fos:meaning>
+               <fos:type>xs:string?</fos:type>
+               <fos:default>()</fos:default>
+            </fos:option>
+            <fos:option key="normalize-newlines">
+               <fos:meaning>Determines whether CR and CRLF character sequences
+                  are treated as equivalent to NL characters.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">No normalization of line endings takes place.
+                  </fos:value>
+                  <fos:value value="true">The character sequences CR (<code>U+000D</code>)
+                     and CRLF (<code>U+000D, U+000A</code>) are converted to the
+                     character NL (<code>U+000A</code>).
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="deterministic">
+               <fos:meaning>Determines whether multiple calls on the function
+                  specifying the same arguments are required to return
+                  the same result.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>true</fos:default>
+               <fos:values>
+                  <fos:value value="false">The function is not deterministic; multiple
+                  calls with the same arguments are not required to return the same result.</fos:value>
+                  <fos:value value="true">Multiple calls specifying the same arguments,
+                     within the same <termref def="execution-scope"/>, are required to 
+                     return the same result.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+         </fos:options>
+                
          <p>The mapping of URIs to the string representation of a resource is the mapping defined in
             the <xtermref
                spec="XP31" ref="dt-available-text-resources"
@@ -17070,9 +17115,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                resources</xtermref> component of the dynamic context.</p>
          <p>If the <code>$href</code> argument is an empty sequence, the function
             returns an empty sequence.</p>
-         <p>The <code>$encoding</code> argument, if present 
+         <p>The <code>encoding</code> option, if present 
             <phrase diff="add" at="2022-12-19"> and non-empty</phrase>, is the name of an encoding. The values
-            for this attribute follow the same rules as for the <code>encoding</code> attribute in
+            for this option follow the same rules as for the <code>encoding</code> attribute in
             an XML declaration. The only values which every
             implementation is <rfc2119>required</rfc2119> to recognize are
                <code>utf-8</code> and <code>utf-16</code>.</p>
@@ -17094,7 +17139,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                      ref="xml"/>, otherwise</p>
             </item>
             <item>
-               <p>the <code>$encoding</code> argument is used if present, otherwise</p>
+               <p>the <code>encoding</code> option is used if present, otherwise</p>
             </item>
             <item>
                <p>the processor <rfc2119>may</rfc2119> use <termref def="implementation-defined"
@@ -17106,12 +17151,16 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </item>
          </olist>
          <p>The result of the function is a string containing the string representation of the
-            resource retrieved using the URI.</p>
-         <p diff="add" at="2023-05-19">End-of-line characters are normalized as known from the
-            <xspecref spec="XML" ref="sec-line-ends">end-of-line handling</xspecref> in <bibref ref="xml"/>,
-            by translating both the two-character sequence <code>x0D</code> <code>x0A</code>
-            and any <code>x0D</code> that is not followed by <code>x0A</code>
-            to a single <code>x0A</code> character.</p>
+            resource retrieved using the URI, decoded according to the specified encoding.</p>
+         
+         <p>Two or more calls on <code>fn:unparsed-text</code>, <code>fn:unparsed-text-lines</code>,
+         or <code>fn:unparsed-text-available</code> within the same <termref def="execution-scope"/>
+            specifying equivalent URIs must return consistent results if all the calls 
+            specify (or default to) <code>deterministic</code> = <code>true</code>.
+            For this purpose URIs are equivalent if they resolve to the same absolute URI
+            when resolved. If the <code>deterministic</code> option is set to <code>false</code>
+            there is no requirement that the results be consistent.</p>
+         
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="UT" code="1170"
@@ -17122,16 +17171,16 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             representation of a resource. </p>
          <p diff="chg" at="2023-06-12">A dynamic error is raised <errorref class="UT" code="1190"
             /> if the value of the
-            <code>$encoding</code> argument is not a valid encoding name, if the
+            <code>encoding</code> option is not a valid encoding name, if the
             processor does not support the specified encoding, if
             the string representation of the retrieved resource contains octets that cannot be
             decoded into Unicode <termref def="character">characters</termref> using the specified
             encoding, or if any resulting character is not a
             <termref def="dt-permitted-character">permitted character</termref>.</p>
          <p>A dynamic error is raised <errorref class="UT" code="1200"
-            /> if <code>$encoding</code>
+            /> if the <code>encoding</code> option
             is absent and the processor cannot infer the
-            encoding using external information and the encoding is not UTF-8.</p>
+            encoding using external information and the actual encoding is not UTF-8.</p>
       </fos:errors>
 
       <fos:notes>
@@ -17171,8 +17220,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   fallback document provided by the error handler.</p>
             </item>
             <item>
-               <p>Implementations may provide user options that relax the requirement for the
-                  function to return deterministic results.</p>
+               <p>For backwards compatibility reasons, implementations may provide 
+                  configuration options that alter the default for the <code>deterministic</code>
+                  option.</p>
             </item>
          </ulist>
 
@@ -17223,7 +17273,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </fos:example>
       </fos:examples>
       <fos:history>
-         <fos:version version="4.0">Changed in 4.0: end-of-line characters in the input are normalized.</fos:version>
+         <fos:version version="4.0">Changed in 4.0: the options parameter is added.</fos:version>
       </fos:history>
 
    </fos:function>
@@ -17231,11 +17281,11 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="unparsed-text-lines" return-type="xs:string*">
             <fos:arg name="href" type="xs:string?"/>
-            <fos:arg name="encoding" type="xs:string?" default="()"/>
+            <fos:arg name="options" type="item()?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>deterministic</fos:property>
+         <fos:property>nondeterministic</fos:property>
          <fos:property dependency="static-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -17247,17 +17297,22 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:rules>
          <p>The <code>unparsed-text-lines</code> function reads an external resource (for example, a
             file) and returns its string representation as a sequence of strings, separated at
-            newline boundaries. </p>
-         <!-- The line-end normalization of 4.0's unparsed-text requires a simplification of 
-            the regular expression, lest users think that  -->
-         <p diff="chg" at="2024-12-26">The result of the single-argument function is the same as the result of the expression
-               <code>fn:tokenize(fn:unparsed-text($href), '\n')[not(position()=last() and
-               .='')]</code>. The result of the two-argument function is the same as the result of
-            the expression <code>fn:tokenize(fn:unparsed-text($href, $encoding),
-               '\n')[not(position()=last() and .='')]</code>. </p>
+            newline boundaries.</p>
+         <p>The <code>$options</code> argument is interpreted in the same way as the <code>$options</code>
+         argument of <code>fn:unparsed-text</code>. In particular, for backwards compatibility,
+            the supplied argument may be either a string (the name of an encoding) or a map.
+         The option <code>normalize-newlines</code> option may be present, but has no effect.</p>
+         
+         <p diff="chg" at="2024-03-25">The result of the function is the same as the result of the expression:</p>
+         
+         <eg>(fn:unparsed-text($href, map:put($options, 'normalize-newlines', true()))
+   => fn:tokenize('\n'))
+   [not(position()=last() and .='')]
+         </eg>
+ 
          <p>The result is thus a sequence of strings containing the text of the resource retrieved
-            using the URI, each string representing one line of text. End-of-line <code>x0D</code> is
-            removed or converted to <code>x0A</code> following the rules of <code>fn:unparsed-text</code>. 
+            using the URI, each string representing one line of text. The line endings <code>x0D</code> 
+            and <code>0x0D, 0x0A</code> are treated as equivalent <code>xOA</code>.
             Newline characters <code>xOA</code> are not
             included in the returned strings. If there are two adjacent newline sequences, a
             zero-length string will be returned to represent the empty line; but if the external
@@ -17277,7 +17332,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="unparsed-text-available" return-type="xs:boolean">
             <fos:arg name="href" type="xs:string?"/>
-            <fos:arg name="encoding" type="xs:string?" default="()"/>
+            <fos:arg name="options" type="item()?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17286,9 +17341,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Because errors in evaluating the <code>fn:unparsed-text</code> function are
-            non-recoverable, these two functions are provided to allow an application to determine
-            whether a call with particular arguments would succeed.</p>
+         <p>Allows an application to determine
+            whether a call on <code>fn:unparsed-text</code> with particular arguments 
+            would succeed.</p>
       </fos:summary>
       <fos:rules>
          <p>The <code>fn:unparsed-text-available</code> function determines whether a call
@@ -17296,10 +17351,18 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             return a string.</p>
          <p>If the first argument is an empty sequence, the function returns <code>false</code>. </p>
          <p>In other cases, the function returns <code>true</code> if a call on
-               <code>fn:unparsed-text</code> with the same arguments would succeed, and
-            <code>false</code> if a call on <code>fn:unparsed-text</code> with the same arguments would
+               <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>
+            with the same arguments would succeed, and
+            <code>false</code> if a call on <code>fn:unparsed-text</code> 
+            or <code>fn:unparsed-text-lines</code> with the same arguments would
             fail with a non-recoverable dynamic error.</p>
-         <p>The functions <code>fn:unparsed-text</code> and
+         <p>If the <code>deterministic</code> option is set to true (which is the default), 
+            this is an absolute guarantee.
+            If the option is set to false, then the availability of the resource
+            identified by the absolute URI may change over time, even within the same execution
+            scope, which means that a call on <code>fn:unparsed-text-available</code> that returns true
+            may be followed by a call on <code>fn:unparsed-text</code> that fails, or vice versa.</p>
+         <!--<p>The functions <code>fn:unparsed-text</code> and
                <code>fn:unparsed-text-available</code> have the same requirement for
                <termref
                def="dt-deterministic"
@@ -17310,10 +17373,13 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             transformation <rfc2119>must</rfc2119> return the same results each time; moreover, the
             results of a call on <code>fn:unparsed-text-available</code>
             <rfc2119>must</rfc2119> be consistent with the results of a subsequent call on
-               <code>unparsed-text</code> with the same arguments.</p>
+               <code>unparsed-text</code> with the same arguments.</p>-->
       </fos:rules>
       <fos:notes>
-         <p>This requires that the <code>fn:unparsed-text-available</code> function should
+         <p>This function was introduced before XQuery and XSLT allowed errors to be caught;
+            with current versions of these host languages, catching an error from
+            <code>fn:unparsed-text</code> may provide a better alternative.</p>
+         <p>The specification requires that the <code>fn:unparsed-text-available</code> function should
             actually attempt to read the resource identified by the URI, and check that it is
             correctly encoded and contains no characters that are invalid in XML. Implementations
             may avoid the cost of repeating these checks for example by caching the validated
@@ -17326,8 +17392,12 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             exactly the same circumstances as <code>fn:unparsed-text</code>, the
                <code>fn:unparsed-text-available</code> function may equally be used to test
             whether a call on <code>fn:unparsed-text-lines</code> would succeed.</p>
+         <p></p>
 
       </fos:notes>
+      <fos:history>
+         <fos:version version="4.0">Changed in 4.0: the options parameter is added.</fos:version>
+      </fos:history>|
 
    </fos:function>
    <fos:function name="environment-variable" prefix="fn">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17049,7 +17049,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>nondeterministic</fos:property>
+         <fos:property>deterministic</fos:property>
          <fos:property dependency="static-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -17091,21 +17091,6 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   </fos:value>
                </fos:values>
             </fos:option>
-            <!--<fos:option key="deterministic">
-               <fos:meaning>Determines whether multiple calls on the function
-                  specifying the same arguments are required to return
-                  the same result.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>true</fos:default>
-               <fos:values>
-                  <fos:value value="false">The function is not deterministic; multiple
-                  calls with the same arguments are not required to return the same result.</fos:value>
-                  <fos:value value="true">Multiple calls specifying the same arguments,
-                     within the same <termref def="execution-scope"/>, are required to 
-                     return the same result.
-                  </fos:value>
-               </fos:values>
-            </fos:option>-->
          </fos:options>
                 
          <p>The mapping of URIs to the string representation of a resource is the mapping defined in
@@ -17153,13 +17138,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p>The result of the function is a string containing the string representation of the
             resource retrieved using the URI, decoded according to the specified encoding.</p>
          
-         <!--<p>Two or more calls on <code>fn:unparsed-text</code>, <code>fn:unparsed-text-lines</code>,
-         or <code>fn:unparsed-text-available</code> within the same <termref def="execution-scope"/>
-            specifying equivalent URIs must return consistent results if all the calls 
-            specify (or default to) <code>deterministic</code> = <code>true</code>.
-            For this purpose URIs are equivalent if they resolve to the same absolute URI
-            when resolved. If the <code>deterministic</code> option is set to <code>false</code>
-            there is no requirement that the results be consistent.</p>-->
+         
          
       </fos:rules>
       <fos:errors>
@@ -17285,7 +17264,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>nondeterministic</fos:property>
+         <fos:property>deterministic</fos:property>
          <fos:property dependency="static-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -17300,8 +17279,13 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             newline boundaries.</p>
          <p>The <code>$options</code> argument is interpreted in the same way as the <code>$options</code>
          argument of <code>fn:unparsed-text</code>. In particular, for backwards compatibility,
-            the supplied argument may be either a string (the name of an encoding) or a map.
-         The option <code>normalize-newlines</code> option may be present, but has no effect.</p>
+            the supplied argument may be either a string (the name of an encoding) or a map.</p>
+         
+         <p>If the <code>normalize-newlines</code> option is set to true, then 
+            the single character <char>U+000A</char>, the single character <char>U+000D</char>,
+            and the character pair (<char>U+000D</char>, <char>U+000A</char>) are all recognized
+            as line delimiters for the purpose of splitting the text into lines. If the option
+            is set to false, then only the single character <char>U+000A</char> is recognized.</p>
          
          <p diff="chg" at="2024-03-25">The result of the function is the same as the result of the expression:</p>
          
@@ -17311,8 +17295,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </eg>
  
          <p>The result is thus a sequence of strings containing the text of the resource retrieved
-            using the URI, each string representing one line of text. The line endings <char>U+000D</char> 
-            and (<char>U+000D</char>, <char>U+000A</char>) are treated as equivalent to <char>U+000A</char>.
+            using the URI, each string representing one line of text. 
             Line ending characters are not
             included in the returned strings. If there are two adjacent newline sequences, a
             zero-length string will be returned to represent the empty line; but if the external
@@ -17356,12 +17339,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             <code>false</code> if a call on <code>fn:unparsed-text</code> 
             or <code>fn:unparsed-text-lines</code> with the same arguments would
             fail with a non-recoverable dynamic error.</p>
-         <p>If the <code>deterministic</code> option is set to true (which is the default), 
-            this is an absolute guarantee.
-            If the option is set to false, then the availability of the resource
-            identified by the absolute URI may change over time, even within the same execution
-            scope, which means that a call on <code>fn:unparsed-text-available</code> that returns true
-            may be followed by a call on <code>fn:unparsed-text</code> that fails, or vice versa.</p>
+         
          <p>The functions <code>fn:unparsed-text</code> and
                <code>fn:unparsed-text-available</code> have the same requirement for
                <termref

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17045,7 +17045,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="unparsed-text" return-type="xs:string?">
             <fos:arg name="href" type="xs:string?"/>
-            <fos:arg name="options" type="item()?" default="()"/>
+            <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>


### PR DESCRIPTION
Reverts the change to unparsed-text and unparsed-text-lines so they no longer normalise line endings by default.

Instead an options parameter is added to select this as a non-default behaviour.

At the same time, we add an option to control whether the function is deterministic (that is, returns the same content if called repeatedly with the same URI). In 3.1 the spec stated that implementations might provide an option to do this, but did not provide an interoperable way of setting this option. For compatibility, the default is still to be deterministic.

Fix #1116