### PR TITLE
Fix keyword tests to treat "fn" = "function"

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11249,7 +11249,7 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <code>fn:parse-html</code> if a key passed to <code>$options</code>, or its value,
                   is not supported by the implementation.</p>
             </error>
-			<error class="DF" code="1280" label="Invalid decimal format name."
+			   <error class="DF" code="1280" label="Invalid decimal format name."
                    type="dynamic">
                <p>This error is raised if the decimal format name supplied to <code>fn:format-number</code> is not a valid QName,
 			   or if the prefix in the QName is undeclared, or if there is no decimal format in the static context with

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11987,6 +11987,12 @@ ISBN 0 521 77752 6.</bibl>
                  <code>9.800000000000000710542735760100185871124267578125</code>, so comparing the two values as
               decimals would return false.</p>
            </item>
+           <item diff="add" at="2024-06-18">
+              <p>In previous versions, unrecognized options supplied to the <code>$options</code>
+              parameter of functions such as <code>fn:parse-json</code> were silently ignored. In
+              4.0, they are rejected as a type error, unless they are QNames with a non-absent namespace,
+              or are extensions recognized by the implementation.</p>
+           </item>
            <item diff="add" at="2022-12-18">
               <p>In version 4.0, omitting the <code>$value</code> of <code>fn:error</code> has the same
                  effect as setting it to an empty sequence. In 3.1, the effects could be different (the effect of omitting
@@ -12017,10 +12023,6 @@ ISBN 0 521 77752 6.</bibl>
                  Previously this was defined as an error, but the kind of error and the error code were left unspecified.
               Accordingly, the function signatures of the constructor functions for built-in list types
               have been changed to use an argument type of <code>xs:string?</code>.</p>
-           </item>
-           <item diff="add" at="issue216">
-              <p>In version 3.1, end-of-line characters were adopted unchanged when calling <code>fn:unparsed-text</code>.
-                 In version 4.0, they are normalized as known from XML (see <bibref ref="xml11"/>).</p>
            </item>
            <item diff="add" at="issue866">
               <p>The way that <code>fn:min</code> and <code>fn:max</code> compare numeric values of different types

--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -74,7 +74,7 @@
             <xsl:text>)</xsl:text>
             <xsl:text>
             return </xsl:text>
-            <xsl:if test="not(starts-with(@return-type, 'function(') or ../../@name = 'random-number-generator')">
+            <xsl:if test="not(starts-with(@return-type, 'function(') or starts-with(@return-type, 'fn(') or ../../@name = 'random-number-generator')">
                <!-- we can't compare functions using deep-equal, nor any other way; so skip this part of the test -->
                <xsl:text>fn:deep-equal($x, </xsl:text>
                <!--<xsl:if test="../..//property[.='focus-dependent']">
@@ -209,7 +209,7 @@
       <xsl:text>/doc</xsl:text>
    </xsl:template>
    
-   <xsl:template match="@type[starts-with(., 'function(')]" priority="5">
+   <xsl:template match="@type[starts-with(., 'function(') or starts-with(., 'fn(')]" priority="5">
       <xsl:variable name="arity" select="count(tokenize(., ','))"/>
       <!--<xsl:message><xsl:copy-of select=".."/>Arity = {$arity}</xsl:message>-->
       <xsl:choose>
@@ -229,30 +229,7 @@
       </xsl:choose>
    </xsl:template>
    
-   <!--<xsl:template match="@type[matches(., 'function\(item\(\)[*+?]?\).*')]" priority="8">
-      <xsl:text>fn:boolean#1</xsl:text>
-   </xsl:template>
    
-   <xsl:template match="@type[matches(., 'function\([^,]+,[^,]+\).*')]" priority="8">
-      <xsl:text>fn:deep-equal#2</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[starts-with(., 'function(xs:anyAtomicType, item()*)')]" priority="9">
-      <xsl:text>fn:deep-equal#2</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[starts-with(., 'function(xs:anyAtomicType, item()*)')]" priority="9">
-      <xsl:text>fn:deep-equal#2</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[starts-with(., 'function(xs:string, xs:string*)')]" priority="9">
-      <xsl:text>fn:contains#2</xsl:text>
-   </xsl:template>
-   
-   <xsl:template match="@type[starts-with(., 'function(item()*, item()*, xs:integer)')]" priority="9">
-      <xsl:text>function($x,$y,$z){0}</xsl:text>
-   </xsl:template>
-   -->
    
    
    <xsl:template match="@type[starts-with(., 'union(')]" priority="9">


### PR DESCRIPTION
When generating keyword tests for higher-order functions, the parameter type now generally uses "fn" rather than "function", which causes the stylesheet to generate incorrect tests.