### PR TITLE
1399 clarify fixed-namespaces spec

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -6610,8 +6610,8 @@ and <code>version="1.0"</code> otherwise.</p>
                      contain a binding for this prefix.</p>
                      <note><p>Including <code>xml</code> in the list has no effect, since the XML namespace
                      will always be in scope anyway.</p></note>
-                     <note><p>If the namespace prefix is explicitly bound to a different namespace, for example
-                     <code>xmlns:math="java:java.util.Math"</code>, then that binding takes precedence.</p></note>
+                     <p>If the namespace prefix is explicitly bound to a different namespace, for example
+                     <code>xmlns:math="java:java.util.Math"</code>, then that binding takes precedence.</p>
                   </item>
                   <item><p>A string in the form <code>prefix=uri</code>, where <code>prefix</code> is an <code>NCName</code>
                      and <code>uri</code> is a (non-empty) namespace URI: for example,


### PR DESCRIPTION
Fix #1399.

The only change is to remove a sentence from `<note>...</note>` markup.