### PR TITLE
1245 Correct properties of format-DT function family

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -10628,14 +10628,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <fos:arg name="place" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
-      <fos:properties arity="2">
+      <fos:properties>
          <fos:property>deterministic</fos:property>
          <fos:property dependency="default-calendar default-language default-place implicit-timezone">context-dependent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:properties arity="5">
-         <fos:property>deterministic</fos:property>
-         <fos:property dependency="implicit-timezone namespaces">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -10658,14 +10653,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <fos:arg name="place" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
-      <fos:properties arity="2">
+      <fos:properties>
          <fos:property>deterministic</fos:property>
          <fos:property dependency="default-calendar default-language default-place implicit-timezone">context-dependent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:properties arity="5">
-         <fos:property>deterministic</fos:property>
-         <fos:property dependency="implicit-timezone namespaces">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -10688,14 +10678,9 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
             <fos:arg name="place" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
-      <fos:properties arity="2">
+      <fos:properties>
          <fos:property>deterministic</fos:property>
          <fos:property dependency="default-calendar default-language default-place implicit-timezone">context-dependent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:properties arity="5">
-         <fos:property>deterministic</fos:property>
-         <fos:property dependency="implicit-timezone namespaces">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>


### PR DESCRIPTION
Fix #1245

Note: since any of the last three arguments can now be present but set to (), the relevant context dependency becomes independent of arity, so the rules can be simplified.