### PR TITLE
1096 Redefine array:index-of to use deep-equal for comparisons

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26250,7 +26250,7 @@ else $fallback($position)</eg>
       <fos:signatures>
          <fos:proto name="index-of" return-type="xs:integer*">
             <fos:arg name="array" type="array(*)"/>
-            <fos:arg name="target" type="xs:anyAtomicType*"/>
+            <fos:arg name="target" type="item()*"/>
             <fos:arg name="collation" type="xs:string?" default="fn:default-collation()"/>
          </fos:proto>
       </fos:signatures>
@@ -26269,26 +26269,16 @@ else $fallback($position)</eg>
                <code>$array</code> of members that are equal to <code>$target</code>.</p>
       </fos:summary>
       <fos:rules>
+         <p>The function returns the result of the expression:</p>
+         <eg>array:index-where($array, fn:deep-equal(?, $target, $collation))</eg>
          <p>Informally, all members of <code>$array</code> are compared with <code>$target</code>.
-            An array member is equal to the target value if it has the same number of items,
-            and if every item matches the corresponding target item under the rules for the
-            <code>eq</code> operator. Items of type <code>xs:untypedAtomic</code>
-            are compared as if they were of type <code>xs:string</code>. Items that cannot be
-            compared, because the <code>eq</code> operator is not defined for their types, are
-            considered to be distinct. If a member compares equal, then the position of that member
-            is included in the result.</p>
+            An array member is compared to the target value using the rules of the
+            <code>fn:deep-equal</code> function, with the specified (or defaulted) collation.
+            The index position of the member is included in the result sequence if the
+            comparison returns true.
+         </p>
          <p>The collation used by this function is determined according to the rules in <specref
-               ref="choosing-a-collation"
-            />. This collation is used when string comparison is required.</p>
-         <p>More formally, the function returns the result of the expression:</p>
-         <eg>
-(1 to array:size($array))[
-  count($array(.)) = count($target) and
-  every(for-each-pair(
-    $array(.), $target, fn($a, $b) { exists(index-of($a, $b, $collation)) }
-  ))
-]
-</eg>
+               ref="choosing-a-collation"/>. This collation is used when string comparison is required.</p>
          <p>The first member in an array is at position 1, not position 0.</p>
          <p>The result sequence is in ascending numeric order.</p>
       </fos:rules>


### PR DESCRIPTION
Fix #1096 

Using deep-equal for comparisons seems a reasonable default that avoids the atomization problem.

Note, I would personally be quite happy to drop the function as an alternative resolution.