### PR TITLE
1207 Allow numeric predicates when filtering arrays

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -8687,14 +8687,19 @@ At evaluation time, the value of a variable reference is the value to which the 
             
             <p>For each item in the input sequence, the result of the
                predicate expression is coerced to an <code>xs:boolean</code>
-               value, called the <term>predicate truth value</term>, as
+               value, called the <termref def="dt-predicate-truth-value"/>, as
                described below. Those items for which the predicate truth value
                is <code>true</code> are retained, and those for which the
                predicate truth value is <code>false</code> are discarded.</p>
             
+            <p><termdef id="dt-predicate-truth-value" term="predicate truth value">The
+            <term>predicate truth value</term> of a value <code>$V</code>
+            is the result of the expression <code>if ($V instance of xs:numeric+)
+            then ($V = position()) else fn:boolean($V)</code>.</termdef></p>
             
-            <p>The predicate truth value is derived by applying the following rules,
-               in order:</p>
+            
+            <p>Expanding this definition, the predicate truth value can be obtained 
+               by applying the following rules, in order:</p>
             
             <olist>
                
@@ -8706,7 +8711,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                      <olist>
                         <item><p><var>V</var> must be an instance of the type
                         <code>xs:numeric+</code> (that is, every item in <var>V</var>
-                           must be numeric). A type error <errorref class="TY" code="0004"/> is
+                           must be numeric). A type error <xerrorref spec="FO40" class="RG" code="0006"/> is
                         raised if this is not the case.</p></item>
                         <item><p>The predicate truth value is <code>true</code> if 
                            <var>V</var> is equal (by the
@@ -8734,10 +8739,9 @@ At evaluation time, the value of a variable reference is the value to which the 
                   
                   <p>It is also possible, and again not generally useful, for the value of the predicate
                   to be numeric for some items in the input sequence, and boolean for others.
-                  For example, the predicate <code>[@special otherwise xs:integer(@seq)]</code>
+                  For example, the predicate <code>[@special otherwise last()]</code>
                   is true for an item that either has an <code>@special</code> attribute,
-                     or if not, has an <code>@seq</code> attribute
-                     that is numerically equal to the position of the item in the input sequence.</p></note>
+                     or is the last item in the input sequence.</p></note>
                   
                   <note><p>The truth value of a numeric predicate does not depend on the order
                   of the numbers in <var>V</var>. The predicates <code>[ 1, 2, 3 ]</code>
@@ -8747,6 +8751,13 @@ At evaluation time, the value of a variable reference is the value to which the 
                   
                   <note><p>The truth value of a numeric predicate whose value is non-integral
                   or non-positive is always false.</p></note>
+                  
+                  <note><p>Beware that using boolean operators (<code>and</code>, <code>or</code>,
+                  <code>not()</code>) with numeric values may not have the intended effect.
+                  For example the predicate <code>[1 or last()]</code> selects every item
+                  in the sequence, because <code>or</code> operates on the <termref def="dt-ebv"/>
+                  of its operands. The required effect can be achieved with the predicate
+                  <code>[1, last()]</code>.</p></note>
                   
                   <note role="xquery">
                      <p>In a region of a query where <termref def="dt-ordering-mode"
@@ -17614,7 +17625,12 @@ declare function recursive-content($item as item()) as record(key, value)* {
             <head>Filter Expressions for Maps and Arrays</head>
             
             <changes>
-               <change issue="1159" PR="1163" date="2024-04-20">Filter expressions for maps and arrays are introduced.</change>
+               <change issue="1159" PR="1163" date="2024-04-20">
+                  Filter expressions for maps and arrays are introduced.
+               </change>
+               <change issue="1207" PR="tba" date="2024-05-15">
+                  Predicates in filter expressions for maps and arrays can now be numeric.
+               </change>
             </changes>
 
                <scrap>
@@ -17634,16 +17650,14 @@ declare function recursive-content($item as item()) as record(key, value)* {
             map, or a single array <errorref class="TY" code="0004"/>. If it is an empty sequence, 
                the result of the expression is an empty sequence.</p>
             
-            <p>The required type of the <code><var>FILTER</var></code> operand is <code>xs:boolean?</code>:
-            that is, the value must either be a single boolean value, or an empty sequence. An empty sequence
-            is treated as <code>false</code>.</p>
-            
+           
             <p>If the value of <code><var>INPUT</var></code> is an array, then the 
                <code><var>FILTER</var></code> expression is evaluated
             for each member of the array, with that member as the context value, with its position in the
             array as the context position, and with the size of the array as the context size. The result
             of the expression is an array containing those members of the input array for which
-               the value of the <code><var>FILTER</var></code> expression is true. The order
+               the <termref def="dt-predicate-truth-value"/> of the 
+               <code><var>FILTER</var></code> expression is true. The order
             of retained members is preserved.</p>
             
             <p>For example, the following expression:</p>
@@ -17654,16 +17668,13 @@ declare function recursive-content($item as item()) as record(key, value)* {
             
             <eg>[(2,3), (4,5,6)]</eg>
             
-            <note><p>Unlike filter expressions for sequences, there is no special treatment of
-            numeric predicate values. This is because it would be unclear whether such an expression
-            should return the member at the specified position, or a singleton array containing that
-            member. Numeric values for the predicate are disallowed to avoid any possible confusion.</p>
+            <note><p>Numeric predicates are handled in the same way as with filter expressions for 
+               sequences. However, the result is always an array, even if only one member
+            is selected. For example, given the <code>$array</code> shown above, the result
+            of <code>$array?[3]</code> is the singleton array <code>[(2, 3)]</code>.
+            Contrast this with <code>$array?3</code> which delivers the sequence <code>2, 3</code>.</p>
             
-            <p>Positional filtering can be achieved by explicit use of the <code>position()</code>
-            function, for example <code>$array?[position() mod 2 = 0]</code>. If an effective boolean
-            value is required, it can be achieved by an explicit call on <code>fn:boolean</code>
-               or <code>fn:exists</code>,
-            for example <code>$array[boolean(normalize-space(.))]</code> or <code>$array[exists(self::a)]</code>.</p>
+            
             </note>
             
             <p>If the value of <code><var>INPUT</var></code> is a map, then the 
@@ -17674,7 +17685,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                The context position is the position of the entry in the map (in an arbitrary ordering),
                and the context size is the number of entries in the map. The result
                of the expression is a map containing those entries of the input map for which
-               the value of the <code><var>FILTER</var></code> expression is true.</p>
+               the <termref def="dt-predicate-truth-value"/> of the <code><var>FILTER</var></code> expression is true.</p>
             
             <p>For example, the following expression:</p>
             
@@ -17683,6 +17694,11 @@ declare function recursive-content($item as item()) as record(key, value)* {
             <p>returns:</p>
             
             <eg>{ 2: "beta", 3: "gamma" }</eg>
+            
+            <note>
+               <p>Filtering of maps based on numeric positions is not generally useful, because the order of entries
+               in a map is unpredictable; but it is available in the interests of orthogonality. </p>
+            </note>
          </div3>
          
          <div3 id="id-pinned-maps-and-arrays">


### PR DESCRIPTION
Fix #1207

Also a minor change: `$V[23, "fred"]` now throws FORG0006 rather than XPTY0004. This keeps it compatible with 3.1 (in case anyone is catching the errors), and is more uniform: it seems unreasonable for `$V[23, "fred"]` and `$V["fred", 23]` to throw different errors. 