### PR TITLE
Revise fn:invisible-xml

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31426,6 +31426,10 @@ let $scan-right := function(
          representation that indicates an error occurred and may
          provide additional error information.</p>
 
+         <p>If the function is called twice with the same arguments, it is 
+         <termref def="dt-nondeterministic">nondeterministic with respect to node identity</termref>.
+         </p>     
+
          <p>For example, the following grammar describes a date as consisting
          of a year, a month, and a day. Each are a sequence of digits and they are
          separated by hyphens:</p>
@@ -31482,7 +31486,8 @@ month = '0', d | '1', ['0'|'1'|'2'] .
          or to produce output formats other than XML.</p>
 
          <p>If <code>$grammar</code> is the empty sequence, a parser is returned
-         for the Invisible XML specification grammar. If <code>$grammar</code> is not
+         for the Invisible XML specification grammar. This <rfc2119>should</rfc2119> be the same
+         grammar that the implementation uses to parse iXML grammars. If <code>$grammar</code> is not
          empty, it <rfc2119>must</rfc2119> be a valid Invisible XML grammar.
          If it is not, <code>fn:invisible-xml</code> raises
          <code>err:FOIX0001</code>.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31403,7 +31403,7 @@ let $scan-right := function(
     
    <fos:function name="invisible-xml" prefix="fn">
       <fos:signatures>
-         <fos:proto name="invisible-xml" return-type="fn(xs:string) as item()">
+         <fos:proto name="invisible-xml" return-type="fn(xs:string) as document-node()">
             <fos:arg name="grammar" type="item()?" default="()"/>
             <fos:arg name="options" type="map(*)?" default="{}"/>
          </fos:proto>


### PR DESCRIPTION
1. Resolve `QT4CG-080-04`: NW to revise p:invisible-xml, fix #991 
2. Resolve `QT4CG-081-04`: NW to update the function signature of fn:invisible-xml
3. Resolve `QT4CG-081-04`: NW to describe why the grammar option can be empty on fn:invisible-xml

