### PR TITLE
1321 leading lone slash

### DIFF
--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -182,12 +182,15 @@
           must be the beginning of a <nt def="PathExpr">PathExpr</nt>, not the entirety of it.</p>
         
         <p>The terminals that can form the start of a <nt def="RelativePathExpr">RelativePathExpr</nt>
-        are: an NCName, QName, StringLiteral, NumericLiteral, or StringTemplate; 
+        are: <code>NCName</code>, <code>QName</code>, <code>URIQualifiedName</code>,
+          <code>StringLiteral</code>, <code>NumericLiteral</code>, 
+          <code>Wildcard</code>, and <code>StringTemplate</code>; 
         plus <code>@</code> <code>.</code> <code>..</code> <code>*</code>
-          <code>$</code>
-          <code>(</code> <code>[</code> <code>{</code>; and in XQuery a StringConstructor, DirElemConstructor,
-          DirCommentConstructor, DirPIConstructor, or Pragma.
+          <code>$</code> <code>?</code> <code>??</code> <code>%</code>
+          <code>(</code> <code>[</code>; and in XQuery <code>StringConstructor</code> and <code>DirectConstructor</code>.
         </p>
+        
+        <!-- The above list was obtained by running the stylesheet leading-tokens.xsl against xpath-grammar.xml -->
         
         <p>A single slash may be used as the left-hand argument of an operator by parenthesizing it:
             <code role="parse-test">(/) * 5</code>. The expression <code role="parse-test">5 *

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -161,18 +161,34 @@
         <head>leading-lone-slash</head>
         <p>A single slash may appear either as a complete path expression or as the first part of a
           path expression in which it is followed by a <nt def="RelativePathExpr"
-            >RelativePathExpr</nt>. In some cases, the next token after the slash is insufficient to
-          allow a parser to distinguish these two possibilities: the <code>*</code> token and
-          keywords like <code>union</code> could be either an operator or a <nt def="NameTest"
-            >NameTest</nt>
-          <phrase role="xquery">, and the <code>&lt;</code> token could be either an operator or the
-            start of a <nt def="DirectConstructor"> DirectConstructor</nt></phrase>. For example,
-          without lookahead the first part of the expression <code>/ * 5</code> is easily taken to
-          be a complete expression, <code role="parse-test">/ *</code>, which has a very different
-          interpretation (the child nodes of <code>/</code>).</p>
-        <p>If the token immediately following a slash
+            >RelativePathExpr</nt>. In some cases, the next terminal after the slash is insufficient to
+          allow a parser to distinguish these two possibilities: a <code>*</code> symbol or a
+          keyword like <code>union</code> could be either an operator or a <nt def="NameTest"
+            >NameTest</nt>. For example, the expression <code>/union/*</code> could be parsed
+          either as <code>(/) union (/*)</code> or as <code>/child::union/child::*</code> (the
+          second interpretation is the one chosen).</p>
+        
+        
+        <p>The situation where <code>/</code> is followed by <code>&lt;</code> is a little more
+          complicated. In XPath, this is unambiguous: the <code>&lt;</code> can only indicate
+          one of the operators <code>&lt;</code>, <code>&lt;=</code>, or <code>&lt;&lt;</code>.
+          In XQuery, however, it can also be the start of a direct constructor: specifically,
+          a direct constructor for an element node, processing instruction node, or comment node.
+          These constructs are identified by the tokenizer, independently of their syntactic
+          context, as described in <specref ref="lexical-structure"/>.</p>         
+          
+        <p>The rule adopted is as follows: if the terminal immediately following a slash
           can form the start of a <nt def="RelativePathExpr">RelativePathExpr</nt>, then the slash
           must be the beginning of a <nt def="PathExpr">PathExpr</nt>, not the entirety of it.</p>
+        
+        <p>The terminals that can form the start of a <nt def="RelativePathExpr">RelativePathExpr</nt>
+        are: an NCName, QName, StringLiteral, NumericLiteral, or StringTemplate; 
+        plus <code>@</code> <code>.</code> <code>..</code> <code>*</code>
+          <code>$</code>
+          <code>(</code> <code>[</code> <code>{</code>; and in XQuery a StringConstructor, DirElemConstructor,
+          DirCommentConstructor, DirPIConstructor, or Pragma.
+        </p>
+        
         <p>A single slash may be used as the left-hand argument of an operator by parenthesizing it:
             <code role="parse-test">(/) * 5</code>. The expression <code role="parse-test">5 *
             /</code>, on the other hand, is syntactically valid without parentheses.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -11101,7 +11101,7 @@ return $incrementors[2](4)]]></eg>
 	 *</code> are valid path expressions containing wildcards,
 	 but <code>/*5</code> and <code>/ * 5</code> raise syntax
 	 errors. Parentheses must be used when <code>/</code> is
-	 used on the left-hand side of an operator, as in <code
+	 used on the left-hand side of an operator that could be confused with a node test, as in <code
                      role="parse-test"
                      >(/) * 5</code>. Similarly, <code>4 + / *
 	 5</code> raises a syntax error, but <code

--- a/style/leading-tokens.xsl
+++ b/style/leading-tokens.xsl
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  version="3.0"
+  xmlns:g="http://www.w3.org/2001/03/XPath/grammar"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  exclude-result-prefixes="#all"
+  default-mode="leading-tokens" 
+  expand-text="yes"
+  xpath-default-namespace="http://www.w3.org/2001/03/XPath/grammar"  >
+    
+    
+    <xsl:key name="productions-by-name" match="production|token" use="@name"/>
+   
+    
+    <xsl:function name="g:leading-tokens" as="xs:string*">
+        <xsl:param name="production" as="element(*)"/>
+        <xsl:param name="already-known" as="xs:string*"/>
+        <xsl:param name="already-visited" as="element(*)*"/>
+        <xsl:variable name="first" select="$production[1]"/>
+        <xsl:variable name="v" select="$already-visited | $production"/>
+        <!--<xsl:message>LT {name($production)} {$production/@name} {string($production)}</xsl:message>-->
+        <xsl:choose>
+            <xsl:when test="$already-visited intersect $production"/>
+            <xsl:when test="$production[@if='fulltext']"/>
+            <xsl:when test="$first[self::string]">
+                <xsl:sequence select="distinct-values(($already-known, if ($first castable as xs:NCName) then 'NCName' else string($first)))"/>
+            </xsl:when>
+            <xsl:when test="$first[self::ref]">
+                <xsl:variable name="target" select="key('productions-by-name', $first/@name, root($production))"/>
+                <xsl:choose>
+                    <xsl:when test="$target/@name = ('DirectConstructor', 'StringConstructor', 'StringTemplate')">
+                        <xsl:sequence select="distinct-values(($already-known, $target/@name))"/>
+                    </xsl:when>
+                    <xsl:when test="$target[self::token][count(*)=1][child::string]">
+                        <!--<xsl:sequence select="distinct-values(($already-known, string($target/string)))"/>-->
+                    </xsl:when>
+                    <xsl:when test="$target[self::token]">
+                        <xsl:sequence select="distinct-values(($already-known, $target/@name))"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:sequence select="distinct-values(($already-known, g:leading-tokens($target/*[1], $already-known, $v)))"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:when test="$first[self::optional or self::zeroOrMore]">
+                <xsl:sequence select="distinct-values(($already-known, 
+                                                         g:leading-tokens($first/*[1], $already-known, $v),
+                                                         g:leading-tokens($first/following-sibling::*[1], $already-known, $v)))"/>
+            </xsl:when>
+            <xsl:when test="$first[self::oneOrMore]">
+                <xsl:sequence select="g:leading-tokens($first/*[1], $already-known, $already-visited)"/>
+            </xsl:when>
+            <xsl:when test="$first[self::choice]">
+                <xsl:sequence select="fold-left($first/*, $already-known,
+                    function($known, $next){g:leading-tokens($next, $known, $v)}) => distinct-values()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$already-known"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+    <xsl:template match="/">
+        <out>
+            <xsl:for-each select="g:leading-tokens(//production[@name='RelativePathExpr']/*[1], (), ())">
+                <xsl:sort lang="en"/>
+                <token>{.}</token>
+            </xsl:for-each>
+        </out>
+    </xsl:template>
+    
+    <xsl:output indent="yes"/>
+ 
+ 
+
+</xsl:stylesheet>

--- a/style/leading-tokens.xsl
+++ b/style/leading-tokens.xsl
@@ -7,62 +7,68 @@
   default-mode="leading-tokens" 
   expand-text="yes"
   xpath-default-namespace="http://www.w3.org/2001/03/XPath/grammar"  >
+   
+   <!-- This stylesheet is designed to be run against xpath-grammar.xsl.
+      It outputs a list of the tokens that can start a RelativePathExpr,
+      which is used, with a little manual massaging, in the XPath/XQuery
+      appendix defining the leading-lone-slash constraint. -->
+   
+   <!-- The stylesheet is not run automatically as part of the build -->
     
     
     <xsl:key name="productions-by-name" match="production|token" use="@name"/>
    
-    
     <xsl:function name="g:leading-tokens" as="xs:string*">
         <xsl:param name="production" as="element(*)"/>
-        <xsl:param name="already-known" as="xs:string*"/>
         <xsl:param name="already-visited" as="element(*)*"/>
-        <xsl:variable name="first" select="$production[1]"/>
+        <xsl:variable name="first" select="$production"/>
         <xsl:variable name="v" select="$already-visited | $production"/>
         <!--<xsl:message>LT {name($production)} {$production/@name} {string($production)}</xsl:message>-->
         <xsl:choose>
             <xsl:when test="$already-visited intersect $production"/>
             <xsl:when test="$production[@if='fulltext']"/>
-            <xsl:when test="$first[self::string]">
-                <xsl:sequence select="distinct-values(($already-known, if ($first castable as xs:NCName) then 'NCName' else string($first)))"/>
+            <xsl:when test="$production[self::string]">
+                <xsl:sequence select="if ($production castable as xs:NCName) then 'NCName' else string($first)"/>
             </xsl:when>
-            <xsl:when test="$first[self::ref]">
-                <xsl:variable name="target" select="key('productions-by-name', $first/@name, root($production))"/>
+           <xsl:when test="$production[self::sequence]">
+                <xsl:sequence select="g:leading-tokens($first/*[1], $v)"/>
+            </xsl:when>
+            <xsl:when test="$production[self::ref]">
+                <xsl:variable name="target" select="key('productions-by-name', $production/@name, root($production))"/>
                 <xsl:choose>
                     <xsl:when test="$target/@name = ('DirectConstructor', 'StringConstructor', 'StringTemplate')">
-                        <xsl:sequence select="distinct-values(($already-known, $target/@name))"/>
+                        <xsl:sequence select="$target/@name"/>
                     </xsl:when>
                     <xsl:when test="$target[self::token][count(*)=1][child::string]">
                         <!--<xsl:sequence select="distinct-values(($already-known, string($target/string)))"/>-->
                     </xsl:when>
                     <xsl:when test="$target[self::token]">
-                        <xsl:sequence select="distinct-values(($already-known, $target/@name))"/>
+                        <xsl:sequence select="$target/@name"/>
                     </xsl:when>
                     <xsl:otherwise>
-                        <xsl:sequence select="distinct-values(($already-known, g:leading-tokens($target/*[1], $already-known, $v)))"/>
+                        <xsl:sequence select="g:leading-tokens($target/*[1], $v)"/>
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:when>
-            <xsl:when test="$first[self::optional or self::zeroOrMore]">
-                <xsl:sequence select="distinct-values(($already-known, 
-                                                         g:leading-tokens($first/*[1], $already-known, $v),
-                                                         g:leading-tokens($first/following-sibling::*[1], $already-known, $v)))"/>
+            <xsl:when test="$production[self::optional or self::zeroOrMore]">
+                <xsl:sequence select="g:leading-tokens($production/*[1], $v),
+                                      $production/following-sibling::*[1] ! g:leading-tokens(., $v)"/>
             </xsl:when>
-            <xsl:when test="$first[self::oneOrMore]">
-                <xsl:sequence select="g:leading-tokens($first/*[1], $already-known, $already-visited)"/>
+            <xsl:when test="$production[self::oneOrMore]">
+                <xsl:sequence select="g:leading-tokens($production/*[1], $already-visited)"/>
             </xsl:when>
-            <xsl:when test="$first[self::choice]">
-                <xsl:sequence select="fold-left($first/*, $already-known,
-                    function($known, $next){g:leading-tokens($next, $known, $v)}) => distinct-values()"/>
+            <xsl:when test="$production[self::choice]">
+               <xsl:for-each select="$production/*">
+                   <xsl:sequence select="g:leading-tokens(., $v)"/>
+               </xsl:for-each>
             </xsl:when>
-            <xsl:otherwise>
-                <xsl:sequence select="$already-known"/>
-            </xsl:otherwise>
+            <xsl:otherwise/>
         </xsl:choose>
     </xsl:function>
     
     <xsl:template match="/">
         <out>
-            <xsl:for-each select="g:leading-tokens(//production[@name='RelativePathExpr']/*[1], (), ())">
+            <xsl:for-each select="distinct-values(g:leading-tokens(//production[@name='RelativePathExpr']/*[1], ()))">
                 <xsl:sort lang="en"/>
                 <token>{.}</token>
             </xsl:for-each>


### PR DESCRIPTION
Fix #1321

Fixed as suggested in the issue. I have added a list of tokens that can appear at the start of a RelativePathExpr, produced by analyzing the grammar using a custom stylesheet leading-tokens.xsl which is available for reuse, but not integrated into the build.