### PR TITLE
1324 Introduce markup for executable specs

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1414,15 +1414,21 @@ must equal the function’s arity.
 
 <div3 id="map-items">
 <head>Map Items</head>
+  
+  <changes>
+    <change issue="1335" date="2024-07-20">Constructors are added, and the single accessor function
+    is now an iterator over the key/value pairs in the map.</change>
+  </changes>
 
 <p><termdef term="map item" id="dt-map-item">A <term>map item</term>
-is a value that represents a map (sometimes called a hash or an
-associative array).</termdef> A map is logically a collection of
+is a value that represents a map (in other languages this is sometimes 
+called a hash, dictionary, or associative array).</termdef> 
+  A map is logically a collection of
 key/value pairs. Each key in the map is unique (there is no other key
-to which it is equal) and has associated with it a value that is a
-single item or sequence of items. There is no uniqueness constraint on
+to which it is equal) and has associated with it a value that is a sequence 
+of zero or more items. There is no uniqueness constraint on
 values. The semantics of equality are described in
-<xspecref spec="FO40" ref="func-same-key"/>.</p>
+<xspecref spec="FO40" ref="func-atomic-equal"/>.</p>
 
 
 
@@ -1434,31 +1440,70 @@ values. The semantics of equality are described in
 </p>
 </note>
 
-<p>There is a single accessor associated with maps, it is defined
-in the following section.</p>
+<p>Constructor and accessor functions for maps are defined in the following sections.</p>
+  
+  <div4 id="dm-empty-map">
+    <head><code>empty-map</code> Constructor</head>
+    <example role="signature">
+      <proto class="dm" name="empty-map" return-type="map(*)" returnSeq="no"/>
+    </example>
+    
+    <p>The <code>dm:empty-map</code> constructor returns a map containing no key/value pairs.</p>
+    
+    <p>The function is exposed in XPath as an empty map constructor, which may be written <code>{}</code>
+    or <code>map{}</code>.</p>
+  </div4>
+  
+  <div4 id="dm-map-put">
+    <head><code>map-put</code> Constructor</head>
+    <example role="signature">
+      <proto class="dm" name="map-put" return-type="map(*)" returnSeq="no">
+        <arg name="map" type="map(*)"/>
+        <arg name="key" type="xs:anyAtomicType"/>
+        <arg name="value" type="item()*"/>
+      </proto>
+    </example>
+    
+    <p>The <code>dm:map:put</code> constructor returns a map based on the contents of a supplied map.</p>
+    <p>The key/value pairs in the returned map are as follows:</p>
+    <ulist>
+      <item><p>One key/value pair for every key/value pair present in <code>$map</code> whose key is
+      not equal to <code>$key</code>; plus</p></item>
+      <item><p>One key/value pair whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p></item>
+    </ulist>
+    
+    <p>The function is exposed in XPath through the function <code>map:put</code>.</p>
+  </div4>
 
-<div4 id="dm-map-keys">
-<head><code>map-entries</code> Accessor</head>
-
-<example role="signature">
-  <proto class="dm" name="map-entries" return-type="array(array(item()))" returnSeq="no">
-    <arg name="map" type="map()"/>
-  </proto>
-</example>
-
-<p>The <function>map-entries</function> accessor returns an array
-of arrays. For each key/value pair in the <code>$map</code>, an
-array will be constructed with the key in position 1 and the value
-in position 2. The array returned by <function>map-entries</function> is
-the array of the arrays constructed for the key/value pairs. The
-order of the members in the array returned is implementation-dependent.</p>
-
-</div4>
+  <div4 id="dm-iterate-map">
+  <head><code>iterate-map</code> Accessor</head>
+  
+    <example role="signature">
+      <proto class="dm" name="iterate-map" return-type="item()*">
+        <arg name="map" type="map(*)"/>
+        <arg name="action" type="function(xs:anyAtomicType, item()*) as item()*"/>
+      </proto>
+    </example>
+    
+    <p>The <function>dm:iterate-map</function> accessor calls the supplied <code>$action</code>
+      function once for each key/value pair in <code>$map</code>, in implementation-dependent order,
+      and returns the sequence concenation of the results.</p>
+      
+      <p>The function is exposed in XPath most directly through the function <code>map:for-each</code>, but
+      it also underpins all other functions giving access to maps, such as <code>map:size</code>,
+      <code>map:contains</code>, and <code>map:get</code>.</p>
+    
+  </div4>
 
 </div3>
 
 <div3 id="array-items">
 <head>Array Items</head>
+  
+  <changes>
+    <change issue="1335" date="2024-07-20">Constructors are added, and the single accessor function
+    is now an iterator over the members of the array.</change>
+  </changes>
 
 <p><termdef term="array item" id="dt-array-item">An <term>array item</term>
 is a value that represents an array.</termdef>
@@ -1474,39 +1519,62 @@ position, in the range 1 to the size of the array.</p>
     operations for deep update of arrays.
   </p></note>
 
-<p>The accessors associated with arrays are defined in the following
-sections.</p>
+<p>Constructor and accessor functions for arrays are defined in the following sections.</p>
+  
+  <div4 id="dm-empty-array">
+    <head><code>empty-array</code> Constructor</head>
+    <example role="signature">
+      <proto class="dm" name="empty-array" return-type="array(*)"/>
+    </example>
+    
+    <p>The <code>dm:empty-array</code> constructor returns an array containing no members.</p>
+    
+    <p>The function is exposed in XPath as an empty array constructor, written <code>[]</code>
+    or <code>array{}</code>.</p>
+  </div4>
+  
+  <div4 id="dm-array-append">
+    <head><code>array-append</code> Constructor</head>
+    <example role="signature">
+      <proto class="dm" name="array-append" return-type="array(*)">
+        <arg name="array" type="array(*)"/>
+        <arg name="member" type="item()*"/>
+      </proto>
+    </example>
+    
+    <p>The <code>dm:array-append</code> constructor returns an array based on the contents of a supplied array.</p>
+    <p>The returned array contains:</p>
+    <ulist>
+      <item><p>One member for every member present in <code>$array</code>, at the same position; plus</p></item>
+      <item><p>One additional member, <code>$member</code>, as the last member in the returned array.</p></item>
+    </ulist>
+    
+    <p>The function is exposed in XPath through the function <code>array:append</code>.</p>
+  </div4>
+  
+  <div4 id="dm-iterate-array">
+  <head><code>iterate-array</code> Accessor</head>
+  
+    <example role="signature">
+      <proto class="dm" name="iterate-array" return-type="item()*">
+        <arg name="array" type="array(*)"/>
+        <arg name="action" type="function(item()*, xs:integer) as item()*"/>
+      </proto>
+    </example>
+    
+    <p>The <code>dm:iterate-array</code> accessor calls the supplied <code>$action</code>
+      function once for each member in <code>$array</code>, in order,
+      and returns the sequence concenation of the results. The <code>$action</code> function
+      is called with two arguments. The first argument is the array member (an arbitrary sequence),
+      and the second is its 1-based ordinal position within the array.</p>
+      
+      <p>The function is exposed in XPath most directly through the function <code>array:for-each</code>, but
+      it also underpins all other functions giving access to arrays, such as <code>array:size</code>
+       and <code>array:get</code>.</p>
+    
+  </div4>
 
-<div4 id="dm-array-size">
-<head><code>array-size</code> Accessor</head>
 
-<example role="signature">
-  <proto class="dm" name="array-size" return-type="xs:nonNegativeInteger" returnSeq="no">
-    <arg name="array" type="array()"/>
-  </proto>
-</example>
-
-<p>The <function>array-size</function> accessor returns the number
-of items in the array.
-</p>
-</div4>
-
-<div4 id="dm-array-get">
-<head><code>array-get</code> Accessor</head>
-
-<example role="signature">
-  <proto class="dm" name="array-get" return-type="item()" returnSeq="yes">
-    <arg name="array" type="array()"/>
-    <arg name="position" type="xs:positiveInteger"/>
-  </proto>
-</example>
-
-<p>The <function>array-get</function> accessor returns the value in the array
-at the position <code>$position</code>. An error is raised
-if the array does not contain a value at that position.
-For all positions greater than 0 and less than or equal to the array size,
-<function>array-get</function> will return a value.</p>
-</div4>
 
 </div3>
 </div2>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1568,8 +1568,9 @@ position, in the range 1 to the size of the array.</p>
       is called with two arguments. The first argument is the array member (an arbitrary sequence),
       and the second is its 1-based ordinal position within the array.</p>
       
-      <p>The function is exposed in XPath most directly through the function <code>array:for-each</code>, but
-      it also underpins all other functions giving access to arrays, such as <code>array:size</code>
+      <p>The function is exposed in XPath most directly through the function <code>array:for-each</code> (but
+        note that <code>array:for-each</code> delivers an array rather than a sequence). 
+        It also underpins all other functions giving access to arrays, such as <code>array:size</code>
        and <code>array:get</code>.</p>
     
   </div4>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -703,9 +703,68 @@ do not contain duplicates. In generalizing node-sets to sequences,
 duplicate removal is provided by functions on node sequences.</p>
 </note>
 <note>
-<p>Arrays and maps are derived from functions and
+<p>Arrays and maps are function items and
 therefore can also be contained within sequences.</p>
 </note>
+  
+  <p>The following constructor and accessor functions are defined for sequences;
+  these provide a formal underpinning for user-visible functions, operators,
+  and language constructs.</p>
+  
+  <div3 id="dm-empty-sequence">
+    <head><code>empty-sequence</code> Constructor</head>
+    <example role="signature">
+      <proto class="dm" name="empty-sequence" return-type="item()*"/>
+    </example>
+    
+    <p>The <code>dm:empty-sequence</code> constructor returns a sequence containing no items.</p>
+    
+    <p>The function is exposed in XPath as an empty sequence expression, written <code>()</code>>.</p>
+  </div3>
+  
+  <div3 id="dm-append-item">
+    <head><code>append-item</code> Constructor</head>
+    <example role="signature">
+      <proto class="dm" name="append-item" return-type="item()*">
+        <arg name="input" type="item()*"/>
+        <arg name="item" type="item()"/>
+      </proto>
+    </example>
+    
+    <p>The <code>dm:append-item</code> constructor returns an sequence based on the contents of a supplied sequence.</p>
+    <p>The returned array contains:</p>
+    <ulist>
+      <item><p>One item for every item present in <code>$input</code>, at the same position; plus</p></item>
+      <item><p>One additional item, <code>$item</code>, as the last item in the returned sequence.</p></item>
+    </ulist>
+    
+    <p>The function is exposed in XPath through the comma operator <code>,</code>, which concatenates
+      two sequences.</p>
+  </div3>
+  
+  <div3 id="dm-iterate-sequence">
+  <head><code>iterate-sequence</code> Accessor</head>
+  
+    <example role="signature">
+      <proto class="dm" name="iterate-sequence" return-type="item()*">
+        <arg name="input" type="array(*)"/>
+        <arg name="action" type="function(item(), xs:integer) as item()*"/>
+      </proto>
+    </example>
+    
+    <p>The <code>dm:iterate-sequence</code> accessor calls the supplied <code>$action</code>
+      function once for each item in <code>$input</code>, in order,
+      and returns the sequence concenation of the results. The <code>$action</code> function
+      is called with two arguments. The first argument is an item in <code>$input</code>,
+      and the second is the 1-based ordinal position of the item within <code>$input</code>.</p>
+      
+      <p>The function is exposed in XPath most directly through the function <code>for-each</code>,
+        as well as <code>for</code> expressions in XPath, <code>for</code> clauses in FLWOR expressions
+        in XQuery, and the <code>xsl:for-each</code> instruction in XSLT.
+        It also underpins all other functions that manipulate sequences, such as <code>fn:count</code>
+       and <code>fn:filter</code>.</p>
+    
+  </div3>
 </div2>
 
 <div2 id="namespace-names">
@@ -1464,7 +1523,7 @@ values. The semantics of equality are described in
       </proto>
     </example>
     
-    <p>The <code>dm:map:put</code> constructor returns a map based on the contents of a supplied map.</p>
+    <p>The <code>dm:map-put</code> constructor returns a map based on the contents of a supplied map.</p>
     <p>The key/value pairs in the returned map are as follows:</p>
     <ulist>
       <item><p>One key/value pair for every key/value pair present in <code>$map</code> whose key is

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -722,24 +722,33 @@ therefore can also be contained within sequences.</p>
     <p>The function is exposed in XPath as an empty sequence expression, written <code>()</code>>.</p>
   </div3>
   
-  <div3 id="dm-append-item">
-    <head><code>append-item</code> Constructor</head>
+  <div3 id="dm-sequence-concat">
+    <head><code>sequence-concat</code> Constructor</head>
     <example role="signature">
-      <proto class="dm" name="append-item" return-type="item()*">
-        <arg name="input" type="item()*"/>
-        <arg name="item" type="item()"/>
+      <proto class="dm" name="sequence-concat" return-type="item()*">
+        <arg name="input1" type="item()*"/>
+        <arg name="input2" type="item()*"/>
       </proto>
     </example>
     
-    <p>The <code>dm:append-item</code> constructor returns an sequence based on the contents of a supplied sequence.</p>
-    <p>The returned array contains:</p>
-    <ulist>
-      <item><p>One item for every item present in <code>$input</code>, at the same position; plus</p></item>
-      <item><p>One additional item, <code>$item</code>, as the last item in the returned sequence.</p></item>
-    </ulist>
+    <p>The <code>dm:sequence-concat</code> constructor returns a sequence by concatenating two supplied sequences.</p>
+    <p>The returned sequence contains the items in <code>$input1</code> (retaining order), followed by the items in
+      <code>$input2</code> (also retaining order).</p>
     
-    <p>The function is exposed in XPath through the comma operator <code>,</code>, which concatenates
-      two sequences.</p>
+    <p>The function is exposed in XPath through the comma operator <code>,</code>.</p>
+  </div3>
+  
+  <div3 id="dm-count">
+    <head><code>count</code> Accessor</head>
+    <example role="signature">
+      <proto class="dm" name="count" return-type="xs:integer">
+        <arg name="input" type="item()*"/>
+      </proto>
+    </example>
+    
+    <p>The <code>dm:count</code> accessor function returns the number of items in <code>$input</code>.</p>
+    
+    <p>The function is exposed in XPath through the <code>fn:count</code> function.</p>
   </div3>
   
   <div3 id="dm-iterate-sequence">

--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -67,6 +67,7 @@
         <xs:element ref="fos:properties" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="fos:summary"/>
         <xs:element ref="fos:rules"/>
+        <xs:element ref="fos:equivalent" minOccurs="0"/>
         <xs:element ref="fos:errors" minOccurs="0"/>
         <xs:element ref="fos:notes" minOccurs="0"/>
         <xs:element ref="fos:examples" minOccurs="0"/>
@@ -230,6 +231,27 @@
         <xs:element ref="fos:record-description"/>
       </xs:choice>
       <xs:attributeGroup ref="fos:diff-markup"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="equivalent">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute name="style">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="xpath-expression"/>
+                <xs:enumeration value="xquery-expression"/>
+                <xs:enumeration value="xquery-function"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="covers-error-cases" use="optional" default="true" type="xs:boolean"/>
+          <xs:attribute name="arity" use="optional" type="xs:nonNegativeInteger"/>
+          <xs:attributeGroup ref="fos:diff-markup"/>         
+        </xs:extension>
+      </xs:simpleContent>
+      
     </xs:complexType>
   </xs:element>
   <xs:element name="errors">

--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -243,6 +243,7 @@
                 <xs:enumeration value="xpath-expression"/>
                 <xs:enumeration value="xquery-expression"/>
                 <xs:enumeration value="xquery-function"/>
+                <xs:enumeration value="dm-primitive"/>
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19339,13 +19339,19 @@ return map:keys($ann) || ': ' || string-join(map:values($ann), ', ')
             in turn, returning the concatenation of the resulting sequences in order.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the value of the expression
-            (provided that ordering mode is <code>ordered</code>):</p>
-         <eg><![CDATA[
-for $item at $pos in $input
-return $action($item, $pos)
-]]></eg>
+         <p>The function calls <code>$action($item, $pos)</code> for each item in <code>$input</code>,
+            where <code>$item</code> is the item in question and <code>$pos</code> is its 1-based
+            ordinal position in <code>$input</code>. The final result is the sequence concatenation
+            of the result of these calls, preserving order
+            (provided that ordering mode is <code>ordered</code>).
+         </p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+fold-left($input, (), 
+          fn($result, $next, $pos) {
+              $result, $action($next, $pos)
+          })         
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -19401,14 +19407,18 @@ return $action($item, $pos)
                <code>$predicate</code> returns <code>true</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the value of the expression:</p>
-         <eg><![CDATA[
-for $item at $pos in $input
-where $predicate($item, $pos)
-return $item
-]]></eg>
+         <p>The function returns a sequence containing those items from <code>$input</code>
+            for which <code>$predicate($item, $pos)</code> returns <code>true</code>, where <code>$item</code>
+            is the item in question, and <code>$pos</code> is its 1-based ordinal position within <code>$input</code>.</p>
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+fold-left($input, (), fn($result, $next, $pos) {
+   if ($predicate($next, $pos))
+   then ($result, $next)
+   else $result
+})                   
+      </fos:equivalent>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error
             occurs if the supplied <code>$predicate</code> function returns anything other than a single
@@ -19433,7 +19443,7 @@ return $item
                <fos:result>(2, 4, 6, 8, 10)</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg><![CDATA[filter(parse-xml('<doc><a id="2"/><a/>')//a, fn{@id eq "2"})]]></eg></fos:expression>
+               <fos:expression><eg><![CDATA[filter(parse-xml('<doc><a id="2"/><a/></doc>')//a, fn{@id eq "2"})]]></eg></fos:expression>
                <fos:result><![CDATA[<a id="2"/>]]></fos:result>
                <fos:postamble>The function returns <code>()</code> when there is no <code>@id</code> attribute;
                this is treated as false.</fos:postamble>
@@ -19480,33 +19490,45 @@ return filter(
             repeatedly to each item in turn, together with an accumulated result value.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is equivalent to the following implementation in XQuery:</p>
-         <eg><![CDATA[
-declare %private function fold-left-helper(
-  $input  as item()*,
-  $zero   as item()*,
-  $action as fn(item()*, item(), xs:integer) as item()*,
-  $pos    as xs:integer
-) as item()* {
-  if (empty($input))
-  then $zero
-  else fold-left-helper(
-    tail($input),
-    $action($zero, head($input), $pos + 1),
-    $action,
-    $pos + 1
-  )
-};
-
-declare function fold-left(
-  $input  as item()*,
-  $zero   as item()*,
-  $action as fn(item()*, item(), xs:integer) as item()*
-) as item()* {
-  fold-left-helper($input, $zero, $action, 1)
-};]]></eg>
+         <p>If <code>$input</code> is empty, the function returns <code>$zero</code>.</p>
+         <p>If <code>$input</code> contains a single item <code>$item1</code>, the function calls 
+            <code>$action($zero, $item1, 1)</code>.</p>
+         <p>If <code>$input</code> contains a second item <code>$item2</code>, the function then calls 
+            <code>$action($zero1, $item2, 2)</code>, where <code>$zero1</code> is the result after
+            processing the first item.</p>
+         <p>This continues in the same way until the end of the <code>$input</code> sequence; the final result is
+         the result of the last call on <code>$action</code>.</p>
 
       </fos:rules>
+      <fos:equivalent style="xquery-function">
+declare %private function fold-left-2 (
+        $input as item()*,
+        $zero as item()*,
+        $action as function(item()*, item()) as item()*) 
+        as item()* {
+  if (empty($input))
+  then $zero
+  else fold-left-2(tail($input), $action($zero, head($input)), $action)
+};
+
+declare function fold-left (
+        $input as item()*,
+        $zero as item()*,
+        $action as function(item()*, item(), xs:integer) as item()*) 
+        as item()* {
+  let $numbered-input := for-each($input, 
+                                  fn($item, $pos) { 
+                                     map{ 'item': $item, 'position': $pos }
+                                  })
+  return fold-left-2($numbered-input, fn($zero, $pair) {
+                                         $action($zero, $pair?item, $pair?position)
+                                      })   
+};
+
+(: Note: a practical implementation can optimize for the case where the
+   supplied $action function has arity 2 :)
+         
+      </fos:equivalent>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error
             occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
@@ -19516,15 +19538,16 @@ declare function fold-left(
       </fos:errors>
       <fos:notes>
          <p>This operation is often referred to in the functional programming literature as
-            “folding” or “reducing” a sequence. It takes a function that operates on a pair of
+            “folding” or “reducing” a sequence. It typically takes a function that operates on a pair of
             values, and applies it repeatedly, with an accumulated result as the first argument, and
-            the next item in the sequence as the second argument. The accumulated result is
+            the next item in the sequence as the second argument. Optionally the <code>$action</code>
+            function may take a third argument, which is set to the 1-based position of the current
+            item in the input sequence. The accumulated result is
             initially set to the value of the <code>$zero</code> argument, which is conventionally a
             value (such as zero in the case of addition, one in the case of multiplication, or a
             zero-length string in the case of string concatenation) that causes the function to
             return the value of the other argument unchanged.</p>
-         <p>The value of the third argument of <code>$action</code> corresponds to the position
-            of the item in the input sequence. It is initally set to <code>1</code>.</p>
+         
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -19653,31 +19676,47 @@ return fold-left($input, (),
             repeatedly to each item in turn, together with an accumulated result value.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is equivalent to the following implementation in XQuery:</p>
-         <eg><![CDATA[
-declare %private function fold-right-helper(
-  $input  as item()*,
-  $zero   as item()*,
-  $action as fn(item(), item()*, xs:integer) as item()*,
-  $pos    as xs:integer
-) as item()* {
+         <p>If <code>$input</code> is empty, the function returns <code>$zero</code>.</p>
+         <p>Let <code>$itemN</code> be the last item in <code>$input</code>, and let <code>$N</code>
+            be its 1-based ordinal position in <code>$input</code> (that is, the size of <code>$input</code>).
+            The function starts by calling <code>$action($itemN, $zero, $N)</code>.</p>
+         <p>If there is a previous item, <code>$itemN-1</code>, at position <code>$N - 1</code>,
+            the function then calls <code>$action($itemN-1, $zeroN, $N - 1)</code>, where <code>$zeroN</code> is the result
+            of the previous call.</p>
+         <p>This continues in the same way until the start of the <code>$input</code> sequence is reached; the final result is
+         the result of the last call on <code>$action</code>.</p>
+         
+      </fos:rules>
+      <fos:equivalent style="xquery-function">
+declare %private function fold-right-2 (
+        $input as item()*,
+        $zero as item()*,
+        $action as function(item(), item()*) as item()*) 
+        as item()* {
   if (empty($input))
   then $zero
-  else $action(
-    head($input),
-    fold-right-helper(tail($input), $zero, $action, $pos - 1),
-    $pos
-  )
+  else $action(head($input), fold-right-2(tail($input), $zero, $action)
 };
 
-declare function fold-right(
-  $input  as item()*,
-  $zero   as item()*,
-  $action as fn(item(), item()*, xs:integer) as item()*
-) as item()* {
-  fold-right-helper($input, $zero, $action, count($input))
-};]]></eg>
-      </fos:rules>
+declare function fold-right (
+        $input as item()*,
+        $zero as item()*,
+        $action as function(item()*, item(), xs:integer) as item()*) 
+        as item()* {
+  let $numbered-input := for-each($input, 
+                                  fn($item, $pos) { 
+                                     map{ 'item': $item, 'position': $pos }
+                                  })
+  return fold-right-2($numbered-input, fn($zero, $pair) {
+                                         $action($pair?item, $zero, $pair?position)
+                                       })   
+};
+
+(: Note: a practical implementation can optimize for the case where the
+   supplied $action function has arity 2 :)
+         
+  
+      </fos:equivalent>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error
             occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -25901,6 +25901,9 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
          <p diff="chg" at="A">More formally, the function returns the value of
             <code>count(array:members($array))</code>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+           count(array:members($array))
+      </fos:equivalent>
       <fos:notes>
          <p>Note that because an array is an item, the <code>fn:count</code> function
             when applied to an array always returns <code>1</code>.</p>
@@ -25942,9 +25945,11 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
          <p>Returns <code>true</code> if the supplied array contains no members.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns <code>true</code> if and only if <code>$array</code> contains no members, that is,
-            if <code>array:size($array) eq 0</code>.</p>
+         <p>The function returns <code>true</code> if and only if <code>$array</code> contains no members.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+         array:size($array) eq 0
+      ]]></fos:equivalent>
       <fos:notes>
          <p>The test for emptiness is not the same as the test used by the
             <code>xsl:on-empty</code> instruction in XSLT. For example, an array 
@@ -26002,11 +26007,13 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
          <p diff="chg" at="2022-12-16">The default <code>$fallback</code> function raises a dynamic error. The call on <code>fn:error</code>
          shown as the default is for illustrative purposes only; apart from the error code (<code>err:FOAY0001</code>)
             the details of the error (such as the error message) are <termref def="implementation-dependent">implementation-dependent</termref>.</p>
-         <p diff="chg" at="2022-12-16">More formally, the function returns the value of:</p> 
-            <eg>if ($position = (1 to array:size($array)))
-then array:members($array)[$position]?value 
-else $fallback($position)</eg>
+        
       </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false"><![CDATA[
+if ($position = (1 to array:size($array)))
+then array:members($array)[$position]?value 
+else $fallback($position)
+      ]]></fos:equivalent>
       <fos:errors>
          <p><phrase diff="add" at="2022-12-16">In the absence of a <code>$fallback</code> function</phrase>,
             a dynamic error occurs <errorref class="AY" code="0001"
@@ -26055,10 +26062,14 @@ else $fallback($position)</eg>
          <p>Informally, the result is an array whose size is <code>array:size($array)</code>, in which all
             members in positions other than <code>$position</code> are the same as the members in the corresponding position
             of <code>$array</code>, and the member in position <code>$position</code> is <code>$member</code>.</p>
-         <p>More formally, the result is the value of the expression
-            <code>$array => array:remove($position) => array:insert-before($position, $member)</code>.</p>
+         
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+$array 
+=> array:remove($position) 
+=> array:insert-before($position, $member)
+       ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
                /> if <code>$position</code> is not in the range <code>1 to
@@ -26109,10 +26120,14 @@ else $fallback($position)</eg>
             members in positions other than <code>$position</code> are the same as the members in the corresponding position
             of <code>$array</code>, and the member in position <code>$position</code> is the result of applying
             the <code>$action</code> function to the original value in that position.</p>
-         <p>More formally, the result is the value of the expression
-            <code>$array => array:remove($position) => array:insert-before($position, $action($array($position)))</code>.</p>
+         
          
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+$array 
+=> array:remove($position) 
+=> array:insert-before($position, $action($array($position)))
+       ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"/> 
             if <code>$position</code> is not in the range <code>1 to
@@ -26172,10 +26187,13 @@ else $fallback($position)</eg>
          <p>Informally, the result is an array whose size is <code>array:size($array) + 1</code>, in which all
             members in positions 1 to <code>array:size($array)</code> are the same as the members in the corresponding position
             of <code>$array</code>, and the member in position <code>array:size($array) + 1</code> is <code>$member</code>.</p>
-         <p diff="chg" at="A">More formally, the result is the value of the expression
-            <code>array:of-members((array:members($array), { 'value': $member }))</code>.</p>
+         <!--<p diff="chg" at="A">More formally, the result is the value of the expression
+            <code>array:of-members((array:members($array), { 'value': $member }))</code>.</p>-->
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+         array:of-members((array:members($array), { 'value': $member }))
+      ]]></fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -26214,9 +26232,12 @@ else $fallback($position)</eg>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function concatenates the members of several arrays into a single array.</p>
-         <p diff="chg" at="A">More formally, the function returns the result of 
-            <code>array:of-members($arrays ! array:members(.))</code>.</p>
+         <!--<p diff="chg" at="A">More formally, the function returns the result of 
+            <code>array:of-members($arrays ! array:members(.))</code>.</p>-->
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+            array:of-members($arrays ! array:members(.))
+       ]]></fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -26270,10 +26291,14 @@ else $fallback($position)</eg>
             version when called with <code>$length</code> equal to the value of
             <code>array:size($array) - $start + 1</code>.</p>
          <p diff="add" at="2022-12-19">Setting the third argument to the empty sequence has the same effect as omitting the argument.</p>
-         <p>Except in error cases, the result of the three-argument version of the function is the 
-            value of the expression
-            <code role="example">array:of-members(array:members($array) => fn:subsequence($start, $length))</code>.</p>
+         
       </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false" arity="3"><![CDATA[
+$array
+=> array:members()
+=> fn:subsequence($start, $length)
+=> array:of-members()
+      ]]></fos:equivalent>     
       <fos:errors>
          <p>A dynamic error is raised <errorref class="AY" code="0001"
                   /> if <code>$start</code> is less than one
@@ -26357,8 +26382,8 @@ else $fallback($position)</eg>
                <code>$array</code> of members that are equal to <code>$target</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the result of the expression:</p>
-         <eg>array:index-where($array, fn:deep-equal(?, $target, $collation))</eg>
+         <!--<p>The function returns the result of the expression:</p>
+         <eg>array:index-where($array, fn:deep-equal(?, $target, $collation))</eg>-->
          <p>Informally, all members of <code>$array</code> are compared with <code>$target</code>.
             An array member is compared to the target value using the rules of the
             <code>fn:deep-equal</code> function, with the specified (or defaulted) collation.
@@ -26370,6 +26395,9 @@ else $fallback($position)</eg>
          <p>The first member in an array is at position 1, not position 0.</p>
          <p>The result sequence is in ascending numeric order.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+            array:index-where($array, fn:deep-equal(?, $target, $collation))
+       ]]></fos:equivalent>
       <fos:notes>
          <p>If <code>$array</code> is the empty array, or if no member in
             <code>$array</code> matches <code>$target</code>, then the function returns the empty
@@ -26433,11 +26461,17 @@ array:index-of(
          <p>The result of the function is a sequence of integers, in monotonic ascending order, representing
             the 1-based positions in the input array of those members for which the supplied predicate function
             returns <code>true</code>. A return value of <code>()</code> is treated as <code>false</code>.</p>
-         <p>More formally, the function returns the result of the XQuery expression:</p>
+         <!--<p>More formally, the function returns the result of the XQuery expression:</p>
          <eg>for member $m at $pos in $array 
 return $pos[$predicate($m, $pos)]</eg>
-         <!--<eg>index-of($array => array:for-each($predicate) => array:values(), true())</eg>-->
+         <!-\-<eg>index-of($array => array:for-each($predicate) => array:values(), true())</eg>-\->
+     --> 
       </fos:rules>
+      
+      <fos:equivalent style="xpath-expression"><![CDATA[
+for member $m at $pos in $array 
+return $pos[$predicate($m, $pos)]
+       ]]></fos:equivalent>
       
       <fos:examples>
          <fos:example>
@@ -26504,18 +26538,23 @@ return $pos[$predicate($m, $pos)]</eg>
          <p>Returns an array containing selected members of a supplied input array based on their position.</p>
       </fos:summary>
       <fos:rules>
-         <p>Returns the value of <code role="example">array:of-members(array:members($array) => fn:slice($start, $end, $step))</code></p>
+         <p>Informally, the array is converted to a sequence, the function <code>fn:slice</code>
+         is applied to this sequence, and the resulting sequence is converted back to an array.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+$array 
+=> array:members() 
+=> fn:slice($start, $end, $step) 
+=> array:of-members()
+       ]]></fos:equivalent>
       <fos:notes>
-         <p>The function is formally defined by converting the array to a sequence, applying 
-            <code>fn:slice</code> to this sequence, and then converting the resulting sequence
-            back to an array.</p>
+
          <p>Note that unlike other operations on arrays, there are no out-of-bounds errors for inappropriate
          values of <code>$start</code>, <code>$end</code>, or <code>$step</code>.</p>
       </fos:notes>
       
       <fos:examples>
-         <fos:variable name="in" id="a-slice" as="xs:string*" select="[ 'a', 'b', 'c', 'd', 'e' ]"/>
+         <fos:variable name="in" id="a-slice" as="array(xs:string)" select="[ 'a', 'b', 'c', 'd', 'e' ]"/>
          <fos:example>
             <fos:test use="a-slice">
                <fos:expression>array:slice($in, start := 2, end := 4)</fos:expression>
@@ -26625,10 +26664,13 @@ return $pos[$predicate($m, $pos)]</eg>
             containing all members from <code>$array</code>
             except the members whose position (counting from 1) is present in the sequence <code>$positions</code>.
          The order of the remaining members is preserved.</p>
-         <p diff="chg" at="A">More formally, the result of the function, except in error cases, is given by the expression
+         <!--<p diff="chg" at="A">More formally, the result of the function, except in error cases, is given by the expression
             <code role="example">array:of-members(array:members($array) => fn:remove($positions))</code>.
-         </p>
+         </p>-->
       </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false"><![CDATA[
+$array => array:members() => fn:remove($positions) => array:of-members()
+       ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="AY" code="0001"
                /> if any integer in <code>$positions</code> is not in the range <code>1 to
@@ -26687,9 +26729,13 @@ return $pos[$predicate($m, $pos)]</eg>
             whose position is less than <code>$position</code>, then a new member given by <code>$member</code>, and
             then all members from <code>$array</code> whose position is greater than or equal to <code>$position</code>. 
             Positions are counted from 1.</p>
-         <p>More formally, except in error cases, the result is the value of the expression
-            <code role="example">array:of-members(array:members($array) => fn:insert-before($position, { 'value': $member }))</code>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false"><![CDATA[
+$array 
+=> array:members() 
+=> fn:insert-before($position, { 'value': $member }) 
+=> array:of-members()
+       ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
                /> if <code>$position</code> is not in the range <code>1 to
@@ -26750,9 +26796,12 @@ return $pos[$predicate($m, $pos)]</eg>
          <p>Returns the first member of an array, that is <code>$array(1)</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns first member of <code>$array</code>,
-            that is the value of <code>array:get($array, 1)</code>.</p>
+         <p>The function returns first member of <code>$array</code><!--,
+            that is the value of <code>array:get($array, 1)</code>-->.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+         array:get($array, 1)
+       ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
             /> if <code>$array</code> is empty.</p>
@@ -26791,11 +26840,15 @@ return $pos[$predicate($m, $pos)]</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the last member of an array, that is <code>$array(array:size($array))</code>.</p>
+         <p>Returns the last member of an array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns last member of <code>$array</code>, that is the value of <code>array:get($array, array:size($array))</code>.</p>
+         <p>The function returns the last member of <code>$array</code>.
+            <!--, that is the value of <code>array:get($array, array:size($array))</code>--></p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+         array:get($array, array:size($array))
+       ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
          /> if <code>$array</code> is empty.</p>
@@ -26836,9 +26889,11 @@ return $pos[$predicate($m, $pos)]</eg>
          <p>Returns an array containing all members except the first from a supplied array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns an array containing all members of the supplied array except the first,
-            that is <code>array:remove($array, 1)</code>.</p>
+         <p>The function returns an array containing all members of the supplied array except the first.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+         array:remove($array, 1)
+       ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
             /> if <code>$array</code> is empty.</p>
@@ -26879,9 +26934,11 @@ return $pos[$predicate($m, $pos)]</eg>
          <p>Returns an array containing all members except the last from a supplied array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns an array containing all members of the supplied array except the last,
-            that is <code>array:remove($array, array:size($array))</code>.</p>
+         <p>The function returns an array containing all members of the supplied array except the last.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+         array:remove($array, array:size($array))
+       ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
          /> if <code>$array</code> is empty.</p>
@@ -26921,9 +26978,15 @@ return $pos[$predicate($m, $pos)]</eg>
          <p>Returns an array containing all the members of a supplied array, but in reverse order.</p>
       </fos:summary>
       <fos:rules>
-         <p diff="chg" at="A">The function returns the result of the expression:
-            <code role="example">array:of-members(array:members($array) => fn:reverse())</code></p>
+         <p diff="chg" at="A">The function returns an array with the same number of members
+         as <code>$array</code>, but in reverse order.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+$array 
+=> array:members() 
+=> fn:reverse() 
+=> array:of-members()
+       ]]></fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -26971,12 +27034,13 @@ return $pos[$predicate($m, $pos)]</eg>
       <fos:rules>
          <p>Informally, the function returns an array whose members are obtained by applying 
          the supplied <code>$function</code> to each member of the input array in turn.</p>
-         <p>More formally, the function returns the result of the expression:</p>
-         <eg><![CDATA[
-for member $member at $pos in $array
-return [ $action($member, $pos) ]
-]]></eg>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+array:of-members(
+  for member $member at $pos in $array
+  return map { 'value': $action($member, $pos) }
+)  
+       ]]></fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -27035,14 +27099,21 @@ return [ $action($member, $pos) ]
       <fos:rules>
          <p>Informally, the function returns an array containing those members of the input
          array that satisfy the supplied predicate.</p>
-         <p>More formally, the function returns the result of the expression:</p>
+         <!--<p>More formally, the function returns the result of the expression:</p>
          <eg><![CDATA[
 array:of-members(
   for member $member at $pos in $array
   where $predicate($member, $pos)
   return $member
-)]]></eg>
+)]]></eg>-->
       </fos:rules>
+      <fos:equivalent style="xquery-expression"><![CDATA[
+array:of-members(
+  for member $member at $pos in $array
+  where $predicate($member, $pos)
+  return map{ 'value': $member }
+)
+       ]]></fos:equivalent>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error occurs if the supplied
             function <code>$function</code> returns anything other than a single <code>xs:boolean</code> item
@@ -27105,15 +27176,16 @@ return array:filter(
             array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is equivalent to the following expression:</p>
-         <eg><![CDATA[
+         <p>The function is defined formally below, in terms of the equivalent <code>fn:fold-left</code>
+            function for sequences.</p>
+      </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
 fold-left(
   array:members($array),
   $zero,
-  fn($result, $member, $pos) { $action($member?value, $result, $pos) }
+  fn($result, $member, $pos) { $action($result, $member?value, $pos) }
 )
-]]></eg>
-      </fos:rules>
+       ]]></fos:equivalent>
       <fos:notes>
          <p>If the supplied array is empty, the function returns <code>$zero</code>.</p>
          <p>If the supplied array contains a single member <code>$m</code>, the function returns <code>$zero => $action($m)</code>.</p>
@@ -27191,15 +27263,16 @@ return array:fold-left($input, (),
             array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is equivalent to the following expression:</p>
-         <eg><![CDATA[
+         <p>The function is defined formally below, in terms of the equivalent <code>fn:fold-right</code>
+            function for sequences.</p>
+      </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
 fold-right(
   array:members($array),
   $zero,
   fn($member, $result, $pos) { $action($member?value, $result, $pos) }
 )
-]]></eg>
-      </fos:rules>
+       ]]></fos:equivalent>
       <fos:notes>
          <p>If the supplied array is empty, the function returns <code>$zero</code>.</p>
          <p>If the supplied array contains a single member <code>$m</code>, the function returns <code>$action($m, $zero)</code>.</p>
@@ -27278,13 +27351,17 @@ return array:fold-right(
             the two supplied arrays.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the result of the expression:</p>
-         <eg><![CDATA[array:join(
-  for $pos in 1 to min(array:size($input1), array:size($input2))
-  return [ $action($input1($pos), $input2($pos), $pos) ]
-)]]></eg>
-         
+         <p>Informally, the function applies <code>$action</code> to each pair of values in corresponding positions
+            within <code>$array1</code> and <code>$array2</code>, ignoring any excess values if one array is longer
+            than the other. The results are then assembed into a new array whose size is equal to the shorter of the
+            two input arrays.</p>        
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+array:of-members(
+  for $pos in 1 to min((array:size($array1), array:size($array2)))
+  return map { 'value': $action($array1($pos), $array2($pos), $pos) }
+)
+       ]]></fos:equivalent>
       <fos:notes>
          <p>If the arrays have different size, excess members in the longer array are ignored.</p>
       </fos:notes>
@@ -27350,14 +27427,13 @@ array:for-each-pair(
          function with <code>fn:identity#1</code> as the second argument.</p>
          <p>Informally, <code>array:build#2</code> applies the supplied function to each item 
             in the input sequence, and the resulting sequence becomes one member of the returned array.</p>
-         <p>More formally, <code>array:build#2</code> returns the result of the expression:</p>
-         <eg>
+      </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
 array:of-members(
   for $item at $pos in $input
-  return { 'value': $action($item, $pos) }
+  return map { 'value': $action($item, $pos) }
 )
-         </eg>
-      </fos:rules>
+       ]]></fos:equivalent>
       <fos:notes>
          <p>The single-argument function <code>array:build($input)</code> is equivalent to the XPath
          expression <code>array { $input }</code>, but it is useful to have this available as a function.</p>
@@ -27427,6 +27503,10 @@ array:build(
          
          
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+for member $member in $array
+return map { 'value': $member }
+       ]]></fos:equivalent>     
       <fos:notes>
          <p>This function is the inverse of <code>array:of-members</code>.</p>   
       </fos:notes>
@@ -27479,6 +27559,10 @@ return deep-equal(
          <p>The members of the array are delivered as a sequence of arrays. 
             Each returned array encapsulates the value of a single array member.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+for member $member in $array
+return [ $member ]
+       ]]></fos:equivalent> 
       <fos:notes>
          <p>The function call <code>array:split($array)</code> produces the same result as the
             expression <code>for member $m in $array return [ $m ]</code>.</p>
@@ -27538,14 +27622,20 @@ return deep-equal(
          <p>Constructs an array from the contents of a sequence of <term>value records</term>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The input items must be <term>value records</term>.  A value record is an item that encapsulates 
+         <p>The input items must be <term>value records</term>, as defined in the type signature.  
+            A value record is an item that encapsulates 
             an arbitrary sequence <code>$S</code>: specifically
             it is a map comprising a single entry whose key is the <code>xs:string</code> value
             <code>"value"</code> and whose corresponding value is <code>$S</code>. The content encapsulated
             by a value record <code>$V</code> can be obtained using the expression <code>$V?value</code>.</p>
-  
+         
+         <p>This function is treated as a primitive; all operations that construct arrays are formally defined
+         (directly or indirectly) in terms of <code>array:of-members</code>, and it therefore has no 
+            formal definition of its own.</p>
+ 
 
       </fos:rules>
+
       <fos:notes>
          <p>This function is the inverse of <code>array:members</code>.</p>
 
@@ -27641,22 +27731,22 @@ return deep-equal(
             (for example, in the case where a non-string sort key is followed by another sort key 
             that requires a collation) the empty string can be supplied.</p>
          
-         <p>The result of the function is defined by reference to the <code>fn:sort</code> function. Specifically,
-         the result of the function is value of the expression:</p>
-         
-         <eg>array:of-members(
-  sort(
-    array:members($array),
-    $collations,
-    for $key in ($keys otherwise data#1)
-    return fn($member as record(value)) as xs:anyAtomicType* {
-      $key($member?value)
-    },
-    $orders
-  )
-)</eg>
-         
+         <p>The result of the function is defined by reference to the <code>fn:sort</code> function.</p>
       </fos:rules>
+            <fos:equivalent style="xpath-expression"><![CDATA[
+$array
+=> array:members()
+=> sort(
+       $collations,
+       for $key in ($keys otherwise data#1)
+       return fn($member as record(value)) as xs:anyAtomicType* {
+         $key($member?value)
+       },
+       $orders
+   )
+=> array:of-members()
+       ]]></fos:equivalent>         
+
       <fos:errors>
          <p>If the set of computed sort keys contains values that are not comparable using the <code>lt</code> operator then the sort 
             operation will fail with a type error (<xerrorref
@@ -27737,15 +27827,25 @@ return array:sort($in, $SWEDISH)
             </item>
          </ulist>
          <p>The process is then repeated so long as the sequence contains an array among its items.</p>
-         <p>The function is equivalent to the following implementation in XQuery:</p>
+         <!--<p>The function is equivalent to the following implementation in XQuery:</p>
          <eg><![CDATA[
 declare function flatten(
   $input as item()*
 ) as item()* {
   for $item in $input
   return if ($item instance of array(*)) then flatten(array:values($item)) else $item
-};]]></eg>
+};]]></eg>-->
       </fos:rules>
+      <fos:equivalent style="xquery-function"><![CDATA[
+declare function array:flatten(
+  $input as item()*
+) as item()* {
+  for $item in $input
+  return if ($item instance of array(*)) 
+         then array:flatten(array:values($item)) 
+         else $item
+};
+       ]]></fos:equivalent>
       <fos:notes>
          <p>The argument to the function will often be a single array item, but this is not essential.</p>
          <p>Unlike atomization, this function retains any nodes contained in the array.</p>
@@ -27791,6 +27891,9 @@ declare function flatten(
          <p>More formally, it returns the result of <code>array:members($array)?value</code>.</p>
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression"><![CDATA[
+array:members($array)?value
+       ]]></fos:equivalent>
       <fos:notes>
          <p>Unlike <code>array:flatten</code>, the function does not apply recursively
          to nested arrays.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21869,7 +21869,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Tests whether a supplied map contains an entry for a given key</p>
+         <p>Tests whether a supplied map contains an entry for a given key.</p>
       </fos:summary>
       <fos:rules>
          <p>The function <code>map:contains</code> returns <code>true</code> if the <termref def="dt-map"
@@ -21973,7 +21973,7 @@ return map:keys-where($birthdays, fn($name, $date) {
                The default <code>$fallback</code> function always returns an empty sequence.</phrase></p>
 
       </fos:rules>
-      <fos:equivalent style="xpath-expression">
+      <fos:equivalent style="dm-primitive">
 let $entry := dm:iterate-map($map, 
                              fn($k, $v) {
                                 if (atomic-equal($k, $key)) {
@@ -26007,11 +26007,11 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             the details of the error (such as the error message) are <termref def="implementation-dependent">implementation-dependent</termref>.</p>
         
       </fos:rules>
-      <fos:equivalent style="xpath-expression" covers-error-cases="false"><![CDATA[
+      <fos:equivalent style="xpath-expression" covers-error-cases="false">
 if ($position = (1 to array:size($array)))
-then array:members($array)[$position]?value 
+then array:members($array)[$position] => map:get('value') 
 else $fallback($position)
-      ]]></fos:equivalent>
+      </fos:equivalent>
       <fos:errors>
          <p><phrase diff="add" at="2022-12-16">In the absence of a <code>$fallback</code> function</phrase>,
             a dynamic error occurs <errorref class="AY" code="0001"
@@ -26121,11 +26121,11 @@ $array
          
          
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
+      <fos:equivalent style="xpath-expression">
 $array 
 => array:remove($position) 
-=> array:insert-before($position, $action($array($position)))
-       ]]></fos:equivalent>
+=> array:insert-before($position, $action(array:get($array, $position)))
+      </fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"/> 
             if <code>$position</code> is not in the range <code>1 to
@@ -26380,8 +26380,7 @@ $array
                <code>$array</code> of members that are equal to <code>$target</code>.</p>
       </fos:summary>
       <fos:rules>
-         <!--<p>The function returns the result of the expression:</p>
-         <eg>array:index-where($array, fn:deep-equal(?, $target, $collation))</eg>-->
+         
          <p>Informally, all members of <code>$array</code> are compared with <code>$target</code>.
             An array member is compared to the target value using the rules of the
             <code>fn:deep-equal</code> function, with the specified (or defaulted) collation.
@@ -26393,9 +26392,9 @@ $array
          <p>The first member in an array is at position 1, not position 0.</p>
          <p>The result sequence is in ascending numeric order.</p>
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
-            array:index-where($array, fn:deep-equal(?, $target, $collation))
-       ]]></fos:equivalent>
+      <fos:equivalent style="xpath-expression">
+            array:index-where($array, deep-equal(?, $target, $collation))
+      </fos:equivalent>
       <fos:notes>
          <p>If <code>$array</code> is the empty array, or if no member in
             <code>$array</code> matches <code>$target</code>, then the function returns the empty
@@ -26459,17 +26458,14 @@ array:index-of(
          <p>The result of the function is a sequence of integers, in monotonic ascending order, representing
             the 1-based positions in the input array of those members for which the supplied predicate function
             returns <code>true</code>. A return value of <code>()</code> is treated as <code>false</code>.</p>
-         <!--<p>More formally, the function returns the result of the XQuery expression:</p>
-         <eg>for member $m at $pos in $array 
-return $pos[$predicate($m, $pos)]</eg>
-         <!-\-<eg>index-of($array => array:for-each($predicate) => array:values(), true())</eg>-\->
-     --> 
+ 
       </fos:rules>
       
-      <fos:equivalent style="xpath-expression"><![CDATA[
-for member $m at $pos in $array 
-return $pos[$predicate($m, $pos)]
-       ]]></fos:equivalent>
+      <fos:equivalent style="xpath-expression">
+array:fold-left($array, (), fn($indices, $member, $pos) {
+   $indices, if ($predicate($member, $pos)) { $pos }
+})   
+      </fos:equivalent>
       
       <fos:examples>
          <fos:example>
@@ -26734,7 +26730,7 @@ $array
       <fos:equivalent style="xpath-expression" covers-error-cases="false"><![CDATA[
 $array 
 => array:members() 
-=> fn:insert-before($position, { 'value': $member }) 
+=> fn:insert-before($position, map:entry('value', $member )) 
 => array:of-members()
        ]]></fos:equivalent>
       <fos:errors>
@@ -26800,9 +26796,9 @@ $array
          <p>The function returns first member of <code>$array</code><!--,
             that is the value of <code>array:get($array, 1)</code>-->.</p>
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
+      <fos:equivalent style="xpath-expression">
          array:get($array, 1)
-       ]]></fos:equivalent>
+      </fos:equivalent>
       <fos:errors>
          <p>A dynamic error occurs <errorref class="AY" code="0001"
             /> if <code>$array</code> is empty.</p>
@@ -27039,7 +27035,7 @@ $array
          array member (which in general is an arbitrary sequence), and the second is the 1-based
          integer position.</p>
       </fos:rules>
-      <fos:equivalent style="dm-primitive">
+      <fos:equivalent style="xpath-expression">
 array:fold-left($array, 
                 [], 
                 fn($zero, $next, $pos) {
@@ -27106,10 +27102,11 @@ array:fold-left($array,
          array that satisfy the supplied predicate.</p>
       </fos:rules>
       <fos:equivalent style="xquery-expression">
-$array
-=> array:members()
-=> filter(fn($item, $pos) { $predicate(map:get($item, 'value'), $pos) })
-=> array:of-members()
+array:fold-left($array, [], fn($result, $next, $pos) {
+   if ($predicate($next, $pos))
+   then array:append($result, $next)
+   else $result
+})   
       </fos:equivalent>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error occurs if the supplied
@@ -27180,7 +27177,7 @@ return array:filter(
 fold-left(
   array:members($array),
   $zero,
-  fn($result, $member, $pos) { $action($result, $member?value, $pos) }
+  fn($result, $member, $pos) { $action($result, map:get($member, 'value'), $pos) }
 )
        ]]></fos:equivalent>
       <fos:notes>
@@ -27267,7 +27264,7 @@ return array:fold-left($input, (),
 fold-right(
   array:members($array),
   $zero,
-  fn($member, $result, $pos) { $action($member?value, $result, $pos) }
+  fn($member, $result, $pos) { $action(map:get($member, 'value'), $result, $pos) }
 )
        ]]></fos:equivalent>
       <fos:notes>
@@ -27356,7 +27353,7 @@ return array:fold-right(
       <fos:equivalent style="xpath-expression"><![CDATA[
 array:of-members(
   for $pos in 1 to min((array:size($array1), array:size($array2)))
-  return map { 'value': $action($array1($pos), $array2($pos), $pos) }
+  return map:entry('value', $action($array1($pos), $array2($pos), $pos))
 )
        ]]></fos:equivalent>
       <fos:notes>
@@ -27426,11 +27423,9 @@ array:for-each-pair(
             in the input sequence, and the resulting sequence becomes one member of the returned array.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-array:of-members(
-   for-each($input, fn($item, $pos) { 
-      map:entry('value', $action($item, $pos))
-   })
-)
+fold-left($input, [], fn($array, $next, $pos) {
+   array:append($array, $action($next, $pos))
+})   
       </fos:equivalent>
       <fos:notes>
          <p>The single-argument function <code>array:build($input)</code> is equivalent to the XPath
@@ -27501,7 +27496,7 @@ array:build(
          
          
       </fos:rules>
-      <fos:equivalent style="xpath-expression">
+      <fos:equivalent style="dm-primitive">
             dm:iterate-array($array, map:entry('value', ?) )
       </fos:equivalent>     
       <fos:notes>
@@ -27886,9 +27881,9 @@ declare function array:flatten(
          <p>Returns the sequence concatenation of the members of an array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> of the members of 
-            <code>$array</code>, retaining order.</p>
-         <p>More formally, it returns the result of <code>array:members($array)?value</code>.</p>
+         <p>The function returns the <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> 
+            of the members of <code>$array</code>, retaining order.</p>
+        
 
       </fos:rules>
       <fos:equivalent style="xpath-expression">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -2670,16 +2670,18 @@ format-number(12345, '0,###^0', {
          followed by a sequence of one or more generalized digits drawn from the first <code>$radix</code> characters
          in the alphabet <code>0123456789abcdefghijklmnopqrstuvwxyz</code>; upper-case alphabetics
          <code>A-Z</code> may be used in place of their lower-case equivalents.</p>
-         <p>The value of a generalized digit corresponds to its position in this alphabet.
-         More formally, in non-error cases the result of the function is given by the XQuery expression:</p>
-         <eg><![CDATA[let $alphabet := characters("0123456789abcdefghijklmnopqrstuvwxyz")
+         <p>The value of a generalized digit corresponds to its position in this alphabet.</p>
+         
+      </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false">
+let $alphabet := characters("0123456789abcdefghijklmnopqrstuvwxyz")
 let $preprocessed-value := translate($value, "_ &#x9;&#xa;&#xd;", "")
 let $digits := translate($preprocessed-value, "+-", "")
 let $abs := sum(
-  for $char at $p in reverse(characters($digits))
+  for $char at $p in reverse(characters(lower-case($digits)))
   return (index-of($alphabet, $char) - 1) * xs:integer(math:pow($radix, $p - 1)))
-return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs]]></eg>
-      </fos:rules>
+return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs                 
+      </fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0011"/>
             if <code>$radix</code> is not in the range 2 to 36.</p>
@@ -6981,10 +6983,12 @@ Tak, tak, tak! - da kommen sie.
             after tokenizing at whitespace boundaries, contains a token
          that is equal to the trimmed value of <code>$token</code> under
          the rules of the selected collation.</p>
-         <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[some $t in $input ! tokenize(.) satisfies 
-  compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0)]]></eg>
+       
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+some $t in $value ! tokenize(.) satisfies 
+   compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0        
+      </fos:equivalent>
       <fos:notes>
          <p>Interior whitespace within <code>$token</code> will cause the function to return <code>false</code>,
          unless such whitespace is ignored by the selected collation.</p>
@@ -12954,6 +12958,9 @@ return distinct-ordered-nodes($x//c, $x//b, $x//a, $x//b) ! name()]]></eg></fos:
          <p>If <code>$input</code> is the empty sequence, the function returns
                <code>true</code>; otherwise, the function returns <code>false</code>. </p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         count($input) eq 0
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -13013,6 +13020,9 @@ return empty($break)
          <p>If <code>$input</code> is a non-empty sequence, the function returns
                <code>true</code>; otherwise, the function returns <code>false</code>. </p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         count($input) gt 0
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -13284,6 +13294,9 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       <fos:rules>
          <p>The function returns <code>$input</code>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         $input
+      </fos:equivalent>
       <fos:notes>
          <p>The function is useful in contexts where a function must be supplied, but no processing is required.</p>
       </fos:notes>
@@ -13341,6 +13354,11 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
                <code>$insert</code>, followed by the remaining elements of <code>$input</code>, in
             that order. </p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+filter($input, fn($item, $pos) { $pos lt $position }),
+$insert,
+filter($input, fn($item, $pos) { $pos ge $position })
+      </fos:equivalent>
       <fos:notes>
          <p>If <code>$input</code> is the empty sequence, <code>$insert</code> is returned. If
                <code>$insert</code> is the empty sequence, <code>$input</code> is returned.</p>
@@ -13405,9 +13423,11 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       <fos:rules>
          <p>The function returns a sequence consisting of all items of <code>$input</code> <phrase diff="chg" at="2023-01-17">whose
             1-based position is not equal to any of the integers in <code>$positions</code>. </phrase></p>
-         <p diff="add" at="2023-01-17">More formally, the function returns the result of the expression
-            <code>$input[not(position() = $positions)]</code>.</p>
+        
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         filter($input, fn($item, $pos) { not($pos eq $positions) })
+      </fos:equivalent>
       <fos:notes>
          <p diff="chg" at="2023-01-17">Any integer in <code>$positions</code> that is less than 1 or greater than the number of items in
                <code>$input</code> is effectively ignored.</p>
@@ -13473,12 +13493,12 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          <p>Returns the first item in a sequence. </p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the value of the expression <code>$input[1]</code></p>
+         <p>The function returns the first item in <code>$input</code>; if <code>$input</code>
+         is empty, it returns an empty sequence.</p>
       </fos:rules>
-      <fos:notes>
-         <p>If <code>$input</code> is the empty sequence, the empty sequence is returned. Otherwise
-            the first item in the sequence is returned.</p>
-      </fos:notes>
+      <fos:equivalent style="xpath-expression">
+         filter($input, fn($item, $pos) { $pos eq 1 })
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -13522,8 +13542,11 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          <p>Returns all but the first item in a sequence. </p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the value of the expression <code>subsequence($input, 2)</code></p>
+         <p>The function all items in <code>$input</code> except the first, retaining order.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+filter($input, fn($item, $pos) { $pos gt 1 })
+      </fos:equivalent>
       <fos:notes>
          <p>If <code>$input</code> is the empty sequence, or a sequence containing a single item, then
             the empty sequence is returned. </p>
@@ -13577,8 +13600,11 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          <p>Returns all but the last item in a sequence. </p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the value of the expression <code>remove($input, count($input))</code></p>
+         <p>The function returns all items in <code>$input</code> except the last, retaining order.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         filter($input, fn($item, $pos) { $pos ne count($input) })
+      </fos:equivalent>
       <fos:notes>
          <p>If <code>$input</code> is the empty sequence, or a sequence containing a single item, then
             the empty sequence is returned. </p>
@@ -13638,6 +13664,9 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       <fos:rules>
          <p>The function returns the value of <code>(1 to $count) ! $input</code>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         fold-left(1 to $count, (), fn($result, $next) { $result, $input })
+      </fos:equivalent>
       <fos:notes>
          <p>If <code>$input</code> is the empty sequence, the empty sequence is returned.</p>
          <p>The <code>$count</code> argument is declared as <code>xs:nonNegativeInteger</code>,
@@ -13705,6 +13734,13 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       <fos:rules>
          <p>The function returns the value of <code>head($input), tail($input) ! ($separator, .)</code>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+for-each($input, fn($item, $pos) {
+   if ($pos eq 1)
+   then $item
+   else ($separator, $item)
+})
+      </fos:equivalent>
       <fos:notes>
          <p>If <code>$input</code> contains less than two items then it is returned unchanged.</p>
          <p>If <code>$separator</code> is the empty sequence then <code>$input</code> is returned unchanged.</p>
@@ -13758,6 +13794,9 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
       <fos:rules>
          <p>The function returns the value of the expression <code>$input[last()]</code></p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         filter($input, fn($item, $pos) { $pos eq count($input) })
+      </fos:equivalent>
       <fos:notes>
          <p>If <code>$input</code> is the empty sequence the empty sequence is returned. </p>
       </fos:notes>
@@ -13798,6 +13837,9 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          <p>The function returns a sequence containing the items in <code>$input</code> in reverse
             order.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+          fold-left($input, (), fn($result, $item) {$item, $result})
+      </fos:equivalent>
       <fos:notes>
          <p>If <code>$input</code> is the empty sequence, the empty sequence is returned. </p>
       </fos:notes>
@@ -13865,6 +13907,16 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          and position() lt round($start) + round($length)]</eg>
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+filter($input,
+       if (empty($length))
+       then fn($item, $pos) {
+                round($start) le $pos
+            }
+       else fn($item, $pos) {
+                round($start) le $pos and $pos lt round($start) + round($length)
+            })
+      </fos:equivalent>
       <fos:notes>
          <p>The first item of a sequence is located at position 1, not position 0.</p>
          <p>If <code>$input</code> is the empty sequence, the empty sequence is returned.</p>
@@ -13939,20 +13991,18 @@ return error((), 'Duplicate IDs found: ' || string-join($ids, ', '))</eg>
          the result is the empty sequence; if <code>$to</code> does not match any items, all items up
          to the last are included in the result.</p>
          
-         <p>More formally, the function returns the result of:</p>
-         
-         <eg>let $start := index-where($input, $from)[1] 
-              otherwise (count($input) + 1)
-let   $end := index-where($input, $to)[. ge $start][1] 
-              otherwise (count($input) + 1)
-return slice($input, $start, $end)</eg>
-         
-         
-         
+ 
  
          
          
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+let $start := index-where($input, $from)[1] 
+              otherwise (count($input) + 1)
+let   $end := index-where($input, $to)[. ge $start][1] 
+              otherwise (count($input) + 1)
+return slice($input, $start, $end)
+      </fos:equivalent>
       <fos:notes>
          <p>The result includes both the item that matches the <code>$from</code> condition
          and the item that matches the <code>$to</code> condition. To select a subsequence that
@@ -14074,12 +14124,13 @@ return slice($input, $start, $end)</eg>
             at positions defined by <code>$at</code>, in the order specified. </p>
       </fos:summary>
       <fos:rules>
-         <p>Returns the value of <code>$at ! fn:subsequence($input, ., 1)</code></p>
+         <p>Returns the items in <code>$input</code> at the positions listed
+         in <code>$at</code>, in order of the integers in the <code>$at</code> argument.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         for-each($at, fn($index) { subsequence($input, $index, 1) })  
+      </fos:equivalent>
       <fos:notes>
-         <p>The effect of the function is to return those items from <code>$input</code>
-         at the positions given by the integers in <code>$at</code>, in the order
-         represented by the integers in <code>$at</code>.</p>
          <p>In the simplest case where <code>$at</code> is a single integer,
          <code>fn:items-at($input, 3)</code> returns the same result as <code>$input[3]</code>.</p>
          <p>Compared with a simple positional filter expression, the function is useful because:</p>
@@ -14184,7 +14235,7 @@ return slice($input, $start, $end)</eg>
          <!-- So slice((a,b,c,d,e,f), 5, 3, -1) ==> slice(reverse(f,e,d,c,b,a), -5, -3, 1) ==> (e,d,c) --> 
          <p>Otherwise the function returns the result of the expression:</p>
          <eg>$input[position() ge $S and position() le $E and (position() - $S) mod $STEP eq 0]</eg>
-         
+         <ednote><edtext>TBA: define formal equivalent.</edtext></ednote>
       </fos:rules>
       <fos:notes>
          <p>The function is inspired by the slice operators in Javascript and Python, but it differs
@@ -14195,7 +14246,7 @@ return slice($input, $start, $end)</eg>
          returns the same result as <code>$in[position() = $start to $end]</code>.</p>
          <p>This function can be used to enhance the <code>RangeExpression</code>, defined
             in <xspecref spec="XP31" ref="id-range-expressions"/>, to construct a sequence
-            of integers based on steps other than 1.</p>
+            of integers based on steps other than 1.</p>        
       </fos:notes>
       
       <fos:examples>
@@ -14318,11 +14369,12 @@ return slice($input, $start, $end)</eg>
       <fos:rules>
          <p>Informally, the function returns <code>true</code> if <code>$input</code> starts with <code>$subsequence</code>,
          when items are compared using the supplied (or default) <code>$compare</code> function.</p>
-         <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[
-count($input) ge count($subsequence) and
-every(for-each-pair($input, $subsequence, $compare))]]></eg>
+         
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+count($input) ge count($subsequence) and
+every(for-each-pair($input, $subsequence, $compare))        
+      </fos:equivalent>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
             of equality comparison. The result is well-defined, for example, even if <code>$compare</code> is not transitive
@@ -14434,9 +14486,11 @@ return starts-with-subsequence(
       <fos:rules>
          <p>Informally, the function returns <code>true</code> if <code>$input</code> ends with <code>$subsequence</code>,
             when items are compared using the supplied (or default) <code>$compare</code> function.</p>
-         <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[starts-with-subsequence(reverse($input), reverse($subsequence), $compare)]]></eg>
+         
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+           starts-with-subsequence(reverse($input), reverse($subsequence), $compare)     
+      </fos:equivalent>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
             of equality comparison. The result is well-defined, for example, even if <code>$compare</code> is not transitive
@@ -14549,14 +14603,13 @@ return ends-with-subsequence(
       <fos:rules>
          <p>Informally, the function returns <code>true</code> if <code>$input</code> contains a consecutive subsequence matching <code>$subsequence</code>,
             when items are compared using the supplied (or default) <code>$compare</code> function.</p>
-         <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[
-some $i in 0 to count($input) - count($subsequence) satisfies (
-  every $j in 1 to count($subsequence)
-  satisfies $compare($input[$i + $j], $subsequence[$j])
-)
-]]></eg>
+         
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+some $i in 0 to count($input) - count($subsequence) satisfies 
+  every $j in 1 to count($subsequence)
+  satisfies $compare($input[$i + $j], $subsequence[$j])   
+      </fos:equivalent>
       <fos:notes>
          <p>There is no requirement that the <code>$compare</code> function should have the traditional qualities
             of equality comparison. The result is well-defined, for example, even if <code>$compare</code> is not transitive
@@ -14704,6 +14757,9 @@ return contains-subsequence(
          <p>The function absorbs the supplied <code>$input</code> argument and
             returns an empty sequence.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         ()
+      </fos:equivalent>
       <fos:notes>
          <p>The function can be used to discard unneeded output of expressions
             (functions, third-party libraries, etc.).</p>
@@ -14761,6 +14817,11 @@ return for-each(1 to 10, $mapping otherwise void#0)</eg></fos:expression>
       <fos:rules>
          <p>Except in error cases, the function returns <code>$input</code> unchanged.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false">
+if (count($input) le 1) 
+then $input 
+else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0003'))
+      </fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0003"
             /> if <code>$input</code>
@@ -14787,6 +14848,11 @@ return for-each(1 to 10, $mapping otherwise void#0)</eg></fos:expression>
          <p>Except in error cases, the function returns <code>$input</code> unchanged.</p>
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false">
+if (count($input) ge 1) 
+then $input 
+else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0004'))
+      </fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0004"
          /> if <code>$input</code> is an
@@ -14811,6 +14877,11 @@ return for-each(1 to 10, $mapping otherwise void#0)</eg></fos:expression>
       <fos:rules>
          <p>Except in error cases, the function returns <code>$input</code> unchanged.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false">
+if (count($input) eq 1) 
+then $input 
+else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0005'))
+      </fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0005"
          /> if <code>$input</code> is an
@@ -15690,8 +15761,11 @@ declare function equal-strings(
       <fos:rules>
          <p>The function returns the number of items in <code>$input</code>.</p>
       </fos:rules>
+      <fos:equivalent style="dm-primitive">
+         dm:count($input)
+      </fos:equivalent>
       <fos:notes>
-         <p>returns <code>0</code>.if <code>$input</code> is the empty sequence.</p>
+         <p>The function returns <code>0</code> if <code>$input</code> is the empty sequence.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="tree" id="v-count-tree"><![CDATA[<doc><chap><p/><p/><p/></chap></doc>]]></fos:variable>
@@ -19731,22 +19805,21 @@ return fold-right(
                      <code>$functions</code>.</p>
             </item>
          </olist>
-         <p>More formally, the function is equivalent to the following implementation in XPath:</p>
-         <eg>
-<![CDATA[let $chain := (
-  let $apply := function($x, $f)  {
-    fn:apply($f,
-      if (function-arity($f) eq 1) then [ $x ]
-      else if ($x instance of array(*)) then $x 
-      else array { $x }
-    )
-  }
-  return fn($input as item()*, $functions as fn(*)*) as item()* {
-    fold-left($functions, $input, $apply)
-  }           
-)]]>
-         </eg>
+         
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+
+let $apply := function($x, $f)  {
+  fn:apply($f,
+    if (function-arity($f) eq 1) then [ $x ]
+    else if ($x instance of array(*)) then $x 
+    else array { $x }
+  )
+}
+return fn($input as item()*, $functions as fn(*)*) as item()* {
+  fold-left($functions, $input, $apply)
+}                   
+      </fos:equivalent>
       <fos:errors>
          <p>An error <errorref class="AP" code="0001" type="type"/> is raised if the arity of any
             function <code>$f</code> in <code>$functions</code> is different from the number of
@@ -20032,8 +20105,8 @@ chain((1, 2, 3, 4), $product3)
                   <code>$pos</code> incremented by <code>1</code>.</p>
             </item>
          </olist>
-         <p>More formally, the function is equivalent to the following implementation in XQuery:</p>
-         <eg><![CDATA[
+      </fos:rules>
+      <fos:equivalent style="xquery-function">
 declare %private function while-do-helper(
   $input     as item()*,
   $predicate as fn(item()*, xs:integer) as xs:boolean?,
@@ -20051,8 +20124,8 @@ declare function while-do(
   $action    as fn(item()*, xs:integer) as item()*
 ) as item()* {
   while-do-helper($input, $predicate, $action, 1)
-};]]></eg>
-      </fos:rules>
+};         
+      </fos:equivalent>
       <fos:notes>
          <p>While-do loops are very common in procedural programming languages, and this function
             provides a way to write functionally clean and interruptible iterations without
@@ -20181,8 +20254,8 @@ return $result?numbers
                <p>When the predicate returns an empty sequence, this is treated as <code>false</code>.</p>
             </item>
          </olist>
-         <p>More formally, the function is equivalent to the following implementation in XQuery:</p>
-         <eg><![CDATA[
+      </fos:rules>
+      <fos:equivalent style="xquery-function">
 declare %private function do-until-helper(
   $input     as item()*,
   $action    as fn(item()*, xs:integer) as item()*,
@@ -20203,8 +20276,8 @@ declare function do-until(
   $predicate as fn(item()*, xs:integer) as xs:boolean?
 ) as item()* {
   do-until-helper($input, $action, $predicate, 1)
-};]]></eg>
-      </fos:rules>
+};         
+      </fos:equivalent>
       <fos:notes>
          <p>Do-until loops are very common in procedural programming languages, and this function
             provides a way to write functionally clean and interruptible iterations without
@@ -20680,10 +20753,10 @@ return sort-with($persons/person, (
          <p>Although <code>$step</code> may return any sequence of nodes, the result is treated as a set: the order of nodes
             in the sequence is ignored, and duplicates are ignored. The result of of the
             <code>transitive-closure</code> function will always be a sequence of nodes in document order with no duplicates.</p>
+      </fos:rules>
+      <fos:equivalent style="xquery-function">
          
-         <p>The result of the function is equivalent to the following XQuery implementation:</p>
-         
-         <eg><![CDATA[declare %private function tc-inclusive(
+declare %private function tc-inclusive(
   $nodes as node()*,
   $step  as (fn(node()) as node()*)
 ) as node()* {
@@ -20698,20 +20771,27 @@ declare function transitive-closure (
   $step  as (fn(node()) as node()*)
 ) as node()* {
   tc-inclusive($node/$step(.), $step)
-};]]></eg>
+};
+     
          
-      <note><p><emph>Explanation:</emph> The private helper function <code>tc-inclusive</code> takes a set of nodes as input,
-      and calls the <code>$step</code> function on each one of those nodes; if the result includes nodes that are not
-      already present in the input, then it makes a recursive call to find nodes reachable from these new nodes, and returns
-      the union of the supplied nodes and the nodes returned from the recursive
-      call (which will always include the new nodes selected in the first step). 
-      If there are no new nodes, the recursion ends, returning the nodes that have been found up to this point.</p>
-         <p>The main function <code>fn:transitive-closure</code> finds the nodes that are reachable from the start node in a single
-            step, and then invokes the helper function <code>tc-inclusive</code> to add nodes that are reachable
-         in multiple steps</p></note>
- 
+(: Explanation:
+
+   The private helper function tc-inclusive takes a set of nodes as input,
+   and calls the $step function on each one of those nodes; if the result 
+   includes nodes that are not already present in the input, then it makes 
+   a recursive call to find nodes reachable from these new nodes, and returns
+   the union of the supplied nodes and the nodes returned from the recursive
+   call (which will always include the new nodes selected in the first step).
+   
+   If there are no new nodes, the recursion ends, returning the nodes that 
+   have been found up to this point.
+   
+   The main function fn:transitive-closure finds the nodes that are reachable 
+   from the start node in a single step, and then invokes the helper function 
+   tc-inclusive to add nodes that are reachable in multiple steps.
+:)   
     
-      </fos:rules>
+      </fos:equivalent>
       <fos:notes>
          <p>Cycles in the data are not a problem; 
             the function stops searching when it finds no new nodes.</p>
@@ -21599,7 +21679,6 @@ map:build($input,
             <termref def="dt-map">map</termref> as its <code>$map</code> argument and returns
             the keys that are present in the map as a sequence of atomic values, in <termref
                def="implementation-dependent">implementation-dependent</termref> order.</p>
-         <p>More formally, the function returns the value of the expression:</p>
          <p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
@@ -25895,9 +25974,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
          <p>Returns the number of members in the supplied array.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, the function returns the number of members in the array.</p>
-         <p diff="chg" at="A">More formally, the function returns the value of
-            <code>count(array:members($array))</code>.</p>
+         <p>The function returns the number of members in the array.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
            count(array:members($array))
@@ -29065,26 +29142,35 @@ tail(fold-left(
          <p>Returns <code>true</code> if every item in the input sequence matches a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the value of the expression:</p>
-         <eg><![CDATA[
-every $boolean in (
-  for $item at $pos in $input
-  return $predicate($item, $pos)
-) satisfies $boolean
-]]></eg>
-      <p>A return value of <code>()</code> from the predicate is treated as false.</p>
+         <p>The function returns true if <code>$input</code> is empty, or if <code>$predicate($item, $pos)</code>
+            returns true for every item <code>$item</code> at position <code>$pos</code> (1-based) in <code>$input</code>.</p>
+      
       </fos:rules>
+      
+      
+      <fos:equivalent style="xpath-expression">
+fold-left($input, true(), fn($result, $item, $pos) {
+   $result and $predicate($item, $pos)
+})
+      </fos:equivalent>
       <fos:errors>
          <p>An error is raised if the <code>$predicate</code> function raises an error. In particular,
-            when the default predicate <code>fn:boolean#1</code> is used, an error is raised if an
-            item has no effective boolean value.</p>
+         when the default predicate <code>fn:boolean#1</code> is used, an error is raised if an
+         item has no effective boolean value.</p>
       </fos:errors>
       <fos:notes>
          <p>If the second argument is omitted or an empty sequence, the predicate defaults
             to <code>fn:boolean#1</code>, which takes the effective boolean value of each item.</p>
+         <p>It is possible for the supplied <code>$predicate</code> to be a function whose arity is less than two.
+            The coercion rules mean that the additional parameters are effectively ignored. Frequently a predicate
+            function will only consider the item itself, and disregard its position in the sequence.</p>
+         <p>The predicate is required to return either <code>true</code>, <code>false</code>, or an empty
+            sequence (which is treated as <code>false</code>). A predicate such as <code>fn{self::h1}</code>
+            results in a type error because it returns a node, not a boolean.</p>
          <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for which the predicate
-            returns <code>false</code>; it is not required to evaluate the predicate for every item,
-            nor is it required to examine items sequentially from left to right.</p>
+         returns <code>false</code>; it is not required to evaluate the predicate for every item,
+         nor is it required to examine items sequentially from left to right.</p>
+      
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -29273,8 +29359,10 @@ return every($dl/*, fn($elem, $pos) {
                def="character">character</termref> in <code>$value</code>.</p>
          <p>If <code>$value</code> is a zero-length string or the empty sequence, the function returns
             the empty sequence.</p>
-         <p>More formally, the function returns the result of the expression <code>fn:string-to-codepoints($value) ! fn:codepoints-to-string(.)</code></p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         fn:string-to-codepoints($value) ! fn:codepoints-to-string(.)
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -29550,12 +29638,13 @@ fn($item) {
             the 1-based positions in the input sequence of those items for which the supplied predicate function
             returns <code>true</code>. A return value of <code>()</code> from the predicate function
          is treated as <code>false</code>.</p>
-         <p>More formally, the function is equivalent to the following expression in XQuery:</p>
-         <eg>
-for $item at $pos in $input
-where $predicate($item, $pos)
-return $pos</eg>
+
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+fold-left($input, (), fn($indices, $item, $pos) {
+   $indices, if ($predicate($item, $pos)) { $pos }
+})
+      </fos:equivalent>
 
       <fos:examples>
          <fos:example>
@@ -29776,16 +29865,18 @@ head(index-where($input, $predicate)) ! subsequence($input, . + 1)
          <p>Returns items from the input sequence prior to the first one that fails to match a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the result of the XQuery expression:</p>
-         <eg><![CDATA[
-for $it at $pos in $input
-while $predicate($it, $pos)
-return $it
-]]></eg>
-         <p>That is, it returns all items in the sequence prior to the first one where the result of
+         <p>The function returns all items in the sequence prior to the first one where the result of
          calling the supplied <code>$predicate</code> function, with the current item and its position
          as arguments, returns the value <code>false</code> or <code>()</code>.</p>
+         <p>If every item in the sequence satisfies the predicate, then <code>$input</code> is returned
+         in its entirety.</p>
+         
       </fos:rules>
+      <fos:equivalent style="xquery-expression">
+for $it at $pos in $input
+while $predicate($it, $pos)
+return $it        
+      </fos:equivalent>
       
       <fos:notes>
          <p>There is no analogous <code>drop-while</code> or <code>skip-while</code> function,
@@ -30141,14 +30232,14 @@ subsequence($input, 1, head(index-where($input, $predicate)) + 1)
          <p>Returns <code>true</code> if at least one item in the input sequence matches a supplied predicate.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the value of the expression:</p>
-         <eg><![CDATA[
-some $boolean in (
-  for $item at $pos in $input
-  return $predicate($item, $pos)
-) satisfies $boolean
-]]></eg>
+         <p>The function returns true if (and only if) there is an item <code>$item</code> at position <code>$pos</code>
+            in the input sequence such that <code>$predicate($item, $pos)</code> returns true.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+fold-left($input, false(), fn($result, $item, $pos) {
+   $result or $predicate($item, $pos)
+})
+      </fos:equivalent>
       <fos:errors>
          <p>An error is raised if the <code>$predicate</code> function raises an error. In particular,
          when the default predicate <code>fn:boolean#1</code> is used, an error is raised if an
@@ -30157,6 +30248,12 @@ some $boolean in (
       <fos:notes>
          <p>If the second argument is omitted or an empty sequence, the predicate defaults
             to <code>fn:boolean#1</code>, which takes the effective boolean value of each item.</p>
+         <p>It is possible for the supplied <code>$predicate</code> to be a function whose arity is less than two.
+            The coercion rules mean that the additional parameters are effectively ignored. Frequently a predicate
+            function will only consider the item itself, and disregard its position in the sequence.</p>
+         <p>The predicate is required to return either <code>true</code>, <code>false</code>, or an empty
+            sequence (which is treated as <code>false</code>). A predicate such as <code>fn{self::h1}</code>
+            results in a type error because it returns a node, not a boolean.</p>
          <p>The implementation <rfc2119>may</rfc2119> deliver a result as soon as one item is found for which the predicate
          returns <code>true</code>; it is not required to evaluate the predicate for every item,
          nor is it required to examine items sequentially from left to right.</p>
@@ -31502,14 +31599,15 @@ path with an explicit <code>file:</code> scheme.</p>
          <p>If the <code>$split-when</code> function returns <code>true</code>, the current partition is wrapped as an array and added to the result,
             and a new current partition is created, initially containing the item <var>J</var> only. If the <code>$split-when</code> 
             function returns <code>false</code> or <code>()</code>, the item <var>J</var> is added to the current partition.</p>
-         <p>More formally, the function returns the result of the expression:</p>
-         <eg>fold-left($input, (), fn($partitions, $next, $pos) {
+  
+      </fos:rules>
+      <fos:equivalent style="xpath-expression">
+fold-left($input, (), fn($partitions, $next, $pos) {
   if (empty($partitions) or $split-when(foot($partitions)?*, $next, $pos))
   then ($partitions, [ $next ])
   else (trunk($partitions), array { foot($partitions)?*, $next })
-})   
-         </eg>  
-      </fos:rules>
+})           
+      </fos:equivalent>
       <fos:notes>
          <p>The function enables a variety of positional grouping problems to be solved. For example:</p>
          <ulist>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21480,7 +21480,10 @@ return fold-left($maps, {},
 
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-         map:build($input, fn { ?key }, fn { ?value }, $combine)
+map:build($input, 
+          fn($pair) { map:get($pair, 'key') }, 
+          fn($pair) { map:get($pair, 'value') }, 
+          $combine)
       </fos:equivalent>
       <fos:errors>
          <p>The function can be made to fail with a dynamic error in the event that
@@ -21790,7 +21793,7 @@ return map:keys-where($birthdays, fn($name, $date) {
 
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-         map:for-each($map, fn($k, $v) { map{ $k: $v } })
+         map:for-each($map, map:entry#2)
       </fos:equivalent>
       <fos:examples>
          <fos:example>
@@ -21837,7 +21840,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             are not guaranteed to produce the results in the same order.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-         map:for-each($map, fn($k, $v) { map{ "key": $k, "value": $v } })
+         map:for-each($map, map:pair#2)
       </fos:equivalent>
       <fos:examples>
          <fos:example>
@@ -21971,9 +21974,15 @@ return map:keys-where($birthdays, fn($name, $date) {
 
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-if (map:contains($map, $key))
-then map:filter($map, fn($k, $v){atomic-equal($k, $key)}) => map:values()
-else $fallback($key)         
+let $entry := dm:iterate-map($map, 
+                             fn($k, $v) {
+                                if (atomic-equal($k, $key)) {
+                                   map:entry($k, $v)
+                                }
+                             })
+return if (exists($entry))
+       then map:values($entry)
+       else $fallback($key)   
       </fos:equivalent>
       <fos:notes>
          <p>A return value of <code>()</code> from <code>map:get</code> could indicate that
@@ -22256,7 +22265,7 @@ declare function map:find($input as item()*,
 
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-         { $key : $value }
+         map:put({}, $key, $value)
       </fos:equivalent>
       <fos:notes>
          
@@ -22312,7 +22321,9 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
             containing <code>$value</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-         map { "key": $key, "value": $value }
+{}
+=> map:put("key", $key)
+=> map:put("value", $value)
       </fos:equivalent>
       <fos:notes>
          <p>The function call <code>map:pair(K, V)</code> produces the same result as the
@@ -22434,9 +22445,8 @@ map:filter($map, fn($k, $v){not(some($keys, atomic-equal($k, ?)))})
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
       </fos:rules>
-      <fos:equivalent style="xpath-expression">
-for key $k value $v in $map
-return $action($k, $v)
+      <fos:equivalent style="dm-primitive">
+        dm:iterate-map($map, $action)
       </fos:equivalent>
       <fos:examples>
          <fos:example>
@@ -22517,10 +22527,12 @@ return <box>{
             the second argument.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
- $map
- => map:pairs()
- => fn:filter(fn($pair){ $predicate($pair?key, $pair?value) })
- => map:of-pairs()
+map:for-each($map, fn($key, $value) {
+                      if ($predicate($key, $value)) {
+                         map:pair($key, $value)
+                      }
+                   })
+=> map:of-pairs()                   
       </fos:equivalent>
       <fos:examples>
          <fos:example>
@@ -26282,7 +26294,7 @@ $array
       <fos:equivalent style="xpath-expression" covers-error-cases="false" arity="3"><![CDATA[
 $array
 => array:members()
-=> fn:subsequence($start, $length)
+=> subsequence($start, $length)
 => array:of-members()
       ]]></fos:equivalent>     
       <fos:errors>
@@ -26530,7 +26542,7 @@ return $pos[$predicate($m, $pos)]
       <fos:equivalent style="xpath-expression"><![CDATA[
 $array 
 => array:members() 
-=> fn:slice($start, $end, $step) 
+=> slice($start, $end, $step) 
 => array:of-members()
        ]]></fos:equivalent>
       <fos:notes>
@@ -26655,7 +26667,10 @@ $array
          </p>-->
       </fos:rules>
       <fos:equivalent style="xpath-expression" covers-error-cases="false"><![CDATA[
-$array => array:members() => fn:remove($positions) => array:of-members()
+$array 
+=> array:members() 
+=> fn:remove($positions) 
+=> array:of-members()
        ]]></fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="AY" code="0001"
@@ -26970,7 +26985,7 @@ $array
       <fos:equivalent style="xpath-expression"><![CDATA[
 $array 
 => array:members() 
-=> fn:reverse() 
+=> reverse() 
 => array:of-members()
        ]]></fos:equivalent>
       <fos:examples>
@@ -27014,15 +27029,22 @@ $array
       </fos:properties>
       <fos:summary>
          <p>Returns an array whose size is the same as <code>array:size($array)</code>, in which
-            each member is computed by applying <code>$function</code> to the corresponding member of
+            each member is computed by applying <code>$action</code> to the corresponding member of
             <code>$array</code>.</p>
       </fos:summary>
       <fos:rules>
          <p>Informally, the function returns an array whose members are obtained by applying 
-         the supplied <code>$function</code> to each member of the input array in turn.</p>
+         the supplied <code>$action</code> function to each member of the input array in turn.</p>
+         <p>The <code>$action</code> function is called with two arguments: the first is the
+         array member (which in general is an arbitrary sequence), and the second is the 1-based
+         integer position.</p>
       </fos:rules>
       <fos:equivalent style="dm-primitive">
-         dm:iterate-array($array, $action)
+array:fold-left($array, 
+                [], 
+                fn($zero, $next, $pos) {
+                   array:append($zero, $action($next, $pos))
+                })
       </fos:equivalent>
       <fos:examples>
          <fos:example>
@@ -27082,21 +27104,13 @@ $array
       <fos:rules>
          <p>Informally, the function returns an array containing those members of the input
          array that satisfy the supplied predicate.</p>
-         <!--<p>More formally, the function returns the result of the expression:</p>
-         <eg><![CDATA[
-array:of-members(
-  for member $member at $pos in $array
-  where $predicate($member, $pos)
-  return $member
-)]]></eg>-->
       </fos:rules>
-      <fos:equivalent style="xquery-expression"><![CDATA[
-array:of-members(
-  for member $member at $pos in $array
-  where $predicate($member, $pos)
-  return map{ 'value': $member }
-)
-       ]]></fos:equivalent>
+      <fos:equivalent style="xquery-expression">
+$array
+=> array:members()
+=> filter(fn($item, $pos) { $predicate(map:get($item, 'value'), $pos) })
+=> array:of-members()
+      </fos:equivalent>
       <fos:errors>
          <p>As a consequence of the function signature and the function calling rules, a type error occurs if the supplied
             function <code>$function</code> returns anything other than a single <code>xs:boolean</code> item
@@ -27411,12 +27425,13 @@ array:for-each-pair(
          <p>Informally, <code>array:build#2</code> applies the supplied function to each item 
             in the input sequence, and the resulting sequence becomes one member of the returned array.</p>
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
+      <fos:equivalent style="xpath-expression">
 array:of-members(
-  for $item at $pos in $input
-  return map { 'value': $action($item, $pos) }
+   for-each($input, fn($item, $pos) { 
+      map:entry('value', $action($item, $pos))
+   })
 )
-       ]]></fos:equivalent>
+      </fos:equivalent>
       <fos:notes>
          <p>The single-argument function <code>array:build($input)</code> is equivalent to the XPath
          expression <code>array { $input }</code>, but it is useful to have this available as a function.</p>
@@ -27486,10 +27501,9 @@ array:build(
          
          
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
-for member $member in $array
-return map { 'value': $member }
-       ]]></fos:equivalent>     
+      <fos:equivalent style="xpath-expression">
+            dm:iterate-array($array, map:entry('value', ?) )
+      </fos:equivalent>     
       <fos:notes>
          <p>This function is the inverse of <code>array:of-members</code>.</p>   
       </fos:notes>
@@ -27542,10 +27556,13 @@ return deep-equal(
          <p>The members of the array are delivered as a sequence of arrays. 
             Each returned array encapsulates the value of a single array member.</p>
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
-for member $member in $array
-return [ $member ]
-       ]]></fos:equivalent> 
+      <fos:equivalent style="xpath-expression">
+array:for-each($array, 
+               fn($member) { 
+                  [] => array:append($member) 
+               }) 
+=> array:values()         
+      </fos:equivalent> 
       <fos:notes>
          <p>The function call <code>array:split($array)</code> produces the same result as the
             expression <code>for member $m in $array return [ $m ]</code>.</p>
@@ -27611,18 +27628,18 @@ return deep-equal(
             it is a map comprising a single entry whose key is the <code>xs:string</code> value
             <code>"value"</code> and whose corresponding value is <code>$S</code>. The content encapsulated
             by a value record <code>$V</code> can be obtained using the expression <code>$V?value</code>.</p>
-         
-         <p>This function is treated as a primitive; all operations that construct arrays are formally defined
-         (directly or indirectly) in terms of <code>array:of-members</code>, and it therefore has no 
-            formal definition of its own.</p>
- 
+        
 
       </fos:rules>
+      
+      <fos:equivalent style="xquery-expression">
+fold-left($input, [], fn($array, $record) { 
+                         array:append($array, map:get($record, 'value'))
+                      })
+      </fos:equivalent>
 
       <fos:notes>
-         <p>This function is the inverse of <code>array:members</code>.</p>
-
-         
+         <p>This function is the inverse of <code>array:members</code>.</p>       
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -27874,9 +27891,9 @@ declare function array:flatten(
          <p>More formally, it returns the result of <code>array:members($array)?value</code>.</p>
 
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
-array:members($array)?value
-       ]]></fos:equivalent>
+      <fos:equivalent style="xpath-expression">
+         for-each(array:members($array), map:get(?, 'value'))
+      </fos:equivalent>
       <fos:notes>
          <p>Unlike <code>array:flatten</code>, the function does not apply recursively
          to nested arrays.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -21307,81 +21307,13 @@ declare function transitive-closure (
                   </fos:option>
                </fos:options>
 
-               <!--<table border="1" cellpadding="1" summary="options for the map:merge function">
-                  <thead>
-                     <tr>
-                        <th>Key</th>
-                        <th>Value</th>
-                        <th>Meaning</th>
-                     </tr>
-                  </thead>
-                  <tbody>
-                     
-                     
-                     <tr>
-                        <td rowspan="6">
-                           <code>duplicates</code>
-                        </td>
-                        <td colspan="2">Determines the policy for handling duplicate keys: specifically, the action to be
-                           taken if two maps in the input sequence <code>$maps</code> contain entries with key values
-                           <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the <termref def="dt-same-key">same key</termref>.
-                           The required type is <code>xs:string</code>. The default value is <code>use-first</code>.</td>
-                     </tr>
-                     <tr>
-                        <td>
-                           <code>reject</code>
-                        </td>
-                        <td>An error is raised <errorref class="JS" code="0003"/> if duplicate keys are encountered.</td>
-                     </tr>
-                     <tr>
-                        <td>
-                           <code>use-first</code>
-                        </td>
-                        <td>If duplicate keys are present, all but the first of a set of duplicates are ignored, 
-                           where the ordering is based on the order of maps in the <code>$maps</code> argument.</td>
-                     </tr>
-                     <tr>
-                        <td>
-                           <code>use-last</code>
-                        </td>
-                        <td>If duplicate keys are present, all but the last of a set of duplicates are ignored, 
-                           where the ordering is based on the order of maps in the <code>$maps</code> argument.</td>
-                     </tr>
-                     <tr>
-                        <td>
-                           <code>combine</code>
-                        </td>
-                        <td>If duplicate keys are present, the result map includes an entry for the key whose 
-                           associated value is the sequence-concatenation of all the values associated with the key, 
-                           retaining order based on the order of maps in the <code>$maps</code> argument.
-
-                           The key value in the result map that corresponds to such a set of duplicates must
-                           be the <termref def="dt-same-key">same key</termref> as each of the duplicates, but it is
-                           otherwise unconstrained: for example if the duplicate keys are <code>xs:byte(1)</code>
-                           and <code>xs:short(1)</code>, the key in the result could legitimately be <code>xs:long(1)</code>.
-                        </td>
-                     </tr>
-                     <tr>
-                        <td>
-                           <code>use-any</code>
-                        </td>
-                        <td>If duplicate keys are present, all but one of a set of duplicates are ignored, 
-                           and it is <termref def="implementation-dependent">implementation-dependent</termref>
-                           which one is retained. 
-                        </td>
-                     </tr>
-                     
-                     
-                   
-                     
-                  </tbody>
-               </table>-->
+               
             </item>
          </olist>
-         <p>The result of the function call <code>map:merge($MAPS, $OPTIONS)</code>
-         is defined to be consistent with the result of the expression:</p>
+ 
 
-         <eg><![CDATA[
+      </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false">
 let $FOJS0003 := QName("http://www.w3.org/2005/xqt-errors", "FOJS0003")
 let $duplicates-handler := {
   "use-first": fn($a, $b) { $a },
@@ -21397,9 +21329,22 @@ let $combine := fn($A as map(*), $B as map(*), $deduplicator as fn(*)) {
     else map:put($z, $k, $B($k))
   })
 }
-return fold-left($MAPS, {},
-  $combine(?, ?, $duplicates-handler($OPTIONS?duplicates otherwise "use-first"))
-)]]></eg>
+return fold-left($maps, {},
+  $combine(?, ?, $duplicates-handler($options?duplicates otherwise "use-first"))
+)        
+      </fos:equivalent>
+     
+      <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0003"
+               /> if the value of 
+          <code>$options</code> indicates that duplicates are to be rejected, and a duplicate key is encountered.</p>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0005"
+               /> if the value of 
+          <code>$options</code> includes an entry whose key is defined 
+          in this specification, and whose value is not a permitted value for that key.</p>
+      </fos:errors>
+
+      <fos:notes>
          <note>
             <p>By way of explanation, <code>$combine</code> is a function that combines
             two maps by iterating over the keys of the second map, adding each key and its corresponding
@@ -21422,19 +21367,6 @@ return fold-left($MAPS, {},
 
          </note>
 
-
-      </fos:rules>
-      <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0003"
-               /> if the value of 
-          <code>$options</code> indicates that duplicates are to be rejected, and a duplicate key is encountered.</p>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0005"
-               /> if the value of 
-          <code>$options</code> includes an entry whose key is defined 
-          in this specification, and whose value is not a permitted value for that key.</p>
-      </fos:errors>
-
-      <fos:notes>
          <p>If the input is an empty sequence, the result is an empty map.</p>
          <p>If the input is a sequence of length one, the result map is 
             <phrase>indistinguishable from the supplied map</phrase>.</p>
@@ -21544,12 +21476,12 @@ return fold-left($MAPS, {},
          <p>The optional <code>$combine</code> argument can be used to define how
          duplicate keys should be handled. The default is to form the sequence concatenation 
          of the corresponding values, retaining their order in the input sequence.</p>
-         
-         <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:pairs($week) => map:build(fn { ?key }, fn { ?value }, $combine)</eg>
-
+        
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         map:build($input, fn { ?key }, fn { ?value }, $combine)
+      </fos:equivalent>
       <fos:errors>
          <p>The function can be made to fail with a dynamic error in the event that
          duplicate keys are present in the input sequence by supplying a <code>$combine</code>
@@ -21665,15 +21597,15 @@ return fold-left($MAPS, {},
             the keys that are present in the map as a sequence of atomic values, in <termref
                def="implementation-dependent">implementation-dependent</termref> order.</p>
          <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[
-map:for-each($map, fn($key, $value) { $key })
-]]></eg>
          <p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         map:for-each($map, fn($key, $value) { $key })
+      </fos:equivalent>
       <fos:notes>
          <p>The number of items in the result will be the same as the number of entries in the map,
             and the result sequence will contain no duplicate values.</p>
@@ -21713,18 +21645,18 @@ map:for-each($map, fn($key, $value) { $key })
             entries for which the predicate function returns <code>true</code> in <termref
                def="implementation-dependent">implementation-dependent</termref> order.
          A return value of <code>()</code> is treated as <code>false</code>.</p>
-         <p>More formally, the function returns the value of the expression:</p>
-         <eg><![CDATA[
-map:for-each($map, fn($key, $value) {
-  if ($predicate($key, $value)) { $key }
-})
-]]></eg>
+         
          <p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+map:for-each($map, fn($key, $value) {
+  if ($predicate($key, $value)) { $key }
+})         
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -21803,6 +21735,9 @@ return map:keys-where($birthdays, fn($name, $date) {
             are not guaranteed to produce the results in the same order.</p>
          <p>The effect of the function is equivalent to <code>$map?*</code>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         map:for-each($map, fn($key, $value){ $value })
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -21852,9 +21787,11 @@ return map:keys-where($birthdays, fn($name, $date) {
                ref="properties-of-functions"
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
-         <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:for-each($map, fn($k, $v) { { $k: $v } })</eg>
+
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         map:for-each($map, fn($k, $v) { map{ $k: $v } })
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -21898,9 +21835,10 @@ return map:keys-where($birthdays, fn($name, $date) {
                ref="properties-of-functions"
             />). This means that two calls with the same argument
             are not guaranteed to produce the results in the same order.</p>
-         <p>The effect of the function is equivalent to the expression:</p>
-         <eg>map:for-each($map, fn($k, $v) { { "key": $k, "value": $v } })</eg>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         map:for-each($map, fn($k, $v) { map{ "key": $k, "value": $v } })
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -21935,7 +21873,9 @@ return map:keys-where($birthdays, fn($name, $date) {
                >map</termref> supplied as <code>$map</code> contains an entry with the <termref
                   def="dt-same-key">same key</termref> as <code>$key</code>; otherwise it returns <code>false</code>.</p>
       </fos:rules>
-
+      <fos:equivalent style="xpath-expression">
+         some( map:keys($map), atomic-equal(?, $key) )
+      </fos:equivalent>
       <fos:examples>
          <fos:variable name="week" id="v-map-contains-week"
             select="{&#xa;  0: &quot;Sonntag&quot;, 1: &quot;Montag&quot;, 2: &quot;Dienstag&quot;, 3: &quot;Mittwoch&quot;,&#xa;  4: &quot;Donnerstag&quot;, 5: &quot;Freitag&quot;, 6: &quot;Samstag&quot;&#xa;}"/>
@@ -21982,6 +21922,9 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>The function returns <code>true</code> if and only if <code>$map</code> contains no
             entries, that is, if <code>map:size($map) eq 0</code>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         map:size($map) eq 0
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -22027,6 +21970,11 @@ return map:keys-where($birthdays, fn($name, $date) {
                The default <code>$fallback</code> function always returns an empty sequence.</phrase></p>
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+if (map:contains($map, $key))
+then map:filter($map, fn($k, $v){atomic-equal($k, $key)}) => map:values()
+else $fallback($key)         
+      </fos:equivalent>
       <fos:notes>
          <p>A return value of <code>()</code> from <code>map:get</code> could indicate that
             the key is present in the map with an associated value of <code>()</code>, or it could
@@ -22144,6 +22092,30 @@ return map:keys-where($birthdays, fn($name, $date) {
          </olist>
 
       </fos:rules>
+      <!--<fos:equivalent style="xquery-function">
+declare function map:find($input as item()*, 
+                          $key as xs:anyAtomicType) 
+                          as array(*) {
+   array:of-members(                       
+      for $item in $input
+      return typeswitch($item) {
+         case $a as array(*)
+            return
+               for member $member in $a
+               return map:find($member, $key)
+         case $m as map(*)
+            return 
+               for key $k value $v in $m
+               return (
+                  if (atomic-equal($k, $key)) { map {'value': $v} },
+                  map:find($v, $key)
+               )
+         default
+            return ()
+      }
+   )
+};   
+      </fos:equivalent>-->
       <fos:notes>
          <p>If <code>$input</code> is an empty sequence, map, or array, or if the requested <code>$key</code> is not found,
             the result will be a zero-length array.</p>
@@ -22206,7 +22178,7 @@ return map:keys-where($birthdays, fn($name, $date) {
                >same key</termref> as <code>$key</code>, together with a new
          entry whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p>
 
-         <p>The effect of the function call <code>map:put($MAP, $KEY, $VALUE)</code> is equivalent
+         <!--<p>The effect of the function call <code>map:put($MAP, $KEY, $VALUE)</code> is equivalent
          to the result of the following steps:</p>
 
          <olist>
@@ -22227,9 +22199,13 @@ return map:keys-where($birthdays, fn($name, $date) {
                   </item>
                </olist>
             </item>
-         </olist>
+         </olist>-->
 
       </fos:rules>
+      
+      <fos:equivalent style="dm-primitive">
+          dm:map-put($map, $key, $value)
+      </fos:equivalent>
 
       <fos:notes>
          <p>There is no requirement that the type of <code>$key</code> and <code>$value</code> be consistent with the types
@@ -22279,9 +22255,11 @@ return map:keys-where($birthdays, fn($name, $date) {
 
 
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         { $key : $value }
+      </fos:equivalent>
       <fos:notes>
-         <p>The function call <code>map:entry(K, V)</code> produces the same result as the
-         expression <code>{ K : V }</code>.</p>
+         
          <p>The function <code>map:entry</code> is intended primarily for use in conjunction with
             the function <code>map:merge</code>. For example, a map containing seven entries may be
             constructed like this:</p>
@@ -22333,6 +22311,9 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
             containing <code>$key</code> and the other (with the key <code>"value"</code>)
             containing <code>$value</code>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         map { "key": $key, "value": $value }
+      </fos:equivalent>
       <fos:notes>
          <p>The function call <code>map:pair(K, V)</code> produces the same result as the
          expression <code>{ "key": K, "value": V }</code>.</p>
@@ -22386,16 +22367,11 @@ map:of-pairs((
             <code>$keys</code>.</p>
          <p>No failure occurs <phrase>if an item in <code>$keys</code> does not correspond to any entry in <code>$map</code>;
             that key value is simply ignored</phrase>.</p>
-         <p>More formally, the function returns the value of the expression:</p>
-         <eg diff="chg" at="2023-01-25"><![CDATA[
-map:merge(
-  map:for-each($map, fn($k, $v) { 
-    if (some $key in $keys satisfies atomic-equal($k, $key))
-    then () 
-    else map:entry($k, $v)
-  })
-)]]></eg>
+        
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+map:filter($map, fn($k, $v){not(some($keys, atomic-equal($k, ?)))})              
+      </fos:equivalent>
 
       <fos:examples>
          <fos:variable name="week" id="v-map-remove-week"
@@ -22439,8 +22415,8 @@ map:merge(
          
       </fos:properties>
       <fos:summary>
-         <p>Applies a supplied function to every entry in a map, returning the concatenation of the
-            results.</p>
+         <p>Applies a supplied function to every entry in a map, returning the 
+            <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> of the results.</p>
       </fos:summary>
       <fos:rules>
          <p>The function <code>map:for-each</code> takes any <termref def="dt-map"
@@ -22458,6 +22434,10 @@ map:merge(
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+for key $k value $v in $map
+return $action($k, $v)
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -22536,6 +22516,12 @@ return <box>{
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+ $map
+ => map:pairs()
+ => fn:filter(fn($pair){ $predicate($pair?key, $pair?value) })
+ => map:of-pairs()
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -22588,15 +22574,12 @@ return <box>{
             obtained by applying the supplied <code>$action</code> to an empty sequence.</p>
 
 
-         <p>The effect of the function call <code>map:replace($MAP, $KEY, $VALUE)</code> is equivalent
-            to the result of the expression:</p>
-
-         <eg>if (map:contains($MAP, $KEY)) 
-then map:put($MAP, $KEY, $ACTION(map:get($MAP, $KEY)))
-else map:put($MAP, $KEY, $ACTION(())</eg>
-
-
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+if (map:contains($map, $key)) 
+then map:put($map, $key, $action(map:get($map, $key)))
+else map:put($map, $key, $action(()))        
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -22605,7 +22588,7 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
             </fos:test>
             <fos:test>
                <fos:expression>map:replace({ 1: "alpha", 2: "beta" }, 3, upper-case#1)</fos:expression>
-               <fos:result>{ 1: "alpha", 2: "beta" 3: "" }</fos:result>
+               <fos:result>{ 1: "alpha", 2: "beta", 3: "" }</fos:result>
             </fos:test>
             <fos:test>
                <fos:expression><eg>fold-left(
@@ -22703,19 +22686,19 @@ else map:put($MAP, $KEY, $ACTION(())</eg>
                function to combine the existing value for the key with the new value,
                and replaces the entry with this combined value.</p></item>
          </ulist>
-         <p>More formally, the function returns the value of the expression:</p>
-         <eg>
+      </fos:rules>
+      <fos:equivalent style="xpath-expression">
 fold-left($input, {}, fn($map, $item, $pos) {
   let $v := $value($item, $pos)
-  return fold-left($key($item, $pos), $map, fn($m, $k) {
+  return fold-left($keys($item, $pos), $map, fn($m, $k) {
     if (map:contains($m, $k)) then (
       map:put($m, $k, $combine($m($k), $v))
     ) else (
       map:put($m, $k, $v)
     )
   })
-})         </eg>
-      </fos:rules>
+})            
+      </fos:equivalent>
       
       <fos:notes>
          <p>Although defined to process the input sequence in order, this is only relevant when combining the entries
@@ -22807,7 +22790,7 @@ return map:build($titles/title, fn($title) { $title/ix })
                <fos:result><eg><![CDATA[
 {
   "Java": (
-    <title>A Beginner's Guide to <ix>Java</ix></title>,
+    <title>A Beginner’s Guide to <ix>Java</ix></title>,
     <title>Using <ix>XML</ix> with <ix>Java</ix></title>
   ),
   "XML": (
@@ -22868,6 +22851,9 @@ return map:build($titles/title, fn($title) { $title/ix })
             as its <code>$map</code> argument and returns the number of entries that are present
             in the map.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         count(map:entries($map))
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -26191,9 +26177,9 @@ $array
             <code>array:of-members((array:members($array), { 'value': $member }))</code>.</p>-->
 
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
-         array:of-members((array:members($array), { 'value': $member }))
-      ]]></fos:equivalent>
+      <fos:equivalent style="dm-primitive">
+         dm:array-append($array, $member)
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -27035,12 +27021,9 @@ $array
          <p>Informally, the function returns an array whose members are obtained by applying 
          the supplied <code>$function</code> to each member of the input array in turn.</p>
       </fos:rules>
-      <fos:equivalent style="xpath-expression"><![CDATA[
-array:of-members(
-  for member $member at $pos in $array
-  return map { 'value': $action($member, $pos) }
-)  
-       ]]></fos:equivalent>
+      <fos:equivalent style="dm-primitive">
+         dm:iterate-array($array, $action)
+      </fos:equivalent>
       <fos:examples>
          <fos:example>
             <fos:test>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -516,77 +516,155 @@ for transition to Proposed Recommendation. </p>'>
          <div2 id="func-signatures">
             <head>Function signatures and descriptions</head>
             <p>Each function (or group of functions having the same name) is defined in this specification using
-            a standard proforma.</p>
-            <p>The function name is a <code>QName</code> as defined in <bibref ref="xmlschema-2"/>
-               and must adhere to its syntactic conventions. Following the precedent set by <bibref ref="xpath"/>,
-               function names are generally composed of English words separated by hyphens (<code>-</code>). Abbreviations are
-               used only where there is a strong precedent in other programming languages (as with <code>math:sin</code> and 
-               <code>math:cos</code> for sine and cosine). If a
-               function name contains a <bibref ref="xmlschema-2"/> datatype name, it may have
-               intercapitalized spelling and is used in the function name as such. An example is <code>fn:timezone-from-dateTime</code>.</p>
-            <p>The first section in the proforma is a short summary of what the function does. This is intended
-            to be informative rather than normative.</p>
-            <p>Each function is then defined by specifying its signature(s), which define the
-               types of the parameters and of the result value.</p>
-            <p diff="add" at="2022-11-29">Where functions take a variable number of arguments, two conventions are used:</p>
-            <ulist diff="add" at="2022-11-29">
-               <item><p>Wherever possible, a single function signature is used giving default values
-               for those parameters that can be omitted.</p></item>
-               <item><p>If this is not possible, because the effect of omitting a parameter cannot
-               be specified by giving a default value, multiple signatures are given for the function.</p></item>
-            </ulist>
-            <p>Each function signature is presented in a form like this:</p>
-            <example role="signature">
-               <proto role="example" name="function-name" return-type="return-type">
-                  <arg name="parameter-name" type="parameter-type"/>
-                  <arg name="..." type=""/>
-               </proto>
-            </example>
-            <p>In this notation, <term>function-name</term>, in bold-face, is the 
-               <phrase diff="add" at="2023-01-17">local</phrase> name of the
-                    function whose signature is being specified. <phrase>The prefix <term>fn</term>
-                    indicates that the function is in the namespace <code>http://www.w3.org/2005/xpath-functions</code>:
-                       this is one of the conventional prefixes listed in <specref ref="namespace-prefixes"/>.</phrase>
-                    If the function takes no
-                    parameters, then the name is followed by an empty parameter list:
-                    <code>()</code>; otherwise, the name is followed by a parenthesized list of
-                    parameter declarations. Each parameter declaration includes:</p>
-            <ulist diff="add" at="2022-11-29">
-               <item><p>The name of the parameter (which in 4.0 is significant because it can be used
-               as a keyword in a function call)</p></item>
-               <item><p>The static type of the parameter (in italics)</p></item>
-               <item><p>If this is the last parameter of a variadic function, an ellipsis (<code>...</code>)</p></item>
-               <item><p>If the parameter is optional, then an expression giving the default value 
-                  (preceded by the symbol <code>:=</code>).</p>
-                     <p diff="add" at="2023-12-04">The default value expression is evaluated using the static and
-                     dynamic context of the function caller (or of a named function reference). For example, 
-                     if the default value is given as <code>.</code>, then it evaluates to the context value 
-                     from the dynamic context of the function caller; if it is given as <code>default-collation</code>,
-                     then its value is the default collation from the static context of the function caller;
-                     if it is given as <code>deep-equal#2</code>, then the third argument supplied to <code>deep-equal</code>
-                     is the default collation from the static context of the caller.</p></item>
-            </ulist>
-            <p>If there are two or more parameter declarations, they are separated by a comma.</p> 
-            <p>The <emph> <code>return-type</code></emph>, also in italics, specifies the static type of the value returned by the
-                    function. The dynamic type of the value returned by the function is the same as its static
-                    type or derived from the static type. All parameter types and return types are
-                    specified using the SequenceType notation defined in <xspecref spec="XP31" ref="id-sequencetype-syntax"/>.</p>
+            a standard proforma. This has the following sections:</p>
             
+            <div3 id="id-function-signatures-name">
+               <head>Function name</head>
            
-            <p>One function, <code>fn:concat</code>, has a variable number of arguments (zero or more).
-            More strictly, there is an infinite set of functions having the name <code>fn:concat</code>, with arity
-            ranging from 0 to infinity. For this special case, a single function signature is given, with an ellipsis
-            indicating an indefinite number of arguments.</p>
+               <p>The function name is a <code>QName</code> as defined in <bibref ref="xmlschema-2"/>
+                  and must adhere to its syntactic conventions. Following the precedent set by <bibref ref="xpath"/>,
+                  function names are generally composed of English words separated by hyphens: 
+                  specifically <char>U+002D</char>. Abbreviations are
+                  used only where there is a strong precedent in other programming languages (as with <code>math:sin</code> and 
+                  <code>math:cos</code> for sine and cosine). If a
+                  function name contains a <bibref ref="xmlschema-2"/> datatype name, it may have
+                  intercapitalized spelling and is used in the function name as such. An example is <code>fn:timezone-from-dateTime</code>.</p>
+            </div3>
+            <div3 id="id-function-signatures-summary">
+               <head>Function summary</head>
             
+                <p>The first section in the proforma is a short summary of what the function does. This is intended
+                to be informative rather than normative.</p>
+            </div3>
+            <div3 id="id-function-signatures-signature">
+               <head>Function signature</head>
             
-            <p>The next section in the proforma defines the semantics of the function as a set of rules. 
-               The order in which the rules appear is significant; they are to be applied in the order in which
-               they are written. Error conditions, however, are generally listed in a separate section that follows
-            the main rules, and take precedence over non-error rules except where otherwise stated. The principles outlined
-            in <xspecref spec="XP31" ref="id-errors-and-opt"/> apply by default: to paraphrase, if the result of the function
-            can be determined without evaluating all its arguments, then it is not necessary to evaluate the remaining arguments
-            merely in order to determine whether any error conditions apply.</p>
-            <p>Where the proforma includes sections headed <emph>Notes</emph> or <emph>Examples</emph>, these are non-normative.</p>
+               <p>Each function is then defined by specifying its signature(s), which define the
+                  types of the parameters and of the result value.</p>
+               <p diff="add" at="2022-11-29">Where functions take a variable number of arguments, two conventions are used:</p>
+               <ulist diff="add" at="2022-11-29">
+                  <item><p>Wherever possible, a single function signature is used giving default values
+                  for those parameters that can be omitted.</p></item>
+                  <item><p>If this is not possible, because the effect of omitting a parameter cannot
+                  be specified by giving a default value, multiple signatures are given for the function.</p></item>
+               </ulist>
+               <p>Each function signature is presented in a form like this:</p>
+               <example role="signature">
+                  <proto role="example" name="function-name" return-type="return-type">
+                     <arg name="parameter-name" type="parameter-type"/>
+                     <arg name="..." type=""/>
+                  </proto>
+               </example>
+               <p>In this notation, <term>function-name</term>, in bold-face, is the 
+                  <phrase diff="add" at="2023-01-17">local</phrase> name of the
+                       function whose signature is being specified. <phrase>The prefix <term>fn</term>
+                       indicates that the function is in the namespace <code>http://www.w3.org/2005/xpath-functions</code>:
+                          this is one of the conventional prefixes listed in <specref ref="namespace-prefixes"/>.</phrase>
+                       If the function takes no
+                       parameters, then the name is followed by an empty parameter list:
+                       <code>()</code>; otherwise, the name is followed by a parenthesized list of
+                       parameter declarations. Each parameter declaration includes:</p>
+               <ulist diff="add" at="2022-11-29">
+                  <item><p>The name of the parameter (which in 4.0 is significant because it can be used
+                  as a keyword in a function call)</p></item>
+                  <item><p>The static type of the parameter (in italics)</p></item>
+                  <item><p>If this is the last parameter of a variadic function, an ellipsis (<code>...</code>)</p></item>
+                  <item><p>If the parameter is optional, then an expression giving the default value 
+                     (preceded by the symbol <code>:=</code>).</p>
+                        <p diff="add" at="2023-12-04">The default value expression is evaluated using the static and
+                        dynamic context of the function caller (or of a named function reference). For example, 
+                        if the default value is given as <code>.</code>, then it evaluates to the context value 
+                        from the dynamic context of the function caller; if it is given as <code>default-collation</code>,
+                        then its value is the default collation from the static context of the function caller;
+                        if it is given as <code>deep-equal#2</code>, then the third argument supplied to <code>deep-equal</code>
+                        is the default collation from the static context of the caller.</p></item>
+               </ulist>
+               <p>If there are two or more parameter declarations, they are separated by a comma.</p> 
+               <p>The <emph> <code>return-type</code></emph>, also in italics, specifies the static type of the value returned by the
+                       function. The dynamic type of the value returned by the function is the same as its static
+                       type or derived from the static type. All parameter types and return types are
+                       specified using the SequenceType notation defined in <xspecref spec="XP31" ref="id-sequencetype-syntax"/>.</p>
+               
+              
+               <p>One function, <code>fn:concat</code>, has a variable number of arguments (zero or more).
+               More strictly, there is an infinite set of functions having the name <code>fn:concat</code>, with arity
+               ranging from 0 to infinity. For this special case, a single function signature is given, with an ellipsis
+               indicating an indefinite number of arguments.</p>
+               
+               <ednote><edtext>concat() is no longer the only variadic function.</edtext></ednote>
+            </div3>
+            
+            <div3 id="id-function-signatures-rules">
+               <head>Function rules</head>
+               
+            
+               <p>The next section in the proforma defines the semantics of the function as a set of rules. 
+                  The order in which the rules appear is significant; they are to be applied in the order in which
+                  they are written. Error conditions, however, are generally listed in a separate section that follows
+               the main rules, and take precedence over non-error rules except where otherwise stated. The principles outlined
+               in <xspecref spec="XP31" ref="id-errors-and-opt"/> apply by default: to paraphrase, if the result of the function
+               can be determined without evaluating all its arguments, then it is not necessary to evaluate the remaining arguments
+               merely in order to determine whether any error conditions apply.</p>
+            </div3>
+            
+            <div3 id="id-function-signatures-formal-specification">
+               <head>Formal Specification</head>
+               
+               <p>Some functions supplement the prose rules with a formal specification that describes the effect
+               of the function in terms of an equivalent XPath or XQuery implementation. This is intended to take
+               precedence over the prose rules in the event of any conflict; however, both sections are intended
+               to be complete and not to rely on each other.</p>
+               
+               <p>In writing the formal specifications, a number of guidelines have been followed:</p>
+               
+               <olist>
+                  <item><p>Where the equivalent code calls other functions, these should either be primitives
+                  defined in the data model specification (see <bibref ref="xpath-datamodel-31"/>), or
+                  functions that themselves have a formal specification; and the dependencies should not
+                  be circular.</p></item>
+                  <item><p>There should be minimal reliance on XPath or XQuery language features.
+                  Although no attempt has been made to precisely define a core set of language constructs,
+                  the specifications try to avoid relying on features other than function calls
+                  and a few basic operators including the comma operator, equality testing, and
+                  simple integer arithmetic.</p></item>
+               </olist>
+               
+               <p>There is no attempt to write formal specifications for functions that have complex logic
+               (such as <code>fn:format-number</code>) or dependencies (such as <code>fn:doc</code>); the aim
+               of the formal specifications is to define as rigorously as possible a platform of basic
+               functionality that can be used as a solid foundation for more complex features.</p>
+               
+               <ednote><edtext>This worthy intent is not yet fully achieved; for example there are
+               formal specifications that invoke fn:atomic-equal.</edtext></ednote>
+               
+            </div3>
+            
+            <div3 id="id-function-signatures-notes">
+               <head>Notes</head>
+               
+               <p>Where the proforma includes a section headed <emph>Notes</emph>, these are non-normative.</p>
+               
+            </div3>
+            
+            <div3 id="id-function-signatures-examples">
+               <head>Examples</head>
+               
+               <p>Where the proforma includes a section headed <emph>Examples</emph>, these are non-normative.</p>
+               
+               <p>Many of the examples are given in structured form, showing example expressions and their expected results.
+               These published examples are derived from executable test cases, so they follow a standard format. In general,
+               the actual result of the expression is expected to be deep-equal to the presented result, under the
+               rules of the <code>fn:deep-equal</code> function with default options. In some cases the result is qualified
+               to indicate that the order of items in the result is implementation-dependent, or that numeric results
+               are approximate.</p>
+               
+               <p>For more complex functions, examples may be given using informal narrative prose.</p>
+               
+            </div3>
+               
+         </div2>
+         <div2 id="id-function-calls">
+            <head>Function calls</head>
             
             <p>Rules for passing parameters to operators are described in the relevant sections
                     of <bibref ref="xquery-40"/> and <bibref ref="xpath-40"/>. For example, the rules for
@@ -865,7 +943,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                <p>It also uses the term <quote>expanded-QName</quote> defined below.</p>
                <p><termdef id="expanded-name" term="expanded-QName"> An <term>expanded-QName</term> 
                   is a value in the value space of the <code>xs:QName</code> datatype as defined in the XDM data model 
-                  (see <bibref ref="xpath-datamodel-31"/>): that is, a triple containing namespace prefix (optional), namespace URI (optional), 
+                  (see <bibref ref="xpath-datamodel-40"/>): that is, a triple containing namespace prefix (optional), namespace URI (optional), 
                   and local name. Two expanded QNames are equal if the namespace URIs are the same (or both absent) 
                   and the local names are the same. The prefix plays no part in the comparison, but is used only 
                   if the expanded QName needs to be converted back to a string.</termdef></p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -629,13 +629,15 @@ for transition to Proposed Recommendation. </p>'>
                   simple integer arithmetic.</p></item>
                </olist>
                
+               <ednote><edtext>This worthy intent is not yet fully achieved; for example there are
+               formal specifications that invoke fn:atomic-equal.</edtext></ednote>
+               
                <p>There is no attempt to write formal specifications for functions that have complex logic
                (such as <code>fn:format-number</code>) or dependencies (such as <code>fn:doc</code>); the aim
                of the formal specifications is to define as rigorously as possible a platform of basic
                functionality that can be used as a solid foundation for more complex features.</p>
                
-               <ednote><edtext>This worthy intent is not yet fully achieved; for example there are
-               formal specifications that invoke fn:atomic-equal.</edtext></ednote>
+               
                
             </div3>
             

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7626,6 +7626,32 @@ return <table>
          
          </div2>
          
+         <div2 id="formal-specification-of-maps">
+            <head>Formal Specification of Maps</head>
+            <p>The XDM data model (<bibref ref="xpath-datamodel-40"/>) defines three primitive operations on maps:</p>
+            <ulist>
+               <item><p><code>dm:empty-map</code> constructs an empty map.</p></item>
+               <item><p><code>dm:map-put</code> adds or replaces an entry in a map.</p></item>
+               <item><p><code>dm:iterate-map</code> applies a supplied function to every entry in a map.</p></item>
+            </ulist>
+            
+            <p>The functions in this section are all specified by means of equivalent expressions that either call
+            these primitives directly, or invoke other functions that rely on these primitives. The specifications
+            avoid relying on XPath language constructs that manipulate maps, such as map constructor syntax, lookup
+            expressions, or FLWOR expressions. This is done to allow these language constructs
+            to be specified by reference to this function library, without risk of circularity.</p>
+            
+            <p>There is one exception to this rule: for convenience, the notation <code>{}</code> is used to represent
+            an empty map, in preference to a call on <code>dm:empty-map()</code>.</p>
+            
+            <p>The formal specifications are not intended to provide a realistic way of implementating the
+            functions (in particular, any real implementation might be expected to implement <code>map:get</code>
+            and <code>map:put</code> much more efficiently). They do, however, provide a framework that allows
+            the correctness of a practical implementation to be verified.</p>
+            
+            <ednote><edtext>TODO: as yet there is no formal specification of <code>map:find()</code>.</edtext></ednote>
+         </div2>
+         
          <div2 id="map-functions">
             <head>Functions that Operate on Maps</head>
             
@@ -7742,6 +7768,32 @@ return <table>
             <code>function($index as xs:integer) as item()*</code>. 
             The fact that an array is a function item allows it to be passed as an argument to higher-order functions 
             that expect a function item as one of their arguments.</p>
+         
+         <div2 id="formal-specification-of-arrays">
+            <head>Formal Specification of Arrays</head>
+            <p>The XDM data model (<bibref ref="xpath-datamodel-40"/>) defines three primitive operations on maps:</p>
+            <ulist>
+               <item><p><code>dm:empty-array</code> constructs an empty array.</p></item>
+               <item><p><code>dm:array-append</code> adds a member to an array.</p></item>
+               <item><p><code>dm:iterate-array</code> applies a supplied function to every member of an array, in order.</p></item>
+            </ulist>
+            
+            <p>The functions in this section are all specified by means of equivalent expressions that either call
+            these primitives directly, or invoke other functions that rely on these primitives. The specifications
+            avoid relying on XPath language constructs that manipulate arrays, such as array constructor syntax, lookup
+            expressions, or FLWOR expressions. This is done to allow these language constructs
+            to be specified by reference to this function library, without risk of circularity.</p>
+            
+            <p>There is one exception to this rule: for convenience, the notation <code>[]</code> is used to represent
+            an empty array, in preference to a call on <code>dm:empty-array()</code>.</p>
+            
+            <p>The formal specifications are not intended to provide a realistic way of implementating the
+            functions (in particular, any real implementation might be expected to implement <code>array:get</code>
+            much more efficiently). They do, however, provide a framework that allows
+            the correctness of a practical implementation to be verified.</p>
+            
+            
+         </div2>
          
          
          <div2 id="array-functions">

--- a/specifications/xpath-functions-40/style/generate-equivalence-tests.xsl
+++ b/specifications/xpath-functions-40/style/generate-equivalence-tests.xsl
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="4.0"
+   xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace"
+   xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   xpath-default-namespace="http://www.w3.org/xpath-functions/spec/namespace"
+   expand-text="yes">
+   
+   <!-- Generate an XQuery module that tests the examples in the spec against
+        the executable "formal specifications" of those functions that have such a
+        specification -->
+   
+   <!-- Run against the function-catalog.xml source document -->
+   
+   <xsl:output method="text"/>
+   <xsl:strip-space elements="*"/>
+   <xsl:variable name="NL" select="char(10)"/>
+   <xsl:mode on-no-match="deep-skip"/>
+   
+   <xsl:template match="/">
+      <xsl:text>xquery version "4.0";{$NL}{$NL}</xsl:text>
+      <xsl:text>(: This file is generated automatically by the
+   qtspecs build process. Any changes you 
+   make to this file will be lost on the next build. Have a nice day. :){$NL}{$NL}</xsl:text>
+      
+      <xsl:text>declare namespace array="http://dummy/array";{$NL}{$NL}</xsl:text>
+      <xsl:text>declare namespace array0="http://www.w3.org/2005/xpath-functions/array";{$NL}{$NL}</xsl:text>
+      
+      <xsl:apply-templates select="//fos:function[@prefix='array']"/>
+      <xsl:text>element result {{</xsl:text>
+      <xsl:apply-templates select="//fos:test"/>
+      <xsl:text>()}}</xsl:text>
+
+ 
+   </xsl:template>
+   
+   <xsl:template match="fos:function[fos:equivalent]">
+      <xsl:apply-templates select="fos:equivalent"/>
+   </xsl:template>
+   
+   <xsl:template match="fos:function[not(fos:equivalent)]" name="redirect">
+      <xsl:text>{fos:sig(.)} {{ {$NL}{$NL}</xsl:text>
+      <xsl:text>    array0:{@name}( </xsl:text>
+      <xsl:value-of select="fos:signatures/fos:proto[1]/fos:arg ! ('$' || @name)" separator=", "/>
+      <xsl:text>){$NL} }};{$NL}</xsl:text>
+   </xsl:template>
+   
+   <xsl:template match="fos:function[@name='get' and @prefix='array']" priority="100">
+      <!-- Special case for now because Saxon can't handle the default value of the @fallback arg -->
+      <xsl:text>declare function array:get($array as array(*), $index as xs:integer, $fallback as item()* := ()) {{ 
+         array0:get($array, $index, $fallback)
+}};{$NL}{$NL} </xsl:text>
+   </xsl:template>
+   
+   
+   <xsl:function name="fos:sig" as="xs:string">
+      <xsl:param name="fn" as="element(fos:function)"/>
+      <xsl:value-of>
+         <xsl:text>declare function {$fn/@prefix}:{$fn/@name} ({$NL}</xsl:text>
+         <xsl:for-each select="$fn/fos:signatures[1]/fos:proto[last()]/fos:arg">
+            <xsl:variable name="not-last" select="exists(following-sibling::fos:arg)"/>
+            <xsl:text>   ${@name} as {@type}{if (@default) then (' := ' || @default) else ()}{','[$not-last]}{$NL}</xsl:text>
+         </xsl:for-each>
+         <xsl:text>) </xsl:text>
+      </xsl:value-of>
+   </xsl:function>
+   
+   
+   <xsl:template match="fos:equivalent[@style='xquery-function']">
+      <xsl:value-of select="."/>
+      <xsl:text>{$NL}{$NL}</xsl:text>
+   </xsl:template>
+   
+   <xsl:template match="fos:equivalent[@style=('xquery-expression', 'xpath-expression')]">
+      <xsl:text>{fos:sig(..)} {{ {$NL}{$NL}</xsl:text>
+      <xsl:value-of select="."/>
+      <xsl:text>}};{$NL}{$NL}</xsl:text>
+   </xsl:template>
+   
+   <xsl:template match="fos:test[ancestor::fos:function//fos:equivalent]">
+      <xsl:variable name="this" select="."/>
+      <xsl:variable name="desc" select="ancestor::fos:function/(@prefix || ':' || @name || '#') 
+                                          || generate-id()"/>
+      <xsl:text>(: {$desc} :){$NL}</xsl:text>
+      <xsl:for-each select="tokenize(@use)">
+         <xsl:variable name="var" select="$this/ancestor::fos:function/fos:examples/fos:variable[@id=current()]"/>
+         <xsl:assert test="exists($var)">Failed to find declaration of variable ${.}</xsl:assert>
+         <xsl:text>let ${$var/@name} as {$var/@as otherwise 'item()*'} := {$var/@select} return{$NL}</xsl:text>
+      </xsl:for-each>
+      <xsl:text>let $result := {fos:expression}
+         return 
+            if (deep-equal($result, ({fos:result}))) 
+            then () 
+            else 'failed {$desc} actual = ' || serialize($result, {{'method':'adaptive'}}) || char(10), {$NL}{$NL}</xsl:text>
+   </xsl:template>
+   
+   <!-- Tests temporarily excluded because not implemented in Saxon -->
+   <xsl:template match="fos:function[@prefix='array'][@name='sort']//fos:test" priority="100"/>
+   
+   
+   
+</xsl:stylesheet>

--- a/specifications/xpath-functions-40/style/generate-equivalence-tests.xsl
+++ b/specifications/xpath-functions-40/style/generate-equivalence-tests.xsl
@@ -29,20 +29,20 @@
       <xsl:text>declare namespace map0="http://www.w3.org/2005/xpath-functions/map";{$NL}{$NL}</xsl:text>
       
       <xsl:text>declare function dm:iterate-array($array as array(*), $action as fn(item()*, xs:integer) as item()*) {{
-      array0:for-each($array, $action)
-}};</xsl:text>
+      array0:for-each($array, $action) => array0:values()
+}};{$NL}</xsl:text>
       
       <xsl:text>declare function dm:array-append($array as array(*), $member as item()*) {{
       array0:append($array, $member)
-}};</xsl:text>
+}};{$NL}</xsl:text>
       
       <xsl:text>declare function dm:iterate-map($map as map(*), $action as fn(xs:anyAtomicType, item()*) as item()*) {{
       map0:for-each($map, $action)
-}};</xsl:text>
+}};{$NL}</xsl:text>
       
       <xsl:text>declare function dm:map-put($map as map(*), $key as xs:anyAtomicType, $value as item()*) {{
       map0:put($map, $key, $value)
-}};</xsl:text>
+}};{$NL}</xsl:text>
       
       <xsl:apply-templates select="//fos:function[@prefix=('array', 'map')]"/>
       <xsl:text>element result {{</xsl:text>
@@ -79,7 +79,7 @@
             <xsl:variable name="not-last" select="exists(following-sibling::fos:arg)"/>
             <xsl:text>   ${@name} as {@type}{if (@default) then (' := ' || @default) else ()}{','[$not-last]}{$NL}</xsl:text>
          </xsl:for-each>
-         <xsl:text>) </xsl:text>
+         <xsl:text>) as {$fn/fos:signatures[1]/fos:proto[last()]/@return-type}</xsl:text>
       </xsl:value-of>
    </xsl:function>
    

--- a/specifications/xpath-functions-40/style/generate-equivalence-tests.xsl
+++ b/specifications/xpath-functions-40/style/generate-equivalence-tests.xsl
@@ -22,10 +22,29 @@
    qtspecs build process. Any changes you 
    make to this file will be lost on the next build. Have a nice day. :){$NL}{$NL}</xsl:text>
       
+      <xsl:text>declare namespace dm="http://www.w3.org/qt4/datamodel";{$NL}{$NL}</xsl:text>
       <xsl:text>declare namespace array="http://dummy/array";{$NL}{$NL}</xsl:text>
       <xsl:text>declare namespace array0="http://www.w3.org/2005/xpath-functions/array";{$NL}{$NL}</xsl:text>
+      <xsl:text>declare namespace map="http://dummy/map";{$NL}{$NL}</xsl:text>
+      <xsl:text>declare namespace map0="http://www.w3.org/2005/xpath-functions/map";{$NL}{$NL}</xsl:text>
       
-      <xsl:apply-templates select="//fos:function[@prefix='array']"/>
+      <xsl:text>declare function dm:iterate-array($array as array(*), $action as fn(item()*, xs:integer) as item()*) {{
+      array0:for-each($array, $action)
+}};</xsl:text>
+      
+      <xsl:text>declare function dm:array-append($array as array(*), $member as item()*) {{
+      array0:append($array, $member)
+}};</xsl:text>
+      
+      <xsl:text>declare function dm:iterate-map($map as map(*), $action as fn(xs:anyAtomicType, item()*) as item()*) {{
+      map0:for-each($map, $action)
+}};</xsl:text>
+      
+      <xsl:text>declare function dm:map-put($map as map(*), $key as xs:anyAtomicType, $value as item()*) {{
+      map0:put($map, $key, $value)
+}};</xsl:text>
+      
+      <xsl:apply-templates select="//fos:function[@prefix=('array', 'map')]"/>
       <xsl:text>element result {{</xsl:text>
       <xsl:apply-templates select="//fos:test"/>
       <xsl:text>()}}</xsl:text>
@@ -39,7 +58,7 @@
    
    <xsl:template match="fos:function[not(fos:equivalent)]" name="redirect">
       <xsl:text>{fos:sig(.)} {{ {$NL}{$NL}</xsl:text>
-      <xsl:text>    array0:{@name}( </xsl:text>
+      <xsl:text>    {@prefix}0:{@name}( </xsl:text>
       <xsl:value-of select="fos:signatures/fos:proto[1]/fos:arg ! ('$' || @name)" separator=", "/>
       <xsl:text>){$NL} }};{$NL}</xsl:text>
    </xsl:template>
@@ -70,9 +89,9 @@
       <xsl:text>{$NL}{$NL}</xsl:text>
    </xsl:template>
    
-   <xsl:template match="fos:equivalent[@style=('xquery-expression', 'xpath-expression')]">
+   <xsl:template match="fos:equivalent[@style=('xquery-expression', 'xpath-expression', 'dm-primitive')]">
       <xsl:text>{fos:sig(..)} {{ {$NL}{$NL}</xsl:text>
-      <xsl:value-of select="."/>
+      <xsl:value-of select="replace(., '(\n)', '$1        ')"/>
       <xsl:text>}};{$NL}{$NL}</xsl:text>
    </xsl:template>
    

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -1,7 +1,9 @@
 <?xml version='1.0'?>
 <xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="fos xs">
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+	exclude-result-prefixes="fos xs"
+	expand-text="yes">
 
 	<xsl:output method="xml" doctype-system="../../../schema/xsl-query.dtd"/>
 
@@ -151,6 +153,15 @@
 					<xsl:apply-templates select="$fspec/fos:rules/node()"/>
 				</def>
 			</gitem>
+			<xsl:if test="$fspec/fos:equivalent">
+				<gitem>
+					<label>Formal Specification</label>
+					<def>
+						<xsl:copy-of select="$fspec/fos:eqivalent/(@diff, @at)"/>
+						<xsl:apply-templates select="$fspec/fos:equivalent"/>
+					</def>
+				</gitem>
+			</xsl:if>
 			<xsl:if test="$fspec/fos:errors">
 				<gitem>
 					<label>Error Conditions</label>
@@ -170,35 +181,35 @@
 				</gitem>
 			</xsl:if>
 
-  <xsl:if test="$fspec/fos:examples">
-    <gitem>
-      <label>Examples</label>
-      <def role="example">
-	<xsl:copy-of select="$fspec/fos:examples/(@diff, @at)"/>
-   <xsl:if test="$fspec//fos:variable">
-   	<table role="medium">
-   		<thead><tr><th>Variables</th></tr></thead>
-   		<tbody>
-   			<xsl:apply-templates select="$fspec/fos:examples/fos:variable"/>
-   		</tbody>
-   	</table>
-   </xsl:if>
-	<table role="medium">
-	  <xsl:if test="fos:use-two-column-format($fspec/fos:examples)">
-	    <thead>
-	      <tr>
-		<th>Expression</th>
-		<th>Result</th>
-	      </tr>
-	    </thead>
-	  </xsl:if>
-	  <tbody>
-	    <xsl:apply-templates select="$fspec/fos:examples/node()[not(self::fos:variable)]"/>
-	  </tbody>
-	</table>						
-      </def>
-    </gitem>
-  </xsl:if>
+		  <xsl:if test="$fspec/fos:examples">
+		    <gitem>
+		      <label>Examples</label>
+		      <def role="example">
+					<xsl:copy-of select="$fspec/fos:examples/(@diff, @at)"/>
+				   <xsl:if test="$fspec//fos:variable">
+				   	<table role="medium">
+				   		<thead><tr><th>Variables</th></tr></thead>
+				   		<tbody>
+				   			<xsl:apply-templates select="$fspec/fos:examples/fos:variable"/>
+				   		</tbody>
+				   	</table>
+				   </xsl:if>
+					<table role="medium">
+					  <xsl:if test="fos:use-two-column-format($fspec/fos:examples)">
+					    <thead>
+					      <tr>
+						<th>Expression</th>
+						<th>Result</th>
+					      </tr>
+					    </thead>
+					  </xsl:if>
+					  <tbody>
+					    <xsl:apply-templates select="$fspec/fos:examples/node()[not(self::fos:variable)]"/>
+					  </tbody>
+					</table>						
+				 </def>
+		    </gitem>
+		  </xsl:if>
 			<xsl:if test="$fspec/fos:history">
 				<gitem>
 					<label>History</label>
@@ -304,6 +315,31 @@
 		<arg occur="{if (xs:boolean(@required)) then 'req' else 'opt'}">
 			<xsl:copy-of select="@name, @type, @type-ref, @diff, @at"/>
 		</arg>
+	</xsl:template>
+	
+	<xsl:template match="fos:equivalent[@style=('xpath-expression', 'xquery-expression')]">
+		<xsl:variable name="lang" select="if (@style='xpath-expression') then 'XPath' else 'XQuery'"/>
+		<p><xsl:text>The effect of the function is equivalent to the result of the following {$lang} expression</xsl:text>
+			<xsl:if test="xs:boolean(@covers-error-cases) = false()">
+				<xsl:text>, except in error cases</xsl:text>
+			</xsl:if>
+			<xsl:text>.</xsl:text>
+		</p>
+		<eg>
+			<xsl:value-of select="string(.) => replace('^\s+', '') => replace('\s+$', '')"/>
+		</eg>
+	</xsl:template>
+	
+	<xsl:template match="fos:equivalent[@style='xquery-function']">
+		<p><xsl:text>The function delivers the same result as the following XQuery implementation</xsl:text>
+			<xsl:if test="xs:boolean(@covers-error-cases) = false()">
+				<xsl:text>, except in error cases</xsl:text>
+			</xsl:if>
+			<xsl:text>.</xsl:text>
+		</p>
+		<eg>
+			<xsl:value-of select="string(.) => replace('^\s+', '') => replace('\s+$', '')"/>
+		</eg>
 	</xsl:template>
 
 	<xsl:template match="fos:example">

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -341,6 +341,23 @@
 			<xsl:value-of select="string(.) => replace('^\s+', '') => replace('\s+$', '')"/>
 		</eg>
 	</xsl:template>
+	
+	<xsl:template match="fos:equivalent[@style='dm-primitive']">
+		<p>The function is defined as follows, making use of primitive constructors and accessors defined
+		in <bibref ref="xpath-datamodel-40"/><xsl:text/>
+			<xsl:if test="xs:boolean(@covers-error-cases) = false()">
+				<xsl:text>, except in error cases</xsl:text>
+			</xsl:if>
+			<xsl:text>.</xsl:text>
+		</p>
+		<eg>
+			<xsl:value-of select="string(.) => replace('^\s+', '') => replace('\s+$', '')"/>
+		</eg>
+	</xsl:template>
+	
+	<xsl:template match="fos:equivalent">
+		<xsl:message terminate="yes">Non-matching fos:equivalent for {../@name}</xsl:message>
+	</xsl:template>
 
 	<xsl:template match="fos:example">
 		<xsl:apply-templates/>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -20627,14 +20627,14 @@ named <code>discounted</code>, independently of its value:</p>
          <head>Switch Expressions</head>
          
          <changes>
-            <change>
+            <change issue="328" PR="364" date="2023-03-07">
                Switch expressions now allow a <code>case</code> clause to match multiple atomic values.
             </change>
-            <change>
+            <change issue="365" PR="587" date="2023-11-07">
                Switch and typeswitch expressions can now be written with curly braces,
                   to improve readability.
             </change>
-            <change>
+            <change issue="671" PR="678" date="2023-09-12">
                The comparand expression in a switch expression can be omitted, allowing
                the switch cases to be provided as arbitrary boolean expressions.
             </change>
@@ -21288,7 +21288,7 @@ matching</termref>; otherwise it returns <code>false</code>. For example:</p>
             <head>Typeswitch</head>
             
             <changes>
-               <change>
+               <change issue="365" PR="587" date="2023-11-07">
                   Switch and typeswitch expressions can now be written with curly braces,
                   to improve readability.
                </change>


### PR DESCRIPTION
This PR does the following:

1. Makes schema changes for the function catalog to allow an executable specification of a function to be marked up as such.
2. Uses this markup initially for functions in the array namespace.
3. Makes stylesheet changes to render this markup in the published spec.
4. Commits an XSLT stylesheet (not yet integrated into the build system) that runs against the function catalog to produce an XQuery module whose effect is to declare functions based on the "executable specifications" and run the published executable examples against these functions, checking that they produce the expected result. The "success" output of this query (which runs with no source document) is an XML document containing an empty element `<result/>`. (If it has content, this will relate to tests that failed).

To get this to work, I had to tweak a couple of functions (array:sort and array:get) where Saxon has not yet implemented the required functionality. Although the test query is using the implementations from the spec, not those from Saxon, these implementations make calls on other functions where the Saxon implementation is used. For example array:fold-left calls fn:fold-left and this currently uses the Saxon implementation of fn:fold-left.

The query binds a dummy namespace to the `array` prefix to avoid problems with reserved namespaces. There are a couple of "core" functions that have no executable specification -- notably array:of-members() -- and the generated query contains an implementation of these that maps the function in the dummy array namespace to the function in the true array namespace.

This is phase 1. Most of the machinery is in place. It now needs to be applied to executable specifications of functions in other namespaces.

The stylesheet has no Saxon dependencies, but it does include a couple of template rules to exclude specific functions/tests that Saxon does not currently implement. The stylesheet could be made portable across implementations by moving these exception cases to an overriding stylesheet module.

I did find a few examples of supposedly executable code that needed fixing; hopefully these will show up in the diff version.