### PR TITLE
Fixed typo in the example of scan-right

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31499,7 +31499,7 @@ let $scan-right := function(
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>scan-right(1 to 5, 0, op('+'))</eg></fos:expression>
+               <fos:expression><eg>scan-right(1 to 10, 0, op('+'))</eg></fos:expression>
                <fos:result><eg>[ 55 ], [ 54 ], [ 52 ], [ 49 ], [ 45 ],
 [ 40 ], [ 34 ], [ 27 ], [ 19 ], [ 10 ], [ 0 ]</eg></fos:result>
             </fos:test>


### PR DESCRIPTION
Fixed a minor typo in one of the examples for fn:scan-right