### PR TITLE
Fix issue 1291 (rounding)

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -1354,7 +1354,7 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
             <fos:arg name="precision" type="xs:integer?" default="0"/>
             <fos:arg name="rounding-mode" type="enum('floor',&#xa; 'ceiling',&#xa; 
                'toward-zero',&#xa; 'away-from-zero',&#xa; 'half-to-floor',&#xa; 
-               'half-to-ceiling',&#xa; 'half-toward-zero',&#xa; 'half-away-from-zero',&#xa; 'to-even')?" default="'half-to-ceiling'"/>
+               'half-to-ceiling',&#xa; 'half-toward-zero',&#xa; 'half-away-from-zero',&#xa; 'half-to-even')?" default="'half-to-ceiling'"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -1429,7 +1429,7 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
                   returns <var>U</var> if <code>$value</code> is positive, otherwise <var>L</var>.</p></td>
                </tr>
                <tr>
-                  <td><p><code>'to-even'</code></p></td>
+                  <td><p><code>'half-to-even'</code></p></td>
                   <td><p>Returns <var>N</var>, unless midway, in which case it
                   returns whichever of <var>L</var> and <var>U</var> has a last significant
                   digit that is even.</p></td>
@@ -1667,7 +1667,7 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
                value <code>150.014999389...</code>, which is closer to
                <code>150.01</code> than to <code>150.02</code>.</p>
          <p>From 4.0, the effect of this function can also be achieved by
-         calling <code>fn:round</code> with the third argument set to <code>"to-even"</code>.</p>
+         calling <code>fn:round</code> with the third argument set to <code>"half-to-even"</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1783,15 +1783,11 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
             <?local-function-index?>
             
             <note>
-              <p><code>fn:round</code> and <code>fn:round-half-to-even</code> produce the same
-                 result in all cases except when the argument is exactly midway between two values
-                 with the required precision.</p>
-              <p>Other ways of rounding midway values can be achieved as follows:</p>
-              <ulist>
-                <item><p>Towards negative infinity: <code>-round(-$x)</code></p></item>
-                <item><p>Away from zero: <code>round(abs($x)) * compare($x, 0)</code></p></item>
-                <item><p>Towards zero: <code>abs(round(-$x)) * -compare($x, 0)</code></p></item>
-              </ulist>
+               <p>The <code>fn:round</code> function has been extended with a third argument
+               in version 4.0 of this specification; this means that the <code>fn:ceiling</code>,
+               <code>fn:floor</code>, and <code>fn:round-half-to-even</code> functions are now
+               technically redundant. They are retained, however, both for backwards compatibility
+               and for convenience.</p>             
             </note>
             
             <div3 id="func-abs">


### PR DESCRIPTION
Delete an obsolete note.

Make the spec consistent with regard to the keyword "to-even" vs "half-to-even".

Fix #1291