### PR TITLE
31 Introduce "for key $k value $v in $map"

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -869,11 +869,11 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>-->
 
   <g:production name="ForExpr" if="xpath40  xslt40-patterns">
-    <g:ref name="XPForClause"/>
+    <g:ref name="ForClause"/>
     <g:ref name="ForLetReturn"/>
   </g:production>
 
-  <g:production name="XPForClause" if="xpath40 xslt40-patterns" node-type="void">
+  <!--<g:production name="XPForClause" if="xpath40 xslt40-patterns" node-type="void">
     <g:string>for</g:string>
     <g:ref name="XPForBinding" if="xpath40  xslt40-patterns"/>
     <g:zeroOrMore name="SimpleForClauseTail">
@@ -882,9 +882,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       </g:choice>
       <g:ref name="XPForBinding" if="xpath40  xslt40-patterns"/>
     </g:zeroOrMore>
-  </g:production>
+  </g:production>-->
 
-  <g:production name="XPForBinding" if="xpath40  xslt40-patterns"><!-- also unfolded for -->
+  <!--<g:production name="XPForBinding" if="xpath40  xslt40-patterns"><!-\- also unfolded for -\->
     <g:optional>
       <g:string>member</g:string>
     </g:optional>
@@ -898,7 +898,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:optional>    
     <g:string>in</g:string>
     <g:ref name="ExprSingle"/>
-  </g:production>
+  </g:production>-->
   
   <g:production name="ForLetReturn" if="xpath40  xslt40-patterns">
     <g:choice>
@@ -914,11 +914,11 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   
 
   <g:production name="LetExpr" if="xpath40  xslt40-patterns">
-    <g:ref name="XPLetClause"/>
+    <g:ref name="LetClause"/>
     <g:ref name="ForLetReturn"/>
   </g:production>
 
-  <g:production name="XPLetClause" if="xpath40  xslt40-patterns">
+  <!--<g:production name="XPLetClause" if="xpath40  xslt40-patterns">
     <g:string>let</g:string>
     <g:ref name="XPLetBinding"/>
     <g:zeroOrMore>
@@ -927,9 +927,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       </g:choice>
       <g:ref name="XPLetBinding"/>
     </g:zeroOrMore>
-  </g:production>
+  </g:production>-->
 
-  <g:production name="XPLetBinding" if="xpath40  xslt40-patterns">
+  <!--<g:production name="XPLetBinding" if="xpath40  xslt40-patterns">
     <g:string>$</g:string>
     <g:ref name="VarName"/>
     <g:optional>
@@ -937,7 +937,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:optional>
     <g:string>:=</g:string>
     <g:ref name="ExprSingle"/>
-  </g:production>
+  </g:production>-->
 
   <!-- ] end ForExpr + LetExpr -->
 
@@ -971,29 +971,30 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:choice>
   </g:production>
 
-  <g:production name="ForClause" if="xquery40">
+  <g:production name="ForClause">
     <g:string>for</g:string>
     <g:ref name="ForBinding"/>
-    <g:zeroOrMore if="xquery40" name="ForClauseTail">
+    <g:zeroOrMore name="ForClauseTail">
       <g:string>,</g:string>
       <g:ref name="ForBinding"/>
     </g:zeroOrMore>
   </g:production>
   
-  <g:production name="ForBinding" if="xquery40">
+  <g:production name="ForBinding">
     <g:choice>
       <g:ref name="ForItemBinding"/>
-      <g:ref name="ForMemberBinding"/>     
+      <g:ref name="ForMemberBinding"/>
+      <g:ref name="ForEntryBinding"/>
     </g:choice>
   </g:production>
 
-  <g:production name="ForItemBinding" if="xquery40">
+  <g:production name="ForItemBinding">
     <g:string>$</g:string>
     <g:ref name="VarName"/>
     <g:optional>
       <g:ref name="TypeDeclaration"/>
     </g:optional>
-    <g:optional>
+    <g:optional if="xquery40">
       <g:ref name="AllowingEmpty"/>
     </g:optional>
     <g:optional>
@@ -1006,7 +1007,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="ExprSingle"/>
   </g:production>
   
-  <g:production name="ForMemberBinding" if="xquery40">
+  <g:production name="ForMemberBinding">
     <g:string>member</g:string>
     <g:string>$</g:string>
     <g:ref name="VarName"/>
@@ -1020,64 +1021,74 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="ExprSingle"/>
   </g:production>
   
-  
-
   <g:production name="AllowingEmpty" if="xquery40">
     <g:string>allowing</g:string>
     <g:string>empty</g:string>
   </g:production>
   
-  <!--<g:production name="ForMemberClause" if="xquery40">
-    <g:string>for</g:string>
-    <g:string>member</g:string>
-    <g:ref name="ForMemberBinding"/>
-    <g:zeroOrMore>
-      <g:string>,</g:string>
-      <g:ref name="ForMemberBinding"/>
-    </g:zeroOrMore>
-  </g:production>
-  
-  <g:production name="ForMemberBinding" if="xquery40">
-    <g:string>$</g:string>
-    <g:ref name="VarName"/>
-    <g:optional>
-      <g:ref name="TypeDeclaration"/>
-    </g:optional>
+  <g:production name="ForEntryBinding">
+    <g:choice>
+      <g:sequence>
+        <g:ref name="ForEntryKeyBinding"/>
+        <g:optional>
+          <g:ref name="ForEntryValueBinding"/>
+        </g:optional>
+      </g:sequence>
+      <g:ref name="ForEntryValueBinding"/>
+    </g:choice>
     <g:optional>
       <g:ref name="PositionalVar"/>
     </g:optional>
     <g:string>in</g:string>
     <g:ref name="ExprSingle"/>
-  </g:production>-->
+  </g:production>
+  
+  <g:production name="ForEntryKeyBinding">    
+    <g:string>key</g:string>
+    <g:string>$</g:string>
+    <g:ref name="VarName"/>
+    <g:optional>
+      <g:ref name="TypeDeclaration"/>
+    </g:optional>    
+  </g:production>
+  
+  <g:production name="ForEntryValueBinding">    
+    <g:string>value</g:string>
+    <g:string>$</g:string>
+    <g:ref name="VarName"/>
+    <g:optional>
+      <g:ref name="TypeDeclaration"/>
+    </g:optional>    
+  </g:production>
 
-  <g:production name="PositionalVar" if=" xquery40">
+  <g:production name="PositionalVar">
     <g:string>at</g:string>
     <g:string>$</g:string>
     <g:ref name="VarName"/>
   </g:production>
   
-  <g:production name="XPPositionalVar" if="xpath40 xslt40-patterns">
+  <!--<g:production name="XPPositionalVar" if="xpath40 xslt40-patterns">
     <g:string>at</g:string>
     <g:string>$</g:string>
     <g:ref name="VarName"/>
   </g:production>
-
+-->
   <g:production name="FTScoreVar" if="fulltext">
     <g:string>score</g:string>
     <g:string>$</g:string>
     <g:ref name="VarName"/>
   </g:production>
 
-  <g:production name="LetClause" if=" xquery40">
+  <g:production name="LetClause">
     <g:string>let</g:string>
-    <g:ref name="LetBinding" if="xquery40"/>
-    <g:zeroOrMore if="xquery40" name="LetClauseTail">
+    <g:ref name="LetBinding"/>
+    <g:zeroOrMore name="LetClauseTail">
       <g:string>,</g:string>
-      <g:ref name="LetBinding" if="xquery40"/>
+      <g:ref name="LetBinding"/>
     </g:zeroOrMore>
   </g:production>
 
-  <g:production name="LetBinding" if="xquery40"><!-- also unfolded for  xquery10 -->
+  <g:production name="LetBinding">
     <g:choice>
       <g:sequence>
         <g:string>$</g:string>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -1074,8 +1074,9 @@ It is a static error if the name of a feature in
       
       <error spec="XP" code="0141" class="TY" type="type">
          <p>In a <code>for</code> <phrase role="xpath">expression</phrase><phrase role="xquery">clause</phrase>,
-         when the keyword <code>member</code> precedes the variable name, the value of the binding collection
-         must be a single array.</p>
+         when the keyword <code>member</code> is present, the value of the binding collection
+         must be a single array; and when either or both of the keywords <code>key</code> and <code>value</code>
+         are present, the value of the binding collection must be a single map.</p>
       </error>
       
       <error spec="XP" code="0144" class="TY" type="type">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16511,7 +16511,7 @@ let $z := g($x, $y)]]></eg>
                <change issue="49" PR="344" date="2023-02-10">A <code>for member</code> clause is added to 
                   FLWOR expressions to allow iteration over an array.
                </change>
-               <change issue="31" date="2024-06-01">A <code>for key/value</code> clause is added to 
+               <change issue="31" PR="1249" date="2024-06-01">A <code>for key/value</code> clause is added to 
                   FLWOR expressions to allow iteration over a map.
                </change>
                <change issue="189" PR="820" date="2023-11-08">
@@ -16561,8 +16561,7 @@ let $z := g($x, $y)]]></eg>
                   class="TY" code="0141"/>.</p>
                <p>If both the <code>key</code> and <code>value</code> variables are declared,
                their <termref def="dt-expanded-qname">expanded
-			        QNames</termref> must be distinct from the <termref def="dt-expanded-qname"
-                  >expanded QName</termref> <errorref
+			        QNames</termref> must be distinct <errorref
                   class="ST" code="0089"/>.</p></item>
             </ulist>
             
@@ -18460,13 +18459,13 @@ return ($i, $j)]]></eg>
          <head>For Expressions</head>
          
          <changes>
-            <change>A <code>for member</code> clause is added to FLWOR expressions to allow iteration over
+            <change issue="49" PR="344" date="2023-02-10">A <code>for member</code> clause is added to FLWOR expressions to allow iteration over
                an array.</change>
             <change issue="22" PR="28" date="2020-12-18">
                Multiple <code>for</code> and <code>let</code> clauses can be combined
                in an expression without an intervening <code>return</code> keyword.
             </change>
-            <change issue="31" date="2024-06-01">
+            <change issue="31" PR="1249" date="2024-06-01">
                A <code>for key/value</code> clause is added to FLWOR expressions to allow iteration over
                maps.</change>
             <change issue="231" PR="1131" date="2024-04-01">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -18720,7 +18720,7 @@ return $line/value]]></eg>
          <changes>
             <change issue="22" PR="28" date="2020-12-18">
                Multiple <code>for</code> and <code>let</code> clauses can be combined
-               in an expression without an intervenint <code>return</code> keyword.
+               in an expression without an intervening <code>return</code> keyword.
             </change>
             <change issue="796" PR="1131" date="2024-04-01">
                The type of a variable used in a <code>let</code> expression can be declared.

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16457,7 +16457,15 @@ let $z := g($x, $y)]]></eg>
                </item>
 
                <item>
-                  <p>A given variable name may be bound more than once in a FLWOR expression, or even within one  clause of a FLWOR expression. In such a case, each new binding occludes the previous one, which becomes inaccessible in the remainder of the FLWOR expression.</p>
+                  <p>A given variable name may be bound more than once in a FLWOR expression, 
+                     or even within one clause of a FLWOR expression. In such a case, each new 
+                     binding occludes the previous one, which becomes inaccessible in the 
+                     remainder of the FLWOR expression.</p>
+                  <p>For example, it is valid to write:</p>
+                  <eg>let $x := 0, $x := $x*2, $x := $x + 1</eg>
+                  <p>This binds three separate variables, each of which happens to have the
+                  same name. It should not be construed as binding a series of different values
+                  to the same variable.</p>
                </item>
 
                <item>
@@ -16568,7 +16576,7 @@ let $z := g($x, $y)]]></eg>
 
             <p>If a <code>for</code> clause contains multiple bindings separated by commas 
                it is semantically equivalent to multiple <code>for</code> clauses, 
-               each containing one of bindings in the original <code>for</code> clause.</p>
+               each containing one of the bindings in the original <code>for</code> clause.</p>
 
             <p>Example:</p>
 
@@ -16653,13 +16661,6 @@ for member $y in $expr2]]></eg>
                   <p>Output tuple stream contains no tuples.</p>
                </item>
                
-               <item diff="add" at="A">
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for member $x allowing empty in [] ]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($x = ())]]></eg>
-               </item>
-               
                <item>
                   <p>Initial clause:</p>
                   <eg><![CDATA[for key $k value $v in {'x':1, 'y':2} ]]></eg>
@@ -16732,7 +16733,7 @@ for member $y in $expr2]]></eg>
                and if <code>allowing empty</code> is not specified, the input tuple generates zero output tuples 
                (it is not represented in the output tuple stream.)</p>
             
-            <p diff="chg" at="2023-10-16">The <code>allowing empty</code> option is available only when processing sequences, not when processing arrays.
+            <p>The <code>allowing empty</code> option is available only when processing sequences, not when processing arrays or maps.
                The effect is that if the binding collection is an empty sequence, the input tuple generates one output tuple, 
                with the original variable bindings plus a binding of the new variable to an empty sequence.</p>
             
@@ -18520,7 +18521,8 @@ return ($i, $j)]]></eg>
                   that follows the <code>return</code> keyword) is called the <term>return expression</term>. 
                </p>
                <p><termdef id="dt-binding-collection-xp" term="binding collection">The 
-                  <term>binding expression</term> in a <code>for</code> expression is called the 
+                  result of evaluating the <term>binding expression</term> in a 
+                  <code>for</code> expression is called the 
                   <term>binding collection</term></termdef>.</p>
             </item>
             <item>
@@ -18545,10 +18547,8 @@ return ($i, $j)]]></eg>
                         (if present) is bound to the one-based position of that item in the 
                         <termref def="dt-binding-collection-xp"/>, as an instance of type 
                         <code>xs:integer</code>.</p></item>
-                     <item><p>The result of the single-variable <code>for</code> expression is the result
-                        of contenating the resulting values (as if by the <termref def="dt-comma-operator"
-                           >comma operator</termref>) in the order of the items in the binding collection from which 
-                        they were derived.</p></item>
+                     <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
+                        of the results of the successive evaluations of the <term>return expression</term>.</p></item>
                   </olist>
               
                </p>
@@ -18572,13 +18572,14 @@ return ($i, $j)]]></eg>
                         the <term>range variable</term> is bound to that member, and the <term>position variable</term> 
                         (if present) is bound to the one-based position of that member in the <termref def="dt-binding-collection-xp"/>.</p></item>
                      <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
-                        of the results of the successive evaluations of the <term>return expression</term>.</p></item>
+                        of the results of the successive evaluations of the <term>return expression</term>.</p>
+                     <p>Note that the result is a sequence, not an array.</p></item>
                   </olist>   
                   
                   
       
                </p>
-               <p>Note that the result is a sequence, not an array.</p>
+               
             </item>
             <item>
                <p>When the <code>key</code> and/or <code>value</code> keywords are present:
@@ -18615,10 +18616,11 @@ return ($i, $j)]]></eg>
                         <termref def="dt-implementation-dependent"/> ordering of the 
                         <termref def="dt-binding-collection-xp"/>.</p></item>
                      <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
-                        of the results of the successive evaluations of the <term>return expression</term>.</p></item>
+                        of the results of the successive evaluations of the <term>return expression</term>.</p>
+                     <p>Note that the result is a sequence, not a map.</p></item>
                   </olist>   
                </p>
-               <p>Note that the result is a sequence, not a map.</p>
+               
             </item>
          </olist>
          <p role="xpath"
@@ -18679,16 +18681,24 @@ return ($i + $j)</phrase>
          </eg>
          <p>The result of the above expression, expressed as a sequence of numbers, is as follows: <code>11, 12, 21, 22</code>
          </p>
-         <p>The scope of a variable bound in a <code>for</code> expression comprises all subexpressions of the <code>for</code> expression
-that appear after the variable binding. The scope does not
-include the expression to which the variable is bound. The following example illustrates how a variable binding may reference another variable bound earlier in the same  <code>for</code> expression:</p>
+         <p>The scope of a variable bound in a <code>for</code> expression is the <term>return expression</term>. 
+            The scope does not include the expression to which the variable is bound. 
+            The following example illustrates how a variable binding may reference another variable 
+            bound earlier in the same  <code>for</code> expression:</p>
          <eg role="parse-test"><phrase role="parse-test">for $x in $z, $y in f($x)
 return g($x, $y)</phrase>
          </eg>
 
-         <p diff="add" at="A">The following example illustrates processing of an array.</p>
-         <eg diff="add" at="A">for member $map in parse-json('[{ "x": 1, "y": 2 }, { "x": 10, "y": 20 }]') return $map ! (?x + ?y)</eg>
-         <p diff="add" at="A">The result is the sequence <code>(3, 30)</code>.</p>
+         <p>The following example illustrates processing of an array.</p>
+         <eg>for member $map in parse-json('[{ "x": 1, "y": 2 }, { "x": 10, "y": 20 }]') 
+return $map ! (?x + ?y)</eg>
+         <p>The result is the sequence <code>(3, 30)</code>.</p>
+         
+         <p>The following example illustrates processing of a map.</p>
+         <eg>for key $key value $value in { "x": 1, "y": 2, "z: 3 }
+return `{$key}={$value}`</eg>
+         <p>The result is the sequence <code>("x=1", "y=2", "z=3")</code> (but
+         not necessarily in that order).</p>
          
          <note>
             <p>The focus for evaluation of the <code>return</code> clause of a <code>for</code> expression
@@ -18702,7 +18712,7 @@ order-items, is therefore incorrect:
 
 Instead, the expression must be written to use the variable bound in the <code>for</code> clause:</p>
             <eg role="parse-test"
-               ><![CDATA[sum(for $i in order-item return $i/@price * $i/@qty)]]></eg>
+               ><![CDATA[sum(for $i in order-item return $i!(@price * @qty))]]></eg>
          </note>
          <note diff="add" at="2023-02-16">
             <p>XPath 4.0 allows the format:</p>
@@ -18770,8 +18780,8 @@ binding sequence. </p>
 
          </ulist>
 
-         <p>The scope of a variable bound in a let expression comprises all
-subexpressions of the let expression that appear after the variable binding.
+         <p>The scope of a variable bound in a let expression is the
+            <term>return expression</term>.
 The scope does not include the expression to which the variable is bound.
 The following example illustrates how a variable binding may reference
 another variable bound earlier in the same let expression:</p>
@@ -18794,12 +18804,7 @@ return upper-case($x)
             three separate variables which happen to have the same name; it should not be read as declaring
             a single variable and binding it successively to different values.</p>
          </note>
-         <note diff="add" at="2023-02-16">
-            <p>XPath 4.0 generalizes the <code>LetExpression</code> to allow multiple 
-               <code>let</code> clauses and <code>for</code> clauses to be combined
-               without an intermediate <code>return</code>, and also to allow the required
-               type to be declared.</p>
-         </note>
+         
       </div3>
 
       </div2>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16355,9 +16355,2108 @@ element because it is defined by a <termref
          </div3>
       </div2>
 
+      <div2 id="id-flwor-expressions">
+         <head><phrase role="xquery">FLWOR Expressions</phrase><phrase role="xpath">For and Let Expressions</phrase></head>
+         <p role="xquery">XQuery provides a versatile expression called a FLWOR expression 
+            that may contain multiple clauses. The FLWOR expression can be used for many purposes, 
+            including iterating over sequences, joining multiple documents, and performing grouping 
+            and aggregation. The name FLWOR, pronounced "flower", is suggested by the keywords 
+            <code>for</code>, <code>let</code>, <code>where</code>, <code>order by</code>, 
+            and <code>return</code>, which introduce some of the clauses used in FLWOR expressions 
+            (but this is not a complete list of such clauses.)</p>
+         <p role="xquery">The complete syntax of a FLWOR expression is shown here, and relevant parts 
+            of the syntax are repeated in subsequent sections of this document.</p>
+         <p role="xpath">XPath provides two closely-related expressions, called For and Let
+         expressions, that can be used to bind variables to values. The complete syntax is shown
+         here, and relevant parts 
+            of the syntax are repeated in subsequent sections of this document.</p>
+         <scrap>
+            <head/>
+            <prodrecap id="ForExpr" ref="ForExpr" role="xpath"/>
+            <prodrecap id="ForExpr" ref="LetExpr" role="xpath"/>
+            <prodrecap id="FLWORExpr" ref="FLWORExpr11" role="xquery"/>
+            <prodrecap id="InitialClause" ref="InitialClause" role="xquery"/>
+            <prodrecap id="IntermediateClause" ref="IntermediateClause" role="xquery"/>
+            <prodrecap id="ForClause" ref="ForClause"/>
+            <prodrecap id="ForBinding" ref="ForBinding"/>
+            <prodrecap id="ForItemBinding" ref="ForItemBinding"/>
+            <prodrecap id="ForMemberBinding" ref="ForMemberBinding"/>
+            <prodrecap id="ForEntryBinding" ref="ForEntryBinding"/>
+            <prodrecap id="ForEntryKeyBinding" ref="ForEntryKeyBinding"/>
+            <prodrecap id="ForEntryValueBinding" ref="ForEntryValueBinding"/>
+            <prodrecap id="LetClause" ref="LetClause"/>
+            <prodrecap id="LetBinding" ref="LetBinding"/>
+            <prodrecap ref="TypeDeclaration"/>
+            <prodrecap id="AllowingEmpty" ref="AllowingEmpty" role="xquery"/>
+            <prodrecap id="PositionalVar" ref="PositionalVar"/>
+            <prodrecap id="WindowClause" ref="WindowClause" role="xquery"/>
+            <prodrecap id="TumblingWindowClause" ref="TumblingWindowClause" role="xquery"/>
+            <prodrecap id="SlidingWindowClause" ref="SlidingWindowClause" role="xquery"/>
+            <prodrecap id="WindowStartCondition" ref="WindowStartCondition" role="xquery"/>
+            <prodrecap id="WindowEndCondition" ref="WindowEndCondition" role="xquery"/>
+            <prodrecap id="WindowVars" ref="WindowVars" role="xquery"/>
+            <prodrecap id="CurrentItem" ref="CurrentItem" role="xquery"/>
+            <prodrecap id="PreviousItem" ref="PreviousItem" role="xquery"/>
+            <prodrecap id="NextItem" ref="NextItem" role="xquery"/>
+            <prodrecap ref="CountClause" role="xquery"/>
+            <prodrecap ref="WhereClause" role="xquery"/>
+            <prodrecap ref="WhileClause" role="xquery"/>
+            <prodrecap id="GroupByClause" ref="GroupByClause" role="xquery"/>
+            <prodrecap id="GroupingSpecList" ref="GroupingSpecList" role="xquery"/>
+            <prodrecap id="GroupingSpec" ref="GroupingSpec" role="xquery"/>
+            <prodrecap id="GroupingVariable" ref="GroupingVariable" role="xquery"/>
+            <prodrecap ref="OrderByClause" role="xquery"/>
+            <prodrecap ref="OrderSpecList" id="OrderSpecList" role="xquery"/>
+            <prodrecap ref="OrderSpec" id="OrderSpec" role="xquery"/>
+            <prodrecap ref="OrderModifier" id="OrderModifier" role="xquery"/>
+            <prodrecap ref="ReturnClause" id="ReturnClause" role="xquery"/>
+            <prodrecap id="ForLetReturn" ref="ForLetReturn" role="xpath"/>
+         </scrap>
+         <p role="xquery">The semantics of FLWOR expressions are based on a concept called a <term>tuple stream</term>. <termdef
+               id="id-tuple-stream-foobar" term="tuple stream"
+                  >A <term>tuple stream</term> is an ordered sequence of zero or more <term>tuples</term>.</termdef>
+            <termdef term="tuple" id="id-tuple-foobar"
+                  >A <term>tuple</term> is a set of zero or more named variables, each of which is bound to a value that is an <termref
+                  def="dt-data-model-instance"
+               >XDM instance</termref>.</termdef> Each tuple stream is homogeneous in the sense that all its  tuples contain variables with the same names and the same <termref
+               def="dt-static-type"
+               >static types</termref>. The following example illustrates a tuple stream consisting of four tuples, each containing three variables named <code>$x</code>, <code>$y</code>, and <code>$z</code>:</p>
+         <eg role="xquery">($x = 1003, $y = "Fred", $z = &lt;age&gt;21&lt;/age&gt;)
+($x = 1017, $y = "Mary", $z = &lt;age&gt;35&lt;/age&gt;)
+($x = 1020, $y = "Bill", $z = &lt;age&gt;18&lt;/age&gt;)
+($x = 1024, $y = "John", $z = &lt;age&gt;29&lt;/age&gt;)</eg>
+         <note role="xquery">
+            <p>In this section, tuple streams are represented as shown in the above example. Each tuple is on a separate line and is enclosed in parentheses, and the variable bindings inside each tuple are separated by commas. This notation does not represent XQuery syntax, but is simply a representation of a tuple stream for the purpose of defining the semantics of  FLWOR expressions.</p>
+         </note>
+         <p role="xquery">Tuples and tuple streams are not part of the <termref def="dt-datamodel"
+               >data model</termref>. They exist only as conceptual intermediate results during the processing of a FLWOR expression.</p>
+         <p role="xquery">Conceptually, the first clause generates a tuple stream. Each clause between the first clause and the return clause takes the tuple stream generated by the previous clause as input and generates a (possibly different) tuple stream as output. The return clause takes a tuple stream as input and, for each tuple in this tuple stream, generates an <termref
+               def="dt-data-model-instance"
+               >XDM instance</termref>; the final result of the FLWOR expression is the ordered concatenation of these <termref
+               def="dt-data-model-instance">XDM instances</termref>.</p>
+         <p role="xquery">The initial clause in a FLWOR expression may be a <code>for</code>, <code>let</code>, or <code>window</code> clause. 
+Intermediate clauses may be <code>for</code>, <code>let</code>, <code>window</code>, <code>count</code>, <code>where</code>, <code>group by</code>, or <code>order by</code> clauses. These intermediate clauses may be repeated as many times as desired, in any order. The final clause of the FLWOR expression must be a <code>return</code> clause. The semantics of the various clauses are described in the following sections.</p>
+
+         <div3 id="id-binding-rules" role="xquery">
+            <head>Variable Bindings</head>
+            <p>The following clauses in FLWOR expressions bind values to variables: 
+<code>for</code>, <code>let</code>, <code>window</code>, <code>count</code>, and <code>group by</code>. 
+The binding of variables for <code>for</code>, <code>let</code>, and <code>count</code> is governed by the following rules
+(the binding of variables in <code>group by</code> is discussed in <specref
+                  ref="id-group-by"
+                  />,
+the binding of variables in <code>window</code> clauses is discussed in <specref
+                  ref="id-windows"/>):</p>
+
+            <olist>
+
+               <item>
+                  <p>The scope of a bound variable includes all subexpressions of the containing FLWOR that appear after the variable binding. The scope does not include the expression to which the variable is bound. The following code fragment, containing two <code>let</code> clauses, illustrates how variable bindings may reference variables that were bound in earlier clauses, or in earlier bindings in the same clause:</p>
+                  <eg><![CDATA[let $x := 47, $y := f($x)
+let $z := g($x, $y)]]></eg>
+               </item>
+
+               <item>
+                  <p>A given variable name may be bound more than once in a FLWOR expression, or even within one  clause of a FLWOR expression. In such a case, each new binding occludes the previous one, which becomes inaccessible in the remainder of the FLWOR expression.</p>
+               </item>
+
+               <item>
+                  <p>
+                     <termdef term="type declaration" id="dt-type-declaration"
+                           >A variable binding may be accompanied by a <term>type declaration</term>, which consists of the keyword <code>as</code> followed by the static type of the variable, declared using the syntax in  <specref
+                           ref="id-sequencetype-syntax"
+                        />.</termdef> <phrase diff="add" at="2022-11-17">The type declaration defines a required type for the
+                        value. At run-time, the supplied value for the variable is converted to the required type
+                        by applying the <termref def="dt-coercion-rules"/>. If conversion is not possible, </phrase>                    
+                        a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
+                        code="0004"
+                        />. For example, the following <code>let</code> clause raises a <termref
+                        def="dt-type-error"
+                        >type error</termref> because the variable <code>$salary</code> has a type declaration that is not satisfied by the value that is bound to it:</p>
+                  <eg><![CDATA[let $salary as xs:decimal :=  "cat"]]></eg>
+                  <p  diff="add" at="2022-11-17">The following <code>let</code> clause, however, succeeds, because the <termref def="dt-coercion-rules"/>
+                  allow an <code>xs:decimal</code> to be supplied where an <code>xs:double</code> is required:</p>
+                  <eg><![CDATA[let $temperature as xs:double := 32.5]]></eg>
+                  <p>In applying the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
+               </item>
+               <item diff="add" at="A">
+                  <p>
+                     <termdef id="dt-binding-collection" term="binding collection"
+                        >In a <code>for</code> clause, when an expression is 
+                        preceded by the keyword <code>in</code>, the value of that expression is 
+                        called a <term>binding collection</term>.</termdef> The collection may be either
+                     a sequence, an array, or a map. The <code>for</code>  
+                     clause iterates over its binding collection, producing multiple bindings for one or more variables. 
+                     Details on how binding collections are used in <code>for</code> clauses 
+                     are described in the following sections.</p>
+               </item>
+               <item diff="chg" at="A">
+                  <p>
+                     <termdef id="dt-binding-sequence" term="binding sequence"
+                           >In a <code>window</code> clause, when an expression is 
+                        preceded by the keyword <code>in</code>, the value of that expression is 
+                        called a <term>binding sequence</term>.</termdef> The <code>window</code> 
+                     clause iterates over its binding sequence, producing multiple bindings for one or more variables. 
+                     Details on how binding sequences are used in <code>for</code> and <code>window</code> clauses 
+                     are described in the following sections.</p>
+               </item>
+               
+            </olist>
+         </div3>
+
+         <div3 id="id-xquery-for-clause" role="xquery">
+            <head>For Clause</head>
+            
+            <changes>
+               <change issue="49" PR="344" date="2023-02-10">A <code>for member</code> clause is added to 
+                  FLWOR expressions to allow iteration over an array.
+               </change>
+               <change issue="31" date="2024-06-01">A <code>for key/value</code> clause is added to 
+                  FLWOR expressions to allow iteration over a map.
+               </change>
+               <change issue="189" PR="820" date="2023-11-08">
+                  The value bound to a variable in a <code>for</code> clause is now converted
+                     to the declared type by applying the coercion rules.
+               </change>
+            </changes>
+            
+            <scrap>
+               <head/>
+               <prodrecap ref="ForClause"/>
+               <prodrecap ref="ForBinding"/>
+               <prodrecap ref="ForItemBinding"/>
+               <prodrecap ref="ForMemberBinding"/>
+               <prodrecap ref="ForEntryBinding"/>
+               <prodrecap ref="ForEntryKeyBinding"/>
+               <prodrecap ref="ForEntryValueBinding"/>
+               <prodrecap ref="TypeDeclaration"/>
+               <prodrecap ref="AllowingEmpty"/>
+               <prodrecap ref="PositionalVar"/>
+            </scrap>
+            <p>A <code>for</code> clause is used for iteration. Each variable in a <code>for</code> clause iterates over a 
+               sequence, an array, or a map.</p>
+            
+            <p>The expression following the keyword <code>in</code> is evaluated; we refer to the 
+               resulting sequence, array, or map generically as the <termref def="dt-binding-collection"/>, and to
+               its items, members, or entries as the <code>components</code> of the collection.</p>
+            
+            <ulist>
+               <item><p>When a <nt def="ForItemBinding">ForItemBinding</nt> is used (that is, when none of the
+                  keywords <code>member</code>, <code>key</code>, or <code>value</code> is used), 
+                  the range variable is bound in turn to each item in the <termref def="dt-binding-collection"/>,
+                  which is treated as a sequence of items.</p></item>
+               <item><p>When a <nt def="ForItemBinding">ForMemberBinding</nt> is used (that is, when the
+               keyword <code>member</code> is used), 
+               the range variable is bound in turn to each member of the array.</p>
+                  <p>In this case the corresponding <code>ExprSingle</code>
+                  must evaluate to a single array, otherwise a type error is raised <errorref
+                  class="TY" code="0141"/>.</p></item>
+               <item><p>When a <nt def="ForItemBinding">ForEntryBinding</nt> is used (that is, when either
+                  or both of the keywords <code>key</code> and <code>value</code> are used), 
+                  the <code>key</code> range variable (if present) is bound in turn to each key in the map 
+                  (in <termref def="dt-implementation-dependent"/> order), and the <code>value</code>
+                  range variable (if present) is bound to the corresponding value.</p>
+                  <p>In this case the corresponding <code>ExprSingle</code>
+                  must evaluate to a single map, otherwise a type error is raised <errorref
+                  class="TY" code="0141"/>.</p>
+               <p>If both the <code>key</code> and <code>value</code> variables are declared,
+               their <termref def="dt-expanded-qname">expanded
+			        QNames</termref> must be distinct from the <termref def="dt-expanded-qname"
+                  >expanded QName</termref> <errorref
+                  class="ST" code="0089"/>.</p></item>
+            </ulist>
+            
+
+            <p>If a <code>for</code> clause contains multiple bindings separated by commas 
+               it is semantically equivalent to multiple <code>for</code> clauses, 
+               each containing one of bindings in the original <code>for</code> clause.</p>
+
+            <p>Example:</p>
+
+            <ulist>
+               <item>
+                  <p>The clause</p>
+                  <eg><![CDATA[for $x in $expr1, $y in $expr2]]></eg>
+                  <p>is semantically equivalent to:</p>
+                  <eg><![CDATA[for $x in $expr1
+for $y in $expr2]]></eg>
+               </item>
+               <item>
+                  <p>The clause</p>
+                  <eg><![CDATA[for member $x in $expr1, member $y in $expr2]]></eg>
+                  <p>is semantically equivalent to:</p>
+                  <eg><![CDATA[for member $x in $expr1
+for member $y in $expr2]]></eg>
+               </item>
+            </ulist>
+            
+            
+           
+
+            <p>In the remainder of this section, we define the semantics of a <code>for</code> clause containing 
+               a single variable and an associated expression 
+               (following the keyword <code>in</code>) whose value is the <termref
+                  def="dt-binding-collection">binding collection</termref> for that variable.</p>
+            <p>If a single-variable <code>for</code> clause is the initial clause in a FLWOR expression, it iterates over its <termref
+               def="dt-binding-collection">binding collection</termref>, binding the variable(s) to each component in turn. 
+               The resulting sequence of variable bindings becomes the initial tuple stream that serves as input to the next clause 
+               of the FLWOR expression. If <termref
+                  def="dt-ordering-mode"
+                  >ordering mode</termref> is <code>ordered</code>, the order of tuples in the tuple stream preserves the order of the <termref
+                  def="dt-binding-collection"
+                     >binding collection</termref>; otherwise the order of the tuple stream is <termref
+                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+            <p>If the <termref def="dt-binding-sequence"
+                  >binding collection</termref> is empty, the output tuple stream depends on whether <code>allowing empty</code> is specified. 
+               If <code>allowing empty</code> is specified, the output tuple stream consists of one tuple in which the variable is bound to an empty sequence.
+               This option is not available when the keywords <code>member</code>, <code>key</code>, or <code>value</code>
+               are used.
+               If <code>allowing empty</code> is not specified, the output tuple stream consists of zero tuples.</p>
+            <p>The following  examples illustrates tuple streams that are generated by initial <code>for</code> clauses:</p>
+            <ulist>
+
+               <item>
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for $x in (100, 200, 300)]]></eg>
+                  <p>or (equivalently):</p>
+                  <eg><![CDATA[for $x allowing empty in (100, 200, 300)]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($x = 100)
+($x = 200)
+($x = 300)]]></eg>
+               </item>
+
+               <item>
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for $x in ()]]></eg>
+                  <p>Output tuple stream contains no tuples.</p>
+               </item>
+
+               <item>
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for $x allowing empty in ()]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($x = ())]]></eg>
+               </item>
+               
+               <item diff="add" at="A">
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for member $x in [ 1, 2, (5 to 10) ] ]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($x = (1))
+($x = (2))
+($x = (5, 6, 7, 8, 9, 10)]]></eg>
+               </item>
+               
+               <item diff="add" at="A">
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for member $x in []]]></eg>
+                  <p>Output tuple stream contains no tuples.</p>
+               </item>
+               
+               <item diff="add" at="A">
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for member $x allowing empty in [] ]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($x = ())]]></eg>
+               </item>
+               
+               <item>
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for key $k value $v in {'x':1, 'y':2} ]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($k = 'x', $v = 1)
+($k = 'y', $v = 2)]]></eg>
+               </item>
+            </ulist>
+            <p>
+               <termdef term="positional variable" id="dt-positional-variable">A <term>positional variable</term> 
+                  is a variable that is preceded by the keyword <code>at</code>.</termdef> A positional variable 
+               may be associated with the range variable(s) that are bound in a <code>for</code> clause. In this case, as 
+               the main range variable(s) iterate over the components of its <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, 
+               the positional variable iterates over the integers that represent the ordinal numbers of these component in the 
+               <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, starting with one. Each tuple in the output 
+               tuple stream contains bindings for both the main variable and the positional variable. If the 
+               <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref> is empty and <code>allowing empty</code> is 
+               specified, the positional variable in the output tuple is bound to the integer zero. Positional variables  
+               have the implied type <code>xs:integer</code>.</p>
+            <p>The <termref def="dt-expanded-qname">expanded
+			        QName</termref> of a positional variable must be distinct from the <termref def="dt-expanded-qname"
+                  >expanded QName</termref> of the main variable with which it is associated <errorref
+                  class="ST" code="0089"/>.</p>
+            <p>The following  examples illustrate how a positional variable would have affected the results of the previous examples that generated tuples:</p>
+            <ulist>
+
+               <item>
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for $x at $i in (100, 200, 300)]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($x = 100, $i = 1)
+($x = 200, $i = 2)
+($x = 300, $i = 3)]]></eg>
+               </item>
+               
+               <item diff="add" at="A">
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for $x at $i in [1 to 3, 11 to 13, 21 to 23]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($x = (1, 2, 3), $i = 1)
+($x = (11, 12, 13), $i = 2)
+($x = (21, 22, 23), $i = 3)]]></eg>
+               </item>
+
+               <item>
+                  <p>Initial clause:</p>
+                  <eg><![CDATA[for $x allowing empty at $i in ()]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($x = (), $i = 0)]]></eg>
+               </item>
+            </ulist>
+            <p>If a single-variable <code>for</code> clause is an intermediate clause in a FLWOR expression, its <termref
+                  def="dt-binding-collection" diff="chg" at="A"
+                  >binding collection</termref> is evaluated for each input tuple, given the bindings in that input tuple. Each input tuple generates 
+                  zero or more tuples in the output tuple stream. Each of these output tuples consists of  the original variable bindings of the 
+                  input tuple plus a binding of the new variable to one of the items in its <termref
+                     def="dt-binding-collection" diff="chg" at="A">binding collecction</termref>.</p>
+            <note>
+               <p>Although the <termref def="dt-binding-collection" diff="chg" at="A"
+                     >binding collection</termref> is conceptually evaluated independently for each input tuple, 
+                  an optimized implementation may sometimes be able to avoid re-evaluating the <termref
+                     def="dt-binding-collection" diff="chg" at="A"
+                     >binding collection</termref> if it can show that the variables that the <termref
+                        def="dt-binding-collection" diff="chg" at="A"
+                  >binding collection</termref> depends on have the same values as in a previous evaluation.</p>
+            </note>
+            <p>For a given input tuple, if the <termref def="dt-binding-collection" diff="chg" at="A"
+                  >binding collection</termref> for the new variable in the <code>for</code> clause <phrase diff="add" at="A">is empty 
+               (that is, it is an empty sequence or an empty array depending on whether <code>member</code> is specified)</phrase>,
+               and if <code>allowing empty</code> is not specified, the input tuple generates zero output tuples 
+               (it is not represented in the output tuple stream.)</p>
+            
+            <p diff="chg" at="2023-10-16">The <code>allowing empty</code> option is available only when processing sequences, not when processing arrays.
+               The effect is that if the binding collection is an empty sequence, the input tuple generates one output tuple, 
+               with the original variable bindings plus a binding of the new variable to an empty sequence.</p>
+            
+            <note diff="add" at="2023-10-16"><p>If a type declaration is present and <code>allowing empty</code> is specified, the type declaration
+            should include an occurrence indicator of <code>"?"</code> to indicate that the variable may be bound to an
+            empty sequence.</p></note>
+            
+            <p>If the new variable introduced by a <code>for</code> clause has an associated <termref
+                  def="dt-positional-variable"
+                  >positional variable</termref>, the output tuples generated by the <code>for</code> clause  also contain bindings for the <termref
+                  def="dt-positional-variable"
+                  >positional variable</termref>. In this case, as the new variable is bound to each item in its <termref
+                     def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, the <termref
+                  def="dt-positional-variable"
+                  >positional variable</termref> is bound to the ordinal position of that item within the <termref
+                     def="dt-binding-collection" diff="chg" at="A"
+                  >binding collection</termref>, starting with one. Note that, since the <termref
+                  def="dt-positional-variable"
+                  >positional variable</termref> represents a position within a <termref
+                     def="dt-binding-collection" diff="chg" at="A"
+                  >binding collection</termref>, the output tuples corresponding to each input tuple are independently numbered, starting with one. For a given input tuple, if the <termref
+                     def="dt-binding-collection"  diff="chg" at="A"
+                  >binding collection</termref> is empty and <code>allowing empty</code> is specified, the <termref
+                  def="dt-positional-variable"
+               >positional variable</termref> in the output tuple is bound to the integer zero.</p>
+            <p>If <termref def="dt-ordering-mode"
+                  >ordering mode</termref> is <code>ordered</code>, the tuples in the output tuple stream are ordered primarily by the order of the input tuples from which they are derived, and secondarily by the order of the <termref
+                  def="dt-binding-sequence"
+                  >binding sequence</termref> for the new variable; otherwise the order of the output tuple stream is <termref
+                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+            <p>The following examples illustrates the effects of  intermediate <code>for</code> clauses:</p>
+            <ulist>
+
+               <item>
+                  <p>Input tuple stream:</p>
+                  <eg><![CDATA[($x = 1)
+($x = 2)
+($x = 3)
+($x = 4)]]></eg>
+                  <p>Intermediate <code>for</code> clause:</p>
+                  <eg><![CDATA[for $y in ($x to 3)]]></eg>
+                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
+                        >ordering mode</termref> is <code>ordered</code>):</p>
+                  <eg><![CDATA[($x = 1, $y = 1)
+($x = 1, $y = 2)
+($x = 1, $y = 3)
+($x = 2, $y = 2)
+($x = 2, $y = 3)
+($x = 3, $y = 3)
+]]></eg>
+                  <note>
+                     <p>In this example, there is no output tuple that corresponds to the input tuple <code>($x = 4)</code> because, when the <code>for</code> clause is evaluated with the bindings in this input tuple, the resulting <termref
+                        def="dt-binding-collection" diff="chg" at="A"
+                        >binding collection</termref> for <code>$y</code> is empty.</p>
+                  </note>
+               </item>
+               
+
+               <item>
+                  <p>This  example shows how the previous example would have been affected by a <termref
+                        def="dt-positional-variable"
+                     >positional variable</termref> (assuming the same input tuple stream):</p>
+                  <eg><![CDATA[for $y at $j in ($x to 3)]]></eg>
+                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
+                        >ordering mode</termref> is <code>ordered</code>):</p>
+                  <eg><![CDATA[($x = 1, $y = 1, $j = 1)
+($x = 1, $y = 2, $j = 2)
+($x = 1, $y = 3, $j = 3)
+($x = 2, $y = 2, $j = 1)
+($x = 2, $y = 3, $j = 2)
+($x = 3, $y = 3, $j = 1)
+]]></eg>
+               </item>
+
+               <item>
+                  <p>This example shows how the previous example would have been affected by <code>allowing empty</code>. Note that <code>allowing empty</code> causes the input tuple <code>($x = 4)</code> to be represented in the output tuple stream, even though the <termref
+                        def="dt-binding-sequence"
+                        >binding sequence</termref> for <code>$y</code> contains no items for this input tuple.
+                        This example illustrates that <code>allowing empty</code> in a <code>for</code> clause
+                        serves a purpose similar to that of an “outer join” in a relational database query.
+                        (Assume the same input tuple stream as in the previous example.)</p>
+                  <eg><![CDATA[for $y allowing empty at $j in ($x to 3)]]></eg>
+                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
+                        >ordering mode</termref> is <code>ordered</code>):</p>
+                  <eg><![CDATA[($x = 1, $y = 1, $j = 1)
+($x = 1, $y = 2, $j = 2)
+($x = 1, $y = 3, $j = 3)
+($x = 2, $y = 2, $j = 1)
+($x = 2, $y = 3, $j = 2)
+($x = 3, $y = 3, $j = 1)
+($x = 4, $y = (), $j = 0)
+]]></eg>
+               </item>
+               
+               <item diff="add" at="A">
+                  <p>This example illustrates processing of arrays:</p>
+                  <p>Input tuple stream:</p>
+                  <eg><![CDATA[($x = 1)
+($x = 2)
+($x = 3)]]></eg>
+                  <p>Intermediate <code>for</code> clause:</p>
+                  <eg><![CDATA[for member $y in [[$x+1, $x+2], [[$x+3, $x+4]] ]]></eg>
+                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
+                     >ordering mode</termref> is <code>ordered</code>):</p>
+                  <eg><![CDATA[($x = 1, $y = [ 2, 3 ])
+($x = 1, $y = [ 4, 5 ])
+($x = 2, $y = [ 3, 4 ])
+($x = 2, $y = [ 5, 6 ])
+($x = 3, $y = [ 4, 5 ])
+($x = 3, $y = [ 6, 7 ])
+]]></eg>
+                  
+               </item>
+               
+
+               <item>
+                  <p>This example shows how a <code>for</code> clause that binds two variables is semantically equivalent to two <code>for</code> clauses that bind one variable each. We assume that this <code>for</code> clause occurs at the beginning of a FLWOR expression. It is equivalent to an initial single-variable <code>for</code> clause that provides an input tuple stream to an intermediate single-variable <code>for</code> clause.</p>
+                  <eg><![CDATA[for $x in (1, 2, 3, 4), $y in ($x to 3)]]></eg>
+                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
+                        >ordering mode</termref> is <code>ordered</code>):</p>
+                  <eg><![CDATA[($x = 1, $y = 1)
+($x = 1, $y = 2)
+($x = 1, $y = 3)
+($x = 2, $y = 2)
+($x = 2, $y = 3)
+($x = 3, $y = 3)
+]]></eg>
+               </item>
+            </ulist>
+            <p>In the above examples, if <termref def="dt-ordering-mode"
+                  >ordering mode</termref> had been <code>unordered</code>, the output tuple streams would have consisted of the same tuples, with the same values for the <termref
+                  def="dt-positional-variable"
+                  >positional variables</termref>, but the ordering of the tuples would have been <termref
+                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+            <p>A <code>for</code> clause may contain one or more <termref def="dt-type-declaration"
+                  >type declarations</termref>, identified by the keyword <code>as</code>. The semantics of <termref
+                  def="dt-type-declaration">type declarations</termref> are defined in <specref
+                  ref="id-binding-rules"/>.</p>
+         </div3>
+         <div3 id="id-xquery-let-clause" role="xquery">
+            <head>Let Clause</head>
+            
+            <changes>
+               <change issue="189" PR="254" date="2022-11-29">
+                  The value bound to a variable in a <code>let</code> clause is now converted
+               to the declared type by applying the coercion rules.
+               </change>
+            </changes>
+            <scrap>
+               <head/>
+               <prodrecap ref="LetClause"/>
+               <prodrecap ref="LetBinding"/>
+               <prodrecap ref="TypeDeclaration"/>
+            </scrap>
+            <p>The purpose of a <code>let</code> clause is to bind values to one or more variables. Each variable is bound to the result of evaluating an expression.</p>
+            <p>If a <code>let</code> clause contains multiple variables, it is semantically equivalent to multiple <code>let</code> clauses, each containing a single variable. For example, the clause</p>
+            <eg><![CDATA[let $x := $expr1, $y := $expr2]]></eg>
+            <p>is semantically equivalent to the following sequence of clauses:</p>
+            <eg><![CDATA[let $x := $expr1
+let $y := $expr2]]></eg>
+            <p>In the remainder of this section, we define the semantics of a <code>let</code> clause containing a single variable <emph>V</emph> and an associated expression <emph>E</emph>.</p>
+            <p>If a single-variable <code>let</code> clause is the initial clause in a FLWOR expression, it simply binds the variable <emph>V</emph> to the result of the expression <emph>E</emph>. The result of the <code>let</code> clause is a tuple stream consisting of one tuple with a single binding that binds <emph>V</emph> to the result of <emph>E</emph>. This tuple stream serves as input to the next clause in the FLWOR expression.</p>
+            <p>If a single-variable <code>let</code> clause is an intermediate clause in a FLWOR expression, it adds a new binding for variable <emph>V</emph> to each tuple in the input tuple stream. For each input tuple, the value bound to <emph>V</emph> is the result of evaluating expression <emph>E</emph>, given the bindings that are already present in that input tuple. The resulting tuples become the output tuple stream of the <code>let</code> clause.</p>
+            <p>The number of tuples in the output tuple stream of an intermediate <code>let</code> clause is the same as the number of tuples in the input tuple stream. The number of bindings in the output tuples is one more than the number of bindings in the input tuples, unless the input tuples already contain bindings for <emph>V</emph>; in this case, the new binding for <emph>V</emph> occludes (replaces) the earlier binding for <emph>V</emph>, and the number of bindings is unchanged.</p>
+            <p>A <code>let</code> clause may contain one or more <termref def="dt-type-declaration"
+                  >type declarations</termref>, identified by the keyword <code>as</code>. The semantics of type declarations are defined in <specref
+                  ref="id-binding-rules"/>.</p>
+            <p>The following code fragment illustrates how a <code>for</code> clause and a <code>let</code> clause can be used together. The <code>for</code> clause produces an initial tuple stream containing a binding for variable <code>$d</code> to each department number found in a given input document. The <code>let</code> clause adds an additional binding to each tuple, binding variable <code>$e</code> to a sequence of employees whose department number matches the value of <code>$d</code> in that tuple.</p>
+            <eg><![CDATA[for $d in doc("depts.xml")/depts/deptno
+let $e := doc("emps.xml")/emps/emp[deptno eq $d]]]></eg>
+         </div3>
 
 
-      <div2 role="xpath" id="id-for-expressions">
+
+         <div3 id="id-windows" role="xquery">
+            <head>Window Clause</head>
+            
+            <changes>
+               <change issue="452" PR="483" date="2023-05-18">
+                  The <code>start</code> clause in window expressions has become optional, as well as
+                  the <code>when</code> keyword and its associated expression.
+               </change>
+            </changes>
+            
+            <scrap>
+               <head/>
+               <prodrecap ref="WindowClause"/>
+               <prodrecap ref="TumblingWindowClause"/>
+               <prodrecap ref="SlidingWindowClause"/>
+               <prodrecap ref="WindowStartCondition"/>
+               <prodrecap ref="WindowEndCondition"/>
+               <prodrecap ref="WindowVars"/>
+               <prodrecap ref="CurrentItem"/>
+               <prodrecap ref="PositionalVar"/>
+               <prodrecap ref="PreviousItem"/>
+               <prodrecap ref="NextItem"/>
+            </scrap>
+
+            <p>Like a <code>for</code> clause, a <code>window</code> clause
+iterates over its <termref
+                  def="dt-binding-sequence"
+                  >binding
+sequence</termref> and generates a sequence of tuples. In the case of
+a <code>window</code> clause, each tuple represents a window. <termdef
+                  term="window" id="dt-window"
+                     >A <term>window</term> is a sequence of
+consecutive items drawn from the <termref
+                     def="dt-binding-sequence"
+               >binding sequence</termref>.</termdef> Each
+window is represented by at least one and at most nine bound
+variables. The variables have user-specified names, but their roles
+are as follows:</p>
+
+            <ulist>
+
+               <item>
+                  <p>
+                     <emph>Window-variable:</emph> Bound to the sequence of
+  items from the <termref
+                        def="dt-binding-sequence"
+                     >binding
+  sequence</termref> that comprise the window.</p>
+               </item>
+
+               <item>
+                  <p>
+                     <emph>Start-item:</emph> (Optional) Bound to the first item
+  in the window.</p>
+               </item>
+
+               <item>
+                  <p>
+                     <emph>Start-item-position:</emph> (Optional) Bound to the
+  ordinal position of the first window item in the <termref
+                        def="dt-binding-sequence"
+                        >binding
+  sequence</termref>. <emph>Start-item-position</emph> is a <termref
+                        def="dt-positional-variable"
+                        >positional variable</termref>; hence, its type
+  is <code>xs:integer</code>.
+                  </p>
+               </item>
+
+               <item>
+                  <p>
+                     <emph>Start-previous-item:</emph> (Optional) Bound to the
+  item in the <termref
+                        def="dt-binding-sequence"
+                     >binding
+  sequence</termref> that precedes the first item in the window (empty
+  sequence if none).</p>
+               </item>
+
+               <item>
+                  <p>
+                     <emph>Start-next-item:</emph> (Optional) Bound to the item
+  in the <termref
+                        def="dt-binding-sequence"
+                     >binding sequence</termref>
+  that follows the first item in the window (empty sequence if
+  none).</p>
+               </item>
+
+               <item>
+                  <p>
+                     <emph>End-item:</emph> (Optional) Bound to the last item in
+  the window.</p>
+               </item>
+
+               <item>
+                  <p>
+                     <emph>End-item-position:</emph> (Optional) Bound to the
+  ordinal position of the last window item in the <termref
+                        def="dt-binding-sequence"
+                        >binding
+  sequence</termref>. <emph>End-item-position</emph> is a <termref
+                        def="dt-positional-variable"
+                        >positional variable</termref>; hence, its type
+  is <code>xs:integer</code>.
+                  </p>
+               </item>
+
+               <item>
+                  <p>
+                     <emph>End-previous-item:</emph> (Optional) Bound to the
+  item in the <termref
+                        def="dt-binding-sequence"
+                     >binding
+  sequence</termref> that precedes the last item in the window (empty
+  sequence if none).</p>
+               </item>
+
+               <item>
+                  <p>
+                     <emph>End-next-item:</emph> (Optional) Bound to the item in
+  the <termref
+                        def="dt-binding-sequence"
+                     >binding sequence</termref>
+  that follows the last item in the window (empty sequence if
+  none).</p>
+               </item>
+
+            </ulist>
+
+            <p>All variables in a <code>window</code> clause must have distinct names;
+ otherwise a <termref
+                  def="dt-static-error">static error</termref> is raised <errorref class="ST"
+                  code="0103"/>.</p>
+
+            <p>The following is an example of a <code>window</code> clause that
+binds nine variables to the roles listed above. In this example, the
+variables are named <code>$w</code>, <code>$s</code>,
+<code>$spos</code>, <code>$sprev</code>, <code>$snext</code>,
+<code>$e</code>, <code>$epos</code>, <code>$eprev</code>, and
+<code>$enext</code> respectively. A <code>window</code> clause always
+binds the window variable, but typically binds only a subset of the
+other variables.</p>
+
+            <eg><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10)
+  start $s at $spos previous $sprev next $snext when true() 
+  end   $e at $epos previous $eprev next $enext when true()]]></eg>
+
+            <p>Windows are
+created by iterating over the items in the <termref
+                  def="dt-binding-sequence"
+                  >binding sequence</termref>, in order,
+identifying the start item and the end item of each window by
+evaluating the <nt
+                  def="WindowStartCondition">WindowStartCondition</nt> and the <nt
+                  def="WindowEndCondition"
+                  >WindowEndCondition</nt>. Each of these
+conditions is satisfied if the <termref
+                  def="dt-ebv"
+                  >effective boolean
+value</termref> of the expression following the <code>when</code>
+keyword is <code>true</code>.
+
+The start item of the window is an item that satisfies the <nt
+                  def="WindowStartCondition">WindowStartCondition</nt> (see <specref
+                  ref="id-tumbling-windows"/> and <specref ref="id-sliding-windows"
+                  /> for a more complete explanation.) The end item of the window is the first item in the <termref
+                  def="dt-binding-sequence"
+                  >binding sequence</termref>, beginning with the start item, that satisfies the <nt
+                  def="WindowEndCondition">WindowEndCondition</nt> (again, see <specref
+                  ref="id-tumbling-windows"/> and <specref ref="id-sliding-windows"
+                  /> for more details.) Each window contains its start item, its end
+item, and all items that occur between them in the <termref
+                  def="dt-binding-sequence"
+                  >binding sequence</termref>.
+If the end item is the start item, then the window contains only one
+item.  If a start item is identified, but no following item in the <termref
+                  def="dt-binding-sequence">binding sequence</termref> satisfies the <nt
+                  def="WindowEndCondition"
+                  >WindowEndCondition</nt>, then the <code>only</code> keyword determines whether a window is
+generated: if <code>only end</code> is specified, then no window is
+generated; otherwise, the end item is set to the last item in the
+<termref
+                  def="dt-binding-sequence"
+               >binding sequence</termref> and a window is generated.</p>
+            <p>In the above example, the <nt def="WindowStartCondition"
+                  >WindowStartCondition</nt> and <nt def="WindowEndCondition"
+                  >WindowEndCondition</nt> are both <code>true</code>,
+which causes each item in the <termref
+                  def="dt-binding-sequence"
+                  >binding sequence</termref> to be in a separate window. 
+Typically, the <nt
+                  def="WindowStartCondition">WindowStartCondition</nt> and <nt
+                  def="WindowEndCondition"
+                  >WindowEndCondition</nt> are expressed in terms of bound variables. For example, the following <nt
+                  def="WindowStartCondition"
+                  >WindowStartCondition</nt> might be used to start a new window for every item in the <termref
+                  def="dt-binding-sequence"
+               >binding sequence</termref> that is larger than both the previous item and the following item:</p>
+            <eg>start $s previous $sprev next $snext
+ when $s &gt; $sprev and $s &gt; $snext</eg>
+            <p>The scoping rules for the variables bound by a <code>window</code> clause are as follows:</p>
+            <ulist>
+
+
+
+               <item>
+                  <p>In the <code>when</code>-expression of the <nt def="WindowStartCondition"
+                        >WindowStartCondition</nt>, the following variables (identified here by their roles) are in scope (if bound): <emph>start-item, start-item-position, start-previous-item, start-next-item.</emph>
+                  </p>
+               </item>
+
+
+
+               <item>
+                  <p>In the <code>when</code>-expression of the <nt def="WindowEndCondition"
+                        >WindowEndCondition</nt>, the following variables (identified here by their roles) are in scope (if bound): <emph>start-item, start-item-position, start-previous-item, start-next-item, end-item, end-item-position, end-previous-item, end-next-item.</emph>
+                  </p>
+               </item>
+
+
+
+               <item>
+                  <p>In the clauses of the FLWOR expression that follow the <code>window</code> clause, all nine of the variables bound by the <code>window</code> clause (including <emph>window-variable</emph>) are in scope (if bound).</p>
+               </item>
+            </ulist>
+
+            <p>The <code>when</code> keyword of a condition and the associated expression is optional.
+               If omitted, the expression defaults to <code>true()</code>.
+               If the complete <code>start</code> clause is omitted, no variables are bound and
+               the expression also defaults to <code>true()</code>.
+               The <code>end</code> clause can be omitted only within a <nt
+                  def="TumblingWindowClause">TumblingWindowClause</nt>.</p>
+
+            <p>In a <code>window</code> clause, the keyword <code>tumbling</code> or <code>sliding</code> determines the way in which the starting item of each window is identified, as explained in the following sections.</p>
+            <div4 id="id-tumbling-windows">
+               <head>Tumbling Windows</head>
+
+
+
+               <p>If the window type is <code>tumbling</code>, then windows
+never overlap. The search for the start of the first window begins at the beginning of the <termref
+                     def="dt-binding-sequence"
+                     >binding sequence</termref>. After each window is generated, the search
+for the start of the next window begins with the item in the <termref
+                     def="dt-binding-sequence"
+                     >binding sequence</termref> that occurs after the ending item of the last generated
+window. Thus, no item that occurs in one window can occur in another
+window drawn from the same <termref
+                     def="dt-binding-sequence"
+                     >binding sequence</termref> (unless the sequence contains the same item more than once). 
+In a tumbling window clause,
+the <code>end</code> clause is optional; if it is omitted, the
+<code>start</code> clause is applied to identify all potential
+starting items in the <termref
+                     def="dt-binding-sequence"
+                     >binding sequence</termref>, and a window is constructed
+for each starting item, including all items from that starting item up
+to the item before the next window’s starting item, or the end of the
+<termref
+                     def="dt-binding-sequence"
+                  >binding sequence</termref>, whichever comes first.</p>
+               <p>The following examples illustrate the use of tumbling windows.</p>
+               <ulist>
+
+
+
+                  <item>
+                     <p>Show non-overlapping windows of three items.</p>
+                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
+  start at $s
+  only end at $e when $e - $s eq 2
+return <window>{ $w }</window>]]></eg>
+
+                     <p>Result:</p>
+                     <eg><![CDATA[<window>2 4 6</window>
+<window>8 10 12</window>]]></eg>
+                  </item>
+
+
+
+                  <item>
+                     <p>Show averages of non-overlapping three-item windows.</p>
+                     <eg role="parse-test"><![CDATA[
+for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
+  start at $s
+  only end at $e when $e - $s eq 2
+return avg($w)]]></eg>
+
+                     <p>Result:</p>
+                     <eg><![CDATA[4 10]]></eg>
+                  </item>
+
+
+
+                  <item>
+                     <p>Show first and last items in each window of three items.</p>
+                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
+  start $first at $s
+  only end $last at $e when $e - $s eq 2
+return <window>{ $first, $last }</window>]]></eg>
+
+                     <p>Result:</p>
+                     <eg><![CDATA[<window>2 6</window>
+<window>8 12</window>]]></eg>
+                  </item>
+
+
+
+                  <item>
+                     <p>Show non-overlapping windows of up to three items (illustrates <code>end</code> clause without the <code>only</code> keyword).</p>
+                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
+  start at $s
+  end at $e when $e - $s eq 2
+return <window>{ $w }</window>]]></eg>
+
+                     <p>Result:</p>
+                     <eg><![CDATA[<window>2 4 6</window>
+<window>8 10 12</window>
+<window>14</window>]]></eg>
+                  </item>
+
+
+
+                  <item>
+                     <p>Show non-overlapping windows of up to three items (illustrates use of <code>start</code> without explicit <code>end</code>).</p>
+                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
+  start at $s when $s mod 3 = 1
+return <window>{ $w }</window>]]></eg>
+
+                     <p>Result:</p>
+                     <eg><![CDATA[<window>2 4 6</window>
+<window>8 10 12</window>
+<window>14</window>]]></eg>
+                  </item>
+
+
+
+                  <item>
+                     <p>Show non-overlapping sequences starting with a number divisible by 3.</p>
+
+                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
+  start $first when $first mod 3 = 2
+return <window>{ $w }</window>]]></eg>
+
+                     <p>Result:</p>
+                     <eg><![CDATA[<window>2 4 6</window>
+<window>8 10 12</window>
+<window>14</window>]]></eg>
+                  </item>
+
+                  <item>
+                     <p>Show non-overlapping sequences ending with a number divisible by 3.</p>
+
+                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
+  end $last when $last mod 3 = 0
+return <window>{ $w }</window>]]></eg>
+
+                     <p>Result (identical to the result of the previous query):</p>
+                     <eg><![CDATA[<window>2 4 6</window>
+<window>8 10 12</window>
+<window>14</window>]]></eg>
+                  </item>
+
+               </ulist>
+
+
+
+
+
+
+
+
+
+
+            </div4>
+            <div4 id="id-sliding-windows">
+               <head>Sliding Windows</head>
+
+               <p>If the window type is <code>sliding window</code>, then windows may
+overlap. Every item in the <termref
+                     def="dt-binding-sequence">binding sequence</termref> that satisfies the <nt
+                     def="WindowStartCondition"
+                     >WindowStartCondition</nt> is the starting item of a new window. Thus, a given
+item may be found in multiple windows drawn from the same <termref
+                     def="dt-binding-sequence">binding sequence</termref>.</p>
+               <p>The following examples illustrate the use of sliding windows.</p>
+
+
+               <ulist>
+
+
+
+                  <item>
+                     <p>Show windows of three items.</p>
+                     <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
+  start at $s
+  only end at $e when $e - $s eq 2
+return <window>{ $w }</window>]]></eg>
+
+                     <p>Result:</p>
+
+                     <eg><![CDATA[<window>2 4 6</window>
+<window>4 6 8</window>
+<window>6 8 10</window>
+<window>8 10 12</window>
+<window>10 12 14</window>]]></eg>
+                  </item>
+
+
+
+                  <item>
+                     <p>Show moving averages of three items.</p>
+
+                     <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
+  start at $s
+  only end at $e when $e - $s eq 2
+return avg($w)]]></eg>
+
+                     <p>Result:</p>
+                     <eg><![CDATA[4 6 8 10 12]]></eg>
+                  </item>
+
+
+
+                  <item>
+                     <p>Show overlapping windows of up to three items (illustrates <code>end</code> clause without the <code>only</code> keyword).</p>
+
+                     <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
+  start at $s
+  end at $e when $e - $s eq 2
+return <window>{ $w }</window>]]></eg>
+
+                     <p>Result:</p>
+                     <eg><![CDATA[<window>2 4 6</window>
+<window>4 6 8</window>
+<window>6 8 10</window>
+<window>8 10 12</window>
+<window>10 12 14</window>
+<window>12 14</window>
+<window>14</window>]]></eg>
+                  </item>
+               </ulist>
+
+
+
+
+
+            </div4>
+            <div4 id="id-effects-of-window-clauses">
+               <head>Effects of Window Clauses on the Tuple Stream</head>
+               <p>The effects of a <code>window</code> clause on the tuple stream are similar to the effects of a <code>for</code> clause. As described in <specref
+                     ref="id-windows"
+                  />, a <code>window</code> clause generates zero or more windows, each of which is represented by at least one and at most nine bound variables.</p>
+               <p>If the <code>window</code> clause is the initial clause in a FLWOR expression, the bound variables that describe each window become an output tuple. These tuples form the initial tuple stream that serves as input to the next clause of the FLWOR expression. If <termref
+                     def="dt-ordering-mode"
+                     >ordering mode</termref> is <code>ordered</code>, the order of tuples in the tuple stream is the
+order in which their start items appear in the <termref
+                     def="dt-binding-sequence"
+                     >binding sequence</termref>; otherwise the order of the tuple stream is <termref
+                     def="dt-implementation-dependent"
+                  >implementation-dependent</termref>. The cardinality of the tuple stream is equal to the number of windows.</p>
+               <p>If a <code>window</code> clause is an intermediate clause in a FLWOR expression, each input tuple generates zero or more output tuples, each consisting of  the original bound variables of the input tuple plus the new bound variables that represent one of the generated windows. For each tuple <emph>T</emph> in the input tuple stream, the output tuple stream will contain <emph>N<sub>T</sub>
+                  </emph> tuples, where <emph>N<sub>T</sub>
+                  </emph> is the number of windows generated by the <code>window</code> clause, given the bindings in the input tuple <emph>T</emph>. Input tuples for which no windows are generated are not represented in the output tuple stream. If <termref
+                     def="dt-ordering-mode"
+                     >ordering mode</termref> is <code>ordered</code>, the order of tuples in the output stream is determined primarily by the order of the input tuples from which they were derived, and secondarily by the order in which their start items appear in the <termref
+                     def="dt-binding-sequence">binding sequence</termref>. If <termref
+                     def="dt-ordering-mode"
+                     >ordering mode</termref> is <code>unordered</code>, the order of tuples in the output stream is <termref
+                     def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+               <p>The following example illustrates a <code>window</code> clause that is the initial clause in a FLWOR expression. The example is based on input data that consists of a sequence of closing stock prices for a specific company. For this example we assume the following input data (assume that the <code>price</code> elements have a validated type of <code>xs:decimal</code>):</p>
+               <eg><![CDATA[<stock>
+  <closing> <date>2008-01-01</date> <price>105</price> </closing>
+  <closing> <date>2008-01-02</date> <price>101</price> </closing>
+  <closing> <date>2008-01-03</date> <price>102</price> </closing>
+  <closing> <date>2008-01-04</date> <price>103</price> </closing>
+  <closing> <date>2008-01-05</date> <price>102</price> </closing>
+  <closing> <date>2008-01-06</date> <price>104</price> </closing>
+</stock>]]></eg>
+               <p>A user wishes to find “run-ups,” which are defined as sequences of dates that begin with a “low” and end with a “high” price (that is, the stock price begins to rise on the first day of the run-up, and continues to rise or remain even through the last day of the run-up.) The following query uses a tumbling window to find run-ups in the input data:</p>
+               <eg role="parse-test">for tumbling window $w in //closing
+   start $first next $second when $first/price &lt; $second/price
+   end $last next $beyond when $last/price &gt; $beyond/price
+return
+  &lt;run-up&gt;
+    &lt;start-date&gt;{ data($first/date) }&lt;/start-date&gt;
+    &lt;start-price&gt;{ data($first/price) }&lt;/start-price&gt;
+    &lt;end-date&gt;{ data($last/date) }&lt;/end-date&gt;
+    &lt;end-price&gt;{ data($last/price) }&lt;/end-price&gt;
+  &lt;/run-up&gt;</eg>
+               <p>For our sample input data, this <code>tumbling window</code> clause generates a tuple stream consisting of two tuples, each representing a window and containing five bound variables named <code>$w</code>, <code>$first</code>, <code>$second</code>, <code>$last</code>, and <code>$beyond</code>. The <code>return</code> clause is evaluated for each of these tuples, generating the following query result:</p>
+               <eg>&lt;run-up&gt;
+  &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
+  &lt;start-price&gt;101&lt;/start-price&gt;
+  &lt;end-date&gt;2008-01-04&lt;/end-date&gt;
+  &lt;end-price&gt;103&lt;/end-price&gt;
+&lt;/run-up&gt;
+&lt;run-up&gt;
+  &lt;start-date&gt;2008-01-05&lt;/start-date&gt;
+  &lt;start-price&gt;102&lt;/start-price&gt;
+  &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
+  &lt;end-price&gt;104&lt;/end-price&gt;
+&lt;/run-up&gt;</eg>
+               <p>The following example illustrates a <code>window</code> clause that is an intermediate clause in a FLWOR expression. In this example, the input data contains closing stock prices for several different companies, each identified by a three-letter symbol. We assume the following input data (again assuming that the type of the <code>price</code> element is <code>xs:decimal</code>):</p>
+               <eg><![CDATA[<stocks>
+  <closing> <symbol>ABC</symbol> <date>2008-01-01</date> <price>105</price> </closing>
+  <closing> <symbol>DEF</symbol> <date>2008-01-01</date> <price>057</price> </closing>
+  <closing> <symbol>ABC</symbol> <date>2008-01-02</date> <price>101</price> </closing>
+  <closing> <symbol>DEF</symbol> <date>2008-01-02</date> <price>054</price> </closing>
+  <closing> <symbol>ABC</symbol> <date>2008-01-03</date> <price>102</price> </closing>
+  <closing> <symbol>DEF</symbol> <date>2008-01-03</date> <price>056</price> </closing>
+  <closing> <symbol>ABC</symbol> <date>2008-01-04</date> <price>103</price> </closing>
+  <closing> <symbol>DEF</symbol> <date>2008-01-04</date> <price>052</price> </closing>
+  <closing> <symbol>ABC</symbol> <date>2008-01-05</date> <price>101</price> </closing>
+  <closing> <symbol>DEF</symbol> <date>2008-01-05</date> <price>055</price> </closing>
+  <closing> <symbol>ABC</symbol> <date>2008-01-06</date> <price>104</price> </closing>
+  <closing> <symbol>DEF</symbol> <date>2008-01-06</date> <price>059</price> </closing>
+</stocks>]]></eg>
+               <p>As in the previous example, we want to find "run-ups," which are defined as sequences of dates that begin with a "low" and end with a "high" price for a specific company. In this example, however, the input data consists of stock prices for multiple companies. Therefore it is necessary to isolate the stock prices of each company before forming windows. This can be accomplished by an initial <code>for</code> and <code>let</code> clause, followed by a <code>window</code> clause, as follows:</p>
+               <eg role="parse-test">for $symbol in distinct-values(//symbol)
+let $closings := //closing[symbol = $symbol]
+for tumbling window $w in $closings
+  start $first next $second when $first/price &lt; $second/price
+  end $last next $beyond when $last/price &gt; $beyond/price
+return
+  &lt;run-up symbol="{ $symbol }"&gt;
+    &lt;start-date&gt;{ data($first/date) }&lt;/start-date&gt;
+    &lt;start-price&gt;{ data($first/price) }&lt;/start-price&gt;
+    &lt;end-date&gt;{ data($last/date) }&lt;/end-date&gt;
+    &lt;end-price&gt;{ data($last/price) }&lt;/end-price&gt;
+  &lt;/run-up&gt;</eg>
+               <note>
+                  <p>In the above example, the <code>for</code> and <code>let</code> clauses could be rewritten as follows:</p>
+                  <eg><![CDATA[for $closings in //closing
+let $symbol := $closings/symbol
+group by $symbol]]></eg>
+                  <p>The <code>group by</code> clause is described in <specref ref="id-group-by"
+                     />.</p>
+               </note>
+               <p>The <code>for</code> and <code>let</code> clauses in this query generate an initial tuple stream consisting of two tuples. In the first tuple, <code>$symbol</code> is bound to "ABC" and <code>$closings</code> is bound to the sequence of <code>closing</code> elements for company ABC. In the second tuple, <code>$symbol</code> is bound to "DEF" and <code>$closings</code> is bound to the sequence of <code>closing</code> elements for company DEF.</p>
+               <p>The <code>window</code> clause operates on this initial tuple stream, generating two windows for the first tuple and two windows for the second tuple. The result is a tuple stream consisting of four tuples, each with the following bound variables: <code>$symbol</code>, <code>$closings</code>, <code>$w</code>, <code>$first</code>, <code>$second</code>, <code>$last</code>, and <code>$beyond</code>. The <code>return</code> clause is then evaluated for each of these tuples, generating the following query result:</p>
+               <eg>&lt;run-up symbol="ABC"&gt;
+   &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
+   &lt;start-price&gt;101&lt;/start-price&gt;
+   &lt;end-date&gt;2008-01-04&lt;/end-date&gt;
+   &lt;end-price&gt;103&lt;/end-price&gt;
+&lt;/run-up&gt;
+&lt;run-up symbol="ABC"&gt;
+   &lt;start-date&gt;2008-01-05&lt;/start-date&gt;
+   &lt;start-price&gt;101&lt;/start-price&gt;
+   &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
+   &lt;end-price&gt;104&lt;/end-price&gt;
+&lt;/run-up&gt;
+&lt;run-up symbol="DEF"&gt;
+   &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
+   &lt;start-price&gt;054&lt;/start-price&gt;
+   &lt;end-date&gt;2008-01-03&lt;/end-date&gt;
+   &lt;end-price&gt;056&lt;/end-price&gt;
+&lt;/run-up&gt;
+&lt;run-up symbol="DEF"&gt;
+   &lt;start-date&gt;2008-01-04&lt;/start-date&gt;
+   &lt;start-price&gt;052&lt;/start-price&gt;
+   &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
+   &lt;end-price&gt;059&lt;/end-price&gt;
+&lt;/run-up&gt;</eg>
+            </div4>
+         </div3>
+
+
+         
+         
+         <div3 id="id-where" role="xquery">
+            <head>Where Clause</head>
+            <scrap>
+               <head/>
+               <prodrecap id="WhereClause" ref="WhereClause"/>
+            </scrap>
+            <p>A <code>where</code> clause serves as a filter for the tuples in its input tuple stream. The expression in the <code>where</code> clause, called the <term>where-expression</term>, is evaluated once for
+               each of these tuples. If the <termref
+                  def="dt-ebv"
+                  >effective boolean value</termref> of the
+               where-expression is <code>true</code>, the tuple is retained in the output tuple stream; otherwise the tuple is discarded.</p>
+            <p>Examples:</p>
+            <ulist>
+               
+               
+               
+               <item>
+                  <p>This example illustrates the effect of a <code>where</code> clause on a tuple stream:</p>
+                  <p>Input tuple stream:</p>
+                  <eg><![CDATA[($a = 5, $b = 11)
+($a = 91, $b = 42)
+($a = 17, $b = 30)
+($a = 85, $b = 63)]]></eg>
+                  <p>
+                     <code>where</code> clause:</p>
+                  <eg>where $a &gt; $b</eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($a = 91, $b = 42)
+($a = 85, $b = 63)]]></eg>
+               </item>
+               
+               
+               
+               <item>
+                  <p>The following query illustrates how a <code>where</code> clause might be used with a <termref
+                     def="dt-positional-variable"
+                     >positional variable</termref> to perform sampling on an input sequence. The query returns one value out of each one hundred input values.</p>
+                  <eg role="parse-test">
+                     <phrase role="parse-test">for $x at $i in $input
+where $i mod 100 = 0
+return $x</phrase>
+                  </eg>
+               </item>
+            </ulist>
+         </div3>
+         
+         <div3 id="id-while" diff="add" at="issue187" role="xquery">
+            <head>While Clause</head>
+            
+            <changes>
+               <change issue="187" PR="943" date="2024-02-06">
+                  A FLWOR expression may now include a <code>while</code> clause,
+               which causes early exit from the iteration when a condition is encountered.
+               </change>
+            </changes>
+            
+            <scrap>
+               <head/>
+               <prodrecap id="WhileClause" ref="WhileClause"/>
+            </scrap>
+            
+            <p>A <code>while</code> clause serves as a filter for the tuples 
+               in its input tuple stream. The expression in the while clause, 
+               called the <code>while-expression</code>, is evaluated once for each of these tuples. 
+               If the <termref def="dt-ebv">effective boolean value</termref> 
+               of the <code>while-expression</code> is true, the 
+               tuple is retained in the output tuple stream; otherwise the tuple 
+               and all subsequent tuples in the stream are discarded.</p>
+            
+            <p>Examples:</p>
+            
+            <ulist>
+               <item>
+                  <p>This example illustrates the effect of a <code>while</code> clause on a tuple stream.</p>
+                  <p>Input tuple stream:</p>
+                  <eg><![CDATA[($a = 13, $b = 11)
+($a = 91, $b = 42)
+($a = 17, $b = 30)
+($a = 85, $b = 63)]]></eg><p>while clause:</p>
+                  <eg>while $a > $b</eg>
+                  <p> Output tuple stream:</p>
+                  <eg><![CDATA[($a = 13, $b = 11)
+($a = 91, $b = 42)]]></eg>
+               </item>
+               <item>
+                  <p>The following query illustrates how a <code>while</code> clause might be used to 
+                     extract all items in an input sequence before the first one that 
+                     fails to satisfy some condition. In this case it selects the 
+                     leading <code>para</code> elements in the input sequence, stopping 
+                     before the first element that is not a <code>para</code> element.
+                  </p>
+                  <eg><![CDATA[for $x in $section/*
+while $x[self::para]
+return $x]]></eg>
+               </item>
+               <item>
+                  <p>The following query illustrates how a <code>while</code> clause might be used to 
+                     limit the number of items returned in the query result.
+                  </p>
+                  <eg><![CDATA[for $x in $section/para
+where contains($x, 'the')
+count $total
+while $total le 10
+return $x]]></eg>
+                  <p>In this example a <code>where</code> clause would have exactly the same effect,
+                  but might require a smarter optimizer to deliver the same performance.</p>
+               </item>
+            </ulist>
+            
+            <note>
+               <p>Although the semantics are described in terms of discarding 
+                  all the tuples following the first one that fails to match 
+                  the condition, a practical implementation is likely to avoid 
+                  evaluating those tuples, thus giving an "early exit" from 
+                  the iteration performed by the FLWOR expression.
+               </p>
+            </note>
+            
+            <note><p>The expression <code>for $i in $input while $i le 3</code> differs
+               from the expression <code>subsequence-where($input, to := fn {. gt 3 })</code> in that
+               the <code>while</code> expression drops the first item that is greater than 3,
+               while the <code>subsequence-where</code> expression retains it.</p></note>
+            
+            <note><p>The effect of the <code>while</code> clause is unpredictable in cases
+            where the ordering of the tuple stream is unpredictable. This can happen, for example,
+            when <termref def="dt-ordering-mode"/> is <code>unordered</code>, or when iterating
+            over the entries in a map.</p></note>
+            
+            <ednote><edtext>Add to changes appendix.</edtext></ednote>
+            
+         </div3>
+
+         <div3 id="id-count" role="xquery">
+            <head>Count Clause</head>
+            <scrap>
+               <head/>
+               <prodrecap id="CountClause" ref="CountClause"/>
+            </scrap>
+
+            <p>The purpose of a <code>count</code> clause is to enhance the tuple
+stream with a new variable that is bound, in each tuple, to the
+ordinal position of that tuple in the tuple stream. The name of the
+new variable is specified in the <code>count</code> clause. Its type
+            is implicitly <code>xs:integer</code>.</p>
+
+            <p>The output tuple stream of a <code>count</code> clause is the same
+as its input tuple stream, with each tuple enhanced by one additional
+variable that is bound to the ordinal position of that tuple in the
+tuple stream. However, if the name of the new variable is the same as
+the name of an existing variable in the input tuple stream, the new
+variable occludes (replaces) the existing variable of the same name,
+and the number of bound variables in each tuple is unchanged.</p>
+
+            <p>The following examples illustrate uses of the <code>count</code> clause:</p>
+
+
+            <ulist>
+
+
+
+               <item>
+                  <p>This example illustrates the effect of a <code>count</code> clause on an input tuple stream:</p>
+                  <p>Input tuple stream:</p>
+                  <eg><![CDATA[($name = "Bob", $age = 21)
+($name = "Carol", $age = 19)
+($name = "Ted", $age = 20)
+($name = "Alice", $age = 22)]]></eg>
+                  <p>
+                     <code>count</code> clause:</p>
+                  <eg><![CDATA[count $counter]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($name = "Bob", $age = 21, $counter = 1)
+($name = "Carol", $age = 19, $counter = 2)
+($name = "Ted", $age = 20, $counter = 3)
+($name = "Alice", $age = 22, $counter = 4)]]></eg>
+               </item>
+
+
+
+
+
+               <item>
+                  <p>This example illustrates how a counter might be used to filter the result of a query. The query ranks products in order by decreasing sales, and returns the three products with the highest sales. Assume that the variable <code>$products</code> is bound to a sequence of <code>product</code> elements, each of which has <code>name</code> and <code>sales</code> child-elements.</p>
+                  <eg role="parse-test">for $p in $products
+order by $p/sales descending
+count $rank
+while $rank &lt;= 3
+return &lt;product rank="{ $rank }"&gt;{ $p/name, $p/sales }&lt;/product&gt;</eg>
+                  <p>The result of this query has the following structure:</p>
+                  <eg>&lt;product rank="1"&gt;
+  &lt;name&gt;Toaster&lt;/name&gt;
+  &lt;sales&gt;968&lt;/sales&gt;
+&lt;/product&gt;
+&lt;product rank="2"&gt;
+  &lt;name&gt;Blender&lt;/name&gt;
+  &lt;sales&gt;520&lt;/sales&gt;
+&lt;/product&gt;
+&lt;product rank="3"&gt;
+  &lt;name&gt;Can Opener&lt;/name&gt;
+  &lt;sales&gt;475&lt;/sales&gt;
+&lt;/product&gt;</eg>
+               </item>
+            </ulist>
+         </div3>
+
+         <div3 id="id-group-by" role="xquery">
+            <head>Group By Clause</head>
+            <scrap>
+               <head/>
+               <prodrecap ref="GroupByClause"/>
+               <prodrecap ref="GroupingSpecList"/>
+               <prodrecap ref="GroupingSpec"/>
+               <prodrecap ref="GroupingVariable"/>
+            </scrap>
+
+
+            <p>A <code>group by</code> clause generates an output tuple stream in which each tuple represents a group of tuples from the input tuple stream
+that have equivalent grouping keys. 
+We will refer to the tuples in the input tuple stream as  <term>pre-grouping tuples</term>, and the tuples in the output tuple stream as <term>post-grouping tuples</term>.</p>
+
+            <p>The <code>group by</code> clause assigns each pre-grouping tuple to a group, and
+generates one post-grouping tuple for each group. 
+
+In the post-grouping tuple for a group, each grouping key is represented by a variable that was specified in a <nt
+                  def="GroupingSpec"
+               >GroupingSpec</nt>, and every variable that appears in the pre-grouping tuples that were assigned to that group is represented by a variable of the same name, bound to a sequence of all values bound to the variable in any of these pre-grouping tuples.
+
+Subsequent clauses in the FLWOR expression see only the variable
+bindings in the post-grouping tuples; they no longer have access to
+the variable bindings in the pre-grouping tuples. 
+The number of post-grouping tuples is less than or equal to
+the number of pre-grouping tuples.</p>
+
+            <p>A <code>group by</code> clause contains one or more <nt def="GroupingSpec"
+                  >grouping specifications</nt>, as shown in the grammar. <termdef
+                  id="dt-grouping-variable" term="grouping variable"
+                     >Each grouping specification specifies one <nt def="GroupingVariable"
+                     >grouping variable</nt>, which refers to variable bindings in the pre-grouping tuples. The values of the grouping variables are used to assign pre-grouping tuples to groups.</termdef> Each grouping specification may optionally provide an expression to which its grouping variable is bound.  If no expression is provided, the grouping variable name must be equal (by the <code>eq</code> operator on <termref
+                  def="dt-expanded-qname"
+                  >expanded QNames</termref>) to the name of a variable in the input tuple stream, and it refers to that variable; otherwise a <termref
+                  def="dt-static-error">static error</termref> is raised <errorref class="ST"
+                  code="0094"
+                  />. For each grouping specification that contains a binding expression, a <code>let</code> binding is created in the pre-grouping tuples, and the grouping variable refers to that <code>let</code> binding. For example, the clause:</p>
+
+            <eg><![CDATA[group by $g1, $g2 := $expr1, $g3 := $expr2 collation "Spanish"]]></eg>
+
+            <p>is semantically equivalent to the following sequence of clauses:</p>
+
+            <eg><![CDATA[let $g2 := $expr1
+let $g3 := $expr2
+group by $g1, $g2, $g3 collation "Spanish"]]></eg>
+
+            <p>The process of group formation proceeds as follows:
+
+<olist> <item>
+                     <p>
+                        <termdef term="grouping key" id="dt-grouping-key"
+                              >The
+  atomized value of a <termref def="dt-grouping-variable"
+                              >grouping
+  variable</termref> is called a <term>grouping key</term>.</termdef>
+  For each pre-grouping tuple, the <termref
+                           def="dt-grouping-key">grouping keys</termref> are created by
+  <termref
+                           def="dt-atomization">atomizing</termref> the values of the
+  <termref
+                           def="dt-grouping-variable"
+                           >grouping variables</termref> (in
+  the post-grouping tuples, each grouping variable is set to the value
+  of the corresponding grouping key, as discussed below).
+
+  If the value of any <termref
+                           def="dt-grouping-variable"
+                           >grouping variable</termref> consists of
+  more than one item, a <termref
+                           def="dt-type-error">type
+  error</termref> is raised <errorref class="TY"
+                           code="0004"
+                           />. If a type declaration is present
+  and the resulting atomized value is not an instance of the specified
+  type, a <termref
+                           def="dt-type-error">type error</termref> is raised
+  <errorref class="TY"
+                           code="0004"/>.</p>
+                  </item> <item>
+                     <p>The input tuple stream is partitioned into groups of tuples
+  whose grouping keys are <termref
+                           def="dt-equivalent-grouping-keys">equivalent</termref>. <termdef
+                           id="dt-equivalent-grouping-keys" term="equivalent grouping keys"
+                              >Two
+  tuples <var>T1</var> and <var>T2</var> have <term>equivalent
+  grouping keys</term> if and only if, for each grouping variable
+  <var>GV</var>, the atomized value of <var>GV</var> in <var>T1</var>
+  is deep-equal to the atomized value of <var>GV</var> in
+  <var>T2</var>, as defined by applying the function
+  <function>fn:deep-equal</function> using the appropriate
+  collation.</termdef></p>
+                     
+                     <note diff="add" at="2023-12-05"><p>The <function>fn:deep-equal</function> has been changed
+                     in &language; so that it is now transitive; the problem that existed
+                     in earlier versions when comparing numeric values of different
+                     types has thereby been resolved.</p></note>
+
+  <note>
+                        <p>The atomized grouping key will always be either an empty
+     sequence or a single atomic value. Defining equivalence by
+     reference to the <function>fn:deep-equal</function> function
+     ensures that the empty sequence is equivalent only to the empty
+     sequence, that <code>NaN</code> is equivalent to
+     <code>NaN</code>, that untypedAtomic values are compared as
+     strings, and that values for which the <code>eq</code> operator
+     is not defined are considered
+     non-equivalent.</p>
+                     </note> </item> <item>
+                     <p>The appropriate collation for comparing two grouping keys is the collation
+   specified in the pertinent <nt
+                           def="GroupingSpec"
+                           >GroupingSpec</nt> if present, or the default collation
+                        from the <phrase diff="chg" at="2023-05-19">dynamic</phrase> context otherwise. 
+                        If the collation is specified by a relative
+   URI, that relative URI is  <termref
+                           def="dt-resolve-relative-uri"
+                           >resolved to
+   an absolute URI</termref> using the <termref
+                           def="dt-static-base-uri"
+                           >Static Base URI</termref>.
+   If the specified collation is not found in statically known
+   collations, a static error is raised  <errorref
+                           class="ST" code="0076"/>.</p>
+                  </item> </olist>
+            </p>
+
+
+
+            <p>Each group of tuples produced by the above process results in one
+post-grouping tuple. The pre-grouping tuples from which the group is
+derived have <emph>equivalent</emph>
+               <termref def="dt-grouping-key"
+                  >grouping keys</termref>, but these keys are not
+necessarily identical (for example, the strings <code>"Frog"</code> and <code>"frog"</code>
+might be <emph>equivalent</emph> according to the collation in use.)
+
+In the post-grouping tuple, each <termref
+                  def="dt-grouping-variable"
+               >grouping variable</termref> is bound to the
+value of the corresponding grouping key. 
+</p>
+
+            <p>In the post-grouping tuple generated for a given group, each
+non-grouping variable is bound to a sequence containing the
+concatenated values of that variable in all the pre-grouping tuples
+that were assigned to that group. If <termref
+                  def="dt-ordering-mode"
+                  >ordering mode</termref> is
+<code>ordered</code>, the values derived from individual tuples are
+concatenated in a way that preserves the order of the pre-grouping
+tuple stream; otherwise the ordering of these values is <termref
+                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+
+
+            <note>
+               <p>This behavior may be surprising to SQL programmers, since SQL reduces
+the equivalent of a non-grouping variable to one representative
+value. Consider the following query:</p>
+
+               <eg role="parse-test"><![CDATA[let $x := 64000
+for $c in //customer
+where $c/salary > $x
+group by $d := $c/department
+return <department name="{ $d }">
+  Number of employees earning more than ${ $x } is { count($c) }
+</department>]]></eg>
+
+               <p>If there are three qualifying customers in the sales department this
+evaluates to:</p>
+
+               <eg><![CDATA[
+<department name="sales">
+  Number of employees earning more than $64000 64000 64000 is 3
+</department>]]></eg>
+
+               <p>In XQuery, each group is a sequence of items that match the group
+by criteria&mdash;in a tree-structured language like XQuery, this is
+convenient, because further structures can be built based on the items
+in this sequence. Because there are three items in the group,
+<code>$x</code> evaluates to a sequence of three items. To reduce this
+to one item, use <code>fn:distinct-values()</code>:</p>
+
+               <eg role="parse-test"><![CDATA[
+let $x := 64000
+for $c in //customer
+let $d := $c/department
+where $c/salary > $x
+group by $d
+return <department name="{ $d }">
+  Number of employees earning more than ${ distinct-values($x) } is { count($c) }
+</department>]]></eg>
+            </note>
+
+            <note>
+               <p>In general, the <termref def="dt-static-type"
+                     >static
+type</termref> of a variable in a post-grouping tuple is different
+from the <termref
+                     def="dt-static-type"
+                  >static type</termref> of the
+variable with the same name in the pre-grouping
+tuples.</p>
+            </note>
+            <p>The order in which tuples appear in the
+post-grouping tuple stream is <termref
+                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+            <note>
+               <p>An
+<code>order by</code> clause can be used to impose a value-based
+ordering on the post-grouping tuple stream. Similarly, if it is
+desired to impose a value-based ordering within a group (i.e., on the
+sequence of items bound to a non-grouping variable), this can be
+accomplished by a nested FLWOR expression that iterates over these
+items and applies an <code>order by</code> clause. In some cases, a
+value-based ordering within groups can be accomplished by applying an
+<code>order by</code> clause on a non-grouping variable before
+applying the <code>group by</code> clause.</p>
+            </note>
+            <p>A <code>group
+by</code> clause rebinds all the variables in the input tuple
+stream. The scopes of these variables are not affected by the
+<code>group by</code> clause, but in post-grouping tuples the values
+of the variables represent group properties rather than properties of
+individual pre-grouping tuples.</p>
+
+            <p>Examples:</p>
+            <ulist>
+               <item>
+                  <p>This example illustrates the effect of a <code>group by</code> clause on a tuple stream.</p>
+
+                  <p>Input tuple stream:</p>
+
+                  <eg>($storeno = &lt;storeno&gt;S101&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P78395&lt;/itemno&gt;)
+($storeno = &lt;storeno&gt;S102&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P94738&lt;/itemno&gt;)
+($storeno = &lt;storeno&gt;S101&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P41653&lt;/itemno&gt;)
+($storeno = &lt;storeno&gt;S102&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P70421&lt;/itemno&gt;)
+</eg>
+
+                  <p>
+                     <code>group by</code> clause:</p>
+
+                  <eg><![CDATA[group by $storeno]]></eg>
+
+                  <p>Output tuple stream:</p>
+
+                  <eg>($storeno = S101, $itemno = (&lt;itemno&gt;P78395&lt;/itemno&gt;, &lt;itemno&gt;P41653&lt;/itemno&gt;))
+($storeno = S102, $itemno = (&lt;itemno&gt;P94738&lt;/itemno&gt;, &lt;itemno&gt;P70421&lt;/itemno&gt;))</eg>
+               </item>
+            </ulist>
+            <ulist>
+
+
+
+               <item>
+                  <p>This example and the ones that follow are based on two separate sequences of elements, named <code>$sales</code> and <code>$products</code>. We assume that the variable <code>$sales</code> is bound to a sequence of elements with the following structure:</p>
+                  <eg>&lt;sales&gt;
+  &lt;storeno&gt;S101&lt;/storeno&gt;
+  &lt;itemno&gt;P78395&lt;/itemno&gt;
+  &lt;qty&gt;125&lt;/qty&gt;
+&lt;/sales&gt;</eg>
+                  <p>We also assume that the variable <code>$products</code> is bound to a sequence of  elements with the following structure:</p>
+                  <eg>&lt;product&gt;
+  &lt;itemno&gt;P78395&lt;/itemno&gt;
+  &lt;price&gt;25.00&lt;/price&gt;
+  &lt;category&gt;Men's Wear&lt;/category&gt;
+&lt;/product&gt;</eg>
+                  <p>The simplest kind of grouping query has a single <termref
+                        def="dt-grouping-variable"
+                     >grouping variable</termref>. The query in this example finds the total quantity of items sold by each store:</p>
+                  <eg role="parse-test">for $s in $sales
+let $storeno := $s/storeno
+group by $storeno
+return &lt;store number="{ $storeno }" total-qty="{ sum($s/qty) }"/&gt;</eg>
+                  <p>The result of this query is a sequence of elements with the following structure:</p>
+                  <eg>&lt;store number="S101" total-qty="1550" /&gt;
+&lt;store number="S102" total-qty="2125" /&gt;</eg>
+               </item>
+
+
+
+               <item>
+                  <p>In a more realistic example, a user might be interested in the total revenue generated by each store for each product category. Revenue depends on both the quantity sold of various items and the price of each item. The following query joins the two input sequences and groups the resulting tuples by two <termref
+                        def="dt-grouping-variable">grouping variables</termref>:</p>
+
+                  <eg role="parse-test">
+for $s in $sales
+for $p in $products[itemno = $s/itemno]
+let $revenue := $s/qty * $p/price
+group by $storeno := $s/storeno, 
+         $category := $p/category
+return &lt;summary storeno="{ $storeno }"
+                category="{ $category }"
+                revenue="{ sum($revenue) }"/>
+</eg>
+
+
+                  <p>The result of this query is a sequence of elements with the following structure:</p>
+                  <eg>&lt;summary storeno="S101" category="Men's Wear" revenue="10185"/&gt;
+&lt;summary storeno="S101" category="Stationery" revenue="4520"/&gt;
+&lt;summary storeno="S102" category="Men's Wear" revenue="9750"/&gt;
+&lt;summary storeno="S102" category="Appliances" revenue="22650"/&gt;
+&lt;summary storeno="S102" category="Jewelry" revenue="30750"/&gt;</eg>
+               </item>
+
+
+
+               <item>
+                  <p>The result of the previous example was a “flat” list of elements. A user might prefer the query result to be presented in the form of a  hierarchical report, grouped primarily by store (in order by store number) and secondarily by product category. Within each store, the user might want to see only those product categories whose total revenue exceeds $10,000, presented in descending order by their total revenue. This report is generated by the following query:</p>
+                  <eg role="parse-test">for $s1 in $sales
+let $storeno := $s1/storeno
+group by $storeno
+order by $storeno
+return &lt;store storeno="{ $storeno }"&gt;{
+  for $s2 in $s1
+  for $p in $products[itemno = $s2/itemno]
+  let $category := $p/category
+  let $revenue := $s2/qty * $p/price
+  group by $category
+  let $group-revenue := sum($revenue)
+  where $group-revenue &gt; 10000
+  order by $group-revenue descending
+  return &lt;category name="{ $category }" revenue="{ $group-revenue }"/&gt;
+}&lt;/store&gt;
+</eg>
+                  <p>The result of this example query has the following structure:</p>
+                  <eg>&lt;store storeno="S101"&gt;
+  &lt;category name="Men's Wear" revenue="10185"/&gt;
+&lt;/store&gt;
+&lt;store storeno="S102"&gt;
+  &lt;category name="Jewelry" revenue="30750"/&gt;
+  &lt;category name="Appliances" revenue="22650"/&gt;
+&lt;/store&gt;</eg>
+               </item>
+
+
+
+               <item>
+                  <p>The following example illustrates how to avoid a possible pitfall in writing grouping queries.</p>
+
+                  <p>In each post-grouping tuple, all variables except for the grouping
+variable are bound to sequences of items derived from all the
+pre-grouping tuples from which the group was formed. For instance, in
+the following query, <code>$high-price</code> is bound to a sequence
+of items in the post-grouping tuple.</p>
+
+                  <eg role="parse-test">let $high-price := 1000
+for $p in $products[price &gt; $high-price]
+let $category := $p/category
+group by $category
+return &lt;category name="{ $category }"&gt;{
+  count($p) || ' products have price greater than ' || $high-price || '.'
+}&lt;/category&gt;</eg>
+                  <p>If three products in the “Men’s Wear” category have prices greater than 1000, the result of this query might look (in part) like this:</p>
+                  <eg>&lt;category name="Men’s Wear"&gt;
+  3 products have price greater than 1000 1000 1000.
+&lt;/category&gt;</eg>
+                  <p>The repetition of "1000" in this query result is due to the fact that <code>$high-price</code> is not a <termref
+                        def="dt-grouping-variable"
+                        >grouping variable</termref>. One way to avoid this repetition is to move the binding of <code>$high-price</code> to an outer-level FLWOR expression, as follows:</p>
+                  <eg role="parse-test">let $high-price := 1000
+return (
+  for $p in $products[price &gt; $high-price]
+  let $category := $p/category
+  group by $category
+  return &lt;category name="{ $category }"&gt;{
+    count($p) || ' products have price greater than ' || $high-price || '.'
+  }&lt;/category&gt;  
+)</eg>
+                  <p>The result of the revised query might contain the following element:</p>
+                  <eg>&lt;category name="Men's Wear"&gt;
+  3 products have price greater than 1000.
+&lt;/category&gt;</eg>
+               </item>
+            </ulist>
+            <note>
+               <p>If a collation name is specified, it must be supplied as a literal string; it cannot
+                  be computed dynamically. A workaround in such cases is to use
+                   the <code>fn:collation-key</code> function. For example:</p>
+               
+               <eg role="parse-test">for $p in $products
+group by collation-key($p/description, $collation)
+return $product/@code</eg>
+               
+               <p>Note however that the <code>fn:collation-key</code> function might not work
+                  for all collations.</p>
+            </note>
+         </div3>
+         <div3 id="id-order-by-clause" role="xquery">
+            <head>Order By Clause</head>
+            <scrap>
+               <head/>
+               <prodrecap id="OrderByClause" ref="OrderByClause"/>
+               <prodrecap ref="OrderSpecList"/>
+               <prodrecap ref="OrderSpec"/>
+               <prodrecap ref="OrderModifier"/>
+
+            </scrap>
+            <p>The purpose of an <code>order by</code> clause is to impose a value-based ordering on the tuples in the tuple stream. The output tuple stream of the <code>order by</code> clause contains the same tuples as its input tuple stream, but the tuples may be in a different order.</p>
+            <p>An <code>order by</code> clause contains one or more ordering specifications, called <nt
+                  def="OrderSpec"
+                  >orderspecs</nt>, as shown in the grammar. For each tuple in the input tuple stream, the orderspecs are evaluated, using the variable bindings in that tuple. The relative order of two tuples is determined by comparing the values of their orderspecs, working from left to right until a pair of unequal values is encountered. If an orderspec specifies a <termref
+                  def="dt-collation"
+                  >collation</termref>, that collation is used in comparing values of type <code>xs:string</code>, <code>xs:anyURI</code>, or types derived from them (otherwise, the <termref
+                  def="dt-def-collation"
+                  >default collation</termref> is used in comparing values of these types). If an orderspec specifies a collation by a relative URI, that relative URI is  <termref
+                  def="dt-resolve-relative-uri"
+                  >resolved to an absolute URI</termref> using the <termref def="dt-static-base-uri"
+                  >Static Base URI</termref>. 
+If an orderspec specifies a collation that is not found in <termref
+                  def="dt-static-collations"
+                  >statically known collations</termref>, an error is raised <errorref class="ST"
+                  code="0076"/>.</p>
+            <p>The process of evaluating and comparing the orderspecs is based on
+the following rules:</p>
+
+            <ulist>
+
+               <item>
+                  <p>
+                     <termref def="dt-atomization"
+                        >Atomization</termref> is applied to the result of the expression
+    in each orderspec.  If the result of atomization is neither a single atomic value nor an empty sequence, a <termref
+                        def="dt-type-error">type error</termref> is raised <errorref class="TY"
+                        code="0004"/>.</p>
+               </item>
+
+
+ <!--              <item>
+                  <p>If the value of an orderspec has the <termref def="dt-dynamic-type"
+                        >dynamic type</termref>
+                     <code>xs:untypedAtomic</code> (such as character
+    data in a schemaless document), it is cast to the type <code>xs:string</code>.</p>
+                  <note>
+                     <p>Consistently treating untyped values as strings enables the sorting process to begin without complete knowledge of the types of all the values to be sorted.</p>
+                  </note>
+               </item>
+
+
+
+
+               <item>
+                  <p>If the resulting sequence contains values that are instances of more than one primitive type (meaning the 19 primitive types defined in <xspecref
+                        spec="XS2" ref="built-in-primitive-datatypes"/>, then:</p>
+                  <olist>
+                     <item>
+                        <p>If each value is an instance of one of the types <code>xs:string</code> or <code>xs:anyURI</code>, then all values are cast to type <code>xs:string</code>.</p>
+                     </item>
+                     <item>
+                        <p>If each value is an instance of one of the types <code>xs:decimal</code> or <code>xs:float</code>, then all values are cast to type <code>xs:float</code>.</p>
+                     </item>
+                     <item>
+                        <p>If each value is an instance of one of the types <code>xs:decimal</code>, <code>xs:float</code>, or <code>xs:double</code>, then all values are cast to type <code>xs:double</code>.</p>
+                     </item>
+                     <item>
+                        <p>Otherwise, a <termref def="dt-type-error"
+                              >type error</termref> is raised <errorref class="TY" code="0004"
+                           />.</p>
+                        <note>
+                           <p>The primitive type of an <code>xs:integer</code> value for this purpose is <code>xs:decimal</code>.</p>
+                        </note>
+                     </item>
+                  </olist>
+               </item>-->
+            </ulist>
+
+
+            <!-- <change diff="chg" at="XQ.E17"> -->
+            <p>For the purpose of determining their relative position in the ordering sequence, the <emph>greater-than</emph>
+             relationship between two orderspec values <var>W</var> and <var>V</var> is defined as follows:</p>
+            <ulist>
+               <item>
+                  <p>When the orderspec specifies <code>empty least</code>,
+                   the following rules are applied in order:
+                </p>
+                  <olist>
+                     <item>
+                        <p>If <var>V</var> is an empty sequence and <var>W</var> is not an empty sequence,
+                         then <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V </var> is true.</p>
+                     </item>
+                     <item>
+                        <p>If <var>V</var> is <code>NaN</code> and <var>W</var> is neither <code>NaN</code>
+                         nor an empty sequence, then
+                         <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true.</p>
+                     </item>
+                     <item>
+                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:string</code>,
+                        <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>, they are compared
+                           using the function <code>fn:compare(V, W, C)</code> where <var>C</var> is the
+                        requested collation, defaulting to the default collation from the static context.</p>
+                        
+                        <p>If <code>fn:compare(V, W, C)</code> is less than
+                         zero, then <emph>W</emph>
+                           <emph>greater-than</emph>
+                           <emph>V</emph> is true; otherwise <emph>W</emph>
+                           <emph>greater-than</emph>
+                           <emph>V</emph> is false.</p>
+                     </item>
+                     <item>
+                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:numeric</code>,
+                           they are compared
+                           using the function <code>fn:compare(V, W)</code>.</p>
+                        
+                        <p>If <code>fn:compare(V, W)</code> is less than
+                           zero, then <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true; otherwise <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is false.</p>
+                     </item>
+                     <item>
+                        <p>If none of the above rules apply, then:</p>
+                        <p>If <code>W gt V</code> is true,
+                         then <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true; otherwise <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is false.</p>
+                     </item>
+                  </olist>
+               </item>
+               <item>
+                  <p>When the orderspec specifies <code>empty greatest</code>,
+                   the following rules are applied in order:
+                </p>
+                  <olist>
+                     <item>
+                        <p>If <var>W</var> is an empty sequence and <emph>V</emph> is not an empty sequence,
+                         then <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true.</p>
+                     </item>
+                     <item>
+                        <p>If <var>W</var> is <code>NaN</code> and <var>V</var> is neither <code>NaN</code>
+                         nor an empty sequence, then
+                         <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true.</p>
+                     </item>
+                     <item>
+                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:string</code>,
+                           <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>, they are compared
+                           using the function <code>fn:compare(V, W, C)</code> where <var>C</var> is the
+                           requested collation, defaulting to the default collation from the static context.</p>
+                        
+                        <p>If <code>fn:compare(V, W, C)</code> is less than
+                           zero, then <emph>W</emph>
+                           <emph>greater-than</emph>
+                           <emph>V</emph> is true; otherwise <emph>W</emph>
+                           <emph>greater-than</emph>
+                           <emph>V</emph> is false.</p>
+                     </item>
+                     <item>
+                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:numeric</code>,
+                           they are compared
+                           using the function <code>fn:compare(V, W)</code>.</p>
+                        
+                        <p>If <code>fn:compare(V, W)</code> is less than
+                           zero, then <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true; otherwise <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is false.</p>
+                     </item>
+                     <item>
+                        <p>If none of the above rules apply, then:</p>
+                        <p>If <code>W gt V</code> is true,
+                           then <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is true; otherwise <var>W</var>
+                           <emph>greater-than</emph>
+                           <var>V</var> is false.</p>
+                     </item>
+                  </olist>
+               </item>
+               <item>
+                  <p>When the orderspec specifies neither <code>empty least</code>
+                   nor <code>empty greatest</code>, the
+                   <termref
+                        def="dt-default-empty-order"
+                        >default order for empty
+                   sequences</termref> in the
+                   <termref
+                        def="dt-static-context"
+                        >static context</termref>
+                   determines whether the rules for <code>empty least</code>
+                   or <code>empty greatest</code> are used.
+                </p>
+               </item>
+            </ulist>
+            <!-- </change> -->
+
+            <p>If <emph>T1</emph> and <emph>T2</emph> are two tuples in the input tuple stream, and <emph>V1</emph> and <emph>V2</emph> are the first pair of  values encountered when evaluating their orderspecs  from left to right for which one value is <emph>greater-than</emph> the other (as defined above), then:</p>
+
+
+            <olist>
+
+
+
+
+               <item>
+                  <p>If <emph>V1</emph> is <emph>greater-than</emph>
+                     <emph>V2:</emph> If the orderspec specifies <code>descending</code>, then <emph>T1</emph> precedes <emph>T2</emph> in the output tuple stream; otherwise, <emph>T2</emph> precedes <emph>T1</emph> in the output tuple stream.</p>
+               </item>
+
+
+
+               <item>
+                  <p>If <emph>V2</emph> is <emph>greater-than</emph>
+                     <emph>V1</emph>: If the orderspec specifies <code>descending</code>, then <emph>T2</emph> precedes <emph>T1</emph> in the output tuple stream; otherwise, <emph>T1</emph> precedes <emph>T2</emph> in the output tuple stream.</p>
+               </item>
+
+
+
+            </olist>
+            <p>If neither <emph>V1</emph> nor <emph>V2</emph> is <emph>greater-than</emph> the other for any pair of orderspecs for tuples <emph>T1</emph> and <emph>T2</emph>, the following rules apply.</p>
+
+            <olist>
+
+
+
+               <item>
+                  <p>If <code>stable</code> is specified, the original order of <emph>T1</emph> and <emph>T2</emph> is preserved in the output tuple stream.</p>
+               </item>
+
+
+
+               <item>
+                  <p>If <code>stable</code> is not specified, the order of <emph>T1</emph> and <emph>T2</emph> in the output tuple stream is <termref
+                        def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+               </item>
+            </olist>
+            <note>
+               <p>If two orderspecs return the special floating-point values positive and negative zero, neither of these values is <emph>greater-than</emph> the other, since <code
+                     role="parse-test">+0.0 gt -0.0</code> and <code role="parse-test"
+                     >-0.0 gt +0.0</code> are both <code>false</code>.</p>
+            </note>
+            <p>Examples:</p>
+            <ulist>
+
+
+
+               <item>
+                  <p>This example illustrates the effect of an <code>order by</code> clause on a tuple stream. The keyword <code>stable</code> indicates that, when two tuples have equal sort keys, their order in the input tuple stream is preserved.</p>
+                  <p>Input tuple stream:</p>
+                  <eg><![CDATA[($license = "PFQ519", $make = "Ford",  $value = 16500)
+($license = "HAJ865", $make = "Honda", $value = 22750)
+($license = "NKV473", $make = "Ford",  $value = 21650)
+($license = "RCM922", $make = "Dodge", $value = 11400)
+($license = "ZBX240", $make = "Ford",  $value = 16500)
+($license = "KLM030", $make = "Dodge", $value = () )]]></eg>
+                  <p>
+                     <code>order by</code> clause:</p>
+                  <eg><![CDATA[stable order by $make,
+  $value descending empty least]]></eg>
+                  <p>Output tuple stream:</p>
+                  <eg><![CDATA[($license = "RCM922", $make = "Dodge", $value = 11400)
+($license = "KLM030", $make = "Dodge", $value = () )
+($license = "NKV473", $make = "Ford",  $value = 21650)
+($license = "PFQ519", $make = "Ford",  $value = 16500)
+($license = "ZBX240", $make = "Ford",  $value = 16500)
+($license = "HAJ865", $make = "Honda", $value = 22750)]]></eg>
+               </item>
+
+
+
+               <item>
+                  <p>The following example shows how an <code>order by</code> clause can be used to sort the result of a query, even if the sort key is not included in the query result. This query returns employee names in descending order by salary, without returning the actual salaries:</p>
+                  <eg role="parse-test"><![CDATA[for $e in $employees
+order by $e/salary descending
+return $e/name]]></eg>
+
+               </item>
+            </ulist>
+            <note>
+               <p>If a collation name is specified, it must be supplied as a literal string; it cannot
+                  be computed dynamically. Two possible workarounds are to use the <code>fn:sort</code> function
+               or the <code>fn:collation-key</code> function.</p>
+               <p>Using <code>fn:sort</code> the expression</p>
+               <eg role="parse-test">for $b in $books/book[price &lt; 100]
+order by $b/title
+return $b</eg>
+
+               <p>can be replaced with the following, which uses a dynamically-chosen collation:</p>
+
+               <eg role="parse-test">
+sort(
+  $books/book[price &lt; 100],
+  $collation,
+  function($book) { $book/title }
+)
+</eg>
+               
+               <p>Alternatively, it is possible to compute collation keys using a dynamically-chosen
+               collation, and sort on the values of the collation keys:</p>
+               
+               <eg role="parse-test">for $b in $books/book[price &lt; 100]
+order by collation-key($b/title, $collation)
+return $b</eg>
+               
+               <p>Note however that the <code>fn:collation-key</code> function might not work
+               for all collations.</p>
+               
+            </note>
+
+
+         </div3>
+         <div3 id="id-return-clause" role="xquery">
+            <head>Return Clause</head>
+            <scrap>
+               <head/>
+
+
+               <prodrecap ref="ReturnClause"/>
+            </scrap>
+            <p>The <code>return</code> clause is the final clause of a FLWOR expression. The <code>return</code> clause is evaluated once for each tuple in its input tuple stream,  using the variable bindings in the respective tuples, in the order in which these tuples appear in the input tuple stream. The results of these evaluations are concatenated, as if by the <termref
+                  def="dt-comma-operator"
+               >comma operator</termref>, to form the result of the FLWOR expression.</p>
+            <p>The following example illustrates a FLWOR expression containing several clauses. The <code>for</code> clause iterates over all the departments in an input document named <code>depts.xml</code>, binding the variable <code>$d</code> to each department  in turn. For each binding of <code>$d</code>, the <code>let</code> clause binds variable <code>$e</code> to all the employees in the given department, selected from another input document named <code>emps.xml</code> (the relationship between employees and departments is represented by matching their <code>deptno</code> values). Each tuple in the resulting tuple stream contains a pair of bindings for <code>$d</code> and <code>$e</code> (<code>$d</code> is bound to a department and <code>$e</code> is bound to a set of employees in that department). The <code>where</code> clause filters the tuple stream, retaining only those tuples that represent departments having at least ten employees. The <code>order by</code> clause orders the surviving tuples in descending order by the average salary of the employees in the department. The <code>return</code> clause constructs a new <code>big-dept</code> element for each surviving tuple, containing the department number, headcount, and average salary.</p>
+            <eg role="parse-test"><![CDATA[for $d in doc("depts.xml")//dept
+let $e := doc("emps.xml")//emp[deptno eq $d/deptno]
+where count($e) >= 10
+order by avg($e/salary) descending
+return <big-dept>{
+  $d/deptno,
+  <headcount>{count($e)}</headcount>,
+  <avgsal>{avg($e/salary)}</avgsal>
+}</big-dept>]]></eg>
+            <notes>
+               <ulist>
+
+
+
+                  <item>
+                     <p>The order in which items appear in the result of a FLWOR expression depends on the ordering of the input tuple stream to the <code>return</code> clause, which in turn is influenced by <code>order by</code> clauses and by <termref
+                           def="dt-ordering-mode"
+                        >ordering mode</termref>. For example, consider the following query, which is based on the same two input documents as the previous example:</p>
+                     <eg role="parse-test">for $d in doc("depts.xml")//dept
+order by $d/deptno
+for $e in doc("emps.xml")//emp[deptno eq $d/deptno]
+return &lt;assignment&gt;{
+  $d/deptno, $e/name
+}&lt;/assignment&gt;</eg>
+                     <p>The result of this query is a sequence of <code>assignment</code> elements, each containing a <code>deptno</code> element and a <code>name</code> element. The sequence will be ordered primarily by the <code>deptno</code> values because of the <code>order by</code> clause. If <termref
+                           def="dt-ordering-mode"
+                           >ordering mode</termref> is <code>ordered</code>, subsequences of <code>assignment</code> elements with equal <code>deptno</code> values will be ordered by the document order of their <code>name</code> elements within the <code>emps.xml</code> document; otherwise the ordering of these subsequences will be <termref
+                           def="dt-implementation-dependent">implementation-dependent</termref>.</p>
+                  </item>
+
+                  <item>
+                     <p>Parentheses are helpful in <code>return</code> clauses that contain comma operators,
+since FLWOR expressions have a higher precedence than the comma
+operator. For example, the following query raises an error because
+after the comma, <code>$j</code> is no longer within the FLWOR expression, and is an
+undefined variable:</p>
+                     <eg role="parse-test"><![CDATA[let $i := 5
+let $j := 20 * $i
+return $i, $j]]></eg>
+                     <p>Parentheses can be used to bring <code>$j</code> into the <code>return</code> clause of the FLWOR expression, as the
+programmer probably intended:</p>
+                     <eg role="parse-test"><![CDATA[let $i := 5
+let $j := 20 * $i
+return ($i, $j)]]></eg>
+                  </item>
+               </ulist>
+            </notes>
+         </div3>
+      <div3 role="xpath" id="id-for-expressions">
          <head>For Expressions</head>
          
          <changes>
@@ -16365,8 +18464,11 @@ element because it is defined by a <termref
                an array.</change>
             <change issue="22" PR="28" date="2020-12-18">
                Multiple <code>for</code> and <code>let</code> clauses can be combined
-               in an expression without an intervenint <code>return</code> keyword.
+               in an expression without an intervening <code>return</code> keyword.
             </change>
+            <change issue="31" date="2024-06-01">
+               A <code>for key/value</code> clause is added to FLWOR expressions to allow iteration over
+               maps.</change>
             <change issue="231" PR="1131" date="2024-04-01">
                A positional variable can be defined in a <code>for</code> expression.
             </change>
@@ -16376,26 +18478,30 @@ element because it is defined by a <termref
          </changes>
 
          <p>XPath provides an iteration facility called a <term>for expression</term>. 
-         <phrase diff="add" at="2023-02-09">It can be used to iterate over the items of a sequence, or the
-            members of an array.</phrase></p>
+         It can be used to iterate over the items of a sequence, the
+            members of an array, or the entries in a map.</p>
 
          <scrap>
             <head/>
-            <prodrecap id="ForExpr" ref="ForExpr"/>
-            <prodrecap id="XPForClause" ref="XPForClause"/>
-            <prodrecap id="XPForBinding" ref="XPForBinding"/>
-            <prodrecap id="ForLetReturn" ref="ForLetReturn"/>
+            <prodrecap ref="ForExpr"/>
+            <prodrecap ref="ForClause"/>
+            <prodrecap ref="ForBinding"/>
+            <prodrecap ref="ForItemBinding"/>
+            <prodrecap ref="ForMemberBinding"/>
+            <prodrecap ref="ForEntryBinding"/>
+            <prodrecap ref="ForLetReturn"/>
             <prodrecap ref="TypeDeclaration"/>
-            <prodrecap id="XPPositionalVar" ref="XPPositionalVar"/>
+            <prodrecap ref="PositionalVar"/>
          </scrap>
 
          <p>A <code>for</code> expression is evaluated as follows:</p>
          <olist>
 
             <item>
-               <p>If the <nt def="XPForClause">XPForClause</nt> binds multiple range variables with a comma separator, 
+               <p>If the <nt def="ForClause">ForClause</nt> includes multiple 
+                  <nt def="ForBinding">ForBinding</nt>s with a comma separator, 
                   the <code>for</code>expression is first expanded to a set of nested <code>for</code> 
-                  expressions, each of which uses only one variable.
+                  expressions, each of which contains a single <nt def="ForBinding">ForBinding</nt>.
                More specifically, every separating comma is replaced by <code>for</code>.</p>
                <p>For example, the expression
                <code role="parse-test">for $x in X, $y in Y return $x + $y</code> is expanded to
@@ -16404,9 +18510,9 @@ element because it is defined by a <termref
             
             <item>
                <p>Having performed this expansion, 
-                  the variable bound in the <nt def="XPForClause">XPForClause</nt>
-                  is called the <term>range variable</term>,
-                  the variable named in the <nt def="XPPositionalVar">XPPositionalVar</nt> (if present)
+                  variables bound in the <nt def="ForClause">ForClause</nt>
+                  are called the <term>range variables</term>,
+                  the variable named in the <nt def="PositionalVar">PositionalVar</nt> (if present)
                   is called the <term>position variable</term>,
                   the expression that follows the <code>in</code> keyword is called the <term>binding expression</term>, 
                   and the expression in the <nt def="ForLetReturn">ForLetReturn</nt> part 
@@ -16421,12 +18527,15 @@ element because it is defined by a <termref
             <item>
                <p>If a <term>position variable</term> is declared, its type is implicitly
                   <code>xs:integer</code>. Its name (as a QName) must be
-               different from the name of the <term>range variable</term> 
+               different from the name of a <term>range variable</term> declared in the same
+                <nt def="ForBinding">ForBinding</nt>.  
                   <errorref spec="XQ" class="ST" code="0089"/>.
                </p>
             </item>
             <item>
-               <p><phrase diff="add" at="A">When the <code>member</code> keyword is absent</phrase>:
+               <p>When a <nt def="ForItemBinding">ForItemBinding</nt> is used (that is, when none
+                  of the keywords <code>member</code>, <code>key</code>, or <code>value</code>
+                  is used), the expression iterates over the items in a sequence:
                   <olist>
                      <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
                         is present then each item in the <termref def="dt-binding-collection-xp"/>
@@ -16445,7 +18554,7 @@ element because it is defined by a <termref
               
                </p>
             </item>
-            <item diff="add" at="A">
+            <item>
                <p>When the <code>member</code> keyword is present:
                   <olist>
                      <item><p>The value of the <termref def="dt-binding-collection-xp"/> must be a single array.
@@ -16463,16 +18572,54 @@ element because it is defined by a <termref
                         with a dynamic context in which
                         the <term>range variable</term> is bound to that member, and the <term>position variable</term> 
                         (if present) is bound to the one-based position of that member in the <termref def="dt-binding-collection-xp"/>.</p></item>
-                     <item><p>The result of the <code>for</code> expression is the result
-                        of contenating the resulting values (as if by the <termref def="dt-comma-operator"
-                           >comma operator</termref>) in the order of the members in the binding collection array from which 
-                        they were derived.</p></item>
+                     <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
+                        of the results of the successive evaluations of the <term>return expression</term>.</p></item>
                   </olist>   
                   
                   
       
                </p>
                <p>Note that the result is a sequence, not an array.</p>
+            </item>
+            <item>
+               <p>When the <code>key</code> and/or <code>value</code> keywords are present:
+                  <olist>
+                     <item><p>The value of the <termref def="dt-binding-collection-xp"/> must be a single map.
+                        Otherwise, a <termref def="dt-type-error">type error</termref> is raised: 
+                        <errorref class="TY" code="0141"/>. The map is treated as a sequence of key/value
+                        pairs, in <termref def="dt-implementation-dependent"/> order.
+                     </p></item>
+                     <item><p>If the <code>key</code> keyword is present, then the corresponding
+                     variable is bound to the key part of the key/value pair.</p></item>
+                     <item><p>If the <code>value</code> keyword is present, then the corresponding
+                     variable is bound to the value part of the key/value pair.</p></item>
+                     <item><p>If both the <code>key</code> and <code>value</code> keywords are present, 
+                        then the corresponding variables must have distinct names.
+                        <errorref spec="XQ" class="ST" code="0089"/>.</p></item>
+                     <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
+                        is present for the key, then each key is converted to the specified type by 
+                        applying the <termref def="dt-coercion-rules"/>.</p></item>
+                     <item><p>If a <nt def="TypeDeclaration">TypeDeclaration</nt>
+                        is present for the value, then each value is converted to the specified type by 
+                        applying the <termref def="dt-coercion-rules"/>.</p></item>
+                     <item><p>The result of the single-variable <code>for key/value</code> expression is obtained
+                        by evaluating the <term>return expression</term> once 
+                        for each entry in the map, with the range variables bound to that entry as described.</p></item>
+                     <item><p>The <term>return expression</term> is evaluated once 
+                        for each entry of the <termref def="dt-binding-collection-xp"/> map, 
+                        with a dynamic context in which
+                        the <code>key</code> <term>range variable</term> (if present)
+                        is bound to the key part of that entry, 
+                        the <code>value</code> <term>range variable</term> (if present)
+                        is bound to the value part of that entry, and the <term>position variable</term> 
+                        (if present) is bound to the one-based position of that entry in the 
+                        <termref def="dt-implementation-dependent"/> ordering of the 
+                        <termref def="dt-binding-collection-xp"/>.</p></item>
+                     <item><p>The result of the <code>for</code> expression is the <termref def="dt-sequence-concatenation"/>
+                        of the results of the successive evaluations of the <term>return expression</term>.</p></item>
+                  </olist>   
+               </p>
+               <p>Note that the result is a sequence, not a map.</p>
             </item>
          </olist>
          <p role="xpath"
@@ -16566,9 +18713,9 @@ return $line/value]]></eg>
             <p>primarily because it is familiar to XQuery users, some of whom may regard it as more
             readable than the XPath 3.1 alternative which uses a comma in place of the second <code>for</code>.</p>
          </note>
-      </div2>
+      </div3>
 
-      <div2 id="id-let-expressions" role="xpath">
+      <div3 id="id-let-expressions" role="xpath">
          <head>Let Expressions</head>
          
          <changes>
@@ -16585,9 +18732,9 @@ return $line/value]]></eg>
 
          <scrap>
             <head/>
-            <prodrecap id="LetExpr" ref="LetExpr"/>
-            <prodrecap id="XPLetClause" ref="XPLetClause"/>
-            <prodrecap id="XPLetBinding" ref="XPLetBinding"/>
+            <prodrecap ref="LetExpr"/>
+            <prodrecap ref="LetClause"/>
+            <prodrecap ref="LetBinding"/>
             <prodrecap ref="ForLetReturn"/>
             <prodrecap ref="TypeDeclaration"/>
          </scrap>
@@ -16654,8 +18801,12 @@ return upper-case($x)
                without an intermediate <code>return</code>, and also to allow the required
                type to be declared.</p>
          </note>
-      </div2>
+      </div3>
 
+      </div2>
+      
+
+      
       
 
       <div2 id="id-maps-and-arrays">
@@ -18438,2049 +20589,6 @@ declare function recursive-content($item as item()) as record(key, value)* {
             
          </div3>-->
          
-      </div2>
-      <div2 id="id-flwor-expressions" role="xquery">
-         <head>FLWOR Expressions</head>
-         <p>XQuery provides a versatile expression called a FLWOR expression that may contain multiple clauses. The FLWOR expression can be used for many purposes, including iterating over sequences, joining multiple documents, and performing grouping and aggregation. The name FLWOR, pronounced "flower", is suggested by the keywords <code>for</code>, <code>let</code>, <code>where</code>, <code>order by</code>, and <code>return</code>, which introduce some of the clauses used in FLWOR expressions (but this is not a complete list of such clauses.)</p>
-         <p>The complete syntax of a FLWOR expression is shown here, and relevant parts of the syntax are repeated in subsequent sections of this document.</p>
-         <scrap>
-            <head/>
-            <prodrecap id="FLWORExpr" ref="FLWORExpr11"/>
-            <prodrecap id="InitialClause" ref="InitialClause"/>
-            <prodrecap id="IntermediateClause" ref="IntermediateClause"/>
-            <prodrecap ref="ForClause"/>
-            <prodrecap ref="ForBinding"/>
-            <prodrecap ref="ForItemBinding"/>
-            <prodrecap ref="ForMemberBinding"/>
-            <prodrecap ref="LetClause"/>
-            <prodrecap ref="LetBinding"/>
-            <prodrecap ref="TypeDeclaration"/>
-            <prodrecap id="AllowingEmpty" ref="AllowingEmpty"/>
-            <prodrecap id="PositionalVar" ref="PositionalVar"/>
-            <prodrecap id="WindowClause" ref="WindowClause"/>
-            <prodrecap id="TumblingWindowClause" ref="TumblingWindowClause"/>
-            <prodrecap id="SlidingWindowClause" ref="SlidingWindowClause"/>
-            <prodrecap id="WindowStartCondition" ref="WindowStartCondition"/>
-            <prodrecap id="WindowEndCondition" ref="WindowEndCondition"/>
-            <prodrecap id="WindowVars" ref="WindowVars"/>
-            <prodrecap id="CurrentItem" ref="CurrentItem"/>
-            <prodrecap id="PreviousItem" ref="PreviousItem"/>
-            <prodrecap id="NextItem" ref="NextItem"/>
-            <prodrecap ref="CountClause"/>
-            <prodrecap ref="WhereClause"/>
-            <prodrecap ref="WhileClause"/>
-            <prodrecap id="GroupByClause" ref="GroupByClause"/>
-            <prodrecap id="GroupingSpecList" ref="GroupingSpecList"/>
-            <prodrecap id="GroupingSpec" ref="GroupingSpec"/>
-            <prodrecap id="GroupingVariable" ref="GroupingVariable"/>
-            <prodrecap ref="OrderByClause"/>
-            <prodrecap ref="OrderSpecList" id="OrderSpecList"/>
-            <prodrecap ref="OrderSpec" id="OrderSpec"/>
-            <prodrecap ref="OrderModifier" id="OrderModifier"/>
-            <prodrecap ref="ReturnClause" id="ReturnClause"/>
-         </scrap>
-         <p>The semantics of FLWOR expressions are based on a concept called a <term>tuple stream</term>. <termdef
-               id="id-tuple-stream-foobar" term="tuple stream"
-                  >A <term>tuple stream</term> is an ordered sequence of zero or more <term>tuples</term>.</termdef>
-            <termdef term="tuple" id="id-tuple-foobar"
-                  >A <term>tuple</term> is a set of zero or more named variables, each of which is bound to a value that is an <termref
-                  def="dt-data-model-instance"
-               >XDM instance</termref>.</termdef> Each tuple stream is homogeneous in the sense that all its  tuples contain variables with the same names and the same <termref
-               def="dt-static-type"
-               >static types</termref>. The following example illustrates a tuple stream consisting of four tuples, each containing three variables named <code>$x</code>, <code>$y</code>, and <code>$z</code>:</p>
-         <eg>($x = 1003, $y = "Fred", $z = &lt;age&gt;21&lt;/age&gt;)
-($x = 1017, $y = "Mary", $z = &lt;age&gt;35&lt;/age&gt;)
-($x = 1020, $y = "Bill", $z = &lt;age&gt;18&lt;/age&gt;)
-($x = 1024, $y = "John", $z = &lt;age&gt;29&lt;/age&gt;)</eg>
-         <note>
-            <p>In this section, tuple streams are represented as shown in the above example. Each tuple is on a separate line and is enclosed in parentheses, and the variable bindings inside each tuple are separated by commas. This notation does not represent XQuery syntax, but is simply a representation of a tuple stream for the purpose of defining the semantics of  FLWOR expressions.</p>
-         </note>
-         <p>Tuples and tuple streams are not part of the <termref def="dt-datamodel"
-               >data model</termref>. They exist only as conceptual intermediate results during the processing of a FLWOR expression.</p>
-         <p>Conceptually, the first clause generates a tuple stream. Each clause between the first clause and the return clause takes the tuple stream generated by the previous clause as input and generates a (possibly different) tuple stream as output. The return clause takes a tuple stream as input and, for each tuple in this tuple stream, generates an <termref
-               def="dt-data-model-instance"
-               >XDM instance</termref>; the final result of the FLWOR expression is the ordered concatenation of these <termref
-               def="dt-data-model-instance">XDM instances</termref>.</p>
-         <p>The initial clause in a FLWOR expression may be a <code>for</code>, <code>let</code>, or <code>window</code> clause. 
-Intermediate clauses may be <code>for</code>, <code>let</code>, <code>window</code>, <code>count</code>, <code>where</code>, <code>group by</code>, or <code>order by</code> clauses. These intermediate clauses may be repeated as many times as desired, in any order. The final clause of the FLWOR expression must be a <code>return</code> clause. The semantics of the various clauses are described in the following sections.</p>
-
-         <div3 id="id-binding-rules">
-            <head>Variable Bindings</head>
-            <p>The following clauses in FLWOR expressions bind values to variables: 
-<code>for</code>, <code>let</code>, <code>window</code>, <code>count</code>, and <code>group by</code>. 
-The binding of variables for <code>for</code>, <code>let</code>, and <code>count</code> is governed by the following rules
-(the binding of variables in <code>group by</code> is discussed in <specref
-                  ref="id-group-by"
-                  />,
-the binding of variables in <code>window</code> clauses is discussed in <specref
-                  ref="id-windows"/>):</p>
-
-            <olist>
-
-               <item>
-                  <p>The scope of a bound variable includes all subexpressions of the containing FLWOR that appear after the variable binding. The scope does not include the expression to which the variable is bound. The following code fragment, containing two <code>let</code> clauses, illustrates how variable bindings may reference variables that were bound in earlier clauses, or in earlier bindings in the same clause:</p>
-                  <eg><![CDATA[let $x := 47, $y := f($x)
-let $z := g($x, $y)]]></eg>
-               </item>
-
-               <item>
-                  <p>A given variable may be bound more than once in a FLWOR expression, or even within one  clause of a FLWOR expression. In such a case, each new binding occludes the previous one, which becomes inaccessible in the remainder of the FLWOR expression.</p>
-               </item>
-
-               <item>
-                  <p>
-                     <termdef term="type declaration" id="dt-type-declaration"
-                           >A variable binding may be accompanied by a <term>type declaration</term>, which consists of the keyword <code>as</code> followed by the static type of the variable, declared using the syntax in  <specref
-                           ref="id-sequencetype-syntax"
-                        />.</termdef> <phrase diff="add" at="2022-11-17">The type declaration defines a required type for the
-                        value. At run-time, the supplied value for the variable is converted to the required type
-                        by applying the <termref def="dt-coercion-rules"/>. If conversion is not possible, </phrase>                    
-                        a <termref def="dt-type-error">type error</termref> is raised <errorref class="TY"
-                        code="0004"
-                        />. For example, the following <code>let</code> clause raises a <termref
-                        def="dt-type-error"
-                        >type error</termref> because the variable <code>$salary</code> has a type declaration that is not satisfied by the value that is bound to it:</p>
-                  <eg><![CDATA[let $salary as xs:decimal :=  "cat"]]></eg>
-                  <p  diff="add" at="2022-11-17">The following <code>let</code> clause, however, succeeds, because the <termref def="dt-coercion-rules"/>
-                  allow an <code>xs:decimal</code> to be supplied where an <code>xs:double</code> is required:</p>
-                  <eg><![CDATA[let $temperature as xs:double := 32.5]]></eg>
-                  <p>In applying the <termref def="dt-coercion-rules"/>, <termref def="dt-xpath-compat-mode"/> does not apply.</p>
-               </item>
-               <item diff="add" at="A">
-                  <p>
-                     <termdef id="dt-binding-collection" term="binding collection"
-                        >In a <code>for</code> clause, when an expression is 
-                        preceded by the keyword <code>in</code>, the value of that expression is 
-                        called a <term>binding collection</term>.</termdef> The collection may be either
-                     a sequence or an array. The <code>for</code>  
-                     clause iterates over its binding collection, producing multiple bindings for one or more variables. 
-                     Details on how binding collections are used in <code>for</code> clauses 
-                     are described in the following sections.</p>
-               </item>
-               <item diff="chg" at="A">
-                  <p>
-                     <termdef id="dt-binding-sequence" term="binding sequence"
-                           >In a <code>window</code> clause, when an expression is 
-                        preceded by the keyword <code>in</code>, the value of that expression is 
-                        called a <term>binding sequence</term>.</termdef> The <code>window</code> 
-                     clause iterates over its binding sequence, producing multiple bindings for one or more variables. 
-                     Details on how binding sequences are used in <code>for</code> and <code>window</code> clauses 
-                     are described in the following sections.</p>
-               </item>
-               
-            </olist>
-         </div3>
-
-         <div3 id="id-xquery-for-clause">
-            <head>For Clause</head>
-            
-            <changes>
-               <change issue="49" PR="344" date="2023-02-10">A <code>for member</code> clause is added to FLWOR expressions to allow iteration over
-                  an array.
-               </change>
-               <change issue="189" PR="820" date="2023-11-08">
-                  The value bound to a variable in a <code>for</code> clause is now converted
-                     to the declared type by applying the coercion rules.
-               </change>
-            </changes>
-            
-            <scrap>
-               <head/>
-               <prodrecap id="ForClause" ref="ForClause"/>
-               <prodrecap id="ForBinding" ref="ForBinding"/>
-               <prodrecap id="ForItemBinding" ref="ForItemBinding"/>
-               <prodrecap id="ForMemberBinding" ref="ForMemberBinding"/>
-               <prodrecap ref="TypeDeclaration"/>
-               <prodrecap ref="AllowingEmpty"/>
-               <prodrecap ref="PositionalVar"/>
-            </scrap>
-            <p>A <code>for</code> clause is used for iteration. Each variable in a <code>for</code> clause iterates over a 
-               sequence <phrase diff="add" at="A">or array</phrase> and is bound in turn to each item in the sequence,
-               <phrase diff="add" at="A">or to each member in the array</phrase>.</p>
-
-            <p>If a <code>for</code> clause contains multiple variables, it is semantically equivalent to multiple <code>for</code> clauses, each containing one of the variables in the original <code>for</code> clause.</p>
-
-            <p>Example:</p>
-
-            <ulist>
-               <item>
-                  <p>The clause</p>
-                  <eg><![CDATA[for $x in $expr1, $y in $expr2]]></eg>
-                  <p>is semantically equivalent to:</p>
-                  <eg><![CDATA[for $x in $expr1
-for $y in $expr2]]></eg>
-               </item>
-               <item>
-                  <p>The clause</p>
-                  <eg><![CDATA[for member $x in $expr1, member $y in $expr2]]></eg>
-                  <p>is semantically equivalent to:</p>
-                  <eg><![CDATA[for member $x in $expr1
-for member $y in $expr2]]></eg>
-               </item>
-            </ulist>
-            
-            <p diff="add" at="A">Without the <code>member</code> keyword, the expression iterates over the items in a sequence. 
-               With the <code>member</code> keyword, it iterates over the members of an array. We refer to the sequence
-               or array generically as the <termref def="dt-binding-collection">binding collection</termref>, and to
-               its items or members as the <code>components</code> of the collection.</p>
-            
-            <p diff="add" at="A">If <code>member</code> is specified, then the corresponding <code>ExprSingle</code>
-               must evaluate to a single array, otherwise a type error is raised <errorref
-               class="TY" code="0141"/>.</p>
-
-            <p>In the remainder of this section, we define the semantics of a <code>for</code> clause containing a single variable and an associated expression 
-               (following the keyword <code>in</code>) whose value is the <termref
-                  def="dt-binding-collection">binding collection</termref> for that variable.</p>
-            <p>If a single-variable <code>for</code> clause is the initial clause in a FLWOR expression, it iterates over its <termref
-               def="dt-binding-collection">binding collection</termref>, binding the variable to each component in turn. 
-               The resulting sequence of variable bindings becomes the initial tuple stream that serves as input to the next clause 
-               of the FLWOR expression. If <termref
-                  def="dt-ordering-mode"
-                  >ordering mode</termref> is <code>ordered</code>, the order of tuples in the tuple stream preserves the order of the <termref
-                  def="dt-binding-collection"
-                     >binding collection</termref>; otherwise the order of the tuple stream is <termref
-                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-            <p>If the <termref def="dt-binding-sequence"
-                  >binding collection</termref> is empty, the output tuple stream depends on whether <code>allowing empty</code> is specified. 
-               If <code>allowing empty</code> is specified, the output tuple stream consists of one tuple in which the variable is bound to an empty sequence.
-               This option is not available with "for member".
-               If <code>allowing empty</code> is not specified, the output tuple stream consists of zero tuples.</p>
-            <p>The following  examples illustrates tuple streams that are generated by initial <code>for</code> clauses:</p>
-            <ulist>
-
-               <item>
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for $x in (100, 200, 300)]]></eg>
-                  <p>or (equivalently):</p>
-                  <eg><![CDATA[for $x allowing empty in (100, 200, 300)]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($x = 100)
-($x = 200)
-($x = 300)]]></eg>
-               </item>
-
-               <item>
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for $x in ()]]></eg>
-                  <p>Output tuple stream contains no tuples.</p>
-               </item>
-
-               <item>
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for $x allowing empty in ()]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($x = ())]]></eg>
-               </item>
-               
-               <item diff="add" at="A">
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for member $x in [ 1, 2, (5 to 10) ] ]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($x = (1))
-($x = (2))
-($x = (5, 6, 7, 8, 9, 10)]]></eg>
-               </item>
-               
-               <item diff="add" at="A">
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for member $x in []]]></eg>
-                  <p>Output tuple stream contains no tuples.</p>
-               </item>
-               
-               <item diff="add" at="A">
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for member $x allowing empty in [] ]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($x = ())]]></eg>
-               </item>
-            </ulist>
-            <p>
-               <termdef term="positional variable" id="dt-positional-variable">A <term>positional variable</term> 
-                  is a variable that is preceded by the keyword <code>at</code>.</termdef> A positional variable 
-               may be associated with a variable that is bound in a <code>for</code> clause. In this case, as 
-               the main variable iterates over the components of its <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, 
-               the positional variable iterates over the integers that represent the ordinal numbers of these component in the 
-               <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, starting with one. Each tuple in the output 
-               tuple stream contains bindings for both the main variable and the positional variable. If the 
-               <termref def="dt-binding-collection" diff="chg" at="A">binding collection</termref> is empty and <code>allowing empty</code> is 
-               specified, the positional variable in the output tuple is bound to the integer zero. Positional variables  
-               have the implied type <code>xs:integer</code>.</p>
-            <p>The <termref def="dt-expanded-qname">expanded
-			        QName</termref> of a positional variable must be distinct from the <termref def="dt-expanded-qname"
-                  >expanded QName</termref> of the main variable with which it is associated <errorref
-                  class="ST" code="0089"/>.</p>
-            <p>The following  examples illustrate how a positional variable would have affected the results of the previous examples that generated tuples:</p>
-            <ulist>
-
-               <item>
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for $x at $i in (100, 200, 300)]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($x = 100, $i = 1)
-($x = 200, $i = 2)
-($x = 300, $i = 3)]]></eg>
-               </item>
-               
-               <item diff="add" at="A">
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for $x at $i in [1 to 3, 11 to 13, 21 to 23]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($x = (1, 2, 3), $i = 1)
-($x = (11, 12, 13), $i = 2)
-($x = (21, 22, 23), $i = 3)]]></eg>
-               </item>
-
-               <item>
-                  <p>Initial clause:</p>
-                  <eg><![CDATA[for $x allowing empty at $i in ()]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($x = (), $i = 0)]]></eg>
-               </item>
-            </ulist>
-            <p>If a single-variable <code>for</code> clause is an intermediate clause in a FLWOR expression, its <termref
-                  def="dt-binding-collection" diff="chg" at="A"
-                  >binding collection</termref> is evaluated for each input tuple, given the bindings in that input tuple. Each input tuple generates 
-                  zero or more tuples in the output tuple stream. Each of these output tuples consists of  the original variable bindings of the 
-                  input tuple plus a binding of the new variable to one of the items in its <termref
-                     def="dt-binding-collection" diff="chg" at="A">binding collecction</termref>.</p>
-            <note>
-               <p>Although the <termref def="dt-binding-collection" diff="chg" at="A"
-                     >binding collection</termref> is conceptually evaluated independently for each input tuple, 
-                  an optimized implementation may sometimes be able to avoid re-evaluating the <termref
-                     def="dt-binding-collection" diff="chg" at="A"
-                     >binding collection</termref> if it can show that the variables that the <termref
-                        def="dt-binding-collection" diff="chg" at="A"
-                  >binding collection</termref> depends on have the same values as in a previous evaluation.</p>
-            </note>
-            <p>For a given input tuple, if the <termref def="dt-binding-collection" diff="chg" at="A"
-                  >binding collection</termref> for the new variable in the <code>for</code> clause <phrase diff="add" at="A">is empty 
-               (that is, it is an empty sequence or an empty array depending on whether <code>member</code> is specified)</phrase>,
-               and if <code>allowing empty</code> is not specified, the input tuple generates zero output tuples 
-               (it is not represented in the output tuple stream.)</p>
-            
-            <p diff="chg" at="2023-10-16">The <code>allowing empty</code> option is available only when processing sequences, not when processing arrays.
-               The effect is that if the binding collection is an empty sequence, the input tuple generates one output tuple, 
-               with the original variable bindings plus a binding of the new variable to an empty sequence.</p>
-            
-            <note diff="add" at="2023-10-16"><p>If a type declaration is present and <code>allowing empty</code> is specified, the type declaration
-            should include an occurrence indicator of <code>"?"</code> to indicate that the variable may be bound to an
-            empty sequence.</p></note>
-            
-            <p>If the new variable introduced by a <code>for</code> clause has an associated <termref
-                  def="dt-positional-variable"
-                  >positional variable</termref>, the output tuples generated by the <code>for</code> clause  also contain bindings for the <termref
-                  def="dt-positional-variable"
-                  >positional variable</termref>. In this case, as the new variable is bound to each item in its <termref
-                     def="dt-binding-collection" diff="chg" at="A">binding collection</termref>, the <termref
-                  def="dt-positional-variable"
-                  >positional variable</termref> is bound to the ordinal position of that item within the <termref
-                     def="dt-binding-collection" diff="chg" at="A"
-                  >binding collection</termref>, starting with one. Note that, since the <termref
-                  def="dt-positional-variable"
-                  >positional variable</termref> represents a position within a <termref
-                     def="dt-binding-collection" diff="chg" at="A"
-                  >binding collection</termref>, the output tuples corresponding to each input tuple are independently numbered, starting with one. For a given input tuple, if the <termref
-                     def="dt-binding-collection"  diff="chg" at="A"
-                  >binding collection</termref> is empty and <code>allowing empty</code> is specified, the <termref
-                  def="dt-positional-variable"
-               >positional variable</termref> in the output tuple is bound to the integer zero.</p>
-            <p>If <termref def="dt-ordering-mode"
-                  >ordering mode</termref> is <code>ordered</code>, the tuples in the output tuple stream are ordered primarily by the order of the input tuples from which they are derived, and secondarily by the order of the <termref
-                  def="dt-binding-sequence"
-                  >binding sequence</termref> for the new variable; otherwise the order of the output tuple stream is <termref
-                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-            <p>The following examples illustrates the effects of  intermediate <code>for</code> clauses:</p>
-            <ulist>
-
-               <item>
-                  <p>Input tuple stream:</p>
-                  <eg><![CDATA[($x = 1)
-($x = 2)
-($x = 3)
-($x = 4)]]></eg>
-                  <p>Intermediate <code>for</code> clause:</p>
-                  <eg><![CDATA[for $y in ($x to 3)]]></eg>
-                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
-                        >ordering mode</termref> is <code>ordered</code>):</p>
-                  <eg><![CDATA[($x = 1, $y = 1)
-($x = 1, $y = 2)
-($x = 1, $y = 3)
-($x = 2, $y = 2)
-($x = 2, $y = 3)
-($x = 3, $y = 3)
-]]></eg>
-                  <note>
-                     <p>In this example, there is no output tuple that corresponds to the input tuple <code>($x = 4)</code> because, when the <code>for</code> clause is evaluated with the bindings in this input tuple, the resulting <termref
-                        def="dt-binding-collection" diff="chg" at="A"
-                        >binding collection</termref> for <code>$y</code> is empty.</p>
-                  </note>
-               </item>
-               
-
-               <item>
-                  <p>This  example shows how the previous example would have been affected by a <termref
-                        def="dt-positional-variable"
-                     >positional variable</termref> (assuming the same input tuple stream):</p>
-                  <eg><![CDATA[for $y at $j in ($x to 3)]]></eg>
-                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
-                        >ordering mode</termref> is <code>ordered</code>):</p>
-                  <eg><![CDATA[($x = 1, $y = 1, $j = 1)
-($x = 1, $y = 2, $j = 2)
-($x = 1, $y = 3, $j = 3)
-($x = 2, $y = 2, $j = 1)
-($x = 2, $y = 3, $j = 2)
-($x = 3, $y = 3, $j = 1)
-]]></eg>
-               </item>
-
-               <item>
-                  <p>This example shows how the previous example would have been affected by <code>allowing empty</code>. Note that <code>allowing empty</code> causes the input tuple <code>($x = 4)</code> to be represented in the output tuple stream, even though the <termref
-                        def="dt-binding-sequence"
-                        >binding sequence</termref> for <code>$y</code> contains no items for this input tuple.
-                        This example illustrates that <code>allowing empty</code> in a <code>for</code> clause
-                        serves a purpose similar to that of an “outer join” in a relational database query.
-                        (Assume the same input tuple stream as in the previous example.)</p>
-                  <eg><![CDATA[for $y allowing empty at $j in ($x to 3)]]></eg>
-                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
-                        >ordering mode</termref> is <code>ordered</code>):</p>
-                  <eg><![CDATA[($x = 1, $y = 1, $j = 1)
-($x = 1, $y = 2, $j = 2)
-($x = 1, $y = 3, $j = 3)
-($x = 2, $y = 2, $j = 1)
-($x = 2, $y = 3, $j = 2)
-($x = 3, $y = 3, $j = 1)
-($x = 4, $y = (), $j = 0)
-]]></eg>
-               </item>
-               
-               <item diff="add" at="A">
-                  <p>This example illustrates processing of arrays:</p>
-                  <p>Input tuple stream:</p>
-                  <eg><![CDATA[($x = 1)
-($x = 2)
-($x = 3)]]></eg>
-                  <p>Intermediate <code>for</code> clause:</p>
-                  <eg><![CDATA[for member $y in [[$x+1, $x+2], [[$x+3, $x+4]] ]]></eg>
-                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
-                     >ordering mode</termref> is <code>ordered</code>):</p>
-                  <eg><![CDATA[($x = 1, $y = [ 2, 3 ])
-($x = 1, $y = [ 4, 5 ])
-($x = 2, $y = [ 3, 4 ])
-($x = 2, $y = [ 5, 6 ])
-($x = 3, $y = [ 4, 5 ])
-($x = 3, $y = [ 6, 7 ])
-]]></eg>
-                  
-               </item>
-               
-
-               <item>
-                  <p>This example shows how a <code>for</code> clause that binds two variables is semantically equivalent to two <code>for</code> clauses that bind one variable each. We assume that this <code>for</code> clause occurs at the beginning of a FLWOR expression. It is equivalent to an initial single-variable <code>for</code> clause that provides an input tuple stream to an intermediate single-variable <code>for</code> clause.</p>
-                  <eg><![CDATA[for $x in (1, 2, 3, 4), $y in ($x to 3)]]></eg>
-                  <p>Output tuple stream (assuming <termref def="dt-ordering-mode"
-                        >ordering mode</termref> is <code>ordered</code>):</p>
-                  <eg><![CDATA[($x = 1, $y = 1)
-($x = 1, $y = 2)
-($x = 1, $y = 3)
-($x = 2, $y = 2)
-($x = 2, $y = 3)
-($x = 3, $y = 3)
-]]></eg>
-               </item>
-            </ulist>
-            <p>In the above examples, if <termref def="dt-ordering-mode"
-                  >ordering mode</termref> had been <code>unordered</code>, the output tuple streams would have consisted of the same tuples, with the same values for the <termref
-                  def="dt-positional-variable"
-                  >positional variables</termref>, but the ordering of the tuples would have been <termref
-                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-            <p>A <code>for</code> clause may contain one or more <termref def="dt-type-declaration"
-                  >type declarations</termref>, identified by the keyword <code>as</code>. The semantics of <termref
-                  def="dt-type-declaration">type declarations</termref> are defined in <specref
-                  ref="id-binding-rules"/>.</p>
-         </div3>
-         <div3 id="id-xquery-let-clause">
-            <head>Let Clause</head>
-            
-            <changes>
-               <change issue="189" PR="254" date="2022-11-29">
-                  The value bound to a variable in a <code>let</code> clause is now converted
-               to the declared type by applying the coercion rules.
-               </change>
-            </changes>
-            <scrap>
-               <head/>
-               <prodrecap id="LetClause" ref="LetClause"/>
-               <prodrecap id="LetBinding" ref="LetBinding"/>
-               <prodrecap ref="TypeDeclaration"/>
-            </scrap>
-            <p>The purpose of a <code>let</code> clause is to bind values to one or more variables. Each variable is bound to the result of evaluating an expression.</p>
-            <p>If a <code>let</code> clause contains multiple variables, it is semantically equivalent to multiple <code>let</code> clauses, each containing a single variable. For example, the clause</p>
-            <eg><![CDATA[let $x := $expr1, $y := $expr2]]></eg>
-            <p>is semantically equivalent to the following sequence of clauses:</p>
-            <eg><![CDATA[let $x := $expr1
-let $y := $expr2]]></eg>
-            <p>In the remainder of this section, we define the semantics of a <code>let</code> clause containing a single variable <emph>V</emph> and an associated expression <emph>E</emph>.</p>
-            <p>If a single-variable <code>let</code> clause is the initial clause in a FLWOR expression, it simply binds the variable <emph>V</emph> to the result of the expression <emph>E</emph>. The result of the <code>let</code> clause is a tuple stream consisting of one tuple with a single binding that binds <emph>V</emph> to the result of <emph>E</emph>. This tuple stream serves as input to the next clause in the FLWOR expression.</p>
-            <p>If a single-variable <code>let</code> clause is an intermediate clause in a FLWOR expression, it adds a new binding for variable <emph>V</emph> to each tuple in the input tuple stream. For each input tuple, the value bound to <emph>V</emph> is the result of evaluating expression <emph>E</emph>, given the bindings that are already present in that input tuple. The resulting tuples become the output tuple stream of the <code>let</code> clause.</p>
-            <p>The number of tuples in the output tuple stream of an intermediate <code>let</code> clause is the same as the number of tuples in the input tuple stream. The number of bindings in the output tuples is one more than the number of bindings in the input tuples, unless the input tuples already contain bindings for <emph>V</emph>; in this case, the new binding for <emph>V</emph> occludes (replaces) the earlier binding for <emph>V</emph>, and the number of bindings is unchanged.</p>
-            <p>A <code>let</code> clause may contain one or more <termref def="dt-type-declaration"
-                  >type declarations</termref>, identified by the keyword <code>as</code>. The semantics of type declarations are defined in <specref
-                  ref="id-binding-rules"/>.</p>
-            <p>The following code fragment illustrates how a <code>for</code> clause and a <code>let</code> clause can be used together. The <code>for</code> clause produces an initial tuple stream containing a binding for variable <code>$d</code> to each department number found in a given input document. The <code>let</code> clause adds an additional binding to each tuple, binding variable <code>$e</code> to a sequence of employees whose department number matches the value of <code>$d</code> in that tuple.</p>
-            <eg><![CDATA[for $d in doc("depts.xml")/depts/deptno
-let $e := doc("emps.xml")/emps/emp[deptno eq $d]]]></eg>
-         </div3>
-
-
-
-         <div3 id="id-windows">
-            <head>Window Clause</head>
-            
-            <changes>
-               <change issue="452" PR="483" date="2023-05-18">
-                  The <code>start</code> clause in window expressions has become optional, as well as
-                  the <code>when</code> keyword and its associated expression.
-               </change>
-            </changes>
-            
-            <scrap>
-               <head/>
-               <prodrecap ref="WindowClause"/>
-               <prodrecap ref="TumblingWindowClause"/>
-               <prodrecap ref="SlidingWindowClause"/>
-               <prodrecap ref="WindowStartCondition"/>
-               <prodrecap ref="WindowEndCondition"/>
-               <prodrecap ref="WindowVars"/>
-               <prodrecap ref="CurrentItem"/>
-               <prodrecap ref="PositionalVar"/>
-               <prodrecap ref="PreviousItem"/>
-               <prodrecap ref="NextItem"/>
-            </scrap>
-
-            <p>Like a <code>for</code> clause, a <code>window</code> clause
-iterates over its <termref
-                  def="dt-binding-sequence"
-                  >binding
-sequence</termref> and generates a sequence of tuples. In the case of
-a <code>window</code> clause, each tuple represents a window. <termdef
-                  term="window" id="dt-window"
-                     >A <term>window</term> is a sequence of
-consecutive items drawn from the <termref
-                     def="dt-binding-sequence"
-               >binding sequence</termref>.</termdef> Each
-window is represented by at least one and at most nine bound
-variables. The variables have user-specified names, but their roles
-are as follows:</p>
-
-            <ulist>
-
-               <item>
-                  <p>
-                     <emph>Window-variable:</emph> Bound to the sequence of
-  items from the <termref
-                        def="dt-binding-sequence"
-                     >binding
-  sequence</termref> that comprise the window.</p>
-               </item>
-
-               <item>
-                  <p>
-                     <emph>Start-item:</emph> (Optional) Bound to the first item
-  in the window.</p>
-               </item>
-
-               <item>
-                  <p>
-                     <emph>Start-item-position:</emph> (Optional) Bound to the
-  ordinal position of the first window item in the <termref
-                        def="dt-binding-sequence"
-                        >binding
-  sequence</termref>. <emph>Start-item-position</emph> is a <termref
-                        def="dt-positional-variable"
-                        >positional variable</termref>; hence, its type
-  is <code>xs:integer</code>.
-                  </p>
-               </item>
-
-               <item>
-                  <p>
-                     <emph>Start-previous-item:</emph> (Optional) Bound to the
-  item in the <termref
-                        def="dt-binding-sequence"
-                     >binding
-  sequence</termref> that precedes the first item in the window (empty
-  sequence if none).</p>
-               </item>
-
-               <item>
-                  <p>
-                     <emph>Start-next-item:</emph> (Optional) Bound to the item
-  in the <termref
-                        def="dt-binding-sequence"
-                     >binding sequence</termref>
-  that follows the first item in the window (empty sequence if
-  none).</p>
-               </item>
-
-               <item>
-                  <p>
-                     <emph>End-item:</emph> (Optional) Bound to the last item in
-  the window.</p>
-               </item>
-
-               <item>
-                  <p>
-                     <emph>End-item-position:</emph> (Optional) Bound to the
-  ordinal position of the last window item in the <termref
-                        def="dt-binding-sequence"
-                        >binding
-  sequence</termref>. <emph>End-item-position</emph> is a <termref
-                        def="dt-positional-variable"
-                        >positional variable</termref>; hence, its type
-  is <code>xs:integer</code>.
-                  </p>
-               </item>
-
-               <item>
-                  <p>
-                     <emph>End-previous-item:</emph> (Optional) Bound to the
-  item in the <termref
-                        def="dt-binding-sequence"
-                     >binding
-  sequence</termref> that precedes the last item in the window (empty
-  sequence if none).</p>
-               </item>
-
-               <item>
-                  <p>
-                     <emph>End-next-item:</emph> (Optional) Bound to the item in
-  the <termref
-                        def="dt-binding-sequence"
-                     >binding sequence</termref>
-  that follows the last item in the window (empty sequence if
-  none).</p>
-               </item>
-
-            </ulist>
-
-            <p>All variables in a <code>window</code> clause must have distinct names;
- otherwise a <termref
-                  def="dt-static-error">static error</termref> is raised <errorref class="ST"
-                  code="0103"/>.</p>
-
-            <p>The following is an example of a <code>window</code> clause that
-binds nine variables to the roles listed above. In this example, the
-variables are named <code>$w</code>, <code>$s</code>,
-<code>$spos</code>, <code>$sprev</code>, <code>$snext</code>,
-<code>$e</code>, <code>$epos</code>, <code>$eprev</code>, and
-<code>$enext</code> respectively. A <code>window</code> clause always
-binds the window variable, but typically binds only a subset of the
-other variables.</p>
-
-            <eg><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10)
-  start $s at $spos previous $sprev next $snext when true() 
-  end   $e at $epos previous $eprev next $enext when true()]]></eg>
-
-            <p>Windows are
-created by iterating over the items in the <termref
-                  def="dt-binding-sequence"
-                  >binding sequence</termref>, in order,
-identifying the start item and the end item of each window by
-evaluating the <nt
-                  def="WindowStartCondition">WindowStartCondition</nt> and the <nt
-                  def="WindowEndCondition"
-                  >WindowEndCondition</nt>. Each of these
-conditions is satisfied if the <termref
-                  def="dt-ebv"
-                  >effective boolean
-value</termref> of the expression following the <code>when</code>
-keyword is <code>true</code>.
-
-The start item of the window is an item that satisfies the <nt
-                  def="WindowStartCondition">WindowStartCondition</nt> (see <specref
-                  ref="id-tumbling-windows"/> and <specref ref="id-sliding-windows"
-                  /> for a more complete explanation.) The end item of the window is the first item in the <termref
-                  def="dt-binding-sequence"
-                  >binding sequence</termref>, beginning with the start item, that satisfies the <nt
-                  def="WindowEndCondition">WindowEndCondition</nt> (again, see <specref
-                  ref="id-tumbling-windows"/> and <specref ref="id-sliding-windows"
-                  /> for more details.) Each window contains its start item, its end
-item, and all items that occur between them in the <termref
-                  def="dt-binding-sequence"
-                  >binding sequence</termref>.
-If the end item is the start item, then the window contains only one
-item.  If a start item is identified, but no following item in the <termref
-                  def="dt-binding-sequence">binding sequence</termref> satisfies the <nt
-                  def="WindowEndCondition"
-                  >WindowEndCondition</nt>, then the <code>only</code> keyword determines whether a window is
-generated: if <code>only end</code> is specified, then no window is
-generated; otherwise, the end item is set to the last item in the
-<termref
-                  def="dt-binding-sequence"
-               >binding sequence</termref> and a window is generated.</p>
-            <p>In the above example, the <nt def="WindowStartCondition"
-                  >WindowStartCondition</nt> and <nt def="WindowEndCondition"
-                  >WindowEndCondition</nt> are both <code>true</code>,
-which causes each item in the <termref
-                  def="dt-binding-sequence"
-                  >binding sequence</termref> to be in a separate window. 
-Typically, the <nt
-                  def="WindowStartCondition">WindowStartCondition</nt> and <nt
-                  def="WindowEndCondition"
-                  >WindowEndCondition</nt> are expressed in terms of bound variables. For example, the following <nt
-                  def="WindowStartCondition"
-                  >WindowStartCondition</nt> might be used to start a new window for every item in the <termref
-                  def="dt-binding-sequence"
-               >binding sequence</termref> that is larger than both the previous item and the following item:</p>
-            <eg>start $s previous $sprev next $snext
- when $s &gt; $sprev and $s &gt; $snext</eg>
-            <p>The scoping rules for the variables bound by a <code>window</code> clause are as follows:</p>
-            <ulist>
-
-
-
-               <item>
-                  <p>In the <code>when</code>-expression of the <nt def="WindowStartCondition"
-                        >WindowStartCondition</nt>, the following variables (identified here by their roles) are in scope (if bound): <emph>start-item, start-item-position, start-previous-item, start-next-item.</emph>
-                  </p>
-               </item>
-
-
-
-               <item>
-                  <p>In the <code>when</code>-expression of the <nt def="WindowEndCondition"
-                        >WindowEndCondition</nt>, the following variables (identified here by their roles) are in scope (if bound): <emph>start-item, start-item-position, start-previous-item, start-next-item, end-item, end-item-position, end-previous-item, end-next-item.</emph>
-                  </p>
-               </item>
-
-
-
-               <item>
-                  <p>In the clauses of the FLWOR expression that follow the <code>window</code> clause, all nine of the variables bound by the <code>window</code> clause (including <emph>window-variable</emph>) are in scope (if bound).</p>
-               </item>
-            </ulist>
-
-            <p>The <code>when</code> keyword of a condition and the associated expression is optional.
-               If omitted, the expression defaults to <code>true()</code>.
-               If the complete <code>start</code> clause is omitted, no variables are bound and
-               the expression also defaults to <code>true()</code>.
-               The <code>end</code> clause can be omitted only within a <nt
-                  def="TumblingWindowClause">TumblingWindowClause</nt>.</p>
-
-            <p>In a <code>window</code> clause, the keyword <code>tumbling</code> or <code>sliding</code> determines the way in which the starting item of each window is identified, as explained in the following sections.</p>
-            <div4 id="id-tumbling-windows">
-               <head>Tumbling Windows</head>
-
-
-
-               <p>If the window type is <code>tumbling</code>, then windows
-never overlap. The search for the start of the first window begins at the beginning of the <termref
-                     def="dt-binding-sequence"
-                     >binding sequence</termref>. After each window is generated, the search
-for the start of the next window begins with the item in the <termref
-                     def="dt-binding-sequence"
-                     >binding sequence</termref> that occurs after the ending item of the last generated
-window. Thus, no item that occurs in one window can occur in another
-window drawn from the same <termref
-                     def="dt-binding-sequence"
-                     >binding sequence</termref> (unless the sequence contains the same item more than once). 
-In a tumbling window clause,
-the <code>end</code> clause is optional; if it is omitted, the
-<code>start</code> clause is applied to identify all potential
-starting items in the <termref
-                     def="dt-binding-sequence"
-                     >binding sequence</termref>, and a window is constructed
-for each starting item, including all items from that starting item up
-to the item before the next window’s starting item, or the end of the
-<termref
-                     def="dt-binding-sequence"
-                  >binding sequence</termref>, whichever comes first.</p>
-               <p>The following examples illustrate the use of tumbling windows.</p>
-               <ulist>
-
-
-
-                  <item>
-                     <p>Show non-overlapping windows of three items.</p>
-                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-  start at $s
-  only end at $e when $e - $s eq 2
-return <window>{ $w }</window>]]></eg>
-
-                     <p>Result:</p>
-                     <eg><![CDATA[<window>2 4 6</window>
-<window>8 10 12</window>]]></eg>
-                  </item>
-
-
-
-                  <item>
-                     <p>Show averages of non-overlapping three-item windows.</p>
-                     <eg role="parse-test"><![CDATA[
-for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-  start at $s
-  only end at $e when $e - $s eq 2
-return avg($w)]]></eg>
-
-                     <p>Result:</p>
-                     <eg><![CDATA[4 10]]></eg>
-                  </item>
-
-
-
-                  <item>
-                     <p>Show first and last items in each window of three items.</p>
-                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-  start $first at $s
-  only end $last at $e when $e - $s eq 2
-return <window>{ $first, $last }</window>]]></eg>
-
-                     <p>Result:</p>
-                     <eg><![CDATA[<window>2 6</window>
-<window>8 12</window>]]></eg>
-                  </item>
-
-
-
-                  <item>
-                     <p>Show non-overlapping windows of up to three items (illustrates <code>end</code> clause without the <code>only</code> keyword).</p>
-                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-  start at $s
-  end at $e when $e - $s eq 2
-return <window>{ $w }</window>]]></eg>
-
-                     <p>Result:</p>
-                     <eg><![CDATA[<window>2 4 6</window>
-<window>8 10 12</window>
-<window>14</window>]]></eg>
-                  </item>
-
-
-
-                  <item>
-                     <p>Show non-overlapping windows of up to three items (illustrates use of <code>start</code> without explicit <code>end</code>).</p>
-                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-  start at $s when $s mod 3 = 1
-return <window>{ $w }</window>]]></eg>
-
-                     <p>Result:</p>
-                     <eg><![CDATA[<window>2 4 6</window>
-<window>8 10 12</window>
-<window>14</window>]]></eg>
-                  </item>
-
-
-
-                  <item>
-                     <p>Show non-overlapping sequences starting with a number divisible by 3.</p>
-
-                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-  start $first when $first mod 3 = 2
-return <window>{ $w }</window>]]></eg>
-
-                     <p>Result:</p>
-                     <eg><![CDATA[<window>2 4 6</window>
-<window>8 10 12</window>
-<window>14</window>]]></eg>
-                  </item>
-
-                  <item>
-                     <p>Show non-overlapping sequences ending with a number divisible by 3.</p>
-
-                     <eg role="parse-test"><![CDATA[for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
-  end $last when $last mod 3 = 0
-return <window>{ $w }</window>]]></eg>
-
-                     <p>Result (identical to the result of the previous query):</p>
-                     <eg><![CDATA[<window>2 4 6</window>
-<window>8 10 12</window>
-<window>14</window>]]></eg>
-                  </item>
-
-               </ulist>
-
-
-
-
-
-
-
-
-
-
-            </div4>
-            <div4 id="id-sliding-windows">
-               <head>Sliding Windows</head>
-
-               <p>If the window type is <code>sliding window</code>, then windows may
-overlap. Every item in the <termref
-                     def="dt-binding-sequence">binding sequence</termref> that satisfies the <nt
-                     def="WindowStartCondition"
-                     >WindowStartCondition</nt> is the starting item of a new window. Thus, a given
-item may be found in multiple windows drawn from the same <termref
-                     def="dt-binding-sequence">binding sequence</termref>.</p>
-               <p>The following examples illustrate the use of sliding windows.</p>
-
-
-               <ulist>
-
-
-
-                  <item>
-                     <p>Show windows of three items.</p>
-                     <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-  start at $s
-  only end at $e when $e - $s eq 2
-return <window>{ $w }</window>]]></eg>
-
-                     <p>Result:</p>
-
-                     <eg><![CDATA[<window>2 4 6</window>
-<window>4 6 8</window>
-<window>6 8 10</window>
-<window>8 10 12</window>
-<window>10 12 14</window>]]></eg>
-                  </item>
-
-
-
-                  <item>
-                     <p>Show moving averages of three items.</p>
-
-                     <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-  start at $s
-  only end at $e when $e - $s eq 2
-return avg($w)]]></eg>
-
-                     <p>Result:</p>
-                     <eg><![CDATA[4 6 8 10 12]]></eg>
-                  </item>
-
-
-
-                  <item>
-                     <p>Show overlapping windows of up to three items (illustrates <code>end</code> clause without the <code>only</code> keyword).</p>
-
-                     <eg role="parse-test"><![CDATA[for sliding window $w in (2, 4, 6, 8, 10, 12, 14)
-  start at $s
-  end at $e when $e - $s eq 2
-return <window>{ $w }</window>]]></eg>
-
-                     <p>Result:</p>
-                     <eg><![CDATA[<window>2 4 6</window>
-<window>4 6 8</window>
-<window>6 8 10</window>
-<window>8 10 12</window>
-<window>10 12 14</window>
-<window>12 14</window>
-<window>14</window>]]></eg>
-                  </item>
-               </ulist>
-
-
-
-
-
-            </div4>
-            <div4 id="id-effects-of-window-clauses">
-               <head>Effects of Window Clauses on the Tuple Stream</head>
-               <p>The effects of a <code>window</code> clause on the tuple stream are similar to the effects of a <code>for</code> clause. As described in <specref
-                     ref="id-windows"
-                  />, a <code>window</code> clause generates zero or more windows, each of which is represented by at least one and at most nine bound variables.</p>
-               <p>If the <code>window</code> clause is the initial clause in a FLWOR expression, the bound variables that describe each window become an output tuple. These tuples form the initial tuple stream that serves as input to the next clause of the FLWOR expression. If <termref
-                     def="dt-ordering-mode"
-                     >ordering mode</termref> is <code>ordered</code>, the order of tuples in the tuple stream is the
-order in which their start items appear in the <termref
-                     def="dt-binding-sequence"
-                     >binding sequence</termref>; otherwise the order of the tuple stream is <termref
-                     def="dt-implementation-dependent"
-                  >implementation-dependent</termref>. The cardinality of the tuple stream is equal to the number of windows.</p>
-               <p>If a <code>window</code> clause is an intermediate clause in a FLWOR expression, each input tuple generates zero or more output tuples, each consisting of  the original bound variables of the input tuple plus the new bound variables that represent one of the generated windows. For each tuple <emph>T</emph> in the input tuple stream, the output tuple stream will contain <emph>N<sub>T</sub>
-                  </emph> tuples, where <emph>N<sub>T</sub>
-                  </emph> is the number of windows generated by the <code>window</code> clause, given the bindings in the input tuple <emph>T</emph>. Input tuples for which no windows are generated are not represented in the output tuple stream. If <termref
-                     def="dt-ordering-mode"
-                     >ordering mode</termref> is <code>ordered</code>, the order of tuples in the output stream is determined primarily by the order of the input tuples from which they were derived, and secondarily by the order in which their start items appear in the <termref
-                     def="dt-binding-sequence">binding sequence</termref>. If <termref
-                     def="dt-ordering-mode"
-                     >ordering mode</termref> is <code>unordered</code>, the order of tuples in the output stream is <termref
-                     def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-               <p>The following example illustrates a <code>window</code> clause that is the initial clause in a FLWOR expression. The example is based on input data that consists of a sequence of closing stock prices for a specific company. For this example we assume the following input data (assume that the <code>price</code> elements have a validated type of <code>xs:decimal</code>):</p>
-               <eg><![CDATA[<stock>
-  <closing> <date>2008-01-01</date> <price>105</price> </closing>
-  <closing> <date>2008-01-02</date> <price>101</price> </closing>
-  <closing> <date>2008-01-03</date> <price>102</price> </closing>
-  <closing> <date>2008-01-04</date> <price>103</price> </closing>
-  <closing> <date>2008-01-05</date> <price>102</price> </closing>
-  <closing> <date>2008-01-06</date> <price>104</price> </closing>
-</stock>]]></eg>
-               <p>A user wishes to find “run-ups,” which are defined as sequences of dates that begin with a “low” and end with a “high” price (that is, the stock price begins to rise on the first day of the run-up, and continues to rise or remain even through the last day of the run-up.) The following query uses a tumbling window to find run-ups in the input data:</p>
-               <eg role="parse-test">for tumbling window $w in //closing
-   start $first next $second when $first/price &lt; $second/price
-   end $last next $beyond when $last/price &gt; $beyond/price
-return
-  &lt;run-up&gt;
-    &lt;start-date&gt;{ data($first/date) }&lt;/start-date&gt;
-    &lt;start-price&gt;{ data($first/price) }&lt;/start-price&gt;
-    &lt;end-date&gt;{ data($last/date) }&lt;/end-date&gt;
-    &lt;end-price&gt;{ data($last/price) }&lt;/end-price&gt;
-  &lt;/run-up&gt;</eg>
-               <p>For our sample input data, this <code>tumbling window</code> clause generates a tuple stream consisting of two tuples, each representing a window and containing five bound variables named <code>$w</code>, <code>$first</code>, <code>$second</code>, <code>$last</code>, and <code>$beyond</code>. The <code>return</code> clause is evaluated for each of these tuples, generating the following query result:</p>
-               <eg>&lt;run-up&gt;
-  &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
-  &lt;start-price&gt;101&lt;/start-price&gt;
-  &lt;end-date&gt;2008-01-04&lt;/end-date&gt;
-  &lt;end-price&gt;103&lt;/end-price&gt;
-&lt;/run-up&gt;
-&lt;run-up&gt;
-  &lt;start-date&gt;2008-01-05&lt;/start-date&gt;
-  &lt;start-price&gt;102&lt;/start-price&gt;
-  &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
-  &lt;end-price&gt;104&lt;/end-price&gt;
-&lt;/run-up&gt;</eg>
-               <p>The following example illustrates a <code>window</code> clause that is an intermediate clause in a FLWOR expression. In this example, the input data contains closing stock prices for several different companies, each identified by a three-letter symbol. We assume the following input data (again assuming that the type of the <code>price</code> element is <code>xs:decimal</code>):</p>
-               <eg><![CDATA[<stocks>
-  <closing> <symbol>ABC</symbol> <date>2008-01-01</date> <price>105</price> </closing>
-  <closing> <symbol>DEF</symbol> <date>2008-01-01</date> <price>057</price> </closing>
-  <closing> <symbol>ABC</symbol> <date>2008-01-02</date> <price>101</price> </closing>
-  <closing> <symbol>DEF</symbol> <date>2008-01-02</date> <price>054</price> </closing>
-  <closing> <symbol>ABC</symbol> <date>2008-01-03</date> <price>102</price> </closing>
-  <closing> <symbol>DEF</symbol> <date>2008-01-03</date> <price>056</price> </closing>
-  <closing> <symbol>ABC</symbol> <date>2008-01-04</date> <price>103</price> </closing>
-  <closing> <symbol>DEF</symbol> <date>2008-01-04</date> <price>052</price> </closing>
-  <closing> <symbol>ABC</symbol> <date>2008-01-05</date> <price>101</price> </closing>
-  <closing> <symbol>DEF</symbol> <date>2008-01-05</date> <price>055</price> </closing>
-  <closing> <symbol>ABC</symbol> <date>2008-01-06</date> <price>104</price> </closing>
-  <closing> <symbol>DEF</symbol> <date>2008-01-06</date> <price>059</price> </closing>
-</stocks>]]></eg>
-               <p>As in the previous example, we want to find "run-ups," which are defined as sequences of dates that begin with a "low" and end with a "high" price for a specific company. In this example, however, the input data consists of stock prices for multiple companies. Therefore it is necessary to isolate the stock prices of each company before forming windows. This can be accomplished by an initial <code>for</code> and <code>let</code> clause, followed by a <code>window</code> clause, as follows:</p>
-               <eg role="parse-test">for $symbol in distinct-values(//symbol)
-let $closings := //closing[symbol = $symbol]
-for tumbling window $w in $closings
-  start $first next $second when $first/price &lt; $second/price
-  end $last next $beyond when $last/price &gt; $beyond/price
-return
-  &lt;run-up symbol="{ $symbol }"&gt;
-    &lt;start-date&gt;{ data($first/date) }&lt;/start-date&gt;
-    &lt;start-price&gt;{ data($first/price) }&lt;/start-price&gt;
-    &lt;end-date&gt;{ data($last/date) }&lt;/end-date&gt;
-    &lt;end-price&gt;{ data($last/price) }&lt;/end-price&gt;
-  &lt;/run-up&gt;</eg>
-               <note>
-                  <p>In the above example, the <code>for</code> and <code>let</code> clauses could be rewritten as follows:</p>
-                  <eg><![CDATA[for $closings in //closing
-let $symbol := $closings/symbol
-group by $symbol]]></eg>
-                  <p>The <code>group by</code> clause is described in <specref ref="id-group-by"
-                     />.</p>
-               </note>
-               <p>The <code>for</code> and <code>let</code> clauses in this query generate an initial tuple stream consisting of two tuples. In the first tuple, <code>$symbol</code> is bound to "ABC" and <code>$closings</code> is bound to the sequence of <code>closing</code> elements for company ABC. In the second tuple, <code>$symbol</code> is bound to "DEF" and <code>$closings</code> is bound to the sequence of <code>closing</code> elements for company DEF.</p>
-               <p>The <code>window</code> clause operates on this initial tuple stream, generating two windows for the first tuple and two windows for the second tuple. The result is a tuple stream consisting of four tuples, each with the following bound variables: <code>$symbol</code>, <code>$closings</code>, <code>$w</code>, <code>$first</code>, <code>$second</code>, <code>$last</code>, and <code>$beyond</code>. The <code>return</code> clause is then evaluated for each of these tuples, generating the following query result:</p>
-               <eg>&lt;run-up symbol="ABC"&gt;
-   &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
-   &lt;start-price&gt;101&lt;/start-price&gt;
-   &lt;end-date&gt;2008-01-04&lt;/end-date&gt;
-   &lt;end-price&gt;103&lt;/end-price&gt;
-&lt;/run-up&gt;
-&lt;run-up symbol="ABC"&gt;
-   &lt;start-date&gt;2008-01-05&lt;/start-date&gt;
-   &lt;start-price&gt;101&lt;/start-price&gt;
-   &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
-   &lt;end-price&gt;104&lt;/end-price&gt;
-&lt;/run-up&gt;
-&lt;run-up symbol="DEF"&gt;
-   &lt;start-date&gt;2008-01-02&lt;/start-date&gt;
-   &lt;start-price&gt;054&lt;/start-price&gt;
-   &lt;end-date&gt;2008-01-03&lt;/end-date&gt;
-   &lt;end-price&gt;056&lt;/end-price&gt;
-&lt;/run-up&gt;
-&lt;run-up symbol="DEF"&gt;
-   &lt;start-date&gt;2008-01-04&lt;/start-date&gt;
-   &lt;start-price&gt;052&lt;/start-price&gt;
-   &lt;end-date&gt;2008-01-06&lt;/end-date&gt;
-   &lt;end-price&gt;059&lt;/end-price&gt;
-&lt;/run-up&gt;</eg>
-            </div4>
-         </div3>
-
-
-         
-         
-         <div3 id="id-where">
-            <head>Where Clause</head>
-            <scrap>
-               <head/>
-               <prodrecap id="WhereClause" ref="WhereClause"/>
-            </scrap>
-            <p>A <code>where</code> clause serves as a filter for the tuples in its input tuple stream. The expression in the <code>where</code> clause, called the <term>where-expression</term>, is evaluated once for
-               each of these tuples. If the <termref
-                  def="dt-ebv"
-                  >effective boolean value</termref> of the
-               where-expression is <code>true</code>, the tuple is retained in the output tuple stream; otherwise the tuple is discarded.</p>
-            <p>Examples:</p>
-            <ulist>
-               
-               
-               
-               <item>
-                  <p>This example illustrates the effect of a <code>where</code> clause on a tuple stream:</p>
-                  <p>Input tuple stream:</p>
-                  <eg><![CDATA[($a = 5, $b = 11)
-($a = 91, $b = 42)
-($a = 17, $b = 30)
-($a = 85, $b = 63)]]></eg>
-                  <p>
-                     <code>where</code> clause:</p>
-                  <eg>where $a &gt; $b</eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($a = 91, $b = 42)
-($a = 85, $b = 63)]]></eg>
-               </item>
-               
-               
-               
-               <item>
-                  <p>The following query illustrates how a <code>where</code> clause might be used with a <termref
-                     def="dt-positional-variable"
-                     >positional variable</termref> to perform sampling on an input sequence. The query returns one value out of each one hundred input values.</p>
-                  <eg role="parse-test">
-                     <phrase role="parse-test">for $x at $i in $input
-where $i mod 100 = 0
-return $x</phrase>
-                  </eg>
-               </item>
-            </ulist>
-         </div3>
-         
-         <div3 id="id-while" diff="add" at="issue187">
-            <head>While Clause</head>
-            
-            <changes>
-               <change issue="187" PR="943" date="2024-02-06">
-                  A FLWOR expression may now include a <code>while</code> clause,
-               which causes early exit from the iteration when a condition is encountered.
-               </change>
-            </changes>
-            
-            <scrap>
-               <head/>
-               <prodrecap id="WhileClause" ref="WhileClause"/>
-            </scrap>
-            
-            <p>A <code>while</code> clause serves as a filter for the tuples 
-               in its input tuple stream. The expression in the while clause, 
-               called the <code>while-expression</code>, is evaluated once for each of these tuples. 
-               If the <termref def="dt-ebv">effective boolean value</termref> 
-               of the <code>while-expression</code> is true, the 
-               tuple is retained in the output tuple stream; otherwise the tuple 
-               and all subsequent tuples in the stream are discarded.</p>
-            
-            <p>Examples:</p>
-            
-            <ulist>
-               <item>
-                  <p>This example illustrates the effect of a <code>while</code> clause on a tuple stream.</p>
-                  <p>Input tuple stream:</p>
-                  <eg><![CDATA[($a = 13, $b = 11)
-($a = 91, $b = 42)
-($a = 17, $b = 30)
-($a = 85, $b = 63)]]></eg><p>while clause:</p>
-                  <eg>while $a > $b</eg>
-                  <p> Output tuple stream:</p>
-                  <eg><![CDATA[($a = 13, $b = 11)
-($a = 91, $b = 42)]]></eg>
-               </item>
-               <item>
-                  <p>The following query illustrates how a <code>while</code> clause might be used to 
-                     extract all items in an input sequence before the first one that 
-                     fails to satisfy some condition. In this case it selects the 
-                     leading <code>para</code> elements in the input sequence, stopping 
-                     before the first element that is not a <code>para</code> element.
-                  </p>
-                  <eg><![CDATA[for $x in $section/*
-while $x[self::para]
-return $x]]></eg>
-               </item>
-               <item>
-                  <p>The following query illustrates how a <code>while</code> clause might be used to 
-                     limit the number of items returned in the query result.
-                  </p>
-                  <eg><![CDATA[for $x in $section/para
-where contains($x, 'the')
-count $total
-while $total le 10
-return $x]]></eg>
-                  <p>In this example a <code>where</code> clause would have exactly the same effect,
-                  but might require a smarter optimizer to deliver the same performance.</p>
-               </item>
-            </ulist>
-            
-            <note>
-               <p>Although the semantics are described in terms of discarding 
-                  all the tuples following the first one that fails to match 
-                  the condition, a practical implementation is likely to avoid 
-                  evaluating those tuples, thus giving an "early exit" from 
-                  the iteration performed by the FLWOR expression.
-               </p>
-            </note>
-            
-            <note><p>The expression <code>for $i in $input while $i le 3</code> differs
-               from the expression <code>subsequence-where($input, to := fn {. gt 3 })</code> in that
-               the <code>while</code> expression drops the first item that is greater than 3,
-               while the <code>subsequence-where</code> expression retains it.</p></note>
-            
-            <note><p>The effect of the <code>while</code> clause is unpredictable in cases
-            where the ordering of the tuple stream is unpredictable. This can happen, for example,
-            when <termref def="dt-ordering-mode"/> is <code>unordered</code>, or when iterating
-            over the entries in a map.</p></note>
-            
-            <ednote><edtext>Add to changes appendix.</edtext></ednote>
-            
-         </div3>
-
-         <div3 id="id-count">
-            <head>Count Clause</head>
-            <scrap>
-               <head/>
-               <prodrecap id="CountClause" ref="CountClause"/>
-            </scrap>
-
-            <p>The purpose of a <code>count</code> clause is to enhance the tuple
-stream with a new variable that is bound, in each tuple, to the
-ordinal position of that tuple in the tuple stream. The name of the
-new variable is specified in the <code>count</code> clause. Its type
-            is implicitly <code>xs:integer</code>.</p>
-
-            <p>The output tuple stream of a <code>count</code> clause is the same
-as its input tuple stream, with each tuple enhanced by one additional
-variable that is bound to the ordinal position of that tuple in the
-tuple stream. However, if the name of the new variable is the same as
-the name of an existing variable in the input tuple stream, the new
-variable occludes (replaces) the existing variable of the same name,
-and the number of bound variables in each tuple is unchanged.</p>
-
-            <p>The following examples illustrate uses of the <code>count</code> clause:</p>
-
-
-            <ulist>
-
-
-
-               <item>
-                  <p>This example illustrates the effect of a <code>count</code> clause on an input tuple stream:</p>
-                  <p>Input tuple stream:</p>
-                  <eg><![CDATA[($name = "Bob", $age = 21)
-($name = "Carol", $age = 19)
-($name = "Ted", $age = 20)
-($name = "Alice", $age = 22)]]></eg>
-                  <p>
-                     <code>count</code> clause:</p>
-                  <eg><![CDATA[count $counter]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($name = "Bob", $age = 21, $counter = 1)
-($name = "Carol", $age = 19, $counter = 2)
-($name = "Ted", $age = 20, $counter = 3)
-($name = "Alice", $age = 22, $counter = 4)]]></eg>
-               </item>
-
-
-
-
-
-               <item>
-                  <p>This example illustrates how a counter might be used to filter the result of a query. The query ranks products in order by decreasing sales, and returns the three products with the highest sales. Assume that the variable <code>$products</code> is bound to a sequence of <code>product</code> elements, each of which has <code>name</code> and <code>sales</code> child-elements.</p>
-                  <eg role="parse-test">for $p in $products
-order by $p/sales descending
-count $rank
-while $rank &lt;= 3
-return &lt;product rank="{ $rank }"&gt;{ $p/name, $p/sales }&lt;/product&gt;</eg>
-                  <p>The result of this query has the following structure:</p>
-                  <eg>&lt;product rank="1"&gt;
-  &lt;name&gt;Toaster&lt;/name&gt;
-  &lt;sales&gt;968&lt;/sales&gt;
-&lt;/product&gt;
-&lt;product rank="2"&gt;
-  &lt;name&gt;Blender&lt;/name&gt;
-  &lt;sales&gt;520&lt;/sales&gt;
-&lt;/product&gt;
-&lt;product rank="3"&gt;
-  &lt;name&gt;Can Opener&lt;/name&gt;
-  &lt;sales&gt;475&lt;/sales&gt;
-&lt;/product&gt;</eg>
-               </item>
-            </ulist>
-         </div3>
-
-         <div3 id="id-group-by">
-            <head>Group By Clause</head>
-            <scrap>
-               <head/>
-               <prodrecap ref="GroupByClause"/>
-               <prodrecap ref="GroupingSpecList"/>
-               <prodrecap ref="GroupingSpec"/>
-               <prodrecap ref="GroupingVariable"/>
-            </scrap>
-
-
-            <p>A <code>group by</code> clause generates an output tuple stream in which each tuple represents a group of tuples from the input tuple stream
-that have equivalent grouping keys. 
-We will refer to the tuples in the input tuple stream as  <term>pre-grouping tuples</term>, and the tuples in the output tuple stream as <term>post-grouping tuples</term>.</p>
-
-            <p>The <code>group by</code> clause assigns each pre-grouping tuple to a group, and
-generates one post-grouping tuple for each group. 
-
-In the post-grouping tuple for a group, each grouping key is represented by a variable that was specified in a <nt
-                  def="GroupingSpec"
-               >GroupingSpec</nt>, and every variable that appears in the pre-grouping tuples that were assigned to that group is represented by a variable of the same name, bound to a sequence of all values bound to the variable in any of these pre-grouping tuples.
-
-Subsequent clauses in the FLWOR expression see only the variable
-bindings in the post-grouping tuples; they no longer have access to
-the variable bindings in the pre-grouping tuples. 
-The number of post-grouping tuples is less than or equal to
-the number of pre-grouping tuples.</p>
-
-            <p>A <code>group by</code> clause contains one or more <nt def="GroupingSpec"
-                  >grouping specifications</nt>, as shown in the grammar. <termdef
-                  id="dt-grouping-variable" term="grouping variable"
-                     >Each grouping specification specifies one <nt def="GroupingVariable"
-                     >grouping variable</nt>, which refers to variable bindings in the pre-grouping tuples. The values of the grouping variables are used to assign pre-grouping tuples to groups.</termdef> Each grouping specification may optionally provide an expression to which its grouping variable is bound.  If no expression is provided, the grouping variable name must be equal (by the <code>eq</code> operator on <termref
-                  def="dt-expanded-qname"
-                  >expanded QNames</termref>) to the name of a variable in the input tuple stream, and it refers to that variable; otherwise a <termref
-                  def="dt-static-error">static error</termref> is raised <errorref class="ST"
-                  code="0094"
-                  />. For each grouping specification that contains a binding expression, a <code>let</code> binding is created in the pre-grouping tuples, and the grouping variable refers to that <code>let</code> binding. For example, the clause:</p>
-
-            <eg><![CDATA[group by $g1, $g2 := $expr1, $g3 := $expr2 collation "Spanish"]]></eg>
-
-            <p>is semantically equivalent to the following sequence of clauses:</p>
-
-            <eg><![CDATA[let $g2 := $expr1
-let $g3 := $expr2
-group by $g1, $g2, $g3 collation "Spanish"]]></eg>
-
-            <p>The process of group formation proceeds as follows:
-
-<olist> <item>
-                     <p>
-                        <termdef term="grouping key" id="dt-grouping-key"
-                              >The
-  atomized value of a <termref def="dt-grouping-variable"
-                              >grouping
-  variable</termref> is called a <term>grouping key</term>.</termdef>
-  For each pre-grouping tuple, the <termref
-                           def="dt-grouping-key">grouping keys</termref> are created by
-  <termref
-                           def="dt-atomization">atomizing</termref> the values of the
-  <termref
-                           def="dt-grouping-variable"
-                           >grouping variables</termref> (in
-  the post-grouping tuples, each grouping variable is set to the value
-  of the corresponding grouping key, as discussed below).
-
-  If the value of any <termref
-                           def="dt-grouping-variable"
-                           >grouping variable</termref> consists of
-  more than one item, a <termref
-                           def="dt-type-error">type
-  error</termref> is raised <errorref class="TY"
-                           code="0004"
-                           />. If a type declaration is present
-  and the resulting atomized value is not an instance of the specified
-  type, a <termref
-                           def="dt-type-error">type error</termref> is raised
-  <errorref class="TY"
-                           code="0004"/>.</p>
-                  </item> <item>
-                     <p>The input tuple stream is partitioned into groups of tuples
-  whose grouping keys are <termref
-                           def="dt-equivalent-grouping-keys">equivalent</termref>. <termdef
-                           id="dt-equivalent-grouping-keys" term="equivalent grouping keys"
-                              >Two
-  tuples <var>T1</var> and <var>T2</var> have <term>equivalent
-  grouping keys</term> if and only if, for each grouping variable
-  <var>GV</var>, the atomized value of <var>GV</var> in <var>T1</var>
-  is deep-equal to the atomized value of <var>GV</var> in
-  <var>T2</var>, as defined by applying the function
-  <function>fn:deep-equal</function> using the appropriate
-  collation.</termdef></p>
-                     
-                     <note diff="add" at="2023-12-05"><p>The <function>fn:deep-equal</function> has been changed
-                     in &language; so that it is now transitive; the problem that existed
-                     in earlier versions when comparing numeric values of different
-                     types has thereby been resolved.</p></note>
-
-  <note>
-                        <p>The atomized grouping key will always be either an empty
-     sequence or a single atomic value. Defining equivalence by
-     reference to the <function>fn:deep-equal</function> function
-     ensures that the empty sequence is equivalent only to the empty
-     sequence, that <code>NaN</code> is equivalent to
-     <code>NaN</code>, that untypedAtomic values are compared as
-     strings, and that values for which the <code>eq</code> operator
-     is not defined are considered
-     non-equivalent.</p>
-                     </note> </item> <item>
-                     <p>The appropriate collation for comparing two grouping keys is the collation
-   specified in the pertinent <nt
-                           def="GroupingSpec"
-                           >GroupingSpec</nt> if present, or the default collation
-                        from the <phrase diff="chg" at="2023-05-19">dynamic</phrase> context otherwise. 
-                        If the collation is specified by a relative
-   URI, that relative URI is  <termref
-                           def="dt-resolve-relative-uri"
-                           >resolved to
-   an absolute URI</termref> using the <termref
-                           def="dt-static-base-uri"
-                           >Static Base URI</termref>.
-   If the specified collation is not found in statically known
-   collations, a static error is raised  <errorref
-                           class="ST" code="0076"/>.</p>
-                  </item> </olist>
-            </p>
-
-
-
-            <p>Each group of tuples produced by the above process results in one
-post-grouping tuple. The pre-grouping tuples from which the group is
-derived have <emph>equivalent</emph>
-               <termref def="dt-grouping-key"
-                  >grouping keys</termref>, but these keys are not
-necessarily identical (for example, the strings <code>"Frog"</code> and <code>"frog"</code>
-might be <emph>equivalent</emph> according to the collation in use.)
-
-In the post-grouping tuple, each <termref
-                  def="dt-grouping-variable"
-               >grouping variable</termref> is bound to the
-value of the corresponding grouping key. 
-</p>
-
-            <p>In the post-grouping tuple generated for a given group, each
-non-grouping variable is bound to a sequence containing the
-concatenated values of that variable in all the pre-grouping tuples
-that were assigned to that group. If <termref
-                  def="dt-ordering-mode"
-                  >ordering mode</termref> is
-<code>ordered</code>, the values derived from individual tuples are
-concatenated in a way that preserves the order of the pre-grouping
-tuple stream; otherwise the ordering of these values is <termref
-                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-
-
-            <note>
-               <p>This behavior may be surprising to SQL programmers, since SQL reduces
-the equivalent of a non-grouping variable to one representative
-value. Consider the following query:</p>
-
-               <eg role="parse-test"><![CDATA[let $x := 64000
-for $c in //customer
-where $c/salary > $x
-group by $d := $c/department
-return <department name="{ $d }">
-  Number of employees earning more than ${ $x } is { count($c) }
-</department>]]></eg>
-
-               <p>If there are three qualifying customers in the sales department this
-evaluates to:</p>
-
-               <eg><![CDATA[
-<department name="sales">
-  Number of employees earning more than $64000 64000 64000 is 3
-</department>]]></eg>
-
-               <p>In XQuery, each group is a sequence of items that match the group
-by criteria&mdash;in a tree-structured language like XQuery, this is
-convenient, because further structures can be built based on the items
-in this sequence. Because there are three items in the group,
-<code>$x</code> evaluates to a sequence of three items. To reduce this
-to one item, use <code>fn:distinct-values()</code>:</p>
-
-               <eg role="parse-test"><![CDATA[
-let $x := 64000
-for $c in //customer
-let $d := $c/department
-where $c/salary > $x
-group by $d
-return <department name="{ $d }">
-  Number of employees earning more than ${ distinct-values($x) } is { count($c) }
-</department>]]></eg>
-            </note>
-
-            <note>
-               <p>In general, the <termref def="dt-static-type"
-                     >static
-type</termref> of a variable in a post-grouping tuple is different
-from the <termref
-                     def="dt-static-type"
-                  >static type</termref> of the
-variable with the same name in the pre-grouping
-tuples.</p>
-            </note>
-            <p>The order in which tuples appear in the
-post-grouping tuple stream is <termref
-                  def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-            <note>
-               <p>An
-<code>order by</code> clause can be used to impose a value-based
-ordering on the post-grouping tuple stream. Similarly, if it is
-desired to impose a value-based ordering within a group (i.e., on the
-sequence of items bound to a non-grouping variable), this can be
-accomplished by a nested FLWOR expression that iterates over these
-items and applies an <code>order by</code> clause. In some cases, a
-value-based ordering within groups can be accomplished by applying an
-<code>order by</code> clause on a non-grouping variable before
-applying the <code>group by</code> clause.</p>
-            </note>
-            <p>A <code>group
-by</code> clause rebinds all the variables in the input tuple
-stream. The scopes of these variables are not affected by the
-<code>group by</code> clause, but in post-grouping tuples the values
-of the variables represent group properties rather than properties of
-individual pre-grouping tuples.</p>
-
-            <p>Examples:</p>
-            <ulist>
-               <item>
-                  <p>This example illustrates the effect of a <code>group by</code> clause on a tuple stream.</p>
-
-                  <p>Input tuple stream:</p>
-
-                  <eg>($storeno = &lt;storeno&gt;S101&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P78395&lt;/itemno&gt;)
-($storeno = &lt;storeno&gt;S102&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P94738&lt;/itemno&gt;)
-($storeno = &lt;storeno&gt;S101&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P41653&lt;/itemno&gt;)
-($storeno = &lt;storeno&gt;S102&lt;/storeno&gt;, $itemno = &lt;itemno&gt;P70421&lt;/itemno&gt;)
-</eg>
-
-                  <p>
-                     <code>group by</code> clause:</p>
-
-                  <eg><![CDATA[group by $storeno]]></eg>
-
-                  <p>Output tuple stream:</p>
-
-                  <eg>($storeno = S101, $itemno = (&lt;itemno&gt;P78395&lt;/itemno&gt;, &lt;itemno&gt;P41653&lt;/itemno&gt;))
-($storeno = S102, $itemno = (&lt;itemno&gt;P94738&lt;/itemno&gt;, &lt;itemno&gt;P70421&lt;/itemno&gt;))</eg>
-               </item>
-            </ulist>
-            <ulist>
-
-
-
-               <item>
-                  <p>This example and the ones that follow are based on two separate sequences of elements, named <code>$sales</code> and <code>$products</code>. We assume that the variable <code>$sales</code> is bound to a sequence of elements with the following structure:</p>
-                  <eg>&lt;sales&gt;
-  &lt;storeno&gt;S101&lt;/storeno&gt;
-  &lt;itemno&gt;P78395&lt;/itemno&gt;
-  &lt;qty&gt;125&lt;/qty&gt;
-&lt;/sales&gt;</eg>
-                  <p>We also assume that the variable <code>$products</code> is bound to a sequence of  elements with the following structure:</p>
-                  <eg>&lt;product&gt;
-  &lt;itemno&gt;P78395&lt;/itemno&gt;
-  &lt;price&gt;25.00&lt;/price&gt;
-  &lt;category&gt;Men's Wear&lt;/category&gt;
-&lt;/product&gt;</eg>
-                  <p>The simplest kind of grouping query has a single <termref
-                        def="dt-grouping-variable"
-                     >grouping variable</termref>. The query in this example finds the total quantity of items sold by each store:</p>
-                  <eg role="parse-test">for $s in $sales
-let $storeno := $s/storeno
-group by $storeno
-return &lt;store number="{ $storeno }" total-qty="{ sum($s/qty) }"/&gt;</eg>
-                  <p>The result of this query is a sequence of elements with the following structure:</p>
-                  <eg>&lt;store number="S101" total-qty="1550" /&gt;
-&lt;store number="S102" total-qty="2125" /&gt;</eg>
-               </item>
-
-
-
-               <item>
-                  <p>In a more realistic example, a user might be interested in the total revenue generated by each store for each product category. Revenue depends on both the quantity sold of various items and the price of each item. The following query joins the two input sequences and groups the resulting tuples by two <termref
-                        def="dt-grouping-variable">grouping variables</termref>:</p>
-
-                  <eg role="parse-test">
-for $s in $sales
-for $p in $products[itemno = $s/itemno]
-let $revenue := $s/qty * $p/price
-group by $storeno := $s/storeno, 
-         $category := $p/category
-return &lt;summary storeno="{ $storeno }"
-                category="{ $category }"
-                revenue="{ sum($revenue) }"/>
-</eg>
-
-
-                  <p>The result of this query is a sequence of elements with the following structure:</p>
-                  <eg>&lt;summary storeno="S101" category="Men's Wear" revenue="10185"/&gt;
-&lt;summary storeno="S101" category="Stationery" revenue="4520"/&gt;
-&lt;summary storeno="S102" category="Men's Wear" revenue="9750"/&gt;
-&lt;summary storeno="S102" category="Appliances" revenue="22650"/&gt;
-&lt;summary storeno="S102" category="Jewelry" revenue="30750"/&gt;</eg>
-               </item>
-
-
-
-               <item>
-                  <p>The result of the previous example was a “flat” list of elements. A user might prefer the query result to be presented in the form of a  hierarchical report, grouped primarily by store (in order by store number) and secondarily by product category. Within each store, the user might want to see only those product categories whose total revenue exceeds $10,000, presented in descending order by their total revenue. This report is generated by the following query:</p>
-                  <eg role="parse-test">for $s1 in $sales
-let $storeno := $s1/storeno
-group by $storeno
-order by $storeno
-return &lt;store storeno="{ $storeno }"&gt;{
-  for $s2 in $s1
-  for $p in $products[itemno = $s2/itemno]
-  let $category := $p/category
-  let $revenue := $s2/qty * $p/price
-  group by $category
-  let $group-revenue := sum($revenue)
-  where $group-revenue &gt; 10000
-  order by $group-revenue descending
-  return &lt;category name="{ $category }" revenue="{ $group-revenue }"/&gt;
-}&lt;/store&gt;
-</eg>
-                  <p>The result of this example query has the following structure:</p>
-                  <eg>&lt;store storeno="S101"&gt;
-  &lt;category name="Men's Wear" revenue="10185"/&gt;
-&lt;/store&gt;
-&lt;store storeno="S102"&gt;
-  &lt;category name="Jewelry" revenue="30750"/&gt;
-  &lt;category name="Appliances" revenue="22650"/&gt;
-&lt;/store&gt;</eg>
-               </item>
-
-
-
-               <item>
-                  <p>The following example illustrates how to avoid a possible pitfall in writing grouping queries.</p>
-
-                  <p>In each post-grouping tuple, all variables except for the grouping
-variable are bound to sequences of items derived from all the
-pre-grouping tuples from which the group was formed. For instance, in
-the following query, <code>$high-price</code> is bound to a sequence
-of items in the post-grouping tuple.</p>
-
-                  <eg role="parse-test">let $high-price := 1000
-for $p in $products[price &gt; $high-price]
-let $category := $p/category
-group by $category
-return &lt;category name="{ $category }"&gt;{
-  count($p) || ' products have price greater than ' || $high-price || '.'
-}&lt;/category&gt;</eg>
-                  <p>If three products in the “Men’s Wear” category have prices greater than 1000, the result of this query might look (in part) like this:</p>
-                  <eg>&lt;category name="Men’s Wear"&gt;
-  3 products have price greater than 1000 1000 1000.
-&lt;/category&gt;</eg>
-                  <p>The repetition of "1000" in this query result is due to the fact that <code>$high-price</code> is not a <termref
-                        def="dt-grouping-variable"
-                        >grouping variable</termref>. One way to avoid this repetition is to move the binding of <code>$high-price</code> to an outer-level FLWOR expression, as follows:</p>
-                  <eg role="parse-test">let $high-price := 1000
-return (
-  for $p in $products[price &gt; $high-price]
-  let $category := $p/category
-  group by $category
-  return &lt;category name="{ $category }"&gt;{
-    count($p) || ' products have price greater than ' || $high-price || '.'
-  }&lt;/category&gt;  
-)</eg>
-                  <p>The result of the revised query might contain the following element:</p>
-                  <eg>&lt;category name="Men's Wear"&gt;
-  3 products have price greater than 1000.
-&lt;/category&gt;</eg>
-               </item>
-            </ulist>
-            <note>
-               <p>If a collation name is specified, it must be supplied as a literal string; it cannot
-                  be computed dynamically. A workaround in such cases is to use
-                   the <code>fn:collation-key</code> function. For example:</p>
-               
-               <eg role="parse-test">for $p in $products
-group by collation-key($p/description, $collation)
-return $product/@code</eg>
-               
-               <p>Note however that the <code>fn:collation-key</code> function might not work
-                  for all collations.</p>
-            </note>
-         </div3>
-         <div3 id="id-order-by-clause">
-            <head>Order By Clause</head>
-            <scrap>
-               <head/>
-               <prodrecap id="OrderByClause" ref="OrderByClause"/>
-               <prodrecap ref="OrderSpecList"/>
-               <prodrecap ref="OrderSpec"/>
-               <prodrecap ref="OrderModifier"/>
-
-            </scrap>
-            <p>The purpose of an <code>order by</code> clause is to impose a value-based ordering on the tuples in the tuple stream. The output tuple stream of the <code>order by</code> clause contains the same tuples as its input tuple stream, but the tuples may be in a different order.</p>
-            <p>An <code>order by</code> clause contains one or more ordering specifications, called <nt
-                  def="OrderSpec"
-                  >orderspecs</nt>, as shown in the grammar. For each tuple in the input tuple stream, the orderspecs are evaluated, using the variable bindings in that tuple. The relative order of two tuples is determined by comparing the values of their orderspecs, working from left to right until a pair of unequal values is encountered. If an orderspec specifies a <termref
-                  def="dt-collation"
-                  >collation</termref>, that collation is used in comparing values of type <code>xs:string</code>, <code>xs:anyURI</code>, or types derived from them (otherwise, the <termref
-                  def="dt-def-collation"
-                  >default collation</termref> is used in comparing values of these types). If an orderspec specifies a collation by a relative URI, that relative URI is  <termref
-                  def="dt-resolve-relative-uri"
-                  >resolved to an absolute URI</termref> using the <termref def="dt-static-base-uri"
-                  >Static Base URI</termref>. 
-If an orderspec specifies a collation that is not found in <termref
-                  def="dt-static-collations"
-                  >statically known collations</termref>, an error is raised <errorref class="ST"
-                  code="0076"/>.</p>
-            <p>The process of evaluating and comparing the orderspecs is based on
-the following rules:</p>
-
-            <ulist>
-
-               <item>
-                  <p>
-                     <termref def="dt-atomization"
-                        >Atomization</termref> is applied to the result of the expression
-    in each orderspec.  If the result of atomization is neither a single atomic value nor an empty sequence, a <termref
-                        def="dt-type-error">type error</termref> is raised <errorref class="TY"
-                        code="0004"/>.</p>
-               </item>
-
-
- <!--              <item>
-                  <p>If the value of an orderspec has the <termref def="dt-dynamic-type"
-                        >dynamic type</termref>
-                     <code>xs:untypedAtomic</code> (such as character
-    data in a schemaless document), it is cast to the type <code>xs:string</code>.</p>
-                  <note>
-                     <p>Consistently treating untyped values as strings enables the sorting process to begin without complete knowledge of the types of all the values to be sorted.</p>
-                  </note>
-               </item>
-
-
-
-
-               <item>
-                  <p>If the resulting sequence contains values that are instances of more than one primitive type (meaning the 19 primitive types defined in <xspecref
-                        spec="XS2" ref="built-in-primitive-datatypes"/>, then:</p>
-                  <olist>
-                     <item>
-                        <p>If each value is an instance of one of the types <code>xs:string</code> or <code>xs:anyURI</code>, then all values are cast to type <code>xs:string</code>.</p>
-                     </item>
-                     <item>
-                        <p>If each value is an instance of one of the types <code>xs:decimal</code> or <code>xs:float</code>, then all values are cast to type <code>xs:float</code>.</p>
-                     </item>
-                     <item>
-                        <p>If each value is an instance of one of the types <code>xs:decimal</code>, <code>xs:float</code>, or <code>xs:double</code>, then all values are cast to type <code>xs:double</code>.</p>
-                     </item>
-                     <item>
-                        <p>Otherwise, a <termref def="dt-type-error"
-                              >type error</termref> is raised <errorref class="TY" code="0004"
-                           />.</p>
-                        <note>
-                           <p>The primitive type of an <code>xs:integer</code> value for this purpose is <code>xs:decimal</code>.</p>
-                        </note>
-                     </item>
-                  </olist>
-               </item>-->
-            </ulist>
-
-
-            <!-- <change diff="chg" at="XQ.E17"> -->
-            <p>For the purpose of determining their relative position in the ordering sequence, the <emph>greater-than</emph>
-             relationship between two orderspec values <var>W</var> and <var>V</var> is defined as follows:</p>
-            <ulist>
-               <item>
-                  <p>When the orderspec specifies <code>empty least</code>,
-                   the following rules are applied in order:
-                </p>
-                  <olist>
-                     <item>
-                        <p>If <var>V</var> is an empty sequence and <var>W</var> is not an empty sequence,
-                         then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V </var> is true.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> is <code>NaN</code> and <var>W</var> is neither <code>NaN</code>
-                         nor an empty sequence, then
-                         <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:string</code>,
-                        <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>, they are compared
-                           using the function <code>fn:compare(V, W, C)</code> where <var>C</var> is the
-                        requested collation, defaulting to the default collation from the static context.</p>
-                        
-                        <p>If <code>fn:compare(V, W, C)</code> is less than
-                         zero, then <emph>W</emph>
-                           <emph>greater-than</emph>
-                           <emph>V</emph> is true; otherwise <emph>W</emph>
-                           <emph>greater-than</emph>
-                           <emph>V</emph> is false.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:numeric</code>,
-                           they are compared
-                           using the function <code>fn:compare(V, W)</code>.</p>
-                        
-                        <p>If <code>fn:compare(V, W)</code> is less than
-                           zero, then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true; otherwise <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is false.</p>
-                     </item>
-                     <item>
-                        <p>If none of the above rules apply, then:</p>
-                        <p>If <code>W gt V</code> is true,
-                         then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true; otherwise <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is false.</p>
-                     </item>
-                  </olist>
-               </item>
-               <item>
-                  <p>When the orderspec specifies <code>empty greatest</code>,
-                   the following rules are applied in order:
-                </p>
-                  <olist>
-                     <item>
-                        <p>If <var>W</var> is an empty sequence and <emph>V</emph> is not an empty sequence,
-                         then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true.</p>
-                     </item>
-                     <item>
-                        <p>If <var>W</var> is <code>NaN</code> and <var>V</var> is neither <code>NaN</code>
-                         nor an empty sequence, then
-                         <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:string</code>,
-                           <code>xs:anyURI</code>, or <code>xs:untypedAtomic</code>, they are compared
-                           using the function <code>fn:compare(V, W, C)</code> where <var>C</var> is the
-                           requested collation, defaulting to the default collation from the static context.</p>
-                        
-                        <p>If <code>fn:compare(V, W, C)</code> is less than
-                           zero, then <emph>W</emph>
-                           <emph>greater-than</emph>
-                           <emph>V</emph> is true; otherwise <emph>W</emph>
-                           <emph>greater-than</emph>
-                           <emph>V</emph> is false.</p>
-                     </item>
-                     <item>
-                        <p>If <var>V</var> and <var>W</var> are both instances of <code>xs:numeric</code>,
-                           they are compared
-                           using the function <code>fn:compare(V, W)</code>.</p>
-                        
-                        <p>If <code>fn:compare(V, W)</code> is less than
-                           zero, then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true; otherwise <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is false.</p>
-                     </item>
-                     <item>
-                        <p>If none of the above rules apply, then:</p>
-                        <p>If <code>W gt V</code> is true,
-                           then <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is true; otherwise <var>W</var>
-                           <emph>greater-than</emph>
-                           <var>V</var> is false.</p>
-                     </item>
-                  </olist>
-               </item>
-               <item>
-                  <p>When the orderspec specifies neither <code>empty least</code>
-                   nor <code>empty greatest</code>, the
-                   <termref
-                        def="dt-default-empty-order"
-                        >default order for empty
-                   sequences</termref> in the
-                   <termref
-                        def="dt-static-context"
-                        >static context</termref>
-                   determines whether the rules for <code>empty least</code>
-                   or <code>empty greatest</code> are used.
-                </p>
-               </item>
-            </ulist>
-            <!-- </change> -->
-
-            <p>If <emph>T1</emph> and <emph>T2</emph> are two tuples in the input tuple stream, and <emph>V1</emph> and <emph>V2</emph> are the first pair of  values encountered when evaluating their orderspecs  from left to right for which one value is <emph>greater-than</emph> the other (as defined above), then:</p>
-
-
-            <olist>
-
-
-
-
-               <item>
-                  <p>If <emph>V1</emph> is <emph>greater-than</emph>
-                     <emph>V2:</emph> If the orderspec specifies <code>descending</code>, then <emph>T1</emph> precedes <emph>T2</emph> in the output tuple stream; otherwise, <emph>T2</emph> precedes <emph>T1</emph> in the output tuple stream.</p>
-               </item>
-
-
-
-               <item>
-                  <p>If <emph>V2</emph> is <emph>greater-than</emph>
-                     <emph>V1</emph>: If the orderspec specifies <code>descending</code>, then <emph>T2</emph> precedes <emph>T1</emph> in the output tuple stream; otherwise, <emph>T1</emph> precedes <emph>T2</emph> in the output tuple stream.</p>
-               </item>
-
-
-
-            </olist>
-            <p>If neither <emph>V1</emph> nor <emph>V2</emph> is <emph>greater-than</emph> the other for any pair of orderspecs for tuples <emph>T1</emph> and <emph>T2</emph>, the following rules apply.</p>
-
-            <olist>
-
-
-
-               <item>
-                  <p>If <code>stable</code> is specified, the original order of <emph>T1</emph> and <emph>T2</emph> is preserved in the output tuple stream.</p>
-               </item>
-
-
-
-               <item>
-                  <p>If <code>stable</code> is not specified, the order of <emph>T1</emph> and <emph>T2</emph> in the output tuple stream is <termref
-                        def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-               </item>
-            </olist>
-            <note>
-               <p>If two orderspecs return the special floating-point values positive and negative zero, neither of these values is <emph>greater-than</emph> the other, since <code
-                     role="parse-test">+0.0 gt -0.0</code> and <code role="parse-test"
-                     >-0.0 gt +0.0</code> are both <code>false</code>.</p>
-            </note>
-            <p>Examples:</p>
-            <ulist>
-
-
-
-               <item>
-                  <p>This example illustrates the effect of an <code>order by</code> clause on a tuple stream. The keyword <code>stable</code> indicates that, when two tuples have equal sort keys, their order in the input tuple stream is preserved.</p>
-                  <p>Input tuple stream:</p>
-                  <eg><![CDATA[($license = "PFQ519", $make = "Ford",  $value = 16500)
-($license = "HAJ865", $make = "Honda", $value = 22750)
-($license = "NKV473", $make = "Ford",  $value = 21650)
-($license = "RCM922", $make = "Dodge", $value = 11400)
-($license = "ZBX240", $make = "Ford",  $value = 16500)
-($license = "KLM030", $make = "Dodge", $value = () )]]></eg>
-                  <p>
-                     <code>order by</code> clause:</p>
-                  <eg><![CDATA[stable order by $make,
-  $value descending empty least]]></eg>
-                  <p>Output tuple stream:</p>
-                  <eg><![CDATA[($license = "RCM922", $make = "Dodge", $value = 11400)
-($license = "KLM030", $make = "Dodge", $value = () )
-($license = "NKV473", $make = "Ford",  $value = 21650)
-($license = "PFQ519", $make = "Ford",  $value = 16500)
-($license = "ZBX240", $make = "Ford",  $value = 16500)
-($license = "HAJ865", $make = "Honda", $value = 22750)]]></eg>
-               </item>
-
-
-
-               <item>
-                  <p>The following example shows how an <code>order by</code> clause can be used to sort the result of a query, even if the sort key is not included in the query result. This query returns employee names in descending order by salary, without returning the actual salaries:</p>
-                  <eg role="parse-test"><![CDATA[for $e in $employees
-order by $e/salary descending
-return $e/name]]></eg>
-
-               </item>
-            </ulist>
-            <note>
-               <p>If a collation name is specified, it must be supplied as a literal string; it cannot
-                  be computed dynamically. Two possible workarounds are to use the <code>fn:sort</code> function
-               or the <code>fn:collation-key</code> function.</p>
-               <p>Using <code>fn:sort</code> the expression</p>
-               <eg role="parse-test">for $b in $books/book[price &lt; 100]
-order by $b/title
-return $b</eg>
-
-               <p>can be replaced with the following, which uses a dynamically-chosen collation:</p>
-
-               <eg role="parse-test">
-sort(
-  $books/book[price &lt; 100],
-  $collation,
-  function($book) { $book/title }
-)
-</eg>
-               
-               <p>Alternatively, it is possible to compute collation keys using a dynamically-chosen
-               collation, and sort on the values of the collation keys:</p>
-               
-               <eg role="parse-test">for $b in $books/book[price &lt; 100]
-order by collation-key($b/title, $collation)
-return $b</eg>
-               
-               <p>Note however that the <code>fn:collation-key</code> function might not work
-               for all collations.</p>
-               
-            </note>
-
-
-         </div3>
-         <div3 id="id-return-clause">
-            <head>Return Clause</head>
-            <scrap>
-               <head/>
-
-
-               <prodrecap ref="ReturnClause"/>
-            </scrap>
-            <p>The <code>return</code> clause is the final clause of a FLWOR expression. The <code>return</code> clause is evaluated once for each tuple in its input tuple stream,  using the variable bindings in the respective tuples, in the order in which these tuples appear in the input tuple stream. The results of these evaluations are concatenated, as if by the <termref
-                  def="dt-comma-operator"
-               >comma operator</termref>, to form the result of the FLWOR expression.</p>
-            <p>The following example illustrates a FLWOR expression containing several clauses. The <code>for</code> clause iterates over all the departments in an input document named <code>depts.xml</code>, binding the variable <code>$d</code> to each department  in turn. For each binding of <code>$d</code>, the <code>let</code> clause binds variable <code>$e</code> to all the employees in the given department, selected from another input document named <code>emps.xml</code> (the relationship between employees and departments is represented by matching their <code>deptno</code> values). Each tuple in the resulting tuple stream contains a pair of bindings for <code>$d</code> and <code>$e</code> (<code>$d</code> is bound to a department and <code>$e</code> is bound to a set of employees in that department). The <code>where</code> clause filters the tuple stream, retaining only those tuples that represent departments having at least ten employees. The <code>order by</code> clause orders the surviving tuples in descending order by the average salary of the employees in the department. The <code>return</code> clause constructs a new <code>big-dept</code> element for each surviving tuple, containing the department number, headcount, and average salary.</p>
-            <eg role="parse-test"><![CDATA[for $d in doc("depts.xml")//dept
-let $e := doc("emps.xml")//emp[deptno eq $d/deptno]
-where count($e) >= 10
-order by avg($e/salary) descending
-return <big-dept>{
-  $d/deptno,
-  <headcount>{count($e)}</headcount>,
-  <avgsal>{avg($e/salary)}</avgsal>
-}</big-dept>]]></eg>
-            <notes>
-               <ulist>
-
-
-
-                  <item>
-                     <p>The order in which items appear in the result of a FLWOR expression depends on the ordering of the input tuple stream to the <code>return</code> clause, which in turn is influenced by <code>order by</code> clauses and by <termref
-                           def="dt-ordering-mode"
-                        >ordering mode</termref>. For example, consider the following query, which is based on the same two input documents as the previous example:</p>
-                     <eg role="parse-test">for $d in doc("depts.xml")//dept
-order by $d/deptno
-for $e in doc("emps.xml")//emp[deptno eq $d/deptno]
-return &lt;assignment&gt;{
-  $d/deptno, $e/name
-}&lt;/assignment&gt;</eg>
-                     <p>The result of this query is a sequence of <code>assignment</code> elements, each containing a <code>deptno</code> element and a <code>name</code> element. The sequence will be ordered primarily by the <code>deptno</code> values because of the <code>order by</code> clause. If <termref
-                           def="dt-ordering-mode"
-                           >ordering mode</termref> is <code>ordered</code>, subsequences of <code>assignment</code> elements with equal <code>deptno</code> values will be ordered by the document order of their <code>name</code> elements within the <code>emps.xml</code> document; otherwise the ordering of these subsequences will be <termref
-                           def="dt-implementation-dependent">implementation-dependent</termref>.</p>
-                  </item>
-
-                  <item>
-                     <p>Parentheses are helpful in <code>return</code> clauses that contain comma operators,
-since FLWOR expressions have a higher precedence than the comma
-operator. For example, the following query raises an error because
-after the comma, <code>$j</code> is no longer within the FLWOR expression, and is an
-undefined variable:</p>
-                     <eg role="parse-test"><![CDATA[let $i := 5
-let $j := 20 * $i
-return $i, $j]]></eg>
-                     <p>Parentheses can be used to bring <code>$j</code> into the <code>return</code> clause of the FLWOR expression, as the
-programmer probably intended:</p>
-                     <eg role="parse-test"><![CDATA[let $i := 5
-let $j := 20 * $i
-return ($i, $j)]]></eg>
-                  </item>
-               </ulist>
-            </notes>
-         </div3>
       </div2>
       <div2 role="xquery" id="id-unordered-expressions">
          <head>Ordered and Unordered Expressions</head>


### PR DESCRIPTION
Implements ForClause / ForExpression iterating over entries in maps.

Note that the feature is described differently in XP and XQ - I have made some starter attempts to reconverge the two specs, but there is more to be done. (However, the change involved reordering sections, which will adversely affect the diff version).