### PR TITLE
QT4CG-072-01 Clarify schema type terminology

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1764,9 +1764,10 @@ but it does not place any constraints on how XDM instances are constructed.</p>
                      >XDM instance</termref> has a <term>type annotation</term> (described in <xspecref
                      spec="DM40" ref="types"
                   />). 
-The type annotation of a node is a reference to an XML Schema type. 
+The type annotation of a node is a reference to a <termref def="dt-schema-type"/>. 
 </termdef>  The <code>type-name</code> of a node is the name of the type referenced by its <termref
-                  def="dt-type-annotation">type annotation</termref>. 
+                  def="dt-type-annotation">type annotation</termref> (but note that the
+               type annotation can be a reference to an anonymous type). 
 If the <termref
                   def="dt-data-model-instance"
                   >XDM instance</termref> was derived from a validated XML document as described in <xspecref
@@ -1787,7 +1788,7 @@ nodes. The <termref
                   def="dt-type-annotation"
                   >type annotation</termref> of an element node indicates how the values in
 its child text nodes are to be interpreted. An element that has not been validated (such as might occur in a schemaless document) is annotated
-with the schema type <code>xs:untyped</code>. An element that has been validated and found to be partially valid is annotated with the schema type <code>xs:anyType</code>. If an element node is annotated as <code>xs:untyped</code>, all its descendant element nodes are also annotated as <code>xs:untyped</code>. However, if an element node is annotated as <code>xs:anyType</code>, some of its descendant element nodes may have a more specific <termref
+with the <termref def="dt-schema-type"/> <code>xs:untyped</code>. An element that has been validated and found to be partially valid is annotated with the schema type <code>xs:anyType</code>. If an element node is annotated as <code>xs:untyped</code>, all its descendant element nodes are also annotated as <code>xs:untyped</code>. However, if an element node is annotated as <code>xs:anyType</code>, some of its descendant element nodes may have a more specific <termref
                   def="dt-type-annotation">type annotation</termref>.</p>
 
 
@@ -3483,33 +3484,58 @@ defined in <xspecref
       as are <code>attribute(A)</code> and <code>attribute(A, xs:anySimpleType)</code>.</p></note>
          <p>
             <termdef id="dt-schema-type" term="schema type"
-                  >A <term>schema type</term> is a type that is (or could be) defined using the facilities of <bibref
+                  >A <term>schema type</term> is a type that is defined using the facilities of <bibref
                   ref="XMLSchema10"/> or <bibref ref="XMLSchema11"
-               /> (including the built-in types).</termdef> A schema type can be used as a type annotation on an
-element or attribute node (unless it is a non-instantiable type such as <code>xs:NOTATION</code> or <code>xs:anyAtomicType</code>, in which case its derived
-types can be so used). Every schema type is either a <term>complex type</term> or a
+               /> (including the built-in types defined in the XSD specification, and a few additional
+               types defined in this specification).</termdef> 
+            Every schema type is either a <term>complex type</term> or a
 <term>simple type</term>; simple types are further subdivided into <term>list types</term>, <term>union
 types</term>, and <term>atomic types</term> (see <bibref
                ref="XMLSchema10"/> or <bibref ref="XMLSchema11"
             /> for definitions and explanations of these terms.)</p>
       
+      <p><termdef id="dt-atomic-type" term="atomic type">An <term>atomic type</term>
+      is a simple type (and therefore a <termref def="dt-schema-type"/>)
+      whose variety is atomic; it is either a built-in atomic
+      type (defined either in the XSD specification or in this specification), or
+      it is a user-defined atomic type included in an imported schema.</termdef></p>
+      
+      <p>A schema type can appear as a type annotation on an
+         element or attribute node. The type annotation on an element node can be
+         a complex type or a simple type; the type annotation on an attribute node
+         is always a simple type. Non-instantiable types such as <code>xs:NOTATION</code> or
+         <code>xs:anyAtomicType</code> never appear as type annotations, but their derived
+         types can be so used. Union types never appear as type annotations; when
+         an element or attribute is validated against a union type, the resulting
+         type annotation will be one of the types in the transitive membership of 
+         the union type.</p>
+      
       <note><p>Local union types (see <specref ref="id-choice-item-types"/>) and 
-         enumeration types (see <specref ref="id-enumeration-types"/>) are classified as 
-         <termref def="dt-schema-type">schema types</termref>, even though they are not defined in any XSD schema.</p></note>
+         <termref def="dt-enumeration-type">enumeration types</termref> cannot be
+         used as the target for schema validation.</p></note>
 
          <p>
             <termdef id="dt-generalized-atomic-type" term="generalized atomic type"
-                  >A <term>generalized atomic type</term> is a 
-               <phrase diff="chg" at="2023-02-20"><termref def="dt-schema-type"/></phrase> 
-               that is either (a) an atomic type or (b) a <termref def="dt-pure-union-type">pure union type</termref>
+                  >A <term>generalized atomic type</term> is a type whose instances are all
+               atomic values. Generalized atomic types include (a) 
+               <termref def="dt-atomic-type">atomic types</termref>, either built-in
+               (for example <code>xs:integer</code>) or imported from a schema, 
+               (b) <termref def="dt-pure-union-type">pure union types</termref>, either built-in
+               (<code>xs:numeric</code> and <code>xs:error</code>) or imported from a schema,
+               (c) <termref def="dt-choice-item-type">choice item types</termref> if their alternatives
+               are all generalized atomic types, and 
+               (d) <termref def="dt-enumeration-type">enumeration types</termref>.
             </termdef>.</p>
 
          <p>
             <termdef id="dt-pure-union-type" term="pure union type"
                >A <term>pure union type</term> is a <phrase diff="chg" at="2023-02-20"><term>simple type</term></phrase> 
                that satisfies the following constraints:
-               (1) <code>{variety}</code> is <code>union</code>, (2) the <code>{facets}</code> property is empty, (3) no type in the transitive membership of the union type has <code>{variety}</code>
-               <code>list</code>, and (4) no type in the transitive membership of the union type is a type with <code>{variety}</code>
+               (a) <code>{variety}</code> is <code>union</code>, 
+               (b) the <code>{facets}</code> property is empty, 
+               (c) no type in the transitive membership of the union type has <code>{variety}</code>
+               <code>list</code>, and 
+               (d) no type in the transitive membership of the union type is a type with <code>{variety}</code>
                <code>union</code> having a non-empty <code>{facets}</code> property</termdef>.</p>
 
          <note>
@@ -3518,7 +3544,7 @@ types</term>, and <term>atomic types</term> (see <bibref
 excludes union types derived by non-trivial restriction from other
 union types, as well as union types that include list types in their
 membership. Pure union types have the property that every
-instance of an atomic type defined as one of the member types of the
+instance of an <termref def="dt-atomic-type"/> defined as one of the member types of the
 union is also a valid instance of the union type.</p>
          </note>
 
@@ -3536,18 +3562,12 @@ types only if they are defined directly as the union of a number of
 atomic types.</p>
          </note>
       
-         <note diff="add" at="2023-02-20"><p>A local union type (see <specref ref="id-choice-item-types"/>) is
-            always a <termref def="dt-pure-union-type">pure union type</termref></p></note>
-
+         
          <p>
-            <termref def="dt-generalized-atomic-type"
-               >Generalized atomic types</termref>
-represent the intersection between the categories of <termref
-               def="dt-sequence-type">sequence type</termref> and <termref def="dt-schema-type"
-               >schema type</termref>. A generalized atomic type, such as <code>xs:integer</code> or <code>my:hatsize</code>, is both a <termref
-               def="dt-sequence-type">sequence type</termref> and a
-<termref def="dt-schema-type"
-               >schema type</termref>.</p>
+            <termref def="dt-atomic-type">Atomic types</termref>
+            and <termref def="dt-pure-union-type">pure union types</termref>
+            are usable both as <termref def="dt-schema-type">schema types</termref>
+            and as <termref def="dt-item-type">item types</termref>.</p>
          
 
 
@@ -3604,16 +3624,18 @@ represent the intersection between the categories of <termref
                   <p>
                      <termdef term="xs:untyped" id="dt-untyped">
                         <code>xs:untyped</code> is  used as the <termref def="dt-type-annotation"
-                           >type annotation</termref> of an element node that has not been validated, or has been validated in <code>skip</code> mode.</termdef> No predefined schema types are derived from <code>xs:untyped</code>.</p>
+                           >type annotation</termref> of an element node that has not been validated, or has been validated in <code>skip</code> mode.</termdef> 
+                        No predefined schema types are derived from <code>xs:untyped</code>.</p>
                </item>
 
                <item>
                   <p>
                      <termdef id="dt-untypedAtomic" term="xs:untypedAtomic">
                         <code>xs:untypedAtomic</code>
-is an atomic type that is used to denote untyped atomic data, such as text that has not been assigned a more specific type.</termdef> An attribute that has been validated in <code>skip</code> mode is represented in the <termref
-                        def="dt-datamodel"
-                        >data model</termref> by an attribute node with the <termref
+                        is an <termref def="dt-atomic-type"/> that is used to denote untyped atomic data, 
+                        such as text that has not been assigned a more specific type.</termdef> 
+                        An attribute that has been validated in <code>skip</code> mode is represented in the <termref
+                        def="dt-datamodel">data model</termref> by an attribute node with the <termref
                         def="dt-type-annotation">type annotation</termref>
                      <code>xs:untypedAtomic</code>. No predefined schema types are derived from <code>xs:untypedAtomic</code>.</p>
                </item>
@@ -3639,7 +3661,8 @@ components.</termdef>
                <item>
                   <p>
                      <termdef term="xs:anyAtomicType" id="dt-anyAtomicType">
-                        <code>xs:anyAtomicType</code> is an atomic type that includes all atomic values (and no values that
+                        <code>xs:anyAtomicType</code> is an <termref def="dt-atomic-type"/> 
+                        that includes all atomic values (and no values that
 are not atomic). Its base type is
 <code>xs:anySimpleType</code> from which all simple types, including atomic,
 list, and union types, are derived. All primitive atomic types, such as
@@ -4247,7 +4270,8 @@ the schema type named <code>us:address</code>.</p>
                   then it is taken as a reference to the corresponding item type. The rules that
                apply are the rules for the expanded item type definition.</p></item>
                <item><p>Otherwise, it must match the name of a type in the <termref def="dt-is-types">in-scope schema types</termref>
-                  in the <termref def="dt-static-context"/>: specifically, an atomic type or a plain union type.
+                  in the <termref def="dt-static-context"/>: specifically, an <termref def="dt-atomic-type"/> 
+                  or a <termref def="dt-pure-union-type"/>.
                   See <specref ref="id-atomic-and-union-types"/> for details.
                   </p>
                <note><p>A name in the <code>xs</code> namespace will always fall into this category, since the namespace
@@ -4294,7 +4318,8 @@ the schema type named <code>us:address</code>.</p>
                      an <nt def="ItemType">ItemType</nt> in any of the following ways:</p>
                   
                   <ulist>
-                     <item><p>Using the QName of a type in the <termref def="dt-issd"/> that is an atomic type
+                     <item><p>Using the QName of a type in the <termref def="dt-issd"/> that is an 
+                        <termref def="dt-atomic-type"/>
                      or a <termref def="dt-pure-union-type"/>.</p></item>
                      <item><p>Using a QName that identifies a <termref def="dt-named-item-type"/> that resolves
                         to a <termref def="dt-generalized-atomic-type"/>.</p></item>
@@ -4353,22 +4378,22 @@ the schema type named <code>us:address</code>.</p>
                
                <p>If all the alternatives are <termref
                   def="dt-generalized-atomic-type">generalized atomic types</termref>
-                  then the <code>ChoiceItemType</code> is itself a generalized atomic type,
+                  then the <termref def="dt-choice-item-type"/> is itself a generalized atomic type,
                which means, for example, that it can be used as the target of a cast expression.</p>
                
-               <p><termdef id="dt-local-union-type" term="local union type">A <code>ChoiceItemType</code>
+               <p>A <termref def="dt-choice-item-type"/>
                   in which all the alternatives are <termref
                      def="dt-generalized-atomic-type">generalized atomic types</termref>
-               is referred to as a <term>local union type</term>; a local union type
-               is itself a generalized atomic type.</termdef></p>
+               is itself a generalized atomic type.</p>
                
-               <p>A <termref def="dt-local-union-type"/> defines an anonymous union type locally (for example,
-               within a function signature) which may be more convenient than defining the type in an
-               imported schema.</p>
+               <note>
+                  <p>A <termref def="dt-choice-item-type"/> in which all the alternatives are atomic
+                  behaves in most respects like a schema-defined <termref def="dt-pure-union-type"/>.
+                     However, because it can be defined at the point of use (for example,
+                     within a function signature), it may be more convenient than defining the type in an
+                     imported schema.</p>
+               </note>
                
-               <p>A <termref def="dt-local-union-type"/> is classified
-               as a <termref def="dt-schema-type">schema type</termref> even though it is not 
-                  defined in any XSD schema.</p>
                
                   
                <note>
@@ -4389,7 +4414,7 @@ the schema type named <code>us:address</code>.</p>
             
             <div3 id="id-enumeration-types" diff="add" at="A">
                <head>Enumeration Types</head>
-               <p><termdef id="dt-EnumerationType" term="EnumerationType">An <term>EnumerationType</term> 
+               <p><termdef id="dt-enumeration-type" term="EnumerationType">An <term>EnumerationType</term> 
                   accepts a fixed set of string values.</termdef></p>
                <scrap headstyle="show">
                   <head/>
@@ -4408,7 +4433,7 @@ the schema type named <code>us:address</code>.</p>
                
                <ulist>
                   <item><p>An enumeration type with a single enumerated value (such as 
-                     <code>enum("red")</code>) is an atomic type
+                     <code>enum("red")</code>) is equivalent to an <termref def="dt-atomic-type"/>
                      derived from <code>xs:string</code> by restriction using an enumeration facet
                      that permits only the value <code>"red"</code>. This is referred to
                      as a <term>singleton enumeration type</term>. It is equivalent to the XSD-defined type:</p>
@@ -5337,11 +5362,14 @@ name.</p>
                      error will occur only if a call on the function actually returns an empty sequence. </p>
                </note>
 
-               <p diff="del" at="issue730">Because of the rules for subtyping of function types according to their signature, it follows that the item type
-  <code>function(A) as item()*</code>, where A is an atomic type, also matches any map, regardless of the type of the keys actually
-  found in the map. For example, a map whose keys are all strings can be supplied where the required type is 
-  <code>function(xs:integer) as item()*</code>; a call on the map that treats it as a function with an integer argument will always succeed,
-  and will always return an empty sequence.</p>
+               <p diff="del" at="issue730">Because of the rules for subtyping of function 
+                  types according to their signature, it follows that the item type
+                  <code>function(A) as item()*</code>, where A is an <termref def="dt-atomic-type"/>, 
+                  also matches any map, regardless of the type of the keys actually
+                  found in the map. For example, a map whose keys are all strings can be 
+                  supplied where the required type is <code>function(xs:integer) as item()*</code>; 
+                  a call on the map that treats it as a function with an integer argument 
+                  will always succeed, and will always return an empty sequence.</p>
 
 
 
@@ -6114,7 +6142,8 @@ name.</p>
                      is true for every item type <var>M</var> among the alternatives of <var>A</var>.</p>
                   
                   <note>
-                     <p>Because enumeration types are defined as unions of singleton enumerations, these
+                     <p>Because an <termref def="dt-enumeration-type"/> is defined as a choice type
+                        of singleton enumerations, these
                      rules have the consequence, for example, that <code>enum("A", "B")</code> is a subtype
                      of <code>enum("A", "B", "C")</code>.</p>
                   </note>
@@ -6140,7 +6169,7 @@ name.</p>
                                     type derived from <code>xs:string</code>.</p></item>
                                  <item><p><code>enum("red") ⊆ enum("red", "green")</code> because the 
                                     enumeration type <code>enum("red", "green")</code> is defined to be a union type
-                                       that has the atomic type <code>enum("red")</code> as a member type.</p></item>
+                                       that has the generalized atomic type <code>enum("red")</code> as a member type.</p></item>
                               </ulist>
                            </example>
                         </item>
@@ -6166,11 +6195,11 @@ name.</p>
                                     is a subtype of one of the two members of the union type.</p></item>
                               </ulist>                             
                            </example>
-                           <note><p>This rule applies both when <code>A</code> is a schema-defined union type
+                           <!--<note><p>This rule applies both when <code>A</code> is a schema-defined union type
                               and when it is a <termref def="dt-local-union-type"/>; in addition it
                               applies when <code>A</code> is an enumeration type with multiple enumerated values,
                               which is defined to be equivalent to a union type.
-                           </p></note>
+                           </p></note>-->
                         </item>
              
                      </olist>
@@ -6957,7 +6986,7 @@ name.</p>
                                  <olist>
                                     <item>
                                        <p>If <var>R</var> is an 
-                                       <termref def="dt-EnumerationType"/> then
+                                       <termref def="dt-enumeration-type"/> then
                                        <var>A</var> is cast to <code>xs:string</code>.</p></item>
                                     <item>
                                        <p>If <var>R</var> is <termref
@@ -20442,7 +20471,7 @@ equivalent to <code
 
                <item diff="add" at="issue688">
                   <p>If
-<code>usa:zipcode</code> is a user-defined atomic type
+                     <code>usa:zipcode</code> is a user-defined <termref def="dt-atomic-type"/>
 in the <termref
                         def="dt-is-types"
                         >in-scope schema types</termref>, then the
@@ -20468,7 +20497,7 @@ usa:zipcode?)</code>.</p>
 
             <note>
                <p>
-  An instance of an atomic type that is not in a namespace can be
+                  An instance of an <termref def="dt-atomic-type"/> that is not in a namespace can be
   constructed by using a <nt def="URIQualifiedName">URIQualifiedName</nt> 
   in either a cast expression or a constructor function call.  Examples:
   </p>


### PR DESCRIPTION
Responding to an action from the review of PR #1132, this editorial PR attempts to improve the definitions and usage of terms such as "schema type", "atomic type", "pure union type", "generalized atomic type".