### PR TITLE
Updated list of incompatibilities in F+O

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11249,7 +11249,7 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <code>fn:parse-html</code> if a key passed to <code>$options</code>, or its value,
                   is not supported by the implementation.</p>
             </error>
-			<error class="DF" code="1280" label="Invalid decimal format name."
+			   <error class="DF" code="1280" label="Invalid decimal format name."
                    type="dynamic">
                <p>This error is raised if the decimal format name supplied to <code>fn:format-number</code> is not a valid QName,
 			   or if the prefix in the QName is undeclared, or if there is no decimal format in the static context with

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11987,6 +11987,12 @@ ISBN 0 521 77752 6.</bibl>
                  <code>9.800000000000000710542735760100185871124267578125</code>, so comparing the two values as
               decimals would return false.</p>
            </item>
+           <item diff="add" at="2024-06-18">
+              <p>In previous versions, unrecognized options supplied to the <code>$options</code>
+              parameter of functions such as <code>fn:parse-json</code> were silently ignored. In
+              4.0, they are rejected as a type error, unless they are QNames with a non-absent namespace,
+              or are extensions recognized by the implementation.</p>
+           </item>
            <item diff="add" at="2022-12-18">
               <p>In version 4.0, omitting the <code>$value</code> of <code>fn:error</code> has the same
                  effect as setting it to an empty sequence. In 3.1, the effects could be different (the effect of omitting
@@ -12017,10 +12023,6 @@ ISBN 0 521 77752 6.</bibl>
                  Previously this was defined as an error, but the kind of error and the error code were left unspecified.
               Accordingly, the function signatures of the constructor functions for built-in list types
               have been changed to use an argument type of <code>xs:string?</code>.</p>
-           </item>
-           <item diff="add" at="issue216">
-              <p>In version 3.1, end-of-line characters were adopted unchanged when calling <code>fn:unparsed-text</code>.
-                 In version 4.0, they are normalized as known from XML (see <bibref ref="xml11"/>).</p>
            </item>
            <item diff="add" at="issue866">
               <p>The way that <code>fn:min</code> and <code>fn:max</code> compare numeric values of different types


### PR DESCRIPTION
Added an incompatibility regarding unrecognized option values.

Removed an incompatibility regarding normalisation of line endings in unparsed-text().

Fix #1285