### PR TITLE
1395 Revise rules for subtyping of choice item types

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -6254,18 +6254,29 @@ name.</p>
                
                <div4 id="id-item-subtype-choice">
                   <head>Choice Item Types</head>
-                  <p>If <var>B</var> is a <termref def="dt-choice-item-type"/>, then 
-                     <code><var>A</var> ⊆ <var>B</var></code> is true if <code><var>A</var> ⊆ <var>M</var></code>
-                  is true for some item type <var>M</var> among the alternatives of <var>B</var>.</p>
-                  <p>If <var>A</var> is a <termref def="dt-choice-item-type"/>, then 
-                     <code><var>A</var> ⊆ <var>B</var></code> is true if <code><var>M</var> ⊆ <var>B</var></code>
-                     is true for every item type <var>M</var> among the alternatives of <var>A</var>.</p>
+                  <p>The following rules determine whether <code><var>A</var> ⊆ <var>B</var></code> is true in the
+                  case where either <var>A</var> or <var>B</var> or both is a <termref def="dt-choice-item-type"/>.</p>
                   
+                  <p>Firstly, if one of the operands is <emph>not</emph> a choice item type, then it is treated
+                  as a choice item type with a single member type. The rule is then:</p>
+                  
+                  <p><code><var>A</var> ⊆ <var>B</var></code> is true if for every member type <var>a</var> in 
+                  <var>A</var>, there is a member type <var>b</var> in <var>B</var> such that <code><var>a</var> ⊆ <var>b</var></code>.</p>
+                  
+                  <p>For example, <code>(xs:int | xs:long)</code> is a subtype of <code>(xs:decimal | xs:date)</code>
+                  because both <code>xs:int</code> and <code>xs:long</code> are subtypes of <code>xs:decimal</code>.</p>
+                  
+                 
                   <note>
                      <p>Because an <termref def="dt-enumeration-type"/> is defined as a choice type
                         of singleton enumerations, these
                      rules have the consequence, for example, that <code>enum("A", "B")</code> is a subtype
                      of <code>enum("A", "B", "C")</code>.</p>
+                  </note>
+                  <note>
+                     <p>The type <code>xs:int</code> is not a subtype of <code>(xs:negativeInteger | xs:nonNegativeInteger)</code>,
+                     because it does not satisfy this rule. This is despite the fact that the value space of <code>xs:int</code>
+                     is a subset of the value space of <code>(xs:negativeInteger | xs:nonNegativeInteger)</code>.</p>
                   </note>
                </div4>
                <div4 id="id-item-subtype-atomic">


### PR DESCRIPTION
Corrects/clarifies the rules for determining whether A is a subtype of B when either or both is a choice item type.

Fix #1395