### PR TITLE
Fix Norm's affiliation

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -175,11 +175,10 @@ for transition to Proposed Recommendation. </p>'>
     <loc href="https://www.w3.org/TR/2014/REC-xpath-datamodel-30-20140408/">https://www.w3.org/TR/2014/REC-xpath-datamodel-30-20140408/</loc>
   </prevrec>
   <authlist>
-
     <author>
-      <name>Norman Walsh (XML Query WG)</name>
-      <affiliation>MarkLogic Corporation</affiliation>
-      <email href="mailto:Norman.Walsh@marklogic.com">Norman.Walsh@marklogic.com</email>
+      <name>Norm Tovey-Walsh</name>
+      <affiliation>Saxonica, Ltd</affiliation>
+      <email href="mailto:norm@saxonica.com">norm@saxonica.com</email>
     </author>
     <author>
       <name><phrase><loc href="http://john.snelson.org.uk">John Snelson</loc> (XML Query WG)</phrase></name>


### PR DESCRIPTION
Someone preparing a QT4 status talk for a conference observed that my affiliation on the data model spec was out-of-date.

I'm just going to merge this one without any fanfare.