### PR TITLE
296 Allow default-namespace=##any

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -364,7 +364,7 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
          <div3 id="static_context">
             <head>Static Context</head>
             <changes>
-               <change issue="296" PR="TBA" date="2023-04-30">
+               <change issue="296" PR="1181" date="2024-04-30">
                   The <termref def="dt-default-namespace-elements-and-types"/> can be set to the value <code>##any</code>,
                   allowing unprefixed names in axis steps to match elements with a given local name in any namespace.
                </change>
@@ -11016,7 +11016,7 @@ return if (every $r in $R satisfies $r instance of node())
             <div4 id="node-tests">
                <head>Node Tests</head>
                <changes>
-                  <change issue="296" PR="TBA" date="2024-04-30">
+                  <change issue="296" PR="1181" date="2024-04-30">
                      If the default namespace for elements and types has the special value <code>##any</code>,
                      then an unprefixed name in a <code>NameTest</code> acts as a wildcard, matching
                      names in any namespace or none.

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -363,6 +363,12 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
 
          <div3 id="static_context">
             <head>Static Context</head>
+            <changes>
+               <change issue="296" PR="TBA" date="2023-04-30">
+                  The <termref def="dt-default-namespace-elements-and-types"/> can be set to the value <code>##any</code>,
+                  allowing unprefixed names in axis steps to match elements with a given local name in any namespace.
+               </change>
+            </changes>
             <p>
                <termdef id="dt-static-context" term="static context"
                   >The <term>static context</term> of an expression is
@@ -438,8 +444,8 @@ and by <termref def="dt-namespace-decl-attr"
                <item>
                   <p diff="chg" at="A">
                      <termdef id="dt-default-namespace-elements-and-types" term="default namespace for elements and types">
-                        <term>Default namespace for elements and types.</term> This is a
-				namespace URI, <!--or the special value <code>"##any"</code>,--> or <xtermref spec="DM40" ref="dt-absent"
+                        <term>Default namespace for elements and types.</term> This is either a
+				namespace URI, or the special value <code>"##any"</code>, or <xtermref spec="DM40" ref="dt-absent"
                         />. This indicates how unprefixed QNames are interpreted when
                         they appear in a position  where an element name or type name is expected.</termdef></p>
                   <ulist>
@@ -447,12 +453,17 @@ and by <termref def="dt-namespace-decl-attr"
                         this namespace is used for any such unprefixed QName. The URI value is
                whitespace-normalized according to the rules for the <code>xs:anyURI</code> type in <xspecref
                            spec="XS1-2" ref="anyURI"/> or <xspecref spec="XS11-2" ref="anyURI"/>.</p></item>
-                     <!--<item><p diff="chg" at="issue372">The special value <code>"##any"</code> indicates that
-                        for an unprefixed QName used as a <termref def="dt-name-test"/> for selecting
-                        named elements in an <termref def="dt-axis-step"/>, all elements with a matching
-                        local name will be selected, regardless of their namespace (or lack of it). 
-                        For an unprefixed QName representing an element or type
-                        name in any other context, the name is interpreted as being in no namespace.</p></item>-->
+                     <item><p>The special value <code>"##any"</code> indicates that:</p>
+                        <ulist>
+                           <item><p>When an unprefixed QName is used as a <termref def="dt-name-test"/> for selecting
+                              named elements in an <termref def="dt-axis-step"/>, the <termref def="dt-name-test"/>
+                           will match an element having the specified local name, in any namespace or none.</p></item>
+                           <item><p>When an unprefixed QName is used in a context where a type name is expected
+                           (but not as a function name), the default namespace is the <code>xs</code>
+                           namespace, <code>http://www.w3.org/2001/XMLSchema</code>.</p></item>
+                           <item><p>In any other context, an unprefixed QName represents a name in no namespace.</p></item>
+                        </ulist>
+                     </item>
                      <item><p diff="chg" at="issue372">If the value is <xtermref spec="DM40" ref="dt-absent"/>,
                         an unprefixed QName representing an element or type
                         name is interpreted as being in no namespace.</p></item>
@@ -4703,6 +4714,11 @@ the schema type named <code>us:address</code>.</p>
                      and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
                      including a wildcard.
                   </change>
+                  <change>
+                     Setting the default namespace for elements and types to the special value
+                     <code>##any</code> causes an unprefixed element name to act as a wildcard,
+                     matching by local name regardless of namespace.
+                  </change>
                </changes>
 
                <scrap diff="chg" at="A">
@@ -4726,7 +4742,13 @@ the schema type named <code>us:address</code>.</p>
                   within the <code>NameTestUnion</code> is interpreted according to the
                   <termref def="dt-default-namespace-elements-and-types"/>.
                   The name need not be present in the <termref
-                     def="dt-is-attrs">in-scope element declarations</termref>.</p>
+                     def="dt-is-attrs">in-scope element declarations</termref>.
+               </p>
+               <p>If the <termref def="dt-default-namespace-elements-and-types"/>
+               has the special value <code>##any</code>, then an unprefixed name
+               <var>N</var> is interpreted as a wildcard <code>*:<var>N</var></code>.</p>
+               <p>It is always possible to match no-namespace names explicitly
+               by using the form <code>Q{}<var>N</var></code></p>
                
                <p diff="chg" at="Issue23">An unprefixed <nt def="TypeName"
                   >TypeName</nt> is interpreted according to the
@@ -4736,6 +4758,9 @@ the schema type named <code>us:address</code>.</p>
                   <errorref class="ST" code="0008"/>                 
                   
                   </p>
+               <p>If the <termref def="dt-default-namespace-elements-and-types"/>
+                  has the special value <code>##any</code>, then an unprefixed type name
+                  <var>T</var> is interpreted as <code>Q{http://www.w3.org/2001/XMLSchema}<var>T</var></code>.</p>
                      
                <note><p><termref
                      def="dt-substitution-group"
@@ -4909,9 +4934,9 @@ matches any nilled or non-nilled element node whose type annotation is
                      def="dt-static-namespaces"
                      >statically known namespaces</termref>, or if unprefixed, the
                   is interpreted according to the
-                  <termref def="dt-default-namespace-elements-and-types"/>.<!-- If this has the special
+                  <termref def="dt-default-namespace-elements-and-types"/>. If this has the special
                   value <code>"##any"</code>, an unprefixed name represents a name in no namespace.
--->
+
     If the <nt
                      def="ElementName">ElementName</nt> specified in the <nt def="SchemaElementTest"
                      >SchemaElementTest</nt>
@@ -10990,6 +11015,13 @@ return if (every $r in $R satisfies $r instance of node())
             </div4>
             <div4 id="node-tests">
                <head>Node Tests</head>
+               <changes>
+                  <change issue="296" PR="TBA" date="2024-04-30">
+                     If the default namespace for elements and types has the special value <code>##any</code>,
+                     then an unprefixed name in a <code>NameTest</code> acts as a wildcard, matching
+                     names in any namespace or none.
+                  </change>
+               </changes>
                <p>
                   <termdef id="dt-node-test" term="node test"
                         >A <term>node test</term> is a condition on the name, kind (element, attribute, text, document, comment,
@@ -11061,6 +11093,10 @@ return if (every $r in $R satisfies $r instance of node())
                <ulist>
                   <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is a namespace URI,
                   then the name is interpreted as having that namespace URI.</p></item>
+                  <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is the
+                     special value <code>"##any</code>,
+                     then the name is interpreted as a wildcard that matches any element with
+                     the specified local name, in any namespace or none.</p></item>
                   <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is absent,
                      then the name is interpreted as being in no namespace.</p></item>
                   
@@ -21818,7 +21854,7 @@ return $rectangle =?> area()</eg>
                def="dt-static-error">static error</termref> is raised <errorref class="ST"
                code="0104"
             />.  If the type name is unprefixed, it is
-        interpreted as a name in the <termref def="dt-default-namespace-elements-and-types"/>.
+        interpreted according to the <termref def="dt-default-namespace-elements-and-types"/>.
     </p>
 
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -270,7 +270,7 @@
       declaration is considered to be a “base URI embedded in content”. If no base URI declaration
       is present, <termref def="dt-static-base-uri">Static Base URI</termref> property is
       established according to the principles outlined in <bibref ref="RFC3986"/> Section
-      5.1&mdash;that is, it defaults first to the base URI of the encapsulating entity, then to the
+      5.1—that is, it defaults first to the base URI of the encapsulating entity, then to the
       URI used to retrieve the entity, and finally to an implementation-defined default. If the
       URILiteral in the base URI declaration is a relative URI, then it is made absolute by
       resolving it with respect to this same hierarchy. For example, if the URILiteral in the base
@@ -978,6 +978,10 @@ return $node/xx:bing]]>
         for a query module, meaning it is unaffected by a namespace declaration appearing on a direct
         element constructor.
       </change>
+      <change issue="296" PR="TBA" date="2023-04-30">
+        The <termref def="dt-default-namespace-elements-and-types"/> can be set to the value <code>##any</code>,
+        allowing unprefixed names in axis steps to match elements with a given local name in any namespace.
+      </change>
     </changes>
     <scrap>
       <head></head>
@@ -1012,12 +1016,14 @@ return $node/xx:bing]]>
             <item><p>The empty string <code>""</code>. In this case unprefixed names appearing where
               an element or type name is expected are treated as being in no namespace: the
               <termref def="dt-default-namespace-elements-and-types"/> is set to <xtermref spec="DM40" ref="dt-absent"/>.</p></item>
-            <!--<item><p>The string <code>"##any"</code>. In this case an unprefixed name appearing
+            <item><p>The string <code>"##any"</code>. In this case an unprefixed name appearing
               as a <nt def="NameTest">NameTest</nt> in an axis step whose principal node kind is element
               is interpreted as a wildcard (the unprefixed name <code>N</code> is treated as equivalent
-              to the wildcard <code>*:N</code>), while an unprefixed name appearing in any other context
+              to the wildcard <code>*:N</code>); an unprefixed name used appearing where an item type name
+              is expected is interpreted as a local name in namespace <code>http://www.w3.org/2001/XMLSchema</code>,
+              while an unprefixed name appearing in any other context
               where an element or type name is expected is treated as being in no namespace.</p>
-            </item>-->
+            </item>
           </ulist>
           <p>The following example illustrates the declaration of a
           default namespace for elements and types:</p>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -978,7 +978,7 @@ return $node/xx:bing]]>
         for a query module, meaning it is unaffected by a namespace declaration appearing on a direct
         element constructor.
       </change>
-      <change issue="296" PR="TBA" date="2023-04-30">
+      <change issue="296" PR="1181" date="2023-04-30">
         The <termref def="dt-default-namespace-elements-and-types"/> can be set to the value <code>##any</code>,
         allowing unprefixed names in axis steps to match elements with a given local name in any namespace.
       </change>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -9141,9 +9141,9 @@ and <code>version="1.0"</code> otherwise.</p>
                <head>Unprefixed Lexical QNames in Expressions and Patterns</head>
                
                <changes>
-                  <change issue="" PR="TBA" date="2024-04-30">
+                  <change issue="296" PR="1181" date="2024-04-30">
                      The <code>[xsl:]xpath-default-namespace</code> attribute can be set to the value
-                     <code>#any</code>, which causes unprefixed element names to match in any namespace
+                     <code>##any</code>, which causes unprefixed element names to match in any namespace
                      or none.
                   </change>
                </changes>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -9140,6 +9140,13 @@ and <code>version="1.0"</code> otherwise.</p>
             <div3 id="unprefixed-qnames" diff="chg" at="2022-01-01">
                <head>Unprefixed Lexical QNames in Expressions and Patterns</head>
                
+               <changes>
+                  <change issue="" PR="TBA" date="2024-04-30">
+                     The <code>[xsl:]xpath-default-namespace</code> attribute can be set to the value
+                     <code>#any</code>, which causes unprefixed element names to match in any namespace
+                     or none.
+                  </change>
+               </changes>
                
                <div4 id="unprefixed-element-names">
                   <head>Unprefixed Element Names</head>
@@ -9149,7 +9156,8 @@ and <code>version="1.0"</code> otherwise.</p>
                   namespace that will be used for an unprefixed element or type name within an XPath expression, and
                   in certain other contexts listed below.</p>
                
-               <p>The value of the attribute is the namespace URI to be used.</p>
+               <p>The value of the attribute is either the namespace URI to be used, or a zero-length string,
+                  or the value <code>##any</code>.</p>
                   
                   
                   <p>For any element in the stylesheet, this attribute has an effective value, which is the value of 
@@ -9169,16 +9177,22 @@ and <code>version="1.0"</code> otherwise.</p>
                      it determines the namespace used for any
                      unprefixed type name or element name.</p>
                   
-                  <!--<p>The special value <code>##any</code> only affects an unprefixed element name used in a 
-                     <xnt ref="prod-xpath40-NameTest" spec="XP40">NameTest</xnt>, either within an XPath expression or a <termref def="dt-pattern"/>.
-                     Its effect is that an unprefixed name matches any element having the required local name,
-                  irrespective of the namespace URI (or lack of it). A pattern such as <code>match="title"</code>
-                  is therefore interpreted as a wildcard match <code>match="*:title</code>. The default priority
-                  of such a pattern changes accordingly.</p>-->
+                  <p>The special value <code>##any</code> only affects:</p>
+                  <ulist>
+                     <item><p>An unprefixed element name used in a 
+                        <xnt ref="prod-xpath40-NameTest" spec="XP40">NameTest</xnt>, 
+                        either within an XPath expression or a <termref def="dt-pattern"/>.
+                        Its effect is that an unprefixed name matches any element having the required local name,
+                        irrespective of the namespace URI (or lack of it). A pattern such as <code>match="title"</code>
+                        is therefore interpreted as a wildcard match <code>match="*:title</code>. The default priority
+                        of such a pattern changes accordingly.</p></item>
+                     <item><p>An unprefixed type name; the effect is to treat the name as
+                     referring to a type whose namespace is <code>http://www.w3.org/2001/XMLSchema</code>.</p></item>
+                  </ulist>
                   
 
                   
-                  <p>The effective value of this attribute applies to any of the following
+                  <p>Any other value of this attribute sets the default namespace for any of the following
                      constructs appearing within its scope:</p>
                   <ulist>
                      <item>
@@ -9223,7 +9237,8 @@ and <code>version="1.0"</code> otherwise.</p>
                <p>If the effective value of the attribute is a zero-length string, which will be the
                   case if it is explicitly set to a zero-length string or if it is not specified at
                   all, then an unprefixed element name or type name refers to a name that is in no
-                  namespace. The default namespace of the parent element (see <xspecref spec="DM30" ref="ElementNode"/>) is <emph>not</emph> used.</p>
+                  namespace. The default namespace of the parent element (see <xspecref spec="DM30" ref="ElementNode"/>) 
+                  is <emph>not</emph> used.</p>
                   <p>The attribute does not affect other names, for example function names, 
                      variable names, or template names, or strings that are interpreted 
                      as lexical QNames during stylesheet evaluation, such as the effective value 
@@ -17478,16 +17493,12 @@ and <code>version="1.0"</code> otherwise.</p>
                         <phrase diff="chg" at="2023-05-04"><termref def="dt-applicable-static-namespaces"/></phrase> for the containing element in the
                         stylesheet</td>
                   </tr>
-                  <tr diff="chg" at="2022-01-01">
-                     <td rowspan="1" colspan="1">Default element namespace</td>
+                  <tr diff="chg" at="2024-04-30">
+                     <td rowspan="1" colspan="1">Default namespace for elements and types</td>
                      <td rowspan="1" colspan="1">determined by the <code>xpath-default-namespace</code> attribute if present
-                        (see <specref ref="unprefixed-qnames"/>); otherwise the null namespace</td>
+                        (see <specref ref="unprefixed-qnames"/>); otherwise absent</td>
                   </tr>
-                  <tr diff="chg" at="2022-01-01">
-                     <td rowspan="1" colspan="1">Default type namespace</td>
-                     <td rowspan="1" colspan="1">determined by the <code>xpath-default-namespace</code> attribute if present
-                        (see <specref ref="unprefixed-qnames"/>); otherwise the null namespace</td>
-                  </tr>
+                  
                   <tr diff="chg" at="2023-05-04">
                      <td rowspan="1" colspan="1">Default function namespace</td>
                      <td rowspan="1" colspan="1">the <termref def="dt-standard-function-namespace"/>.


### PR DESCRIPTION
Allows the default namespace for elements and types to have the special value "##any", which causes unprefixed QNames to match elements in any namespace. Use cases include:

- Casual ad-hoc XPath queries, where over-retrieval isn't a problem
- Use with HTML, where it can be unpredictable whether elements will be in a namespace, and where users are accustomed to browser behaviour with its "wilful violation" of the XPath 1.0 specification
- Any environment where multiple namespaces are in use for variants of what is essentially the same vocabulary of element names (for example, where the XML designer has made the mistake of versioning the namespace URI)