### PR TITLE
QT4CG-076-01 Add examples of coercions

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7868,8 +7868,8 @@ return $f(12.3)]]></eg>
                         </tr>
                         <tr>
                            <td valign="top"><code>(1.5, 2.5, 3.5)</code></td>
-                           <td valign="top"><p>A type error is raised, except in the case where XPath 1.0
-                           compatibility is enabled, in which case all values after the first are discarded.</p>
+                           <td valign="top"><p>A type error is raised<phrase role="xpath">, except in the case where XPath 1.0
+                           compatibility is enabled, in which case all values after the first are discarded</phrase>.</p>
                            </td>
                         </tr>
                         <tr>
@@ -7881,10 +7881,10 @@ return $f(12.3)]]></eg>
                         </tr>
                         <tr role="xpath">
                            <td valign="top"><code>"12.2"</code></td>
-                           <td valign="top"><p>Supplying a string where an <code>xs:decimal</code> is a type error,
+                           <td valign="top"><p>Supplying a string where an <code>xs:decimal</code> is a type error<phrase role="xpath">,
                               even if XPath 1.0 compatibility mode is enabled. The rules for compatibility
                               mode would allow conversion if the required type were <code>xs:double</code>,
-                              but not for <code>xs:decimal</code>.
+                              but not for <code>xs:decimal</code></phrase>.
                         </p></td>
                         </tr>
                         <tr>
@@ -7922,7 +7922,7 @@ return $f(12.3)]]></eg>
                            <td valign="top"><p>The supplied value is of type <code>xs:integer</code>. Because the supplied value and
                               the required type, <code>xs:positiveInteger</code>, both come under the primitive
                            type <code>xs:decimal</code>, and the value <code>12</code> is within the value space
-                           of <code>xs:integer</code>, the value is relabeled as an <code>xs:positiveInteger</code>
+                           of <code>xs:positiveInteger</code>, the value is relabeled as an <code>xs:positiveInteger</code>
                            and the call succeeds.</p></td>
                         </tr>
                         <tr>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7731,6 +7731,322 @@ return $f(12.3)]]></eg>
                </note>
                
             </div3>
+            
+            <div3 id="id-coercion-examples">
+               <head>Examples of Coercions</head>
+               <p>This section illustrates the effect of the coercion rules with examples.</p>
+               <example id="eg-coercion-to-string">
+                  <head>Coercion to <code>xs:string</code></head>
+                  <p>Consider the case where the required type (of a variable, or a function argument)
+                  is <code>xs:string</code>. For example, the second argument of <code>fn:matches</code>,
+                  which expects a regular expression. The table below illustrates the values that might be supplied, and
+                  the coercions that are applied.</p>
+                  
+                  <table role="medium">
+                     <thead>
+                        <tr>
+                           <th align="left">Supplied Value</th>
+                           <th align="left">Coercion</th>
+                        </tr>
+                     </thead>
+                     <tbody>
+                        <tr>
+                           <td valign="top"><code>"[0-9]"</code></td>
+                           <td valign="top"><p>None; the supplied value is an instance of the required type.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>default-language()</code></td>
+                           <td valign="top"><p>None; the supplied value is an instance of <code>xs:language</code>, which
+                              is a subtype of the required type <code>xs:string</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code><![CDATA[<a>[0-9]</a>]]></code></td>
+                           <td valign="top"><p>The supplied element node is atomized. Unless it has been schema-validated,
+                           the typed value will be an instance of <code>xs:untypedAtomic</code>, which
+                           is accepted when the required type is <code>xs:string</code>.</p>
+                              <p>Supplying an element whose type annotation is (say) <code>xs:date</code> 
+                                 will fail with a type error.</p>
+                              <p role="xpath">The effect is subtly different if XPath 1.0
+                                 compatibility mode is enabled. In this case coercion takes the string
+                              value of the element node. This differs from the typed value only
+                              in the case where the element has been schema-validated and has a type
+                              annotation other than <code>xs:string</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code><![CDATA[xs:anyURI("urn:dummy")]]></code></td>
+                           <td valign="top"><p>Supplying an instance of <code>xs:anyURI</code> where the expected type
+                              is <code>xs:string</code> is permitted; this is one of the pairs of types
+                           where implicit casting is allowed.</p></td>
+                        </tr>
+                        <tr role="xpath">
+                           <td valign="top"><code>17.2</code></td>
+                           <td valign="top"><p>Supplying a number where a string is expected raises a type error.</p>
+                              <p role="xpath">However, if XPath 1.0
+                              compatibility mode is enabled, the number is converted to a string as if
+                           by the <code>fn:string</code> function.</p></td>
+                        </tr>
+                        <tr role="xpath">
+                           <td valign="top"><code>//author/@id</code></td>
+                           <td valign="top"><p>Supplying a sequence of nodes where a single string is expected will raise a type
+                              error unless either there is only one node in the sequence. In this case
+                              the typed value of the node will be used (this must be of type
+                              <code>xs:string</code>, <code>xs:untypedAtomic</code>, or <code>xs:anyURI</code>).</p>
+                              <p role="xpath">If XPath 1.0 compatibility mode is enabled, however, 
+                                 all strings after the first are discarded, and the string value of 
+                                 the first node is used; if the sequence is empty, a zero-length string is supplied.</p></td>
+                        </tr>
+                        <tr role="xpath">
+                           <td valign="top"><code>("red", "green", "blue")</code></td>
+                           <td valign="top"><p>Supplying a sequence of strings where a single string is expected 
+                              raises a type error.</p>
+                              <p role="xpath">If XPath 1.0
+                              compatibility mode is enabled, however, all strings after the first are discarded; the effect
+                              is as if the supplied value were <code>"red"</code>.</p></td>
+                        </tr>
+                        <tr role="xpath">
+                           <td valign="top"><code>()</code></td>
+                           <td valign="top"><p>Supplying an empty sequence where a single string is expected will fail.</p>
+                              <p role="xpath">If XPath 1.0 compatibility mode is enabled, however, the value is coerced by
+                                 applying the function <code>fn:string(())</code>,
+                                 which delivers the zero-length string.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code><![CDATA[["a|b"]]]></code></td>
+                           <td valign="top"><p>Supplying an array holding a single string succeeds, because the rules cause the
+                              array to be atomized, and the value after atomization is a single string.</p>
+                              <p>Supplying an array holding multiple strings would fail.</p>
+                              <p role="xpath">In XPath 1.0 compatibility mode, supplying an array will fail, 
+                                 regardless of the array contents, because the <code>fn:string</code> function does not 
+                                 accept arrays.</p>
+                           </td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </example>
+               
+               <example id="eg-coercion-to-decimal">
+                  <head>Coercion to <code>xs:decimal?</code></head>
+                  <p>Consider the case where the required type (of a variable, or a function argument)
+                     is <code>xs:decimal?</code>. For example, the first argument of <code>fn:seconds</code>,
+                     which expects a decimal number of seconds. The table below illustrates the values that might be supplied, and
+                     the coercions that are applied.</p>
+                  
+                  <table role="medium">
+                     <thead>
+                        <tr>
+                           <th align="left">Supplied Value</th>
+                           <th align="left">Coercion</th>
+                        </tr>
+                     </thead>
+                     <tbody>
+                        <tr>
+                           <td valign="top"><code>12.4</code></td>
+                           <td valign="top"><p>None; the supplied value is an instance of the required type.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>()</code></td>
+                           <td valign="top"><p>None; an empty sequence is an instance of the required type.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>42</code></td>
+                           <td valign="top"><p>None; the supplied value is an instance of <code>xs:integer</code>,
+                              which is a subtype of the required type.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>math:pi()</code></td>
+                           <td valign="top"><p>The supplied value is an instance of <code>xs:double</code>,
+                              which can be converted to <code>xs:decimal</code> under the coercion rules.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>("a", "b")[.="c"]</code></td>
+                           <td valign="top"><p>The supplied value is an empty sequence, which is a valid
+                              instance of the required type <code>xs:decimal?</code>. However,
+                           the processor may (optionally) reject this as an implausible coercion,
+                           on the grounds that it can only succeed in one special case, namely
+                           where the filter expression selects no values. </p>
+                              </td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>(1.5, 2.5, 3.5)</code></td>
+                           <td valign="top"><p>A type error is raised, except in the case where XPath 1.0
+                           compatibility is enabled, in which case all values after the first are discarded.</p>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code><![CDATA[<a>3.14159</a>]]></code></td>
+                           <td valign="top"><p>The element node is atomized; unless it has been schema-validated, the
+                              result will be <code>"3.14159"</code> as an instance of <code>xs:untypedAtomic</code>.
+                             This is converted to an instance of <code>xs:decimal</code> following the rules
+                           of the <code>cast as</code> operator.</p></td>
+                        </tr>
+                        <tr role="xpath">
+                           <td valign="top"><code>"12.2"</code></td>
+                           <td valign="top"><p>Supplying a string where an <code>xs:decimal</code> is a type error,
+                              even if XPath 1.0 compatibility mode is enabled. The rules for compatibility
+                              mode would allow conversion if the required type were <code>xs:double</code>,
+                              but not for <code>xs:decimal</code>.
+                        </p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>[1.5]</code></td>
+                           <td valign="top"><p>The array is atomized, and the result is a valid instance of the required
+                           type <code>xs:decimal?</code></p>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>[]</code></td>
+                           <td valign="top"><p>The array is atomized, and the result is an empty sequence, which is a valid instance of the required
+                              type <code>xs:decimal?</code></p>
+                           </td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </example>
+               
+               <example id="eg-coercion-to-positive-integer">
+                  <head>Coercion to <code>xs:positive-integer</code></head>
+                  <p>Consider the case where the required type (of a variable, or a function argument)
+                     is <code>xs:positive-integer</code>. The table below illustrates the values that might be supplied, and
+                     the coercions that are applied.</p>
+                  
+                  <table role="medium">
+                     <thead>
+                        <tr>
+                           <th align="left">Supplied Value</th>
+                           <th align="left">Coercion</th>
+                        </tr>
+                     </thead>
+                     <tbody>
+                        <tr>
+                           <td valign="top"><code>12</code></td>
+                           <td valign="top"><p>The supplied value is of type <code>xs:integer</code>. Because the supplied value and
+                              the required type, <code>xs:positiveInteger</code>, both come under the primitive
+                           type <code>xs:decimal</code>, and the value <code>12</code> is within the value space
+                           of <code>xs:integer</code>, the value is relabeled as an <code>xs:positiveInteger</code>
+                           and the call succeeds.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>12.1</code></td>
+                           <td valign="top"><p>This fails with a type error, because the <code>xs:decimal</code> value <code>12.1</code>
+                              is not a value in the value space of <code>xs:positiveInteger</code>. This is so even though
+                           casting to <code>xs:positiveInteger</code> would succeed.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>math:pi()</code></td>
+                           <td valign="top"><p>This fails with a type error. A value of type <code>xs:double</code> is accepted
+                           where the required type is <code>xs:decimal</code> or <code>xs:float</code>,
+                           but not where it is <code>xs:positiveInteger</code>.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code><![CDATA[<a>1200</a>]]></code></td>
+                           <td valign="top"><p>The supplied element node is atomized. If the element has not been schema-validated,
+                           the result will be an <code>xs:untypedAtomic</code> value, which is successfully cast to the
+                           required type <code>xs:positiveInteger</code>. If the element has been validated against a schema,
+                           then coercion succeeds if the typed value would itself be acceptable, for example if it
+                           is an <code>xs:positiveInteger</code>, or some other <code>xs:decimal</code> within the value space
+                           of <code>xs:positiveInteger</code>.</p>
+                           </td>
+                        </tr>
+                     </tbody>
+                  </table>
+               </example>
+               <example id="eg-coercion-to-union">
+                  <head>Coercion to a union type</head>
+                  <p>Consider the first parameter of the function <code>fn:char</code>, whose declared
+                  type is <code>(xs:string | xs:positiveInteger)</code>. The rules are the same
+                  as if it were a union typed declared in an imported schema.</p>
+                  
+                  <table role="medium">
+                     <thead>
+                        <tr>
+                           <th align="left">Supplied Value</th>
+                           <th align="left">Coercion</th>
+                        </tr>
+                     </thead>
+                     <tbody>
+                        <tr>
+                           <td valign="top"><code>"amp"</code></td>
+                           <td valign="top"><p>The supplied value is of type <code>xs:string</code>, which is one of the allowed
+                           types. The call therefore succeeds.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>"#"</code></td>
+                           <td valign="top"><p>The supplied value is of type <code>xs:string</code>, which is one of the allowed
+                              types. As far as the coercion rules are concerned, the call therefore succeeds. Under the
+                              semantic rules for the <code>fn:char</code> function, however, this value is not accepted;
+                              a dynamic error (as distinct from a type error) is therefore raised.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>0x25</code></td>
+                           <td valign="top"><p>The supplied value is of type <code>xs:integer</code>. Although this is not one of the allowed
+                              types, it is acceptable because coercion of the value to type <code>xs:positiveInteger</code>
+                              succeeds. The value is relabeled as an instance of <code>xs:positiveInteger</code>.</p></td>                          
+                        </tr>
+                        <tr>
+                           <td valign="top"><code><![CDATA[<a>0x25</a>]]></code></td>
+                           <td valign="top"><p>The supplied element node is atomized. Assuming that the node has not been schema-validated,
+                              the result is an instance of <code>xs:untypedAtomic</code>. The member types of the choice
+                              are tested in order. Conversion to <code>xs:string</code> with the value "0x25" succeeds, so 
+                              the <code>fn:char</code> function is called supplying this string; but the function rejects this
+                              string as semantically invalid. The same would happen if the value were, say, <![CDATA[<a>37</a>]]>.
+                              Supplying such a value requires an explicit cast, for example <code>fn:char( xs:positiveInteger( ./a ))</code>.</p>
+                           </td>
+                        </tr>
+                        
+                        
+                     </tbody>
+                  </table>
+               </example>
+               <example id="eg-coercion-to-choice">
+                  <head>Coercion to a choice type</head>
+                  <p>Suppose the required type is <code>(record(x as xs:decimal, y as xs:decimal, *) | record(size as enum("S", "M", "L", "XL"), *))</code>.</p>
+                  
+                  <table role="medium">
+                     <thead>
+                        <tr>
+                           <th align="left">Supplied Value</th>
+                           <th align="left">Coercion</th>
+                        </tr>
+                     </thead>
+                     <tbody>
+                        <tr>
+                           <td valign="top"><code>{"x":1, "y":2, "z":3}</code></td>
+                           <td valign="top"><p>The supplied value is an instance of the first record type: no coercion is necessary.</p></td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>{"size":"M"}</code></td>
+                           <td valign="top"><p>The supplied value is an instance of the second record type: no coercion is necessary.</p></td>                          
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>{"x":1, "y":2, "size":"XL"}</code></td>
+                           <td valign="top"><p>The supplied value is an instance of both record types: no coercion is necessary.</p>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>{"x":1.0e0, "y":2.0e0, "size":"XL"}</code></td>
+                           <td valign="top"><p>The supplied value is not an instance of the first record type because the fields are of
+                              type <code>xs:double</code> rather than <code>xs:decimal</code>. It is however an instance
+                              of the second record type. It is therefore accepted <emph>as is</emph>; the fields
+                           <code>x</code> and <code>y</code> are not converted from <code>xs:double</code> to
+                           <code>xs:decimal</code>.</p>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td valign="top"><code>{"x":1.0e0, "y":2.0e0, "size":"XXL"}</code></td>
+                           <td valign="top"><p>The supplied value is not an instance of the first record type because the fields are of
+                              type <code>xs:double</code> rather than <code>xs:decimal</code>, and it is not an instance
+                              of the second record type because the <code>size</code> value does not match the enumeration
+                              type. Coercion is therefore attempted to the first record type, and succeeds. The <code>x</code>
+                           and <code>y</code> fields are coerced to <code>xs:decimal</code>, and the <code>size</code> field
+                           is accepted <emph>as is</emph>.</p>
+                           </td>
+                        </tr>
+                        
+                        
+                     </tbody>
+                  </table>
+               </example>
+            </div3>
             </div2>
          
          


### PR DESCRIPTION
Added examples of coercion rules in action, as requested.

Note to reviewers: the XPath spec contains addition paragraphs explaining the effect of the 1.0 compatibility rules.