### PR TITLE
122 Choice item types (generalizing local union types)

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -85,18 +85,14 @@ apply.
       <g:ref name="MapTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ArrayTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
-      <!--<g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>-->
       <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
-      <!--<g:ref name="NamedItemType" lookahead="2" if="xpath40 xquery40"/>-->
     </g:choice>
     <g:ref name="PredicateList"/>
   </g:production>
   
   <g:production name="WrappedItemTest" if="xslt40-patterns">
       <g:string>type</g:string>
-      <g:string>(</g:string>
-      <g:ref name="ItemType"/>
-      <g:string>)</g:string>   
+      <g:ref name="ChoiceItemType"/>  
   </g:production>
   
   <g:production name="NodePattern" if="xslt40-patterns">

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -85,7 +85,7 @@ apply.
       <g:ref name="MapTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ArrayTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
-      <g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <!--<g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>-->
       <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <!--<g:ref name="NamedItemType" lookahead="2" if="xpath40 xquery40"/>-->
     </g:choice>
@@ -1602,7 +1602,10 @@ ErrorVal ::= "$" VarName
         <g:sequence name="CastableExprOps">
           <g:string>castable</g:string>
           <g:string>as</g:string>
-          <g:ref name="SingleType"/>
+          <g:ref name="CastTarget"/>
+          <g:optional>
+            <g:string>?</g:string>
+          </g:optional>
         </g:sequence>
       </g:postfix>
     </g:level>
@@ -1611,7 +1614,10 @@ ErrorVal ::= "$" VarName
         <g:sequence name="CastExprOps">
           <g:string>cast</g:string>
           <g:string>as</g:string>
-          <g:ref name="SingleType"/>
+          <g:ref name="CastTarget"/>
+          <g:optional>
+            <g:string>?</g:string>
+          </g:optional>
         </g:sequence>
       </g:postfix>
     </g:level>
@@ -2657,13 +2663,13 @@ ErrorVal ::= "$" VarName
 
   <!-- [ start Types + Tests -->
 
-  <g:production name="SingleType" >
+  <!--<g:production name="SingleType" >
     <g:ref name="CastTarget"/>
     <g:optional name="OptionalOccurrenceIndicator">
       <g:string process-value="yes">?</g:string>
     </g:optional>
   </g:production>
-
+-->
   <g:production name="TypeDeclaration" if=" xpath40 xquery40  xslt40-patterns">
     <g:string>as</g:string>
     <g:ref name="SequenceType"/>
@@ -2702,9 +2708,9 @@ ErrorVal ::= "$" VarName
       <g:ref name="MapTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="ArrayTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
-      <g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
+      <!--<g:ref name="LocalUnionType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>-->
       <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
-      <g:ref name="ParenthesizedItemType" if="xpath40 xquery40  xslt40-patterns"/>
+      <g:ref name="ChoiceItemType" if="xpath40 xquery40  xslt40-patterns"/>
     </g:choice>
   </g:production>
   
@@ -2841,7 +2847,7 @@ ErrorVal ::= "$" VarName
     <g:ref name="TypeName" not-if="xpath40 xquery40"/>
     <g:choice if="xpath40 xquery40">
       <g:ref name="TypeName"/>
-      <g:ref name="LocalUnionType"/>
+      <g:ref name="ChoiceItemType"/>
       <g:ref name="EnumerationType"/>
     </g:choice>
   </g:production>
@@ -2963,7 +2969,7 @@ ErrorVal ::= "$" VarName
     <g:string>*</g:string>
   </g:production>
   
-  <g:production name="LocalUnionType" if="xpath40 xquery40 xslt40-patterns">
+  <!--<g:production name="LocalUnionType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>union</g:string>
     <g:string>(</g:string>
     <g:ref name="ItemType"/>
@@ -2972,7 +2978,7 @@ ErrorVal ::= "$" VarName
       <g:ref name="ItemType"/>
     </g:zeroOrMore>
     <g:string>)</g:string>
-  </g:production>
+  </g:production>-->
   
   <g:production name="EnumerationType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>enum</g:string>
@@ -3013,9 +3019,13 @@ ErrorVal ::= "$" VarName
     <g:string>)</g:string>
   </g:production>-->
 
-  <g:production name="ParenthesizedItemType" if="xpath40 xquery40  xslt40-patterns">
+  <g:production name="ChoiceItemType" if="xpath40 xquery40  xslt40-patterns">
     <g:string>(</g:string>
     <g:ref name="ItemType"/>
+    <g:zeroOrMore>
+      <g:string>|</g:string>
+      <g:ref name="ItemType"/>
+    </g:zeroOrMore>
     <g:string>)</g:string>
   </g:production>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17336,7 +17336,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="serialize" return-type="xs:string">
             <fos:arg name="input" type="item()*" usage="absorption"/>
-            <fos:arg name="options" type="element(output:serialization-parameters) | map(*)" usage="absorption" default="()" example="{}"/>
+            <fos:arg name="options" type="(element(output:serialization-parameters) | map(*))" usage="absorption" default="()" example="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -28071,7 +28071,7 @@ return every($dl/*, fn($elem, $pos) {
    <fos:function name="char" prefix="fn">
       <fos:signatures>
          <fos:proto name="char" return-type="xs:string">
-            <fos:arg name="value" type="xs:string | xs:positiveInteger"/>
+            <fos:arg name="value" type="(xs:string | xs:positiveInteger)"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -60,7 +60,7 @@
    <fos:type id="parse-html-options">
       <fos:record extensible="true">        
          <fos:field name="method" type="xs:string" required="false"/>
-         <fos:field name="html-version" type="union(enum('LS'), xs:decimal)" required="false"/>
+         <fos:field name="html-version" type="(enum('LS') | xs:decimal)" required="false"/>
          <fos:field name="encoding" type="xs:string?" required="false"/>
          <fos:field name="include-template-content" type="xs:boolean?" required="false"/>
       </fos:record>
@@ -89,7 +89,7 @@
          <fos:field name="columns" type="xs:string*" required="true"/>
          <fos:field name="column-index" type="map(xs:string, xs:positiveInteger)" required="true"/>
          <fos:field name="rows" type="array(xs:string)*" required="true"/>
-         <fos:field name="get" required="true" type="function(xs:positiveInteger, union(xs:positiveInteger, xs:string)) as xs:string?"/>
+         <fos:field name="get" required="true" type="function(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string?"/>
       </fos:record>
    </fos:type>
 
@@ -2207,7 +2207,7 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
          <fos:proto name="format-number" return-type="xs:string">
             <fos:arg name="value" type="xs:numeric?"/>
             <fos:arg name="picture" type="xs:string"/>
-            <fos:arg name="format-name" type="union(xs:string, xs:QName)?" default="()"/>
+            <fos:arg name="format-name" type="(xs:string | xs:QName)?" default="()"/>
             <fos:arg name="format" type="map(*)?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -2308,7 +2308,7 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
             representing higher powers of ten) always precede digits with lower significance, even when 
             the rendered text flow is from right to left.</p>
          <p diff="add" at="issue780">The type of the third argument changes in version 4.0 from 
-            <code>xs:string</code> to <code>union(xs:string, xs:QName)</code>. This introduces a
+            <code>xs:string</code> to <code>(xs:string | xs:QName)</code>. This introduces a
             minor incompatibility: for example, it is no longer possible to supply a value
          of type <code>xs:anyURI</code>.</p>
 
@@ -4833,7 +4833,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
    <fos:function name="hash" prefix="fn" at="2024-01-10" diff="add">
       <fos:signatures>
          <fos:proto name="hash" return-type="xs:hexBinary?">
-            <fos:arg name="value" type="union(xs:string, xs:hexBinary, xs:base64Binary)?"/>
+            <fos:arg name="value" type="(xs:string | xs:hexBinary | xs:base64Binary)?"/>
             <fos:arg name="options" type="map(*)?" default="{}"/>
             <!--<fos:arg name="algorithm" type="xs:string?" default="'MD5'"/>-->
          </fos:proto>
@@ -11205,7 +11205,7 @@ else QName("", $value)</eg>
    <fos:function name="namespace-uri-for-prefix" prefix="fn">
       <fos:signatures>
          <fos:proto name="namespace-uri-for-prefix" return-type="xs:anyURI?">
-            <fos:arg name="value" type="union(xs:NCName, enum(''))?"/>
+            <fos:arg name="value" type="(xs:NCName | enum(''))?"/>
             <fos:arg name="element" type="element()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -11255,7 +11255,7 @@ else QName("", $value)</eg>
    <fos:function name="in-scope-namespaces" prefix="fn" diff="add" at="A">
       <fos:signatures>
          <fos:proto name="in-scope-namespaces"
-            return-type="map(union(xs:NCName, enum('')), xs:anyURI)">
+            return-type="map((xs:NCName | enum('')), xs:anyURI)">
             <fos:arg name="element" type="element()" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -11336,8 +11336,8 @@ else QName("", $value)</eg>
    <fos:function name="binary-equal" prefix="op">
       <fos:signatures>
          <fos:proto name="binary-equal" return-type="xs:boolean">
-            <fos:arg name="value1" type="union(xs:hexBinary, xs:base64Binary)"/>
-            <fos:arg name="value2" type="union(xs:hexBinary, xs:base64Binary)"/>
+            <fos:arg name="value1" type="(xs:hexBinary | xs:base64Binary)"/>
+            <fos:arg name="value2" type="(xs:hexBinary | xs:base64Binary)"/>
          </fos:proto>
       </fos:signatures>
       <fos:opermap operator="eq" types="xs:binary" other-operators="ne"
@@ -11357,8 +11357,8 @@ else QName("", $value)</eg>
    <fos:function name="binary-less-than" prefix="op">
       <fos:signatures>
          <fos:proto name="binary-less-than" return-type="xs:boolean">
-            <fos:arg name="arg1" type="union(xs:hexBinary, xs:base64Binary)"/>
-            <fos:arg name="arg2" type="union(xs:hexBinary, xs:base64Binary)"/>
+            <fos:arg name="arg1" type="(xs:hexBinary | xs:base64Binary)"/>
+            <fos:arg name="arg2" type="(xs:hexBinary | xs:base64Binary)"/>
          </fos:proto>
       </fos:signatures>
       <fos:opermap operator="lt" types="xs:hexBinary" other-operators="ge"
@@ -17336,7 +17336,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="serialize" return-type="xs:string">
             <fos:arg name="input" type="item()*" usage="absorption"/>
-            <fos:arg name="options" type="item()?" usage="absorption" default="()" example="{}"/>
+            <fos:arg name="options" type="element(output:serialization-parameters) | map(*)" usage="absorption" default="()" example="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17587,7 +17587,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                      <code>json-node-output-method</code>
                   </td>
                   <td>
-                     <code>union(xs:string, xs:QName)?</code>
+                     <code>(xs:string | xs:QName)?</code>
                   </td>
                   <td>See Notes 1, 2</td>
                   <td>
@@ -17609,7 +17609,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                      <code>method</code>
                   </td>
                   <td>
-                     <code>union(xs:string, xs:QName)?</code>
+                     <code>(xs:string | xs:QName)?</code>
                   </td>
                   <td>See Notes 1, 2</td>
                   <td>
@@ -17707,7 +17707,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 
          <olist>
             <item>
-               <p>The notation <code>union(A, B)</code> is used to represent a union type whose member types are <code>A</code>
+               <p>The notation <code>(A | B)</code> represents a union type whose member types are <code>A</code>
             and <code>B</code>.</p>
             </item>
             <item>
@@ -17835,7 +17835,7 @@ serialize(
    <fos:function name="parse-html" prefix="fn">
       <fos:signatures>
          <fos:proto name="parse-html" return-type="document-node(element(*:html))?">
-            <fos:arg name="html" type="union(xs:string, xs:hexBinary, xs:base64Binary)?"/>
+            <fos:arg name="html" type="(xs:string | xs:hexBinary | xs:base64Binary)?"/>
             <fos:arg name="options" type-ref="parse-html-options"
                      default="{
                                  &quot;method&quot;: &quot;html&quot;,
@@ -19771,8 +19771,8 @@ else let $rel = op:simple-compare(head($a), head($b), $C)
             then op:lexicographic-compare(tail($a), tail($b), $C)
             else $rel</eg></item>
                   <item><p>Here <code>op:simple-compare($k1, $k2)</code> is defined as follows:</p>
-                     <eg>if ($k1 instance of union(xs:string, xs:anyURI, xs:untypedAtomic)
-    and $k2 instance of union(xs:string, xs:anyURI, xs:untypedAtomic))
+                     <eg>if ($k1 instance of (xs:string | xs:anyURI | xs:untypedAtomic)
+    and $k2 instance of (xs:string | xs:anyURI | xs:untypedAtomic))
 then compare($k1, $k2, $C)
 else if ($k1 instance of xs:numeric and $k2 instance of xs:numeric)
 then compare($k1, $k2)
@@ -22518,7 +22518,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      converting to <code>xs:double</code> using the XPath casting rules.
                      Supplying the value <code>xs:decimal#1</code> will instead convert to <code>xs:decimal</code>
                      (which potentially retains more precision, but disallows exponential notation), while
-                     supplying a function that casts to <code>union(xs:decimal, xs:double)</code> will treat
+                     supplying a function that casts to <code>(xs:decimal | xs:double)</code> will treat
                      the value as <code>xs:decimal</code> if there is no exponent, or as <code>xs:double</code>
                      otherwise. Supplying the value <code>fn:identity#1</code> causes the value to be retained
                      unchanged as an <code>xs:untypedAtomic</code>. Before calling the supplied <code>number-parser</code>,
@@ -23267,7 +23267,7 @@ return json-to-xml($json, $options)]]></eg>
                      <p>parameter names: (<var>$row</var>, <var>$col</var>)</p>
                   </item>
                   <item>
-                     <p>signature: <code>(xs:positiveInteger, union(xs:xs:positiveInteger, xs:string)) => xs:string?</code></p>
+                     <p>signature: <code>(xs:positiveInteger, (xs:positiveInteger | xs:string)) => xs:string?</code></p>
                   </item>
                   <item>
                      <p>non-local variable bindings: none</p>
@@ -24388,7 +24388,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
                      converting to <code>xs:double</code> using the XPath casting rules.
                      Supplying the value <code>xs:decimal#1</code> will instead convert to <code>xs:decimal</code>
                      (which potentially retains more precision, but disallows exponential notation), while
-                     supplying a function that casts to <code>union(xs:decimal, xs:double)</code> will treat
+                     supplying a function that casts to <code>(xs:decimal | xs:double)</code> will treat
                      the value as <code>xs:decimal</code> if there is no exponent, or as <code>xs:double</code>
                      otherwise. Supplying the value <code>fn:identity#1</code> causes the value to be retained
                      unchanged as an <code>xs:untypedAtomic</code>. 
@@ -28071,7 +28071,7 @@ return every($dl/*, fn($elem, $pos) {
    <fos:function name="char" prefix="fn">
       <fos:signatures>
          <fos:proto name="char" return-type="xs:string">
-            <fos:arg name="value" type="union(xs:string, xs:positiveInteger)"/>
+            <fos:arg name="value" type="xs:string | xs:positiveInteger"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -1091,11 +1091,11 @@ It is a static error if the name of a feature in
             operator.)</p>
       </error>
       
-      <error spec="XP" code="0147" class="ST" type="static">
+      <!--<error spec="XP" code="0147" class="ST" type="static">
          <p>It is a <termref def="dt-static-error">static error</termref> if a type used as a member
          type in a <nt def="LocalUnionType">LocalUnionType</nt> is not a 
          <termref def="dt-generalized-atomic-type"/>.</p>
-      </error>
+      </error>-->
       
       <error spec="XQ" role="xquery" code="0148" class="ST" type="static">
          <p>It is a <termref def="dt-static-error">static error</termref> if an optional parameter

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3493,7 +3493,7 @@ types</term>, and <term>atomic types</term> (see <bibref
                ref="XMLSchema10"/> or <bibref ref="XMLSchema11"
             /> for definitions and explanations of these terms.)</p>
       
-      <note><p>Local union types (see <specref ref="id-local-union-types"/>) and 
+      <note><p>Local union types (see <specref ref="id-choice-item-types"/>) and 
          enumeration types (see <specref ref="id-enumeration-types"/>) are classified as 
          <termref def="dt-schema-type">schema types</termref>, even though they are not defined in any XSD schema.</p></note>
 
@@ -3536,7 +3536,7 @@ types only if they are defined directly as the union of a number of
 atomic types.</p>
          </note>
       
-         <note diff="add" at="2023-02-20"><p>A local union type (see <specref ref="id-local-union-types"/>) is
+         <note diff="add" at="2023-02-20"><p>A local union type (see <specref ref="id-choice-item-types"/>) is
             always a <termref def="dt-pure-union-type">pure union type</termref></p></note>
 
          <p>
@@ -4222,11 +4222,11 @@ the schema type named <code>us:address</code>.</p>
                <prodrecap ref="FunctionTest"/>
                <prodrecap ref="AnyFunctionTest"/>
                <prodrecap ref="TypedFunctionTest"/>
-               <prodrecap id="ParenthesizedItemType" ref="ParenthesizedItemType"/>
+               <prodrecap id="ChoiceItemType" ref="ChoiceItemType"/>
                <prodrecap ref="MapTest"/>
                <prodrecap ref="RecordTest"/>
                <prodrecap ref="ArrayTest"/>
-               <prodrecap ref="LocalUnionType"/>
+               <!--<prodrecap ref="LocalUnionType"/>-->
                <prodrecap ref="EnumerationType"/>
             </scrap>
 
@@ -4270,10 +4270,15 @@ the schema type named <code>us:address</code>.</p>
                </item>
                <item>
                   
-                     <p>A <nt def="ParenthesizedItemType"
-                        >ParenthesizedItemType</nt> designates the same <termref def="dt-item-type"/>
-                        as the <nt def="ItemType">ItemType</nt> that is in parentheses.</p>
-                      <note><p>Parenthesized item types are used primarily when defining nested item types in a function
+                     <p>A <nt def="ChoiceItemType"
+                        >ChoiceItemType</nt> lists a number of alternative item types,
+                        separated by <code>"|"</code>. An item matches a <code>ChoiceItemType</code>
+                        it if matches any of the alternatives.</p>
+                      <note><p>If there is only one alternative, the <code>ChoiceItemType</code>
+                         designates the same <termref def="dt-item-type"/>
+                         as the <nt def="ItemType">ItemType</nt> that is in parentheses.
+                         A singleton choice (that is, a parenthesized item type) is used primarily 
+                         when defining nested item types in a function
                       signature. For example, a sequence of functions that each return a single boolean might be denoted
                       <code>(function() as xs:boolean)*</code>. In this example the parentheses
                       are needed to indicate where the occurrence indicator belongs.</p></note>
@@ -4293,9 +4298,9 @@ the schema type named <code>us:address</code>.</p>
                      or a <termref def="dt-pure-union-type"/>.</p></item>
                      <item><p>Using a QName that identifies a <termref def="dt-named-item-type"/> that resolves
                         to a <termref def="dt-generalized-atomic-type"/>.</p></item>
-                     <item><p>Using a <nt def="ParenthesizedItemType">ParenthesizedItemType</nt> where the parentheses enclose
-                        a <termref def="dt-generalized-atomic-type"/>.</p></item>
-                     <item><p>Using a <nt def="LocalUnionType">LocalUnionType</nt> as described below.</p></item>
+                     <item><p>Using a <nt def="ChoiceItemType">ChoiceItemType</nt> where every alternative
+                        is itself a <termref def="dt-generalized-atomic-type"/>.</p></item>
+                     <!--<item><p>Using a <nt def="LocalUnionType">LocalUnionType</nt> as described below.</p></item>-->
                      <item><p>Using an <nt def="EnumerationType">EnumerationType</nt> as described below.</p></item>
                   </ulist>
                
@@ -4326,109 +4331,123 @@ the schema type named <code>us:address</code>.</p>
                               >generalized atomic type</termref> with an occurrence indicator, such as
     <code>xs:IDREF+</code>.</p>
                      </note>
+               </div3>
+            <div3 id="id-choice-item-types">
+               <head>Choice Item Types</head>
+               
+               <p><termdef id="dt-choice-item-type" term="choice item type">A 
+                  <term>choice item type</term> defines an item type that is the union
+               of a number of alternatives. For example the type 
+               <code>(xs:hexBinary | xs:base64Binary)</code> defines the union of 
+               these two primitive atomic types, while the type <code>(map(*) | array(*))</code>
+               matches any item that is either a map or an array.</termdef></p>
+               
+               <p>An item matches a <code>ChoiceItemType</code> if it matches any of the 
+                  alternatives listed within the parentheses.</p>
+               
+               
+               <p>For example, the type <code>(xs:NCName | enum(""))</code> matches any value that is either
+                  an instance of <code>xs:NCName</code>, or a zero-length string. This might be a suitable type for
+                  a variable that holds a namespace prefix.</p>
+               
+               
+               <p>If all the alternatives are <termref
+                  def="dt-generalized-atomic-type">generalized atomic types</termref>
+                  then the <code>ChoiceItemType</code> is itself a generalized atomic type,
+               which means, for example, that it can be used as the target of a cast expression.</p>
+               
+               <p><termdef id="dt-local-union-type" term="local union type">A <code>ChoiceItemType</code>
+                  in which all the alternatives are <termref
+                     def="dt-generalized-atomic-type">generalized atomic types</termref>
+               is referred to as a <term>local union type</term>; a local union type
+               is itself a generalized atomic type.</termdef></p>
+               
+               <p>A <termref def="dt-local-union-type"/> defines an anonymous union type locally (for example,
+               within a function signature) which may be more convenient than defining the type in an
+               imported schema.</p>
+               
+               <p>A <termref def="dt-local-union-type"/> is classified
+               as a <termref def="dt-schema-type">schema type</termref> even though it is not 
+                  defined in any XSD schema.</p>
+               
                   
-                  <div4 id="id-local-union-types" diff="add" at="A">
-                     <head>Local Union Types</head>
-                     <p>A <code>LocalUnionType</code> defines an anonymous union type locally (for example,
-                     within a function signature) which may be more convenient than defining the type in an
-                     imported schema.</p>
-                        <scrap headstyle="show">
-                           <head/>
-                           <prodrecap id="LocalUnionType" ref="LocalUnionType"/>   
-                        </scrap>
-                        
-                        <p>Although the grammar allows any <code>ItemType</code> to appear, each <code>ItemType</code>
-                        must identify a <termref def="dt-generalized-atomic-type"/> <errorref class="ST" code="0147"/>.</p>
-                     
-                     <p diff="add" at="2023-02-20">A <code>LocalUnionType</code> is a 
-                        <termref def="dt-generalized-atomic-type">generalized atomic type</termref>. It is classified
-                     as a <termref def="dt-schema-type">schema type</termref> even though it is not defined in any
-                     XSD schema.</p>
-                     
-                        <p>An item matches a <code>LocalUnionType</code> if it matches any of the 
-                           <termref def="dt-generalized-atomic-type">generalized atomic types</termref>
-                           listed within the parentheses.</p>
-                        
-                        <p>For example, the type <code>union(xs:date, xs:dateTime, xs:time)</code> matches any value that is an instance
-                           of <code>xs:date</code>, <code>xs:dateTime</code>, or <code>xs:time</code>.</p>
-                     
-                        <p>Similarly, the type <code>union(xs:NCName, enum(""))</code> matches any value that is either
-                        an instance of <code>xs:NCName</code>, or a zero-length string. This might be a suitable type for
-                        a variable that holds a namespace prefix.</p>
-                        
-                        <note>
-                           <p>Local union types are particularly useful in function signatures, allowing a function to take arguments
-                           of a variety of types. The semantics are identical to using a named union type, but a local union type is more
-                           convenient because it does not need to be defined in a schema, and does not require a schema-aware processor.</p>
-                           <p>A local union type can also be used in a cast expression: <code>cast @when as union(xs:date, xs:dateTime)</code>
-                           allows the attribute <code>@when</code> to be either a date, or a dateTime.</p>
-                           <p>An <code>instance of</code> expression can be used to test whether a value belongs to one
-                           of a number of specified types: <code>$x instance of union(xs:string, xs:anyURI, xs:untypedAtomic)</code>
-                           returns <code>true</code> if <code>$x</code> is an instance of any of these three atomic types.</p>
-                        </note>
-                  </div4>
-                  
-                  <div4 id="id-enumeration-types" diff="add" at="A">
-                     <head>Enumeration Types</head>
-                     <p><termdef id="dt-EnumerationType" term="EnumerationType">An <term>EnumerationType</term> 
-                        accepts a fixed set of string values.</termdef></p>
-                     <scrap headstyle="show">
-                        <head/>
-                        <prodrecap id="EnumerationType" ref="EnumerationType"/>   
-                     </scrap>
-                     
-                     <p>An <code>EnumerationType</code> has a value space consisting of a set of <code>xs:string</code>
-                        values. When matching strings against an enumeration type, strings are always compared
-                     using the Unicode codepoint collation.</p>
-                     
-                     <p>For example, if an argument of a function declares the required type 
-                        as <code>enum("red", "green", "blue")</code>, then the string <code>"green"</code> is accepted,
-                        while <code>"yellow"</code> is rejected with a type error.</p>
-                     
-                     <p>Technically, enumeration types are defined as follows:</p>
-                     
-                     <ulist>
-                        <item><p>An enumeration type with a single enumerated value (such as 
-                           <code>enum("red")</code>) is an atomic type
-                           derived from <code>xs:string</code> by restriction using an enumeration facet
-                           that permits only the value <code>"red"</code>. This is referred to
-                           as a <term>singleton enumeration type</term>. It is equivalent to the XSD-defined type:</p>
-                        <eg><![CDATA[
+               <note>
+                  <p>Choice item types are particularly useful in function signatures, 
+                     allowing a function to take arguments
+                  of a variety of types. If the choice item type is a local union type, 
+                  then the semantics are identical to using a named union type, but a local union type is more
+                  convenient because it does not need to be defined in a schema, and does not require a schema-aware processor.</p>
+                  <p>A local union type can also be used in a cast expression: <code>cast @when as (xs:date | xs:dateTime)</code>
+                  allows the attribute <code>@when</code> to be either an <code>xs:date</code>, or an <code>xs:dateTime</code>.</p>
+                  <p>An <code>instance of</code> expression can be used to test whether a value belongs to one
+                  of a number of specified types: <code>$x instance of (xs:string | xs:anyURI | xs:untypedAtomic)</code>
+                  returns <code>true</code> if <code>$x</code> is an instance of any of these three atomic types,
+                  while <code>$x instance of (map(*) | array(*))</code> tests whether <code>$x</code> is
+                  a map or array.</p>
+               </note>
+            </div3>
+            
+            <div3 id="id-enumeration-types" diff="add" at="A">
+               <head>Enumeration Types</head>
+               <p><termdef id="dt-EnumerationType" term="EnumerationType">An <term>EnumerationType</term> 
+                  accepts a fixed set of string values.</termdef></p>
+               <scrap headstyle="show">
+                  <head/>
+                  <prodrecap id="EnumerationType" ref="EnumerationType"/>   
+               </scrap>
+               
+               <p>An <code>EnumerationType</code> has a value space consisting of a set of <code>xs:string</code>
+                  values. When matching strings against an enumeration type, strings are always compared
+               using the Unicode codepoint collation.</p>
+               
+               <p>For example, if an argument of a function declares the required type 
+                  as <code>enum("red", "green", "blue")</code>, then the string <code>"green"</code> is accepted,
+                  while <code>"yellow"</code> is rejected with a type error.</p>
+               
+               <p>Technically, enumeration types are defined as follows:</p>
+               
+               <ulist>
+                  <item><p>An enumeration type with a single enumerated value (such as 
+                     <code>enum("red")</code>) is an atomic type
+                     derived from <code>xs:string</code> by restriction using an enumeration facet
+                     that permits only the value <code>"red"</code>. This is referred to
+                     as a <term>singleton enumeration type</term>. It is equivalent to the XSD-defined type:</p>
+                  <eg><![CDATA[
 <xs:simpleType>
-  <xs:restriction base="xs:string">
-    <xs:enumeration value="red"/>
-  </xs:restriction>
+<xs:restriction base="xs:string">
+<xs:enumeration value="red"/>
+</xs:restriction>
 </xs:simpleType>]]></eg></item>
-                        <item><p>Two singleton enumeration types are the same type if and only
-                        if they have the same (single) enumerated value, as determined using the Unicode
-                        codepoint collation.</p></item>
-                        <item><p>An enumeration type with multiple
-                           enumerated values is a union of singleton enumeration types, 
-                           so <code>enum("red", "green", "blue")</code>
-                           is equivalent to <code>union(enum("red"), enum("green"), enum("blue"))</code>.</p></item>
-                        <item><p>In consequence, an enumeration type <var>T</var> is a subtype
-                        of an enumeration type <var>U</var> if the enumerated values of <var>T</var>
-                        are a subset of the enumerated values of <var>U</var>: 
-                           see <specref ref="id-itemtype-subtype"/>.</p></item>
-                        
-                     </ulist>
-                     
-                     <p>An enumeration type is thus a <termref def="dt-generalized-atomic-type"/>.</p>
-                     
-                     <p>It follows from these rules that an atomic value will only satisfy an <code>instance of</code>
-                     test if it has the correct type annotation, and this can only be achieved using an explicit cast or
-                     constructor function. So the expression <code>"red" instance of enum("red", "green", "blue")</code>
-                     returns <code>false</code>. 
-                        However, the <termref def="dt-coercion-rules"/> ensure that where a variable
-                     or function declaration specifies an enumeration type as the required type, a string 
-                     (or indeed an <code>xs:untypedAtomic</code> or <code>xs:anyURI</code> value) equal
-                     to one of the enumerated values will be accepted.</p>
-                     
-       
-                  </div4>   
+                  <item><p>Two singleton enumeration types are the same type if and only
+                  if they have the same (single) enumerated value, as determined using the Unicode
+                  codepoint collation.</p></item>
+                  <item><p>An enumeration type with multiple
+                     enumerated values is a union of singleton enumeration types, 
+                     so <code>enum("red", "green", "blue")</code>
+                     is equivalent to <code>(enum("red") | enum("green") | enum("blue"))</code>.</p></item>
+                  <item><p>In consequence, an enumeration type <var>T</var> is a subtype
+                  of an enumeration type <var>U</var> if the enumerated values of <var>T</var>
+                  are a subset of the enumerated values of <var>U</var>: 
+                     see <specref ref="id-itemtype-subtype"/>.</p></item>
+                  
+               </ulist>
+               
+               <p>An enumeration type is thus a <termref def="dt-generalized-atomic-type"/>.</p>
+               
+               <p>It follows from these rules that an atomic value will only satisfy an <code>instance of</code>
+               test if it has the correct type annotation, and this can only be achieved using an explicit cast or
+               constructor function. So the expression <code>"red" instance of enum("red", "green", "blue")</code>
+               returns <code>false</code>. 
+                  However, the <termref def="dt-coercion-rules"/> ensure that where a variable
+               or function declaration specifies an enumeration type as the required type, a string 
+               (or indeed an <code>xs:untypedAtomic</code> or <code>xs:anyURI</code> value) equal
+               to one of the enumerated values will be accepted.</p>
+               
+ 
+            </div3>   
 
                
-               </div3>
+
             <div3 id="node-types">
                <head>Node Types</head>
                
@@ -6084,6 +6103,22 @@ name.</p>
                         every member type <var>T</var> satisfies <code><var>T</var> ⊆ <var>B</var></code>.</p>
                   </note>
                </div4>
+               
+               <div4 id="id-item-subtype-choice">
+                  <head>Choice Item Types</head>
+                  <p>If <var>B</var> is a <termref def="dt-choice-item-type"/>, then 
+                     <code><var>A</var> ⊆ <var>B</var></code> is true if <code><var>A</var> ⊆ <var>M</var></code>
+                  is true for some item type <var>M</var> among the alternatives of <var>B</var>.</p>
+                  <p>If <var>A</var> is a <termref def="dt-choice-item-type"/>, then 
+                     <code><var>A</var> ⊆ <var>B</var></code> is true if <code><var>M</var> ⊆ <var>B</var></code>
+                     is true for every item type <var>M</var> among the alternatives of <var>A</var>.</p>
+                  
+                  <note>
+                     <p>Because enumeration types are defined as unions of singleton enumerations, these
+                     rules have the consequence, for example, that <code>enum("A", "B")</code> is a subtype
+                     of <code>enum("A", "B", "C")</code>.</p>
+                  </note>
+               </div4>
                <div4 id="id-item-subtype-atomic">
                   <head>Atomic and Union Types</head>
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
@@ -6132,7 +6167,7 @@ name.</p>
                               </ulist>                             
                            </example>
                            <note><p>This rule applies both when <code>A</code> is a schema-defined union type
-                              and when it is a <nt def="LocalUnionType">LocalUnionType</nt>; in addition it
+                              and when it is a <termref def="dt-local-union-type"/>; in addition it
                               applies when <code>A</code> is an enumeration type with multiple enumerated values,
                               which is defined to be equivalent to a union type.
                            </p></note>
@@ -6895,7 +6930,7 @@ name.</p>
                      </note>
 
                   </item>
-
+                  
                   <item>
                      <p>If <var>R</var> is a <termref def="dt-generalized-atomic-type"/>, then the following conversions are applied,
                         <phrase diff="add" at="2022-01-01">in order</phrase>:</p>
@@ -7038,6 +7073,15 @@ name.</p>
 
                        
                      </olist>
+                  </item>
+                  
+                  <item>
+                     <p>If <var>R</var> is a <termref def="dt-choice-item-type"/> that is not
+                     a <termref def="dt-generalized-atomic-type"/>, then the following rules
+                        are applied with <var>R</var> set to each of the alternatives in the
+                        choice item type, in order, until an alternative is found that
+                        does not result in a type error; a type error is raised
+                        only if all alternatives fail.</p>
                   </item>
 
                   <item diff="add" at="A">
@@ -16398,18 +16442,10 @@ declare function recursive-content($item as item()) as map(*)* {
                content obtained by expanding any maps or arrays in the immediate content.
                </p></note>
                
-               <p>In addition we define the function <code>array-or-map</code> as follows:</p>
-               
-               <eg><![CDATA[declare function array-or-map($item as item()) {
-  typeswitch ($item) {
-    case array(*) | map(*) return $item
-    default return error(xs:QName("err:XPTY0004"))
-  }
-}]]></eg>
                
                <p>The result of the expression <code>E??KS</code>, where <code>E</code> is any expression
                and <code>KS</code> is any <code>KeySpecifier</code>, is then:</p>
-               <eg>(<var>E</var> =!> array-or-map() => recursive-content())?<var>KS</var></eg>
+               <eg>(<var>E</var> treat as (map(*)|array(*))* => recursive-content())?<var>KS</var></eg>
                
                <note>
                   <p>This is best explained by considering examples.</p>
@@ -20129,10 +20165,8 @@ be used to process an expression in a way that depends on its <termref
             <scrap>
                <head/>
                <prodrecap id="CastExpr" ref="CastExpr"/>
-               <prodrecap id="SingleType" ref="SingleType"/>
-               <prodrecap id="SimpleTypeName" ref="SimpleTypeName"/>
-               <prodrecap ref="TypeName"/>
-               <prodrecap ref="LocalUnionType"/>
+               <prodrecap id="CastTarget" ref="CastTarget"/>
+               <prodrecap ref="ChoiceItemType"/>
                <prodrecap ref="EnumerationType"/>
             </scrap>
             <p>Sometimes
@@ -20142,16 +20176,18 @@ creates a new value of a specific type based on an existing value. A
 <code>cast</code> expression takes two operands: an <term>input
 expression</term> and a <term>target type</term>. The type of the
 atomized value of the input expression is called the <term>input type</term>. 
-The <phrase diff="chg" at="A">target type</phrase> must be one of:</p>
+The target type must be a <termref def="dt-generalized-atomic-type"/>. In practice
+               this means it may be any of:</p>
             <ulist>
                <item diff="add" at="issue688"><p>The name of an <termref def="dt-named-item-type">named item type</termref>
                defined in the <termref def="dt-static-context"/>, which in turn must refer to an item
                type in one of the following categories.</p></item>
                <item><p>The name of a type defined in the  <termref def="dt-is-types">in-scope schema types</termref>, 
-                  which must be a simple type <errorref class="ST" code="0052"/>.
+                  which must be a simple type (of variety atomic, list or union) <errorref class="ST" code="0052"/> .
                   In addition, the target type cannot be <code>xs:NOTATION</code>, <code>xs:anySimpleType</code>,
                   or <code>xs:anyAtomicType</code></p></item>
-               <item diff="add" at="A"><p>A <code>LocalUnionType</code> such as <code>union(xs:date, xs:dateTime)</code>.</p></item>
+               <item diff="add" at="A"><p>A <code>ChoiceItemType</code> representing a 
+                  <termref def="dt-generalized-atomic-type"/> (such as <code>(xs:date | xs:dateTime)</code>).</p></item>
                <item diff="add" at="issue688"><p>An <code>EnumerationType</code> such as <code>enum("red", "green", "blue")</code>.</p></item>
             </ulist>
                <p>Otherwise, a static error is raised <errorref class="ST" code="0080"/>.</p> 
@@ -20273,30 +20309,16 @@ The result of a cast expression is one of the following:
                <head/>
 
                <prodrecap id="CastableExpr" ref="CastableExpr"/>
-               <prodrecap ref="SingleType"/>
-               <prodrecap ref="SimpleTypeName"/>
-               <prodrecap ref="TypeName"/>
-               <prodrecap ref="LocalUnionType"/>
+               <prodrecap ref="CastTarget"/>
+               <prodrecap ref="ChoiceItemType"/>
                <prodrecap ref="EnumerationType"/>
             </scrap>
             <p>&language;
 provides an expression that tests whether a given value
 is castable into a given target type. 
 
-The <phrase diff="chg" at="A">target type</phrase> must be one of:</p>
-            
-            <ulist>
-               <item diff="add" at="issue688"><p>The name of an <termref def="dt-named-item-type">named item type</termref>
-                  defined in the <termref def="dt-static-context"/>, which in turn must refer to an item
-                  type in one of the following categories.</p></item>
-               <item><p>The name of a type defined in the  <termref def="dt-is-types">in-scope schema types</termref>, 
-                  which must be a simple type <errorref class="ST" code="0052"/>.
-                  In addition, the target type cannot be <code>xs:NOTATION</code>, <code>xs:anySimpleType</code>,
-                  or <code>xs:anyAtomicType</code></p></item>
-               <item diff="add" at="A"><p>A <code>LocalUnionType</code> such as <code>union(xs:date, xs:dateTime)</code>.</p></item>
-               <item diff="add" at="issue688"><p>An <code>EnumerationType</code> such as <code>enum("red", "green", "blue")</code>.</p></item>
-            </ulist>
-            
+The <phrase diff="chg" at="A">target type</phrase> is subject to the same
+               rules as the target type of a <code>cast</code> expression.</p>
 
             <p>The expression <code role="parse-test"
                   >E castable as T</code> returns <code>true</code> 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -4667,7 +4667,7 @@
 
                   <p>Other than its appearance as a child of <elcode>xsl:override</elcode>, the
                      overriding declaration is a normal <elcode>xsl:function</elcode>,
-                        <elcode>xsl:template</elcode>, ,
+                        <elcode>xsl:template</elcode>,
                      <elcode>xsl:variable</elcode>, <elcode>xsl:param</elcode>, or
                         <elcode>xsl:attribute-set</elcode> element. In the case of
                         <elcode>xsl:variable</elcode> and <elcode>xsl:param</elcode>, the variable
@@ -4888,9 +4888,9 @@
                               types is different.</p>
                            <p>Consider a function that accepts an argument
                            whose declared type is a union type with member types <code>xs:double</code>
-                           and <code>xs:decimal</code>, in that order (we might write this as <code>union(xs:double, xs:decimal)</code>).
+                           and <code>xs:decimal</code>, in that order (we might write this as <code>(xs:double | xs:decimal)</code>).
                            Using the same notation, this can be overridden by a function that declares the argument
-                           type as <code>union(xs:decimal, xs:double)</code>. This does not affect type checking:
+                           type as <code>(xs:decimal | xs:double)</code>. This does not affect type checking:
                               a function call that passes the type checking rules with one signature will also pass the
                               type checking rules with the other. It does however affect the way that the function
                            conversion rules work: a call that passes the <code>xs:untypedAtomic</code> value
@@ -10385,11 +10385,17 @@ and <code>version="1.0"</code> otherwise.</p>
                      followed by zero or more predicates in square
                      brackets, and it matches any item of type <var>T</var> which each of the predicates evaluates
                      to <code>true</code>.</termdef></p>
+                  <p>The parameter <var>T</var> can also be a list of item types, separated by <code>"|"</code>.
+                  For example, <code>type(array(*) | map(*))</code> matches arrays and maps, while 
+                  <code>type(text() | comment())</code> matches text nodes and comment nodes.</p>
                   <p>The most commonly used type patterns can be abbreviated. For example, <code>match="type(record(F1, F2, *))"</code> 
                      can be abbrevated to <code>match="record(F1, F2, *)"</code>, and <code>match="type(array(xs:string))"</code>
                      can be abbreviated to <code>match="array(xs:string)"</code>. The main case where such abbreviation is
                   not possible is with atomic values: <code>match="type(xs:date)"</code> cannot be abbreviated because
-                  a bare QName is interpreted as a node pattern, matching elements named <code>xs:date</code>.</p>
+                  a bare QName is interpreted as a node pattern, matching elements named <code>xs:date</code>.
+                  The pattern <code>match="type(text() | comment())"</code> has almost the same effect as
+                  <code>match="text() | comment()"</code>, except that the rules for calculating a default priority
+                  are different.</p>
                   
                </item>
                <item>
@@ -10489,8 +10495,18 @@ and <code>version="1.0"</code> otherwise.</p>
                                  that the result of calling the function with the argument value <code>42</code> is <code>true</code>.</p>
                            </item>
                            <item>
-                              <p><code>union(xs:date, xs:dateTime, xs:time)</code> matches any atomic value
+                              <p><code>type(xs:date | xs:dateTime | xs:time)</code> matches any atomic value
                                  that is an instance of <code>xs:date</code>, <code>xs:dateTime</code>, or <code>xs:time</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>type(array(xs:date) | array(xs:dateTime) | array(xs:time))</code> matches any array whose
+                                 members are all of type <code>xs:date</code>, any array whose
+                                 members are all of type <code>xs:dateTime</code>, or any array whose
+                                 members are all of type <code>xs:time</code>.</p>
+                           </item>
+                           <item>
+                              <p><code>type(map((xs:string|xs:untypedAtomic), *)</code> matches any map
+                                 whose keys are all instances of <code>xs:string</code> or <code>xs:untypedAtomic</code>.</p>
                            </item>
                            <item>
                               <p><code>enum("red", "green", "blue")</code> matches any one of the three strings
@@ -10736,6 +10752,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <head></head>
                      <prodrecap ref="TypePattern"/>
                      <prodrecap ref="WrappedItemTest" id="WrappedItemTest"/>
+                     <prodrecap ref="ChoiceItemType" id="ChoiceItemType"/>
                      <prodrecap ref="AnyItemTest" id="AnyItemTest"/>
                      <prodrecap ref="FunctionTest" id="FunctionTest"/>
                      <prodrecap ref="MapTest" id="MapTest"/>
@@ -10764,7 +10781,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         <code>xs:integer</code></p></item>
                      <item><p><code>type(xs:integer)[. gt 0]</code> matches
                         any positive integer.</p></item>
-                     <item><p><code>union(xs:string, xs:untypedAtomic)[matches(., '[0-9]+')]</code> matches
+                     <item><p><code>type(xs:string | xs:untypedAtomic)[matches(., '[0-9]+')]</code> matches
                         any instance of <code>xs:string</code> or <code>xs:untypedAtomic</code> that
                         contains a sequence of decimal digits.</p></item>
                      <item><p><code>type(node())</code> matches any node. (This is not the same as the pattern
@@ -12825,7 +12842,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            in preference to <code>type(xs:integer)</code> which in turn is chosen in preference
                            to <code>type(xs:decimal)</code>.</p></item>
                         <item><p>The match pattern <code>type(xs:integer)</code> is chosen
-                           in preference to <code>union(xs:integer, xs:double)</code> which in turn is chosen in preference
+                           in preference to <code>type(xs:integer | xs:double)</code> which in turn is chosen in preference
                            to <code>type(xs:numeric)</code>.</p></item>
                         <item><p>The match pattern <code>record(longitude, latitude, altitude)</code> is
                            chosen in preference to the pattern <code>record(longitude, latitude, *)</code>,
@@ -16702,6 +16719,12 @@ and <code>version="1.0"</code> otherwise.</p>
                         after applying any permitted conversions. [XSLT 3.0 Erratum E22, bug 30238].</p>
                   </error>
                </p>
+               
+               <p>For example, the following declares a parameter that requires the supplied
+               value (after atomization) to be either a QName, or the string <code>"*"</code>, 
+                  or an empty sequence:</p>
+               
+               <eg><![CDATA[<xsl:param name="n" as="(xs:QName | enum('*'))?"/>]]></eg>
 
             </div3>
             <div3 id="default-values-of-parameters">
@@ -35029,158 +35052,7 @@ the same group, and the-->
          <head>Maps</head>
          
          <p diff="chg" at="2022-01-01">Maps are defined in the XDM Data Model.</p>
-         <div2 id="map-type" diff="del" at="2022-01-01">
-            <head>The Type of a Map</head>
-
-
-            <p>The syntax of <xnt ref="prod-xpath40-ItemType" spec="XP40">ItemType</xnt> as defined
-               in XPath is extended as follows:</p>
-            <scrap headstyle="show" id="MapType-scrap">
-               <head>MapType</head>
-               <prodgroup>
-                  <prod num="69" id="NT-ItemType-2">
-                     <lhs>ItemType</lhs>
-                     <rhs>KindTest | ("item" "(" ")") | FunctionTest | AtomicOrUnionType |
-                        ParenthesizedItemType<br/> | MapType</rhs>
-                  </prod>
-                  <prod num="201" id="NT-MapType">
-                     <lhs>MapType</lhs>
-                     <rhs>'map' '(' ( '*' | (<xnt ref="doc-xpath40-AtomicOrUnionType" spec="XP40">AtomicOrUnionType</xnt> ',' <xnt ref="prod-xpath40-SequenceType" spec="XP40">SequenceType</xnt>) ')'</rhs>
-                  </prod>
-               </prodgroup>
-            </scrap>
-
-            <p>The following rules express the matching rules for a map item type
-               and a map, and extend the set of rules given in <xspecref spec="XP40" ref="id-matching-item"/>:</p>
-
-            <ulist>
-               <item>
-                  <p>The <code>ItemType</code>
-                     <code>map(K, V)</code> matches an item <var>M</var> if (a) <var>M</var> is a
-                        map, and (b) every entry in <var>M</var> has
-                     a key that matches <var>K</var> and an associated value that matches
-                        <var>V</var>. For example, <code>map(xs:integer, element(employee))</code>
-                     matches a map if all the keys in the map are integers, and all the associated
-                     values are <code>employee</code> elements. Note that a map (like a sequence)
-                     carries no intrinsic type information separate from the types of its entries,
-                     and the type of existing entries in a map does not constrain the type of new
-                     entries that can be added to the map.</p>
-                  <note>
-                     <p>In consequence, <code>map(K, V)</code> matches an empty
-                        map, whatever the types <var>K</var> and <var>V</var> might be.</p>
-                  </note>
-               </item>
-               <item>
-                  <p>The <code>ItemType</code>
-                     <code>map(*)</code> matches any map regardless of its contents. It is
-                     equivalent to <code>map(xs:anyAtomicType, item()*)</code>.</p>
-               </item>
-            </ulist>
-
-            <p>A map also acts as a function. This means that maps match certain
-               function item types. Specifically, the following rule extends the list of rules in
-                  <xspecref spec="XP40" ref="id-function-test"/>:</p>
-
-            <ulist>
-               <item>
-                  <p><code>function(*)</code> matches any map.</p>
-               </item>
-               <item>
-                  <p><code>function(xs:anyAtomicType) as item()*</code> matches any map.</p>
-               </item>
-            </ulist>
-
-            <p>Because of the rules for subtyping of function types according to
-               their signature, it follows that the item type <code>function(A) as item()*</code>,
-               where A is an atomic type, also matches any map, regardless of the type of the keys
-               actually found in the map. For example, a map whose keys are all strings can be
-               supplied where the required type is <code>function(xs:integer) as item()*</code>; a
-               call on the map that treats it as a function with an integer argument will always
-               succeed, and will always return an empty sequence.</p>
-
-            <p>The function signature of the map, treated as a function, is always
-                  <code>function(xs:anyAtomicType) as item()*</code>, regardless of the actual types
-               of the keys and values in the map. This means that a function item type with a more
-               specific return type, such as <code>function(xs:anyAtomicType) as xs:integer</code>,
-               does not match a map in the sense required to satisfy the <code>instance of</code>
-               operator. However, the rules for function coercion mean that any map can be supplied
-               as a value in a context where such a type is the required type, and a type error will
-               only occur if an actual call on the map (treated as a function) returns a value that
-               is not an instance of the required return type.</p>
-
-            <note>
-               <p>So, given a map <code>$M</code> whose keys are integers and whose results are
-                  strings, such as <code>{ 0: "no", 1: "yes" }</code>, the following relations hold,
-                  among others:</p>
-               <ulist>
-                  <item>
-                     <p><code>$M instance of map(*)</code></p>
-                  </item>
-                  <item>
-                     <p><code>$M instance of map(xs:integer, xs:string)</code></p>
-                  </item>
-                  <item>
-                     <p><code>$M instance of map(xs:decimal, xs:anyAtomicType)</code></p>
-                  </item>
-                  <item>
-                     <p><code>not($M instance of map(xs:int, xs:string))</code></p>
-                  </item>
-                  <item>
-                     <p><code>not($M instance of map(xs:integer, xs:token))</code></p>
-                  </item>
-                  <item>
-                     <p><code>$M instance of function(*)</code></p>
-                  </item>
-                  <item>
-                     <p><code>$M instance of function(xs:anyAtomicType) as item()*</code></p>
-                  </item>
-                  <item>
-                     <p><code>$M instance of function(xs:integer) as item()*</code></p>
-                  </item>
-                  <item>
-                     <p><code>$M instance of function(xs:int) as item()*</code></p>
-                  </item>
-                  <item>
-                     <p><code>$M instance of function(xs:string) as item()*</code></p>
-                  </item>
-                  <item>
-                     <p><code>not($M instance of function(xs:integer) as xs:string)</code></p>
-                  </item>
-               </ulist>
-               <p>The last case might seem surprising; however, function coercion ensures that
-                     <code>$M</code> can be used successfully anywhere that the required type is
-                     <code>function(xs:integer) as xs:string</code>.</p>
-            </note>
-
-            <p>The rules for judging whether one item type is a subtype of
-               another, given in <xspecref spec="XP40" ref="id-itemtype-subtype"/>, are extended
-               with some additional rules. The judgement <code>subtype-itemtype(Ai, Bi)</code> is
-               true if:</p>
-
-            <ulist>
-               <item>
-                  <p><code>Ai</code> is <code>map(K, V)</code> and <code>Bi</code> is
-                        <code>map(*)</code>, for any <code>K</code> and <code>V</code>.</p>
-               </item>
-               <item>
-                  <p><code>Ai</code> is <code>map(Ka, Va)</code> and <code>Bi</code> is
-                        <code>map(Kb, Vb)</code>, where <code>subtype-itemtype(Ka, Kb)</code> and
-                        <code>subtype(Va, Vb)</code>.</p>
-               </item>
-               <item>
-                  <p><code>Ai</code> is <code>map(*)</code> (or, because of the transitivity rules,
-                     any other map type) and <code>Bi</code> is <code>function(*)</code>.</p>
-               </item>
-               <item>
-                  <p><code>Ai</code> is <code>map(*)</code>, (or, because of the transitivity rules,
-                     any other map type) and <code>Bi</code> is <code>function(xs:anyAtomicType) as
-                        item()*</code>.</p>
-               </item>
-            </ulist>
-
-
-
-         </div2>
+         
          
          <div2 id="map-instructions">
             <head>Map Instructions</head>
@@ -39663,7 +39535,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                   <function>function-available</function>,
                   <function>type-available</function>, and
                   <function>system-property</function> have an argument whose type has changed
-                  from <code>xs:string</code> to <code>union(xs:string, xs:QName)</code>.
+                  from <code>xs:string</code> to <code>(xs:string | xs:QName)</code>.
                   This change means that certain non-string values are no longer accepted:
                   for example <code>xs:anyURI</code> values or 
                   (with <termref def="dt-backwards-compatible-behavior"/> enabled) 


### PR DESCRIPTION
Fix #122.

Allows the new item type syntax `(A | B)`, replacing `union(A, B)`; the alternatives are no longer restricted to be atomic types. The choice item type is a generalized atomic type if and only if all the alternatives are generalized atomic types.

Note that #122 also proposed unions of sequence types. While that is also viable, I found that unions of item types handled pretty well all practical use cases, and it seems excessive to offer both. Unions of item types proved (a) more useful (b) easier to combine with the existing feature of local union types, and (c) easier to handle in the coercion rules. Providing both is also tricky to handle in the grammar.