### PR TITLE
Update schema for XSLT 4.0 to include agreed syntax changes

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -725,14 +725,14 @@ of problems processing the schema using various tools
       <xs:complexContent>
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:attribute name="name" type="xsl:EQName"/>
-          <xs:attribute name="decimal-separator" type="xsl:char" default="."/>
-          <xs:attribute name="grouping-separator" type="xsl:char" default=","/>
+          <xs:attribute name="decimal-separator" type="xsl:char-optionally-expanded" default="."/>
+          <xs:attribute name="grouping-separator" type="xsl:char-optionally-expanded" default=","/>
           <xs:attribute name="infinity" type="xs:string" default="Infinity"/>
-          <xs:attribute name="minus-sign" type="xsl:char" default="-"/>
-          <xs:attribute name="exponent-separator" type="xsl:char" default="e"/>
+          <xs:attribute name="minus-sign" type="xs:string" default="-"/>
+          <xs:attribute name="exponent-separator" type="xsl:char-optionally-expanded" default="e"/>
           <xs:attribute name="NaN" type="xs:string" default="NaN"/>
-          <xs:attribute name="percent" type="xsl:char" default="%"/>
-          <xs:attribute name="per-mille" type="xsl:char" default="~"/>
+          <xs:attribute name="percent" type="xsl:char-optionally-expanded" default="%"/>
+          <xs:attribute name="per-mille" type="xsl:char-optionally-expanded" default="~"/>
           <xs:attribute name="zero-digit" type="xsl:zero-digit" default="0"/>
           <xs:attribute name="digit" type="xsl:char" default="#"/>
           <xs:attribute name="pattern-separator" type="xsl:char" default=";"/>
@@ -981,6 +981,7 @@ of problems processing the schema using various tools
           <xs:attribute name="override-extension-function" type="xsl:yes-or-no"/>
           <xs:attribute name="new-each-time" type="xsl:yes-or-no-or-maybe"/>
           <xs:attribute name="cache" type="xsl:yes-or-no"/>
+          <xs:attribute name="variadic" type="xsl:yes-or-no"/>
           <xs:attribute name="_name" type="xs:string"/>
           <xs:attribute name="_override" type="xs:string"/>
           <xs:attribute name="_as" type="xs:string"/>
@@ -989,6 +990,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_override-extension-function" type="xs:string"/>
           <xs:attribute name="_new-each-time" type="xs:string"/>
           <xs:attribute name="_cache" type="xs:string"/>
+          <xs:attribute name="_variadic" type="xs:string"/>
           <xs:assert test="exists(@name | @_name)"/>
           <xs:assert test="every $e in xsl:param satisfies empty($e/(@visibility | @_visibility))">
             <xs:annotation>
@@ -2233,6 +2235,20 @@ of problems processing the schema using various tools
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:length value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="char-optionally-expanded">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+           A string containing either a single character, or a single character
+           followed by a colon followed by an arbitrary string
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value=".(:.*)?"/>
     </xs:restriction>
   </xs:simpleType>
   


### PR DESCRIPTION
Updates the schema for XSLT 4.0 stylesheets to accommodate changes recently agreed:

* Support for xsl:function/@variadic
* Support for extensions to decimal-format properties, for example `percent="%:pc"`.