### PR TITLE
1142 Drop restriction disallowing items-equal with unordered

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -14456,9 +14456,7 @@ return for-each(1 to 10, $mapping otherwise void#0)</eg></fos:expression>
                      or <code>false</code> to indicate that two items are or are not
                      equal, overriding the normal rules that would apply to those items;
                      or it can return an empty sequence, to indicate that the normal
-                     rules should be followed. If this option is present then the 
-                     <code>ordered</code> option <rfc2119>must</rfc2119> be <code>true</code> and the
-                     <code>unordered-elements</code> option <rfc2119>must</rfc2119> be an empty sequence.
+                     rules should be followed.
                   </fos:meaning>
                   <fos:type>function(item(), item()) as xs:boolean?</fos:type>
                   <fos:default>fn:void#0</fos:default>
@@ -14997,6 +14995,10 @@ declare function equal-strings(
          should return the same result as <code>items-equal(B, A)</code>, and <emph>transitive</emph>
             means that <code>items-equal(A, B)</code> and <code>items-equal(B, C)</code> should
             imply <code>items-equal(A, C)</code>.</p>
+         
+         <p>Setting the <code>ordered</code> option to <code>false</code> or supplying the
+            <code>unordered-elements</code> option may result in poor performance when comparing
+            long sequences, especially if the <code>items-equal</code> callback function is supplied.</p>
          
       </fos:notes>
       <fos:examples>


### PR DESCRIPTION
Allows the use of an items-equal callback even when comparisons are unordered, despite the fact that this may have atrocious performance.

close #1142