### PR TITLE
1337 Atomic value becomes atomic item

### DIFF
--- a/specifications/grammar-40/parser/javacc.xsl
+++ b/specifications/grammar-40/parser/javacc.xsl
@@ -620,7 +620,7 @@
   Revision 1.7  2002/03/13 15:45:05  sboag
   Don changes (XPathXQuery.xml, introduction.xml, fragment.xml):
   I have attempted to update these files with the latest terminology
-   (mainly changing "simple value" to "atomic value" and related changes.)
+   (mainly changing "simple value" to "atomic item" and related changes.)
 
   Grammar changes:
   Moral equal of Philip Wadler's structural changes of 02/05/2002.

--- a/specifications/xpath-datamodel-40/src/attribute.xml
+++ b/specifications/xpath-datamodel-40/src/attribute.xml
@@ -348,7 +348,7 @@ is its <function>string-value</function> as an <code>xs:untypedAtomic</code>.
 </p>
 </item>
 <item>
-<p>Otherwise, a sequence of zero or more atomic values as described in 
+<p>Otherwise, a sequence of zero or more atomic items as described in 
 <specref ref="TypedValueDetermination"/>. The relationship between the 
 type-name, typed-value, and string-value of an attribute node is 
 consistent with XML Schema validation.</p>
@@ -371,7 +371,7 @@ an implementation <rfc2119>may</rfc2119> raise a dynamic error.
 The <emph role='dm-node-property'>is-id</emph>
 property is always true for attributes named <code>xml:id</code>.</p>
 <p>Otherwise, if the typed-value of the attribute consists of
-exactly one atomic value and that value is of type <code>xs:ID</code>,
+exactly one atomic item and that value is of type <code>xs:ID</code>,
 or a type derived from <code>xs:ID</code>,
 the <emph role='dm-node-property'>is-id</emph>
 property is <code>true</code>, otherwise it is <code>false</code>.</p>
@@ -407,7 +407,7 @@ attributes named <att>xml:id</att>.</p>
 <gitem>
 <label><emph role='dm-node-property'>is-idrefs</emph></label>
 <def>
-<p>If any of the atomic values in the typed-value of the
+<p>If any of the atomic items in the typed-value of the
 attribute is of type <code>xs:IDREF</code> or <code>xs:IDREFS</code>, or
 a type derived from one of those types, the
 <emph role='dm-node-property'>is-idrefs</emph>
@@ -427,7 +427,7 @@ values of type <code>xs:IDREF</code> alongside values of other types.
 <phrase diff="add" at="2015-03-26">A node
 has the
 <emph role='dm-node-property'>is-idrefs</emph> property only if the typed value contains at least
-one atomic value that is an instance of <code>xs:IDREF</code>;
+one atomic item that is an instance of <code>xs:IDREF</code>;
 it is not sufficient that the type annotation permits such values.</phrase>
 </p>
 </note>

--- a/specifications/xpath-datamodel-40/src/element.xml
+++ b/specifications/xpath-datamodel-40/src/element.xml
@@ -676,7 +676,7 @@ is the empty sequence.
 <p>If the element has a simple type or a complex type with simple content:
 its typed value is computed as described in
 <specref ref="TypedValueDetermination"/>.
-The result is a sequence of zero or more atomic values. The
+The result is a sequence of zero or more atomic items. The
 relationship between the type-name, typed-value, and string-value of an
 element node is consistent with XML Schema validation.
 </p>
@@ -712,7 +712,7 @@ Attempting to access this property with the
 the <emph role='dm-node-property'>is-id</emph>
 property is <code>false</code>.
 Otherwise, if the typed-value of the element consists of exactly
-one atomic value and that value is of type <code>xs:ID</code>,
+one atomic item and that value is of type <code>xs:ID</code>,
 or a type derived from <code>xs:ID</code>,
 the <emph role='dm-node-property'>is-id</emph>
 property is <code>true</code>, otherwise it is <code>false</code>.</p>
@@ -738,7 +738,7 @@ is uniquely identified by this ID.</p>
 <p>If the element has a complex type with element-only content, the
 <emph role='dm-node-property'>is-id</emph>
 property is <code>false</code>. Otherwise, if the typed-value of the element
-consists of exactly one atomic value that value is of type <code>xs:ID</code>, or
+consists of exactly one atomic item that value is of type <code>xs:ID</code>, or
 a type derived from <code>xs:ID</code>, the
 <emph role='dm-node-property'>is-id</emph> property is <code>true</code>,
 otherwise it is <code>false</code>.</p>
@@ -752,7 +752,7 @@ otherwise it is <code>false</code>.</p>
 <p>If the element has a complex type with element-only content, the
 <emph role='dm-node-property'>is-idrefs</emph>
 property is <code>false</code>. 
-Otherwise, if any of the atomic values in the typed-value of the
+Otherwise, if any of the atomic items in the typed-value of the
 element is of type <code>xs:IDREF</code> or <code>xs:IDREFS</code>, or
 a type derived from one of those types, the
 <emph role='dm-node-property'>is-idrefs</emph>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -262,7 +262,7 @@ the <bibref ref="xml-infoset"/>
     complex values. </p>
   </item>
   <item>
-    <p>Support for typed atomic values.</p>
+    <p>Support for typed atomic items.</p>
   </item>
   <item>
     <p>Support for ordered, heterogeneous sequences.</p>
@@ -280,7 +280,7 @@ values of expressions used during the intermediate calculations.
 Examples include the input document or document repository (represented
 as a &documentNode; or a sequence of &documentNode;s), the result of a
 path expression (represented as a sequence of nodes), the result of an
-arithmetic or a logical expression (represented as an atomic value),
+arithmetic or a logical expression (represented as an <termref def="dt-atomic-item"/>),
 a sequence expression resulting in a sequence of items, etc.
 </p>
 
@@ -328,7 +328,7 @@ explanatory purposes and are not normative.</p>
     influence the behavior.</p>
 
 <p>This specification distinguishes between the data model as a general
-concept and specific items (documents, elements, atomic values, etc.)
+concept and specific items (documents, elements, <termref def="dt-atomic-item">atomic items</termref>, etc.)
 that are concrete examples of the data model by identifying all concrete
 examples as <termref def="dt-instance">instances of the data model</termref>.
 </p>
@@ -360,6 +360,9 @@ examples as <termref def="dt-instance">instances of the data model</termref>.
       <change issue="225" PR="232" date="2022-11-05">
         Clarified the terminology concerning atomic types and type annotations.
       </change>
+      <change issue="1337" date="2024-08-02">
+        The term <term>atomic value</term> has been replaced by <termref def="dt-atomic-item"/>.
+      </change>
     </changes>
 
 <p><termdef id="dt-instance" term="instance of the data model">Every
@@ -381,7 +384,7 @@ ref="sequences"/>.</p>
 is either
 a <termref def="dt-node">node</termref>,
 a <termref def="dt-function-item">function</termref>,
-or an <termref def="dt-atomic-value">atomic value</termref>.</termdef>
+or an <termref def="dt-atomic-item">atomic item</termref>.</termdef>
 </p>
 
     <p diff="add" at="2022-11-05"><termdef id="dt-item-type" term="item type">An <term>item type</term> represents
@@ -423,12 +426,12 @@ tree whose root node is a &documentNode; is referred to as a
 term="fragment">A tree whose root node is not a &documentNode; is
 referred to as a <term>fragment</term>.</termdef></p>
 
-<p diff="chg" at="2022-11-05"><termdef id="dt-atomic-value" term="atomic value">An
-<term>atomic value</term> is a pair (<var>T</var>, <var>D</var>) where <var>T</var> (the <termref def="dt-type-annotation"/>)
+<p diff="chg" at="2022-11-05"><termdef id="dt-atomic-item" term="atomic item">An
+<term>atomic item</term> is a pair (<var>T</var>, <var>D</var>) where <var>T</var> (the <termref def="dt-type-annotation"/>)
   is an <termref def="dt-atomic-type"/>, and <var>D</var> (the <termref def="dt-datum"/>)
   is a point in the value space of <var>T</var>.</termdef></p>
     
-    <p diff="chg" at="2022-11-05"><termdef id="dt-datum" term="datum">The <term>datum</term> of an <termref def="dt-atomic-value"/>
+    <p diff="chg" at="2022-11-05"><termdef id="dt-datum" term="datum">The <term>datum</term> of an <termref def="dt-atomic-item"/>
       is a point in the value space of its type, which is also a point in the value space of
       the primitive type from which that type is derived.</termdef> There are 20 primitive atomic types (19 defined
       in XSD, plus <code>xs:untypedAtomic</code>), and these have non-overlapping value spaces, so each
@@ -458,7 +461,7 @@ another atomic type.</termdef>
 in <specref ref="xs-types"/>.</termdef></p>
     
     <p diff="chg" at="2022-11-05"><termdef id="dt-type-annotation" term="type annotation">The term <term>type annotation</term> has
-      two slightly different meanings. For an atomic value, the type annotation of the value
+      two slightly different meanings. For an <termref def="dt-atomic-item"/>, the type annotation of the value
       is the most specific <termref def="dt-atomic-type"/> that it is an instance of (it is also an instance of every type from which that
       type is derived). For an element or attribute node, the type annotation is the <termref def="dt-schema-type"/>
       (a simple or complex type) against which the node has been validated, defaulting to
@@ -468,7 +471,7 @@ in <specref ref="xs-types"/>.</termdef></p>
     <p><phrase diff="chg" at="2022-11-05">Named types are identified</phrase> in the data model by an
     <termref def="dt-expanded-qname">expanded QName</termref>. <phrase diff="add" at="2022-11-05">A schema 
       may also contain anonymous types, and these may be used as <termref def="dt-type-annotation">type annotations</termref> 
-      on nodes and atomic values; anonymous types, however, cannot be referenced explicitly in programs.</phrase>
+      on nodes and atomic items; anonymous types, however, cannot be referenced explicitly in programs.</phrase>
     </p>
     
    
@@ -602,7 +605,7 @@ a node is distinct from its value or other intrinsic properties; nodes may be
 distinct even when they have the same values for all intrinsic
 properties other than their identity.
 (The
-identity of atomic values, by contrast, is determined solely by their
+identity of <termref def="dt-atomic-item">atomic items</termref>, by contrast, is determined solely by their
 intrinsic properties. No two distinct integers, for example, have the
 same value;
 every instance of the value “5” as an integer is identical to every
@@ -682,12 +685,13 @@ stable but implementation-dependent.</imp-dep-feature>
 <head>Sequences</head>
 
 <p>An important characteristic of the data model is that there is no
-distinction between an <termref def="dt-item"/> (a node, function, or atomic value) and a
+distinction between an <termref def="dt-item"/> (a node, function, or <termref def="dt-atomic-item"/>) and a
 singleton <termref def="dt-sequence"/> containing that item. An item is
 equivalent to a singleton sequence containing that item and vice
 versa.</p>
 
-<p>A sequence may contain any mixture of nodes, functions, and atomic values. When a node is added to a sequence its
+<p>A sequence may contain any mixture of nodes, functions, and 
+  <termref def="dt-atomic-item">atomic items</termref>. When a node is added to a sequence its
 identity remains the same. Consequently a node may occur in more than
 one sequence and a sequence may contain duplicate items.</p>
 
@@ -854,7 +858,7 @@ may be used in language constructs only if the components are present in
 the static context.</p>
 </item>
 <item>
-<p>Values including element and attribute nodes, and atomic values,
+<p>Values including element and attribute nodes, and <termref def="dt-atomic-item">atomic items</termref>,
 have a property called a type annotation whose value is a type: this is
 a reference to a type definition in the Schema Component Model.
 </p>
@@ -1022,7 +1026,7 @@ It is the responsibility of the host language to define the
 size and scope of the processing context.</p>
   
   <note diff="add" at="2022-11-05"><p>The type annotation of a schema-validated node,
-  or of an atomic value extracted by atomizing a schema-validated node,
+  or of an <termref def="dt-atomic-item"/> extracted by atomizing a schema-validated node,
   may be an anonymous type. Queries and expressions cannot refer explicitly
   to anonymous types, but it is always possible to test whether such an item
   matches a named type from which the anonymous type is derived.</p></note>
@@ -1045,7 +1049,7 @@ size and scope of the processing context.</p>
     arithmetic operations (such as comparing two durations) are available in XPath only on these
     subtypes of <code>xs:duration</code>, not on the primitive type <code>xs:duration</code> itself.</p>
     <p>The datatype <code>xs:anyAtomicType</code> is an atomic type that
-      includes all atomic values (and no values that are not atomic). Its
+      includes all atomic items (and no values that are not atomic). Its
       base type is <code>xs:anySimpleType</code>, from which all simple
       types, including atomic, list, and union types are derived. All
       primitive atomic types, such as <code>xs:decimal</code> and
@@ -1154,7 +1158,7 @@ be consumed by the processor, <rfc2119>must</rfc2119> ensure that</p>
 well-formedness criteria of the selected version of XML.</p>
 </item>
 <item><p>Any schema validation carried out using an XML Schema 1.0 or 1.1 schema rejects
-any nodes or atomic values containing characters that do not satisfy the
+any nodes or <termref def="dt-atomic-item">atomic items</termref> containing characters that do not satisfy the
 constraints of the selected version of XML.</p></item>
 </olist>
   
@@ -1195,7 +1199,7 @@ constraints of the selected version of XML.</p></item>
       <code>comment()</code>, <code>processing-instruction()</code>, or
       <code>namespace()</code>. Nodes may also be instances of more specific
       types characterized by the node name and type annotation.</p></item>
-    <item><p>Every <termref def="dt-atomic-value"/> is an instance of a specific <termref def="dt-atomic-type"/>
+    <item><p>Every <termref def="dt-atomic-item"/> is an instance of a specific <termref def="dt-atomic-type"/>
       determined by its <termref def="dt-type-annotation"/>; it is also an instance of every type from which that
       type is derived by restriction (directly or indirectly), and of every union type that
       includes that type as a member type.</p></item>
@@ -1270,10 +1274,16 @@ can be used as type annotations on nodes).</p>
 
 
 <div3 id="AtomicValue">
-<head>Atomic Values</head>
+<head>Atomic Items</head>
+  
+  <changes>
+    <change issue="1337" date="2024-08-02">
+      The term <term>atomic value</term> has been replaced by <termref def="dt-atomic-item"/>.
+    </change>
+  </changes>
 
-<p>An <termref def="dt-atomic-value"/> can be constructed from a lexical
-representation. Given a string and an <termref def="dt-atomic-type"/>, the atomic value is
+<p>An <termref def="dt-atomic-item"/> can be constructed from a lexical
+representation. Given a string and an <termref def="dt-atomic-type"/>, the atomic item is
 constructed in such a way as to be
 <loc href="#typed-string-relationships">consistent with schema validation</loc>.
 If the
@@ -1289,9 +1299,9 @@ section of <bibref ref="xpath-functions-40"/>.
 <div3 id="StringValue">
 <head>String Values</head>
 
-<p>A string value can be constructed from an atomic value.
+<p>A string value can be constructed from an <termref def="dt-atomic-item"/>.
 Such a value is constructed by
-converting the atomic value to its string representation as described
+converting the atomic item to its string representation as described
 in <xspecref spec="FO40" ref="casting"/>.
 </p>
 </div3>
@@ -1742,7 +1752,7 @@ tables in a database.
 Data model construction from sources other than
 an Infoset or PSVI is implementation-defined.
 Regardless of how an instance of the data model
-is constructed, every node and atomic value in the data model must
+is constructed, every node and <termref def="dt-atomic-item"/> in the data model must
 have a typed value that is consistent with its type.</p>
 
 <imp-def-feature>Data model construction from sources other than
@@ -1753,7 +1763,7 @@ by <bibref ref="xml-infoset"/>. Examples of these are
 <termref def="dt-fragment">document fragments</termref>
 and sequences of &documentNode;s.
 The data model also supports values that are not nodes. Examples of
-these are sequences of <termref def="dt-atomic-value">atomic values</termref>,
+these are sequences of <termref def="dt-atomic-item">atomic items</termref>,
 or sequences mixing nodes and atomic
 values. These are necessary to be able to represent the results of
 intermediate expressions in the data model during expression
@@ -2004,7 +2014,7 @@ or a complex type with simple content. For other kinds of
 &attributeNode;s, see <specref ref="const-psvi-attribute"/>.</p>
 
 <p>The typed value of &attributeNode;s and some &elementNode;s is a
-sequence of atomic values. The
+sequence of <termref def="dt-atomic-item">atomic items</termref>. The
 types of the items in the typed value of a node may differ from
 the type of the node itself. This section describes how the typed
 value of a node is derived from the properties of an information item
@@ -2057,8 +2067,9 @@ is simply <code>T</code>.
 </ulist>
 
 <p>The typed value determination process is guaranteed to result in a
-sequence of atomic values, each having a well-defined atomic type. This
-sequence of atomic values, in turn, determines the
+sequence of <termref def="dt-atomic-item">atomic items</termref>, 
+  each having a well-defined atomic type. This
+sequence of atomic items, in turn, determines the
 typed-value property of the node in the data model.</p>
 </div4>
 
@@ -2320,7 +2331,7 @@ that defines the namespace bindings.</p>
 <p>When qualified names exist as values of nodes in a well-formed document,
 it is always possible to determine such a namespace context. However,
 the data model also allows qualified names to exist as freestanding
-atomic values, or as the name or value of a parentless attribute node,
+<termref def="dt-atomic-item">atomic items</termref>, or as the name or value of a parentless attribute node,
 and in these cases no namespace context is available.</p>
 
 <p>In this Data Model, therefore, the value space for qualified names

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -243,7 +243,7 @@
                      <code>dm:string-value</code> accessor defined in <bibref
                ref="xpath-datamodel-31"/> (see <xspecref spec="DM40" ref="dm-string-value"/>).</p>
 
-         <p>If <code>$value</code> is an atomic value, the function returns the result of the expression <code>$value cast
+         <p>If <code>$value</code> is an atomic item, the function returns the result of the expression <code>$value cast
                      as xs:string</code> (see <specref
                ref="casting"/>).</p>
 
@@ -272,7 +272,7 @@
       </fos:errors>
       <fos:notes>
          <p>Every node has a string value, even an element with element-only
-            content (which has no typed value). Moreover, casting an atomic value to a string always
+            content (which has no typed value). Moreover, casting an atomic item to a string always
             succeeds. Functions, maps, and arrays have no string value, so these are the
             only arguments that satisfy the type signature but cause failure.</p>
       </fos:notes>
@@ -338,15 +338,15 @@
          <p>If the argument is omitted, it defaults to the context value (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
             behavior of the function if the argument is omitted is exactly the same as if the
             context value had been passed as the argument.</phrase></p>
-         <p> The result of <code>fn:data</code> is the sequence of atomic values produced by
+         <p> The result of <code>fn:data</code> is the sequence of atomic items produced by
             applying the following rules to each item in <code>$input</code>:</p>
          <ulist>
             <item>
-               <p>If the item is an atomic value, it is appended to the result sequence.</p>
+               <p>If the item is an atomic item, it is appended to the result sequence.</p>
             </item>
             <item>
                <p>If the item is a node, the typed value of the node is appended to the result
-                  sequence. The typed value is a sequence of zero or more atomic values:
+                  sequence. The typed value is a sequence of zero or more atomic items:
                   specifically, the result of the <code>dm:typed-value</code> accessor as defined in
                      <bibref
                      ref="xpath-datamodel-31"/> (See <xspecref spec="DM40" ref="dm-typed-value"
@@ -374,7 +374,7 @@
          <p>The process of applying the <code>fn:data</code> function to a sequence is referred to
             as <code>atomization</code>. In many cases an explicit call on <code>fn:data</code> is
             not required, because atomization is invoked implicitly when a node or sequence of nodes
-            is supplied in a context where an atomic value or sequence of atomic values is
+            is supplied in a context where an atomic item or sequence of atomic items is
             required.</p>
          <p>The result of atomizing an empty sequence is an empty sequence.</p>
          <p>The result of atomizing an empty array is an empty sequence.</p>
@@ -4181,7 +4181,7 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
             the first value is less than, equal to, or greater than the second value.</p>
       </fos:summary>
       <fos:rules>
-         <p>Compares two atomic values <code>$value1</code> and <code>$value2</code> for order, and
+         <p>Compares two atomic items <code>$value1</code> and <code>$value2</code> for order, and
             returns the integer value <code>-1</code>, <code>0</code>, or <code>1</code>,
             depending on whether <code>$value1</code> is less than, equal to, or greater than
             <code>$value2</code>, respectively.</p>
@@ -4511,11 +4511,11 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
             the parameter is declared optional, so a call with no arguments is also permitted.</p>
          
          <p>The coercion rules ensure that each supplied <code>$values</code> argument is first converted to
-            a sequence of atomic values by applying atomization.</p>
+            a sequence of atomic items by applying atomization.</p>
          <p>The result of the function is then obtained by forming the 
             <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> of these atomized
             values and applying the function <code>fn:string-join#1</code> to the result. The call
-            on <code>fn:string-join</code> has the effect of casting each atomic value in the sequence
+            on <code>fn:string-join</code> has the effect of casting each atomic item in the sequence
             to an <code>xs:string</code>.</p>
          
          <p>If XPath 1.0 compatibility mode is set to true in the static context of a
@@ -4632,7 +4632,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
             calling the two-argument version with <code>$separator</code> set to a zero-length
             string.</p>
          <p>The coercion rules ensure that the supplied <code>$values</code> argument is first converted to
-            a sequence of atomic values by applying atomization.</p>
+            a sequence of atomic items by applying atomization.</p>
          <p>The function then returns an <code>xs:string</code> created by casting each item 
             in the atomized sequence to an <code>xs:string</code>, 
             and then concatenating the result strings in order, 
@@ -4889,7 +4889,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <p>As a consequence of the rules given above, a type error is raised 
            <xerrorref spec="XP" class="TY" code="0004" type="type"/> if the context value
             cannot be atomized, or if the result of atomizing the context value is a sequence
-            containing more than one atomic value.</p>
+            containing more than one atomic item.</p>
       </fos:errors>
       <fos:notes>
          <p>Unlike some programming languages, a <termref def="codepoint"
@@ -4973,7 +4973,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <p>As a consequence of the rules given above, a type error is raised 
            <xerrorref spec="XP" class="TY" code="0004" type="type"/> if the context value
             cannot be atomized, or if the result of atomizing the context value is a sequence
-            containing more than one atomic value.</p>
+            containing more than one atomic item.</p>
       </fos:errors>
       <fos:notes>
          <p>The definition of whitespace is unchanged in <bibref ref="xml11"
@@ -12248,7 +12248,7 @@ else QName("", $value)</eg>
          <p>As a consequence of the rules given above, a type error is raised 
            <xerrorref spec="XP" class="TY" code="0004" type="type"/> if the context value
             cannot be atomized, or if the result of atomizing the context value is a sequence
-            containing more than one atomic value.</p>
+            containing more than one atomic item.</p>
          <!-- bug 16745 -->
       </fos:errors>
       <fos:notes>
@@ -12955,7 +12955,7 @@ return distinct-ordered-nodes($x//c, $x//b, $x//a, $x//b) ! name()]]></eg></fos:
             <code>$input</code> matches <code>$target</code>, then the function returns the empty
             sequence.</p>
          <p>No error occurs if non-comparable values are encountered. So when comparing two atomic
-            values, the effective boolean value of <code>fn:index-of($a, $b)</code> is <code>true</code> if
+            items, the effective boolean value of <code>fn:index-of($a, $b)</code> is <code>true</code> if
                <code>$a</code> and <code>$b</code> are equal, <code>false</code> if they are not equal or not
             comparable.</p>
       </fos:notes>
@@ -15001,7 +15001,7 @@ else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0005'))
       <fos:summary>
          <p> This function assesses whether two sequences are deep-equal to each other. To be
             deep-equal, they must contain items that are pairwise deep-equal; and for two items to
-            be deep-equal, they must either be atomic values that compare equal, or nodes of the
+            be deep-equal, they must either be atomic items that compare equal, or nodes of the
             same kind, with the same name, whose children are deep-equal<phrase>,
                or maps with matching entries, or arrays with matching members.</phrase></p>
       </fos:summary>
@@ -15228,11 +15228,11 @@ declare function equal-strings(
                <p>All of the following conditions are true:</p>
                <olist>
                   <item>
-                     <p><code>$i1</code> is an atomic value.</p></item>
+                     <p><code>$i1</code> is an atomic item.</p></item>
                   <item>
-                     <p><code>$i2</code> is an atomic value.</p></item>
+                     <p><code>$i2</code> is an atomic item.</p></item>
                   <item>
-                     <p>Either the <code>type-annotations</code> option is <code>false</code>, or both atomic values have
+                     <p>Either the <code>type-annotations</code> option is <code>false</code>, or both atomic items have
                      the same type annotation.</p>
                   </item>
                   <item>
@@ -15604,7 +15604,7 @@ declare function equal-strings(
             affect the result; this has been changed in 4.0 so that adjacent text nodes are merged
             after comments and processing instructions have been stripped.</phrase></p>
          <p>Comparing items of different kind (for example, comparing an atomic
-            value to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns <code>false</code>, 
+            item to a node, or a map to an array, or an integer to an <code>xs:date</code>) returns <code>false</code>, 
             it does not return an error. So
             the result of <code>fn:deep-equal(1, current-dateTime())</code> is <code>false</code>.</p>
          
@@ -16573,7 +16573,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <code>ID</code> in a DTD.</p>
          <!--Text replaced by erratum E13 change 1"-->
          <p> If the data model is constructed from a PSVI, an element or attribute will have the
-               <code>is-id</code> property if its typed value is a single atomic value of type
+               <code>is-id</code> property if its typed value is a single atomic item of type
                <code>xs:ID</code> or a type derived by restriction from <code>xs:ID</code>.</p>
          <!--End of text replaced by erratum E13-->
          <p> No error is raised in respect of a candidate <code>IDREF</code> value that does not
@@ -16745,7 +16745,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <code>ID</code> in a DTD.</p>
          <!--Text replaced by erratum E13 change 1"-->
          <p> If the data model is constructed from a PSVI, an element or attribute will have the
-               <code>is-id</code> property if its typed value is a single atomic value of type
+               <code>is-id</code> property if its typed value is a single atomic item of type
                <code>xs:ID</code> or a type derived by restriction from <code>xs:ID</code>.</p>
          <!--End of text replaced by erratum E13-->
          <p> No error is raised in respect of a candidate <code>IDREF</code> value that does not
@@ -16911,9 +16911,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             ill-formed candidate <code>ID</code> values and ill-formed <code>IDREF</code> values are
             ignored.</p>
          <p>If the data model is constructed from a PSVI, the typed value of a node that has the
-               <code>is-idrefs</code> property will contain at least one atomic value of type
+               <code>is-idrefs</code> property will contain at least one atomic item of type
                <code>xs:IDREF</code> (or a type derived by restriction from <code>xs:IDREF</code>).
-            It may also contain atomic values of other types. These atomic values are treated as
+            It may also contain atomic items of other types. These atomic items are treated as
             candidate <code>ID</code> values <phrase>if two conditions are met: their lexical form must be valid as an
                <code>xs:NCName</code>, and there must be at least one instance of <code>xs:IDREF</code>
             in the typed value of the node. If these conditions are not satisfied, such values are ignored.</phrase></p>
@@ -17877,7 +17877,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 
          </fos:example>
          <fos:example>
-            <p>Since the keys in a map must be atomic values, it is possible to use generated IDs
+            <p>Since the keys in a map must be atomic items, it is possible to use generated IDs
                as surrogates for nodes when constructing a map. For example, in some implementations,
                testing whether a node <code>$N</code> is a member of a large node-set <code>$S</code>
                using the expression <code>exists($N intersect $S)</code> may be expensive; there
@@ -20684,7 +20684,7 @@ for-each-pair(
             <item>
                <p>Each sort key value for a given item is obtained by applying the sort key
                function of the corresponding sort key definition to that item. The result
-               of this function is in the general case a sequence of atomic values.
+               of this function is in the general case a sequence of atomic items.
                Two sort key values <code>$a</code> and <code>$b</code> are compared as follows:</p>
                <olist>
                   <item><p>Let <var>$C</var> be the collation in the corresponding
@@ -21153,13 +21153,13 @@ declare function transitive-closure (
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Determines whether two atomic values are equal, under the rules used for comparing keys in a map.</p>
+         <p>Determines whether two atomic items are equal, under the rules used for comparing keys in a map.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>fn:atomic-equal</code> is used to compare two atomic values for equality. This function
+         <p>The function <code>fn:atomic-equal</code> is used to compare two atomic items for equality. This function
          has the following properties (which do not all apply to the <code>eq</code> operator):</p>
          <ulist>
-            <item><p>Any two atomic values can be compared, regardless of their type.</p></item>
+            <item><p>Any two atomic items can be compared, regardless of their type.</p></item>
             <item><p>No dynamic error is ever raised (the result is either <code>true</code> or <code>false</code>).</p></item>
             <item><p>The result of the comparison never depends on the static or dynamic context.</p></item>
             <item><p>Every value (including <code>NaN</code>) is equal to itself.</p></item>
@@ -21311,7 +21311,7 @@ declare function transitive-closure (
             is available directly to applications.</p>
          
          <p>The function is used to assess whether two atomic
-            values are considered to be duplicates when used as keys in a map. A map cannot
+            items are considered to be duplicates when used as keys in a map. A map cannot
             contain two separate entries whose keys are <term>the same</term> as defined by this function. 
             The function is also used when matching keys in functions such as <code>map:get</code>
             and <code>map:remove</code>.</p>
@@ -21322,14 +21322,14 @@ declare function transitive-closure (
                <p><term>Context-free</term>: there is no dependency on the static or dynamic context</p>
             </item>
             <item>
-               <p><term>Error-free</term>: any two atomic values can be compared, and the result is either <code>true</code> or <code>false</code>, never an error</p>
+               <p><term>Error-free</term>: any two atomic items can be compared, and the result is either <code>true</code> or <code>false</code>, never an error</p>
             </item>
             <item>
                <p><term>Transitive</term>: if <var>A</var> is the same key as <var>B</var>, and <var>B</var> is the same key as <var>C</var>, 
                then <var>A</var> is the same key as <var>C</var>.</p>
             </item>
          </ulist>
-         <p>Two atomic values may be distinguishable even though they are equal under this comparison. For example: they may have
+         <p>Two atomic items may be distinguishable even though they are equal under this comparison. For example: they may have
          different type annotations; dates and times may have different timezones; <code>xs:QName</code> values may have different
          prefixes.</p>
          <p>Unlike the <code>eq</code> operator and the <code>fn:deep-equal</code> function, <code>xs:hexBinary</code> and
@@ -21793,7 +21793,7 @@ map:build($input,
       <fos:rules>
          <p>Informally, the function <code>map:keys</code> takes any
             <termref def="dt-map">map</termref> as its <code>$map</code> argument and returns
-            the keys that are present in the map as a sequence of atomic values, in <termref
+            the keys that are present in the map as a sequence of atomic items, in <termref
                def="implementation-dependent">implementation-dependent</termref> order.</p>
          <p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
@@ -23640,7 +23640,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      that is valid according to the JSON grammar, but which does not represent a
                      character that is valid in the version of XML supported by the processor.
                      In the case of surrogates, it is called once for any six-character escape sequence
-                     that is not properly paired with another surrogate. The untyped atomic value
+                     that is not properly paired with another surrogate. The untyped atomic item
                      supplied as the argument will always be a two- or six-character escape
                      sequence, starting with a backslash, that conforms to the rules in the JSON grammar
                      (as extended by the implementation if <code>liberal:true()</code> is specified):
@@ -25516,7 +25516,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
                      directly or as an escape sequence), but which does not represent a
                      character that is valid in the version of XML supported by the processor.
                      It is called once for any surrogate
-                     that is not properly paired with another surrogate. The untyped atomic value
+                     that is not properly paired with another surrogate. The untyped atomic item
                      supplied as the argument will always be a two- or six-character escape
                      sequence, starting with a backslash, that conforms to the rules in the JSON grammar
                      (as extended by the implementation if <code>liberal:true()</code> is specified):
@@ -25884,12 +25884,12 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
          
          <ulist>
             <item>
-               <p><emph>Atomic values</emph></p>
+               <p><emph>atomic items</emph></p>
                <ulist>
                   <item><p>An <code>xs:boolean</code> value is output as the JSON value <code>true</code> or <code>false</code>.</p></item>
                   <item><p>A numeric value, other than <code>INF</code>, <code>-INF</code>, or <code>NaN</code>,
                   is output as a JSON number.</p></item>
-                  <item><p>Any other atomic value is cast to <code>xs:string</code>, and the result is output as a JSON string,
+                  <item><p>Any other atomic item is cast to <code>xs:string</code>, and the result is output as a JSON string,
                   escaped as described below.</p></item>
                </ulist>
             </item>
@@ -29242,7 +29242,7 @@ return $result?output//body
          form of the function with an implementation-dependent seed.</p>
          <p>Calling the <code>fn:random-number-generator</code> function with an empty sequence as <code>$seed</code> 
             is equivalent to calling the single-argument form of the function with an implementation-dependent seed.</p>
-         <p>If a <code>$seed</code> is supplied, it may be an atomic value of any type.</p>
+         <p>If a <code>$seed</code> is supplied, it may be an atomic item of any type.</p>
          <p>Both forms of the function are <termref def="dt-deterministic"
                />: calling the function twice with the same arguments, within a single
          <termref

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -378,7 +378,7 @@ for transition to Proposed Recommendation. </p>'>
             repertoire of characters permitted during processing that goes beyond even what
             version of XML is supported. A processor
             <rfc2119>may</rfc2119> allow the user to construct nodes
-            and atomic values that contain characters not allowed by any version of
+            and atomic items that contain characters not allowed by any version of
             XML.
             <termdef id="dt-permitted-character" term="permitted character">A <term>permitted character</term>
             is one within the repertoire accepted by the implementation.</termdef></p>
@@ -848,7 +848,7 @@ rather than types derived by extension or restriction.</p>
 the relationship of various item types.</p>
       
       <p>Item types are used to characterize the various types of item that can appear
-      in a sequence (nodes, atomic values, and functions), and they are therefore used
+      in a sequence (nodes, atomic items, and functions), and they are therefore used
       in declaring the types of variables or the argument types and result types of functions.</p>
       
       
@@ -902,6 +902,13 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
 
          <div2 id="terminology">
             <head>Terminology</head>
+            
+            <changes>
+               <change issue="1337" date="2024-08-02">
+                  The term <term>atomic value</term> has been replaced by <term>atomic item</term>.
+               </change>
+            </changes>
+
             <p>The terminology used to describe the functions and operators on types defined in <bibref ref="xmlschema-2"/> is defined in the body of this specification. The terms defined
             in this section are used in building those definitions.</p>
             <note><p>Following in the tradition of <bibref ref="xmlschema-2"/>, the terms <term>type</term>
@@ -1056,7 +1063,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
               
                
                <olist>
-                  <item><p>Both items are atomic values, of precisely the same type, and the values are equal as defined using the <code>eq</code> operator,
+                  <item><p>Both items are atomic items, of precisely the same type, and the values are equal as defined using the <code>eq</code> operator,
                      using the Unicode codepoint collation when comparing strings.</p></item>
                   <item><p>Both items are nodes, and represent the same node.</p></item>
                   <item><p>Both items are maps, both maps have the same number of entries, 
@@ -1341,7 +1348,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                                <code>typed-value</code>
                            </td>
                      <td>zero or more items</td>
-                     <td>a sequence of atomic values</td>
+                     <td>a sequence of atomic items</td>
                   </tr>
                   <tr>
                      <td>
@@ -1497,7 +1504,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   is <code>xs:untypedAtomic</code> (or a node whose atomized value is <code>xs:untypedAtomic</code>), then it will
                   be cast to the union type <code>xs:numeric</code> using the rules in <specref ref="casting-to-union"/>.
                Because the lexical space of <code>xs:double</code> subsumes the lexical space of the other member types, and
-               <code>xs:double</code> is listed first, the effect is that if the untyped atomic value is in the lexical space of
+               <code>xs:double</code> is listed first, the effect is that if the untyped atomic item is in the lexical space of
                <code>xs:double</code>, it will be converted to an <code>xs:double</code>, and if not, a dynamic error occurs.</p></item>
                <item><p>When the return type of a function is given as <code>xs:numeric</code>, the actual value returned will be
                an instance of one of the three member types (and perhaps also of types derived from these by restriction). The rules
@@ -5514,7 +5521,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
       <div1 id="sequence-functions">
          <head>Functions and operators on sequences</head>
          <p>A <code>sequence</code> is an ordered collection of zero or more <code>items</code>.
-                An <code>item</code> is a node, an atomic value, or a function, such as a map or an array. The terms
+                An <code>item</code> is a node, an atomic item, or a function, such as a map or an array. The terms
                 <code>sequence</code> and <code>item</code> are defined formally in <bibref ref="xquery-40"/> and <bibref ref="xpath-40"/>. </p>
          <div2 id="general-seq-funcs">
             <head>General functions and operators on sequences</head>
@@ -7634,10 +7641,10 @@ return <table>
          
          <p><termdef id="dt-map" term="map">A <term>map</term> consists of a set of entries, also known
             as key-value pairs. Each entry comprises a key 
-            which is an arbitrary atomic value, and an arbitrary sequence called the associated value.</termdef></p>
+            which is an arbitrary atomic item, and an arbitrary sequence called the associated value.</termdef></p>
          
          <p><termdef id="dt-same-key" term="same key">Within a map, no two entries have the <term>same key</term>. 
-            Two atomic values <code>K1</code> and <code>K2</code> are the <term>same key</term>
+            Two atomic items <code>K1</code> and <code>K2</code> are the <term>same key</term>
             for this purpose if the <phrase diff="chg" at="2023-01-25">function call <code>fn:atomic-equal($K1, $K2)</code></phrase>
             returns <code>true</code>.</termdef></p>
          
@@ -7665,7 +7672,7 @@ return <table>
 
          
          <p>It is often useful to decompose a map into a sequence of entries, or key-value pairs 
-            (in which the key is an atomic value and the value is an arbitrary sequence). Subsequently it may be necessary
+            (in which the key is an atomic item and the value is an arbitrary sequence). Subsequently it may be necessary
             to reconstruct a map from these components, typically after modification.</p>
             
             <p>There are two conventional ways of representing key-value pairs,
@@ -8126,7 +8133,7 @@ return <table>
                 Implementations <rfc2119>may</rfc2119> additionally provide
                 a constructor functions for the new datatype <code>xs:dateTimeStamp</code> introduced in <bibref ref="xmlschema11-2"/>.</p>
 <p>
-A constructor function is not defined for <code>xs:anyAtomicType</code> as there are no atomic values with type annotation <code>xs:anyAtomicType</code> at runtime, although this can be a statically inferred type.
+A constructor function is not defined for <code>xs:anyAtomicType</code> as there are no atomic items with type annotation <code>xs:anyAtomicType</code> at runtime, although this can be a statically inferred type.
 A constructor function is not defined for <code>xs:NOTATION</code> since it is defined as an abstract type in <bibref ref="xmlschema-2"/>.  If the static context (See <xspecref spec="XP31" ref="static_context"/>) contains a type derived from
 <code>xs:NOTATION</code> then a constructor function is defined for it.
 See <specref ref = 'constructor-functions-for-user-defined-types'/>.
@@ -8584,7 +8591,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                     value. The reason for this design choice is to retain compatibility with the function conversion rules:
                     functions such as <code>fn:abs</code> and <code>fn:round</code> are declared to expect an instance
                     of <code>xs:numeric</code> as their first or only argument, and compatibility with the function conversion
-                    rules defined in earlier versions of these specifications demands that when an untyped atomic value
+                    rules defined in earlier versions of these specifications demands that when an untyped atomic item
                     (or untyped node) is supplied as the argument, it is converted to an <code>xs:double</code> value
                        even if its lexical form is that (say) of an integer.</p></note>
                  </item>
@@ -8880,13 +8887,13 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
             <p>Casting is not supported to or from <code>xs:anySimpleType</code>. Thus, there is no row
                or column for this type in the table below. For any node that has not been validated or 
                has been validated as <code>xs:anySimpleType</code>, the typed value of the node is an 
-               atomic value of type <code>xs:untypedAtomic</code>. There are no atomic values with the 
+               atomic item of type <code>xs:untypedAtomic</code>. There are no atomic items with the 
                type annotation <code>xs:anySimpleType</code> at runtime. 
                   Casting to
                      <code>xs:anySimpleType</code> is not permitted and raises a static error:
                      <xerrorref spec="XP" class="ST" code="0080"/>.</p>
             <p>Similarly, casting is not supported to or from <code>xs:anyAtomicType</code> and will raise 
-               a static error: <xerrorref spec="XP" class="ST" code="0080"/>. There are no atomic values 
+               a static error: <xerrorref spec="XP" class="ST" code="0080"/>. There are no atomic items 
                with the type annotation <code>xs:anyAtomicType</code> at runtime, although this can be a 
                statically inferred type.</p>
             <p>If casting is attempted from an <emph>ST</emph> to a <emph>TT</emph> for which
@@ -10737,7 +10744,7 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
             <head>Casting from derived types to parent types</head>
             
             <p>
-               It is always possible to cast an atomic value <var>A</var> to a type <var>T</var>
+               It is always possible to cast an atomic item <var>A</var> to a type <var>T</var>
                if the relation <code>A instance of T</code> is true, provided that <var>T</var>
                is not an abstract type.
             </p>
@@ -10942,7 +10949,7 @@ purposes of this rule that casting to <code>xs:NOTATION</code> succeeds.
             constructing an element or attribute node whose string value is <var>S</var>,
             validating it using <var>L</var> as the governing type, and atomizing the resulting
             node. The result will always be either failure, or a sequence of zero or
-            more atomic values each of which is an instance of the item type of <var>L</var>
+            more atomic items each of which is an instance of the item type of <var>L</var>
             (or if the item type of <var>L</var> is a union type, an instance of one of the
             atomic types in its transitive membership).</p>
             

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -5,7 +5,7 @@
 <div2 id="promotion">
 <head>Type Promotion</head>
 
-<p><termdef term="type promotion" id="dt-type-promotion">Under certain circumstances, an atomic value can be promoted from
+<p><termdef term="type promotion" id="dt-type-promotion">Under certain circumstances, an atomic item can be promoted from
   one type to another.</termdef> <term>Type promotion</term> is used in a number of contexts:</p>
   
   <ulist>
@@ -20,7 +20,7 @@
       (see <specref ref="id-order-by-clause"/>)</phrase>.</p></item>
   </ulist>
   
-  <p>In general, type promotion takes a set of one or more atomic values as input, potentially
+  <p>In general, type promotion takes a set of one or more atomic items as input, potentially
     having different types, and selects a single common type to which all the input values can
     be converted by casting.</p>
   
@@ -99,7 +99,7 @@ operators <code>eq</code> and <code>lt</code>, and the arithmetic operators
   The result of an operator may be the raising of an error by its operator 
   function, as defined in <bibref ref="xpath-functions-40"/>. The operator 
   function fully defines the semantics of a given operator for the case 
-  where the operands are single atomic values of the types given in the table. 
+  where the operands are single atomic items of the types given in the table. 
   For the definition of each operator (including its
 behavior for empty sequences or sequences of length greater than one),
 see the descriptive material in the main part of this
@@ -1248,12 +1248,12 @@ See
 <inform-div1 id="id-atomic-comparisons">
   <head>Atomic Comparisons: An Overview</head>
   <p>This appendix provides a non-normative summary of the various functions and operators used for comparison
-    of atomic values, with some background on the history and rationale.</p>
+    of atomic items, with some background on the history and rationale.</p>
   
   
   <div2 id="id-equality-comparison">
     <head>Equality Comparisons</head>
-    <p>In &language; there are essentially four ways of comparing two atomic values for equality:</p>
+    <p>In &language; there are essentially four ways of comparing two atomic items for equality:</p>
     
     <ulist>
       <item><p><code>$A = $B</code></p>
@@ -1265,9 +1265,9 @@ See
             two sequences compares equal.</p>
             <p>In consequence, if either operand is an empty sequence, the result is false.</p></item>
           <item><p>If nodes are supplied, they are atomized.</p></item>
-          <item><p>Untyped atomic values appearing in one operand are converted to the type of the
+          <item><p>Untyped atomic items appearing in one operand are converted to the type of the
             other operand (if both operands are untyped atomic, they are compared as strings).</p></item>
-          <item><p>As a result, the operator is not transitive: the untyped atomic values <code>"4.0"</code>
+          <item><p>As a result, the operator is not transitive: the untyped atomic items <code>"4.0"</code>
             and <code>"4"</code> are not equal to each other, but both compare equal to the integer value 
             <code>4</code>.</p></item>
           <item><p>Comparison of certain values is context-sensitive. In particular, comparison of strings
@@ -1286,11 +1286,11 @@ See
           cases involving comparisons across different numeric types this was not entirely achieved.</p>
         <p>With a value comparison, the rules are:</p>
         <ulist>
-          <item><p>Each operand must either be a single atomic value, or an empty sequence.</p></item>
+          <item><p>Each operand must either be a single atomic item, or an empty sequence.</p></item>
           <item><p>If either operand is an empty sequence, the result is an empty sequence; in most
             contexts this has the same effect as returning false.</p></item>
           <item><p>If nodes are supplied, they are atomized.</p></item>
-          <item><p>Untyped atomic values are converted to strings (regardless of the type of the other operand).</p></item>
+          <item><p>Untyped atomic items are converted to strings (regardless of the type of the other operand).</p></item>
           <item><p>Numeric values of types <code>xs:integer</code>, <code>xs:decimal</code>, or <code>xs:float</code>
             are converted to <code>xs:double</code>.</p>
             <p>This can lead to problems with implementations of <code>xs:decimal</code> that support more precision 
@@ -1306,7 +1306,7 @@ See
       </item>
       <item><p><code>deep-equal($A, $B)</code></p>
         <p>As the name implies, the <code>deep-equal</code> function was introduced primarily for comparing nodes,
-          or sequences of nodes; however in its simplest form it can also be used to compare two atomic values. The semantics
+          or sequences of nodes; however in its simplest form it can also be used to compare two atomic items. The semantics
           of the comparison used by <code>deep-equal($A, $B)</code> are also invoked by a wide variety of other functions
           including <code>distinct-values</code>, <code>all-equal</code>, and <code>all-different</code>; it is also
           used to underpin grouping constructs in both XQuery 4.0 and XSLT 4.0.</p>
@@ -1488,7 +1488,7 @@ See
   </div2>
   <div2 id="id-ordering-comparison">
     <head>Ordering Comparisons</head>
-    <p>In &language; there are essentially three ways of comparing two atomic values for their relative ordering:</p>
+    <p>In &language; there are essentially three ways of comparing two atomic items for their relative ordering:</p>
     
     <ulist>
       <item><p><code>$A &lt; $B</code></p></item>
@@ -1640,7 +1640,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       <item><p>The arrow operator <code>=></code> is now complemented by a “mapping arrow” operator <code>=!></code>
         which applies a the supplied function to each item in the input sequence independently.</p></item>
       <item><p>The “function conversion rules” are now renamed “coercion rules”.</p></item>
-      <item><p>The coercion rules allow “relabeling” of a supplied atomic value where
+      <item><p>The coercion rules allow “relabeling” of a supplied atomic item where
         the required type is a derived atomic type: for example, it is now permitted to supply
         the value 3 when calling a function that expects an instance of <code>xs:positiveInteger</code>.</p></item>
       <item><p>In XQuery, the coercion rules are now used when binding values to variables (both
@@ -1657,7 +1657,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
         errors that the author intended to prevent.
       </p></item>
       <item><p>Support for higher-order functions is now a mandatory feature (in 3.1 it was optional).</p></item>
-      <item role="xquery"><p>Switch expressions now allow a <code>case</code> clause to match multiple atomic values.</p></item>
+      <item role="xquery"><p>Switch expressions now allow a <code>case</code> clause to match multiple atomic items.</p></item>
       <item><p>Numeric literals can now be written in hexadecimal or binary notation; and underscores can be included
       for readability.</p></item>
       <item role="xquery"><p>Switch and typeswitch expressions can now be written with curly braces,
@@ -1701,7 +1701,7 @@ specification since the publication of XPath 3.1 Recommendation.</p>
       <item><p>Record types are added as a new kind of <code>ItemType</code>, constraining
         the value space of maps.</p></item>
       <item><p>Local union types are added as a new kind of <code>ItemType</code>, constraining
-        the value space of atomic values.</p></item>
+        the value space of atomic items.</p></item>
       <item><p>Enumeration types are added as a new kind of <code>ItemType</code>, constraining
         the value space of strings.</p></item>
       

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -1044,7 +1044,7 @@ It is a static error if the name of a feature in
 
 <!--  DELETED
       <error spec="XQ" code="0136" class="DY" type="dynamic">
-         <p>A map key must be a single atomic value.</p>
+         <p>A map key must be a single atomic item.</p>
       </error>
 -->
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5,6 +5,12 @@
       
       <div2 id="id-terminology">
          <head>Terminology</head>
+         
+         <changes>
+            <change issue="1337" date="2024-08-02">
+               The term <term>atomic value</term> has been replaced by <term>atomic item</term>.
+            </change>
+         </changes>
 
       
       <p>The basic  building block of &language; is the
@@ -70,6 +76,12 @@ of <bibref
 
       <div3 id="id-values">
          <head>Values</head>
+         
+         <changes>
+            <change issue="1337" date="2024-08-02">
+               The term <term>atomic value</term> has been replaced by <termref def="dt-atomic-item"/>.
+            </change>
+         </changes>
       
       <p>
          <termdef term="value" id="dt-value">In the <termref def="dt-datamodel"
@@ -83,12 +95,12 @@ of <bibref
                def="dt-item">items</termref>.</termdef></p>
          <p><termdef id="dt-item" term="item">
   An <term>item</term> is either an <termref
-               def="dt-atomic-value">atomic value</termref>, a <termref def="dt-node"
+               def="dt-atomic-item">atomic item</termref>, a <termref def="dt-node"
                >node</termref>,
 or a <termref def="dt-function-item">function item</termref>.</termdef></p>
          
-      <p><termdef id="dt-atomic-value" term="atomic value">An <term>atomic
-	 value</term> is a value in the value space of an <term>atomic
+      <p><termdef id="dt-atomic-item" term="atomic item">An <term>atomic
+	 item</term> is a value in the value space of an <term>atomic
 	 type</term>, as defined in <bibref
                ref="XMLSchema10"/>  or <bibref ref="XMLSchema11"/>.</termdef></p>
          
@@ -98,7 +110,7 @@ or a <termref def="dt-function-item">function item</termref>.</termdef></p>
                spec="DM40" ref="Node"
             />.</termdef>
 Each node has a unique <term>node identity</term>, a <term>typed value</term>, and a <term>string value</term>. In addition, some nodes have a <term>name</term>. The <term>typed value</term> of a node is a sequence
-	 of zero or more atomic values. The <term>string value</term> of a node is a
+	 of zero or more atomic items. The <term>string value</term> of a node is a
 	 value of type <code>xs:string</code>. The <term>name</term> of a node is a value of type <code>xs:QName</code>.</p>
          
          <p><termdef id="dt-function-item" term="function item">A <term>function item</term> is an item that can
@@ -2155,9 +2167,9 @@ data (step DQ4), and on the <termref
                      be a subtype of all the others, in which case it makes sense to speak of “the dynamic type” of the value as 
                      meaning this single most specific type. In other cases (examples are empty maps and empty arrays) none of the 
                      dynamic types is more specific than all the others.</p>
-               <note diff="chg" at="B"><p>An atomic value has a <termref def="dt-type-annotation"/> which will always be
+               <note diff="chg" at="B"><p>An atomic item has a <termref def="dt-type-annotation"/> which will always be
                   a <termref def="dt-subtype"/> of all the other types that it matches; we can therefore refer to 
-                  this as the <termref def="dt-dynamic-type"/> of the atomic value without ambiguity.</p></note>
+                  this as the <termref def="dt-dynamic-type"/> of the atomic item without ambiguity.</p></note>
                
                <p diff="chg" at="B">A value may match a dynamic type that is more specific than the <termref def="dt-static-type"/> 
                   of the expression that computed it (for example, the static type of an expression might be <code>xs:integer*</code>, 
@@ -3267,7 +3279,7 @@ tree T2.</p>
                
                <termdef term="typed value" id="dt-typed-value"
                   >The <term>typed
-                     value</term> of a node is a sequence of atomic values and can be
+                     value</term> of a node is a sequence of atomic items and can be
                   extracted by applying the <xspecref
                      spec="FO40" ref="func-data"/> function to the
                   node.</termdef>
@@ -3356,7 +3368,7 @@ tree T2.</p>
                   <p>Example: A2 is an attribute with type
                      annotation <code>xs:IDREFS</code>, which is a list datatype whose item type is the atomic datatype <code>xs:IDREF</code>. Its string value is
                      <code>"bar baz faz"</code>. The typed value of A2 is a sequence of
-                     three atomic values (<code>"bar"</code>, <code>"baz"</code>",
+                     three atomic items (<code>"bar"</code>, <code>"baz"</code>",
                      <code>"faz"</code>"), each of type <code>xs:IDREF</code>. The typed
                      value of a node is never treated as an instance of a named list
                      type. Instead, if the type annotation of a node is a list type (such
@@ -3478,8 +3490,8 @@ tree T2.</p>
                   def="dt-atomization"
                   >atomization</termref>. Atomization is
 applied to a value when the value is used in a context in which a
-sequence of atomic values is required. The result of atomization is
-either a sequence of atomic values or a <termref
+sequence of atomic items is required. The result of atomization is
+either a sequence of atomic items or a <termref
                   def="dt-type-error">type error</termref>
                <xerrorref spec="FO40" class="TY" code="0012"/>.  <termdef id="dt-atomization"
                   term="atomization">
@@ -3489,13 +3501,13 @@ is defined as the result of invoking the <code>fn:data</code> function, as defin
             </p>
             <p> The semantics of
 <code>fn:data</code> are repeated here for convenience. The result of
-<code>fn:data</code> is the sequence of atomic values produced by
+<code>fn:data</code> is the sequence of atomic items produced by
 applying the following rules to each item in the input
 sequence:</p>
             <ulist>
 
                <item>
-                  <p>If the item is an atomic value, it is
+                  <p>If the item is an atomic item, it is
 returned.</p>
                </item>
 
@@ -3618,7 +3630,7 @@ defined in <xspecref
 
             <note role="xquery">
                <p>The <termref def="dt-ebv"
-                     >effective boolean value</termref> of a sequence that contains at least one node and at least one atomic value is <termref
+                     >effective boolean value</termref> of a sequence that contains at least one node and at least one atomic item is <termref
                      def="dt-implementation-dependent"
                      >implementation-dependent</termref> in regions of a query where <termref
                      def="dt-ordering-mode">ordering mode</termref> is <code>unordered</code>.</p>
@@ -3779,7 +3791,7 @@ defined in <xspecref
 		<bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/> in two ways:</p>
       
          <ulist>
-            <item><p>Atomic values in &language; (which are one kind of <termref def="dt-item"/>)
+            <item><p>atomic items in &language; (which are one kind of <termref def="dt-item"/>)
                have <termref def="dt-atomic-type">atomic types</termref> such as <code>xs:string</code>,
                <code>xs:boolean</code>, and <code>xs:integer</code>. These types are taken directly
                from their definitions in <bibref ref="XMLSchema10"/> or <bibref ref="XMLSchema11"/>.</p></item>
@@ -3821,7 +3833,7 @@ defined in <xspecref
             syntax. Item types match individual <termref def="dt-item">items</termref>.</termdef>
          
          In most cases, the set of items matched by an item type consists either
-         exclusively of <termref def="dt-atomic-value">atomic values</termref>,
+         exclusively of <termref def="dt-atomic-item">atomic items</termref>,
          exclusively of <termref def="dt-node">nodes</termref>, 
          or exclusively of <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>.
          Exceptions include the generic types <code>item()</code>, which matches all items, <code>xs:error</code>,
@@ -4263,7 +4275,7 @@ the schema type named <code>us:address</code>.</p>
                   <p>
                      <termdef id="dt-generalized-atomic-type" term="generalized atomic type"
                         >A <term>generalized atomic type</term> is an item type whose instances are all
-                        atomic values. Generalized atomic types include (a) 
+                        atomic items. Generalized atomic types include (a) 
                         <termref def="dt-atomic-type">atomic types</termref>, either built-in
                         (for example <code>xs:integer</code>) or imported from a schema, 
                         (b) <termref def="dt-pure-union-type">pure union types</termref>, either built-in
@@ -4298,7 +4310,7 @@ the schema type named <code>us:address</code>.</p>
                      <item><p>Using an <nt def="EnumerationType">EnumerationType</nt> as described below.</p></item>
                   </ulist>
                
-                  <p diff="add" at="2023-02-20">An atomic value <var>A</var> matches the 
+                  <p diff="add" at="2023-02-20">An atomic item <var>A</var> matches the 
                      <termref def="dt-generalized-atomic-type"/> <var>GAT</var> 
                      if the <termref def="dt-type-annotation">type annotation</termref> of <var>A</var> 
                      (call it <var>T</var>) satisfies the condition <code>derives-from(T, GAT)</code>.</p>
@@ -4360,7 +4372,7 @@ the schema type named <code>us:address</code>.</p>
                      derived by restriction from another union.</p>
                   
                   <p>This problem is fixed in XSD 1.1, but the effect of the resolution
-                     is that an atomic value labeled with an atomic type cannot be treated
+                     is that an atomic item labeled with an atomic type cannot be treated
                      as being substitutable for a union type without explicit validation.
                      This specification therefore allows union types to be used as item
                      types only if they are defined directly as the union of a number of
@@ -4512,7 +4524,7 @@ the schema type named <code>us:address</code>.</p>
                
                <p>An enumeration type is thus a <termref def="dt-generalized-atomic-type"/>.</p>
                
-               <p>It follows from these rules that an atomic value will only satisfy an <code>instance of</code>
+               <p>It follows from these rules that an atomic item will only satisfy an <code>instance of</code>
                test if it has the correct type annotation, and this can only be achieved using an explicit cast or
                constructor function. So the expression <code>"red" instance of enum("red", "green", "blue")</code>
                returns <code>false</code>. 
@@ -5439,7 +5451,7 @@ name.</p>
                <note diff="add" at="issue730">
                   <p>To understand this rule, consider the use of a map <code>$M</code> in a function 
                   call <code>$M($K)</code>, which is equivalent to the function call <code>map:get($M, $K)</code>.
-                  This function accepts any atomic value for the argument <code>$K</code>, and hence satisfies
+                  This function accepts any atomic item for the argument <code>$K</code>, and hence satisfies
                   a function test that requires an argument type of <code>xs:anyAtomicType</code>. If the
                   key <code>$K</code> is present in the map, the result of the function will be a value of
                   type <var>V</var>; if not, it will be an empty sequence. The map is therefore substitutable
@@ -7011,7 +7023,7 @@ name.</p>
                   The term "function conversion rules" used in 3.1 has been replaced by the term "coercion rules".
                </change>
                <change issue="117" PR="254" date="2022-11-29">
-                  The coercion rules allow “relabeling” of a supplied atomic value where
+                  The coercion rules allow “relabeling” of a supplied atomic item where
                   the required type is a derived atomic type: for example, it is now permitted to supply
                   the value 3 when calling a function that expects an instance of <code>xs:positiveInteger</code>.
                </change>
@@ -7116,11 +7128,11 @@ name.</p>
                      (for example, if it is an <termref def="dt-atomic-type"/>,
                      a <termref def="dt-pure-union-type"/>, or
                      an <termref def="dt-enumeration-type"/>), and <var>J</var>
-                     is not an atomic value, then:
+                     is not an atomic item, then:
                      <olist>
-                        <item><p><var>J</var> is atomized to produce a sequence of atomic values
+                        <item><p><var>J</var> is atomized to produce a sequence of atomic items
                         <var>JJ</var>.</p></item>
-                        <item><p>Each atomic value in <var>JJ</var> is coerced to the required
+                        <item><p>Each atomic item in <var>JJ</var> is coerced to the required
                         type <var>R</var> by recursive application of the item coercion rules (the 
                         rules in this section) to produce a value <var>V</var>.</p></item>
                         <item><p>The result is the sequence-concatenation of the <var>V</var> values.</p></item>
@@ -7198,19 +7210,19 @@ name.</p>
                   
                   <!--<item>
                      <p>If <var>R</var> is an <termref def="dt-atomic-type"/>
-                        and <var>J</var> is not an atomic value,
+                        and <var>J</var> is not an atomic item,
                         then <var>J</var> is <termref def="dt-atomization">atomized</termref>. 
                         The result of atomization is
-                        in general a sequence of atomic values. The item coercion rules
+                        in general a sequence of atomic items. The item coercion rules
                         (that is, the rules in this section) are then applied recursively to each of
-                        these atomic values in turn, with the same item type <var>R</var>
+                        these atomic items in turn, with the same item type <var>R</var>
                         as the required type, and the results are concatenated
                         in order to form the result sequence.</p>
                   </item>-->
                         
                   <item>
                      <p>If <var>R</var> is an <termref def="dt-atomic-type"/>
-                     and <var>J</var> is an <termref def="dt-atomic-value"/>, then:</p>
+                     and <var>J</var> is an <termref def="dt-atomic-item"/>, then:</p>
 
                            <olist>
                               <item diff="chg" at="2024-01-04"><p>If <var>J</var> is an instance of 
@@ -7281,7 +7293,7 @@ name.</p>
                                     <item><p>The <xtermref spec="DM40" ref="dt-datum"/> of <var>J</var> is 
                                        within the value space of <var>R</var>.</p></item>
                                  </ulist>
-                                 <p>Relabeling an atomic value changes the <termref def="dt-type-annotation"/> but not the 
+                                 <p>Relabeling an atomic item changes the <termref def="dt-type-annotation"/> but not the 
                                     <xtermref spec="DM40" ref="dt-datum"/>. For example, the
                                     <code>xs:integer</code> value 3 can be relabeled as an instance of <code>xs:unsignedByte</code>, because
                                     the datum is within the value space of <code>xs:unsignedByte</code>.</p>
@@ -8257,7 +8269,7 @@ return $f(12.3)]]></eg>
                <p>
                   <termdef term="xs:anyAtomicType" id="dt-anyAtomicType">
                      <code>xs:anyAtomicType</code> is an <termref def="dt-atomic-type"/> 
-                     that includes all atomic values (and no values that
+                     that includes all atomic items (and no values that
                      are not atomic). Its base type is
                      <code>xs:anySimpleType</code> from which all simple types, including atomic,
                      list, and union types, are derived. All primitive atomic types, such as
@@ -8480,7 +8492,7 @@ and <nt def="OrExpr"
             <p>
                <termdef id="dt-literal" term="literal"
                   >A <term>literal</term> is a direct syntactic representation of an
-		atomic value.</termdef> &language; supports two kinds of literals: numeric literals and
+		atomic item.</termdef> &language; supports two kinds of literals: numeric literals and
 		string literals.</p>
             
             
@@ -8530,17 +8542,17 @@ and <nt def="OrExpr"
                      <code>0b1111_1111</code> represents the integer 255.</p>
                   </item>
                   <item><p>The value of a <term>numeric literal</term> containing no <code>.</code> and 
-                     no <code>e</code> or <code>E</code> character is an atomic value of type <code>xs:integer</code>;
+                     no <code>e</code> or <code>E</code> character is an atomic item of type <code>xs:integer</code>;
                      the value is obtained by casting from <code>xs:string</code> to <code>xs:integer</code> as specified in
                      <xspecref spec="FO40" ref="casting-from-strings"/>.</p>
                   </item>
                   <item><p>The value of a numeric literal containing <code>.</code> but no <code>e</code> or <code>E</code> 
-                     character is an atomic value of type <code>xs:decimal</code>;
+                     character is an atomic item of type <code>xs:decimal</code>;
                      the value is obtained by casting from <code>xs:string</code> to <code>xs:decimal</code> as specified in
                      <xspecref spec="FO40" ref="casting-from-strings"/>.</p>
                   </item>
                   <item><p>The value of a numeric literal 
-                     containing an <code>e</code> or <code>E</code> character is an atomic value of type 
+                     containing an <code>e</code> or <code>E</code> character is an atomic item of type 
                      <code>xs:double</code>;
                      the value is obtained by casting from <code>xs:string</code> to <code>xs:double</code> as specified in
                      <xspecref spec="FO40" ref="casting-from-strings"/>.</p>
@@ -8634,7 +8646,7 @@ and <nt def="OrExpr"
  
 
 
-            <p>The value of a <term>string literal</term> is an atomic value whose type is
+            <p>The value of a <term>string literal</term> is an atomic item whose type is
                <code>xs:string</code> and whose value is the string denoted by the characters between the
 		delimiting apostrophes or quotation marks. If the literal is delimited by apostrophes, two adjacent 
 		apostrophes within the literal are interpreted as a single apostrophe. Similarly, if the literal 
@@ -8829,7 +8841,7 @@ and <nt def="OrExpr"
             <p>Constructor functions are available for all simple types,
 including union types. For example, if <code>my:dt</code> is a user-defined union
 type whose member types are <code>xs:date</code>, <code>xs:time</code>, and <code>xs:dateTime</code>, then
-the expression <code>my:dt("2011-01-10")</code> creates an atomic value of type
+the expression <code>my:dt("2011-01-10")</code> creates an atomic item of type
 <code>xs:date</code>. The rules follow XML Schema validation rules for union types:
 the effect is to choose the first member type that accepts the given
 string in its lexical space.</p>
@@ -8843,7 +8855,7 @@ string in its lexical space.</p>
                   <p>
                      <code role="parse-test"
                         >9 cast as
-                        hatsize</code> returns the atomic value <code>9</code>
+                        hatsize</code> returns the atomic item <code>9</code>
 			 whose type is  <code>hatsize</code>.</p>
                </item>
             </ulist>
@@ -13075,7 +13087,7 @@ error</termref> is raised. <xerrorref
          </olist>
          <p>After evaluation of the operands, if the types of the operands are a valid combination
 for the given arithmetic operator, the operator is applied to the operands,
-resulting in an atomic value or a <termref
+resulting in an atomic item or a <termref
                def="dt-dynamic-error"
                >dynamic error</termref> (for example, an error
 might result from dividing by zero). The combinations of atomic types
@@ -13232,13 +13244,13 @@ course to the use of parentheses. Therefore, the following two examples have dif
                         <p>
                            <termref def="dt-atomization"
                               >Atomization</termref> is applied to the value of the enclosed expression, 
-                           converting it to a sequence of atomic values.</p>
+                           converting it to a sequence of atomic items.</p>
                         
                      </item>
                      
                      <item>
                         <p>If the result of atomization is an empty sequence, the result 
-                           is the zero-length string. Otherwise, each atomic value in the 
+                           is the zero-length string. Otherwise, each atomic item in the 
                            atomized sequence is cast into a string.</p>
                      </item>
                      
@@ -13482,7 +13494,7 @@ must be followed; thus <code>&lt;</code> must be written as
 <code>&amp;lt;</code>.</p>
          </note>
          
-         <p>For a summary of the differences between different ways of comparing atomic values
+         <p>For a summary of the differences between different ways of comparing atomic items
          in &language;, see <specref ref="id-atomic-comparisons"/>.</p>
 
 
@@ -13591,7 +13603,7 @@ definitions of the operator functions are found in <bibref
                   ref="xpath-functions-40"/>.</p>
 
             <p>Informally, if both atomized operands consist of exactly one atomic
-value, then the result of the comparison is <code>true</code> if the value of the
+item, then the result of the comparison is <code>true</code> if the value of the
 first operand is (equal, not equal, less than, less than or equal,
 greater than, greater than or equal) to the value of the second
 operand; otherwise the result of the comparison is <code>false</code>.</p>
@@ -13668,7 +13680,7 @@ always <code>true</code> or <code>false</code>.</p>
             <olist role="xpath">
 
                <item>
-                  <p>If either operand is a single atomic value that is an instance of
+                  <p>If either operand is a single atomic item that is an instance of
 <code>xs:boolean</code>, then the other operand is converted to <code>xs:boolean</code> by taking its
 <termref
                         def="dt-ebv">effective boolean value</termref>.</p>
@@ -13677,7 +13689,7 @@ always <code>true</code> or <code>false</code>.</p>
                <item>
                   <p>
                      <termref def="dt-atomization"
-                     >Atomization</termref> is applied to each operand. After atomization, each operand is a sequence of atomic values.</p>
+                     >Atomization</termref> is applied to each operand. After atomization, each operand is a sequence of atomic items.</p>
 
                </item>
 
@@ -13689,9 +13701,9 @@ operand sequences is converted to the type  <code>xs:double</code> by applying t
 
                <item>
                   <p>The result of the comparison is <code>true</code> if and only if there is a pair of
-atomic values, one in the first operand sequence and the other in the second operand sequence, that have the required
+atomic items, one in the first operand sequence and the other in the second operand sequence, that have the required
 <term>magnitude relationship</term>. Otherwise the result of the  comparison is
-<code>false</code> or an error. The <term>magnitude relationship</term> between two atomic values is determined by
+<code>false</code> or an error. The <term>magnitude relationship</term> between two atomic items is determined by
 applying the following rules. If a <code>cast</code> operation called for by these rules is not successful, a <termref
                         def="dt-dynamic-error">dynamic error</termref>  is raised. <xerrorref
                         spec="FO40" class="RG" code="0001"/>
@@ -13700,20 +13712,20 @@ applying the following rules. If a <code>cast</code> operation called for by the
                   <olist>
 
                      <item>
-                        <p>If at least one of the two atomic values is an instance of a <termref
+                        <p>If at least one of the two atomic items is an instance of a <termref
                               def="dt-numeric"
-                              >numeric</termref> type, then both atomic values are converted to the type <code>xs:double</code> by
+                              >numeric</termref> type, then both atomic items are converted to the type <code>xs:double</code> by
 applying the <code>fn:number</code> function.</p>
                      </item>
 
                      <item>
-                        <p>If at least one of the two atomic values is an instance of <code>xs:string</code>,
-or if both atomic values are instances of <code>xs:untypedAtomic</code>, then both
-atomic values are cast to the type <code>xs:string</code>.</p>
+                        <p>If at least one of the two atomic items is an instance of <code>xs:string</code>,
+or if both atomic items are instances of <code>xs:untypedAtomic</code>, then both
+atomic items are cast to the type <code>xs:string</code>.</p>
                      </item>
 
                      <item>
-                        <p>If one of the atomic values is an instance of <code>xs:untypedAtomic</code> and the other is not an instance of <code>xs:string</code>, <code>xs:untypedAtomic</code>, or any <termref
+                        <p>If one of the atomic items is an instance of <code>xs:untypedAtomic</code> and the other is not an instance of <code>xs:string</code>, <code>xs:untypedAtomic</code>, or any <termref
                               def="dt-numeric"
                               >numeric</termref> type, then the <code>xs:untypedAtomic</code> value is
 cast to the <termref
@@ -13721,7 +13733,7 @@ cast to the <termref
                      </item>
 
                      <item>
-                        <p>After performing the conversions described above, the atomic values are
+                        <p>After performing the conversions described above, the atomic items are
 compared using one of the value comparison operators <code>eq</code>, <code>ne</code>, <code>lt</code>, <code>le</code>, <code>gt</code>, or
 <code>ge</code>, depending on whether the general comparison operator was <code>=</code>, <code>!=</code>, <code>&lt;</code>, <code>&lt;=</code>,
 <code>&gt;</code>, or <code>&gt;=</code>. The values have the required <term>magnitude relationship</term> if and only if the result
@@ -13741,15 +13753,15 @@ of this value comparison is <code>true</code>.</p>
                <item>
                   <p>
                      <termref def="dt-atomization"
-                     >Atomization</termref> is applied to each operand. After atomization, each operand is a sequence of atomic values.</p>
+                     >Atomization</termref> is applied to each operand. After atomization, each operand is a sequence of atomic items.</p>
 
                </item>
 
                <item>
                   <p>The result of the comparison is <code>true</code> if and only if there is a pair of
-atomic values, one in the first operand sequence and the other in the second operand sequence, that have the required
+atomic items, one in the first operand sequence and the other in the second operand sequence, that have the required
 <term>magnitude relationship</term>. Otherwise the result of the  comparison is
-<code>false</code> or an error. The <term>magnitude relationship</term> between two atomic values is determined by
+<code>false</code> or an error. The <term>magnitude relationship</term> between two atomic items is determined by
 applying the following rules. If a <code>cast</code> operation called for by these rules is not successful, a <termref
                         def="dt-dynamic-error">dynamic error</termref>  is raised. <xerrorref
                         spec="FO40" class="RG" code="0001"/>
@@ -13763,12 +13775,12 @@ applying the following rules. If a <code>cast</code> operation called for by the
                   <olist>
 
                      <item>
-                        <p>If both atomic values are instances of <code>xs:untypedAtomic</code>,
+                        <p>If both atomic items are instances of <code>xs:untypedAtomic</code>,
                 then the values are cast to the type <code>xs:string</code>.
              </p>
                      </item>
                      <item>
-                        <p>If exactly one of the atomic values is an instance of
+                        <p>If exactly one of the atomic items is an instance of
                 <code>xs:untypedAtomic</code>, it is cast to a type depending on
                 the other value’s dynamic type T according to the following rules,
                 in which V denotes the value to be cast:
@@ -13801,7 +13813,7 @@ applying the following rules. If a <code>cast</code> operation called for by the
                         </note>
                      </item>
                      <item>
-                        <p>After performing the conversions described above, the atomic values are
+                        <p>After performing the conversions described above, the atomic items are
 compared using one of the value comparison operators <code>eq</code>, <code>ne</code>, <code>lt</code>, <code>le</code>, <code>gt</code>, or
 <code>ge</code>, depending on whether the general comparison operator was <code>=</code>, <code>!=</code>, <code>&lt;</code>, <code>&lt;=</code>,
 <code>&gt;</code>, or <code>&gt;=</code>. The values have the required <term>magnitude relationship</term> if and only if the result
@@ -14332,12 +14344,12 @@ character (that is, the pair <code>"{{"</code> represents the
                         <item>
                            <p>
                               <termref def="dt-atomization"
-                              >Atomization</termref> is applied to the value of the enclosed expression, converting it to a sequence of atomic values.</p>
+                              >Atomization</termref> is applied to the value of the enclosed expression, converting it to a sequence of atomic items.</p>
 
                         </item>
 
                         <item>
-                           <p>If the result of atomization is an empty sequence, the result is the zero-length string. Otherwise, each atomic value in the atomized sequence is cast into a string.</p>
+                           <p>If the result of atomization is an empty sequence, the result is the zero-length string. Otherwise, each atomic item in the atomized sequence is cast into a string.</p>
                         </item>
 
                         <item>
@@ -14620,7 +14632,7 @@ attribute is processed as follows:</p>
                      def="dt-predefined-entity-reference"
                      >predefined entity references</termref>, and <termref
                      def="dt-enclosed-expression"
-                  >enclosed expressions</termref>. In general, the value of an enclosed expression may be any sequence of nodes and/or atomic values. Enclosed expressions can be used in the content of an element  constructor to compute both the content and the attributes of the constructed node.</p>
+                  >enclosed expressions</termref>. In general, the value of an enclosed expression may be any sequence of nodes and/or atomic items. Enclosed expressions can be used in the content of an element  constructor to compute both the content and the attributes of the constructed node.</p>
 
                <p>Conceptually, the content of an element constructor is processed as
 follows:</p>
@@ -14702,7 +14714,7 @@ node.</p>
                               </item>
 
                               <item>
-                                 <p>For each adjacent sequence of one or more atomic values returned by an enclosed expression, a new text node is constructed, containing the result of casting each atomic value to a string, with a single space character inserted between adjacent values.</p>
+                                 <p>For each adjacent sequence of one or more atomic items returned by an enclosed expression, a new text node is constructed, containing the result of casting each atomic item to a string, with a single space character inserted between adjacent values.</p>
                                  <note>
                                     <p>The insertion of blank characters between adjacent values applies even if one or both of the values is a zero-length string.</p>
                                  </note>
@@ -15120,7 +15132,7 @@ end of the content, or by a <nt
                      <p>Example:</p>
                      <eg role="parse-test"
                         >&lt;a&gt;{ [ "one", "little", "fish" ] }&lt;/a&gt;</eg>
-                     <p>This example constructs an element containing the text <code>one little fish</code>, because the array is flattened, and the resulting sequence of atomic values is converted to a text node with a single blank between values.</p>
+                     <p>This example constructs an element containing the text <code>one little fish</code>, because the array is flattened, and the resulting sequence of atomic items is converted to a text node with a single blank between values.</p>
                   </item>
 
                </ulist>
@@ -15266,7 +15278,7 @@ if the EQName is a  <termref
                         <termref def="dt-atomization"
                            >Atomization</termref> is applied to the value of the <termref
                            def="dt-name-expression"
-                           >name expression</termref>. If the result of atomization is not a single atomic value of type <code>xs:QName</code>, <code>xs:string</code>, or <code>xs:untypedAtomic</code>, a <termref
+                           >name expression</termref>. If the result of atomization is not a single atomic item of type <code>xs:QName</code>, <code>xs:string</code>, or <code>xs:untypedAtomic</code>, a <termref
                            def="dt-type-error">type
    error</termref> is raised <errorref
                            class="TY" code="0004"/>.</p>
@@ -15580,7 +15592,7 @@ element {
      of <termref
                            def="dt-atomization"
                            >atomization</termref> is not a
-     single atomic value of type <code>xs:QName</code>,
+     single atomic item of type <code>xs:QName</code>,
      <code>xs:string</code>, or <code>xs:untypedAtomic</code>, a
      <termref
                            def="dt-type-error">type error</termref> is raised
@@ -15699,7 +15711,7 @@ attribute node.</p>
      applied to the result of the <termref
                            def="dt-content-expression"
                            >content expression</termref>,
-     converting it to a sequence of atomic values. (If the <termref
+     converting it to a sequence of atomic items. (If the <termref
                            def="dt-content-expression"
                         >content expression</termref> is
      absent, the result of this step is an empty
@@ -15712,7 +15724,7 @@ attribute node.</p>
                   <item>
                      <p>If the result of atomization is an empty sequence, the
      value of the attribute is the zero-length string. Otherwise, each
-     atomic value in the atomized sequence is cast into a
+     atomic item in the atomized sequence is cast into a
      string.</p>
                   </item>
 
@@ -15928,11 +15940,11 @@ attribute {
                         <termref def="dt-atomization"
                            >Atomization</termref> is applied to the value of the <termref
                            def="dt-content-expression"
-                        >content expression</termref>, converting it to a sequence of atomic values.</p>
+                        >content expression</termref>, converting it to a sequence of atomic items.</p>
                   </item>
 
                   <item>
-                     <p>If the result of atomization is an empty sequence, no text node is constructed. Otherwise, each atomic value in the atomized sequence is cast into a string.</p>
+                     <p>If the result of atomization is an empty sequence, no text node is constructed. Otherwise, each atomic item in the atomized sequence is cast into a string.</p>
                   </item>
 
                   <item>
@@ -15972,7 +15984,7 @@ attribute {
                            def="dt-name-expression"
                            >name expression</termref>. If the result of <termref
                            def="dt-atomization"
-                           >atomization</termref> is not a single atomic value of type <code>xs:NCName</code>, <code>xs:string</code>, or <code>xs:untypedAtomic</code>, a <termref
+                           >atomization</termref> is not a single atomic item of type <code>xs:NCName</code>, <code>xs:string</code>, or <code>xs:untypedAtomic</code>, a <termref
                            def="dt-type-error">type
    error</termref> is raised <errorref
                            class="TY" code="0004"/>.</p>
@@ -16004,14 +16016,14 @@ attribute {
                         <termref def="dt-atomization"
                            >Atomization</termref> is applied to the value of the <termref
                            def="dt-content-expression"
-                           >content expression</termref>, converting it to a sequence of atomic values. (If the <termref
+                           >content expression</termref>, converting it to a sequence of atomic items. (If the <termref
                            def="dt-content-expression"
                         >content expression</termref> is absent, the result of this step is an empty sequence.)</p>
                   </item>
 
                   <item>
                      <p>If the result of atomization is an empty sequence, it is replaced by a zero-length string.
-                        Otherwise, each atomic value in the atomized sequence is cast into a string.
+                        Otherwise, each atomic item in the atomized sequence is cast into a string.
                         If any of the resulting strings contains the string <code>"?&gt;"</code>, a <termref
                            def="dt-dynamic-error">dynamic error</termref>
                         <errorref class="DY" code="0026"/> is raised.</p>
@@ -16065,11 +16077,11 @@ return processing-instruction { $target } { "beep" }]]></eg>
                         <termref def="dt-atomization"
                            >Atomization</termref> is applied to the value of the <termref
                            def="dt-content-expression"
-                        >content expression</termref>, converting it to a sequence of atomic values.</p>
+                        >content expression</termref>, converting it to a sequence of atomic items.</p>
                   </item>
 
                   <item>
-                     <p>If the result of atomization is an empty sequence, it is replaced by a zero-length string. Otherwise, each atomic value in the atomized sequence is cast into a string.</p>
+                     <p>If the result of atomization is an empty sequence, it is replaced by a zero-length string. Otherwise, each atomic item in the atomized sequence is cast into a string.</p>
                   </item>
 
                   <item>
@@ -16130,7 +16142,7 @@ return comment { concat($homebase, ", we have a problem.") }]]></eg>
   If the result of <termref def="dt-atomization"
                            >atomization</termref>
     is an empty sequence
-    or a single atomic value of type <code>xs:string</code> or <code>xs:untypedAtomic</code>,
+    or a single atomic item of type <code>xs:string</code> or <code>xs:untypedAtomic</code>,
   then the following rules are applied in order:</p>
 
                      <olist>
@@ -16143,7 +16155,7 @@ return comment { concat($homebase, ", we have a problem.") }]]></eg>
                         <item>
                            <p>If the result is the empty sequence
                   or a zero-length <code>xs:string</code>
-                  or <code>xs:untypedAtomic</code> value,
+                  or <code>xs:untypedAtomic</code> item,
            the new namespace node has no name (such a namespace node represents a binding for the default namespace).</p>
                         </item>
 
@@ -16158,7 +16170,7 @@ return comment { concat($homebase, ", we have a problem.") }]]></eg>
 
                   <item>
                      <p>If the result of atomization is not an empty sequence
-                           or a single atomic value of type <code>xs:string</code> or <code>xs:untypedAtomic</code>,
+                           or a single atomic item of type <code>xs:string</code> or <code>xs:untypedAtomic</code>,
   a type error is raised <errorref
                            class="TY" code="0004"/>.</p>
                   </item>
@@ -17885,11 +17897,11 @@ group by $g1, $g2, $g3 collation "Spanish"]]></eg>
 
   <note>
                         <p>The atomized grouping key will always be either an empty
-     sequence or a single atomic value. Defining equivalence by
+     sequence or a single atomic item. Defining equivalence by
      reference to the <function>fn:deep-equal</function> function
      ensures that the empty sequence is equivalent only to the empty
      sequence, that <code>NaN</code> is equivalent to
-     <code>NaN</code>, that untypedAtomic values are compared as
+     <code>NaN</code>, that untypedAtomic items are compared as
      strings, and that values for which the <code>eq</code> operator
      is not defined are considered
      non-equivalent.</p>
@@ -18207,7 +18219,7 @@ the following rules:</p>
                   <p>
                      <termref def="dt-atomization"
                         >Atomization</termref> is applied to the result of the expression
-    in each orderspec.  If the result of atomization is neither a single atomic value nor an empty sequence, a <termref
+    in each orderspec.  If the result of atomization is neither a single atomic item nor an empty sequence, a <termref
                         def="dt-type-error">type error</termref> is raised <errorref class="TY"
                         code="0004"/>.</p>
                </item>
@@ -19064,7 +19076,7 @@ processing with JSON processing.</p>
                      def="dt-type-error">type error</termref>
                   <errorref class="TY" code="0004"
                      /> occurs if the result is
-    not a single atomic value.
+    not a single atomic item.
 
       The associated value is the
     result of evaluating the corresponding
@@ -19090,7 +19102,7 @@ processing with JSON processing.</p>
     values.</p>
                   </note>
                   <termdef id="dt-same-key" term="same key"
-                        >Two atomic values <code>K1</code> and
+                        >Two atomic items <code>K1</code> and
     <code>K2</code> have the <term>same key value</term> if
     
     
@@ -19970,7 +19982,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                      is converted to an integer (by virtue of the coercion rules applying to a call
                      on <code>array:get</code>). With a deep lookup expression <code>$A??$x</code>, by
                      contrast, the semantics are defined in terms of a map lookup, in which 
-                     <code>xs:untypedAtomic</code> values are always treated as strings.
+                     <code>xs:untypedAtomic</code> items are always treated as strings.
                   </p>
                </note>
                <note>
@@ -20416,7 +20428,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   >implementation-dependent</termref> if the expression calls certain functions that are affected by the ordering of node sequences. These functions include <code>fn:position</code>, <code>fn:last</code>, <code>fn:index-of</code>, <code>fn:insert-before</code>, <code>fn:remove</code>, <code>fn:reverse</code>, and <code>fn:subsequence</code>. 
 The functions <code>fn:boolean</code> and <code>fn:not</code> are <termref
                   def="dt-implementation-dependent"
-                  >implementation-dependent</termref> if ordering mode is <code>unordered</code> and the argument contains at least one node and at least one atomic value (see <specref
+                  >implementation-dependent</termref> if ordering mode is <code>unordered</code> and the argument contains at least one node and at least one atomic item (see <specref
                   ref="id-ebv"/>). 
 
 Also, within a <termref def="dt-path-expression"
@@ -20652,7 +20664,7 @@ named <code>discounted</code>, independently of its value:</p>
          
          <changes>
             <change issue="328" PR="364" date="2023-03-07">
-               Switch expressions now allow a <code>case</code> clause to match multiple atomic values.
+               Switch expressions now allow a <code>case</code> clause to match multiple atomic items.
             </change>
             <change issue="365" PR="587" date="2023-11-07">
                Switch and typeswitch expressions can now be written with curly braces,
@@ -20709,7 +20721,7 @@ raised <errorref class="TY" code="0004"/>. In the absence of a switch comparand,
             <item>
                <p diff="chg" at="2023-02-20">Otherwise, the singleton <term>switch value</term> is compared individually
                with each item in the <term>case value</term> in turn, and a match
-               occurs if and only if these two atomic values compare equal under the rules of
+               occurs if and only if these two atomic items compare equal under the rules of
                the <code>fn:deep-equal</code> function with default options, using the default 
                collation in the static context.</p>
             </item>
@@ -21493,7 +21505,7 @@ are as follows:</p>
 
                <item>
                   <p> If the result of atomization is a
-sequence of more than one atomic value, a <termref
+sequence of more than one atomic item, a <termref
                         def="dt-type-error">type error</termref> is raised <errorref class="TY"
                         code="0004"/>.</p>
                </item>
@@ -21529,7 +21541,7 @@ If <code>?</code> is not specified after the target type, a <termref
 
                <item>
                   <p>If the result of atomization is a single
-atomic value, the result of the cast expression is determined by
+atomic item, the result of the cast expression is determined by
 casting to the target type as described in <xspecref
                         spec="FO40" ref="casting"
                         />. When casting, an
@@ -21858,7 +21870,7 @@ raised <errorref
     obtained by evaluating <code>S</code>. The simple mapping operator
     <code>!</code> can be applied to any sequence, regardless of the
     types of its items, and it can deliver a mixed sequence of nodes,
-    atomic values, and functions. Unlike the similar <code>/</code>
+    atomic items, and functions. Unlike the similar <code>/</code>
     operator, it does not sort nodes into document order or eliminate
     duplicates.
   </p>
@@ -21941,7 +21953,7 @@ raised <errorref
                      <code role="parse-test"
                         >avg( //employee / salary ! translate(., '$', '') ! number(.))</code>
                   </p>
-                  <p>Returns the average salary of the employees, having converted the salary to a number by removing any <code>$</code> sign and then converting to a number. (The second occurrence of <code>!</code> could not be written as <code>/</code> because the left-hand operand of <code>/</code> cannot be an atomic value.)</p>
+                  <p>Returns the average salary of the employees, having converted the salary to a number by removing any <code>$</code> sign and then converting to a number. (The second occurrence of <code>!</code> could not be written as <code>/</code> because the left-hand operand of <code>/</code> cannot be an atomic item.)</p>
                </item>
                <item>
                   <p>

--- a/specifications/xquery-40/src/xpath-backwards-compat.xml
+++ b/specifications/xquery-40/src/xpath-backwards-compat.xml
@@ -108,7 +108,7 @@
             </item>
 
             <item>
-                <p>If one operand in a general comparison is a single atomic value of type
+                <p>If one operand in a general comparison is a single atomic item of type
                         <code>xs:boolean</code>, the other operand is converted to
                         <code>xs:boolean</code> when XPath 1.0 compatibility mode is set to <code>true</code>. In
                     XPath 1.0, if neither operand of a comparison operation using the &lt;, &lt;=,

--- a/specifications/xquery-40/src/xquery-header.xml
+++ b/specifications/xquery-40/src/xquery-header.xml
@@ -114,7 +114,7 @@ values conforming to the data model defined in
 from its most distinctive feature, the path expression, which provides
 a means of hierarchic addressing of the nodes in an XML tree.  As well
 as modeling the tree structure of XML, the data model also includes
-atomic values, function items, maps, arrays, and sequences.  This version of XPath
+atomic items, function items, maps, arrays, and sequences.  This version of XPath
 supports JSON as well as XML, and adds many new functions in <bibref ref="xpath-functions-40"/>.</p>
   
 <p role="xpath" diff="chg">&language; is a superset of XPath 3.1. A detailed list of changes

--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -194,7 +194,8 @@
          <p> The evaluation context for XPath <termref def="dt-expression">expressions</termref>
             includes a component called the <termref def="dt-current-grouping-key">current grouping
                key</termref>, which is a sequence of atomic
-               values. The current grouping key is the <termref def="dt-grouping-key">grouping key</termref> shared in common by all the items within the <termref def="dt-current-group">current group</termref>. </p>
+               items. The current grouping key is the <termref def="dt-grouping-key">grouping key</termref> 
+            shared in common by all the items within the <termref def="dt-current-group">current group</termref>. </p>
 
          <p>The function <function>current-grouping-key</function> returns the <termref def="dt-current-grouping-key">current grouping key</termref>.</p>
 
@@ -243,9 +244,10 @@
 
 
          <p>While an <elcode>xsl:for-each-group</elcode> instruction with a <code>group-by</code> or
-               <code>group-adjacent</code> attribute is being evaluated, the <termref def="dt-current-grouping-key">current grouping key</termref> will be a single atomic
-            value if <code>composite="no"</code> is specified (explicitly
-               or implicitly), or a sequence of atomic values if <code>composite="yes"</code> is
+               <code>group-adjacent</code> attribute is being evaluated, the
+            <termref def="dt-current-grouping-key">current grouping key</termref> will be a single atomic
+            item if <code>composite="no"</code> is specified (explicitly
+               or implicitly), or a sequence of atomic items if <code>composite="yes"</code> is
                specified.
          </p>
 
@@ -260,7 +262,7 @@
                   <code>xs:float</code> while another is a numerically equal
                <code>xs:decimal</code>. The <function>current-grouping-key</function>
             function returns the grouping key of the <termref def="dt-initial-item">initial item</termref> in the group, after atomization and
-            casting of <code>xs:untypedAtomic</code> values to <code>xs:string</code>.</p>
+            casting of <code>xs:untypedAtomic</code> items to <code>xs:string</code>.</p>
 
          <p>The function takes no arguments.</p>
 
@@ -444,7 +446,7 @@
       <fos:rules>
          <p>The evaluation context for XPath <termref def="dt-expression">expressions</termref>
             includes a component called the <termref def="dt-current-merge-key"/>, which is a
-            sequence of atomic values. The current merge key is the <termref def="dt-composite-merge-key-value">composite merge key value</termref> shared in common by all
+            sequence of atomic items. The current merge key is the <termref def="dt-composite-merge-key-value">composite merge key value</termref> shared in common by all
             the items within the <termref def="dt-current-merge-group">current merge
             group</termref>. </p>
 
@@ -454,7 +456,7 @@
       
          <p>While the <elcode>xsl:merge-action</elcode> child of an 
             <elcode>xsl:merge</elcode> instruction is being evaluated, the <termref def="dt-current-merge-key"/> will be a single atomic
-            value if there is a single merge key, or a sequence of atomic values if there are
+            item if there is a single merge key, or a sequence of atomic items if there are
             multiple merge keys.</p>
 
 
@@ -468,7 +470,7 @@
             <code>xs:decimal</code>. The <function>current-merge-key</function>
             function returns the merge key of the 
             first item in the group, after atomization and
-            casting of <code>xs:untypedAtomic</code> values to <code>xs:string</code>.</p>
+            casting of <code>xs:untypedAtomic</code> items to <code>xs:string</code>.</p>
 
 
 
@@ -710,7 +712,7 @@
             the context node, so any attempt to navigate to siblings or ancestors will result in an
             empty sequence being returned.</p>
          <p>All nodes in the result sequence will be parentless.</p>
-         <p>If atomic values or functions (including maps and arrays) are present in the input sequence,
+         <p>If atomic items or functions (including maps and arrays) are present in the input sequence,
          they will be included unchanged at the corresponding position of the result sequence.</p>
          <p>Accumulator values are taken from the copied
             document as described in <specref ref="copying-accumulators"/>.</p>
@@ -769,7 +771,7 @@
          
          <ulist>
             <item>
-               <p>If the supplied item is an atomic value or a function item (including maps
+               <p>If the supplied item is an atomic item or a function item (including maps
             and arrays), then it returns that item unchanged.</p>
             </item>
             <item>
@@ -807,7 +809,7 @@
         <xsl:apply-templates select="$input" mode="internal:snapshot"/>
     </xsl:function>
     
-    <!-- for atomic values and function items, return the item unchanged -->
+    <!-- for atomic items and function items, return the item unchanged -->
     
     <xsl:template match="." mode="internal:snapshot" priority="1">
         <xsl:sequence select="."/>
@@ -979,7 +981,7 @@
             </item>
             <item>
                <p> If <code>$uri-sequence</code> (after atomizing any nodes) contains an 
-                  item other than an atomic value of type <code>xs:string</code>, <code>xs:anyURI</code>, or
+                  item other than an atomic item of type <code>xs:string</code>, <code>xs:anyURI</code>, or
                      <code>xs:untypedAtomic</code> then a type error is raised <xerrorref spec="XP40" class="TY" code="0004"/>. </p>
             </item>
          </ulist>
@@ -1220,7 +1222,7 @@
                <p>If <code>composite</code> is <code>no</code> or
                      absent, the set of requested key values is formed by atomizing the
                   supplied value of the argument, using the standard <termref def="dt-coercion-rules">coercion rules</termref>. Each of
-                  the resulting atomic values is considered as a requested key value. The result of
+                  the resulting atomic items is considered as a requested key value. The result of
                   the function is a sequence of nodes, in document order and with duplicates
                   removed, comprising those nodes in the selected subtree (see below) that are
                   matched by an <elcode>xsl:key</elcode> declaration whose name is the same as the
@@ -1355,9 +1357,9 @@
       </fos:errors>
       <fos:notes>
 
-         <p>Untyped atomic values are converted to strings, not to the type of the other operand.
+         <p>Untyped atomic items are converted to strings, not to the type of the other operand.
             This means, for example, that if the expression in the <code>use</code> attribute
-            returns a date, supplying an untyped atomic value in the call to the
+            returns a date, supplying an untyped atomic item in the call to the
                <function>key</function> function will return an empty sequence.</p>
 
       </fos:notes>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -140,7 +140,7 @@
          covered are:</p>
          <ulist>
             <item><p>Enhancements to the type system to allow more expressive constraints, especially
-            for maps and atomic values.</p></item>
+            for maps and atomic items.</p></item>
             <item><p>Additional functionality for processing arrays.</p></item>
             <item><p>Exploitation of the power afforded by first-class function items.</p></item>
          </ulist>
@@ -256,6 +256,13 @@
          <head>Concepts</head>
          <div2 id="terminology">
             <head>Terminology</head>
+            
+            <changes>
+               <change issue="1337" date="2024-08-02">
+                  The term <term>atomic value</term> has been replaced by <term>atomic item</term>.
+               </change>
+            </changes>
+            
             <p>For a full glossary of terms, see <specref ref="glossary"/>.</p>
             <p>
                <termdef id="dt-processor" term="processor">The software responsible for transforming
@@ -396,7 +403,7 @@
                      <termdef id="dt-atomization" term="atomize">The term <term>atomization</term>
                         is defined in <!--<bibref ref="xpath-30"/>--><xspecref spec="XP40" ref="id-atomization"/>. It is a process that takes as input a sequence of
                            items, and returns a sequence of
-                        atomic values, in which the nodes are replaced by their typed values as
+                        atomic items, in which the nodes are replaced by their typed values as
                         defined in <bibref ref="xpath-datamodel-30"/>. 
                         <phrase diff="del" at="2022-01-01">If the XPath 3.1 feature is implemented,
                         then</phrase> Arrays (see <specref ref="arrays"/>) are atomized by atomizing their
@@ -1447,11 +1454,11 @@
                   representation such as the W3C Document Object Model (DOM) (see <bibref ref="DOM-Level-2-Core"/>),
                      adapted to the data structures offered by the programming language in which the API is defined.
                   To deliver a raw result, processors need to define a representation not only of XDM nodes but
-                  also of sequences, atomic values, maps and even functions. As with the return of a simple tree, 
+                  also of sequences, atomic items, maps and even functions. As with the return of a simple tree, 
                   this may involve a trade-off between strict fidelity to the XDM data model and usability in the particular 
                   programming language environment. It is <emph>not</emph> a requirement that an API should return results 
                      in a way that exposes every property of the XDM data model; for example there may be APIs that do not expose
-                  the precise type annotation of a returned node or atomic value, or that fail to expose the base URI
+                  the precise type annotation of a returned node or atomic item, or that fail to expose the base URI
                   or document URI of a node, or that provide no way of determining whether two nodes in the result
                   sequence are the same node in the sense of the XPath <code>is</code> operator.
                      The way in which maps, arrays, and functions 
@@ -1489,11 +1496,11 @@
        <p>The <code>item-separator</code> property has no effect if the raw result of the transformation is a sequence
        of length zero or one, which in practice will often be the case, especially in a traditional scenario such as
        transformation of an XML document to HTML.</p>
-       <p>If there is no <code>item-separator</code>, then a single space is inserted between adjacent atomic values;
+       <p>If there is no <code>item-separator</code>, then a single space is inserted between adjacent atomic items;
        for example if the raw result is the sequence <code>1 to 5</code>, then sequence normalization produces a tree
        comprising a document node with a single child, the child being a text node with the string value 
        <code>1 2 3 4 5</code>.</p>
-       <p>If there is an <code>item-separator</code>, then it is used not only between adjacent atomic values,
+       <p>If there is an <code>item-separator</code>, then it is used not only between adjacent atomic items,
        but between any pair of items in the raw result. For example if the raw result is a sequence of two
        element nodes <code>A</code> and <code>B</code>, and the <code>item-separator</code> is a comma,
        then the result of sequence normalization will be a document node with three children: a copy of <code>A</code>,
@@ -1834,7 +1841,7 @@
                accesses information from the dynamic context always uses the value at the top of the
                stack.</p>
             <p>The most commonly used component of the dynamic context is the <termref def="dt-context-item"/>. This is an implicit variable whose
-               value is the item currently being processed (it may be a node, an atomic value,
+               value is the item currently being processed (it may be a node, an atomic item,
                   or a function item). The value of the context
                item can be referenced within an XPath expression using the expression <code>.</code>
                (dot).</p>
@@ -2520,10 +2527,10 @@
             <p>The facilities for streaming of XML trees include operations such as <function>copy-of</function>
             and <function>snapshot</function> which are able to take a sequence of streamed nodes as input, 
                and produce a sequence of in-memory (unstreamed) nodes as output. It is also possible to generate
-               a sequence of strings or other atomic values through the process of <termref def="dt-atomization">atomization</termref>.
+               a sequence of strings or other atomic items through the process of <termref def="dt-atomization">atomization</termref>.
                The actual memory usage of a streamed
             XSLT application may depend significantly on whether the processing of the resulting sequence of in-memory
-            nodes or atomic values is pipelined or not. The specification, however, has nothing to say on this matter: 
+            nodes or atomic items is pipelined or not. The specification, however, has nothing to say on this matter: 
             it is considered an area where implementers can exercise their discretion and ingenuity.</p>
             
             <p>Streaming of JSON input receives little attention in this specification. One can envisage an implementation
@@ -4798,7 +4805,7 @@
                            type as <code>(xs:decimal | xs:double)</code>. This does not affect type checking:
                               a function call that passes the type checking rules with one signature will also pass the
                               type checking rules with the other. It does however affect the way that the function
-                           conversion rules work: a call that passes the <code>xs:untypedAtomic</code> value
+                           conversion rules work: a call that passes the <code>xs:untypedAtomic</code> item
                            <code>"93.7"</code> (or an untyped node with this as its string value) will be converted to 
                               an <code>xs:decimal</code> in one case and an <code>xs:double</code> in the other.</p>
                         </item>
@@ -8759,8 +8766,8 @@ and <code>version="1.0"</code> otherwise.</p>
                example, that an attribute described in the DTD as having attribute type
                   <code>NMTOKENS</code> will be annotated in the XDM tree as
                   <code>xs:untypedAtomic</code> rather than <code>xs:NMTOKENS</code>, and its typed
-               value will consist of a single <code>xs:untypedAtomic</code> value rather than a
-               sequence of <code>xs:NMTOKEN</code> values.</p>
+               value will consist of a single <code>xs:untypedAtomic</code> item rather than a
+               sequence of <code>xs:NMTOKEN</code> items.</p>
             <p>Attributes with a DTD-derived type of ID, IDREF, or IDREFS will be marked in the XDM
                tree as having the <code>is-id</code> or <code>is-idrefs</code> properties. It is
                these properties, rather than any <termref def="dt-type-annotation">type
@@ -9518,7 +9525,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   convert an integer to a date is a type error, because such a conversion is never
                   possible. Type errors can be raised statically if they can be detected
                   statically, whether or not the construct in question is ever evaluated. Attempting
-                  to convert the <phrase diff="chg" at="2022-01-01"><code>xs:untypedAtomic</code></phrase> value 
+                  to convert the <phrase diff="chg" at="2022-01-01"><code>xs:untypedAtomic</code></phrase> item 
                   <code>2003-02-29</code> to a date is a dynamic error rather
                   than a type error, because the problem is with this particular value, not with its
                   type. Dynamic errors are raised only if the instructions or expressions that
@@ -9840,7 +9847,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <item>
                         <p><termdef id="dt-context-item" term="context item">The <term>context
                                  item</term> is the item currently being processed. An item (see
-                                 <bibref ref="xpath-datamodel-30"/>) is either an atomic value (such
+                                 <bibref ref="xpath-datamodel-30"/>) is either an atomic item (such
                               as an integer, date, or string), a node, or
                                  a function item. It changes whenever instructions such as
                                  <elcode>xsl:apply-templates</elcode> and
@@ -9882,10 +9889,10 @@ and <code>version="1.0"</code> otherwise.</p>
                   </ulist>
                   <p>
                      <termdef id="dt-context-node" term="context node">If the <termref def="dt-context-item">context item</termref> is a node (as distinct from
-                        an atomic value such as an integer), then it is also referred to as the
+                        an atomic item such as an integer), then it is also referred to as the
                            <term>context node</term>. The context node is not an independent
                         variable, it changes whenever the context item changes. When the context
-                        item is an atomic value or a function
+                        item is an atomic item or a function
                            item, there is no context node.</termdef> The context node is
                      returned by the XPath <termref def="dt-expression">expression</termref>
                      <code>self::node()</code>, and it is used as the starting node for all relative
@@ -10312,7 +10319,7 @@ and <code>version="1.0"</code> otherwise.</p>
          <div2 id="patterns">
             <head>Patterns</head>
 
-            <p>In XSLT 4.0, patterns can match any kind of item: atomic values and
+            <p>In XSLT 4.0, patterns can match any kind of item: atomic items and
                function items as well as nodes.</p>
 
             <p>A <termref def="dt-template-rule">template rule</termref> identifies the items to which it applies by means of a pattern. As
@@ -10336,7 +10343,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>A predicate pattern <code>.[P1][P2]...</code> can be regarded as an abbreviation
                      for the type pattern <code>type(item())[P1][P2]...</code>.</p>
                   <p>The detailed semantics are given in <specref ref="predicate-patterns"/>. This construct can be used to match items of any
-                     kind (nodes, atomic values, and function items). For example, the pattern
+                     kind (nodes, atomic items, and function items). For example, the pattern
                      <code>.[starts-with(., '$')]</code> matches any string that starts with the
                      character <code>$</code>, or a node whose atomized value starts with 
                      <code>$</code>. This example shows a predicate pattern with a single
@@ -10354,7 +10361,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>The most commonly used type patterns can be abbreviated. For example, <code>match="type(record(F1, F2, *))"</code> 
                      can be abbrevated to <code>match="record(F1, F2, *)"</code>, and <code>match="type(array(xs:string))"</code>
                      can be abbreviated to <code>match="array(xs:string)"</code>. The main case where such abbreviation is
-                  not possible is with atomic values: <code>match="type(xs:date)"</code> cannot be abbreviated because
+                  not possible is with atomic items: <code>match="type(xs:date)"</code> cannot be abbreviated because
                   a bare QName is interpreted as a node pattern, matching elements named <code>xs:date</code>.
                   The pattern <code>match="type(text() | comment())"</code> has almost the same effect as
                   <code>match="text() | comment()"</code>, except that the rules for calculating a default priority
@@ -10435,7 +10442,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            </item>
                            <item>
                               <p><code>type(xs:date)</code> matches any
-                                 atomic value of type <code>xs:date</code> (or a type derived by
+                                 atomic item of type <code>xs:date</code> (or a type derived by
                                  restriction from <code>xs:date</code>).</p>
                            </item>
                            <item>
@@ -10458,7 +10465,7 @@ and <code>version="1.0"</code> otherwise.</p>
                                  that the result of calling the function with the argument value <code>42</code> is <code>true</code>.</p>
                            </item>
                            <item>
-                              <p><code>type(xs:date | xs:dateTime | xs:time)</code> matches any atomic value
+                              <p><code>type(xs:date | xs:dateTime | xs:time)</code> matches any atomic item
                                  that is an instance of <code>xs:date</code>, <code>xs:dateTime</code>, or <code>xs:time</code>.</p>
                            </item>
                            <item>
@@ -10652,9 +10659,9 @@ and <code>version="1.0"</code> otherwise.</p>
                <ulist diff="add" at="2022-01-01">
                   <item><p>A <code>PredicatePattern</code> matches items according to conditions that the item must
                   satisfy: for example <code>.[. castable as xs:integer]</code> matches any value (it might
-                  be an atomic value, a node, or an array) that is castable as an integer.</p></item>
+                  be an atomic item, a node, or an array) that is castable as an integer.</p></item>
                   <item><p>A <code>TypePattern</code> matches items according to their type. For example
-                  <code>type(xs:integer)</code> matches an atomic value that is an instance of <code>xs:integer</code>,
+                  <code>type(xs:integer)</code> matches an atomic item that is an instance of <code>xs:integer</code>,
                   while <code>record(longitude, latitude)</code> matches a map that has exactly two entries, with
                   keys <code>"longitude"</code> and <code>"latitude"</code></p></item>
                   <item><p>A <code>NodePattern</code> matches nodes in a tree, typically by specifying a path that
@@ -11581,8 +11588,8 @@ and <code>version="1.0"</code> otherwise.</p>
                         + $y</code> as an integer, and then constructs a text node containing the
                      string representation of this integer (preceded and followed by whitespace).
                      Because the declared result type of the function is <code>xs:integer</code>,
-                     this text node is then atomized, giving an <code>xs:untypedAtomic</code> value,
-                     and the <code>xs:untypedAtomic</code> value is then cast to an
+                     this text node is then atomized, giving an <code>xs:untypedAtomic</code> item,
+                     and the <code>xs:untypedAtomic</code> item is then cast to an
                         <code>xs:integer</code>.</p>
                </example>
 
@@ -11613,7 +11620,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <p>
                <termdef id="dt-sequence-constructor" term="sequence constructor">A <term>sequence
                      constructor</term> is a sequence of zero or more sibling nodes in the <termref def="dt-stylesheet">stylesheet</termref> that can be evaluated to return a
-                  sequence of nodes, atomic values, and function
+                  sequence of nodes, atomic items, and function
                      items. The way that the resulting sequence is used depends on the
                   containing instruction.</termdef>
             </p>
@@ -11651,13 +11658,13 @@ and <code>version="1.0"</code> otherwise.</p>
                      items are nodes, but some instructions (such
                         as
                      <elcode>xsl:sequence</elcode> and <elcode>xsl:copy-of</elcode>) can also
-                     produce atomic values or function items.
+                     produce atomic items or function items.
                      Several instructions, such as <elcode>xsl:element</elcode>, return a newly
                      constructed parentless node (which may have its own attributes, namespaces,
                      children, and other descendants). Other instructions, such as
                         <elcode>xsl:if</elcode>, pass on the items produced by their own nested
                      sequence constructors. The <elcode>xsl:sequence</elcode> instruction may return
-                     atomic values, function items, or existing
+                     atomic items, function items, or existing
                      nodes.</p>
                </item>
                <item>
@@ -11804,7 +11811,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      are not <termref def="dt-atomization">atomized</termref>.</p></note>
                   </item>
                   <item>
-                     <p>Any atomic value in the sequence is cast to a string.</p>
+                     <p>Any atomic item in the sequence is cast to a string.</p>
                      <note>
                         <p>Casting from <code>xs:QName</code> or <code>xs:NOTATION</code> to
                               <code>xs:string</code> always succeeds, because these values retain a
@@ -11972,7 +11979,7 @@ and <code>version="1.0"</code> otherwise.</p>
   &lt;f&gt;12345&lt;/f&gt;
 &lt;/doc&gt;</eg>
                   <p>The difference between the two cases is that for the <code>e</code> element,
-                     the sequence constructor generates a sequence of five atomic values, which are
+                     the sequence constructor generates a sequence of five atomic items, which are
                      therefore separated by spaces. For the <code>f</code> element, the content is a
                      sequence of five text nodes, which are concatenated without space
                      separation.</p>
@@ -12059,18 +12066,18 @@ and <code>version="1.0"</code> otherwise.</p>
                   <eg xml:space="preserve" role="xml">&lt;doc e="1 2 3 4 5" f="12345" g="1 2 3 4 5"/&gt;</eg>
                   <p>The difference between the three cases is as follows. For the
                         <code>e</code> attribute, the sequence constructor generates a sequence of
-                     five atomic values, which are therefore separated by spaces. For the
+                     five atomic items, which are therefore separated by spaces. For the
                         <code>f</code> attribute, the content is supplied as a sequence of five text
                      nodes, which are concatenated without space separation. For the <code>g</code>
                      attribute, the <termref def="dt-text-value-template"/> constructs a text node
                      using the rules for constructing simple content, which insert space separators
-                     between atomic values; the text node is then atomized to form the value of the
+                     between atomic items; the text node is then atomized to form the value of the
                      attribute.</p>
                   <p>Specifying <code>separator=""</code> on the first
                         <elcode>xsl:attribute</elcode> instruction would cause the attribute value
                      to be <code>e="12345"</code>. A <code>separator</code> attribute on the second
                         <elcode>xsl:attribute</elcode> instruction would have no effect, since the
-                     separator only affects the way adjacent atomic values are handled: separators
+                     separator only affects the way adjacent atomic items are handled: separators
                      are never inserted between adjacent text nodes. A
                            <code>separator</code> on the third <elcode>xsl:attribute</elcode>
                         instruction would also have no effect, because text value templates are
@@ -12586,7 +12593,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </p>
             </example>
             <example>
-               <head>Applying Templates to Atomic Values</head>
+               <head>Applying Templates to Atomic Items</head>
                <p>This example reads a non-XML text file and processes it line-by-line, applying
                   different template rules based on the content of each line:</p>
                <eg xml:space="preserve" role="xslt-declarations" diff="chg" at="2022-01-01">&lt;xsl:template name="main"&gt;
@@ -13930,7 +13937,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>This text node may have a string value that is zero-length.</p>
                </note>
                <p>The built-in <termref def="dt-template-rule">template
-                     rule</termref> for atomic values returns a
+                     rule</termref> for atomic items returns a
                   text node containing the value. It is effectively:</p>
                <eg xml:space="preserve" role="xslt-declaration">&lt;xsl:template match=".[. instance of xs:anyAtomicType]" mode="M"&gt;
   &lt;xsl:value-of select="string(.)"/&gt;
@@ -13993,7 +14000,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   subtree. Other unmatched items are also copied unchanged. The subtree is copied
                   unconditionally, without attempting to match nodes in the subtree against template
                   rules.</p>
-               <p>When this default action is selected for a mode <var>M</var>, all items (nodes, atomic values, and functions, including maps and arrays) are processed
+               <p>When this default action is selected for a mode <var>M</var>, all items (nodes, atomic items, and functions, including maps and arrays) are processed
                   using a template rule that is equivalent to the following:</p>
                <eg xml:space="preserve" role="xslt-declaration">&lt;xsl:template match="." mode="M"&gt;
   &lt;xsl:copy-of select="." validation="preserve"/&gt;
@@ -14007,7 +14014,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   copied unchanged to the output, except for nodes where different processing is
                   specified using an explicit <termref def="dt-template-rule">template
                      rule</termref>.</p>
-               <p>When this default action is selected for a mode <var>M</var>, all items (nodes, atomic values, and functions, including maps and arrays) are processed
+               <p>When this default action is selected for a mode <var>M</var>, all items (nodes, atomic items, and functions, including maps and arrays) are processed
                   using a template rule that is equivalent to the following, except that all
                   parameters supplied in <elcode>xsl:with-param</elcode> elements are passed on
                   implicitly to the called templates:</p>
@@ -14220,8 +14227,9 @@ and <code>version="1.0"</code> otherwise.</p>
 &lt;/xsl:template&gt;</eg>
                   </item>
                   <item>
-                     <p>The built-in rule for all items other than document nodes (that is, for all other kinds of node, as well as atomic
-                           values and functions, including
+                     <p>The built-in rule for all items other than document nodes (that is, for all 
+                        other kinds of node, as well as atomic
+                           items and functions, including
                               maps and  and arrays) is to do nothing, that is, to return an empty
                         sequence (without applying templates to any children or ancestors).</p>
                      <p>This is equivalent to the following rule:</p>
@@ -14253,7 +14261,7 @@ and <code>version="1.0"</code> otherwise.</p>
 &lt;/xsl:template&gt;</eg>
 
 
-               <p>The built-in template rule for all other kinds of node, and for atomic values and
+               <p>The built-in template rule for all other kinds of node, and for atomic items and
                   functions (including maps, but not arrays) is empty:
                   that is, when the item is matched, the built-in template rule returns an empty
                   sequence.</p>
@@ -15209,7 +15217,7 @@ and <code>version="1.0"</code> otherwise.</p>
             The <code>select</code> attribute of <elcode>xsl:when</elcode> and <elcode>xsl:otherwise</elcode>
                is introduced for similar reasons: XSLT instructions
             are most useful when contructing node trees, whereas XPath expressions are more convenient when computing
-            atomic values. Again, the main contribution of these enhancements is to reduce visual clutter, making
+            atomic items. Again, the main contribution of these enhancements is to reduce visual clutter, making
             the code more concise and more easily readable.</p>
             <p>The <elcode>xsl:switch</elcode> instruction is introduced in XSLT 4.0 as an alternative to <elcode>xsl:choose</elcode>
             for the common use case where the conditions test for multiple different values of some common expression. By avoiding
@@ -15438,7 +15446,7 @@ and <code>version="1.0"</code> otherwise.</p>
             
             <p>The <elcode>xsl:switch</elcode> element selects one among a number of possible
                alternatives. The <code>select</code> attribute of the <elcode>xsl:switch</elcode> element
-               is evaluated to obtain an atomic value, which is compared with the values given by the
+               is evaluated to obtain an atomic item, which is compared with the values given by the
                <code>test</code> attributes of the <elcode>xsl:when</elcode> elements, in turn.</p>
             <p>The content of the <elcode>xsl:switch</elcode> element consists of a sequence of one or more <elcode>xsl:when</elcode>
                elements followed by an optional <elcode>xsl:otherwise</elcode> element. Each
@@ -15459,7 +15467,7 @@ and <code>version="1.0"</code> otherwise.</p>
             <ulist>
                <item><p>The <code>select</code> expression of the <elcode>xsl:switch</elcode>
                   element is evaluated.</p></item>
-               <item><p>The result of the evaluation is converted to a single atomic value
+               <item><p>The result of the evaluation is converted to a single atomic item
                   by applying the <termref def="dt-coercion-rules"/>; a type error occurs
                   if this conversion is not possible. This value is referred to below as the
                   <term>selector</term>.</p></item>
@@ -15470,9 +15478,9 @@ and <code>version="1.0"</code> otherwise.</p>
                   satisfied, then the <elcode>xsl:otherwise</elcode> element is considered, as
                   described below.</p>
                   <p>An <elcode>xsl:when</elcode> element is tested by first evaluating its <code>test</code>
-                     expression and converting the result to a sequence of atomic values
+                     expression and converting the result to a sequence of atomic items
                      by applying the <termref def="dt-coercion-rules"/>, and then
-                     comparing this sequence of atomic values with the <code>selector</code> value. The
+                     comparing this sequence of atomic items with the <code>selector</code> value. The
                      comparison is performed using the rules of the XPath <code>=</code> operator,
                      using the default collation that is in scope for the <elcode>xsl:switch</elcode>
                      instruction.</p>
@@ -16207,10 +16215,10 @@ and <code>version="1.0"</code> otherwise.</p>
                            </note>
                         </item>
                         <item>
-                           <p>An atomic value such that the result of casting the atomic value to a
+                           <p>An atomic item such that the result of casting the atomic item to a
                               string is zero-length.</p>
                            <note>
-                              <p>This can happen only when the atomic value is of type
+                              <p>This can happen only when the atomic item is of type
                                     <code>xs:string</code>, <code>xs:anyURI</code>,
                                     <code>xs:untypedAtomic</code>, <code>xs:hexBinary</code>, or
                                     <code>xs:base64Binary</code>.</p>
@@ -16269,7 +16277,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </olist>
                
                <p><termdef id="dt-vacuous" term="vacuous">An item is <term>vacuous</term> if
-               it is one of the following: a zero-length text node; a document node with no children; an atomic value which, 
+               it is one of the following: a zero-length text node; a document node with no children; an atomic item which, 
                on casting to <code>xs:string</code>, produces a zero-length string; or <phrase diff="del" at="2022-01-01">(when XPath 3.1 is supported)</phrase> an array 
                   which on flattening using the <xfunction spec="FO40">array:flatten</xfunction> function produces either an empty sequence 
                   or a sequence consisting entirely of <termref def="dt-vacuous"/> items.</termdef></p>
@@ -16554,7 +16562,7 @@ and <code>version="1.0"</code> otherwise.</p>
          </p>
          <p>
             <termdef id="dt-value" term="value">A variable is a binding between a name and a value.
-               The <term>value</term> of a variable is any sequence (of nodes, atomic values,
+               The <term>value</term> of a variable is any sequence (of nodes, atomic items,
                   and/or function items), as defined in <bibref ref="xpath-datamodel-30"/>.</termdef>
          </p>
 
@@ -17894,7 +17902,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <code>xs:untypedAtomic</code>, and the <elcode>xsl:with-param</elcode> element
                   specifies <code>as="xs:integer"</code>, while the <elcode>xsl:param</elcode>
                   element specifies <code>as="xs:double"</code>. Then the node will first be
-                  atomized and the resulting untyped atomic value will be cast to
+                  atomized and the resulting untyped atomic item will be cast to
                      <code>xs:integer</code>. If this succeeds, the <code>xs:integer</code> will
                   then be promoted to an <code>xs:double</code>.</p>
             </note>
@@ -18203,7 +18211,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   </p></item>
                   <item><p>If the declared type is any other atomic or union type, with no occurrence indicator, 
                      then the attribute is treated as an <termref def="dt-attribute-value-template"/>,
-                     and its <termref def="dt-effective-value"/> is treated as an <code>xs:untypedAtomic</code> value,
+                     and its <termref def="dt-effective-value"/> is treated as an <code>xs:untypedAtomic</code> item,
                      which forces conversion to the required type by applying the casting rules.</p></item>
                   <item><p>In all other cases (that is, if the type of the parameter is not declared, 
                      or if it is not atomic, or if there is an occurrence
@@ -19572,7 +19580,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      right, it is vital that the key for this table should correctly reflect what it
                      means for two function calls to have “the same arguments”. Does it matter, for
                      example, that one call passes the <code>xs:string</code> value <code>"Paris"</code>, while
-                     another passes the <code>xs:untypedAtomic</code> value <code>"Paris"</code>? If the function
+                     another passes the <code>xs:untypedAtomic</code> item <code>"Paris"</code>? If the function
                      is declared with <code>new-each-time="maybe"</code>, then the rules say that
                      these cannot be treated as “the same arguments”: the definition of 
                      <xtermref spec="FO40" ref="dt-identical"/> requires them to have the same type
@@ -20124,7 +20132,7 @@ and <code>version="1.0"</code> otherwise.</p>
       <div1 id="creating-new-nodes">
          <head>Creating Nodes and Sequences</head>
          <p>This section describes instructions that directly create new nodes, or sequences of
-            nodes, atomic values, and/or function items.</p>
+            nodes, atomic items, and/or function items.</p>
          <div2 id="literal-result-element">
             <head>Literal Result Elements</head>
             <p>
@@ -21497,7 +21505,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         than one item.</p>
                   </error></p>
 
-               <p>When the selected item is an atomic value
+               <p>When the selected item is an atomic item
                      or function item, the
                      <elcode>xsl:copy</elcode> instruction returns this value. The <termref def="dt-sequence-constructor">sequence constructor</termref> is not evaluated.
                      </p>
@@ -21640,13 +21648,13 @@ and <code>version="1.0"</code> otherwise.</p>
                <head>Deep Copy</head>
                <?element xsl:copy-of?>
                <p>The <elcode>xsl:copy-of</elcode> instruction can be used to construct a copy of a
-                  sequence of nodes, atomic values, and/or function
+                  sequence of nodes, atomic items, and/or function
                      items with each new node containing copies of all the children,
                   attributes, and (by default) namespaces of the original node, recursively. The
                   result of evaluating the instruction is a sequence of items corresponding
                   one-to-one with the supplied sequence, and retaining its order.</p>
                <p>The <rfc2119>required</rfc2119>
-                  <code>select</code> attribute contains an <termref def="dt-expression">expression</termref>, whose value may be any sequence of nodes, atomic values,
+                  <code>select</code> attribute contains an <termref def="dt-expression">expression</termref>, whose value may be any sequence of nodes, atomic items,
                      and/or function items. The items in this
                   sequence are processed as follows:</p>
                <ulist>
@@ -21686,7 +21694,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            <elcode>xsl:copy</elcode> (see <specref ref="shallow-copy"/>).</p>
                   </item>
                   <item>
-                     <p>If the item is an atomic value or a function
+                     <p>If the item is an atomic item or a function
                            item, the value is appended to the result sequence, as with
                            <elcode>xsl:sequence</elcode>.</p>
                   </item>
@@ -21767,11 +21775,11 @@ and <code>version="1.0"</code> otherwise.</p>
             </changes>
             <?element xsl:sequence?>
             <p>The <elcode>xsl:sequence</elcode> instruction may be used within a <termref def="dt-sequence-constructor">sequence constructor</termref> to construct a
-               sequence of nodes, atomic values, and/or function
+               sequence of nodes, atomic items, and/or function
                   items. This sequence is returned as the result of the instruction. Unlike
                most other instructions, <elcode>xsl:sequence</elcode> can return a sequence
                containing existing nodes, rather than constructing new nodes. When
-                  <elcode>xsl:sequence</elcode> is used to select atomic values or function items, the effect is very similar to the
+                  <elcode>xsl:sequence</elcode> is used to select atomic items or function items, the effect is very similar to the
                   <elcode>xsl:copy-of</elcode> instruction.</p>
             
             <p>The <code>select</code> attribute and the contained <termref def="dt-sequence-constructor"/>
@@ -21861,14 +21869,14 @@ and <code>version="1.0"</code> otherwise.</p>
                      <elcode>xsl:value-of</elcode> would create a new text node, which then has to
                   be converted to an <code>xs:decimal</code>. Using <elcode>xsl:sequence</elcode>,
                   which in this case atomizes the existing attribute node and adds an
-                     <code>xs:decimal</code> atomic value to the result sequence, is a more direct
+                     <code>xs:decimal</code> atomic item to the result sequence, is a more direct
                   way of achieving the same result.</p>
                <p>This example could alternatively be solved at the XPath level:</p>
                <eg xml:space="preserve" role="xslt-instruction">&lt;xsl:sequence select="//product/(+@price otherwise @cost*1.5))"/&gt;</eg>
                <p>The apparently redundant <code>+</code> operator is there to atomize the attribute
                   value: the expression on the right hand side of the <code>/</code> operator must
                   not return a  sequence containing both nodes and
-                     non-nodes (atomic values or function items).</p>
+                     non-nodes (atomic items or function items).</p>
             </example>
             
          </div2>
@@ -22623,7 +22631,7 @@ return if ($i le count($S))
             <p>The value of a <termref def="dt-sort-key-component">sort key component</termref> is
                determined either by its <code>select</code> attribute or by the contained <termref def="dt-sequence-constructor">sequence constructor</termref>. If neither is
                present, the default is <code>select="."</code>, which has the effect of sorting on
-               the actual value of the item if it is an atomic value, or on the typed-value of the
+               the actual value of the item if it is an atomic item, or on the typed-value of the
                item if it is a node. If a <code>select</code> attribute is present, its value
                   <rfc2119>must</rfc2119> be an XPath <termref def="dt-expression">expression</termref>.</p>
             <p>
@@ -22997,8 +23005,8 @@ return if ($i le count($S))
                contained <termref def="dt-sort-key-specification">sort key
                specification</termref>.</p>
             <example>
-               <head>Sorting a Sequence of Atomic Values</head>
-               <p>The following stylesheet function sorts a sequence of atomic values using the
+               <head>Sorting a Sequence of Atomic Items</head>
+               <p>The following stylesheet function sorts a sequence of atomic items using the
                   value itself as the sort key.</p>
                <eg xml:space="preserve" role="xslt-declaration xmlns:local='local'">&lt;xsl:function name="local:sort" 
           as="xs:anyAtomicType*"&gt;
@@ -23364,11 +23372,11 @@ return if ($i le count($S))
                   then for each item in the <termref def="dt-population">population</termref> a set
                   of <term>grouping keys</term> is calculated, as follows: the expression contained
                   in the <code>group-by</code> or <code>group-adjacent</code> attribute is
-                  evaluated; the result is atomized; and any <code>xs:untypedAtomic</code> values
+                  evaluated; the result is atomized; and any <code>xs:untypedAtomic</code> items
                   are cast to <code>xs:string</code>. If
                         <code>composite="yes"</code> is specified, there is a single grouping key
                      whose value is the resulting sequence; otherwise, there is a set of grouping
-                     keys, consisting of the distinct atomic values present in the result
+                     keys, consisting of the distinct atomic items present in the result
                      sequence.</termdef>
             </p>
             <p>When calculating grouping keys for an item in the population, the <termref def="dt-expression">expression</termref> contained in the <code>group-by</code> or
@@ -23427,8 +23435,8 @@ return if ($i le count($S))
                      For each item <var>J</var>, the expression in the <code>group-by</code>
                      attribute is evaluated to produce a sequence of zero or more <termref def="dt-grouping-key">grouping key</termref> values. If <code>composite="yes"</code> is specified, there will be a single
                         grouping key, which will in general be a sequence of zero or more atomic
-                        values; otherwise, there will be zero or more grouping keys, each of which
-                        will be a single atomic value. For each one of these <termref def="dt-grouping-key">grouping keys</termref>, if there is already a group
+                        items; otherwise, there will be zero or more grouping keys, each of which
+                        will be a single atomic item. For each one of these <termref def="dt-grouping-key">grouping keys</termref>, if there is already a group
                      created to hold items having that grouping key value, <var>J</var> is appended to that group; otherwise a new group is
                      created for items with that grouping key value, and <var>J</var> becomes its
                      first member.</p>
@@ -23561,8 +23569,8 @@ the same group, and the-->
                </item>
                <item>
                   <p><termdef id="dt-current-grouping-key" term="current grouping key">The
-                           <term>current grouping key</term> is a single atomic value, or in the
-                        case of a composite key, a sequence of atomic values, containing the
+                           <term>current grouping key</term> is a single atomic item, or in the
+                        case of a composite key, a sequence of atomic items, containing the
                            <termref def="dt-grouping-key"/> of the items in the <termref def="dt-current-group"/>.</termdef></p>
                </item>
             </ulist>
@@ -24054,7 +24062,7 @@ the same group, and the-->
          <p>The <elcode>xsl:merge</elcode> instruction allows a sorted sequence of items to be
             constructed by merging several input sequences. Each
             input sequence <rfc2119>must</rfc2119> have a merge key (one or more
-            atomic values that can be computed as a function of the items in the sequence); the
+            atomic items that can be computed as a function of the items in the sequence); the
             input sequence <rfc2119>must</rfc2119> either already be sorted on the value of
             its merge keys, or pre-sorting on these values must be requested. 
             The merge keys for the different input sequences <rfc2119>must</rfc2119> be compatible in the sense that key
@@ -24470,7 +24478,7 @@ the same group, and the-->
 
                <p>Although the merge keys are computed in different ways for the two input
                   sequences, the keys must be compatible across the two sequences: in this case they
-                  are both atomic values of type <code>xs:dateTime</code>.</p>
+                  are both atomic items of type <code>xs:dateTime</code>.</p>
             </example>
 
             <p>In the common case where there is only one input sequence of a particular kind, the
@@ -24539,7 +24547,7 @@ the same group, and the-->
                   portion of the source document delivered by the <function>snapshot</function>
                   function will typically not cause an error, but will return empty results.</p>
                <p>There is no
-                  rule to prevent the <code>select</code> expression returning atomic values, or grounded nodes from a
+                  rule to prevent the <code>select</code> expression returning atomic items, or grounded nodes from a
                   different source document, or newly constructed nodes, but they are still
                   processed using the <function>snapshot</function> function.</p>
                <p>Because the <function>snapshot</function> copies
@@ -24835,7 +24843,7 @@ the same group, and the-->
                </item>
                <item>
                   <p><termdef id="dt-current-merge-key" term="current merge key">The <term>current
-                           merge key</term> is a sequence of atomic values. During evaluation of an
+                           merge key</term> is a sequence of atomic items. During evaluation of an
                            <elcode>xsl:merge</elcode> instruction, as each group of items with equal
                            <termref def="dt-composite-merge-key-value">composite merge key
                            values</termref> is processed, the current merge key is set to the
@@ -25101,7 +25109,7 @@ the same group, and the-->
             <example>
                <head>Merging Two Sequences of Numbers</head>
                <p>The <elcode>xsl:merge</elcode> instruction can be used to determine the union,
-                  intersection, or difference of two sequences of numbers (or other atomic values).
+                  intersection, or difference of two sequences of numbers (or other atomic items).
                   This code gives the union:</p>
                <eg role="xslt-instruction" xml:space="preserve">&lt;xsl:merge&gt;
   &lt;xsl:merge-source select="1 to 30"&gt;
@@ -27648,7 +27656,7 @@ the same group, and the-->
                other U-type, it has the empty sequence <code>()</code> as an instance. For
                convenience, the universal U-type is represented as <var>U{*}</var>; the U-type
                corresponding to the set of 7 node kinds is written <var>U{N}</var>, and the U-type
-               corresponding to all atomic values (that is, the 19 primitive atomic types plus
+               corresponding to all atomic items (that is, the 19 primitive atomic types plus
                   <code>xs:untypedAtomic</code>) is written <var>U{A}</var>.</p>
 
             <p>Because a <termref def="dt-utype"/> is a set, the operations of union, intersection,
@@ -28628,7 +28636,7 @@ the same group, and the-->
                <item>
                   <p><termdef id="dt-grounded" term="grounded"><term>Grounded</term>: indicates that
                         the value returned by the construct does not contain nodes from the streamed
-                        input document</termdef>. Atomic values and function items are always
+                        input document</termdef>. Atomic items and function items are always
                      grounded; nodes are grounded if it is known that they are in a non-streamed
                      document. For example the expressions <code>doc('x')</code> and
                         <code>copy-of(.)</code> both return grounded nodes.</p>
@@ -28740,7 +28748,7 @@ the same group, and the-->
 
             <p>The characterization of an expression as striding, crawling, climbing, or
                roaming applies only to the streamed nodes in the result of the expression. The result of the expression
-               may also contain non-streamed (grounded) nodes or atomic values. For example
+               may also contain non-streamed (grounded) nodes or atomic items. For example
                if <code>/x/y</code> is a striding expression, then <code>(/x/y | $doc//x)</code> is also striding, given
                that <code>$doc</code> contains non-streamed nodes. The assertion that the nodes in the result of a striding
                expression are in document order and are peers thus applies only to the subset of the nodes that are streamed.</p>
@@ -29343,7 +29351,7 @@ the same group, and the-->
                      possible: the posture needs to be statically determined to ensure that
                      streaming does not fail at execution time. It is permitted, however, for
                      streamed nodes to be mixed in a sequence with non-streamed nodes or with atomic
-                     values; in this case the posture of the result will be that of the streamed
+                     items; in this case the posture of the result will be that of the streamed
                      nodes. It is also permitted to have multiple
                         operands delivering streamed nodes in different branches of a conditional,
                         provided the sweep and posture are compatible: for example <code>if (X) then
@@ -30799,7 +30807,7 @@ the same group, and the-->
                      <p>In practice the rules depend very little on the <code>from</code> and
                            <code>count</code> patterns. This is because when the instruction is
                         applied to a streamed node, the instruction will be <termref def="dt-free-ranging"/> regardless of these patterns; while if it is
-                        applied to a grounded node or atomic value, the instruction will normally be
+                        applied to a grounded node or atomic item, the instruction will normally be
                            <termref def="dt-motionless"/> regardless of the values of these
                         patterns. The pattern does matter,
                            however, if it contains a variable reference bound to a <termref def="dt-streaming-parameter"/>;
@@ -30858,7 +30866,7 @@ the same group, and the-->
                   <note>
                      <p>In practice, the <elcode>xsl:perform-sort</elcode> instruction cannot be
                         used to sort nodes from the streamed input document, but it can be used to
-                        sort atomic values or <termref def="dt-grounded"/> nodes, for example a copy
+                        sort atomic items or <termref def="dt-grounded"/> nodes, for example a copy
                         of nodes from the streamed document made using the
                            <function>copy-of</function> function.</p>
                   </note>
@@ -31289,7 +31297,7 @@ the same group, and the-->
                   </example>
 
                   <example>
-                     <head>An unclassified stylesheet function that accepts atomic values</head>
+                     <head>An unclassified stylesheet function that accepts atomic items</head>
                      <p>The <termref def="dt-streamability-category"/> is
                         <code>unclassified</code>.</p>
                      <eg role="xslt-declaration xmlns:f='f'" xml:space="preserve">
@@ -31301,7 +31309,7 @@ the same group, and the-->
                         </eg>
                      <p>The effect of the rules is that a call to this function is streamable under
                         similar circumstances to those that apply to a binary operator such as
-                           <code>+</code>. For example, a call is streamable if two atomic values
+                           <code>+</code>. For example, a call is streamable if two atomic items
                         are supplied, or if two attribute nodes are supplied, whether from streamed
                         or unstreamed documents. The main constraint is that it is not permitted for
                         both arguments to be consuming; for example, if the context node is a node
@@ -31338,7 +31346,7 @@ the same group, and the-->
                   <note>
                      <p>Absorbing functions perform an operation analogous to atomization on their
                         supplied arguments, in that they typically use information from the subtree
-                        rooted at a node to compute atomic values. Atomization can be seen as a
+                        rooted at a node to compute atomic items. Atomization can be seen as a
                         special case of absorption. Calls on absorbing functions are therefore, from
                         a streamability point of view, equivalent to calls on functions that
                         implicitly atomize the supplied nodes.</p>
@@ -31360,7 +31368,7 @@ the same group, and the-->
                      <head>An absorbing stylesheet function</head>
                      <p>The following function is declared as absorbing, and the function body meets
                         the rules for this category because it makes downward selections only, and
-                        returns an atomic value.</p>
+                        returns an atomic item.</p>
                      <eg role="xslt-declaration xmlns:f='f'" xml:space="preserve">
 &lt;xsl:function name="f:count-descendants" as="xs:integer" streamability="absorbing"&gt;
   &lt;xsl:param name="input" as="node()*"/&gt;
@@ -31375,7 +31383,7 @@ the same group, and the-->
                      <head>An absorbing stylesheet function with two arguments</head>
                      <p>The following function is declared as absorbing, and the function body meets
                         the rules for this category because it makes downward selections only from
-                        the node supplied as the first argument, and returns an atomic value.</p>
+                        the node supplied as the first argument, and returns an atomic item.</p>
                      <eg role="xslt-declaration xmlns:f='f'" xml:space="preserve">
 &lt;xsl:function name="f:compare-size" as="xs:integer" streamability="absorbing"&gt;
   &lt;xsl:param name="input0" as="node()"/&gt;
@@ -31543,7 +31551,7 @@ the same group, and the-->
                      
                      <p>Although the name <code>filter</code> suggests that the result must always
                         be a subset of the input, this is not strictly required by the rules. The
-                        function can also return atomic values, as well as attribute and namespace
+                        function can also return atomic items, as well as attribute and namespace
                         nodes.</p>
                   </example>
                </div4>
@@ -35104,7 +35112,7 @@ the same group, and the-->
                </p>
                <p>When evaluation of the <termref def="dt-key-specifier">key
                      specifier</termref> results in a sequence (after atomization) containing more
-                  than one atomic value, the effect depends on the value of the
+                  than one atomic item, the effect depends on the value of the
                      <code>composite</code> attribute:</p>
                <ulist>
                   <item>
@@ -35116,7 +35124,7 @@ the same group, and the-->
                   </item>
                   <item>
                      <p>When the attribute is present and has the value <code>yes</code>, the
-                        sequence of atomic values is treated as a composite key that must be matched
+                        sequence of atomic items is treated as a composite key that must be matched
                         in its entirety. For example, if <code>match="book" use="author"
                            composite="yes"</code> is specified, then a <code>book</code> element may
                         be located using the value of all its <code>author</code> elements, supplied
@@ -35588,7 +35596,7 @@ the same group, and the-->
             <p>The value of the expression is a map whose entries correspond to the key-value pairs
                obtained by evaluating the successive <code>KeyExpr</code> and <code>ValueExpr</code>
                expressions.</p>
-            <p>Each <code>KeyExpr</code> expression is evaluated and atomized; a type error <xerrorref spec="XP40" class="TY" code="0004"/> occurs if the result is not a single atomic value. If the key is of
+            <p>Each <code>KeyExpr</code> expression is evaluated and atomized; a type error <xerrorref spec="XP40" class="TY" code="0004"/> occurs if the result is not a single atomic item. If the key is of
                type <code>xs:untypedAtomic</code> it is converted to <code>xs:string</code>. The
                associated value is the result of evaluating the corresponding
                   <code>ValueExpr</code>. If two or more entries have the <term>same key</term> then 
@@ -36779,7 +36787,7 @@ return ($m?price - $m?discount)</eg>
                <head>External Objects</head>
                <p>An implementation <rfc2119>may</rfc2119> allow an extension function to return an
                   object that does not have any natural representation in the XDM data model,
-                  whether as an atomic value, a node, or a function
+                  whether as an atomic item, a node, or a function
                      item. For example, an extension function <code>sql:connect</code>
                   might return an object that represents a connection to a relational database; the
                   resulting connection object might be passed as an argument to calls on other
@@ -38809,7 +38817,7 @@ return ($m?price - $m?discount)</eg>
          
          <ulist>
             <item><p>A processor that does not provide the <termref def="dt-schema-aware-xslt-processor">schema-awareness</termref>
-            feature restricts the data model so that it does not contain atomic values of types other than the built-in types,
+            feature restricts the data model so that it does not contain atomic items of types other than the built-in types,
             or nodes with non-trivial type annotations.</p></item>
             <item diff="del" at="2023-01-29"><p>A processor that does not provide the <termref def="dt-hof-feature"/> constrains the data model so that
             it does not contain function items other than maps or arrays.</p></item>
@@ -38939,9 +38947,9 @@ return ($m?price - $m?discount)</eg>
                   constraints are not satisfied:</p>
             <ulist>
                <item>
-                  <p>Atomic values <rfc2119>must</rfc2119> belong to one of the atomic types listed
+                  <p>Atomic items <rfc2119>must</rfc2119> belong to one of the atomic types listed
                      in <specref ref="built-in-types"/> (except as noted below).</p>
-                  <p>An atomic value may also belong to an implementation-defined type that has been
+                  <p>An atomic item may also belong to an implementation-defined type that has been
                      added to the context for use with <termref def="dt-extension-function">extension functions</termref> or <termref def="dt-extension-instruction">extension instructions</termref>.</p>
                   <p>The set of constructor functions available are limited to those that construct
                      values of the above atomic types.</p>
@@ -39696,7 +39704,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                </item>
 
                <item>
-                  <p>The coercion rules (previously “function conversion rules”) allow atomic values
+                  <p>The coercion rules (previously “function conversion rules”) allow atomic items
                   of primitive types to be supplied where a restricted type is required: for example
                   if the required type is <code>xs:positiveInteger</code>, it is now acceptable to supply the
                   value <code>42</code>.</p>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -221,7 +221,15 @@ to certain types of input value.</p>
     <term>input tree</term>.</termdef></p> 
 
 
-<div2 id="terminology"><head>Terminology</head>
+<div2 id="terminology">
+  <head>Terminology</head>
+  
+  <changes>
+     <change issue="1337" date="2024-08-02">
+        The term <term>atomic value</term> has been replaced by <term>atomic item</term>.
+     </change>
+  </changes>
+  
 <p>In this specification,
 where they are rendered in small capitals,
 the words <rfc2119>MUST</rfc2119>, <rfc2119>MUST NOT</rfc2119>,
@@ -3471,7 +3479,7 @@ The node is serialized with the serialization parameter <code>omit-xml-declarati
 
 </p></item>
 
-<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-item">atomic
   value</xtermref> in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> with a numeric type, or
 derived from a numeric type <code>xs:float</code>, <code>xs:double</code> or <code>xs:decimal</code> is
 serialized to a JSON number.
@@ -3484,18 +3492,18 @@ raise a serialization error <!--* [err:SERE0020]. *-->
 <errorref code="0020" class="RE"/>.
 </p></item>
 
-<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic value</xtermref> 
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-item">atomic item</xtermref> 
   in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/>
 of type <code>xs:boolean</code> and value <code>true</code>
 is serialized to the JSON token <code>true</code>.</p></item>
 
-<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic value</xtermref> 
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-item">atomic item</xtermref> 
   in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/>
 of type <code>xs:boolean</code> and value <code>false</code> is
 serialized to the JSON token <code>false</code>.</p></item>
   
   <item diff="add" at="2024-02-19">
-    <p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic value</xtermref> 
+    <p>An <xtermref spec="XP40" ref="dt-atomic-item">atomic item</xtermref> 
       of type <code>xs:QName</code> in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/>
      whose namespace part is <code>"http://www.w3.org/2005/xpath-functions"</code> 
     and whose local part is <code>"null"</code> is
@@ -3506,7 +3514,7 @@ serialized to the JSON token <code>false</code>.</p></item>
   circumstances, an explicit representation of <code>null</code> as a recognizable item can make
   some operations on JSON-derived values easier.</p></note></item> 
 
-<item><p>Any other <xtermref spec="XP40" ref="dt-atomic-value">atomic
+<item><p>Any other <xtermref spec="XP40" ref="dt-atomic-item">atomic
   value</xtermref> in the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> 
 is serialized <termref def="to-a-json-string">to a JSON string</termref> by outputting the 
 result of applying the <code>fn:string</code> function to the item.</p></item>
@@ -3768,7 +3776,7 @@ serialized as
 binding is not displayed.</p></note>
 </item>
 
-<item><p>An <xtermref spec="XP40" ref="dt-atomic-value">atomic
+<item><p>An <xtermref spec="XP40" ref="dt-atomic-item">atomic
 value</xtermref> is serialized as follows:</p>
 <ulist>
 <item><p>An instance of <code>xs:boolean</code> is serialized as <code>true()</code> or <code>false()</code>. </p></item>
@@ -3834,7 +3842,7 @@ using the following default decimal format properties:</p>
 </item>
 <item><p>An instance of <code>xs:QName</code> or <code>xs:NOTATION</code> is serialized 
 as a URI-qualified name (that is, in the form <code>Q{uri}local</code>).</p></item>
-<item><p>An atomic value of any other type is serialized using the syntax of a constructor 
+<item><p>An atomic item of any other type is serialized using the syntax of a constructor 
 function: <code>xs:TYPE("VAL")</code> where <code>TYPE</code> is the name of the primitive 
 type, and <code>VAL</code> is the result of applying the <code>fn:string()</code> function.
  For example, <code>xs:date("2015-07-17")</code>.
@@ -3862,7 +3870,7 @@ A <termref def="dt-map-item">map item</termref> is serialized using the syntax o
 <xspecref spec="XP40" ref="doc-xpath40-MapConstructor"/> without the optional <code>map</code>
 keyword, that is in the format <code>{key:value, key:value, ...}</code>.
 The order of entries is implementation-dependent. The key is serialized by applying the rules 
-for serializing an atomic value. The values are serialized in the same way as the members of an array (see above).
+for serializing an atomic item. The values are serialized in the same way as the members of an array (see above).
 </p></item>
 
 <item><p>A <termref def="dt-function-item">function item</termref> is
@@ -3908,7 +3916,7 @@ In many cases the serialization of an item conforms to the syntax of an XQuery e
 is that item. There are exceptions, however. For example, the syntax will not be valid XQuery in the 
 case of free-standing attribute or namespace nodes, or QName values, or anonymous functions; and where 
 it is valid XQuery, the result of evaluating the expression will not necessarily be identical to the 
-original: for example, the distinction between strings and untypedAtomic values is lost.
+original: for example, the distinction between strings and untypedAtomic items is lost.
 </p></note>
 
 <p>
@@ -3930,7 +3938,7 @@ generated text, then the serializer <rfc2119>MAY</rfc2119> include
 hyperlinks to provide additional information for example:</p>
 <ulist>
 <item><p>
-to allow the type of <xtermref spec="XP40" ref="dt-atomic-value">atomic values</xtermref>
+to allow the type of <xtermref spec="XP40" ref="dt-atomic-item">atomic items</xtermref>
 to be ascertained.
 </p></item>
 <item><p>
@@ -3945,14 +3953,14 @@ to provide further information about the cause of error indicators.
 <imp-def-feature>It is <termref
 def="impdef">implementation-defined</termref> whether, when the
 Adaptive output method is used, a serializer includes hyperlinks in
-its output to record the types of atomic values, the bindings of
+its output to record the types of atomic items, the bindings of
 namespace prefixes, the causes of error indicators, and other
 information.
 </imp-def-feature>
 
 <imp-dep-feature>If, when the
 Adaptive output method is used, a serializer includes hyperlinks in
-its output to record the types of atomic values, the bindings of
+its output to record the types of atomic items, the bindings of
 namespace prefixes, the causes of error indicators, and other
 information, then it is <termref
 def="impdep">implementation-dependent</termref> what hyperlinks are


### PR DESCRIPTION
Fix #1337

I was half-expecting this change to have repercussions, but in practice it seems very clean.

There are probably more places that should change, e.g. use "xs:boolean item" rather than "xs:boolean value", but we can deal with them as we come to them.