### PR TITLE
QT4CG-081-03 parse-xml-[fragment]: $options should be optional

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17658,7 +17658,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="parse-xml" return-type="document-node(element(*))?">
             <fos:arg name="value" type="xs:string?" example="'&lt;a/&gt;'"/>
-            <fos:arg name="options" type="map(*)" default="{}"/>
+            <fos:arg name="options" type="map(*)?" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17672,7 +17672,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:summary>
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
-         <p>The <code>$options</code> argument, if present, defines the detailed behavior of the
+         <p>The <code>$options</code> argument, if present and non-empty, defines the detailed behavior of the
          function. The <termref def="option-parameter-conventions"/> apply. The options available
          are as follows:</p>
          
@@ -17789,7 +17789,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="parse-xml-fragment" return-type="document-node()?">
             <fos:arg name="value" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)" default="{}"/>
+            <fos:arg name="options" type="map(*)?" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17817,7 +17817,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p>The string is parsed to form a sequence of nodes which become children of the new
             document node, in the same way as the content of any element is converted into a
             sequence of children for the resulting element node.</p>
-         <p>The <code>$options</code> argument, if present, defines the detailed behavior of the
+         <p>The <code>$options</code> argument, if present and non-empty, defines the detailed behavior of the
          function. The <termref def="option-parameter-conventions"/> apply. The options available
          are as follows:</p>
          


### PR DESCRIPTION
Changes the function signature of parse-xml and parse-xml-fragment so the $options argument can be set to an empty sequence.