### PR TITLE
Fix inconsistent definition of return-type-ref-occurs

### DIFF
--- a/schema/xmlspec.dtd
+++ b/schema/xmlspec.dtd
@@ -1259,10 +1259,10 @@
 <!ATTLIST proto
         %common.att;
 	%local.proto.att;
-        name                      NMTOKEN    #REQUIRED
-        return-type               %argtypes; #IMPLIED
-        return-type-ref	        IDREF		#IMPLIED
-        return-type-ref-occurs	 IDREF		#IMPLIED
+        name                      NMTOKEN	#REQUIRED
+        return-type               %argtypes;	#IMPLIED
+        return-type-ref	          IDREF		#IMPLIED
+        return-type-ref-occurs	  CDATA		#IMPLIED
 >
 ]]>
 


### PR DESCRIPTION
The DTD defines it as a IDREF type which it clearly isn't.