### PR TITLE
517 Major edits to fn:chain, clarification only

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19439,16 +19439,16 @@ return fold-right(
                   to the following rules. <olist>
                      <item>
                         <p>If <code>$f</code> has arity 1, let <code>$input-array</code> be all
-                           items in <code>$input</code> wrapped in an array.</p>
+                           items of <code>$input</code> wrapped in an array.</p>
                      </item>
                      <item>
-                        <p>Otherwise if <code>$input</code> is
+                        <p>Otherwise (<code>$f</code> has arity not equal to 1) if <code>$input</code> is
                            not an array then let <code>$input-array</code> be an array packing each
                            item of <code>$input</code>. </p>
                      </item>
                      <item>
-                        <p>Otherwise (<code>$input</code> is already an array) let
-                              <code>$input-array</code> be <code>$input</code> itself.</p>
+                        <p>Otherwise (<code>$f</code> has arity not equal to 1<code> and $input</code> is 
+                           already an array) let <code>$input-array</code> be <code>$input</code> itself.</p>
                      </item>
                   </olist>
                </p>
@@ -19461,7 +19461,7 @@ return fold-right(
          </olist>
          <p>More formally, the function is equivalent to the following implementation in XPath:</p>
          <eg>
-            <![CDATA[let $chain := (
+<![CDATA[let $chain := (
   let $apply := function($x, $f)  {
     fn:apply($f,
       if (function-arity($f) eq 1) then [ $x ]

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19421,18 +19421,21 @@ return fold-right(
         </fos:properties>
         <fos:summary>
            <p>
-              Processes a supplied sequence through a chain of functions.
+              Passes a supplied sequence through a chain of functions.
            </p>
         </fos:summary>
         <fos:rules>
            <olist>
              <item>
-                 <p>If <code>$functions</code> is empty, then <code>$input</code> is returned.</p>
+               <p>Let <code>$f</code> be the first member of <code>$functions</code>. If
+                     <code>$f</code> is empty, then <code>$input</code> is returned.</p>
              </item>
              <item>
-                 <p>Otherwise, let <code>$output</code> be the results of applying <code>$input</code> 
-                    to the first member of <code>$functions</code>.
-                 </p>
+               <p>Otherwise, let <code>$output</code> be the results of applying <code>$input</code>
+                  to <code>$f</code>. If <code>$f</code> has arity 1, all items in
+                     <code>$input</code> are passed to the first argument, otherwise each nth item
+                  in <code>$input</code> (or each nth member of <code>$input</code> if it is a
+                  single array) is assigned to the nth argument in <code>$f</code>. </p>
              </item>
              <item>
                 <p>Apply the above rules recursively, assigning <code>$output</code> to <code>$input</code> 
@@ -19456,53 +19459,28 @@ return fold-right(
             </eg>
         </fos:rules>
       <fos:errors>
-         <p>A type error is raised <errorref class="AP" code="0001" type="type"
-               /> if the number of items supplied to any given function does not match the expected.</p>
-         <p>An error  <errorref class="RG" code="0006" type="type"/> is raised if an item supplied to
+         <p>An error <errorref class="AP" code="0001" type="type"/> if any function in
+               <code>$functions</code> has arity other than 1, and the arity is not equal to the
+            number of items in the input, or its size if the input is an array.</p>
+         <p>An error <errorref class="RG" code="0006" type="type"/> is raised if any item supplied to
               a function argument cannot be coerced to the required type.</p>
       </fos:errors>
 
-        <fos:notes>
-                <olist>
-                    <item>
-                        <p>
-                            Contrary to the right-to-left evaluation of function-composition as defined in Math, here the functions in
-                            <code>$functions</code> are evaluated in their order from left-to-right (the first function is evaluated first,
-                            then the second,..., and the last function is evaluated last).
-                        </p>
-                    </item>
-                    <item>
-                        <p>
-                            It is not a requirement that every function in <code>$functions</code> must have arity of one.
-                            In fact, each of these functions can have any arity.
-                        </p>
-                    </item>
-                    <item>
-                        <p>
-                            For a function with arity <code>N</code>, greater than <code>1</code>,
-                            the result produced by the application of the previous function must be either a sequence
-                            with <code>N</code> items, or, if some of the parameters of the function could be sequences themselves,
-                            then an array with<code>N</code> members, and each of these <code>N</code> members is passed
-                            by the implementation in the function call as the corresponding argument of this function.
-                        </p>
-                    </item>
-                    <item>
-                        <p>
-                            A consequence of the provided rules is that a type error occurs if the current result does not match the arity 
-                            and the type(s) of the argument(s) of the next function in the chain,
-                            that is, it is a sequence or an array of <code>M</code> items/members and <code>M ne function-arity(current-function)</code>
-                            or the items /members of the current result cannot be coerced to the required types of the arguments of the next function.
-                        </p>
-                    </item>
-                    <item>
-                        <p>
-                            In very simple cases, when it may be possible to use short and meaningful static expressions, one could consider 
-                            using chaining provided via the arrow operators. 
-                            In all such cases one should carefully consider the fact that any such desicion could result in longer and less-understandable
-                            expressions, would involve one or more operators (not needed if <code>fn:chain</code> is used), and the loss of reusability.
-                        </p>
-                    </item>
-                </olist>
+      <fos:notes>
+         <olist>
+            <item>
+               <p>It is not a requirement that every function in <code>$functions</code> must have
+                  arity of one. Any functions may have any arity. </p>
+            </item>
+            <item>
+               <p><code>fn:chain</code> provides a syntactic alternative to nested expressions or
+                  functions chained through arrow operators. <code>chain(('a', 'b'), (string-join#1,
+                     string-length#1))</code> is equivalent to <code>string-length(string-join(('a',
+                     'b')))</code> and <code>('a', 'b') => string-join() => string-length()</code>.
+                  There may be expressions where <code>fn:chain</code> provides greater clarity or
+                  flexibility than alternatives.</p>
+            </item>
+         </olist>
       </fos:notes>
             <fos:examples>
                 <fos:variable name="incr" id="chain-variable-incr"

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19434,17 +19434,17 @@ return fold-right(
                   otherwise let <code>$f</code> be the first member of <code>$functions</code>.</p>
             </item>
             <item>
-               <p>Let <code>$current-output</code> be the results of <code>fn:apply($f,
+               <p>Let <code>$current-output</code> be the result of <code>fn:apply($f,
                      $input-array)</code> where <code>$input-array</code> is constructed according
                   to the following rules. <olist>
                      <item>
-                        <p>If <code>$f</code> has arity 1, let <code>$input-array</code> be all
-                           items of <code>$input</code> wrapped in an array.</p>
+                        <p>If <code>$f</code> has arity 1, let <code>$input-array</code> be an array
+                           containing <code>$input</code> as a single member.</p>
                      </item>
                      <item>
                         <p>Otherwise (<code>$f</code> has arity not equal to 1) if <code>$input</code> is
-                           not an array then let <code>$input-array</code> be an array packing each
-                           item of <code>$input</code>. </p>
+                           not an array then let <code>$input-array</code> be an array containing each
+                           item of <code>$input</code> as a separate member. </p>
                      </item>
                      <item>
                         <p>Otherwise (<code>$f</code> has arity not equal to 1<code> and $input</code> is 
@@ -19454,7 +19454,7 @@ return fold-right(
                </p>
             </item>
             <item>
-               <p>Return to step 1, passing <code>$current-output</code> as
+               <p>Repeat the process from step 1, passing <code>$current-output</code> as
                      <code>$input</code> and <code>fn:tail($functions)</code> as
                      <code>$functions</code>.</p>
             </item>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19420,31 +19420,45 @@ return fold-right(
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-           <p>
-              Passes a supplied sequence through a chain of functions.
-           </p>
+           <p>Applies a sequence of functions starting with an initial
+              input.</p>
         </fos:summary>
-        <fos:rules>
-           <olist>
-             <item>
-               <p>Let <code>$f</code> be the first member of <code>$functions</code>. If
-                     <code>$f</code> is empty, then <code>$input</code> is returned.</p>
-             </item>
-             <item>
-               <p>Otherwise, let <code>$output</code> be the results of applying <code>$input</code>
-                  to <code>$f</code>. If <code>$f</code> has arity 1, all items in
-                     <code>$input</code> are passed to the first argument, otherwise each nth item
-                  in <code>$input</code> (or each nth member of <code>$input</code> if it is a
-                  single array) is assigned to the nth argument in <code>$f</code>. </p>
-             </item>
-             <item>
-                <p>Apply the above rules recursively, assigning <code>$output</code> to <code>$input</code> 
-                  and <code>fn:tail($functions)</code> to <code>$functions</code>.</p>
-             </item>
-           </olist>
-            <p>More formally, the function is equivalent to the following implementation in XPath:</p>
-            <eg>
-<![CDATA[let $chain := (
+      <fos:rules>
+         <p>Informally, the function behaves as follows:</p>
+         <olist>
+            <item>
+               <p>If <code>$functions</code> is empty, then <code>$input</code> is returned,
+                  otherwise let <code>$f</code> be the first member of <code>$functions</code>.</p>
+            </item>
+            <item>
+               <p>Let <code>$current-output</code> be the results of <code>fn:apply($f,
+                     $input-array)</code> where <code>$input-array</code> is constructed according
+                  to the following rules. <olist>
+                     <item>
+                        <p>If <code>$f</code> has arity 1, let <code>$input-array</code> be all
+                           items in <code>$input</code> wrapped in an array.</p>
+                     </item>
+                     <item>
+                        <p>Otherwise if <code>$input</code> is
+                           not an array then let <code>$input-array</code> be an array packing each
+                           item of <code>$input</code>. </p>
+                     </item>
+                     <item>
+                        <p>Otherwise (<code>$input</code> is already an array) let
+                              <code>$input-array</code> be <code>$input</code> itself.</p>
+                     </item>
+                  </olist>
+               </p>
+            </item>
+            <item>
+               <p>Apply the above rules recursively, passing <code>$current-output</code> as
+                     <code>$input</code> and <code>fn:tail($functions)</code> as
+                     <code>$functions</code>.</p>
+            </item>
+         </olist>
+         <p>More formally, the function is equivalent to the following implementation in XPath:</p>
+         <eg>
+            <![CDATA[let $chain := (
   let $apply := function($x, $f)  {
     fn:apply($f,
       if (function-arity($f) eq 1) then [ $x ]
@@ -19456,29 +19470,29 @@ return fold-right(
     fold-left($functions, $input, $apply)
   }           
 )]]>
-            </eg>
-        </fos:rules>
+         </eg>
+      </fos:rules>
       <fos:errors>
-         <p>An error <errorref class="AP" code="0001" type="type"/> if any function in
-               <code>$functions</code> has arity other than 1, and the arity is not equal to the
-            number of items in the input, or its size if the input is an array.</p>
-         <p>An error <errorref class="RG" code="0006" type="type"/> is raised if any item supplied to
+         <p>An error <errorref class="AP" code="0001" type="type"/> is raised if the arity of any
+            function <code>$f</code> in <code>$functions</code> is different from the number of
+            members in the array that is passed to <code>fn:apply</code>.</p>
+         <p>An error <errorref class="RG" code="0006" type="type"/> is raised if any item supplied as
               a function argument cannot be coerced to the required type.</p>
       </fos:errors>
 
       <fos:notes>
          <olist>
             <item>
-               <p>It is not a requirement that every function in <code>$functions</code> must have
-                  arity of one. Any functions may have any arity. </p>
+               <p>Functions are applied in sequence order, not right-to-left (as might be expected in
+                  mathematical composition).</p>
             </item>
             <item>
-               <p><code>fn:chain</code> provides a syntactic alternative to nested expressions or
-                  functions chained through arrow operators. <code>chain(('a', 'b'), (string-join#1,
-                     string-length#1))</code> is equivalent to <code>string-length(string-join(('a',
-                     'b')))</code> and <code>('a', 'b') => string-join() => string-length()</code>.
-                  There may be expressions where <code>fn:chain</code> provides greater clarity or
-                  flexibility than alternatives.</p>
+               <p>It is not a requirement that every function in <code>$functions</code> must have
+                  arity of one. Any function may have any arity. </p>
+            </item>
+            <item>
+               <p>Using <code>fn:chain</code> may result in more readable XPath expressions than
+                  chaining expressions using arrow operators.</p>
             </item>
          </olist>
       </fos:notes>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19454,7 +19454,7 @@ return fold-right(
                </p>
             </item>
             <item>
-               <p>Apply the above rules recursively, passing <code>$current-output</code> as
+               <p>Return to step 1, passing <code>$current-output</code> as
                      <code>$input</code> and <code>fn:tail($functions)</code> as
                      <code>$functions</code>.</p>
             </item>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19420,37 +19420,25 @@ return fold-right(
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>
-                Applies from left to right on an initial argument a chain of functions provided in a sequence.
-            </p>
+           <p>
+              Processes a supplied sequence through a chain of functions.
+           </p>
         </fos:summary>
         <fos:rules>
-            <p>Informally, the function behaves as follows:</p>
-            <olist>
-                <item>
-                    <p>
-                        If <code>$functions</code> is empty, then <code>$input</code> is returned. Else,
-                    </p>
-                </item>
-                <item>
-                    <p>
-                        The first function in <code>$functions</code> is applied on the provided
-                        <code>$input</code>.
-                    </p>
-                </item>
-                <item>
-                    <p>
-                        Then the next function in <code>$functions</code> (if such exists), is applied on the result,
-                        and so on...
-                    </p>
-                </item>
-                <item>
-                    <p>
-                        Finally the last function in <code>$functions</code> is applied on the latest-result obtained so far,
-                        and the result of this final function application is the result of calling <code>fn:chain($input, $functions)</code> .
-                    </p>
-                </item>
-            </olist>
+           <olist>
+             <item>
+                 <p>If <code>$functions</code> is empty, then <code>$input</code> is returned.</p>
+             </item>
+             <item>
+                 <p>Otherwise, let <code>$output</code> be the results of applying <code>$input</code> 
+                    to the first member of <code>$functions</code>.
+                 </p>
+             </item>
+             <item>
+                <p>Apply the above rules recursively, assigning <code>$output</code> to <code>$input</code> 
+                  and <code>fn:tail($functions)</code> to <code>$functions</code>.</p>
+             </item>
+           </olist>
             <p>More formally, the function is equivalent to the following implementation in XPath:</p>
             <eg>
 <![CDATA[let $chain := (
@@ -19469,11 +19457,9 @@ return fold-right(
         </fos:rules>
       <fos:errors>
          <p>A type error is raised <errorref class="AP" code="0001" type="type"
-               /> if the current result does not match the arity 
-                  and the type(s) of the argument(s) of the next function in the chain,
-                  that is, it is a sequence or an array of <code>M</code> items/members and <code>M ne function-arity(current-function)</code>
-                  or <errorref class="RG" code="0006" type="type"/>
-                  if the items /members of the current result cannot be coerced to the required types of the arguments of the next function.</p>
+               /> if the number of items supplied to any given function does not match the expected.</p>
+         <p>An error  <errorref class="RG" code="0006" type="type"/> is raised if an item supplied to
+              a function argument cannot be coerced to the required type.</p>
       </fos:errors>
 
         <fos:notes>


### PR DESCRIPTION
@dnovatchev For your review. The current version of `fn:chain` in the specs has unnecessary verbiage, is out of sync with other comparable spec entries, and has passages that cry out for clarity and concision. I do not think I have made any edits that change any substantive points. A summary:

* Summary simplified
* Rules: prose for the recursive process brought into conformity with other functions in the specs that describe recursive processes.
* Error conditions: two entries, and clarification of the conditions when they are triggered.
* Former note 1 deleted (excessively wordy, introduces unfamiliar or unnecessary terms/concepts).
* Former notes 3 and 4 moved to rules, distilled into more concise prose.
* Former note 5 (now 2) recast to convey what I think was your original intent, and allows the reader to more quickly compare `fn:chain` to two comparable methods.

Signature, properties, XPath rule, and examples are unchanged.
