### PR TITLE
796,231 - Extend XPath for and let expressions

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -869,62 +869,72 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>-->
 
   <g:production name="ForExpr" if="xpath40  xslt40-patterns">
-    <g:ref name="SimpleForClause"/>
-    <g:ref name="SimpleReturnClause"/>
+    <g:ref name="XPForClause"/>
+    <g:ref name="ForLetReturn"/>
   </g:production>
 
-  <g:production name="SimpleForClause" if="xpath40 xslt40-patterns" node-type="void">
+  <g:production name="XPForClause" if="xpath40 xslt40-patterns" node-type="void">
     <g:string>for</g:string>
-    <g:ref name="SimpleForBinding" if="xpath40  xslt40-patterns"/>
+    <g:ref name="XPForBinding" if="xpath40  xslt40-patterns"/>
     <g:zeroOrMore name="SimpleForClauseTail">
       <g:choice>
-        <g:string>for</g:string>
         <g:string>,</g:string>
       </g:choice>
-      <g:ref name="SimpleForBinding" if="xpath40  xslt40-patterns"/>
+      <g:ref name="XPForBinding" if="xpath40  xslt40-patterns"/>
     </g:zeroOrMore>
   </g:production>
 
-  <g:production name="SimpleForBinding" if="xpath40  xslt40-patterns"><!-- also unfolded for -->
+  <g:production name="XPForBinding" if="xpath40  xslt40-patterns"><!-- also unfolded for -->
     <g:optional>
       <g:string>member</g:string>
     </g:optional>
     <g:string>$</g:string>
     <g:ref name="VarName"/>
-    <g:optional if="fulltext">
-      <g:ref name="FTScoreVar"/>
+    <g:optional>
+      <g:ref name="TypeDeclaration"/>
     </g:optional>
+    <g:optional>
+      <g:ref name="XPPositionalVar"/>
+    </g:optional>    
     <g:string>in</g:string>
     <g:ref name="ExprSingle"/>
   </g:production>
   
-  <g:production name="SimpleReturnClause" if="xpath40  xslt40-patterns">
-    <g:string>return</g:string>
-    <g:ref name="ExprSingle"/>
+  <g:production name="ForLetReturn" if="xpath40  xslt40-patterns">
+    <g:choice>
+      <g:ref name="ForExpr"/>
+      <g:ref name="LetExpr"/>
+      <g:sequence>
+        <g:string>return</g:string>
+        <g:ref name="ExprSingle"/>
+      </g:sequence>
+    </g:choice>   
   </g:production>
   
   
 
   <g:production name="LetExpr" if="xpath40  xslt40-patterns">
-    <g:ref name="SimpleLetClause"/>
-    <g:ref name="SimpleReturnClause"/>
+    <g:ref name="XPLetClause"/>
+    <g:ref name="ForLetReturn"/>
   </g:production>
 
-  <g:production name="SimpleLetClause" if="xpath40  xslt40-patterns">
+  <g:production name="XPLetClause" if="xpath40  xslt40-patterns">
     <g:string>let</g:string>
-    <g:ref name="SimpleLetBinding"/>
+    <g:ref name="XPLetBinding"/>
     <g:zeroOrMore>
       <g:choice>
-        <g:string>let</g:string>
         <g:string>,</g:string>
       </g:choice>
-      <g:ref name="SimpleLetBinding"/>
+      <g:ref name="XPLetBinding"/>
     </g:zeroOrMore>
   </g:production>
 
-  <g:production name="SimpleLetBinding" if="xpath40  xslt40-patterns">
+  <g:production name="XPLetBinding" if="xpath40  xslt40-patterns">
     <g:string>$</g:string>
     <g:ref name="VarName"/>
+    <g:optional>
+      <g:ref name="TypeDeclaration"/>
+    </g:optional>
     <g:string>:=</g:string>
     <g:ref name="ExprSingle"/>
   </g:production>
@@ -983,7 +993,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:optional>
       <g:ref name="TypeDeclaration"/>
     </g:optional>
-    <g:optional if="xquery40">
+    <g:optional>
       <g:ref name="AllowingEmpty"/>
     </g:optional>
     <g:optional>
@@ -1041,6 +1051,12 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>-->
 
   <g:production name="PositionalVar" if=" xquery40">
+    <g:string>at</g:string>
+    <g:string>$</g:string>
+    <g:ref name="VarName"/>
+  </g:production>
+  
+  <g:production name="XPPositionalVar" if="xpath40 xslt40-patterns">
     <g:string>at</g:string>
     <g:string>$</g:string>
     <g:ref name="VarName"/>
@@ -2659,14 +2675,7 @@ ErrorVal ::= "$" VarName
 
   <!-- [ start Types + Tests -->
 
-  <!--<g:production name="SingleType" >
-    <g:ref name="CastTarget"/>
-    <g:optional name="OptionalOccurrenceIndicator">
-      <g:string process-value="yes">?</g:string>
-    </g:optional>
-  </g:production>
--->
-  <g:production name="TypeDeclaration" if=" xpath40 xquery40  xslt40-patterns">
+  <g:production name="TypeDeclaration" if=" xquery40 xpath40 xslt40-patterns">
     <g:string>as</g:string>
     <g:ref name="SequenceType"/>
   </g:production>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -221,11 +221,11 @@
             optional parameters).</p>
       </error>
 
-      <!--<error spec="XQ" role="xquery" code="0035" class="ST" type="static">
+      <error spec="XQ" role="xquery" code="0035" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> to import two schema
             components that both define the same name in the same symbol space and in the same
             scope. </p>
-      </error>-->
+      </error>
 
       <!--
 <error spec="XQ" role="xquery" code="0036" class="ST" type="type">
@@ -684,6 +684,13 @@
       <error spec="XQ" role="xquery" code="0089" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> if a variable bound in a
                <code>for</code> or <code>window</code> clause of a FLWOR expression, and its
+            associated positional variable, do not have distinct names (<termref
+               def="dt-expanded-qname">expanded QNames</termref>).</p>
+      </error>
+      
+      <error spec="XQ" role="xpath" code="0089" class="ST" type="static">
+         <p> It is a <termref def="dt-static-error">static error</termref> if a variable bound in a
+            <code>for</code> expression, and its
             associated positional variable, do not have distinct names (<termref
                def="dt-expanded-qname">expanded QNames</termref>).</p>
       </error>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -15480,8 +15480,9 @@ element because it is defined by a <termref
          <olist>
 
             <item>
-               <p>If the <code>for</code> expression uses multiple variables, 
-                  it is first expanded to a set of nested <code>for</code> expressions, each of which uses only one variable.
+               <p>If the <nt def="XPForClause">XPForClause</nt> binds multiple range variables with a comma separator, 
+                  the <code>for</code>expression is first expanded to a set of nested <code>for</code> 
+                  expressions, each of which uses only one variable.
                More specifically, every separating comma is replaced by <code>for</code>.</p>
                <p>For example, the expression
                <code role="parse-test">for $x in X, $y in Y return $x + $y</code> is expanded to
@@ -15489,8 +15490,9 @@ element because it is defined by a <termref
             </item>
             
             <item>
-               <p>In a single-variable <code>for</code> expression, 
-                  the variable is called the <term>range variable</term>,
+               <p>Having performed this expansion, 
+                  the variable bound in the <nt def="XPForClause">XPForClause</nt>
+                  is called the <term>range variable</term>,
                   the variable named in the <nt def="XPPositionalVar">XPPositionalVar</nt> (if present)
                   is called the <term>position variable</term>,
                   the expression that follows the <code>in</code> keyword is called the <term>binding expression</term>, 
@@ -15502,6 +15504,11 @@ element because it is defined by a <termref
                <p><termdef id="dt-binding-collection-xp" term="binding collection">The 
                   <term>binding expression</term> in a <code>for</code> expression is called the 
                   <term>binding collection</term></termdef>.</p>
+            </item>
+            <item>
+               <p>If a <term>position variable</term> is declared, its name (as a QName) must be
+               different from the name of the <term>range variable</term> <errorref spec="XQ" class="ST" code="0089"/>.
+               </p>
             </item>
             <item>
                <p><phrase diff="add" at="A">When the <code>member</code> keyword is absent</phrase>:

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -15532,7 +15532,7 @@ element because it is defined by a <termref
                         is converted to the specified type by applying the <termref def="dt-coercion-rules"/>.
                         (Recall that this can be any sequence, not necessarily a single item). </p></item>
                      <item><p>The result of the single-variable <code>for member</code> expression is obtained
-                        by evaluating the <code>return expression</code> once 
+                        by evaluating the <term>return expression</term> once 
                         for each member of that array, with the range variable bound to that member </p></item>
                      <item><p>The <term>return expression</term> is evaluated once 
                         for each member of the <termref def="dt-binding-collection-xp"/> array, 
@@ -15681,8 +15681,8 @@ the binding sequence. The expression in the <nt def="ForLetReturn">ForLetReturn<
                   (that is, the following <nt def="LetExpr">LetExpr</nt> or
                   <nt def="ForExpr">ForExpr</nt>, or the <nt def="ExprSingle">ExprSingle</nt> 
                   that follows the <code>return</code> keyword) is
-called the return expression. The result of the let expression is obtained
-by evaluating the return expression with a dynamic context in which the range variable is bound to the
+called the <term>return expression</term>. The result of the let expression is obtained
+by evaluating the <term>return expression</term> with a dynamic context in which the range variable is bound to the
 binding sequence. </p>
             </item>
             

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -9697,7 +9697,7 @@ return $a("A")]]></eg>
                <prodrecap ref="FunctionSignature" id="FunctionSignature"/>
                <prodrecap id="ParamList" ref="ParamList"/>
                <prodrecap id="Param" ref="Param"/>
-               <prodrecap ref="TypeDeclaration" role="xpath"/>
+               <prodrecap id="TypeDeclaration" ref="TypeDeclaration"/>
                <prodrecap ref="FunctionBody" role="xpath"/>
             </scrap>
 
@@ -15469,57 +15469,84 @@ element because it is defined by a <termref
          <scrap>
             <head/>
             <prodrecap id="ForExpr" ref="ForExpr"/>
-            <prodrecap id="SimpleForClause" ref="SimpleForClause"/>
-            <prodrecap id="SimpleForBinding" ref="SimpleForBinding"/>
-            <prodrecap id="SimpleReturnClause" ref="SimpleReturnClause"/>
+            <prodrecap id="XPForClause" ref="XPForClause"/>
+            <prodrecap id="XPForBinding" ref="XPForBinding"/>
+            <prodrecap id="ForLetReturn" ref="ForLetReturn"/>
+            <prodrecap ref="TypeDeclaration"/>
+            <prodrecap id="XPPositionalVar" ref="XPPositionalVar"/>
          </scrap>
 
          <p>A <code>for</code> expression is evaluated as follows:</p>
-      
          <olist>
 
             <item>
                <p>If the <code>for</code> expression uses multiple variables, 
                   it is first expanded to a set of nested <code>for</code> expressions, each of which uses only one variable.
-               <phrase diff="add" at="2023-02-09">More specifically, every separating comma or <code>for</code>
-               keyword is replaced by <code>return for</code>.</phrase></p>
+               More specifically, every separating comma is replaced by <code>for</code>.</p>
                <p>For example, the expression
                <code role="parse-test">for $x in X, $y in Y return $x + $y</code> is expanded to
-               <code role="parse-test">for $x in X return for $y in Y return $x + $y</code>.</p>
-               <p diff="add" at="A">Similarly, the expression 
-                  <code role="parse-test">for member $x in X for member $y in Y return $x + $y</code> is expanded to
-                  <code role="parse-test">for member $x in X return for member $y in Y return $x + $y</code>.</p>
+               <code role="parse-test">for $x in X for $y in Y return $x + $y</code>.</p>
             </item>
             
             <item>
                <p>In a single-variable <code>for</code> expression, 
-                  the variable is called the <term>range variable</term>, 
+                  the variable is called the <term>range variable</term>,
+                  the variable named in the <nt def="XPPositionalVar">XPPositionalVar</nt> (if present)
+                  is called the <term>position variable</term>,
                   the expression that follows the <code>in</code> keyword is called the <term>binding expression</term>, 
-                  and the expression that follows the <code>return</code> keyword is called the <term>return expression</term>. 
+                  and the expression in the <nt def="ForLetReturn">ForLetReturn</nt> part 
+                  (that is, the following <nt def="LetExpr">LetExpr</nt> or
+                  <nt def="ForExpr">ForExpr</nt>, or the <nt def="ExprSingle">ExprSingle</nt> 
+                  that follows the <code>return</code> keyword) is called the <term>return expression</term>. 
                </p>
-               <p><termdef id="dt-binding-collection-xp" term="binding collection">The result of evaluating
-               the <term>binding expression</term> in a <code>for</code> expression is called the 
+               <p><termdef id="dt-binding-collection-xp" term="binding collection">The 
+                  <term>binding expression</term> in a <code>for</code> expression is called the 
                   <term>binding collection</term></termdef>.</p>
             </item>
             <item>
-               <p><phrase diff="add" at="A">When the <code>member</code> keyword is absent</phrase>,
-                  the result of the single-variable <code>for</code> expression is obtained by evaluating the 
-                  <code>return</code> expression once 
-                  for each item in the <termref def="dt-binding-collection-xp"/>, with the range variable bound to that item. 
-                  The resulting sequences are concatenated (as if by the <termref def="dt-comma-operator"
-                  >comma operator</termref>) in the order of the items in the binding collection from which they were derived.
+               <p><phrase diff="add" at="A">When the <code>member</code> keyword is absent</phrase>:
+                  <olist>
+                     <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
+                        is present then each item in the <termref def="dt-binding-collection-xp"/>
+                        is converted to the specified type by applying the <termref def="dt-coercion-rules"/>.</p></item>
+                     <item><p>The <term>return expression</term> is evaluated once 
+                        for each item in the <termref def="dt-binding-collection-xp"/>, with a dynamic context in which
+                        the <term>range variable</term> is bound to that item, and the <term>position variable</term> 
+                        (if present) is bound to the one-based position of that item in the <termref def="dt-binding-collection-xp"/>.</p></item>
+                     <item><p>The result of the single-variable <code>for</code> expression is the result
+                        of contenating the resulting values (as if by the <termref def="dt-comma-operator"
+                           >comma operator</termref>) in the order of the items in the binding collection from which 
+                        they were derived.</p></item>
+                  </olist>
+              
                </p>
             </item>
             <item diff="add" at="A">
-               <p>When the <code>member</code> keyword is present,
-                  the value of the <termref def="dt-binding-collection-xp"/> must be a single array.
-                  Otherwise, a <termref def="dt-type-error">type error</termref> is raised: <errorref class="TY" code="0141"/>.
-                  The result of the single-variable <code>for member</code> expression is obtained by evaluating the <code>return</code> expression once 
-                  for each member of that array, with the range variable bound to that member (recall that this can be any sequence,
-                  not necessarily a single item). The resulting sequences 
-                  are concatenated (as if by the <termref def="dt-comma-operator"
-                     >comma operator</termref>) in the order of the members of the <termref def="dt-binding-collection-xp"/> from 
-                  which they were derived.
+               <p>When the <code>member</code> keyword is present:
+                  <olist>
+                     <item><p>The value of the <termref def="dt-binding-collection-xp"/> must be a single array.
+                        Otherwise, a <termref def="dt-type-error">type error</termref> is raised: <errorref class="TY" code="0141"/>.
+                     </p></item>
+                     <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
+                        is present then each member of the <termref def="dt-binding-collection-xp"/> array
+                        is converted to the specified type by applying the <termref def="dt-coercion-rules"/>.
+                        (Recall that this can be any sequence, not necessarily a single item). </p></item>
+                     <item><p>The result of the single-variable <code>for member</code> expression is obtained
+                        by evaluating the <code>return expression</code> once 
+                        for each member of that array, with the range variable bound to that member </p></item>
+                     <item><p>The <term>return expression</term> is evaluated once 
+                        for each member of the <termref def="dt-binding-collection-xp"/> array, 
+                        with a dynamic context in which
+                        the <term>range variable</term> is bound to that member, and the <term>position variable</term> 
+                        (if present) is bound to the one-based position of that member in the <termref def="dt-binding-collection-xp"/>.</p></item>
+                     <item><p>The result of the <code>for</code> expression is the result
+                        of contenating the resulting values (as if by the <termref def="dt-comma-operator"
+                           >comma operator</termref>) in the order of the members in the binding collection array from which 
+                        they were derived.</p></item>
+                  </olist>   
+                  
+                  
+      
                </p>
                <p>Note that the result is a sequence, not an array.</p>
             </item>
@@ -15625,9 +15652,10 @@ return $line/value]]></eg>
          <scrap>
             <head/>
             <prodrecap id="LetExpr" ref="LetExpr"/>
-            <prodrecap id="SimpleLetClause" ref="SimpleLetClause"/>
-            <prodrecap id="SimpleLetBinding" ref="SimpleLetBinding"/>
-            <prodrecap ref="SimpleReturnClause"/>
+            <prodrecap id="XPLetClause" ref="XPLetClause"/>
+            <prodrecap id="XPLetBinding" ref="XPLetBinding"/>
+            <prodrecap ref="ForLetReturn"/>
+            <prodrecap ref="TypeDeclaration"/>
          </scrap>
 
          <p>A let expression is evaluated as follows:</p>
@@ -15636,24 +15664,29 @@ return $line/value]]></eg>
             <item>
                <p>If the let expression uses multiple variables, it is first expanded to a
 set of nested let expressions, each of which uses only one variable. 
-<phrase diff="add" at="2023-02-09">Specifically, any separating comma or <code>let</code>
-keyword is replaced by <code>return let</code></phrase>.</p>
+Specifically, any separating comma is replaced by <code>let</code>.</p>
                <p>For example, the expression 
                   <code role="parse-test">let $x := 4, $y := 3 return $x + $y</code> is expanded to
-                   <code role="parse-test">let $x := 4 return let $y := 3 return $x + $y</code>.</p>
-               <p>Likewise, the expression 
-                  <code role="parse-test">let $x := 4 let $y := 3 return $x + $y</code> is expanded to
-                  <code role="parse-test">let $x := 4 return let $y := 3 return $x + $y</code>.</p>
+                   <code role="parse-test">let $x := 4 let $y := 3 return $x + $y</code>.</p>
+               
             </item>
 
             <item>
                <p>In a single-variable let expression, the variable is called the range
-variable, the value of the expression that follows the <code>:=</code> symbol is called
-the binding sequence, and the expression that follows the return keyword is
+variable. The expression that follows the <code>:=</code> symbol is evaluated, and
+                  if a <nt def="TypeDeclaration">TypeDeclaration</nt> is present, its value is converted
+                     to the specified type by applying the <termref def="dt-coercion-rules"/>.
+                     The resulting value is called
+the binding sequence. The expression in the <nt def="ForLetReturn">ForLetReturn</nt> part 
+                  (that is, the following <nt def="LetExpr">LetExpr</nt> or
+                  <nt def="ForExpr">ForExpr</nt>, or the <nt def="ExprSingle">ExprSingle</nt> 
+                  that follows the <code>return</code> keyword) is
 called the return expression. The result of the let expression is obtained
-by evaluating the return expression with the range variable bound to the
+by evaluating the return expression with a dynamic context in which the range variable is bound to the
 binding sequence. </p>
             </item>
+            
+           
 
          </ulist>
 
@@ -15682,10 +15715,10 @@ return upper-case($x)
             a single variable and binding it successively to different values.</p>
          </note>
          <note diff="add" at="2023-02-16">
-            <p>XPath 4.0 allows the form using multiple <code>let</code> clauses, as illustrated in the previous example,
-               primarily because it is familiar to XQuery users, some of whom may regard it as more
-               readable than the XPath 3.1 alternative which uses a comma in place of the second and
-               subsequent <code>let</code> keywords.</p>
+            <p>XPath 4.0 generalizes the <code>LetExpression</code> to allow multiple 
+               <code>let</code> clauses and <code>for</code> clauses to be combined
+               without an intermediate <code>return</code>, and also to allow the required
+               type to be declared.</p>
          </note>
       </div2>
 
@@ -17165,7 +17198,7 @@ declare function recursive-content($item as item()) as map(*)* {
             <prodrecap ref="ForMemberBinding"/>
             <prodrecap ref="LetClause"/>
             <prodrecap ref="LetBinding"/>
-            <prodrecap id="TypeDeclaration" ref="TypeDeclaration"/>
+            <prodrecap ref="TypeDeclaration"/>
             <prodrecap id="AllowingEmpty" ref="AllowingEmpty"/>
             <prodrecap id="PositionalVar" ref="PositionalVar"/>
             <prodrecap id="WindowClause" ref="WindowClause"/>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -15506,8 +15506,10 @@ element because it is defined by a <termref
                   <term>binding collection</term></termdef>.</p>
             </item>
             <item>
-               <p>If a <term>position variable</term> is declared, its name (as a QName) must be
-               different from the name of the <term>range variable</term> <errorref spec="XQ" class="ST" code="0089"/>.
+               <p>If a <term>position variable</term> is declared, its type is implicitly
+                  <code>xs:positiveInteger</code>. Its name (as a QName) must be
+               different from the name of the <term>range variable</term> 
+                  <errorref spec="XQ" class="ST" code="0089"/>.
                </p>
             </item>
             <item>
@@ -15519,7 +15521,9 @@ element because it is defined by a <termref
                      <item><p>The <term>return expression</term> is evaluated once 
                         for each item in the <termref def="dt-binding-collection-xp"/>, with a dynamic context in which
                         the <term>range variable</term> is bound to that item, and the <term>position variable</term> 
-                        (if present) is bound to the one-based position of that item in the <termref def="dt-binding-collection-xp"/>.</p></item>
+                        (if present) is bound to the one-based position of that item in the 
+                        <termref def="dt-binding-collection-xp"/>, as an instance of type 
+                        <code>xs:positiveInteger</code>.</p></item>
                      <item><p>The result of the single-variable <code>for</code> expression is the result
                         of contenating the resulting values (as if by the <termref def="dt-comma-operator"
                            >comma operator</termref>) in the order of the items in the binding collection from which 
@@ -17443,8 +17447,9 @@ for member $y in $expr2]]></eg>
                <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, starting with one. Each tuple in the output 
                tuple stream contains bindings for both the main variable and the positional variable. If the 
                <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref> is empty and <code>allowing empty</code> is 
-               specified, the positional variable in the output tuple is bound to the integer zero. Positional variables always 
-               have the implied type <code>xs:integer</code>.</p>
+               specified, the positional variable in the output tuple is bound to the integer zero. Positional variables  
+               have the implied type <code>xs:nonNegativeInteger</code> if <code>allowing empty</code> is present, or 
+               <code>xs:positiveInteger</code> if it is absent.</p>
             <p>The <termref def="dt-expanded-qname">expanded
 			        QName</termref> of a positional variable must be distinct from the <termref def="dt-expanded-qname"
                   >expanded QName</termref> of the main variable with which it is associated <errorref
@@ -17723,7 +17728,7 @@ are as follows:</p>
   sequence</termref>. <emph>Start-item-position</emph> is a <termref
                         def="dt-positional-variable"
                         >positional variable</termref>; hence, its type
-  is <code>xs:integer</code>
+  is <code>xs:positiveInteger</code>
                   </p>
                </item>
 
@@ -17762,7 +17767,7 @@ are as follows:</p>
   sequence</termref>. <emph>End-item-position</emph> is a <termref
                         def="dt-positional-variable"
                         >positional variable</termref>; hence, its type
-  is <code>xs:integer</code>
+  is <code>xs:positiveInteger</code>
                   </p>
                </item>
 


### PR DESCRIPTION
Fix #796
Fix #231 

Extends "for" and "let" expressions in XPath to allow a larger subset of XQuery FLWOR expression syntax. Specifically:

- Allow positional variables (`at $pos`)
- Allow type declarations (`as type`)
- Allow let/for clauses to be mixed without an intervening `return`.