### PR TITLE
1162 Positional variables are xs:integer not xs:positiveInteger

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7070,10 +7070,7 @@ name.</p>
                                  <note><p>This differs from previous versions of this specification, where both these calls would fail.</p>
                                     <p>This change allows the arguments of existing functions to be defined with a 
                                        more precise type. For example, the <code>$position</code> argument of <code>array:get</code>
-                                       can be defined as <code>xs:positiveInteger</code> rather than <code>xs:integer</code>. To enable
-                                       this to be done without breaking backwards compatibility in respect of error behavior, 
-                                       system functions in many cases define custom error codes to be raised where 
-                                       relabeling of argument values fails.</p></note>
+                                       could be defined as <code>xs:positiveInteger</code> rather than <code>xs:integer</code>.</p></note>
                                  
                                  <note><p>Numeric promotion and <code>xs:anyURI</code> promotion occur only when <var>T</var>
                                     is a primitive type (<code>xs:double</code>, <code>xs:float</code>, or <code>xs:string</code>).
@@ -15537,7 +15534,7 @@ element because it is defined by a <termref
             </item>
             <item>
                <p>If a <term>position variable</term> is declared, its type is implicitly
-                  <code>xs:positiveInteger</code>. Its name (as a QName) must be
+                  <code>xs:integer</code>. Its name (as a QName) must be
                different from the name of the <term>range variable</term> 
                   <errorref spec="XQ" class="ST" code="0089"/>.
                </p>
@@ -15553,7 +15550,7 @@ element because it is defined by a <termref
                         the <term>range variable</term> is bound to that item, and the <term>position variable</term> 
                         (if present) is bound to the one-based position of that item in the 
                         <termref def="dt-binding-collection-xp"/>, as an instance of type 
-                        <code>xs:positiveInteger</code>.</p></item>
+                        <code>xs:integer</code>.</p></item>
                      <item><p>The result of the single-variable <code>for</code> expression is the result
                         of contenating the resulting values (as if by the <termref def="dt-comma-operator"
                            >comma operator</termref>) in the order of the items in the binding collection from which 
@@ -17781,8 +17778,7 @@ for member $y in $expr2]]></eg>
                tuple stream contains bindings for both the main variable and the positional variable. If the 
                <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref> is empty and <code>allowing empty</code> is 
                specified, the positional variable in the output tuple is bound to the integer zero. Positional variables  
-               have the implied type <code>xs:nonNegativeInteger</code> if <code>allowing empty</code> is present, or 
-               <code>xs:positiveInteger</code> if it is absent.</p>
+               have the implied type <code>xs:integer</code>.</p>
             <p>The <termref def="dt-expanded-qname">expanded
 			        QName</termref> of a positional variable must be distinct from the <termref def="dt-expanded-qname"
                   >expanded QName</termref> of the main variable with which it is associated <errorref
@@ -18061,7 +18057,7 @@ are as follows:</p>
   sequence</termref>. <emph>Start-item-position</emph> is a <termref
                         def="dt-positional-variable"
                         >positional variable</termref>; hence, its type
-  is <code>xs:positiveInteger</code>
+  is <code>xs:integer</code>.
                   </p>
                </item>
 
@@ -18100,7 +18096,7 @@ are as follows:</p>
   sequence</termref>. <emph>End-item-position</emph> is a <termref
                         def="dt-positional-variable"
                         >positional variable</termref>; hence, its type
-  is <code>xs:positiveInteger</code>
+  is <code>xs:integer</code>.
                   </p>
                </item>
 
@@ -18702,7 +18698,8 @@ return $x]]></eg>
             <p>The purpose of a <code>count</code> clause is to enhance the tuple
 stream with a new variable that is bound, in each tuple, to the
 ordinal position of that tuple in the tuple stream. The name of the
-new variable is specified in the <code>count</code> clause.</p>
+new variable is specified in the <code>count</code> clause. Its type
+            is implicitly <code>xs:integer</code>.</p>
 
             <p>The output tuple stream of a <code>count</code> clause is the same
 as its input tuple stream, with each tuple enhanced by one additional


### PR DESCRIPTION
Reverts a change that made the type xs:positiveInteger as the impact of the change was not fully explored, and the same change was not made elsewhere e.g. to the argument type of array:get() or the return type of fn:position().

Note: the use of xs:positiveInteger has been retained for row and column numbers in the CSV functions, and for codepoints in the fn:char() function.