### PR TITLE
1375 bugs in pattern syntax

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -165,13 +165,7 @@ apply.
   </g:production>
   
   <g:production name="OuterFunctionName" if=" xslt40-patterns">
-    <g:choice name="FNameChoice">
-      <g:string process-value="yes">doc</g:string>
-      <g:string process-value="yes">id</g:string>
-      <g:string process-value="yes">element-with-id</g:string>
-      <g:string process-value="yes">key</g:string>
-      <g:ref name="URIQualifiedName"/>
-    </g:choice>
+    <g:ref name="EQName"/>
   </g:production>
 
   <g:production name="ArgumentListP" if=" xslt40-patterns">
@@ -212,7 +206,10 @@ apply.
   </g:production>
   
   <g:production name="PostfixExprP" if=" xslt40-patterns" >
-    <g:ref name="ParenthesizedExprP"/>
+    <g:choice>
+      <g:ref name="FunctionCallP"/>
+      <g:ref name="ParenthesizedExprP"/>
+    </g:choice>
     <g:zeroOrMore>
       <g:ref name="Predicate"/>
     </g:zeroOrMore>

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -248,7 +248,7 @@
 			</xsl:when>
 			<xsl:otherwise>
 				<!-- Typically the XSLT spec -->
-				<xtermref spec="FO30" ref="dt-{.}">
+				<xtermref spec="FO40" ref="dt-{.}">
 					<xsl:value-of select="."/>
 				</xtermref>
 			</xsl:otherwise>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10800,6 +10800,17 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <div4 id="node-patterns">
                   <head>Node Patterns</head>
+                  
+                  <changes>
+                     <change issue="1375">
+                        A function call at the outermost level can now be named using any valid <code>EQName</code>
+                        (for example <code>fn:doc</code>) provided it binds to one of the permitted functions
+                        <xfunction>fn:doc</xfunction>, <xfunction>fn:id</xfunction>, <xfunction>fn:element-with-id</xfunction>, 
+                        <function>fn:key</function>, or <xfunction>fn:root</xfunction>. 
+                        If two functions are called, for example <code>doc('a.xml')/id('abc')</code>,
+                        it is no longer necessary to put the second call in parentheses.
+                     </change>
+                  </changes>
                
 
                <scrap id="NodePatterns-scrap">
@@ -10832,19 +10843,21 @@ and <code>version="1.0"</code> otherwise.</p>
                   the corresponding XPath 3.0 construct without the suffix. Constructs labeled with
                   the suffix “XP40” are defined in <bibref ref="xpath-40"/>.</p>
 
-               <p diff="del" at="2022-01-01">Where the XSLT 3.0 processor implements the XPath 3.1 feature, the definitions that apply to constructs labeled
-                  with the suffix “XP30” are those in [XPath 3.1]</p>
+              
 
 
                <p>In a <nt def="FunctionCallP">FunctionCallP</nt>, the
-                     <code>EQName</code> used for the function name must have local part
-                     <code>doc</code>, <code>id</code>, <code>element-with-id</code>,
-                     <code>key</code>, or
-                     <code>root</code>, and must use the <termref def="dt-standard-function-namespace"/> either explicitly or implicitly.</p>
-
-               <p>In the case of a call to the
-                     <xfunction>root</xfunction> function, the argument list must be empty: that is,
-                  only the zero-arity form of the function is allowed.</p>
+                     <code>EQName</code> used for the function name must bind to
+                  one of the functions <xfunction>fn:doc#1</xfunction>, <xfunction>fn:id#1</xfunction>, 
+                  <xfunction>fn:id#2</xfunction>, <xfunction>fn:element-with-id#1</xfunction>,
+                  <xfunction>fn:element-with-id#2</xfunction>
+                  <function>fn:key#2</function>, <function>fn:key#3</function>
+                  or <xfunction>fn:root#0</xfunction>.</p>
+                  
+                 
+               <note><p>In the case of a call to the
+                     <xfunction>fn:root</xfunction> function, the argument list must be empty: that is,
+                  only the zero-arity form of the function is allowed.</p></note>
 
                <note>
                   <p>As with XPath expressions, the pattern <code>/ union /*</code> can be parsed in
@@ -10852,12 +10865,10 @@ and <code>version="1.0"</code> otherwise.</p>
                         <code>union</code> as an element name rather than as an operator. The other
                      interpretation can be achieved by writing <code>(/) union (/*)</code></p>
                </note>
-                  <note diff="add" at="E">
-                     <p>A peculiarity of this grammar is that <code>doc('a.xml')/(id('abc'))</code> is a 
-                        valid pattern, while <code>doc('a.xml')/id('abc')</code> is not: the <code>/</code> 
-                        operator must be followed either by a parenthesized expression, or by an axis step.</p>
-                  </note>
+                  
             </div4>
+               
+               
             <div4 id="pattern-semantics">
                <head>The Meaning of a Node Pattern</head>
                <p>The meaning of a node pattern is defined formally as follows, where “if” is to be read

--- a/specifications/xslt-40/style/xslt.xsl
+++ b/specifications/xslt-40/style/xslt.xsl
@@ -722,10 +722,10 @@ constructor. These elements are:</p>
   <!--<u><xsl:value-of select="."/></u>-->
   <xsl:variable name="fname" select="string(.)"/>
   <xsl:variable name="link" select="translate(if (contains($fname, '#')) then substring-before($fname, '#') else $fname, ':', '-')"/>
-  <xsl:variable name="vn" select="if (@spec eq 'FO31') then '31' else '30'"/>
+  <xsl:variable name="vn" select="if (@spec eq 'FO31') then '31' else if (@spec eq '30') then '30' else '40'"/>
   <a href="https://www.w3.org/TR/xpath-functions-{$vn}/#func-{$link}">
     <code><xsl:value-of select="."/></code>
-  </a><sup><small><xsl:value-of select="(@spec, 'FO30')[1]"/></small></sup>
+  </a><sup><small><xsl:value-of select="(@spec, 'FO40')[1]"/></small></sup>
 </xsl:template>
   
   <xsl:template match="termref">


### PR DESCRIPTION
1. Changes the pattern syntax to allow any EQName to be used for function calls; the constraints on which functions can be called are defined outside the actual grammar.
2. Reinstate root() as a permitted function
3. Allow `doc()/id()` without requiring parentheses around the second function call
4. Stylesheet changes to point external spec references at the 4.0 specs rather than 3.0.

Fix #1375