### PR TITLE
1146 Inline change log

### DIFF
--- a/schema/xmlspec.dtd
+++ b/schema/xmlspec.dtd
@@ -398,6 +398,18 @@
 <!ATTLIST head %common.att;>
 ]]>
 
+<!--   changes: Optional list of changes after head of each section -->
+<!ELEMENT changes (change)*>
+<!ATTLIST changes %common.att;>
+<!ELEMENT change (%p.pcd.mix;)*>
+<!ATTLIST change 
+        %role.att;
+        PR      CDATA  #IMPLIED
+        issue   CDATA  #IMPLIED
+        date    CDATA  #REQUIRED
+>
+
+
 <!-- ............................................................... -->
 <!-- Major specification structure ................................. -->
 <!-- ............................................................... -->
@@ -407,6 +419,7 @@
 #1999-07-02: maler: Added doctype atts and status att.
 #2000-03-07: maler: Added cr, issues, and dispcmts to w3c-doctype.
 #2011-01-20: Jim Melton: Added per and wgnote to w3c-doctype.
+#2024-04-13: Michael Kay: Added optional changes element after head.
 -->
 
 <!ENTITY % spec.element "INCLUDE">
@@ -481,7 +494,7 @@
 
 <!ENTITY % div1.element "INCLUDE">
 <![%div1.element;[
-<!ELEMENT div1 (head, (%div.mix;)*, div2*)>
+<!ELEMENT div1 (head, changes?, (%div.mix;)*, div2*)>
 ]]>
 <!ENTITY % div1.attlist "INCLUDE">
 <![%div1.attlist;[
@@ -496,7 +509,7 @@
 <!--    inform-div1: Non-normative division in back matter -->
 <!ENTITY % inform-div1.element "INCLUDE">
 <![%inform-div1.element;[
-<!ELEMENT inform-div1 (head, (%div.mix;)*, div2*)>
+<!ELEMENT inform-div1 (head, changes?, (%div.mix;)*, div2*)>
 ]]>
 <!ENTITY % inform-div1.attlist "INCLUDE">
 <![%inform-div1.attlist;[
@@ -505,7 +518,7 @@
 
 <!ENTITY % div2.element "INCLUDE">
 <![%div2.element;[
-<!ELEMENT div2 (head, (%div.mix;)*, div3*)>
+<!ELEMENT div2 (head, changes?, (%div.mix;)*, div3*)>
 ]]>
 <!ENTITY % div2.attlist "INCLUDE">
 <![%div2.attlist;[
@@ -514,7 +527,7 @@
 
 <!ENTITY % div3.element "INCLUDE">
 <![%div3.element;[
-<!ELEMENT div3 (head, (%div.mix;)*, div4*)>
+<!ELEMENT div3 (head, changes?, (%div.mix;)*, div4*)>
 ]]>
 <!ENTITY % div3.attlist "INCLUDE">
 <![%div3.attlist;[
@@ -523,7 +536,7 @@
 
 <!ENTITY % div4.element "INCLUDE">
 <![%div4.element;[
-<!ELEMENT div4 (head, (%div.mix;)*, div5*)>
+<!ELEMENT div4 (head, changes?, (%div.mix;)*, div5*)>
 ]]>
 <!ENTITY % div4.attlist "INCLUDE">
 <![%div4.attlist;[
@@ -532,7 +545,7 @@
 
 <!ENTITY % div5.element "INCLUDE">
 <![%div5.element;[
-<!ELEMENT div5 (head, (%div.mix;)*)>
+<!ELEMENT div5 (head, changes?, (%div.mix;)*)>
 ]]>
 <!ENTITY % div5.attlist "INCLUDE">
 <![%div5.attlist;[

--- a/specifications/css/qtspecs.css
+++ b/specifications/css/qtspecs.css
@@ -207,6 +207,20 @@ th.issue-toc-head { border-bottom-color: black;
                     border-bottom-width: 1pt;
 }
 
+div.changes { border-bottom-color: blue;
+              border-bottom-style: solid;
+	           border-bottom-width: 4pt;
+	           border-top-color: blue;
+              border-top-style: solid;
+	           border-top-width: 4pt;
+	           margin-bottom: 20pt;
+	           color: blue;
+}
+
+p.changesHeading { font-weight: bold; color: blue}
+
+span.tocDelta { font-weight: bold; color: blue}
+
 /* ============================================================ */
 
 :root {

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -628,6 +628,11 @@ nodes.</p></note></div1>
 
 <div1 id="serparam">
 <head>Serialization Parameters</head>
+  <changes>
+    <change issue="530" PR="534" date="2023-06-06">
+      Added the <code>escape-solidus</code> parameter for JSON serialization.
+    </change>
+  </changes>
 <p>There are a number of parameters that influence how serialization
 is performed. <termref def="host-language">Host languages</termref> <rfc2119>MAY</rfc2119> allow users to specify any or all of these parameters, but
 they are not <rfc2119>REQUIRED</rfc2119> to be able to do so. However, the <termref def="host-language">host language</termref>
@@ -2051,42 +2056,15 @@ is not applicable to the XML output method.</p>
 </div2>
 </div1>
 
-<div1 id="xhtml-output"><head>XHTML Output Method</head>
-<!--
-<edtext>
-The mechanism for specifying that serialization is to be to the XHTML syntax of
-HTML5 has yet to be decided, as we could allow the versions of both XML and
-HTML to be specified for the XHTML output method.  For now, what follows
-will simply assume that if the version parameter has the value 5.0,
-the XHTML syntax of HTML5 is requested as an XML 1.0 document, and the
-if the value is 1.0 or 1.1, the HTML4-compatible version of XHTML is
-requested.  In the latter case, the version applies to the version of the XML
-document.
-</edtext>
-</ednote>
--->
-<!--
-<ednote>
-<edtext>
-Open issue:  Need to specify the extent to which Polyglot conformance is
-required, and detail the areas over which the serializer has control and
-over which the user has control.
-</edtext>
-</ednote>
--->
-<!--
-<ednote>
-<edtext>
-Open issue;  The working groups talked about the possibility of 
-having serialization strip any prefixes from elements and
-attributes in the xhtml, svg, mathml namespaces, as it can be difficult
-to use multiple default namespaces in XQuery, but did not come to
-a consensus.  This would make it
-easier to construct data model instances using elements in all of those
-namespaces, while serializing without prefixes as required by HTML5.
-</edtext>
-</ednote>
--->
+<div1 id="xhtml-output">
+  <head>XHTML Output Method</head>
+  <changes>
+    <change issue="318" PR="342" date="2023-02-14">In the HTML and XHTML output methods, the rules for adding and replacing
+      <code>meta</code> elements have been revised to take account of the new HTML5 syntax,
+      for example <code>&lt;meta charset="utf-8"></code>.
+    </change>
+  </changes>
+
   <p>The XHTML output method serializes the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> as
 XML, using the HTML compatibility guidelines defined in the XHTML
 specification
@@ -2610,7 +2588,14 @@ is not applicable to the XHTML output method.</p>
 </div2>
 </div1>
 
-<div1 id="html-output"><head>HTML Output Method</head><p>The HTML output method serializes
+<div1 id="html-output">
+  <head>HTML Output Method</head>
+  <changes>
+    <change issue="318" PR="342" date="2023-02-14">In the HTML and XHTML output methods, the rules for adding and replacing
+      <code>meta</code> elements have been revised to take account of the new HTML5 syntax,
+      for example <code>&lt;meta charset="utf-8"></code>.</change>
+  </changes>
+  <p>The HTML output method serializes
   the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> as
 HTML.</p><example><p>For example, the following XSL stylesheet generates html output,</p>
 <eg xml:space="preserve">&lt;xsl:stylesheet version="2.0" 
@@ -3419,6 +3404,12 @@ is not applicable to the Text output method.</p>
 
 <div1 id="json-output">
 <head>JSON Output Method</head>
+  
+  <changes>
+    <change issue="530" PR="534" date="2023-06-06">
+      Added the <code>escape-solidus</code> parameter for JSON serialization.
+    </change>
+  </changes>
 
   <p>The JSON output method serializes the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> as
 a JSON value using the JSON syntax defined in <bibref ref="rfc7159"/>.
@@ -3960,6 +3951,11 @@ used and how they convey the information.
 
 <div2 id="ADAPTIVE_PARAMS">
 <head>The Influence of Serialization Parameters upon the Adaptive Output Method</head>
+  <changes>
+    <change issue="530" PR="534" date="2023-06-06">
+      Added the <code>escape-solidus</code> parameter for JSON serialization.
+    </change>
+  </changes>
 
 <p>
 For some item types the Adaptive output method will delegate serialization to other output methods. 

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -2854,6 +2854,9 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>
+    <xsl:if test="child::changes">
+      <span class="tocDelta"> Δ </span>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template name="css">

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -1953,6 +1953,25 @@
     </div>
   </xsl:template>
   
+  
+  <xsl:template match="changes">
+    <div class="changes">
+      <p class="changesHeading">Changes in 4.0</p>
+      <ol>
+        <xsl:apply-templates select="change"/>
+      </ol>
+    </div>
+  </xsl:template>
+  
+  <xsl:template match="change">
+    <li>
+      <p>
+        <xsl:apply-templates/>
+        <i xsl:expand-text="yes"> [Issue {@issue} PR {@PR} Applied {format-date(@date, '[D] [MNn] [Y]')}]</i>
+      </p>
+    </li>
+  </xsl:template>
+  
  
 
 </xsl:stylesheet>


### PR DESCRIPTION
This is a first cut at changes to introduce an inline change log - changes shown at the start of each affected section, with a flag in the TOC to indicate which sections have changed.

It is currently applied, for demonstration purposes, to changes made in the serialization spec.

More specifically:

- Added the `changes` and `change` elements to the DTD; `changes` is an optional element that follows `head` within any section
- Changed the XSLT stylesheets and CSS to render the `changes` element, and to add a flag to the TOC entry if a `changes` element is present

There's a lot more to be done:

- Generate an aggregated list of changes in an appendix
- Improve the CSS rendition
- Toggle change markings on and off; browse forward and backward through changed sections
- Add the `changes` data to the other specs