### PR TITLE
1140 Replace 'search' with 'target' for indexing functions

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -12378,7 +12378,7 @@ let $newi := $o/tool</eg>
       <fos:signatures>
          <fos:proto name="index-of" return-type="xs:integer*">
             <fos:arg name="input" type="xs:anyAtomicType*"/>
-            <fos:arg name="search" type="xs:anyAtomicType"/>
+            <fos:arg name="target" type="xs:anyAtomicType"/>
             <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
@@ -12394,16 +12394,16 @@ let $newi := $o/tool</eg>
       </fos:properties>
       <fos:summary>
          <p>Returns a sequence of positive integers giving the positions within the sequence
-               <code>$input</code> of items that are equal to <code>$search</code>.</p>
+               <code>$input</code> of items that are equal to <code>$target</code>.</p>
       </fos:summary>
       <fos:rules>
          <p>The function returns a sequence of positive integers giving the positions within the
-            sequence <code>$input</code> of items that are equal to <code>$search</code>.</p>
+            sequence <code>$input</code> of items that are equal to <code>$target</code>.</p>
          <p>The collation used by this function is determined according to the rules in <specref
                ref="choosing-a-collation"
             />. This collation is used when string comparison is
             required.</p>
-         <p>The items in the sequence <code>$input</code> are compared with <code>$search</code> under
+         <p>The items in the sequence <code>$input</code> are compared with <code>$target</code> under
             the rules for the <code>eq</code> operator. Values of type <code>xs:untypedAtomic</code>
             are compared as if they were of type <code>xs:string</code>. Values that cannot be
             compared, because the <code>eq</code> operator is not defined for their types, are
@@ -12414,7 +12414,7 @@ let $newi := $o/tool</eg>
       </fos:rules>
       <fos:notes>
          <p>If <code>$input</code> is the empty sequence, or if no item in
-            <code>$input</code> matches <code>$search</code>, then the function returns the empty
+            <code>$input</code> matches <code>$target</code>, then the function returns the empty
             sequence.</p>
          <p>No error occurs if non-comparable values are encountered. So when comparing two atomic
             values, the effective boolean value of <code>fn:index-of($a, $b)</code> is <code>true</code> if
@@ -17149,7 +17149,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p>There is no guarantee that a generated unique identifier will be distinct from any
             unique IDs specified in the source document.</p>
          <p>There is no inverse to this function; it is not directly possible to find the node with
-            a given generated ID. Of course, it is possible to search a given sequence of nodes
+            a given generated ID. Of course, it is possible to target a given sequence of nodes
             using an expression such as <code>$nodes[generate-id()=$id]</code>.</p>
          <p>It is advisable, but not required, for implementations to generate IDs that are distinct
             even when compared using a case-blind collation.</p>
@@ -18922,10 +18922,10 @@ declare function fold-left(
             <fos:test>
                <fos:expression><eg>
 let $input := (11 to 21, 21 to 31)
-let $search := 21
+let $target := 21
 return fold-left($input, (),
   fn($result, $curr, $pos) {
-    $result, if ($curr = $search) { $pos }
+    $result, if ($curr = $target) { $pos }
   }
 )
 </eg></fos:expression>
@@ -19042,12 +19042,12 @@ declare function fold-right(
             <fos:test>
                <fos:expression><eg>
 let $input := (11 to 21, 21 to 31)
-let $search := 21
+let $target := 21
 return fold-right(
   $input,
   (),
   action := fn($current, $result, $pos) {
-    $result, $pos[$current = $search]
+    $result, $pos[$current = $target]
   }
 )
 </eg></fos:expression>
@@ -25645,7 +25645,7 @@ else $fallback($position)</eg>
       <fos:signatures>
          <fos:proto name="index-of" return-type="xs:integer*">
             <fos:arg name="array" type="array(*)"/>
-            <fos:arg name="search" type="xs:anyAtomicType*"/>
+            <fos:arg name="target" type="xs:anyAtomicType*"/>
             <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
@@ -25661,12 +25661,12 @@ else $fallback($position)</eg>
       </fos:properties>
       <fos:summary>
          <p>Returns a sequence of positive integers giving the positions within the array
-               <code>$array</code> of members that are equal to <code>$search</code>.</p>
+               <code>$array</code> of members that are equal to <code>$target</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, all members of <code>$array</code> are compared with <code>$search</code>.
-            An array member is equal to the search value if it has the same number of items,
-            and if every item matches the corresponding search item under the rules for the
+         <p>Informally, all members of <code>$array</code> are compared with <code>$target</code>.
+            An array member is equal to the target value if it has the same number of items,
+            and if every item matches the corresponding target item under the rules for the
             <code>eq</code> operator. Items of type <code>xs:untypedAtomic</code>
             are compared as if they were of type <code>xs:string</code>. Items that cannot be
             compared, because the <code>eq</code> operator is not defined for their types, are
@@ -25678,9 +25678,9 @@ else $fallback($position)</eg>
          <p>More formally, the function returns the result of the expression:</p>
          <eg>
 (1 to array:size($array))[
-  count($array(.)) = count($search) and
+  count($array(.)) = count($target) and
   every(for-each-pair(
-    $array(.), $search, fn($a, $b) { exists(index-of($a, $b, $collation)) }
+    $array(.), $target, fn($a, $b) { exists(index-of($a, $b, $collation)) }
   ))
 ]
 </eg>
@@ -25689,7 +25689,7 @@ else $fallback($position)</eg>
       </fos:rules>
       <fos:notes>
          <p>If <code>$array</code> is the empty array, or if no member in
-            <code>$array</code> matches <code>$search</code>, then the function returns the empty
+            <code>$array</code> matches <code>$target</code>, then the function returns the empty
             sequence.</p>
       </fos:notes>
       <fos:examples>
@@ -26469,10 +26469,10 @@ fold-left(
             <fos:test>
                <fos:expression><eg>
 let $input := array { 11 to 21, 21 to 31 }
-let $search := 21
+let $target := 21
 return array:fold-left($input, (),
   fn($result, $curr, $pos) {
-    $result, if ($curr = $search) { $pos }
+    $result, if ($curr = $target) { $pos }
   }
 )
 </eg></fos:expression>
@@ -26556,11 +26556,11 @@ fold-right(
             <fos:test>
                <fos:expression><eg>
 let $input := array { 11 to 21, 21 to 31 }
-let $search := 21
+let $target := 21
 return array:fold-right(
   $input, (),
   action := fn($curr, $result, $pos) {
-    $result, if ($curr = $search) { $pos }
+    $result, if ($curr = $target) { $pos }
   }
 )</eg></fos:expression>
                <fos:result>(12, 11)</fos:result>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17149,7 +17149,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p>There is no guarantee that a generated unique identifier will be distinct from any
             unique IDs specified in the source document.</p>
          <p>There is no inverse to this function; it is not directly possible to find the node with
-            a given generated ID. Of course, it is possible to target a given sequence of nodes
+            a given generated ID. Of course, it is possible to search a given sequence of nodes
             using an expression such as <code>$nodes[generate-id()=$id]</code>.</p>
          <p>It is advisable, but not required, for implementations to generate IDs that are distinct
             even when compared using a case-blind collation.</p>


### PR DESCRIPTION
Close #1140 

Having created the issue, per my outstanding action, I thought I'd take a quick look to see how extensive the change would be. AFAICT (though I confess to not looking exceedingly carefully), only two functions are effected. Here, for your consideration, is a PR that resolves the issue.