### PR TITLE
566-partial Rewrite parse-uri

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30071,7 +30071,8 @@ some $boolean in (
          present. Some portions of the URI are identified by matching
          with a regular expression. This approach is designed to make
          the description clear and unambiguous; it is not implementation
-         advice.</p>
+         advice. Comparison of <emph>scheme</emph> and <emph>authority</emph>
+         components is case insensitive.</p>
 
          <p>Processing begins with a <emph>string</emph> that is equal
          to the <code>$uri</code>. If the <emph>string</emph> contains
@@ -30079,46 +30080,67 @@ some $boolean in (
          slashes (<code>/</code>).</p>
 
          <p>Strip off the fragment identifier and any query:</p>
-
-         <p>If the <emph>string</emph> matches <code>^(.*?)#(.*)$</code>,
-         the <emph>string</emph> is the first match group and the
-         <emph>fragment</emph> is the second match group. Otherwise,
-         the string is unchanged and the <emph>fragment</emph> is the empty
+         
+         <ulist>
+            <item>
+         <p>If the <emph>string</emph> matches <code>^(.*?)#(.*)$</code>, the
+         <emph>string</emph> is the first match group and the
+         <emph>fragment</emph> is the second match group. Otherwise, the string
+         is unchanged and the <emph>fragment</emph> is the empty sequence. If a
+         fragment is present, it is URI decoded. If the fragment is the empty
+         string, it is discarded and the <emph>fragment</emph> is the empty
          sequence.</p>
-
+            </item>
+            <item>
          <p>If the <emph>string</emph> matches <code>^(.*?)\?(.*)$</code>,
          the <emph>string</emph> is the first match group and the
          <emph>query</emph> is the second match group. Otherwise,
          the string is unchanged and the <emph>query</emph> is the empty
          sequence.</p>
+            </item>
+         </ulist>
 
          <p>Attempt to identify the scheme:</p>
 
          <ulist>
             <item>
-               <p>If the <emph>string</emph> matches <code>^[a-zA-Z][:|].*$</code>:</p>
-         <ulist>
-            <item><p>the <emph>scheme</emph> is <code>file</code>;</p></item>
-            <item><p>if the second character in the <emph>string</emph> is <code>|</code>, it is changed to <code>:</code>;</p></item>
-            <item><p>the <emph>filepath</emph> is the <emph>string</emph>; and</p></item>
-            <item><p>a leading slash <code>/</code> is added to the <emph>string</emph>.</p></item>
-         </ulist></item>
-         <item>
-            <p>Otherwise, if the <emph>string</emph> matches
-         <code>^([a-zA-Z][A-Za-z0-9\+\-\.]*):(.*)$</code>:</p>
-         <ulist>
-            <item><p>the <emph>scheme</emph> is the first match group,</p></item>
-            <item><p>the <emph>string</emph> is the second match group, and</p></item>
-            <item><p>the <emph>filepath</emph> is the empty sequence.</p></item>
+               <p>If the <emph>string</emph> matches
+               <code>^([a-zA-Z][A-Za-z0-9\+\-\.]+):(.*)$</code>:</p>
+               <ulist>
+                  <item><p>the <emph>scheme</emph> is the first match group and</p></item>
+                  <item><p>the <emph>string</emph> is the second match group.</p></item>
+               </ulist>
+            </item>
+            <item>
+               <p>Otherwise, the <emph>scheme</emph> is the empty sequence and the
+               <emph>string</emph> is unchanged.</p>
+            </item>
          </ulist>
-         </item>
-         <item><p>Finally, if the <emph>string</emph> does not match either expression:</p>
+
+         <p>If <emph>scheme</emph> is the empty sequence or <code>file</code>:</p>
          <ulist>
-            <item><p>the <emph>scheme</emph> is the empty sequence,</p></item>
-            <item><p>the <emph>string</emph> is unchanged, and</p></item>
-            <item><p>the <emph>filepath</emph> is the empty sequence.</p></item>
-         </ulist>
-         </item>
+            <item>
+               <p>If the <emph>string</emph> matches <code>^/*([a-zA-Z][:|].*)$</code>:</p>
+               <ulist>
+                  <item><p>the <emph>scheme</emph> is <code>file</code> and</p></item>
+                  <item><p>the <emph>string</emph> is a single slash <code>/</code> followed
+                  by the first match group with the
+                  second character changed to <code>:</code>, if necessary.</p></item>
+               </ulist>
+            </item>
+            <item>
+               <p>Otherwise, if <emph>unc-path</emph> is <code>true</code>:</p>
+               <ulist>
+                  <item><p>the <emph>scheme</emph> is <code>file</code> and</p></item>
+                  <item><p>the <emph>string</emph> is unchanged.</p></item>
+               </ulist>
+            </item>
+            <item><p>Finally, if neither of the preceding cases apply:</p>
+            <ulist>
+               <item><p>the <emph>scheme</emph> remains the empty sequence and</p></item>
+               <item><p>the <emph>string</emph> is unchanged.</p></item>
+            </ulist>
+            </item>
          </ulist>
 
          <p>Now that the scheme, if there is one, has been identified,
@@ -30138,36 +30160,57 @@ some $boolean in (
             </item>
          </ulist>
 
-         <p>Then examine the remaining parts of the string.</p>
+         <p>Identify the remaining components according to the scheme and whether
+         or not the URI is hierarchical.</p>
 
          <ulist>
             <item>
-         <p>If the <emph>scheme</emph> is the empty sequence, the
-         <code>unc-path</code> option is <code>true</code>, and the
-         <emph>string</emph> matches <code>^//[^/].*$</code>, then the
-         scheme is <code>file</code>, the <emph>authority</emph> is
-         empty, and the <emph>filepath</emph> is the
-         <emph>string</emph>.
-         </p>
+               <p>If the scheme is <code>file</code>:</p>
+               <ulist>
+                  <item>
+                     <p>The <emph>authority</emph> is the empty sequence.</p>
+                  </item>
+                  <item>
+                     <p>If <emph>unc-path</emph> is true and the string
+                     matches <code>^/*(//[^/].*)$</code>: then <emph>filepath</emph>,
+                     and <emph>string</emph> are both the first match group.</p>
+                  </item>
+                  <item>
+                     <p>Otherwise, the <emph>filepath</emph>
+                     and <emph>string</emph> are the <emph>string</emph>
+                     with any sequence of leading slashes replaced by a single slash.</p>
+                  </item>
+               </ulist>
             </item>
             <item>
-         <p>Otherwise:</p>
-
-         <ulist>
+               <p>If the scheme is <code>hierarchical</code>:</p>
+               <ulist>
+                  <item>
+                     <p>If the <emph>string</emph>
+                     matches <code nobreak="true">^//([^/]+)$</code>, the <emph>authority</emph>
+                     is the first match group and the <emph>string</emph> is empty.</p>
+                  </item>
+                  <item>
+                     <p>If the <emph>string</emph>
+                     matches <code nobreak="true">^//([^/]*)(/.*)$</code>, the <emph>authority</emph>
+                     is the first match group and the <emph>string</emph> is the second
+                     match group.</p>
+                  </item>
+                  <item>
+                     <p>Otherwise,
+                     the <emph>authority</emph> is the empty sequence
+                     and the <emph>string</emph> is unchanged.</p>
+                  </item>
+               </ulist>
+            </item>
             <item>
-         <p>If the scheme is not known or is known to be <code>file</code>
-         and the <emph>string</emph> matches <code>^/*(/[a-zA-Z][:|].*)$</code>,
-         the <emph>authority</emph> is empty and the <emph>string</emph> is
-         the first match group. If the third character in the <emph>string</emph> is <code>|</code>,
-            it is changed to <code>:</code>.</p></item>
-         <item><p>Otherwise, if the <emph>string</emph>
-         matches <code>^///*([^/]+)?(/.*)?$</code>, the <emph>authority</emph>
-         is the first match group and the <emph>string</emph> is the second
-         match group.</p></item>
-         <item><p>Finally, if the <emph>string</emph> does not match either
-         regular expression, the <emph>authority</emph> is the empty sequence
-         and the <emph>string</emph> is unchanged.</p></item>
-         </ulist>
+               <p>If the scheme is not <code>hierarchical</code>:</p>
+               <ulist>
+                  <item>
+                     <p>The <emph>authority</emph> is the empty sequence
+                     and the <emph>string</emph> is unchanged.</p>
+                  </item>
+               </ulist>
             </item>
          </ulist>
 
@@ -30248,7 +30291,6 @@ some $boolean in (
          <p>If the <emph>string</emph> is the empty string, then
          <emph>path</emph> is the empty sequence, otherwise <emph>path</emph>
          is the whole <emph>string</emph>. If the <emph>scheme</emph> is 
-         <code>file</code> or the empty sequence, and <emph>filepath</emph> is
          the empty sequence, <emph>filepath</emph> is also the whole <emph>string</emph>.</p>
 
          <p>The <emph>path separator</emph> is the value of the
@@ -30257,6 +30299,36 @@ some $boolean in (
          tokenizing the <emph>string</emph> on the <emph>path
          separator</emph> and applying <emph>uri decoding</emph> on each
          token.</p>
+
+         <note>
+         <p>The <emph>path</emph> and <emph>path-segments</emph> properties both contain
+         the path portion of the URI. The different formats
+         only become important when the path contains encoded delimiters.</p>
+         <p>Consider <code>/path%2Fsegment</code>. An application may want to decode that,
+         using <code>/path/segment</code> in a database query, for example. At the same
+         time, an application may wish to modify the URI and then reconstruct it.</p>
+
+         <p>In the string form, decoding <code>%2F</code> to <code>/</code> is
+         not reversible. In the <emph>path-segments</emph> form, the path is
+         broken into discrete segments where the syntactic delimiters occur.
+         This means the encoded delimiters can be decoded without introducing
+         ambiguity: <code>("", "path/segment")</code>. In this format, the
+         decoding is reversible: escape the non-syntactic delimiters before
+         reconstructing the path with the syntactic ones.</p>
+
+         <p>A consequence of constructing the <emph>path-segments</emph> this
+         way is that an empty string appears before the first
+         <emph>path-separator</emph>, if the path begins with a
+         <emph>path-separator</emph>, after the last
+         <emph>path-separator</emph>, if the path ends with a
+         <emph>path-separator</emph>, and between consecutive
+         <emph>path-separator</emph>. (If the path consists of a single <emph>path-separator</emph>,
+         that <emph>path-separator</emph> counts as <emph>both</emph> the first and last <emph>path-separator</emph>,
+         producing a segment list containing two empty strings.)</p> <p>The
+         empty strings may seem unnecessary at first glance, but they assure
+         that the path can be reconstructed by joining the segments together
+         again without having to handle the presence or absence of a leading or
+         trailing <emph>path-separator</emph> as special cases.</p></note>
 
          <p>Applying <emph>uri decoding</emph> is equivalent to
          calling <code>fn:decode-from-uri</code> on the string.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30407,438 +30407,434 @@ some $boolean in (
     are elided for editorial clarity. String literals that include an ampersand character
     are written as string templates (for example <code>`Barnes&amp;Noble`</code>) to ensure
     that the examples work in both XPath and XQuery.</p>
-    <fos:test>
-      <fos:expression><eg>parse-uri(
-  "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri"
-)</eg></fos:expression>
-      <fos:result><eg>{
-  "uri": "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri",
-  "scheme": "http",
-  "hierarchical": true(),
+
+<fos:test>
+<fos:expression><eg>parse-uri("http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri")</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "qt4cg.org",
+  "fragment": "parse-uri",
+  "hierarchical": true(),
   "host": "qt4cg.org",
   "path": "/specifications/xpath-functions-40/Overview.html",
-  "fragment": "parse-uri",
-  "path-segments": ("", "specifications", "xpath-functions-40", "Overview.html")
-}</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("http://www.ietf.org/rfc/rfc2396.txt")</fos:expression>
-      <fos:result><eg>{
-  "uri": "http://www.ietf.org/rfc/rfc2396.txt",
+  "path-segments": ("", "specifications", "xpath-functions-40", "Overview.html"),
   "scheme": "http",
-  "hierarchical": true(),
+  "uri": "http://qt4cg.org/specifications/xpath-functions-40/Overview.html#parse-uri"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("http://www.ietf.org/rfc/rfc2396.txt")</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "www.ietf.org",
+  "hierarchical": true(),
   "host": "www.ietf.org",
   "path": "/rfc/rfc2396.txt",
-  "path-segments": ("", "rfc", "rfc2396.txt")
+  "path-segments": ("", "rfc", "rfc2396.txt"),
+  "scheme": "http",
+  "uri": "http://www.ietf.org/rfc/rfc2396.txt"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("https://example.com/path/to/file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "https://example.com/path/to/file",
-  "scheme": "https",
-  "hierarchical": true(),
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("https://example.com/path/to/file")</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "example.com",
-  "host": "example.com",
   "path": "/path/to/file",
-  "path-segments": ("", "path", "to", "file")
-}</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression><eg>parse-uri(
-  `https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`
-)</eg></fos:expression>
-      <fos:result><eg>{
-  "uri": `https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`,
   "scheme": "https",
-  "hierarchical": true(),
-  "authority": "example.com:8080",
+  "path-segments": ("", "path", "to", "file"),
   "host": "example.com",
-  "port": "8080",
+  "hierarchical": true(),
+  "uri": "https://example.com/path/to/file"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri(`https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance`)</eg></fos:expression>
+<fos:result><eg>map {
+  "authority": "example.com:8080",
+  "hierarchical": true(),
+  "host": "example.com",
   "path": "/path",
-  "query": `s=%22hello world%22&amp;sort=relevance`,
-  "query-parameters": {
-    "s": '"hello world"',
+  "path-segments": ("", "path"),
+  "port": "8080",
+  "query": "s=%22hello world%22&amp;sort=relevance",
+  "query-parameters": map {
+    "s": """hello world""",
     "sort": "relevance"
   },
-  "path-segments": ("", "path")
-}</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("https://user@example.com/path/to/file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "https://user@example.com/path/to/file",
   "scheme": "https",
-  "hierarchical": true(),
+  "uri": "https://example.com:8080/path?s=%22hello world%22&amp;sort=relevance"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("https://user@example.com/path/to/file")</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "user@example.com",
-  "userinfo": "user",
+  "hierarchical": true(),
   "host": "example.com",
   "path": "/path/to/file",
-  "path-segments": ("", "path", "to", "file")
+  "path-segments": ("", "path", "to", "file"),
+  "scheme": "https",
+  "uri": "https://user@example.com/path/to/file",
+  "userinfo": "user"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")</fos:expression>
-      <fos:result><eg>{
-  "uri": "ftp://ftp.is.co.za/rfc/rfc1808.txt",
-  "scheme": "ftp",
-  "hierarchical": true(),
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("ftp://ftp.is.co.za/rfc/rfc1808.txt")</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "ftp.is.co.za",
+  "hierarchical": true(),
   "host": "ftp.is.co.za",
   "path": "/rfc/rfc1808.txt",
-  "path-segments": ("", "rfc", "rfc1808.txt")
+  "path-segments": ("", "rfc", "rfc1808.txt"),
+  "scheme": "ftp",
+  "uri": "ftp://ftp.is.co.za/rfc/rfc1808.txt"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("file:////uncname/path/to/file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "file:////uncname/path/to/file",
-  "scheme": "file",
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("file:////uncname/path/to/file")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "/uncname/path/to/file",
   "hierarchical": true(),
-  "authority": "uncname",
-  "host": "uncname",
-  "path": "/path/to/file",
-  "filepath": "/path/to/file",
-  "path-segments": ("", "path", "to", "file")
-}</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("file:///c:/path/to/file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "file:///c:/path/to/file",
+  "path": "/uncname/path/to/file",
+  "path-segments": ("", "uncname", "path", "to", "file"),
   "scheme": "file",
+  "uri": "file:////uncname/path/to/file"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("file:///c:/path/to/file")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "c:/path/to/file",
   "hierarchical": true(),
   "path": "/c:/path/to/file",
-  "filepath": "c:/path/to/file",
-  "path-segments": ("", "c:", "path", "to", "file")
-}</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("file:/C:/Program%20Files/test.jar")</fos:expression>
-      <fos:result><eg>{
-  "uri": "file:/C:/Program%20Files/test.jar",
+  "path-segments": ("", "c:", "path", "to", "file"),
   "scheme": "file",
+  "uri": "file:///c:/path/to/file"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("file:/C:/Program%20Files/test.jar")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "C:/Program Files/test.jar",
   "hierarchical": true(),
   "path": "/C:/Program%20Files/test.jar",
-  "filepath": "C:/Program Files/test.jar",
-  "path-segments": ("", "C:", "Program Files", "test.jar")
-}</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("file:\\c:\path\to\file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "file:\\c:\path\to\file",
+  "path-segments": ("", "C:", "Program Files", "test.jar"),
   "scheme": "file",
+  "uri": "file:/C:/Program%20Files/test.jar"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("file:\\c:\path\to\file")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "c:/path/to/file",
   "hierarchical": true(),
   "path": "/c:/path/to/file",
-  "filepath": "c:/path/to/file",
-  "path-segments": ("", "c:", "path", "to", "file")
-}</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("file:\c:\path\to\file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "file:\c:\path\to\file",
+  "path-segments": ("", "c:", "path", "to", "file"),
   "scheme": "file",
+  "uri": "file:\\c:\path\to\file"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("file:\c:\path\to\file")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "c:/path/to/file",
   "hierarchical": true(),
   "path": "/c:/path/to/file",
-  "filepath": "c:/path/to/file",
-  "path-segments": ("", "c:", "path", "to", "file")
-}</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("c:\path\to\file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "c:\path\to\file",
+  "path-segments": ("", "c:", "path", "to", "file"),
   "scheme": "file",
+  "uri": "file:\c:\path\to\file"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("c:\path\to\file")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "c:/path/to/file",
   "hierarchical": true(),
   "path": "/c:/path/to/file",
-  "filepath": "c:/path/to/file",
-  "path-segments": ("", "c:", "path", "to", "file")
+  "path-segments": ("", "c:", "path", "to", "file"),
+  "scheme": "file",
+  "uri": "c:\path\to\file"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("/path/to/file")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "/path/to/file",
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("/path/to/file")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "/path/to/file",
   "hierarchical": true(),
   "path": "/path/to/file",
-  "filepath": "/path/to/file",
-  "path-segments": ("", "path", "to", "file")
+  "path-segments": ("", "path", "to", "file"),
+  "uri": "/path/to/file"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("#testing")</fos:expression>
-      <fos:result>
-<eg>{
- "uri": "#testing",
- "fragment": "testing"
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("#testing")</eg></fos:expression>
+<fos:result><eg>map {
+  "fragment": "testing",
+  "uri": "#testing"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("?q=1")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "?q=1",
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("?q=1")</eg></fos:expression>
+<fos:result><eg>map {
   "query": "q=1",
-  "query-parameters": {
+  "query-parameters":map {
     "q": "1"
-  }
+  },
+  "uri": "?q=1"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("ldap://[2001:db8::7]/c=GB?objectClass?one")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "ldap://[2001:db8::7]/c=GB?objectClass?one",
-  "scheme": "ldap",
-  "hierarchical": true(),
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("ldap://[2001:db8::7]/c=GB?objectClass?one")</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "[2001:db8::7]",
+  "hierarchical": true(),
   "host": "[2001:db8::7]",
   "path": "/c=GB",
+  "path-segments": ("", "c=GB"),
   "query": "objectClass?one",
-  "query-parameters": {
+  "query-parameters":map {
     "": "objectClass?one"
   },
-  "path-segments": ("", "c=GB")
+  "scheme": "ldap",
+  "uri": "ldap://[2001:db8::7]/c=GB?objectClass?one"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("mailto:John.Doe@example.com")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "mailto:John.Doe@example.com",
-  "scheme": "mailto",
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("mailto:John.Doe@example.com")</eg></fos:expression>
+<fos:result><eg>map {
   "hierarchical": false(),
   "path": "John.Doe@example.com",
-  "path-segments": ("John.Doe@example.com")
+  "path-segments": "John.Doe@example.com",
+  "scheme": "mailto",
+  "uri": "mailto:John.Doe@example.com"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("news:comp.infosystems.www.servers.unix")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "news:comp.infosystems.www.servers.unix",
-  "scheme": "news",
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("news:comp.infosystems.www.servers.unix")</eg></fos:expression>
+<fos:result><eg>map {
   "hierarchical": false(),
   "path": "comp.infosystems.www.servers.unix",
-  "path-segments": ("comp.infosystems.www.servers.unix")
+  "path-segments": "comp.infosystems.www.servers.unix",
+  "scheme": "news",
+  "uri": "news:comp.infosystems.www.servers.unix"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("tel:+1-816-555-1212")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "tel:+1-816-555-1212",
-  "scheme": "tel",
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("tel:+1-816-555-1212")</eg></fos:expression>
+<fos:result><eg>map {
   "hierarchical": false(),
   "path": "+1-816-555-1212",
-  "path-segments": (" 1-816-555-1212")
+  "path-segments": "1-816-555-1212",
+  "scheme": "tel",
+  "uri": "tel:+1-816-555-1212"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("telnet://192.0.2.16:80/")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "telnet://192.0.2.16:80/",
-  "scheme": "telnet",
-  "hierarchical": true(),
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("telnet://192.0.2.16:80/")</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "192.0.2.16:80",
+  "hierarchical": true(),
   "host": "192.0.2.16",
-  "port": "80",
   "path": "/",
-  "path-segments": ("", "")
+  "path-segments": ("", ""),
+  "port": "80",
+  "scheme": "telnet",
+  "uri": "telnet://192.0.2.16:80/"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression><eg>parse-uri(
-  "urn:oasis:names:specification:docbook:dtd:xml:4.1.2"
-)</eg></fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
-  "scheme": "urn",
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")</eg></fos:expression>
+<fos:result><eg>map {
   "hierarchical": false(),
   "path": "oasis:names:specification:docbook:dtd:xml:4.1.2",
-  "path-segments": "oasis:names:specification:docbook:dtd:xml:4.1.2"
+  "path-segments": "oasis:names:specification:docbook:dtd:xml:4.1.2",
+  "scheme": "urn",
+  "uri": "urn:oasis:names:specification:docbook:dtd:xml:4.1.2"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("tag:textalign.net,2015:ns")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "tag:textalign.net,2015:ns",
-  "scheme": "tag",
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("tag:textalign.net,2015:ns")</eg></fos:expression>
+<fos:result><eg>map {
   "hierarchical": false(),
   "path": "textalign.net,2015:ns",
-  "path-segments": "textalign.net,2015:ns"
-}</eg>
-</fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
-    <fos:test>
-      <fos:expression>parse-uri("tag:jan@example.com,1999-01-31:my-uri")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "tag:jan@example.com,1999-01-31:my-uri",
+  "path-segments": "textalign.net,2015:ns",
   "scheme": "tag",
+  "uri": "tag:textalign.net,2015:ns"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("tag:jan@example.com,1999-01-31:my-uri")</eg></fos:expression>
+<fos:result><eg>map {
   "hierarchical": false(),
   "path": "jan@example.com,1999-01-31:my-uri",
-  "path-segments": "jan@example.com,1999-01-31:my-uri"
-}</eg>
-</fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
+  "path-segments": "jan@example.com,1999-01-31:my-uri",
+  "scheme": "tag",
+  "uri": "tag:jan@example.com,1999-01-31:my-uri"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
 <p>This example uses the algorithm described above, not an algorithm that is
 specifically aware of the <code>jar:</code> scheme.</p>
-    <fos:test>
-      <fos:expression><eg>parse-uri(
-  "jar:file:/C:/Program%20Files/test.jar!/foo/bar"
-)</eg></fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar",
-  "scheme": "jar",
+<fos:test>
+<fos:expression><eg>parse-uri("jar:file:/C:/Program%20Files/test.jar!/foo/bar")</eg></fos:expression>
+<fos:result><eg>map {
   "hierarchical": false(),
   "path": "file:/C:/Program%20Files/test.jar!/foo/bar",
-  "path-segments": ("file:", "C:", "Program Files", "test.jar!", "foo", "bar")
-}</eg>
-</fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
+  "path-segments": ("file:", "C:", "Program Files", "test.jar!", "foo", "bar"),
+  "scheme": "jar",
+  "uri": "jar:file:/C:/Program%20Files/test.jar!/foo/bar"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
 <p>This example demonstrates that parsing the URI treats non-URI characters in
 lexical IRIs as “unreserved characters”. The rationale for this is given in the
 description of <code>fn:resolve-uri</code>.</p>
-    <fos:test>
-      <fos:expression>parse-uri("http://www.example.org/Dürst")</fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "http://www.example.org/Dürst",
-  "scheme": "http",
-  "hierarchical": true(),
+<fos:test>
+<fos:expression><eg>parse-uri("http://www.example.org/Dürst")</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "www.example.org",
+  "hierarchical": true(),
   "host": "www.example.org",
   "path": "/Dürst",
-  "path-segments": ("", "Dürst")
-}</eg>
-</fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
+  "path-segments": ("", "Dürst"),
+  "scheme": "http",
+  "uri": "http://www.example.org/Dürst"
+}</eg></fos:result>
+</fos:test>
+</fos:example>
+
+<fos:example>
 <p>This example demonstrates a non-standard query separator.</p>
-    <fos:test>
-      <fos:expression><eg>parse-uri(
-  "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
-  { "query-separator": ";" }
-)</eg></fos:expression>
-      <fos:result>
-<eg>{
-  "uri": "https://example.com:8080/path?s=%22hello world%22;sort=relevance",
-  "scheme": "https",
-  "hierarchical": true(),
+<fos:test>
+<fos:expression><eg>parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance", { "query-separator": ";" })</eg></fos:expression>
+<fos:result><eg>map {
   "authority": "example.com:8080",
+  "hierarchical": true(),
   "host": "example.com",
-  "port": "8080",
   "path": "/path",
+  "path-segments": ("", "path"),
+  "port": "8080",
   "query": "s=%22hello world%22;sort=relevance",
-  "query-parameters": {
-    "s": '"hello world"',
+  "query-parameters":map {
+    "s": """hello world""",
     "sort": "relevance"
   },
-  "path-segments": ("", "path")
+  "scheme": "https",
+  "uri": "https://example.com:8080/path?s=%22hello world%22;sort=relevance"
 }</eg></fos:result>
-    </fos:test>
-  </fos:example>
-  <fos:example>
+</fos:test>
+</fos:example>
+
+<fos:example>
 <p>This example uses an invalid query separator so raises an error.</p>
-    <fos:test>
-      <fos:expression><eg>parse-uri(
-  "https://example.com:8080/path?s=%22hello world%22;;sort=relevance",
-  { "query-separator": ";;" }
-)</eg></fos:expression>
-      <fos:error-result error-code="FOXX0000"/>
-    </fos:test>
-  </fos:example>
+<fos:test>
+<fos:expression><eg>parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance", { "query-separator": ";;" } )</eg></fos:expression>
+<fos:error-result error-code="FOXX0000"/>
+</fos:test>
+</fos:example>
+
 <fos:example>
 <p>This example demonstrates the use of <code>|</code> instead of <code>:</code> in a Windows
 path.</p>
-    <fos:test>
-      <fos:expression>parse-uri("c|/path/to/file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "c|/path/to/file",
-  "scheme": "file",
+<fos:test>
+<fos:expression><eg>parse-uri("c|/path/to/file")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "c:/path/to/file",
   "hierarchical": true(),
   "path": "/c:/path/to/file",
-  "filepath": "c:/path/to/file",
-  "path-segments": ("", "c:", "path", "to", "file")
+  "path-segments": ("", "c:", "path", "to", "file"),
+  "scheme": "file",
+  "uri": "c|/path/to/file"
 }</eg></fos:result>
-    </fos:test>
+</fos:test>
 </fos:example>
+
 <fos:example>
 <p>This example demonstrates the use of <code>|</code> instead of <code>:</code> in a Windows
 path with an explicit <code>file:</code> scheme.</p>
-    <fos:test>
-      <fos:expression>parse-uri("file://c|/path/to/file")</fos:expression>
-      <fos:result><eg>{
-  "uri": "file://c|/path/to/file",
-  "scheme": "file",
+<fos:test>
+<fos:expression><eg>parse-uri("file://c|/path/to/file")</eg></fos:expression>
+<fos:result><eg>map {
+  "filepath": "c:/path/to/file",
   "hierarchical": true(),
   "path": "/c:/path/to/file",
-  "filepath": "c:/path/to/file",
-  "path-segments": ("", "c:", "path", "to", "file")
+  "path-segments": ("", "c:", "path", "to", "file"),
+  "scheme": "file",
+  "uri": "file://c|/path/to/file"
 }</eg></fos:result>
-    </fos:test>
+</fos:test>
 </fos:example>
-      </fos:examples>
-      <fos:history>
+</fos:examples>
+
+<fos:history>
          <fos:version version="4.0">Proposed on 17 Oct 2022 to resolve
          <loc href="https://github.com/qt4cg/qtspecs/issues/72">issue #72</loc>.
          Accepted in principle on 15 Nov 2022, with some details still


### PR DESCRIPTION
What happened was, I discovered I'd messed with the code in two different branches.

In the course of trying to straighten that out, I came to the conclusion that the *real* difficulty in parsing URIs is what to do about all the special cases around `file:`. And that the approach I'd taken in the previous draft was unnecessarily complicated.

I think this is better. 