### PR TITLE
1298 links to multiple issues

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31345,7 +31345,7 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:proto name="scan-left" return-type="array(*)*">
             <fos:arg name="input" type="item()*" usage ="navigation"/>           
             <fos:arg name="zero" type="item()*"/>           
-            <fos:arg name="action" type="fn(item()*, item()) as item()*" usage="inspection"/>   
+            <fos:arg name="action" type="fn(item()*, item(), xs:integer) as item()*" usage="inspection"/>   
          </fos:proto>
        </fos:signatures>
       <fos:properties>
@@ -31354,11 +31354,16 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-        <p>Produces the complete (ordered) sequence of all partial results from every new value 
-        the accumulator is assigned to during the evaluation of fn:fold-left.</p>
+        <p>Produces the complete (ordered) sequence of all intermediate 
+        results of an evaluation of <code>fn:fold-left</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is equivalent to the following implementation in XPath (return clause added in comments for completeness):</p>
+         <p>The result of the function is the value of the expression:</p>
+         <eg>(1 to count($input)) ! 
+   array{ slice($input, end := .) => fold-left($zero, $action) }</eg>
+         
+ <!--        
+         in XPath (return clause added in comments for completeness):</p>
          <eg><![CDATA[
 let $scan-left-inner := fn(
   $input  as item()*, 
@@ -31381,36 +31386,34 @@ let $scan-left := fn(
   $scan-left-inner($input, $zero, $action, $scan-left-inner)
 }
 (: return $scan-left(1 to 10, 0, op('+'))  :)    
-]]></eg>         
+]]></eg>-->         
       </fos:rules>
       <fos:errors>
-         <p>As a consequence of the function signature and the function calling rules, a type error
-            occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
-            the first argument is either the value of <code>$zero</code> or the result of a previous
-            application of <code>$action</code>, and the second 
-            is any single item from the sequence <code>$input</code>.</p>      
+         <p>See <code>fn:fold-left</code>: errors are raised in the same situations.</p>      
       </fos:errors>
         <fos:notes>
-                <olist>
-                    <item>
-                        <p>Note that each intermediate result is placed in a separate singleton array.
-                           This is necessary because we cannot represent a sequence of results, some or all of which are
-                           a sequence - that is "sequence of sequences" as just a single sequence.
-                        </p>
-                    </item>
-                </olist>
+           <p>A practical implementation might be expected to evaluate the result
+           incrementally in a single pass of the input; the equivalent expression
+           given in the rules above is provided purely for formal specification
+           purposes.</p>
+           <p>Each intermediate result is placed in a separate array. The number of arrays
+           in the result is the same as the number of items in <code>$input</code>.</p>
+           <p>The fact that the function has the same signature as <code>fn:fold-left</code>
+           means that this function can conveniently be used to study the behavior of
+           an call on <code>fn:fold-left</code> with the same arguments, perhaps for
+           diagnostic purposes.</p>
         </fos:notes>                
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 5, 0, op('+'))</eg></fos:expression>
-               <fos:result>[ 0 ], [ 1 ], [ 3 ], [ 6 ], [ 10 ], [ 15 ]</fos:result>
+               <fos:result>[ 1 ], [ 3 ], [ 6 ], [ 10 ], [ 15 ]</fos:result>
             </fos:test>
          </fos:example>         
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 3, 0, op('-'))</eg></fos:expression>
-               <fos:result>[ 0 ], [ -1 ], [ -3 ], [ -6 ]</fos:result>
+               <fos:result>[ -1 ], [ -3 ], [ -6 ]</fos:result>
             </fos:test>
          </fos:example>      
          <fos:example>
@@ -31428,7 +31431,7 @@ return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:ex
             <p> Produce the factorials of all numbers from 0 to 5</p>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 5, 1, op('*'))</eg></fos:expression>
-               <fos:result>[ 1 ], [ 1 ], [ 2 ], [ 6 ], [ 24 ], [ 120 ]</fos:result>
+               <fos:result>[ 1 ], [ 2 ], [ 6 ], [ 24 ], [ 120 ]</fos:result>
             </fos:test>
          </fos:example>           
       </fos:examples>          
@@ -31442,7 +31445,7 @@ return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:ex
          <fos:proto name="scan-right" return-type="array(*)*">
             <fos:arg name="input" type="item()*" usage ="navigation"/>           
             <fos:arg name="zero" type="item()*"/>           
-            <fos:arg name="action" type="fn(item()*, item()) as item()*" usage="inspection"/>   
+            <fos:arg name="action" type="fn(item()*, item(), xs:integer) as item()*" usage="inspection"/>   
          </fos:proto>
        </fos:signatures>
       <fos:properties>
@@ -31451,11 +31454,15 @@ return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:ex
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-        <p>Produces the complete (ordered) sequence of all partial results from every new value 
-        the accumulator is assigned to during the evaluation of fn:fold-right.</p>
+        <p>Produces the complete (ordered) sequence of all intermediate 
+        results of an evaluation of <code>fn:fold-right</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is equivalent to the following implementation in XPath (return clause in comments added for completeness):</p>
+         <p>The result of the function is the value of the expression:</p>
+         
+         <eg>reverse(1 to count($input)) ! 
+   array{ slice($input, start := .) => fold-right($zero, $action) }</eg>
+         <!--<p>The function is equivalent to the following implementation in XPath (return clause in comments added for completeness):</p>
          <eg><![CDATA[
 let $scan-right-inner := fn(
   $input  as item()*,
@@ -31477,37 +31484,34 @@ let $scan-right := function(
   $scan-right-inner($input, $zero, $f, $scan-right-inner)
 }        
 (: return $scan-right(1 to 10, 0, op('+')) :)  
-]]></eg>         
+]]></eg>         -->
       </fos:rules>
       <fos:errors>
-         <p>As a consequence of the function signature and the function calling rules, a type error
-            occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
-            the first argument is any item in the sequence <code>$input</code>, and the second is either
-            the value of <code>$zero</code> or the result of a previous application of
-            <code>$action</code>.</p>
+         <p>See <code>fn:fold-left</code>: errors are raised in the same situations.</p>      
       </fos:errors>
         <fos:notes>
-                <olist>
-                    <item>
-                        <p>Note that each intermediate result is placed in a separate singleton array.
-                           This is necessary because we cannot represent a sequence of results, some or all of which are
-                           a sequence - that is "sequence of sequences" as just a single sequence.
-                        </p>
-                    </item>
-                </olist>
-        </fos:notes>                
+           <p>A practical implementation might be expected to evaluate the result
+           incrementally in a single right-to-left pass of the input; the equivalent expression
+           given in the rules above is provided purely for formal specification
+           purposes.</p>
+           <p>Each intermediate result is placed in a separate array. The number of arrays
+           in the result is the same as the number of items in <code>$input</code>.</p>
+           <p>The fact that the function has the same signature as <code>fn:fold-right</code>
+           means that this function can conveniently be used to study the behavior of
+           an call on <code>fn:fold-right</code> with the same arguments, perhaps for
+           diagnostic purposes.</p>
+        </fos:notes>               
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-right(1 to 5, 0, op('+'))</eg></fos:expression>
-               <fos:result><eg>[ 55 ], [ 54 ], [ 52 ], [ 49 ], [ 45 ],
-[ 40 ], [ 34 ], [ 27 ], [ 19 ], [ 10 ], [ 0 ]</eg></fos:result>
+               <fos:result><eg>[ 5 ], [ 9 ], [ 12 ], [ 14 ], [ 15 ]</eg></fos:result>
             </fos:test>
          </fos:example>         
          <fos:example>
             <fos:test>
-               <fos:expression><eg>scan-right(1 to 3, 0, op('-'))</eg></fos:expression>
-               <fos:result>[ 2 ], [ -1 ], [ 3 ], [ 0 ]</fos:result>
+               <fos:expression><eg>scan-right(1 to 5, 0, op('-'))</eg></fos:expression>
+               <fos:result>[ 5 ], [ -1 ], [ 4 ], [ -2 ], [ 3 ]</fos:result>
             </fos:test>
          </fos:example>         
       </fos:examples>      

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19367,7 +19367,7 @@ return filter(
          <fos:proto name="fold-left" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="zero" type="item()*"/>
-            <fos:arg name="action" type="fn(item()*, item(), xs:integer) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn(item()*, item()) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -19383,29 +19383,17 @@ return filter(
       <fos:rules>
          <p>The function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare %private function fold-left-helper(
-  $input  as item()*,
-  $zero   as item()*,
-  $action as fn(item()*, item(), xs:integer) as item()*,
-  $pos    as xs:integer
-) as item()* {
-  if (empty($input))
-  then $zero
-  else fold-left-helper(
-    tail($input),
-    $action($zero, head($input), $pos + 1),
-    $action,
-    $pos + 1
-  )
-};
-
 declare function fold-left(
   $input  as item()*,
   $zero   as item()*,
-  $action as fn(item()*, item(), xs:integer) as item()*
+  $action as fn(item()*, item()) as item()*,
 ) as item()* {
-  fold-left-helper($input, $zero, $action, 1)
-};]]></eg>
+  if (empty($input))
+  then $zero
+  else fold-left(tail($input), 
+                 $action($zero, head($input)),
+                 $action)
+}]]></eg>
 
       </fos:rules>
       <fos:errors>
@@ -19424,8 +19412,7 @@ declare function fold-left(
             value (such as zero in the case of addition, one in the case of multiplication, or a
             zero-length string in the case of string concatenation) that causes the function to
             return the value of the other argument unchanged.</p>
-         <p>The value of the third argument of <code>$action</code> corresponds to the position
-            of the item in the input sequence. It is initally set to <code>1</code>.</p>
+      
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -19436,7 +19423,8 @@ declare function fold-left(
   fn($a, $b) { $a + $b }
 )</eg></fos:expression>
                <fos:result>15</fos:result>
-               <fos:postamble>This returns the sum of the items in the sequence</fos:postamble>
+               <fos:postamble>This returns the sum of the items in the sequence. The result is computed
+               as <code>((((0+1)+2)+3)+4)+5)</code>.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -19515,7 +19503,7 @@ declare function fold-left(
                <fos:result>{ 1: 2, 2: 4, 3: 6, 4: 8, 5: 10 }</fos:result>
             </fos:test>
          </fos:example>
-         <fos:example>
+         <!--<fos:example>
             <fos:test>
                <fos:expression><eg>
 let $input := (11 to 21, 21 to 31)
@@ -19528,25 +19516,24 @@ return fold-left($input, (),
 </eg></fos:expression>
                <fos:result>(11, 12)</fos:result>
             </fos:test>
-         </fos:example>
+         </fos:example>-->
       </fos:examples>
-      <fos:history>
+      <!--<fos:history>
          <fos:version version="4.0">Changed in 4.0: Positional parameter added to action function.</fos:version>
-      </fos:history>
+      </fos:history>-->
    </fos:function>
    <fos:function name="fold-right" prefix="fn">
       <fos:signatures>
          <fos:proto name="fold-right" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
             <fos:arg name="zero" type="item()*"/>
-            <fos:arg name="action" type="fn(item(), item()*, xs:integer) as item()*" usage="inspection"/>
+            <fos:arg name="action" type="fn(item(), item()*) as item()*" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-         
+         <fos:property>focus-independent</fos:property>        
          <fos:property>special-streaming-rules</fos:property>
       </fos:properties>
       <fos:summary>
@@ -19556,27 +19543,17 @@ return fold-left($input, (),
       <fos:rules>
          <p>The function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
-declare %private function fold-right-helper(
+declare function fold-right(
   $input  as item()*,
   $zero   as item()*,
-  $action as fn(item(), item()*, xs:integer) as item()*,
-  $pos    as xs:integer
-) as item()* {
+  $action as fn(item(), item()*) as item()*) 
+  as item()* {
   if (empty($input))
   then $zero
   else $action(
     head($input),
-    fold-right-helper(tail($input), $zero, $action, $pos - 1),
-    $pos
+    fold-right(tail($input), $zero, $action)
   )
-};
-
-declare function fold-right(
-  $input  as item()*,
-  $zero   as item()*,
-  $action as fn(item(), item()*, xs:integer) as item()*
-) as item()* {
-  fold-right-helper($input, $zero, $action, count($input))
 };]]></eg>
       </fos:rules>
       <fos:errors>
@@ -19599,9 +19576,6 @@ declare function fold-right(
          <p>In cases where the function performs an associative operation on its two arguments (such
             as addition or multiplication), <code>fn:fold-right</code> produces the same result as
                <code>fn:fold-left</code>.</p>
-         <p>The value of the third argument of <code>$action</code> corresponds to the position
-            of the item in the input sequence. Thus, in contrast to <code>fn:fold-left</code>,
-            it is initally set to the number of items in the input sequence.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -19612,7 +19586,8 @@ declare function fold-right(
   fn($a, $b) { $a + $b }
 )</eg></fos:expression>
                <fos:result>15</fos:result>
-               <fos:postamble>This returns the sum of the items in the sequence</fos:postamble>
+               <fos:postamble>This returns the sum of the items in the sequence. 
+               The result is computed as <code>(0+(1+(2+(3+(4+5)))))</code>.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -19635,7 +19610,7 @@ declare function fold-right(
                <fos:result>"$f(1, $f(2, $f(3, $f(4, $f(5, $zero)))))"</fos:result>
             </fos:test>
          </fos:example>
-         <fos:example>
+         <!--<fos:example>
             <fos:test>
                <fos:expression><eg>
 let $input := (11 to 21, 21 to 31)
@@ -19650,11 +19625,11 @@ return fold-right(
 </eg></fos:expression>
                <fos:result>(12, 11)</fos:result>
             </fos:test>
-         </fos:example>
+         </fos:example>-->
       </fos:examples>
-      <fos:history>
+      <!--<fos:history>
          <fos:version version="4.0">Changed in 4.0: Positional parameter added to action function.</fos:version>
-      </fos:history>
+      </fos:history>-->
    </fos:function>
    
        <fos:function name="chain" prefix="fn">
@@ -31345,7 +31320,7 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:proto name="scan-left" return-type="array(*)*">
             <fos:arg name="input" type="item()*" usage ="navigation"/>           
             <fos:arg name="zero" type="item()*"/>           
-            <fos:arg name="action" type="fn(item()*, item(), xs:integer) as item()*" usage="inspection"/>   
+            <fos:arg name="action" type="fn(item()*, item()) as item()*" usage="inspection"/>   
          </fos:proto>
        </fos:signatures>
       <fos:properties>
@@ -31354,89 +31329,79 @@ path with an explicit <code>file:</code> scheme.</p>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-        <p>Produces the complete (ordered) sequence of all intermediate 
-        results of an evaluation of <code>fn:fold-left</code>.</p>
+        <p>Produces a sequence containing intermediate results of an evaluation of <code>fn:fold-left</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The result of the function is the value of the expression:</p>
-         <eg>(1 to count($input)) ! 
-   array{ slice($input, end := .) => fold-left($zero, $action) }</eg>
+         <p>The function is equivalent to the following implementation in XQuery:</p>
          
- <!--        
-         in XPath (return clause added in comments for completeness):</p>
          <eg><![CDATA[
-let $scan-left-inner := fn(
-  $input  as item()*, 
-  $zero   as item()*, 
-  $action as fn(item()*, item()) as item()*,
-  $self   as fn(*)
-) as array(*)* {
-  let $result := [$zero]
-  return if (empty($input)) then (
-    $result
-  ) else (
-    $result, $self(tail($input), $action($zero, head($input)), $action, $self)
-  )
-}
-let $scan-left := fn(
-  $input  as item()*, 
-  $zero   as item()*, 
+declare function scan-left(
+  $input  as item()*,
+  $zero   as item()*,
   $action as fn(item()*, item()) as item()*
-) as array(*)*  {
-  $scan-left-inner($input, $zero, $action, $scan-left-inner)
-}
-(: return $scan-left(1 to 10, 0, op('+'))  :)    
-]]></eg>-->         
+) as item()* {
+  array{$zero},
+  if (exists($input)) {
+    scan-left(
+      tail($input),
+      $action($zero, head($input)),
+      $action
+    )
+  }
+};]]></eg>
+         
+         <p>The result is a sequence of arrays representing intermediate results. The first array
+         holds the value of <code>$zero</code>. Subsequent arrays, one per item in <code>$input</code>,
+         represent the result of applying <code>fn:fold-left</code> (with the same values for 
+         <code>$zero</code> and <code>$action</code>) to the subsequence of <code>$input</code>
+         ending at that item.</p>
+
+
       </fos:rules>
       <fos:errors>
-         <p>See <code>fn:fold-left</code>: errors are raised in the same situations.</p>      
+         <p>As a consequence of the function signature and the function calling rules, a type error
+            occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
+            the first argument is either the value of <code>$zero</code> or the result of a previous
+            application of <code>$action</code>, and the second 
+            is any single item from the sequence <code>$input</code>.</p>     
       </fos:errors>
         <fos:notes>
-           <p>A practical implementation might be expected to evaluate the result
-           incrementally in a single pass of the input; the equivalent expression
-           given in the rules above is provided purely for formal specification
-           purposes.</p>
-           <p>Each intermediate result is placed in a separate array. The number of arrays
-           in the result is the same as the number of items in <code>$input</code>.</p>
+           <p>The number of arrays
+           in the result is the same as the number of items in <code>$input</code> plus one.</p>
            <p>The fact that the function has the same signature as <code>fn:fold-left</code>
            means that this function can conveniently be used to study the behavior of
-           an call on <code>fn:fold-left</code> with the same arguments, perhaps for
-           diagnostic purposes.</p>
+           a call on <code>fn:fold-left</code> with the same arguments, perhaps for
+           diagnostic purposes. It can also be used to produce the running totals of
+           a computation.</p>
         </fos:notes>                
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 5, 0, op('+'))</eg></fos:expression>
-               <fos:result>[ 1 ], [ 3 ], [ 6 ], [ 10 ], [ 15 ]</fos:result>
+               <fos:result>[ 0 ], [ 1 ], [ 3 ], [ 6 ], [ 10 ], [ 15 ]</fos:result>
             </fos:test>
          </fos:example>         
          <fos:example>
             <fos:test>
-               <fos:expression><eg>scan-left(1 to 3, 0, op('-'))</eg></fos:expression>
-               <fos:result>[ -1 ], [ -3 ], [ -6 ]</fos:result>
+               <fos:expression><eg>scan-left(1 to 5, 0, op('-'))</eg></fos:expression>
+               <fos:result>[ 0 ], [ -1 ], [ -3 ], [ -6 ], [ -10 ], [ -15 ]</fos:result>
             </fos:test>
-         </fos:example>      
+         </fos:example>
          <fos:example>
-            <p>Produce the intermediate results of mapping each number in a sequence to its doubled value. 
-            This example shows the necessity to place each intermediate result (sequence) into a singleton array - otherwise
-            the sequence of sequences (intermediate results) would not be possible to express as a single sequence
-            without losing completely the intermediate results.</p>
-            <fos:test>
-               <fos:expression><eg>let $double := fn($x) { 2 * $x }
-return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:expression>
-               <fos:result>[ () ], [ 2 ], [ (2, 4) ], [ (2, 4, 6) ] ]</fos:result>
-            </fos:test>
-         </fos:example>  
-         <fos:example>
-            <p> Produce the factorials of all numbers from 0 to 5</p>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 5, 1, op('*'))</eg></fos:expression>
-               <fos:result>[ 1 ], [ 2 ], [ 6 ], [ 24 ], [ 120 ]</fos:result>
+               <fos:result>[ 1 ], [ 1 ], [ 2 ], [ 6 ], [ 24 ], [ 120 ]</fos:result>
             </fos:test>
-         </fos:example>           
+         </fos:example> 
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>scan-left(1 to 3, (), fn($seq, $it) { $seq , fn(.*2) })</eg></fos:expression>
+               <fos:result>[ ], [ 2 ], [ 2, 4 ], [ 2, 4, 6 ]</fos:result>
+            </fos:test>
+         </fos:example>                    
       </fos:examples>          
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0</fos:version>
+         <fos:version version="4.0">New in 4.0</fos:version>
       </fos:history>
    </fos:function>
 
@@ -31445,7 +31410,7 @@ return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:ex
          <fos:proto name="scan-right" return-type="array(*)*">
             <fos:arg name="input" type="item()*" usage ="navigation"/>           
             <fos:arg name="zero" type="item()*"/>           
-            <fos:arg name="action" type="fn(item()*, item(), xs:integer) as item()*" usage="inspection"/>   
+            <fos:arg name="action" type="fn(item(), item()*) as item()*" usage="inspection"/>   
          </fos:proto>
        </fos:signatures>
       <fos:properties>
@@ -31454,69 +31419,63 @@ return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:ex
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-        <p>Produces the complete (ordered) sequence of all intermediate 
-        results of an evaluation of <code>fn:fold-right</code>.</p>
+        <p>Produces a sequence containing intermediate results of an evaluation of <code>fn:fold-right</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The result of the function is the value of the expression:</p>
+         <p>The function is equivalent to the following implementation in XQuery:</p>
          
-         <eg>reverse(1 to count($input)) ! 
-   array{ slice($input, start := .) => fold-right($zero, $action) }</eg>
-         <!--<p>The function is equivalent to the following implementation in XPath (return clause in comments added for completeness):</p>
          <eg><![CDATA[
-let $scan-right-inner := fn(
+declare function scan-right(
   $input  as item()*,
   $zero   as item()*,
-  $action as fn(item()*, item()) as item()*, $self as fn(*)
+  $action as fn(item(), item()*) as item()*
 ) as array(*)* {
   if (empty($input)) then (
-    [ $zero ]
+    array { $zero }
   ) else (
-    let $rightResult := $self(tail($input), $zero, $action, $self)
-    return ([ $action(head($input), head($rightResult)) ], $rightResult)
+    let $rightResult := scan-right(tail($input), $zero, $action)
+    return (array { $action(head($input), head($rightResult)?*) }, $rightResult)
   )
-}
-let $scan-right := function(
-  $input as item()*,
-  $zero  as item()*,
-  $f     as fn(item()*, item()) as item()*
-) as array(*)* {
-  $scan-right-inner($input, $zero, $f, $scan-right-inner)
-}        
-(: return $scan-right(1 to 10, 0, op('+')) :)  
-]]></eg>         -->
+}]]></eg> 
+         
+         <p>The result is a sequence of arrays representing intermediate results. The last array
+         holds the value of <code>$zero</code>. Subsequent arrays, one per item in <code>$input</code>,
+         represent the result of applying <code>fn:fold-right</code> (with the same values for 
+         <code>$zero</code> and <code>$action</code>) to the subsequence of <code>$input</code>
+         starting at that item.</p>
       </fos:rules>
       <fos:errors>
-         <p>See <code>fn:fold-left</code>: errors are raised in the same situations.</p>      
+         <p>As a consequence of the function signature and the function calling rules, a type error
+            occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
+            the first argument is any item in the sequence <code>$input</code>, and the second is either
+            the value of <code>$zero</code> or the result of a previous application of
+            <code>$action</code>.</p>      
       </fos:errors>
         <fos:notes>
-           <p>A practical implementation might be expected to evaluate the result
-           incrementally in a single right-to-left pass of the input; the equivalent expression
-           given in the rules above is provided purely for formal specification
-           purposes.</p>
-           <p>Each intermediate result is placed in a separate array. The number of arrays
-           in the result is the same as the number of items in <code>$input</code>.</p>
+           <p>The number of arrays
+           in the result is the same as the number of items in <code>$input</code> plus one.</p>
            <p>The fact that the function has the same signature as <code>fn:fold-right</code>
            means that this function can conveniently be used to study the behavior of
-           an call on <code>fn:fold-right</code> with the same arguments, perhaps for
-           diagnostic purposes.</p>
+           a call on <code>fn:fold-right</code> with the same arguments, perhaps for
+           diagnostic purposes. It can also be used to produce the running totals of
+           a computation.</p>
         </fos:notes>               
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-right(1 to 5, 0, op('+'))</eg></fos:expression>
-               <fos:result><eg>[ 5 ], [ 9 ], [ 12 ], [ 14 ], [ 15 ]</eg></fos:result>
+               <fos:result><eg>[ 15 ], [ 14 ], [ 12 ], [ 9 ], [ 5 ], [ 0 ]</eg></fos:result>
             </fos:test>
          </fos:example>         
          <fos:example>
             <fos:test>
-               <fos:expression><eg>scan-right(1 to 5, 0, op('-'))</eg></fos:expression>
-               <fos:result>[ 5 ], [ -1 ], [ 4 ], [ -2 ], [ 3 ]</fos:result>
+               <fos:expression><eg>scan-right(1 to 3, 0, op('-'))</eg></fos:expression>
+               <fos:result>[ 2 ], [ -1 ], [ 3 ], [ 0 ]</fos:result>
             </fos:test>
          </fos:example>         
       </fos:examples>      
       <fos:history>
-         <fos:version version="4.0">Proposed for 4.0</fos:version>
+         <fos:version version="4.0">New in 4.0</fos:version>
       </fos:history>
    </fos:function>
     

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -2039,9 +2039,25 @@
         <xsl:if test="@*">
           <i xsl:expand-text="yes">
             <xsl:text>[&#xa0;</xsl:text>
-            <xsl:if test="@issue">Issue <a href="https://github.com/qt4cg/qtspecs/issues/{@issue}">{@issue}&#xa0;</a> </xsl:if>
-            <xsl:if test="@PR">PR <a href="https://github.com/qt4cg/qtspecs/pull/{@PR}">{@PR}&#xa0;</a> </xsl:if>
-            <xsl:if test="@date">Applied {format-date(@date, '[D] [MNn] [Y]')}</xsl:if>
+            <xsl:variable name="issues" select="tokenize(@issue)"/>
+            <xsl:if test="exists($issues)">
+              <xsl:value-of select="if (count($issues) gt 1) then 'Issues ' else 'Issue '"/>
+              <xsl:for-each select="$issues">
+                <xsl:if test="position() != 1">&#xa0;</xsl:if>
+                <a href="https://github.com/qt4cg/qtspecs/issues/{.}">{.}</a>
+              </xsl:for-each>
+            </xsl:if>
+            <xsl:text>&#xa0;</xsl:text>
+            <xsl:variable name="PRs" select="tokenize(@PR)"/>
+            <xsl:if test="exists($PRs)">
+              <xsl:value-of select="if (count($PRs) gt 1) then 'PRs ' else 'PR '"/>
+              <xsl:for-each select="$PRs">
+                <xsl:if test="position() != 1">&#xa0;</xsl:if>
+                <a href="https://github.com/qt4cg/qtspecs/pull/{.}">{.}</a>
+              </xsl:for-each>
+            </xsl:if>
+            <xsl:text>&#xa0;</xsl:text>
+            <xsl:if test="@date">Processed on {format-date(@date, '[D] [MNn] [Y]')}</xsl:if>
             <xsl:text>&#xa0;]</xsl:text>
           </i>
         </xsl:if>


### PR DESCRIPTION
Changes stylesheet so that where a change entry refers to multiple issues or PRs, the links to each one are rendered correctly. (For an example, see "Lookup Expressions" in XQuery.)