### PR TITLE
1391 Change function-annotations to return a sequence

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1409,7 +1409,7 @@ identity, equality, or otherwise, and</phrase> have no serialization.
       <item><p>The required types of the function result (also a <xnt spec="XP40" ref="doc-xpath40-SequenceType">SequenceType</xnt>)</p></item>
       <item><p>A sequence of zero or more <term>function annotations</term>. Each annotation consists
       of an annotation name (an instance of <code>xs:QName</code>) and an annotation value
-      (an arbitrary <termref def="dt-value"/>). Annotations are ordered and it is permitted for two
+      (an arbitrary sequence of atomic items). Annotations are ordered and it is permitted for two
       annotations to share the same name.</p></item>
     </ulist>
       

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1405,8 +1405,8 @@ identity, equality, or otherwise, and</phrase> have no serialization.
       The signature of a function item comprises:
     </p>
     <ulist>
-      <item><p>The required types of its parameters (each on being a <xnt spec="XP40" ref="doc-xpath40-SequenceType">SequenceType</xnt>)</p></item>
-      <item><p>The require types of the function result (also a <xnt spec="XP40" ref="doc-xpath40-SequenceType">SequenceType</xnt>)</p></item>
+      <item><p>The required types of its parameters (each one being a <xnt spec="XP40" ref="doc-xpath40-SequenceType">SequenceType</xnt>)</p></item>
+      <item><p>The required types of the function result (also a <xnt spec="XP40" ref="doc-xpath40-SequenceType">SequenceType</xnt>)</p></item>
       <item><p>A sequence of zero or more <term>function annotations</term>. Each annotation consists
       of an annotation name (an instance of <code>xs:QName</code>) and an annotation value
       (an arbitrary <termref def="dt-value"/>). Annotations are ordered and it is permitted for two

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1391,29 +1391,45 @@ identity, equality, or otherwise, and</phrase> have no serialization.
       <phrase>(<code>xs:QName*</code>)</phrase>:
       A list of distinct names, one for each of the function’s parameters.
     </p>
+    <note><p>This property is currently unused. There is no way of discovering the
+    parameter names of a function item, and there is no functionality
+    that depends on the parameter names.</p></note>
   </item>
   <item>
     <p>
       <term>signature</term>
-      <phrase>
+      <phrase><termdef term="function signature" id="dt-signature">
+        A <term>function signature</term>
+        represents the type of a
+        <termref def="dt-function-item">function</termref>.</termdef></phrase>
+      The signature of a function item comprises:
+    </p>
+    <ulist>
+      <item><p>The required types of its parameters (each on being a <xnt spec="XP40" ref="doc-xpath40-SequenceType">SequenceType</xnt>)</p></item>
+      <item><p>The require types of the function result (also a <xnt spec="XP40" ref="doc-xpath40-SequenceType">SequenceType</xnt>)</p></item>
+      <item><p>A sequence of zero or more <term>function annotations</term>. Each annotation consists
+      of an annotation name (an instance of <code>xs:QName</code>) and an annotation value
+      (an arbitrary <termref def="dt-value"/>). Annotations are ordered and it is permitted for two
+      annotations to share the same name.</p></item>
+    </ulist>
+      
+      
+      <!--<phrase>
         (a <code>FunctionTest</code> of the form
         <code>Annotation* TypedFunctionTest</code>)</phrase>:
 
       The <xnt spec="XP40" ref="doc-xpath40-TypedFunctionTest">TypedFunctionTest</xnt>
         has one <xnt spec="XP40" ref="doc-xpath40-SequenceType">SequenceType</xnt>
         for each parameter, and one SequenceType for the function’s result.
-      <termdef term="function signature" id="dt-signature">
-        A <term>function signature</term>
-        represents the type of a
-        <termref def="dt-function-item">function</termref>.</termdef>
+      
       The presence of annotations is language dependent;
 functions defined in languages, such as XPath, that have no mechanism for defining annotations
 will create functions in the data model with zero annotations.
-    </p>
+    </p>-->
   </item>
   <item>
-    <p diff="chg" at="2023-03-11">
-      <term>body</term>:
+    <p>
+      <term>body</term>
       The body of a function provides the logic
       to map the arguments supplied in a function call into an instance of 
       the function’s result type.</p>
@@ -1436,12 +1452,12 @@ will create functions in the data model with zero annotations.
         </item>
       </ulist>
     <p>These categories are not mutually exclusive; they may be used in combination.</p> 
-    <ednote><edtext>The term “function body” replaces “function implementation”, to avoid confusion with
-    the use of the term “implementation” in phrases such as “implementation-defined”.</edtext></ednote>
+    <note><p>The term “function body” replaces “function implementation”, to avoid confusion with
+    the use of the term “implementation” in phrases such as “implementation-defined”.</p></note>
   </item>
   <item>
-    <p diff="chg" at="2023-03-11">
-      <term>captured context</term>: This includes a static and dynamic context for evaluation
+    <p>
+      <term>captured context</term> This includes a static and dynamic context for evaluation
       of the function body, as described in <xspecref spec="XP40" ref="context"/>. In particular
       it includes a set of <term>nonlocal variable bindings</term>
       (a mapping from <code>xs:QName</code> to <code>item()*</code>),

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19487,29 +19487,54 @@ return function-arity($initial)</eg></fos:expression>
             <code>$function</code> as a sequence of (key, value) pairs.
             Note that several annotations on a function can share the same name. The order
             of the annotations is retained.</p>
+         <p>The result is a sequence of maps, each being an instance of
+            <code>record(key as xs:QName, value as xs:anyAtomicType*)</code>. 
+            If a function (for example, a built-in function) has no annotations,
+            the result of the function is an empty sequence.</p>
          <p>For each annotation, a map is returned, with two entries. One
             entry has the key <code>"key"</code> as an <code>xs:string</code>, with the associated
             value being the name of the annotation as an <code>xs:QName</code>.
             The other has the key <code>"value"</code> as an <code>xs:string</code>, with the
-            associated value being the value of the annotation as a sequence of atomic values.
-            If the annotation has no values, the associated value is an empty sequence.
-            If a function (for example, a built-in function) has no annotations,
-            the result of the function is an empty sequence.</p>
+            associated value being the value of the annotation as a sequence of atomic items.
+            If the annotation has no values, the associated value is an empty sequence.</p>
       </fos:rules>
       <fos:notes>
          <p>The type of the result is the same as the type of the first argument
-            to the <code>map:of-pairs</code> function. This means (assuming that the annotation names are all unique) 
-            that the result of the function can readily be converted into a map by calling 
+            to the <code>map:of-pairs</code> function. This means that in the common case where the annotation names are all unique, 
+            the result of the function can readily be converted into a map by calling 
             <code>map:of-pairs</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
+               <fos:expression><eg>function-annotations(true#0)</eg></fos:expression>
+               <fos:result><eg>()</eg></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
                <fos:expression><eg>
 declare %private function local:inc($c) { $c + 1 };
 function-annotations(local:inc#1)</eg></fos:expression>
-               <fos:result><eg>{ "key": xs:QName("http://www.w3.org/2012/xquery", "private"),
-      "value": () }</eg></fos:result>
+               <fos:result><eg>
+{ "key": xs:QName("http://www.w3.org/2012/xquery", "private"),
+  "value": () 
+}</eg></fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>
+declare %private %variadic 
+        function local:sum($c as xs:integer*) { sum($c) };
+function-annotations(local:sum#3)</eg></fos:expression>
+               <fos:result><eg>
+{ "key": xs:QName("http://www.w3.org/2012/xquery", "private"),
+  "value": () 
+},
+{ "key": xs:QName("http://www.w3.org/2012/xquery", "variadic"),
+  "value": () 
+}</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -19519,16 +19544,14 @@ let $old := %local:deprecated('0.1', '0.2') fn() {}
 let $ann := function-annotations($old)
 return map:of-pairs($ann)
 </eg></fos:expression>
-               <fos:result><eg>{ xs:QName("http://www.w3.org/2012/xquery", "deprecated"): 
-      ("0.1", "0.2")}</eg></fos:result>
+               <fos:result><eg>
+{ xs:QName("http://www.w3.org/2005/xquery-local-functions", "deprecated"):
+    ("0.1", "0.2") 
+}
+</eg></fos:result>
             </fos:test>
          </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression>function-annotations(true#0)</fos:expression>
-               <fos:result><eg>()</eg></fos:result>
-            </fos:test>
-         </fos:example>
+         
       </fos:examples>
       <fos:changes>
          <fos:change issue="36" PR="710" date="2023-09-17">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19470,7 +19470,7 @@ return function-arity($initial)</eg></fos:expression>
 
    <fos:function name="function-annotations" prefix="fn">
       <fos:signatures>
-         <fos:proto name="function-annotations" return-type="map(xs:QName, xs:anyAtomicType*)">
+         <fos:proto name="function-annotations" return-type="record(key as xs:QName, value as xs:anyAtomicType*)*">
             <fos:arg name="function" type="fn(*)"/>
          </fos:proto>
       </fos:signatures>
@@ -19480,24 +19480,36 @@ return function-arity($initial)</eg></fos:expression>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the annotations of the function identified by a function item.</p>
+         <p>Returns the annotations of the function item.</p>
       </fos:summary>
       <fos:rules>
          <p>The <code>fn:function-annotations</code> function returns the annotations of
-            the function identified by <code>$function</code> as a map.
-            For each annotation, a map entry is returned: The key is the name of the annotation.
-            The value is a sequence comprising the annotation values, or an empty sequence
-            if the annotation has no values.
+            <code>$function</code> as a sequence of (key, value) pairs.
+            Note that several annotations on a function can share the same name. The order
+            of the annotations is retained.</p>
+         <p>For each annotation, a map is returned, with two entries. One
+            entry has the key <code>"key"</code> as an <code>xs:string</code>, with the associated
+            value being the name of the annotation as an <code>xs:QName</code>.
+            The other has the key <code>"value"</code> as an <code>xs:string</code>, with the
+            associated value being the value of the annotation as a sequence of atomic values.
+            If the annotation has no values, the associated value is an empty sequence.
             If a function (for example, a built-in function) has no annotations,
-            an empty map is returned.</p>
+            the result of the function is an empty sequence.</p>
       </fos:rules>
+      <fos:notes>
+         <p>The type of the result is the same as the type of the first argument
+            to the <code>map:of-pairs</code> function. This means (assuming that the annotation names are all unique) 
+            that the result of the function can readily be converted into a map by calling 
+            <code>map:of-pairs</code>.</p>
+      </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>
 declare %private function local:inc($c) { $c + 1 };
 function-annotations(local:inc#1)</eg></fos:expression>
-               <fos:result>{ Q{http://www.w3.org/2012/xquery}private: () }</fos:result>
+               <fos:result><eg>map { "key": xs:QName("http://www.w3.org/2012/xquery", "private"),
+      "value": () }</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -19505,15 +19517,16 @@ function-annotations(local:inc#1)</eg></fos:expression>
                <fos:expression><eg>
 let $old := %local:deprecated('0.1', '0.2') fn() {}
 let $ann := function-annotations($old)
-return map:keys($ann) || ': ' || string-join(map:values($ann), ', ')
+return map:of-pairs($ann)
 </eg></fos:expression>
-               <fos:result>local:deprecated: 0.1, 0.2</fos:result>
+               <fos:result><eg>map { xs:QName("http://www.w3.org/2012/xquery", "deprecated"): 
+      ("0.1", "0.2")}</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression>function-annotations(true#0)</fos:expression>
-               <fos:result>{}</fos:result>
+               <fos:result><eg>()</eg></fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19508,7 +19508,7 @@ return function-arity($initial)</eg></fos:expression>
                <fos:expression><eg>
 declare %private function local:inc($c) { $c + 1 };
 function-annotations(local:inc#1)</eg></fos:expression>
-               <fos:result><eg>map { "key": xs:QName("http://www.w3.org/2012/xquery", "private"),
+               <fos:result><eg>{ "key": xs:QName("http://www.w3.org/2012/xquery", "private"),
       "value": () }</eg></fos:result>
             </fos:test>
          </fos:example>
@@ -19519,7 +19519,7 @@ let $old := %local:deprecated('0.1', '0.2') fn() {}
 let $ann := function-annotations($old)
 return map:of-pairs($ann)
 </eg></fos:expression>
-               <fos:result><eg>map { xs:QName("http://www.w3.org/2012/xquery", "deprecated"): 
+               <fos:result><eg>{ xs:QName("http://www.w3.org/2012/xquery", "deprecated"): 
       ("0.1", "0.2")}</eg></fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19530,6 +19530,14 @@ return map:of-pairs($ann)
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="36" PR="710" date="2023-09-17">
+            <p>Changes the function to return a sequence of key-value pairs rather than a map.</p>
+         </fos:change>
+         <fos:change issue="1391" PR="1393" date="2024-08-19">
+            <p>Changes the function to return a sequence of key-value pairs rather than a map.</p>
+         </fos:change>
+      </fos:changes>
    </fos:function>
 
    <fos:function name="for-each" prefix="fn">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5123,9 +5123,9 @@ name.</p>
                   </item>
                   <item role="xquery">
                      <p>
-                        <code>%assertion function(*)</code> matches any <termref 
+                        <code>%my:assertion function(*)</code> matches any <termref 
                            def="dt-function-item"
-                           >function</termref> if the implementation-defined function assertion <code>%assertion</code> is satisfied.
+                           >function</termref> if the implementation-defined function assertion <code>%my:assertion</code> is satisfied.
     </p>
                   </item>
                   <item>
@@ -5138,9 +5138,9 @@ name.</p>
                   </item>
                   <item role="xquery">
                      <p>
-                        <code>%assertion function(xs:int, xs:int) as xs:int</code> matches any <termref
+                        <code>%my:assertion function(xs:int, xs:int) as xs:int</code> matches any <termref
                            def="dt-function-item"/> with the function signature <code>function(xs:int, xs:int) as xs:int</code> 
-                        if the implementation-defined function assertion <code>%assertion</code> is satisfied.
+                        if the implementation-defined function assertion <code>%my:assertion</code> is satisfied.
     </p>
                   </item>
                   <item>
@@ -5164,6 +5164,13 @@ name.</p>
     define any function assertions, but future versions may. Other
     specifications in the XQuery family may also use function
     assertions in the future.</p>
+               
+               <p role="xquery">An unprefixed QName is taken to refer to the namespace
+                  <code>http://www.w3.org/2012/xquery</code>. Since this is a 
+                  <termref def="dt-reserved-namespaces">reserved namespace</termref>,
+                  and no assertions are currently defined in this namespace, this means that
+                  in practice, use of an unprefixed QName is always an error.
+               </p>
 
                <p role="xquery"
                   >Implementations are free to define their own function
@@ -5206,6 +5213,8 @@ name.</p>
 
   
   </p>
+               
+               
 
             </div4>
 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1100,6 +1100,12 @@ return $node/xx:bing]]>
       the statically known namespaces; if no prefix is present, the name is in the
         <code>http://www.w3.org/2012/xquery</code> namespace.</p>
     
+    <note><p>The default namespace is a <termref def="dt-reserved-namespaces">reserved namespace</termref>, which means
+    that unprefixed names cannot be used for implementation-defined or user-defined
+    annotations. It is permitted to use a no-namespace name, which
+    might be written, for example, as <code>%Q{}inline</code>; however, this
+    is discouraged because it is likely to reduce portability across implementations.</p></note>
+    
     <p>In general there is no rule preventing two annotations on the same declaration having
     the same name, although this is disallowed for some specific annotations such as
     <code>%public</code> and <code>%private</code>. The order of annotations may be significant.</p>
@@ -1111,7 +1117,7 @@ return $node/xx:bing]]>
     <p role="xquery"> A few annotations, such as <code>%public</code> and <code>%private</code>,
       have rules defined by this specification. Implementations may define further annotations, whose behavior is
         implementation-defined. For instance, if the <code>eg</code> prefix is bound to a namespace
-        associated with a particular implementation, it could define an annotation like
+        recognized by a particular implementation, then it could be used to define an annotation like
           <code>eg:sequential</code>. 
         If the namespace URI of an annotation is not recognized by the 
         implementation, then the annotation has no effect, other than being available for inspection

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1109,7 +1109,7 @@ return $node/xx:bing]]>
 
     
     <p role="xquery"> A few annotations, such as <code>%public</code> and <code>%private</code>,
-      have rules defined by this specification. Implementations may define further annotations, whose behaviour is
+      have rules defined by this specification. Implementations may define further annotations, whose behavior is
         implementation-defined. For instance, if the <code>eg</code> prefix is bound to a namespace
         associated with a particular implementation, it could define an annotation like
           <code>eg:sequential</code>. 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1094,22 +1094,34 @@ return $node/xx:bing]]>
       in the prolog) and variables. For instance, a function may be declared <code>%public</code> or
         <code>%private</code>. The semantics associated with these properties are described in
         <specref ref="FunctionDeclns"/>.</p>
+    
     <p>Annotations are <code>(QName, value)</code> pairs. If the EQName of the annotation is a
         <termref def="dt-qname">lexical QName</termref>, the prefix of the QName is resolved using
       the statically known namespaces; if no prefix is present, the name is in the
-        <code>http://www.w3.org/2012/xquery</code> namespace. </p>
+        <code>http://www.w3.org/2012/xquery</code> namespace.</p>
+    
+    <p>In general there is no rule preventing two annotations on the same declaration having
+    the same name, although this is disallowed for some specific annotations such as
+    <code>%public</code> and <code>%private</code>. The order of annotations may be significant.</p>
+    
+    <p>If there is no value associated with an annotation, the effective value is the empty sequence.
+    This is the case, for example, with the annotations <code>%public</code> and <code>%private</code>.</p>
 
-
-    <p role="xquery"> Implementations may define further annotations, whose behaviour is
+    
+    <p role="xquery"> A few annotations, such as <code>%public</code> and <code>%private</code>,
+      have rules defined by this specification. Implementations may define further annotations, whose behaviour is
         implementation-defined. For instance, if the <code>eg</code> prefix is bound to a namespace
         associated with a particular implementation, it could define an annotation like
           <code>eg:sequential</code>. 
         If the namespace URI of an annotation is not recognized by the 
-        implementation, then the annotation is ignored. Implementations may also provide a way for users to define their own annotations.
-        Implementations must not define annotations in 
+        implementation, then the annotation has no effect, other than being available for inspection
+        using the <code>fn:function-annotations</code> function.</p> 
+     <p>Implementations may also provide 
+      a way for users to define their own annotations.
+        Implementations must not define annotations, or allow users to define annotations, in 
          <termref def="dt-reserved-namespaces">reserved namespaces</termref>; it 
         is a <termref def="dt-static-error">static error</termref> <errorref class="ST" code="0045"/> 
-        for a user to define an annotation in a <termref def="dt-reserved-namespaces">reserved namespace</termref>.
+        for the name of an annotation to be in a <termref def="dt-reserved-namespaces">reserved namespace</termref>.
      </p>
 
 
@@ -1130,11 +1142,12 @@ return $node/xx:bing]]>
  
     <p>For example, the annotation
         <code>%java:method("java.lang.Math.sin")</code> sets the value of the
-        <code>java:method</code> annotation to the string value <code>java.lang.Math.sin</code>.
+        <code>java:method</code> annotation to the string value <code>java.lang.Math.sin</code>. An implementation
+      might define such annotations to facilitate calling external functions.
     </p>
 
     <note diff="add" at="issue637"><p>The constructs <code>true()</code> and <code>false()</code> must be written as
-    prescribed by the grammar. No namespace prefix is allowed; although the values resemble calls to
+    prescribed by the grammar. No namespace prefix is allowed. Although the values resemble calls to
     functions in the default function namespace, they are unaffected by the namespace
     context.</p></note>
   </div2>


### PR DESCRIPTION
Fix #1391

- Changes the data model to clarify exactly what the annotations of a function item are
- Clarifies the XQuery description of what effect annotations in the query prolog have
- Changes the fn:function-annotations function to return a sequence of key value pairs in which there can be duplicate keys.