### PR TITLE
Update the Saxonica EE repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://dev.saxonica.com/maven" }
+    maven { url "https://maven.saxonica.com/maven" }
   }
 
   // Get rid of that [expletive deleted] warning about xml-apis 2.0.2/1.0.b2


### PR DESCRIPTION
This should be harmless and I would have thought unnecessary, but there were reports of trouble reading Saxon EE 12.2 from Maven. This PR just updates the maven EE repo URI. The old URI redirects to the new one, but maybe that's causing a problem somehow?