### PR TITLE
Rework record descriptions per ACTION QT4CG-070-01

### DIFF
--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -74,15 +74,15 @@ div.proto        {
                  }
 
 div.record        { 
-    padding: .5em;
-		border: .5em;
-		border-left-style: solid;
-		page-break-inside: avoid;
-		margin: 1em auto;
-		border-color: #ffaaff;
-		background: #fff6ff;
-		overflow: auto;
-                 }
+    padding: 0;
+    border: .5em;
+    border-left-style: solid;
+    page-break-inside: avoid;
+    margin: 1em auto;
+    border-color: #ffaaff;
+    background: #fff6ff;
+    overflow: auto;
+}
 
 .record code {
     background-color: inherit;
@@ -95,11 +95,27 @@ div.record        {
     margin: inherit;
 }
 
+.record .title {
+    background-color:  #ffaaff;
+}
+
+/* Don't wrap the record names */
+.record tbody tr td:first-child code {
+    white-space: nowrap;
+}
+
 table.proto tr td,
 table.record tr td, {
   font-family: monospace;
   padding-right: 0.5em;
 }
+
+/*
+table.record tr.arg td code.req {
+  font-weight: bold;
+}
+*/
+
 table.proto tr.arg td:first-child,
 table.record tr.arg td:first-child  {
   padding-left: 0.5em;
@@ -107,6 +123,8 @@ table.record tr.arg td:first-child  {
 table.proto tr.name span.name {
   font-weight: bold;
 }
+
+
 
 table.medium {
     border-collapse: collapse;
@@ -150,4 +168,35 @@ div.changed-function h4::before {
 
 span.content.changed-function::after {
     content: " 🆙";
+}
+
+table.record-description,
+table.fos-options {
+    border-collapse: collapse;
+}
+
+table.record-description,
+table.fos-options thead tr {
+    border-top: 2px solid black;
+    border-bottom: 2px solid black;
+}
+
+table.record-description,
+table.fos-options thead tr th {
+    text-align: left;
+    padding-right: 1em;
+}
+
+table.record-description,
+table.fos-options tbody tr td {
+    vertical-align: top;
+    border-bottom: 2px solid black;
+}
+
+table.record-description,
+table.fos-options tbody tr td:first-child {
+    white-space: nowrap;
+    padding-right: 1em;
+    vertical-align: top;
+    border-bottom: 2px solid black;
 }

--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -84,7 +84,16 @@ div.record        {
 		overflow: auto;
                  }
 
-
+.record code {
+    background-color: inherit;
+    border: inherit;
+    border-radius: 0;
+    padding-top: inherit;
+    padding-bottom: inherit;
+    padding-left: inherit;
+    padding-right: inherit;
+    margin: inherit;
+}
 
 table.proto tr td,
 table.record tr td, {

--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -113,6 +113,7 @@
     <xs:complexType>
       <xs:attribute name="name" use="required" type="fos:NCName-or-ellipsis"/>
       <xs:attribute name="type" use="optional"/>
+      <xs:attribute name="required" type="xs:boolean"/>
       <xs:attribute name="type-ref" type="xs:IDREF" use="optional">
         <xs:annotation>
           <xs:documentation>
@@ -226,6 +227,7 @@
       <xs:choice maxOccurs="unbounded">
         <xs:any namespace="##local" processContents="skip"/>
         <xs:element ref="fos:options"/>
+        <xs:element ref="fos:record-description"/>
       </xs:choice>
       <xs:attributeGroup ref="fos:diff-markup"/>
     </xs:complexType>
@@ -413,4 +415,42 @@
       <xs:attributeGroup ref="fos:diff-markup"/>
     </xs:complexType>
   </xs:element>
+
+  <xs:element name="record-description">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="option" minOccurs="1" maxOccurs="unbounded">
+           <xs:complexType>
+             <xs:sequence>
+               <xs:element name="meaning" type="xs:anyType"/>
+               <xs:element name="type" type="xs:string"/>
+               <xs:element name="required" type="xs:boolean" minOccurs="0"/>
+               <xs:element name="default" type="xs:string" minOccurs="0"/>
+               <xs:element name="default-description" type="xs:anyType" minOccurs="0"/>
+               <xs:element name="values" minOccurs="0">
+                 <xs:complexType>
+                   <xs:sequence>
+                     <xs:element name="value" minOccurs="1" maxOccurs="unbounded">
+                       <xs:complexType mixed="true">
+                         <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                           <xs:any namespace="##local" processContents="skip"/>
+                         </xs:sequence>
+                         <xs:attribute name="value" type="xs:string" use="required"/>
+                       </xs:complexType>
+                     </xs:element>
+                   </xs:sequence>
+                 </xs:complexType>
+               </xs:element>
+             </xs:sequence>
+             <xs:attribute name="key" type="xs:string" use="required"/>
+             <xs:attributeGroup ref="fos:diff-markup"/>
+           </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="id" type="xs:ID" use="required"/>
+      <xs:attribute name="extensible" type="xs:boolean"/>
+      <xs:attributeGroup ref="fos:diff-markup"/>
+    </xs:complexType>
+  </xs:element>
+
 </xs:schema>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17,52 +17,27 @@
       <fos:variable id="v-item3" name="item3" select="$po/line-item[3]"/>
    </fos:global-variables>
 
+   <!-- Not used, but needed for IDREF in this file -->
    <fos:type id="uri-structure-record">
       <fos:record extensible="true">
          <fos:field name="uri" type="xs:string?" required="false"/>
-         <fos:field name="scheme" type="xs:string?" required="false"/>
-         <fos:field name="hierarchical" type="xs:boolean?" required="false"/>
-         <fos:field name="authority" type="xs:string?" required="false"/>
-         <fos:field name="userinfo" type="xs:string?" required="false"/>
-         <fos:field name="host" type="xs:string?" required="false"/>
-         <fos:field name="port" type="xs:string?" required="false"/>
-         <fos:field name="path" type="xs:string?" required="false"/>
-         <fos:field name="query" type="xs:string?" required="false"/>
-         <fos:field name="fragment" type="xs:string?" required="false"/>
-         <fos:field name="path-segments" type="xs:string*" required="false"/>
-         <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false"/>
+         <!-- ... -->
       </fos:record>
    </fos:type>
-   
-   <fos:type id="random-number-generator-record">
-      <fos:record extensible="true">
-         <fos:field name="number" type="xs:double" required="true"/>
-         <fos:field name="next" type="fn() as random-number-generator-record" required="true"/>
-         <fos:field name="permute" type="fn(item()*) as item()*" required="true"/>
-      </fos:record>
-   </fos:type>
-   
-   <fos:type id="load-xquery-module-record">
-      <fos:record extensible="true">
-         <fos:field name="variables" type="map(xs:QName, item()*)" required="true"/>
-         <fos:field name="functions" type="map(xs:QName, map(xs:integer, fn(*)))" required="true"/>
-      </fos:record>
-   </fos:type>
-   
-   <fos:type id="sort-key-record">
-      <fos:record extensible="true">
-         <fos:field name="key" type="fn(item()) as xs:anyAtomicType*" required="true"/>
-         <fos:field name="ascending" type="xs:boolean" required="false"/>
-         <fos:field name="collation" type="xs:string" required="false"/>
-      </fos:record>
-   </fos:type>
-   
+
+   <!-- Not used, but needed for IDREF in this file -->
    <fos:type id="parse-html-options">
       <fos:record extensible="true">        
          <fos:field name="method" type="xs:string" required="false"/>
-         <fos:field name="html-version" type="(enum('LS') | xs:decimal)" required="false"/>
-         <fos:field name="encoding" type="xs:string?" required="false"/>
-         <fos:field name="include-template-content" type="xs:boolean?" required="false"/>
+         <!-- ... -->
+      </fos:record>
+   </fos:type>
+
+   <!-- Not used, but needed for IDREF in this file -->
+   <fos:type id="parsed-csv-structure-record">
+      <fos:record extensible="false">
+         <fos:field name="columns" type="xs:string*" required="true"/>
+         <!-- ... -->
       </fos:record>
    </fos:type>
 
@@ -83,16 +58,6 @@
          <fos:field name="trim-whitespace" type="xs:boolean" required="false"/>
       </fos:record>
    </fos:type>-->
-
-   <fos:type id="parsed-csv-structure-record">
-      <fos:record extensible="false">
-         <fos:field name="columns" type="xs:string*" required="true"/>
-         <fos:field name="column-index" type="map(xs:string, xs:positiveInteger)" required="true"/>
-         <fos:field name="rows" type="array(xs:string)*" required="true"/>
-         <fos:field name="get" required="true" type="fn(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string?"/>
-      </fos:record>
-   </fos:type>
-
 
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
@@ -27627,33 +27592,40 @@ declare function flatten(
          </fos:options>
 
   
-         <p>The result of the function is a map <var>R</var> with two entries:</p>
-         
-         <?type load-xquery-module-record?>
-         
-         <olist>
-            <item>
-               <p>There is an entry whose key is the <code>xs:string</code> value <code>"variables"</code> and whose associated value
-               is a map <var>V</var>. This map (<var>V</var>) contains one entry for each public global variable declared in the library module. 
-               The key of the
-            entry is the name of the variable, as an <code>xs:QName</code> value; the associated value is the value of the variable.</p>
-            </item>
-            <item>
-               <p>There is an entry whose key is the <code>xs:string</code> value <code>"functions"</code> and whose associated value
-               is a map <var>F</var>. This map (<var>F</var>) contains one entry for each distinct QName <var>Q</var> that represents the
-                  name of a public and non-external function declared in the library module. The key of the
-               entry is <var>Q</var>, as an <code>xs:QName</code> value; the associated value is a map <var>A</var>.
-               This map (<var>A</var>) contains one entry for each arity <var>N</var> within the arity range of any of the function declarations
-                  with the given name; its key is <var>N</var>,
-               as an <code>xs:integer</code> value, and its associated value is a function item obtained as if by evaluating
-                  a named function reference <code>Q#N</code>, using the static and dynamic context of the call on
-                  <code>fn:load-xquery-module</code>. The function item
-               can be invoked using the rules for dynamic function invocation.
-            </p>
-               
-            </item>
-         </olist>
+         <p>The result of the function is a map
+         <var>R</var> with two entries:</p>
 
+<fos:record-description id="load-xquery-module-record" extensible="true">
+   <fos:option key="variables">
+      <fos:meaning>
+               <p>This map (<var>V</var> ) contains one entry for each public
+               global variable declared in the library module. The key of the
+               entry is the name of the variable, as an <code>xs:QName</code>
+               value; the associated value is the value of the variable.</p>
+      </fos:meaning>
+      <fos:type>map(xs:QName, item()*)</fos:type>
+      <!-- REQUIRED -->
+   </fos:option>
+   <fos:option key="functions">
+      <fos:meaning>
+         <p>This map (<var>F</var> ) contains one entry for each distinct QName
+         <var>Q</var> that represents the name of a public and non-external
+         function declared in the library module. The key of the entry is
+         <var>Q</var>, as an <code>xs:QName</code> value; the associated value
+         is a map <var>A</var>. This map (<var>A</var>) contains one entry for
+         each arity <var>N</var> within the arity range of any of the function
+         declarations with the given name; its key is <var>N</var>, as an
+         <code>xs:integer</code> value, and its associated value is a function
+         item obtained as if by evaluating a named function reference
+         <code>Q#N</code>, using the static and dynamic context of the call on
+         <code>fn:load-xquery-module</code>. The function item can be invoked
+         using the rules for dynamic function invocation.</p>
+      </fos:meaning>
+      <fos:type>map(xs:QName, map(xs:integer, function(*)))</fos:type>
+      <!-- REQUIRED -->
+   </fos:option>
+</fos:record-description>
+         
          <p>The static and dynamic context of the library module are established according to the rules in 
             <xspecref
                spec="XQ31" ref="id-xq-context-components"/>.</p>
@@ -28524,19 +28496,17 @@ return $result?output//body
                >The function returns a random number generator. A random number generator is represented as a value of type 
             <code>random-number-generator-record</code>, defined as follows:</p>
          
-         <?type random-number-generator-record?>
 
-         
-         
-         <p>That is, the result of the function is a map containing three entries. 
-            The keys of each entry are strings:</p>
-         <olist>
-            <item>
-               <p>The entry with key <code>"number"</code> holds a random number; it is an <code>xs:double</code> greater than or equal
-               to zero (0.0e0), and less than one (1.0e0).</p>
-            </item>
-            <item>
-               <p>The entry with key <code>"next"</code> is a zero-arity function that can be called to return another random number
+   <fos:record-description id="random-number-generator-record" extensible="true">
+      <fos:option key="number">
+         <fos:meaning><p>An <code>xs:double</code> greater than or equal
+               to zero (0.0e0), and less than one (1.0e0).</p></fos:meaning>
+         <fos:type>xs:double</fos:type>
+         <fos:required>true</fos:required>
+      </fos:option>
+      <fos:option key="next">
+         <fos:meaning>
+               <p>A zero-arity function that can be called to return another random number
             generator.</p>
                <p>The properties of this function are as follows:</p>
                <ulist>
@@ -28556,9 +28526,13 @@ return $result?output//body
                      <p>implementation: implementation-dependent</p>
                   </item>
                </ulist>
-            </item>
-            <item>
-               <p>The entry with key <code>"permute"</code> is a function with arity 1 (one), which takes an arbitrary sequence
+         </fos:meaning>
+         <fos:type>function() as random-number-generator-record</fos:type>
+         <fos:required>true</fos:required>
+      </fos:option>
+      <fos:option key="permute">
+         <fos:meaning>
+               <p>A function with arity 1 (one), which takes an arbitrary sequence
             as its argument, and returns a random permutation of that sequence.</p>
                <p>The properties of this function are as follows:</p>
                <ulist>
@@ -28578,8 +28552,12 @@ return $result?output//body
                      <p>implementation: implementation-dependent</p>
                   </item>
                </ulist>
-            </item>
-         </olist>
+         </fos:meaning>
+         <fos:type>function(item()*) as item()*</fos:type>
+         <fos:required>true</fos:required>
+      </fos:option>
+   </fos:record-description>
+
          <p>Calling the <code>fn:random-number-generator</code> function with no arguments is equivalent to calling the single-argument
          form of the function with an implementation-dependent seed.</p>
          <p>Calling the <code>fn:random-number-generator</code> function with an empty sequence as <code>$seed</code> 
@@ -30054,7 +30032,6 @@ some $boolean in (
          can be successfully parsed as URIs.</p>
 
          <p>The following options are available:</p>
-
 
          <fos:options>
             <fos:option key="path-separator">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23705,10 +23705,6 @@ return json-to-xml($json, $options)]]></eg>
             calling the two-argument form with an empty map as the value of the <code>$options</code>
             argument.</p>
 
- 
-
-         
-
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
          <fos:options>
             <fos:option key="field-delimiter">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3377,11 +3377,13 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 
            <p>The structured representation of a URI is described by the
            <code>uri-structure-record</code>:</p>
-            
+<!--
             <?type uri-structure-record?>
+-->
 
-           <p>The parts of this structure are:</p>
+           <p id="uri-structure-record">The parts of this structure are:</p>
 
+<!--
            <table border="0" role="data">
              <caption>The URI structure record</caption>
              <tbody>
@@ -3444,6 +3446,71 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                </tr>
              </tbody>
            </table>
+-->
+
+<fos:options xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace" >
+   <fos:option key="uri">
+      <fos:meaning>
+         <p>The original URI. This element is returned by <code>fn:parse-uri</code>,
+         but ignored by <code>fn:build-uri</code>.</p>
+      </fos:meaning>
+      <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="scheme">
+      <fos:meaning>
+         <p>The URI scheme (e.g., “https” or “file”).</p>
+      </fos:meaning>
+      <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="hierarchical">
+      <fos:meaning>
+         <p>Whether the URI is hierarchical or not.</p>
+      </fos:meaning>
+      <fos:type>xs:boolean?</fos:type>
+   </fos:option>
+   <fos:option key="authority">
+     <fos:meaning>
+       <p>The authority portion of the URI (e.g., “example.com:8080”).</p>
+     </fos:meaning>
+     <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="userinfo">
+     <fos:meaning>Any userinfo that was passed as part of the authority.</fos:meaning>
+     <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="host">
+     <fos:meaning>The host passed as part of the authority (e.g., “example.com”). </fos:meaning>
+     <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="port">
+     <fos:meaning>The port passed as part of the authority (e.g., “8080”).</fos:meaning>
+     <fos:type>xs:integer?</fos:type>
+   </fos:option>
+   <fos:option key="path">
+     <fos:meaning>The path portion of the URI.</fos:meaning>
+     <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="query">
+     <fos:meaning>Any query string.</fos:meaning>
+     <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="fragment">
+     <fos:meaning>Any fragment identifier.</fos:meaning>
+     <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="path-segments">
+     <fos:meaning>Parsed and unescaped path segments.</fos:meaning>
+     <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="query-parameters">
+     <fos:meaning>Parsed and unescaped query key-value pairs.</fos:meaning>
+     <fos:type>map(xs:string, xs:string*)?</fos:type>
+   </fos:option>
+   <fos:option key="filepath">
+     <fos:meaning>The path of the URI, treated as a filepath.</fos:meaning>
+     <fos:type>xs:string?</fos:type>
+   </fos:option>
+</fos:options>
 
            <p>The segmented forms of the path and query parameters provide
            convenient access to commonly used information.</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -143,7 +143,8 @@ for transition to Proposed Recommendation. </p>'>
 
 <!--
 <head><?xml-stylesheet type="text/xsl" href="E:\XMLdocs\XML Query Language (XQuery)\Functions and Operators\Current Functions and Operators Build Files\xquery-operators.xsl"?></head> -->
-<spec id="spec-top" w3c-doctype="&doc.w3c-doctype;" status="ext-review">
+<spec id="spec-top" w3c-doctype="&doc.w3c-doctype;" status="ext-review"
+      xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace">
     <header>
         <title>&language;</title>
         <version>&version;</version>
@@ -3377,78 +3378,12 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 
            <p>The structured representation of a URI is described by the
            <code>uri-structure-record</code>:</p>
-<!--
-            <?type uri-structure-record?>
--->
 
-           <p id="uri-structure-record">The parts of this structure are:</p>
+           <p>The parts of this structure are:</p>
 
-<!--
-           <table border="0" role="data">
-             <caption>The URI structure record</caption>
-             <tbody>
-               <tr>
-                 <td>uri</td>
-                 <td>The original URI. This element is returned by <code>fn:parse-uri</code>,
-                 but ignored by <code>fn:build-uri</code>.</td>
-               </tr>
-               <tr>
-                 <td>scheme</td>
-                 <td>The URI scheme (e.g., “https” or “file”).</td>
-               </tr>
-               <tr>
-                 <td>hierarchical</td>
-                 <td>Whether the URI is hierarchical or not.</td>
-               </tr>
-               <tr>
-                 <td>authority</td>
-                 <td>The authority portion of the URI (e.g., “example.com:8080”).</td>
-               </tr>
-               <tr>
-                 <td>userinfo</td>
-                 <td>Any userinfo that was passed as part of the authority.</td>
-               </tr>
-               <tr>
-                 <td>host</td>
-                 <td>The host passed as part of the authority (e.g., “example.com”). </td>
-               </tr>
-               <tr>
-                 <td>port</td>
-                 <td>The port passed as part of the authority (e.g., “8080”).</td>
-               </tr>
-               <tr>
-                 <td>path</td>
-                 <td>The path portion of the URI.</td>
-               </tr>
-               <tr>
-                 <td>query</td>
-                 <td>Any query string.</td>
-               </tr>
-               <tr>
-                 <td>fragment</td>
-                 <td>Any fragment identifier.</td>
-               </tr>
-               <tr>
-                 <td>path-segments</td>
-                 <td>Parsed and unescaped path segments.</td>
-               </tr>
-               <tr>
-                 <td>query-parameters</td>
-                 <td>Parsed and unescaped query key-value pairs.</td>
-               </tr>
-               <tr>
-                 <td>filepath</td>
-                 <td>The path of the URI, treated as a filepath.</td>
-               </tr>
-               <tr>
-                 <td>*</td>
-                 <td>Additional, information defined structures are allowed.</td>
-               </tr>
-             </tbody>
-           </table>
--->
-
-<fos:options xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace" >
+<fos:record-description id="uri-structure-record"
+                        extensible="true"
+                        xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace" >
    <fos:option key="uri">
       <fos:meaning>
          <p>The original URI. This element is returned by <code>fn:parse-uri</code>,
@@ -3510,7 +3445,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
      <fos:meaning>The path of the URI, treated as a filepath.</fos:meaning>
      <fos:type>xs:string?</fos:type>
    </fos:option>
-</fos:options>
+</fos:record-description>
 
            <p>The segmented forms of the path and query parameters provide
            convenient access to commonly used information.</p>
@@ -6557,22 +6492,10 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <head>HTML parser options</head>
                <p>This section describes the record structure used to pass options to the
                <code>fn:parse-html</code> function.</p>
-               <example role="record">
-                  <record id="parse-html-options">
-                     <arg name="method" type="(enum(&quot;html&quot; | &quot;xhtml&quot;), xs:string)"/>
-                     <arg name="html-version" type="(enum(&quot;LS&quot;) | xs:decimal)"/>
-                     <arg name="encoding?" type="xs:string?"/>
-                     <arg name="include-template-content?" type="xs:boolean?"/>
-                     <arg name="*"/>
-                  </record>
-               </example>
-               <p>The keys of this record type are:</p>
-               <table border="0" role="data">
-                  <caption>The parse-html options record</caption>
-                  <tbody>
-                     <tr>
-                        <td>method</td>
-                        <td>
+
+<fos:record-description id="parse-html-options" extensible="true">
+   <fos:option key="method">
+      <fos:meaning>
                            <p>The approach used to parse the HTML document into XDM nodes.</p>
                            <note>
                               <p>An implementation may use this to specify a specific algorithm, tool, or
@@ -6580,11 +6503,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                               <p>An implementation may also use this to specify a non-standard variant of
                                  HTML to support, such as <code>word</code> for the Microsoft Word HTML variant.</p>
                            </note>
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>html-version</td>
-                        <td>
+      </fos:meaning>
+      <fos:type>xs:string</fos:type>
+   </fos:option>
+   <fos:option key="html-version">
+      <fos:meaning>
                            <p>The version of HTML to support when parsing HTML strings or sequences of octets.</p>
                            <p>Valid values an implementation must support for the <code>html</code> method are:</p>
                            <olist>
@@ -6621,16 +6544,18 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                            </olist>
                            <p>Any other <code>method</code> and <code>html-version</code> combinations are
                               <termref def="implementation-defined">implementation-defined</termref>.</p>
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>encoding</td>
-                        <td>The character encoding to use to decode a sequence of octets that represents
-                           an HTML document.</td>
-                     </tr>
-                     <tr>
-                        <td>include-template-content</td>
-                        <td>
+      </fos:meaning>
+      <fos:type>(enum('LS') | xs:decimal)</fos:type>
+   </fos:option>
+   <fos:option key="encoding">
+      <fos:meaning>
+         <p>The character encoding to use to decode a sequence of octets that
+         represents an HTML document.</p>
+      </fos:meaning>
+      <fos:type>xs:string?</fos:type>
+   </fos:option>
+   <fos:option key="include-template-content">
+      <fos:meaning>
                            <p>Defines how to handle elements in the <code>HTMLTemplateElement.content</code>
                               property.</p>
                            <p>If this option is <code>true()</code>, the <code>template</code> element’s
@@ -6655,21 +6580,18 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                                  </item>
                               </olist>
                            </note>
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>*</td>
-                        <td>
-                           <p>Additional <termref def="implementation-defined"/> parser options.</p>
+      </fos:meaning>
+      <fos:type>xs:boolean?</fos:type>
+   </fos:option>
+</fos:record-description>
+
+   <p>Additional <termref def="implementation-defined"/> parser options are allowed.</p>
                            <example>
                               <head>Example:</head>
                               <p>An implementation may provide keys for options to the <emph>tidy</emph>
                                  HTML parser, allowing a user to configure the behaviour of that parser.</p>
                            </example>
-                        </td>
-                     </tr>
-                  </tbody>
-               </table>
+
             </div3>
             <div3 id="func-parse-html">
                <head><?function fn:parse-html?></head>
@@ -7008,25 +6930,6 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             delivers this capability using XDM maps and functions, while <code>csv-to-xml</code>
             function represents the information using XDM element nodes.</p>
             
-            
-
-
-            <!--<div3 id="common-parsing-options">
-               <head>Common parsing options</head>
-
-               <p>All three functions: <code>fn:csv-to-arrays</code>, <code>fn:csv-to-xml</code>, and
-                  <code>fn:parse-csv</code>, take options to control parsing, in particular
-                  specifying the characters used as delimiters. These core delimiter options are used by the
-                  functions that generate CSV data:</p>
-
-               <?type common-csv-options ?>
-
-               <p>Additionally, the parsing functions share an additional option to control whether
-                  leading and trailing whitespace should be stripped or not.</p>
-
-               <?type csv-parsing-options ?>
-            </div3>
--->
             <div3 id="csv-delimiters">
                <head>CSV delimiters</head>
                
@@ -7181,26 +7084,34 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                   <p>The function returns a
                   <code>parsed-csv-structure-record</code>:</p>
 
-               <?type parsed-csv-structure-record ?>
-               
                <p>The record has four parts, which are always present (though potentially empty):</p>
-                  
-               <ulist>
-                  <item><p><code>columns</code> gives the list of column names, in order.</p></item>
-                  <item><p><code>column-index</code> is a map from column names to the 1-based integer
-                     position of the column.</p></item>
-                  <item><p><code>rows</code> gives the contents of the non-header rows 
-                     in the CSV data, as a sequence
-                     of arrays of <code>xs:string</code> values; each array represents one
-                     row of the CSV data. </p></item>
-                  <item><p><code>get</code> is a function providing ready access to a given
-                  field in a given row. The function has signature:</p>
-                     <eg>function($row as xs:positiveInteger, $column as (xs:string | xs:positiveInteger)) as xs:string?</eg>
-                     <p>The function takes two arguments: the first is an integer giving the
-                        row number (1-based), the second identifies a column either by its name
-                        or by its 1-based position.</p></item>
-               </ulist>
-                  
+
+<fos:record-description id="parsed-csv-structure-record">
+   <fos:option key="columns">
+      <fos:meaning><p>The list of column names, in order.</p></fos:meaning>
+      <fos:type>xs:string*</fos:type>
+   </fos:option>
+   <fos:option key="columns-index">
+      <fos:meaning><p>A map from column names to the 1-based integer position of the column.</p></fos:meaning>
+      <fos:type>map(xs:string,xs:integer)?</fos:type>
+   </fos:option>
+   <fos:option key="rows">
+      <fos:meaning><p>The contents of the non-header rows in the CSV data, as a
+      sequence of arrays of <code>xs:string</code> values; each array represents
+      one row of the CSV data.</p></fos:meaning>
+      <fos:type>array(xs:string)*</fos:type>
+   </fos:option>
+   <fos:option key="get">
+      <fos:meaning><p>A function providing ready access to a given field in a given
+      row. The <code>get</code> function has signature:</p>
+                     <eg>function($row as xs:integer, $column as union(xs:string, xs:integer)) as xs:string?</eg>
+                     <p>The function takes two arguments: the first is an
+                     integer giving the row number (1-based), the second
+                     identifies a column either by its name or by its 1-based
+                     position.</p></fos:meaning>
+      <fos:type>function(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string?</fos:type>
+   </fos:option>
+</fos:record-description>
 
             </div3>
             <div3 id="func-parse-csv">

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -489,6 +489,16 @@
 	<!-- Handle option parameter specifications -->
 
 	<xsl:template match="fos:options">
+
+	  <example role="record">
+	    <record>
+              <xsl:for-each select="fos:option">
+                <arg name="{@key}" type="{fos:type}"/>
+              </xsl:for-each>
+              <arg name="*"/>
+	    </record>
+	  </example>
+
 		<table style="border-collapse: collapse">
 			<xsl:copy-of select="@diff, @at"/>
 			<thead>

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -488,123 +488,135 @@
 
 	<!-- Handle option parameter specifications -->
 
-	<xsl:template match="fos:options">
+	<xsl:template match="fos:options|fos:record-description">
 
-	  <example role="record">
+	  <example role="{if (self::fos:options) then 'record' else 'record-description'}">
 	    <record>
+              <xsl:copy-of select="@id"/>
               <xsl:for-each select="fos:option">
-                <arg name="{@key}" type="{fos:type}"/>
+                <arg name="{@key}">
+                  <xsl:if test="fos:type">
+                    <xsl:attribute name="type" select="fos:type"/>
+                  </xsl:if>
+                  <xsl:attribute name="occur"
+                                 select="if (fos:required = true()) then 'req' else 'opt'"/>
+                </arg>
               </xsl:for-each>
-              <arg name="*"/>
+              <xsl:if test="@extensible != false()">
+                <arg name="*"/>
+              </xsl:if>
 	    </record>
 	  </example>
 
-		<table style="border-collapse: collapse">
-			<xsl:copy-of select="@diff, @at"/>
-			<thead>
-				<tr style="border-top: 2px solid black; border-bottom: 2px solid black">
-					<th style="text-align:left; padding-right: 10px; ">Key</th>
-					<xsl:if test="fos:option/fos:applies-to">
-						<th style="text-align:left; padding-right: 10px; ">Applies to</th>
-					</xsl:if>
-					<xsl:if test="exists(.//fos:values)">
-						<th style="text-align:left; padding-right: 10px; ">Value</th>
-					</xsl:if>
-					<th style="text-align:left">
-						<!--<xsl:if test="exists(.//fos:values)">
-							<xsl:attribute name="colspan">2</xsl:attribute>
-						</xsl:if>-->
-						<xsl:text>Meaning</xsl:text>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				<xsl:apply-templates select="fos:option"/>
-			</tbody>
-		</table>
-	</xsl:template>
+<table class="fos-options">
+  <xsl:copy-of select="@diff, @at"/>
+  <thead>
+    <tr>
+      <th>Key</th>
+      <xsl:if test="fos:option/fos:applies-to">
+	<th>Applies to</th>
+      </xsl:if>
+      <xsl:if test="exists(.//fos:values)">
+	<th>Value</th>
+      </xsl:if>
+      <th>
+	<xsl:text>Meaning</xsl:text>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <xsl:apply-templates select="fos:option"/>
+  </tbody>
+</table>
+</xsl:template>
 
-	<xsl:template match="fos:option">
-		<tr>
-			<xsl:copy-of select="@diff, @at"/>
-			<td
-				style="white-space:nowrap; padding-right: 10px; vertical-align:top; border-bottom: 2px solid black"
-				rowspan="{1 + count(fos:values/fos:value)}">
-				<code>
-					<xsl:value-of select="@key"/>
-				</code>
-			</td>
-			<xsl:if test="../fos:option/fos:applies-to">
-				<td
-					style="white-space:nowrap; padding-right: 10px; vertical-align:top; border-bottom: 2px solid black"
-					rowspan="{1 + count(fos:values/fos:value)}">
-					<xsl:value-of select="fos:applies-to"/>
-				</td>
-			</xsl:if>
-			<xsl:variable name="thickness" select="
-					if (exists(fos:values)) then
-						'1'
-					else
-						'2'"/>
-			<td style="vertical-align:top; border-bottom: {$thickness}px solid black">
-				<xsl:if test="exists(..//fos:values)">
-					<xsl:attribute name="colspan">2</xsl:attribute>
-				</xsl:if>
-				<xsl:apply-templates select="fos:meaning/node()"/>
-				<ulist>
-					<item>
-						<p>
-							<term>Type: </term>
-							<code>
-								<xsl:value-of select="fos:type"/>
-							</code>
-						</p>
-					</item>
-<xsl:if test="fos:default | fos:default-description">
-  <xsl:choose>
-    <xsl:when test="not(fos:default)">
-      <item>
-        <p>
-          <term>Default: </term>
-          <xsl:apply-templates select="fos:default-description/node()"/>
-        </p>
-      </item>
-    </xsl:when>
-    <xsl:otherwise>
-      <item>
-        <p>
-          <term>Default: </term>
-          <xsl:apply-templates select="fos:default"/>
-        </p>
-        <xsl:apply-templates select="fos:default-description"/>
-      </item>
-    </xsl:otherwise>
-  </xsl:choose>
-</xsl:if>
-				</ulist>
-			</td>
-		</tr>
+<xsl:template match="fos:option">
+<tr>
+  <xsl:copy-of select="@diff, @at"/>
+  <td rowspan="{1 + count(fos:values/fos:value)}">
+    <p>
+      <code>
+	<xsl:value-of select="@key"/>
+      </code>
+    </p>
+  </td>
+  <xsl:if test="../fos:option/fos:applies-to">
+    <td rowspan="{1 + count(fos:values/fos:value)}">
+      <xsl:value-of select="fos:applies-to"/>
+    </td>
+  </xsl:if>
+  <xsl:variable name="thickness"
+                select="if (exists(fos:values)) then 'fos-thick' else 'fos-thin'"/>
+  <td class="{$thickness}">
+    <xsl:if test="exists(..//fos:values)">
+      <xsl:attribute name="colspan">2</xsl:attribute>
+    </xsl:if>
+    <xsl:apply-templates select="fos:meaning/node()"/>
+    <xsl:if test="fos:type|fos:default|fos:default-description">
+      <ulist>
+        <xsl:if test="fos:type">
+          <item>
+	    <p>
+	      <term>Type: </term>
+	      <code>
+	        <xsl:value-of select="fos:type"/>
+	      </code>
+	    </p>
+          </item>
+        </xsl:if>
+<!--
+        <xsl:if test="fos:required">
+          <item>
+	    <p>
+	      <term>Required: </term>
+	      <code>
+	        <xsl:value-of select="fos:required"/>
+	      </code>
+	    </p>
+          </item>
+        </xsl:if>
+-->
+        <xsl:if test="fos:default | fos:default-description">
+          <xsl:choose>
+            <xsl:when test="not(fos:default)">
+              <item>
+                <p>
+                  <term>Default: </term>
+                  <xsl:apply-templates select="fos:default-description/node()"/>
+                </p>
+              </item>
+            </xsl:when>
+            <xsl:otherwise>
+              <item>
+                <p>
+                  <term>Default: </term>
+                  <xsl:apply-templates select="fos:default"/>
+                </p>
+                <xsl:apply-templates select="fos:default-description"/>
+              </item>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:if>
+      </ulist>
+    </xsl:if>
+  </td>
+</tr>
 
-		<xsl:for-each select="fos:values/fos:value">
-			<xsl:variable name="thickness" select="
-					if (position() = last()) then
-						'2'
-					else
-						'1'"/>
-			<tr>
-				<td
-					style="white-space:nowrap; padding-right: 10px; vertical-align:top; border-bottom: {$thickness}px solid black">
-					<code>
-						<xsl:value-of select="@value"/>
-					</code>
-				</td>
-				<td style="vertical-align:top; border-bottom: {$thickness}px solid black">
-					<xsl:apply-templates/>
-				</td>
-			</tr>
-		</xsl:for-each>
-
-	</xsl:template>
+<xsl:for-each select="fos:values/fos:value">
+  <xsl:variable name="thickness"
+                select="if (position() = last()) then 'fos-thick' else 'fos-thin'"/>
+  <tr>
+    <td class="{$thickness}">
+      <code>
+	<xsl:value-of select="@value"/>
+      </code>
+    </td>
+    <td>
+      <xsl:apply-templates/>
+    </td>
+  </tr>
+</xsl:for-each>
+</xsl:template>
 
 <xsl:template match="fos:default">
   <code>
@@ -618,7 +630,7 @@
   </p>
 </xsl:template>
 
-	<xsl:template match="fos:history | fos:version"/>
+<xsl:template match="fos:history | fos:version"/>
 
 	<xsl:template match="processing-instruction('type')" expand-text="yes">
 		<xsl:variable name="target" select="$fosdoc//fos:type[@id = normalize-space(current())]"/>

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -443,14 +443,16 @@
   <xsl:variable name="id" select="(@id, ../@id)[1]"/>
   <div class="record">
     <table class="record" border="0">
-      <tr>
-        <td colspan="2">
-          <code id="{$id}" class="return-type-ref">
-            <xsl:value-of select="$id"/>
-          </code>
-          <xsl:text>:</xsl:text>
-        </td>
-      </tr>
+      <xsl:if test="$id ne ''">
+        <tr>
+          <td colspan="2">
+            <code id="{$id}" class="return-type-ref">
+              <xsl:value-of select="$id"/>
+            </code>
+            <xsl:text>:</xsl:text>
+          </td>
+        </tr>
+      </xsl:if>
       <tr>
         <td colspan="2">
           <code>record(</code>

--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -308,6 +308,12 @@
     </div>
   </xsl:template>
 
+  <xsl:template match="example[@role='record-description']" priority="10">
+    <div class="record-description">
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
 <!-- Override proto and arg to print XQuery F/O-style prototypes -->
 
 <xsl:template match="proto">
@@ -442,17 +448,16 @@
 <xsl:template match="record">
   <xsl:variable name="id" select="(@id, ../@id)[1]"/>
   <div class="record">
+    <xsl:if test="$id ne ''">
+      <xsl:attribute name="id" select="$id"/>
+      <div class="title">
+        <code class="return-type-ref">
+          <xsl:value-of select="$id"/>
+        </code>
+        <xsl:text>:</xsl:text>
+      </div>
+    </xsl:if>
     <table class="record" border="0">
-      <xsl:if test="$id ne ''">
-        <tr>
-          <td colspan="2">
-            <code id="{$id}" class="return-type-ref">
-              <xsl:value-of select="$id"/>
-            </code>
-            <xsl:text>:</xsl:text>
-          </td>
-        </tr>
-      </xsl:if>
       <tr>
         <td colspan="2">
           <code>record(</code>
@@ -462,19 +467,22 @@
         <tr class="arg">
           <td>
             <code>
+              <xsl:if test="@occur">
+                <xsl:attribute name="class" select="@occur"/>
+              </xsl:if>
               <xsl:value-of select="@name"/>
               <xsl:if test="@occur = 'opt'">?</xsl:if>
             </code>
           </td>
           <td>
             <xsl:if test="@type">
-              <code class="as">&#160;as&#160;</code>
+              <code class="as">as&#160;</code>
               <code>
                 <xsl:value-of select="@type"/>
               </code>
             </xsl:if>
             <xsl:if test="@type-ref">
-              <code class="as">&#160;as&#160;</code>
+              <code class="as">as&#160;</code>
               <a href="#{@type-ref}">
                 <xsl:value-of select="@type-ref"/>
               </a>
@@ -502,8 +510,10 @@
     </xsl:when>
     <xsl:otherwise>
       <xsl:apply-templates select="@name"/>
-      <code class="as">&#160;as&#160;</code>
-      <xsl:apply-templates select="@type" mode="render-type"/>  
+      <xsl:if test="@type">
+        <code class="as">&#160;as&#160;</code>
+        <xsl:apply-templates select="@type" mode="render-type"/>  
+      </xsl:if>
     </xsl:otherwise>
   </xsl:choose>
 </xsl:template>


### PR DESCRIPTION
I think this PR completes the work I started before and that we reviewed briefly some time ago.

Note: because this PR involves changes to the schemas and the stylesheets, the PR build is going to be...funky. I don't know if the diffs will be useful either. There are no (intentional) technical changes in this PR. You can preview the built result by look at https://qt4cgtest.nwalsh.com/branch/action-qt4cg-70-01/xpath-functions-40/Overview.html

A few notes:

1. Instead of just reusing `fos:options`, I added `fos:record-description` with a very similar content model.
2. I couldn't completely remove some of the `<fos:type>` elements defined in the globals section at the top of the `function-catalog.xml` because it causes IDREF failures when that file is parsed.
3. I tinkered a bit with the styling, and moved a bunch of inline table styles into CSS
