### PR TITLE
1170 Editorial: fn:index-where

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -25879,7 +25879,7 @@ array:index-of(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the position in an input array of members that match a supplied predicate.</p>
+         <p>Returns the positions in an input array of members that match a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
          
@@ -28795,7 +28795,7 @@ function($item) {
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the position in an input sequence of items that match a supplied predicate.</p>
+         <p>Returns the positions in an input sequence of items that match a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
 


### PR DESCRIPTION
Issue: 1170

* Editorial, 2 characters added
* “2. Redundant parens in function signatures“ is obsolete (https://github.com/qt4cg/qtspecs/pull/1182/files#diff-7625c07ae8131ff65c3caa677b188ed2b9b66237312d11c05a2fa2838c6f5c67R21233)

