### PR TITLE
1348 Some grammar simplifications

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -74,7 +74,9 @@ apply.
   
   <g:production name="PredicatePattern" if="xslt40-patterns">
     <g:string>.</g:string>
-    <g:ref name="PredicateList"/>
+    <g:zeroOrMore>
+      <g:ref name="Predicate"/>
+    </g:zeroOrMore>
   </g:production>
   
   <g:production name="TypePattern" if="xslt40-patterns">
@@ -87,7 +89,9 @@ apply.
       <g:ref name="RecordTest" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="EnumerationType" lookahead="2" if="xpath40 xquery40 xslt40-patterns"/>
     </g:choice>
-    <g:ref name="PredicateList"/>
+    <g:zeroOrMore>
+      <g:ref name="Predicate"/>
+    </g:zeroOrMore>
   </g:production>
   
   <g:production name="WrappedItemTest" if="xslt40-patterns">
@@ -143,7 +147,9 @@ apply.
       <g:ref name="VarRef"/>
       <g:ref name="FunctionCallP"/>
     </g:choice>
-    <g:ref name="PredicateList"/>
+    <g:zeroOrMore>
+      <g:ref name="Predicate"/>
+    </g:zeroOrMore>
     <g:optional>
       <g:choice name="RootedPathOperator">
         <g:ref name="Slash"/>
@@ -207,7 +213,9 @@ apply.
   
   <g:production name="PostfixExprP" if=" xslt40-patterns" >
     <g:ref name="ParenthesizedExprP"/>
-    <g:ref name="PredicateList"/>
+    <g:zeroOrMore>
+      <g:ref name="Predicate"/>
+    </g:zeroOrMore>
   </g:production>
   
   <g:production name="ParenthesizedExprP" if=" xslt40-patterns" >
@@ -218,7 +226,9 @@ apply.
   
   <g:production name="AxisStepP" if=" xslt40-patterns" >
     <g:ref name="ForwardStepP"/>
-    <g:ref name="PredicateList"/>
+    <g:zeroOrMore>
+      <g:ref name="Predicate"/>
+    </g:zeroOrMore>
   </g:production>
   
   <g:production name="ForwardStepP"  if=" xslt40-patterns" node-type="void">
@@ -698,14 +708,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:optional>
     <g:string>function</g:string>
     <g:ref name="_Function_QName_or_EQName" unfold="yes"/>   
-    <g:ref name="FunctionSignatureWithDefaults"/>
-    <g:choice name="FunctionDeclBody">
-      <g:ref name="FunctionBody" if="xquery40"/>
-      <g:ref name="External"/>
-    </g:choice>
-  </g:production>
-  
-  <g:production name="FunctionSignatureWithDefaults">
     <g:string>(</g:string>
     <g:optional name="OptionalFamilyParamList">
       <g:ref name="ParamListWithDefaults"/>
@@ -714,6 +716,10 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:optional name="optionFuncFamilyType">
       <g:ref name="TypeDeclaration"/>
     </g:optional>
+    <g:choice name="FunctionDeclBody">
+      <g:ref name="FunctionBody" if="xquery40"/>
+      <g:ref name="External"/>
+    </g:choice>
   </g:production>
   
   <g:production name="FunctionSignature">
@@ -736,11 +742,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="ParamWithDefault" if=" xpath40 xquery40 ">
-    <g:string>$</g:string>
-    <g:ref name="_QName_or_EQName" unfold="yes"/>
-    <g:optional name="OptionalTypeDeclarationForParamWithDefault">
-      <g:ref name="TypeDeclaration"/>
-    </g:optional>
+    <g:ref name="Param"/>
     <g:optional name="OptionalDefaultForParam">
       <g:string>:=</g:string>
       <g:ref name="StandaloneExpr"/>
@@ -1225,10 +1227,6 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="GroupByClause" if="xquery40">
     <g:string>group</g:string>
     <g:string>by</g:string>
-    <g:ref name="GroupingSpecList"/>
-  </g:production>
-
-  <g:production name="GroupingSpecList" if="xquery40">
     <g:ref name="GroupingSpec"/>
     <g:zeroOrMore name="GroupingSpecListTail">
       <g:string>,</g:string>
@@ -1258,21 +1256,11 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
 
 
   <g:production name="OrderByClause" if=" xquery40">
-    <g:choice break="false" name="OrderByOrOrderByStable">
-      <g:sequence>
-        <g:string>order</g:string>
-        <g:string>by</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">stable</g:string>
-        <g:string>order</g:string>
-        <g:string>by</g:string>
-      </g:sequence>
-    </g:choice>
-    <g:ref name="OrderSpecList"/>
-  </g:production>
-
-  <g:production name="OrderSpecList" if=" xquery40">
+    <g:optional>
+      <g:string process-value="yes">stable</g:string>
+    </g:optional>
+    <g:string>order</g:string>
+    <g:string>by</g:string>
     <g:ref name="OrderSpec"/>
     <g:zeroOrMore name="OrderSpecListTail">
       <g:string>,</g:string>
@@ -1498,10 +1486,6 @@ ErrorVal ::= "$" VarName
 
   <g:production name="TryClause" if="xquery40">
     <g:string>try</g:string>
-    <g:ref name="EnclosedTryTargetExpr"/>
-  </g:production>
-
-  <g:production name="EnclosedTryTargetExpr" if="xquery40">
     <g:ref name="EnclosedExpr"/>
   </g:production>
 
@@ -1865,7 +1849,9 @@ ErrorVal ::= "$" VarName
       <g:ref name="ReverseStep" lookahead="2"/>
       <g:ref name="ForwardStep"/>
     </g:choice>
-    <g:ref name="PredicateList"/>
+    <g:zeroOrMore>
+      <g:ref name="Predicate"/>
+    </g:zeroOrMore>
   </g:production>
 
   <g:production name="ForwardStep" node-type="void">
@@ -1877,43 +1863,22 @@ ErrorVal ::= "$" VarName
       <g:ref name="AbbrevForwardStep"/>
     </g:choice>
   </g:production>
-
+  
   <g:production name="ForwardAxis">
     <g:choice break="true" name="ForwardAxisNames">
-      <g:sequence>
-        <g:string process-value="yes">child</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">descendant</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">attribute</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">self</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">descendant-or-self</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">following-sibling</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">following</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence if=" xpath40  xslt40-patterns">
-        <g:string process-value="yes">namespace</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-    </g:choice>
+      <g:string process-value="yes">attribute</g:string>
+      <g:string process-value="yes">child</g:string>
+      <g:string process-value="yes">descendant</g:string>
+      <g:string process-value="yes">descendant-or-self</g:string>     
+      <g:string process-value="yes">following</g:string>
+      <g:string process-value="yes">following-sibling</g:string>
+      <g:string process-value="yes" if="xpath40 xslt40-patterns">namespace</g:string>
+      <g:string process-value="yes">self</g:string>
+    </g:choice>         
+    <g:string>::</g:string>
   </g:production>
+
+ 
 
   <g:production name="AbbrevForwardStep">
     <g:choice>
@@ -1937,27 +1902,13 @@ ErrorVal ::= "$" VarName
 
   <g:production name="ReverseAxis">
     <g:choice break="true" name="ReverseAxisNames">
-      <g:sequence>
-        <g:string process-value="yes">parent</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">ancestor</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">preceding-sibling</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">preceding</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
-      <g:sequence>
-        <g:string process-value="yes">ancestor-or-self</g:string>
-        <g:string>::</g:string>
-      </g:sequence>
+      <g:string process-value="yes">ancestor</g:string>
+      <g:string process-value="yes">ancestor-or-self</g:string>   
+      <g:string process-value="yes">parent</g:string>     
+      <g:string process-value="yes">preceding</g:string> 
+      <g:string process-value="yes">preceding-sibling</g:string>
     </g:choice>
+    <g:string>::</g:string>
   </g:production>
 
   <g:production name="AbbrevReverseStep">
@@ -2077,11 +2028,11 @@ ErrorVal ::= "$" VarName
     <g:ref name="Argument"/> 
   </g:production>
 
-  <g:production name="PredicateList" condition="&gt; 0">
+  <!--<g:production name="PredicateList" condition="&gt; 0">
     <g:zeroOrMore name="PredicatesListX">
       <g:ref name="Predicate"/>
     </g:zeroOrMore>
-  </g:production>
+  </g:production>-->
 
   <g:production name="Predicate">
     <g:string>[</g:string>
@@ -2847,12 +2798,8 @@ ErrorVal ::= "$" VarName
   <g:production name="SchemaAttributeTest" >
     <g:string>schema-attribute</g:string>
     <g:string>(</g:string>
-    <g:ref name="AttributeDeclaration"/>
-    <g:string>)</g:string>
-  </g:production>
-
-  <g:production name="AttributeDeclaration" >
     <g:ref name="AttributeName"/>
+    <g:string>)</g:string>
   </g:production>
 
   <g:production name="ElementTest" >
@@ -2874,12 +2821,8 @@ ErrorVal ::= "$" VarName
   <g:production name="SchemaElementTest" >
     <g:string>schema-element</g:string>
     <g:string>(</g:string>
-    <g:ref name="ElementDeclaration"/>
-    <g:string>)</g:string>
-  </g:production>
-
-  <g:production name="ElementDeclaration" >
     <g:ref name="ElementName"/>
+    <g:string>)</g:string>
   </g:production>
 
   <g:production name="AttributeName" >

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11,8 +11,7 @@
                The term <term>atomic value</term> has been replaced by <term>atomic item</term>.
             </change>
          </changes>
-
-      
+     
       <p>The basic  building block of &language; is the
 	 <term>expression</term>, which is a string of <bibref
             ref="Unicode"/> characters; the version of Unicode to be used is <termref

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3996,15 +3996,12 @@ the schema type named <code>us:address</code>.</p>
                
                <prodrecap ref="ElementTest"/>
                <prodrecap ref="SchemaElementTest"/>
-               <prodrecap ref="ElementDeclaration"/>
                <prodrecap ref="AttributeTest"/>
                
                <prodrecap ref="SchemaAttributeTest"/>
-               <prodrecap ref="AttributeDeclaration"/>
                
-               <!--<prodrecap ref="ElementNameOrWildcard"/>-->
                <prodrecap id="ElementName" ref="ElementName"/>
-               <!--<prodrecap ref="AttribNameOrWildcard"/>-->
+
                
                <prodrecap id="AttributeName" ref="AttributeName"/>
                
@@ -4723,7 +4720,6 @@ matches any nilled or non-nilled element node whose type annotation is
                <scrap>
                   <head/>
                   <prodrecap id="SchemaElementTest" ref="SchemaElementTest"/>
-                  <prodrecap id="ElementDeclaration" ref="ElementDeclaration"/>
                   <prodrecap ref="ElementName"/>
                </scrap>
 
@@ -5000,7 +4996,6 @@ name.</p>
                <scrap>
                   <head/>
                   <prodrecap id="SchemaAttributeTest" ref="SchemaAttributeTest"/>
-                  <prodrecap id="AttributeDeclaration" ref="AttributeDeclaration"/>
                   <prodrecap ref="AttributeName"/>
                </scrap>
 
@@ -11041,7 +11036,7 @@ return if (every $r in $R satisfies $r instance of node())
                <prodrecap ref="AxisStep"/>
                <prodrecap id="ForwardStep" ref="ForwardStep"/>
                <prodrecap id="ReverseStep" ref="ReverseStep"/>
-               <prodrecap ref="PredicateList"/>
+               <prodrecap ref="Predicate"/>
             </scrap>
             <p>
                <termdef term="step" id="dt-step">A <term>step</term> is a part of a <termref
@@ -11784,7 +11779,6 @@ return if (every $r in $R satisfies $r instance of node())
             <scrap>
                <head/>
                <prodrecap id="AxisStep" ref="AxisStep"/>
-               <prodrecap id="PredicateList" ref="PredicateList"/>
                <prodrecap ref="Predicate"/>
             </scrap>
             <p id="dt-predicate"
@@ -16309,11 +16303,9 @@ element because it is defined by a <termref
             <prodrecap ref="WhereClause" role="xquery"/>
             <prodrecap ref="WhileClause" role="xquery"/>
             <prodrecap id="GroupByClause" ref="GroupByClause" role="xquery"/>
-            <prodrecap id="GroupingSpecList" ref="GroupingSpecList" role="xquery"/>
             <prodrecap id="GroupingSpec" ref="GroupingSpec" role="xquery"/>
             <prodrecap id="GroupingVariable" ref="GroupingVariable" role="xquery"/>
             <prodrecap ref="OrderByClause" role="xquery"/>
-            <prodrecap ref="OrderSpecList" id="OrderSpecList" role="xquery"/>
             <prodrecap ref="OrderSpec" id="OrderSpec" role="xquery"/>
             <prodrecap ref="OrderModifier" id="OrderModifier" role="xquery"/>
             <prodrecap ref="ReturnClause" id="ReturnClause" role="xquery"/>
@@ -17583,7 +17575,6 @@ return &lt;product rank="{ $rank }"&gt;{ $p/name, $p/sales }&lt;/product&gt;</eg
             <scrap>
                <head/>
                <prodrecap ref="GroupByClause"/>
-               <prodrecap ref="GroupingSpecList"/>
                <prodrecap ref="GroupingSpec"/>
                <prodrecap ref="GroupingVariable"/>
             </scrap>
@@ -17967,7 +17958,6 @@ return $product/@code</eg>
             <scrap>
                <head/>
                <prodrecap id="OrderByClause" ref="OrderByClause"/>
-               <prodrecap ref="OrderSpecList"/>
                <prodrecap ref="OrderSpec"/>
                <prodrecap ref="OrderModifier"/>
 
@@ -20713,7 +20703,7 @@ query using the <code>fn:error()</code> function.</p>
             <head/>
             <prodrecap id="TryCatchExpr" ref="TryCatchExpr"/>
             <prodrecap id="TryClause" ref="TryClause"/>
-            <prodrecap id="EnclosedTryTargetExpr" ref="EnclosedTryTargetExpr"/>
+            <!--<prodrecap id="EnclosedTryTargetExpr" ref="EnclosedTryTargetExpr"/>-->
             <prodrecap id="CatchClause" ref="CatchClause"/>
             <prodrecap ref="NameTestUnion"/>
             <prodrecap ref="NameTest"/>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1559,9 +1559,9 @@ declare context value as document-node()* := collection($uri); </eg>
       <prodrecap ref="AnnotatedDecl"/>
       <prodrecap ref="Annotation"/>
       <prodrecap id="FunctionDecl" ref="FunctionDecl"/>
-      <prodrecap id="FunctionSignatureWithDefaults" ref="FunctionSignatureWithDefaults"/>
       <prodrecap id="ParamListWithDefaults" ref="ParamListWithDefaults"/>
       <prodrecap id="ParamWithDefault" ref="ParamWithDefault"/>
+      <prodrecap ref="Param"/>
       <prodrecap id="FunctionBody" ref="FunctionBody"/>
       <prodrecap ref="TypeDeclaration"/>
       <prodrecap ref="EnclosedExpr"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10678,7 +10678,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <scrap headstyle="show" id="PredicatePatterns-scrap">
                      <head></head>
                      <prodrecap ref="PredicatePattern"/>
-                     <prodrecap ref="PredicateList" id="PredicateList"/>
+                     <prodrecap ref="Predicate" id="Predicate"/>
                   </scrap>
                   
                   <p>A <nt def="PredicatePattern">PredicatePattern</nt>
@@ -10689,8 +10689,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   
                   
                   <note>
-                     <p>The pattern <code>.</code>, which is a <code>PredicatePattern</code> with an
-                        empty <xnt spec="XP40" ref="prod-xpath40-PredicateList">PredicateList</xnt>,
+                     <p>The pattern <code>.</code>, which is a <code>PredicatePattern</code> with no predicates,
                         matches every item.</p>
                      <p>A predicate with the numeric value 1 (one) always matches, and a predicate with
                         any other numeric value never matches. Numeric predicates in a
@@ -10742,8 +10741,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      <prodrecap ref="FieldName" id="FieldName"/>
                      <prodrecap ref="ExtensibleFlag" id="ExtensibleFlag"/>
                      <prodrecap ref="EnumerationType" id="EnumerationType"/>
-                     <prodrecap ref="NamedItemType" id="NamedItemType"/>
-                     <prodrecap ref="PredicateList"/>
+                     <prodrecap ref="TypeName" id="TypeName"/>
+                     <prodrecap ref="Predicate"/>
                   </scrap>
                   
       
@@ -12937,7 +12936,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      the first <nt def="PathExprP">PathExprP</nt>. </p>
                </item>
                <item>
-                  <p>If the pattern is a <nt def="PredicatePattern">PredicatePattern</nt> then its priority is 1 (one), unless the <xnt spec="XP40" ref="prod-xpath40-PredicateList">PredicateList</xnt> is empty,
+                  <p>If the pattern is a <nt def="PredicatePattern">PredicatePattern</nt> then its priority is 1 (one),
+                     unless there are no predicates,
                      in which case the priority is −1 (minus one).</p>
                   
                   
@@ -32756,7 +32756,7 @@ the same group, and the-->
                                     <code>descendant-or-self</code></p>
                            </item>
                            <item>
-                              <p>There is a predicate <var>P</var> in the <code>PredicateList</code>
+                              <p>There is a predicate <var>P</var> in the list of predicates
                                  that satisfies all the following conditions:</p>
                               <olist>
                                  <item>
@@ -32786,7 +32786,7 @@ the same group, and the-->
 
                      </item>
                      <item>
-                        <p>If the <code>PredicateList</code> contains a <code>Predicate</code> that
+                        <p>If the list of predicates contains a <code>Predicate</code> that
                            is not <termref def="dt-motionless"/>, then the sweep is <termref def="dt-free-ranging"/> and the posture is <termref def="dt-roaming"/>;</p>
                      </item>
 


### PR DESCRIPTION
Fix #1348

Makes some simplifications to the grammar rules, including some of those suggested.

I've avoided removing productions that are referenced by name in the prose of the spec; these names provide a useful handle to relate the syntax to the semantics.

I would love to introduce BNF for a comma-separated list. Invisible XML uses

`XX ** ","`

for zero or more occurrences of XX, separated by ",", and

`XX ++ ","`

for one or more occurrences of XX, separated by ",", and
