### PR TITLE
73 copy&paste typo in fn:graphemes (combining diaeresis should be ZWJ)

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -28949,7 +28949,7 @@ return every($dl/*, fn($elem, $pos) {
             <fos:test>
                <fos:expression>graphemes(char(0x1F476) || char(0x200D) 
 || char(0x1F6D1))</fos:expression>
-               <fos:result>char(0x1F476) || char(0x308) || char(0x1F6D1)</fos:result>
+               <fos:result>char(0x1F476) || char(0x200D) || char(0x1F6D1)</fos:result>
                <fos:postamble>👶 +ZWJ + 🛑, three characters, one grapheme</fos:postamble>
             </fos:test>
          </fos:example>


### PR DESCRIPTION
I wonder which font I need to use in order to see U+1F476 U+200D U+1F6D1 as a single grapheme. When I naively put the character sequence into an HTML page, the two glyphs will be rendered individually. How can we make sure that the grapheme will be rendered as intended for most people when they read the spec?