### PR TITLE
1401 Rewrite of F+O section 20, Casting

### DIFF
--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -48,7 +48,7 @@ td.castN         { background-color: #FF7F7F;
                    vertical-align: middle;
                  }
 
-td.castM         { background-color: white;
+td.castM         { background-color: #ffcc00;
                    color: black;
                    text-align: center;
                    vertical-align: middle;

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8907,7 +8907,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
             <head>Casting from primitive types to primitive types</head>
             
             <changes>
-               <change issue="1401">
+               <change issue="1401" PR="1409">
                   This section now uses the term <term>primitive type</term> strictly to refer to the 20 atomic types
                   that are not derived by restriction from another atomic type: that is, the 19 primitive atomic
                   types defined in XSD, plus <code>xs:untypedAtomic</code>. The three types <code>xs:integer</code>,
@@ -9833,7 +9833,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   <head>Casting date/time values to <code>xs:string</code></head>
                   
                   <changes>
-                     <change issue="1401">
+                     <change issue="1401" PR="1409">
                         The rules for conversion of dates and times to strings are now defined entirely
                         in terms of XSD 1.1 canonical mappings, since these deliver
                         exactly the same result as the XPath 3.1 rules.
@@ -9885,7 +9885,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   <head>Casting <code>xs:duration</code> values to <code>xs:string</code></head>
                   
                   <changes>
-                     <change issue="1401">
+                     <change issue="1401" PR="1409">
                         The rules for conversion of durations to strings are now defined entirely
                         in terms of XSD 1.1 canonical mappings, since the XSD 1.1 rules deliver
                         exactly the same result as the XPath 3.1 rules.

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -273,6 +273,13 @@ for transition to Proposed Recommendation. </p>'>
          values; and it allows any character string to appear as the value of an <code>xs:anyURI</code> item.
          Implementations of this specification <rfc2119>may</rfc2119> support either XSD 1.0 or XSD 1.1 or both.</p>
          
+         <p>In some cases, this specification references XSD for the semantics of operations such as the effect of matching
+         using regular expressions, or conversion of atomic values to strings. In most such cases there is no intended
+         technical difference between the XSD 1.0 and XSD 1.1 specifications, but the 1.1 version often provides clearer
+         explanations and sometimes also corrects technical errors. In such cases this specification
+         often chooses to reference the XSD 1.1 specification. This should not be taken as implying that it is necessary
+         to invoke an XSD 1.1 processor.</p>
+         
          <p>References to specific sections of some of the above documents are indicated by
                 cross-document links in this document. Each such link consists of a pointer to a
                 specific section followed a superscript specifying the linked document. The
@@ -906,6 +913,44 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             in this section are used in building those definitions.</p>
             <note><p>Following in the tradition of <bibref ref="xmlschema-2"/>, the terms <term>type</term>
             and <term>datatype</term> are used interchangeably.</p></note>
+            
+            <div3 id="atomic-terminology">
+               <head>Atomic values</head>
+               
+               <p>The following definitions are adopted from <bibref ref="xpath-datamodel-40"/>.</p>
+          <ulist>
+             <item><p><termdef id="dt-atomic-value" term="atomic value">An
+               <term>atomic value</term> is a pair (<var>T</var>, <var>D</var>) where <var>T</var> 
+                (the <termref def="dt-type-annotation"/>)
+                 is an atomic type, and <var>D</var> (the <termref def="dt-datum"/>)
+                 is a point in the value space of <var>T</var>.</termdef></p></item>
+             <item><p><termdef id="dt-primitive-type" term="primitive type">A <term>primitive type</term> 
+                is one of the 19 <term>primitive atomic</term> types defined in
+                <xspecref spec="XS2" ref="built-in-primitive-datatypes"/>
+                of <bibref ref="xmlschema-2"/>, or the type <code>xs:untypedAtomic</code>
+                defined in <bibref ref="xpath-datamodel-40"/>.</termdef></p></item>
+             <item><p><termdef id="dt-datum" term="datum">The <term>datum</term> of an <termref def="dt-atomic-value"/>
+               is a point in the value space of its type, which is also a point in the value space of
+               the primitive type from which that type is derived.</termdef> There are 20 primitive atomic types (19 defined
+               in XSD, plus <code>xs:untypedAtomic</code>), and these have non-overlapping value spaces, so each
+               datum belongs to exactly one primitive atomic type.</p></item>
+             <item><p diff="chg" at="2022-11-05"><termdef id="dt-type-annotation" term="type annotation">The 
+                <term>type annotation</term> of an atomic value
+               is the most specific atomic type that it is an instance of 
+                (it is also an instance of every type from which that
+               type is derived).</termdef></p>  </item>
+          </ulist>
+               
+               
+          
+    
+    
+    
+    <note diff="chg" at="2022-11-05"><p>The term <term>value space</term> is defined in <bibref ref="xmlschema11-2"/>
+      as a set of <emph>values</emph>. The term <term>datum</term> is used here in preference to <emph>value</emph>,
+      because <term>value</term> has a different meaning in this data model.</p></note>
+          
+            </div3>
             <div3 id="character-terminology"><!-- bug 10870 -->
                <head>Strings, characters, and codepoints</head>
                <p>This document uses the terms <code>string</code>, <code>character</code>, and <code>codepoint</code>
@@ -8030,7 +8075,7 @@ return <table>
             <head>Additional Operations on Arrays</head>
             <p><emph>This section is non-normative.</emph></p>
             <p>The XPath language provides explicit syntax for certain operations on arrays.
-               These constructs can also be specified in terms of functions primitives:</p>
+               These constructs can also be specified in terms of function primitives:</p>
             
             <div3 id="singleton-arrays">
                <head>Singleton Arrays</head>
@@ -8805,9 +8850,11 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
       <div1 id="casting">
          <head>Casting</head>
          <p> Constructor functions and cast expressions accept an expression and return a value
-                of a given type. They both convert a source value, <emph>SV</emph>, of a source type,
-                <emph>ST</emph>, to a target value, <emph>TV</emph>, of the given target type,
-                <emph>TT</emph>, with identical semantics and different syntax. The name of the
+                of a given type. They both convert a source value <var>SV</var>, of a source type,
+                <var>ST</var> to a target value <var>TV</var>, of the given target type
+                <var>TT</var>.</p>
+         <p>Constructor functions and cast expressions have identical semantics 
+                but different syntax. The name of the
                 constructor function is the same as the name of the built-in <bibref ref="xmlschema-2"/> 
                 datatype or the datatype defined in <xspecref spec="DM31" ref="types"/>
                    of <bibref ref="xpath-datamodel-31"/> (see <specref ref="constructor-functions-for-xsd-types"/>) or the user-derived datatype
@@ -8830,21 +8877,27 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
             for specific target types.
             The general rules for casting from <code>xs:string</code> (and <code>xs:untypedAtomic</code>)
             follow in <specref ref="casting-from-strings"/>.
-            Casting to non-primitive types, including atomic types derived by resctriction,
+            Casting to non-primitive types, including atomic types derived by restriction,
             union types, and list types, is described in <specref ref="casting-non-primitive-types"/>.  
             Casting from derived types is defined in <specref ref="casting-from-derived-to-parent"/>, 
             <specref ref="casting-within-branch"/> and <specref ref="casting-across-hierarchy"/>.</p>
          
-         <p><termdef id="dt-cast-primitive-type" term="primitive type">Throughout 
+         <p>Casting is not supported to or from <code>xs:anySimpleType</code>. 
+                  Casting to <code>xs:anySimpleType</code> is not permitted and raises a static error:
+                     <xerrorref spec="XP" class="ST" code="0080"/>.</p>
+            <p>Similarly, casting is not supported to or from <code>xs:anyAtomicType</code> and will raise 
+               a static error: <xerrorref spec="XP" class="ST" code="0080"/>. There are no atomic values 
+               with the type annotation <code>xs:anyAtomicType</code>, although this can be a 
+               statically inferred type.</p>
+         
+         <!--<p><termdef id="dt-primitive-type" term="primitive type">Throughout 
             this section (<specref ref="casting"/>), the term <term>primitive type</term> means either one of
             the 19 primitive types defined in <bibref ref="xmlschema-2"/>, or one of the types
             <code>xs:untypedAtomic</code>, <code>xs:integer</code>, <code>xs:yearMonthDuration</code>
             and <code>xs:dayTimeDuration</code>; and where the text refers to types derived from a particular
             primitive type <var>T</var>, the reference is to types for which <var>T</var> is the nearest
             ancestor-or-self primitive type in the type hierarchy.
-         </termdef></p>
-         <p>When casting from <code>xs:string</code> or <code>xs:untypedAtomic</code>
-            the semantics in <specref ref="casting-from-strings"/> apply, regardless of target type.</p>
+         </termdef></p>-->
          
          
          
@@ -8852,49 +8905,63 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
          <div2 id="casting-from-primitive-to-primitive">
            
             <head>Casting from primitive types to primitive types</head>
-            <p>This section defines casting between <termref def="dt-cast-primitive-type">primitive types</termref>
-               (specifically, the 19 primitive types defined in <bibref ref="xmlschema-2"/> as well as <code>xs:untypedAtomic</code>,
-                    <code>xs:integer</code> and the two derived types of
+            
+            <changes>
+               <change issue="1401">
+                  This section now uses the term <term>primitive type</term> strictly to refer to the 20 atomic types
+                  that are not derived by restriction from another atomic type: that is, the 19 primitive atomic
+                  types defined in XSD, plus <code>xs:untypedAtomic</code>. The three types <code>xs:integer</code>,
+                  <code>xs:dayTimeDuration</code>, and <code>xs:yearMonthDuration</code>, which have custom
+                  casting rules but are not strictly-speaking primitive, are now handled in other subsections.
+               </change>
+            </changes>
+            <p>This section defines casting between <termref def="dt-primitive-type">primitive types</termref>
+               (specifically, the 19 primitive types defined in <bibref ref="xmlschema-2"/> plus <code>xs:untypedAtomic</code>.
+                    <!--<code>xs:integer</code> and the two derived types of
                     <code>xs:duration</code>: <code>xs:yearMonthDuration</code>
-                    and <code>xs:dayTimeDuration</code> which are treated as primitive types in this section. The type conversions
+                    and <code>xs:dayTimeDuration</code> which are treated as primitive types in this section. -->
+               The type conversions
                     that are supported between primitive atomic types are indicated in the table below;
-                    casts between other (non-primitive) types are defined in terms of these primitives.</p> 
+                    casts between other (non-primitive) types are defined in terms of these primitives.</p>
+            
+            <p>Where the target type <var>TT</var> is a primitive type, the result <var>TV</var> will always
+            be an instance of <var>TT</var>. The result <rfc2119>may</rfc2119> also be an instance of a type derived
+            from <var>TT</var>: for example casting an <code>xs:NCName</code> <var>SV</var> 
+               to <code>xs:string</code> <rfc2119>may</rfc2119> return <var>SV</var> unchanged, with its
+            original type annotation.</p>
+            
+            
                     
             <p>In this table, there is a
-               row for each <termref def="dt-cast-primitive-type">primitive type</termref> acting as the source of the conversion and
-               there is a column for each <termref def="dt-cast-primitive-type">primitive type</termref> acting as the target of the conversion. The
-                    intersections of rows and columns contain one of three characters:
-                    <code>Y</code> indicates that a conversion from values of the type to which
-                    the row applies to the type to which the column applies is supported;
-                    <code>N</code> indicates that there are no supported conversions from values
-                    of the type to which the row applies to the type to which the column applies;
-                    and <code>M</code> indicates that a conversion from values of the type to
+               row for each <termref def="dt-primitive-type">primitive type</termref> acting as the source of the conversion and
+               there is a column for each <termref def="dt-primitive-type">primitive type</termref> acting as the target of the conversion. The
+                    intersections of rows and columns contain one of three characters:</p>
+                    <ulist>
+                       <item><p><code>Y</code> indicates that a conversion from values of the type to which
+                        the row applies to the type to which the column applies is supported;</p></item>
+                       <item><p><code>N</code> indicates that there are no supported conversions from values
+                    of the type to which the row applies to the type to which the column applies;</p></item>
+                       <item><p><code>M</code> indicates that a conversion from values of the type to
                     which the row applies to the type to which the column applies may succeed for
-                    some values in the value space and fail for others.</p>
+                    some values in the value space and fail for others.</p></item>
+                    </ulist>
+            <p>There is no row or column for <code>xs:untypedAtomic</code> because the casting rules are exactly the same
+            as for <code>xs:string</code>. When casting from <code>xs:string</code> or <code>xs:untypedAtomic</code>
+            the semantics in <specref ref="casting-from-strings"/> apply, regardless of target type.
+         </p>
             <p>
                <bibref ref="xmlschema-2"/> defines <code>xs:NOTATION</code> as an abstract type. 
                Thus, casting to <code>xs:NOTATION</code> from any other type including <code>xs:NOTATION</code>
                is not permitted and raises a static error <xerrorref spec="XP" class="ST" code="0080"/>.  
                However, casting from one subtype of <code>xs:NOTATION</code> to another subtype of 
                <code>xs:NOTATION</code> is permitted.</p>
-            <p>Casting is not supported to or from <code>xs:anySimpleType</code>. Thus, there is no row
-               or column for this type in the table below. For any node that has not been validated or 
-               has been validated as <code>xs:anySimpleType</code>, the typed value of the node is an 
-               atomic value of type <code>xs:untypedAtomic</code>. There are no atomic values with the 
-               type annotation <code>xs:anySimpleType</code> at runtime. 
-                  Casting to
-                     <code>xs:anySimpleType</code> is not permitted and raises a static error:
-                     <xerrorref spec="XP" class="ST" code="0080"/>.</p>
-            <p>Similarly, casting is not supported to or from <code>xs:anyAtomicType</code> and will raise 
-               a static error: <xerrorref spec="XP" class="ST" code="0080"/>. There are no atomic values 
-               with the type annotation <code>xs:anyAtomicType</code> at runtime, although this can be a 
-               statically inferred type.</p>
-            <p>If casting is attempted from an <emph>ST</emph> to a <emph>TT</emph> for which
+            
+            <p>If casting is attempted from an <var>ST</var> to a <var>TT</var> for which
                     casting is not supported, as defined in the table below, a type error is raised <xerrorref spec="XP" class="TY" code="0004" type="type"/>.</p>
             <p>In the following table, the columns and rows are identified by short codes that
                     identify simple types as follows:</p>
             <slist>
-               <sitem>uA = xs:untypedAtomic</sitem>
+               <!--<sitem>uA = xs:untypedAtomic</sitem>-->
                <sitem>aURI = xs:anyURI</sitem>
                <sitem>b64 = xs:base64Binary</sitem>
                <sitem>bool = xs:boolean</sitem>
@@ -8903,19 +8970,19 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                <sitem>dbl = xs:double</sitem>
                <sitem>dec = xs:decimal</sitem>
                <sitem>dT = xs:dateTime</sitem>
-               <sitem>dTD = xs:dayTimeDuration</sitem>
+               <!--<sitem>dTD = xs:dayTimeDuration</sitem>-->
                <sitem>dur = xs:duration</sitem>
                <sitem>flt = xs:float</sitem>
                <sitem>hxB = xs:hexBinary</sitem>
                <sitem>gMD = xs:gMonthDay</sitem>
                <sitem>gMon = xs:gMonth</sitem>
-               <sitem>int = xs:integer</sitem>
+               <!--<sitem>int = xs:integer</sitem>-->
                <sitem>NOT = xs:NOTATION</sitem>
                <sitem>QN = xs:QName</sitem>
                <sitem>str = xs:string</sitem>
                <sitem>tim = xs:time</sitem>
                <sitem>gYM = xs:gYearMonth</sitem>
-               <sitem>yMD = xs:yearMonthDuration</sitem>
+               <!--<sitem>yMD = xs:yearMonthDuration</sitem>-->
                <sitem>gYr = xs:gYear</sitem>
             </slist>
             <p>In the following table, the notation <quote>S\T</quote> indicates that the source
@@ -8930,15 +8997,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                changing the associated stylesheets. --><table border="1" cellpadding="1" role="casting" summary="Casting table"
                    id="casting-to-primitives-table">
                <col width="5%" span="1"/>
+               <!--<col width="3%" span="1"/>-->
                <col width="3%" span="1"/>
                <col width="3%" span="1"/>
                <col width="3%" span="1"/>
                <col width="3%" span="1"/>
+               <!--<col width="3%" span="1"/>-->
                <col width="3%" span="1"/>
-               <col width="3%" span="1"/>
-               <col width="3%" span="1"/>
-               <col width="3%" span="1"/>
-               <col width="3%" span="1"/>
+               <!--<col width="3%" span="1"/>-->
+               <!--<col width="3%" span="1"/>-->
                <col width="3%" span="1"/>
                <col width="3%" span="1"/>
                <col width="3%" span="1"/>
@@ -8956,15 +9023,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                <thead>
                   <tr>
                      <th>S\T</th>
-                     <th>uA</th>
+                     <!--<th>uA</th>-->
                      <th>str</th>
                      <th>flt</th>
                      <th>dbl</th>
                      <th>dec</th>
-                     <th>int</th>
+                     <!--<th>int</th>-->
                      <th>dur</th>
-                     <th>yMD</th>
-                     <th>dTD</th>
+                     <!--<th>yMD</th>-->
+                     <!--<th>dTD</th>-->
                      <th>dT</th>
                      <th>tim</th>
                      <th>dat</th>
@@ -8982,7 +9049,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                </thead>
                <tbody>
-                  <tr>
+                  <!--<tr>
                      <th>uA</th>
                      <td>Y</td>
                      <td>Y</td>
@@ -9007,18 +9074,18 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                      <td>M</td>
                      <td>M</td>
                      <td>M</td>
-                  </tr>
+                  </tr>-->
                   <tr>
                      <th>str</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>M</td>
                      <td>M</td>
                      <td>M</td>
+                     <!--<td>M</td>-->
                      <td>M</td>
-                     <td>M</td>
-                     <td>M</td>
-                     <td>M</td>
+                     <!--<td>M</td>-->
+                     <!--<td>M</td>-->
                      <td>M</td>
                      <td>M</td>
                      <td>M</td>
@@ -9036,15 +9103,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>flt</th>
-                     <td>Y</td>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
                      <td>Y</td>
                      <td>Y</td>
                      <td>M</td>
-                     <td>M</td>
+                     <!--<td>M</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9062,15 +9129,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>dbl</th>
-                     <td>Y</td>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
                      <td>Y</td>
                      <td>Y</td>
                      <td>M</td>
-                     <td>M</td>
+                     <!--<td>M</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9088,15 +9155,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>dec</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
                      <td>Y</td>
                      <td>Y</td>
                      <td>Y</td>
-                     <td>Y</td>
-                     <td>Y</td>
+                     <!--<td>Y</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9112,7 +9179,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                      <td>N</td>
                      <td>N</td>
                   </tr>
-                  <tr>
+                  <!--<tr>
                      <th>int</th>
                      <td>Y</td>
                      <td>Y</td>
@@ -9137,18 +9204,18 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
-                  </tr>
+                  </tr>-->
                   <tr>
                      <th>dur</th>
-                     <td>Y</td>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
                      <td>Y</td>
-                     <td>Y</td>
-                     <td>Y</td>
+                     <!--<td>Y</td>-->
+                     <!--<td>Y</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9164,7 +9231,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                      <td>N</td>
                      <td>N</td>
                   </tr>
-                  <tr>
+                  <!--<tr>
                      <th>yMD</th>
                      <td>Y</td>
                      <td>Y</td>
@@ -9189,8 +9256,8 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
-                  </tr>
-                  <tr>
+                  </tr>-->
+                  <!--<tr>
                      <th>dTD</th>
                      <td>Y</td>
                      <td>Y</td>
@@ -9215,18 +9282,18 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
-                  </tr>
+                  </tr>-->
                   <tr>
                      <th>dT</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>Y</td>
                      <td>Y</td>
                      <td>Y</td>
@@ -9244,15 +9311,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>tim</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>Y</td>
                      <td>N</td>
@@ -9270,15 +9337,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>dat</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>Y</td>
                      <td>N</td>
                      <td>Y</td>
@@ -9296,15 +9363,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>gYM</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9322,15 +9389,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>gYr</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9348,15 +9415,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>gMD</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9374,15 +9441,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>gDay</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9400,15 +9467,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>gMon</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9426,15 +9493,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>bool</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
                      <td>Y</td>
                      <td>Y</td>
                      <td>Y</td>
-                     <td>Y</td>
-                     <td>Y</td>
+                     <!--<td>Y</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9452,15 +9519,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>b64</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9478,15 +9545,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>hxB</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9504,15 +9571,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>aURI</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9530,15 +9597,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>QN</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9556,15 +9623,15 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                   </tr>
                   <tr>
                      <th>NOT</th>
+                     <!--<td>Y</td>-->
                      <td>Y</td>
-                     <td>Y</td>
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
+                     <!--<td>N</td>-->
                      <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
-                     <td>N</td>
+                     <!--<td>N</td>-->
+                     <!--<td>N</td>-->
                      <td>N</td>
                      <td>N</td>
                      <td>N</td>
@@ -9583,109 +9650,169 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                </tbody>
             </table>
             
+            <div3 id="casting-to-untypedAtomic">
+               <head>Casting to <code>xs:untypedAtomic</code></head>
+               
+               <p>Any atomic value <var>SV</var> can be cast to <code>xs:untypedAtomic</code>.</p>
+               
+               <p>The effect is the same as casting to <code>xs:string</code> (see <specref ref="casting-to-string"/>)
+               and then returning the <code>xs:untypedAtomic</code> value comprising the same sequence of
+               characters.</p>
+            </div3>
             
             <div3 id="casting-to-string">
-               <head>Casting to xs:string and xs:untypedAtomic</head>
-               <p>Casting is permitted from any <termref def="dt-cast-primitive-type">primitive type</termref> to the 
-                  <termref def="dt-cast-primitive-type">primitive types</termref>
-                        <code>xs:string</code> and <code>xs:untypedAtomic</code>.</p>
-               <p>When a value of any simple type is cast as <code>xs:string</code>, the
-                        derivation of the <code>xs:string</code> value <emph>TV</emph> depends on
-                        the <emph>ST</emph> and on the <emph>SV</emph>, as follows.</p>
+               <head>Casting to <code>xs:string</code></head>
+               
+               <p>Any atomic value <var>SV</var> can be cast to <code>xs:string</code>.</p>
+               
+               <p>The resulting <code>xs:string</code> value <var>TV</var> depends on
+                        the source type <var>ST</var> as follows.</p>
                <ulist>
                   <item>
-                     <p>If <emph>ST</emph> is <code>xs:string</code> or a type derived from
-                                <code>xs:string</code>, <emph>TV</emph> is <emph>SV</emph>.</p>
+                     <p>If <var>SV</var> is an instance of <code>xs:string</code>,
+                        <var>TV</var> is an instance of <code>xs:string</code> comprising
+                        the same sequence of characters as <var>SV</var>.</p>
+                     <note><p>The implementation is free to return <var>SV</var> unchanged,
+                     including its original type annotation.</p></note>
                   </item>
                   <item>
-                     <p>If <emph>ST</emph> is <code>xs:anyURI</code>, the type conversion is
-                                performed without escaping any characters.</p>
+                     <p>If <var>SV</var> is an instance of <code>xs:anyURI</code>, the result <var>TV</var> is an instance
+                        of <code>xs:string</code> comprising the same sequence of characters
+                        as <var>SV</var>, but with a type annotation of <code>xs:anyURI</code>.
+                       No escaping of special characters takes place.</p>
                   </item>
                   <item>
-                     <p>If <emph>ST</emph> is <code>xs:QName</code> or <code>xs:NOTATION</code>:</p>
+                     <p>If <var>SV</var> is an instance of <code>xs:QName</code> or <code>xs:NOTATION</code>:</p>
                      <ulist>
                         <item><p>if the qualified name
-          has a prefix, then <emph>TV</emph> is the concatenation of the prefix of <emph>SV</emph>, 
-		  a single colon (:), and the local name of <emph>SV</emph>.</p>
+                           has a prefix, then <var>TV</var> is the concatenation of the prefix of <var>SV</var>, 
+                 		  a single colon (:), and the local name of <var>SV</var>.</p>
                            </item>
                         <item>
-                           <p>otherwise <emph>TV</emph> is the local-name.</p>
+                           <p>otherwise <var>TV</var> is the local name of <var>SV</var>.</p>
                         </item>
                      </ulist>
                   </item>
                   <item>
-                     <p>If <emph>ST</emph> is a numeric type, the following rules apply:</p>
-                     <ulist>
+                     <p>If <var>SV</var> is an instance of <code>xs:numeric</code>, 
+                        the rules in <specref ref="casting-numeric-to-string"/> apply.</p>
+                     
+                  </item>
+                  <item>
+                     <p>If <var>SV</var> is an instance of <code>xs:dateTime</code>, <code>xs:date</code>
+                                or <code>xs:time</code>, the rules in <specref ref="casting-date-time-to-string"/> apply.
+                        
+                     </p>
+                  </item>
+                  <item>
+                     <p>If <var>ST</var> is <code>xs:duration</code>, or any subtype thereof including
+                        <code>xs:yearMonthDuration</code> and <code>xs:dayTimeDuration</code>, then the rules
+                        in <specref ref="casting-duration-to-string"/> apply.</p>
+
+                  </item>
+                  
+                  <item>
+                     <p>In all other cases, <var>TV</var> is the <bibref ref="xmlschema-2"/>
+                                canonical representation of <var>SV</var>. For datatypes that do
+                                not have a canonical representation defined an <termref def="implementation-dependent"/> canonical representation may be used.</p>
+                  </item>
+                  </ulist>
+               <p>To cast as <code>xs:untypedAtomic</code> the value is cast as
+                        <code>xs:string</code>, as described above, and the type annotation changed
+                        to <code>xs:untypedAtomic</code>.</p>
+               
+               
+               <div4 id="casting-numeric-to-string">
+                  <head>Casting numeric values to <code>xs:string</code></head>
+                  <p>The following rules apply when the source type <var>ST</var> is <code>xs:decimal</code>,
+                  <code>xs:double</code>, or <code>xs:float</code>, or any subtype of these including
+                  <code>xs:integer</code>.</p>
+                  <olist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:integer</code>,
-                                        <emph>TV</emph> is the canonical lexical representation of
-                                        <emph>SV</emph> as defined in <bibref ref="xmlschema-2"/>. There
-                                        is no decimal point.</p>
-                        </item>
+                           <p>If <var>SV</var> is an instance of <code>xs:decimal</code>,
+                              then the canonical representation of
+                              <var>SV</var> is returned, as defined in <bibref ref="xmlschema11-2"/>.
+                                 Specifically, see <xspecref spec="XS2" ref="f-decimalCanmap"/>.</p>
+                           
+                           <note>
+                              <p>Unlike previous versions of this specification, no special
+                              rule is given for the case where <var>SV</var> is an instance of
+                              <code>xs:integer</code>. This is because the general rule for
+                              <code>xs:decimal</code> gives the same result. The result 
+                                 in this case will be a sequence of decimal digits in the range
+                              <char>U+0030</char> to <char>U+0039</char>, optionally
+                           preceded by a minus sign, with no leading zeroes. For example:
+                              <code>42</code>, <code>-1</code>, <code>0</code>, or <code>1000000000</code>.</p>
+                           </note>
+                           
+                           <note>
+                              <p>An <code>xs:decimal</code> that is equal to an integer is converted
+                              to a string as if it were first cast to an <code>xs:integer</code>.
+                              Specifically, there will be no decimal point and no fractional part.</p>
+                              <p>If the value is not equal to an integer, then there will be a decimal
+                              point and a fractional part, which will be a sequence of decimal digits
+                              with no trailing zeroes. For example: <code>42.3</code>, <code>-1.5</code>, 
+                                 or <code>0.00001</code>.</p>
+                           </note>
+                        </item>     
+                        <!--<item>
+                           <p>If <var>SV</var> is an instance of <code>xs:integer</code>,
+                                        <var>TV</var> is the canonical representation of
+                                        <var>SV</var> as defined in <bibref ref="xmlschema11-2"/>.</p>
+                           <note><p>The result will thus be a sequence of decimal digits in the range
+                              <char>U+0030</char> to <char>U+0039</char>, optionally
+                           preceded by a minus sign, with no leading zeroes.</p></note>
+                        </item>-->
+                        
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:decimal</code>, then:</p>
-                           <ulist>
-                              <item>
-                                 <p>If <emph>SV</emph> is in the value space of
-                                                <code>xs:integer</code>, that is, if there are no
-                                                significant digits after the decimal point, then the
-                                                value is converted from an <code>xs:decimal</code>
-                                                to an <code>xs:integer</code> and the resulting
-                                                <code>xs:integer</code> is converted to an
-                                                <code>xs:string</code> using the rule above.</p>
-                              </item>
-                              <item>
-                                 <p> Otherwise, the canonical lexical representation of
-                                                <emph>SV</emph> is returned, as defined in <bibref ref="xmlschema-2"/>.</p>
-                              </item>
-                           </ulist>
-                        </item>
-                        <item>
-                           <p> If <emph>ST</emph> is <code>xs:float</code> or
+                           <p> If <var>SV</var> is an instance of <code>xs:float</code> or
                                         <code>xs:double</code>, then:</p>
-                           <ulist>
+                           <olist>
                               <item>
                                  <p>
-                                    <emph>TV</emph> will be an <code>xs:string</code> in the lexical space of <code>xs:double</code> or <code>xs:float</code> that when
-converted to an <code>xs:double</code> or <code>xs:float</code> under the rules of <specref ref="casting-from-strings"/> produces
-a value that is equal to <emph>SV</emph>, or is <code>NaN</code> if <emph>SV</emph> is <code>NaN</code>.
-In addition, <emph>TV</emph> must satisfy the constraints in the
-following sub-bullets.
+                                    <var>TV</var> will be an <code>xs:string</code> in the lexical space 
+                                    of <code>xs:double</code> or <code>xs:float</code> that when
+                                    converted to an <code>xs:double</code> or <code>xs:float</code> under 
+                                    the rules of <specref ref="casting-from-strings"/> produces
+                                    a value that is equal to <var>SV</var>, or is <code>NaN</code> 
+                                    if <var>SV</var> is <code>NaN</code>.
+                                    In addition, <var>TV</var> must satisfy the constraints in the
+                                    following sub-bullets.
 											</p>
-                                 <ulist>
+                                 <olist>
                                     <item>
-                                       <p>If <emph>SV</emph> has an absolute value that is
+                                       <p>If <var>SV</var> has an absolute value that is
                                                 greater than or equal to 0.000001 (one millionth)
                                                 and less than 1000000 (one million), then the value
                                                 is converted to an <code>xs:decimal</code> and the
                                                 resulting <code>xs:decimal</code> is converted to an
                                                 <code>xs:string</code> according to the rules above, as though using an 
-implementation of <code>xs:decimal</code> that imposes no limits on the
-<code>totalDigits</code> or
-<code>fractionDigits</code> facets.</p>
+                                                implementation of <code>xs:decimal</code> that imposes no limits on the
+                                                <code>totalDigits</code> or
+                                                <code>fractionDigits</code> facets.</p>
                                     </item>
                                     <item>
-                                       <p>If <emph>SV</emph> has the value positive or negative zero, <emph>TV</emph> is <code>"0"</code> or <code>"-0"</code>
-respectively.
-</p>
+                                       <p>If <var>SV</var> has the value positive or negative zero, <var>TV</var> 
+                                          is <code>"0"</code> or <code>"-0"</code> respectively.</p>
                                     </item>
                                     <item>
-                                       <p>If <emph>SV</emph> is positive or negative infinity, <emph>TV</emph> is the string <code>"INF"</code> or <code>"-INF"</code> respectively.
-</p>
+                                       <p>If <var>SV</var> is positive or negative infinity, 
+                                          <var>TV</var> is the string <code>"INF"</code> or <code>"-INF"</code> respectively.
+                                       </p>
                                     </item>
                                     <item>
                                        <p>In other cases, the result consists of a mantissa, which has the lexical form
-of an <code>xs:decimal</code>, followed by the letter "E", followed by an exponent which has
-the lexical form of an <code>xs:integer</code>. Leading zeroes and "+" signs are prohibited
-in the exponent. For the mantissa, there must be a decimal point, and there must
-be exactly one digit before the decimal point, which must be non-zero. The  "+"
-sign is prohibited. There must be at least one digit after the decimal point.
-Apart from this mandatory digit, trailing zero digits are prohibited. 
-</p>
+                                       of an <code>xs:decimal</code>, followed by the letter "E", followed by an exponent which has
+                                       the lexical form of an <code>xs:integer</code>. Leading zeroes and "+" signs are prohibited
+                                       in the exponent. For the mantissa, there must be a decimal point, and there must
+                                       be exactly one digit before the decimal point, which must be non-zero. The  "+"
+                                       sign is prohibited. There must be at least one digit after the decimal point.
+                                       Apart from this mandatory digit, trailing zero digits are prohibited. 
+                                       </p>
                                     </item>
-                                 </ulist>
+                                 </olist>
                               </item>
-                           </ulist>
+                           </olist>
                            <note>
                               <p>The above rules allow more than one representation of the same value. 
                                  For example, the <code>xs:float</code> value whose exact decimal representation is 1.26743223E15
@@ -9694,133 +9821,133 @@ Apart from this mandatory digit, trailing zero digits are prohibited.
                                  It is implementation-dependent which of these representations is chosen.</p>
                            </note>
                         </item>
-                     </ulist>
-                  </item>
-                  <item>
-                     <p>If <emph>ST</emph> is <code>xs:dateTime</code>, <code>xs:date</code>
-                                or <code>xs:time</code>, <emph>TV</emph> is the local value. 
-The components of <emph>TV</emph> are individually cast to <code>xs:string</code> using the functions 
-                        described in <bibref ref="casting-to-datetimes"/> 
-                        and the results are concatenated together.  The <code>year</code> component is 
-                        cast to <code>xs:string</code> using <code>eg:convertYearToString</code>.  
-                        The <code>month</code>, <code>day</code>, <code>hour</code> and <code>minute</code> 
-                        components are cast to <code>xs:string</code> using <code>eg:convertTo2CharString</code>.  
-                        The <code>second</code> component is cast to <code>xs:string</code> using 
-                        <code>eg:convertSecondsToString</code>. The timezone component, if present, is 
-                        cast to <code>xs:string</code> using <code>eg:convertTZtoString</code>.  
-</p>
-                     <p> 
-Note that the hours component of the resulting string
-will never be <code>"24"</code>. Midnight is always represented as <code>"00:00:00"</code>.
-</p>
-                  </item>
-                  <item>
-                     <p>If <emph>ST</emph> is <code>xs:yearMonthDuration</code> or <code>xs:dayTimeDuration</code>, <emph>TV</emph> is the 
-                                canonical representation of <emph>SV</emph> as defined in <bibref ref="xmlschema11-2"/>.</p>
-                  </item>
-                  <item>
-                     <p>If <emph>ST</emph> is <code>xs:duration</code>
- then let <emph>SYM</emph> be <emph>
-                           <code>SV</code>
-                        </emph> 
-                        <code>cast as xs:yearMonthDuration</code>, and let <emph>SDT</emph> be <emph>
-                           <code>SV</code>
-                        </emph> 
-                        <code>cast as xs:dayTimeDuration</code>;  Now, let the next intermediate value, <emph>TYM</emph>, 
-be <emph>
-                           <code>SYM</code>
-                        </emph> 
-                        <code>cast as</code> 
-                        <emph>
-                           <code>TT</code>
-                        </emph>, and let <emph>TDT</emph> be <emph>
-                           <code>SDT</code>
-                        </emph> 
-                        <code>cast as</code> 
-                        <emph>
-                           <code>TT</code>
-                        </emph>.  If <emph>TYM</emph> is <code>"P0M"</code>, then <emph>TV</emph> is 
-<emph>TDT</emph>.  Otherwise, <emph>TYM</emph> and <emph>TDT</emph> are merged according to the following rules:</p>
-                     <olist>
-                        <item>
-                           <p>If <emph>TDT</emph> is <code>"PT0S"</code>, then <emph>TV</emph> is <emph>TYM</emph>.</p>
-                        </item>
-                        <item>
-                           <p>Otherwise, <emph>TV</emph> is the concatenation of all the characters in <emph>TYM</emph> and all the
-characters except the first "P" and the optional negative sign in <emph>TDT</emph>.</p>
-                        </item>
                      </olist>
-                  </item>
-                  <item>
-                     <p>In all other cases, <emph>TV</emph> is the <bibref ref="xmlschema-2"/>
-                                canonical representation of <emph>SV</emph>. For datatypes that do
-                                not have a canonical lexical representation defined an <termref def="implementation-dependent"/> canonical representation may be used.</p>
-                  </item>
-                  <!--							<item>
-								<p>If <emph>ST</emph> is <code>string</code>, </<emph>TV</emph> is <emph>SV</emph>.</p>
-							</item>
-							<item>
-								<p>If <emph>ST</emph> is <code>float</code>, <code>double</code>, or <code>decimal</code> then <emph>TV</emph> is the canonical representation of <emph>SV</emph>, as defined by <bibref ref="xmlschema-2"/>.</p>
-							</item>
-							<item>
-								<p>If <emph>ST</emph> is <code>duration</code> then <emph>TV</emph> is the lexical representation of <emph>SV</emph>, as defined in <bibref ref="xmlschema-2"/> in which each integer and decimal component is expressed in its canonical representation.</p>
-							</item>
-<item>
-								<p>If <emph>ST</emph> is <code>yearMonthDuration</code> or <code>dayTimeDuration</code> then <emph>TV</emph> is the canonical representation of <emph>SV</emph>, in which each integer and decimal component is expressed in its canonical representation.</p>
-							</item>
-							<item>
-								<p>If <emph>ST</emph> is <code>dateTime</code> or <code>time</code>, then <emph>TV</emph> is the canonical representation of <emph>SV</emph>, as defined by <bibref ref="xmlschema-2"/>.</p>
-							</item>
-							<item>
-								<p>If <emph>ST</emph> is <code>date</code>, <code>gYearMonth</code>, <code>gYear</code>, <code>gMonthDay</code>, <code>gDay</code>, or <code>gMonth</code>, then <emph>TV</emph> is the lexical representation of <emph>SV</emph>, as defined by <bibref ref="xmlschema-2"/>.</p>
-							</item>
-							<item>
-								<p>If <emph>ST</emph> is <code>boolean</code>, then <emph>TV</emph> is <quote>true</quote> if <emph>SV</emph> is <code>true</code> and <quote>false</quote> if <emph>SV</emph> is <code>false</code>.</p>
-							</item>
-							<item>
-								<p>If <emph>ST</emph> is <code>hexBinary</code>, then <emph>TV</emph> is the canonical representation of <emph>SV</emph>, as defined by <bibref ref="xmlschema-2"/>.</p>
-							</item>
-							<item>
-								<p>If <emph>ST</emph> is <code>anyURI</code>, then <emph>TV</emph> is the lexical representation of <emph>SV</emph>, as defined in <bibref ref="xmlschema-2"/>, with each space replaced by the sequence <quote>%20</quote>.</p>
-							</item>
-							<item>
-								<p>If <emph>ST</emph> is <code>NOTATION</code>, then <emph>TV</emph> is <emph>SV</emph>.</p>
-							</item>  --></ulist>
-               <p>To cast as <code>xs:untypedAtomic</code> the value is cast as
-                        <code>xs:string</code>, as described above, and the type annotation changed
-                        to <code>xs:untypedAtomic</code>.</p>
-               <note>
-                  <p>The string representations of numeric values are backwards compatible
+                  
+                  <note>
+                    <p>The string representations of numeric values are backwards compatible
                             with XPath 1.0 except for the special values positive and negative
                             infinity, negative zero and values outside the range <code>1.0e-6</code> to <code>1.0e+6</code>.</p>
-               </note>
+                  </note>
+               </div4>
+               <div4 id="casting-date-time-to-string">
+                  <head>Casting date/time values to <code>xs:string</code></head>
+                  
+                  <changes>
+                     <change issue="1401">
+                        The rules for conversion of dates and times to strings are now defined entirely
+                        in terms of XSD 1.1 canonical mappings, since these deliver
+                        exactly the same result as the XPath 3.1 rules.
+                     </change>
+                  </changes>
+                  
+                  <p>If <var>SV</var> is an instance of <code>xs:dateTime</code>,
+                     <code>xs:date</code>, <code>xs:time</code>, <code>xs:gYear</code>, 
+                     <code>xs:gYearMonth</code>, <code>xs:gMonth</code>, <code>xs:gMonthDay</code>, or <code>xs:gDay</code>,
+                     then <var>TV</var> is the 
+                     canonical representation of <var>SV</var> as defined in <bibref ref="xmlschema11-2"/>.
+                  </p>
+                  
+                  <note>
+                     <p>The result <var>TV</var> includes the original timezone if a timezone is present.</p>
+                     <p>All these data types contain different combinations of the components year, month, day,
+                     hour, minute, second, and timezone; all the components relevant to the data type (with 
+                     the exception of the timezone) are output, and the results are concatenated together 
+                     with suitable punctuation. Specifically:</p>
+                     <olist>
+                     <item><p>The <code>year</code> component is 
+                        represented as a <code>xs:string</code> of four digits, or more if needed. A leading minus 
+                        sign is present for BCE years.</p></item>
+                     <item><p>The <code>month</code>, <code>day</code>, <code>hour</code> and <code>minute</code> 
+                        components are represented as two digits (with a leading zero if needed).
+                       For example, February is represented as <code>02</code>.</p>
+                     <p>The hours component will never be <code>"24"</code>: midnight 
+                        is always represented as <code>"00:00:00"</code>.</p></item>
+                     <item><p>The <code>second</code> component is output using as a two-digit integer
+                        if it is a whole number (for example, <code>30</code>, <code>05</code>, or <code>00</code>),
+                        or if it is fractional, as two digits followed by a decimal point followed by as many digits as
+                        are necessary, with no trailing zeroes (for example <code>30.5</code> or <code>00.001</code>). </p></item>
+                     <item><p>The timezone component, if present, is 
+                        cast to <code>xs:string</code> by applying the function <code>eg:convertTZtoString</code>
+                     given in <specref ref="casting-to-datetimes"/>. Examples are <code>Z</code>, <code>+01:00</code>,
+                     <code>-05:00</code>, or <code>+05:30</code>.</p></item>
+                  </olist>  
+                      <p>.
+                  </p>
+                  </note>
+                  
+                          
+                        
+                    
+                  
+                 
+               </div4>      
+               <div4 id="casting-duration-to-string">
+                  <head>Casting <code>xs:duration</code> values to <code>xs:string</code></head>
+                  
+                  <changes>
+                     <change issue="1401">
+                        The rules for conversion of durations to strings are now defined entirely
+                        in terms of XSD 1.1 canonical mappings, since the XSD 1.1 rules deliver
+                        exactly the same result as the XPath 3.1 rules.
+                     </change>
+                  </changes>
+                  <p>If <var>SV</var> is an instance of <code>xs:duration</code> (including its subtypes
+                     <code>xs:yearMonthDuration</code> and <code>xs:dayTimeDuration</code>), then <var>TV</var> is the 
+                     canonical representation of <var>SV</var> as defined in <bibref ref="xmlschema11-2"/>.
+                     Specifically, see <xspecref spec="XS2" ref="f-durationCanMap"/>.</p>
+                  
+                  <note>
+                     <p>The rules have the effect of normalizing the value so that the number of months is always
+                     less than 12, the number of hours less than 24, and the number of minutes and seconds less 
+                     than 60. Zero-valued components are omitted. Fractional seconds follow the same rules
+                     as <code>xs:decimal</code>. For example, the duration <code>P15MT30H</code>
+                     is represented as <code>P1Y3M1DT6H</code>. A zero-length duration is output as <code>PT0S</code>.</p>
+                  </note>
+                  
+                  <note>
+                     <p>At the time of writing, the published XSD 1.1 recommendation contains 
+                        cut-and-paste errors in the definition
+                     of the <code>dayTimeDuration</code> canonical mapping. The binding of variable <var>s</var>
+                     should be to <var>dt</var>'s <code>·seconds·</code> (not <code>·months·</code>) component, and the return 
+                        expression given as <code>sgn &amp; 'P' &amp; ·duYearMonthCanonicalFragmentMap·(|s|)</code>
+                     should read <code>sgn &amp; 'P' &amp; ·duDayTimeCanonicalFragmentMap·(|s|)</code></p>
+                     
+                     <p>In reading these XSD formulations, be aware that <code>a &amp; b</code> represents
+                        string concatenation, while <code>|s|</code> computes the absolute value of a number.</p>
+                  </note>
+               
+                     
+               </div4>
             </div3>
             <div3 id="casting-to-numerics">
                <head>Casting to numeric types</head>
+               <p>This section defines the rules for casting to the primitive numeric types <code>xs:float</code>,
+               <code>xs:double</code>, and <code>xs:decimal</code>. Rules for casting to the derived type
+               <code>xs:integer</code> are given in <specref ref="casting-to-integer"/>.</p>
                <div4 id="casting-to-float">
                   <head>Casting to xs:float</head>
                   <p>When a value of any simple type is cast as <code>xs:float</code>, the <code>xs:float</code>
-                            <emph>TV</emph> is derived from the <emph>ST</emph> and the
-                            <emph>SV</emph> as follows:</p>
+                            <var>TV</var> is derived from the <var>ST</var> and the
+                            <var>SV</var> as follows:</p>
                   <ulist>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:float</code>, then <emph>TV</emph>
-                                    is <emph>SV</emph> and the conversion is complete.</p>
+                        <p>If <var>ST</var> is <code>xs:float</code>, then <var>TV</var>
+                                    is <var>SV</var> and the conversion is complete.</p>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:double</code>, then
-                                    <emph>TV</emph> is obtained as follows: </p>
+                        <p>If <var>ST</var> is <code>xs:double</code>, then
+                                    <var>TV</var> is obtained as follows: </p>
                         <ulist>
                            <item>
-                              <p>if <emph>SV</emph> is the <code>xs:double</code> value
+                              <p>if <var>SV</var> is the <code>xs:double</code> value
                                             <code>INF</code>, <code>-INF</code>, <code>NaN</code>,
-                                            positive zero, or negative zero, then <emph>TV</emph> is
+                                            positive zero, or negative zero, then <var>TV</var> is
                                             the <code>xs:float</code> value <code>INF</code>,
                                             <code>-INF</code>, <code>NaN</code>, positive zero, or
                                             negative zero respectively.</p>
                            </item>
                            <item>
-                              <p>otherwise, <emph>SV</emph> can be expressed in the form
+                              <p>otherwise, <var>SV</var> can be expressed in the form
                                                 <code>m &times; 2^e</code> where the mantissa
                                             <code>m</code> and exponent <code>e</code> are signed
                                             <code>xs:integer</code>s whose value range is defined in
@@ -9828,7 +9955,7 @@ characters except the first "P" and the optional negative sign in <emph>TDT</emp
                               <ulist>
                                  <item>
                                     <p>if <code>m</code> (the mantissa of
-                                                  <emph>SV</emph>) is outside the permitted range
+                                                  <var>SV</var>) is outside the permitted range
                                                   for the mantissa of an <code>xs:float</code>
                                                   value <code>(-2^24-1 to +2^24-1)</code>, then it
                                                   is divided by <code>2^N</code> where
@@ -9845,20 +9972,20 @@ characters except the first "P" and the optional negative sign in <emph>TDT</emp
                                  <item>
                                     <p>if <code>E</code> exceeds <code>104</code> (the
                                                   maximum exponent value in the value space of
-                                                  <code>xs:float</code>) then <emph>TV</emph> is
+                                                  <code>xs:float</code>) then <var>TV</var> is
                                                   the <code>xs:float</code> value <code>INF</code>
                                                   or <code>-INF</code> depending on the sign of <code>M</code>.</p>
                                  </item>
                                  <item>
                                     <p>if <code>E</code> is less than <code>-149</code>
                                                   (the minimum exponent value in the value space
-                                                  of <code>xs:float</code>) then <emph>TV</emph> is
+                                                  of <code>xs:float</code>) then <var>TV</var> is
                                                   the <code>xs:float</code> value positive or
                                                   negative zero depending on the sign of <code>M</code>
                                                 </p>
                                  </item>
                                  <item>
-                                    <p>otherwise, <emph>TV</emph> is the
+                                    <p>otherwise, <var>TV</var> is the
                                                   <code>xs:float</code> value <code>M &times; 2^E</code>.</p>
                                  </item>
                               </ulist>
@@ -9866,19 +9993,19 @@ characters except the first "P" and the optional negative sign in <emph>TDT</emp
                         </ulist>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:decimal</code>, or
-                                    <code>xs:integer</code>, then <emph>TV</emph> is <code>xs:float(</code>
-                                    <emph>SV</emph>
+                        <p>If <var>ST</var> is <code>xs:decimal</code>, or
+                                    <code>xs:integer</code>, then <var>TV</var> is <code>xs:float(</code>
+                                    <var>SV</var>
                                     <code> cast as xs:string)</code> and the conversion is complete.</p>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:boolean</code>, <emph>SV</emph> is
-                                    converted to <code>1.0E0</code> if <emph>SV</emph> is
-                                    <code>true</code> and to <code>0.0E0</code> if <emph>SV</emph>
+                        <p>If <var>ST</var> is <code>xs:boolean</code>, <var>SV</var> is
+                                    converted to <code>1.0E0</code> if <var>SV</var> is
+                                    <code>true</code> and to <code>0.0E0</code> if <var>SV</var>
                                     is <code>false</code> and the conversion is complete.</p>
                      </item>
                      <item>
-                        <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                        <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                     or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>. 
                         </p>
@@ -9896,50 +10023,50 @@ characters except the first "P" and the optional negative sign in <emph>TDT</emp
                <div4 id="casting-to-double">
                   <head>Casting to xs:double</head>
                   <p>When a value of any simple type is cast as <code>xs:double</code>, the
-                            <code>xs:double</code> value <emph>TV</emph> is derived from the
-                            <emph>ST</emph> and the <emph>SV</emph> as follows:</p>
+                            <code>xs:double</code> value <var>TV</var> is derived from the
+                            <var>ST</var> and the <var>SV</var> as follows:</p>
                   <ulist>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:double</code>, then
-                                    <emph>TV</emph> is <emph>SV</emph> and the conversion is complete.</p>
+                        <p>If <var>ST</var> is <code>xs:double</code>, then
+                                    <var>TV</var> is <var>SV</var> and the conversion is complete.</p>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:float</code> or a type derived
-                                    from <code>xs:float</code>, then <emph>TV</emph> is obtained as follows:</p>
+                        <p>If <var>ST</var> is <code>xs:float</code> or a type derived
+                                    from <code>xs:float</code>, then <var>TV</var> is obtained as follows:</p>
                         <ulist>
                            <item>
-                              <p>if <emph>SV</emph> is the <code>xs:float</code> value
+                              <p>if <var>SV</var> is the <code>xs:float</code> value
                                             <code>INF</code>, <code>-INF</code>, <code>NaN</code>,
-                                            positive zero, or negative zero, then <emph>TV</emph> is
+                                            positive zero, or negative zero, then <var>TV</var> is
                                             the <code>xs:double</code> value <code>INF</code>,
                                             <code>-INF</code>, <code>NaN</code>, positive zero, or
                                             negative zero respectively. </p>
                            </item>
                            <item>
-                              <p>otherwise, <emph>SV</emph> can be expressed in the form
+                              <p>otherwise, <var>SV</var> can be expressed in the form
                                                 <code>m &times; 2^e</code> where the
                                             mantissa <code>m</code> and exponent <code>e</code> are
                                             signed <code>xs:integer</code> values whose value range
                                             is defined in <bibref ref="xmlschema-2"/>, and
-                                            <emph>TV</emph> is the <code>xs:double</code> value
+                                            <var>TV</var> is the <code>xs:double</code> value
                                                 <code>m &times; 2^e</code>. </p>
                            </item>
                         </ulist>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:decimal</code> or
-                                    <code>xs:integer</code>, then <emph>TV</emph> is <code>xs:double(</code>
-                                    <emph>SV</emph>
+                        <p>If <var>ST</var> is <code>xs:decimal</code> or
+                                    <code>xs:integer</code>, then <var>TV</var> is <code>xs:double(</code>
+                                    <var>SV</var>
                                     <code> cast as xs:string)</code> and the conversion is complete.</p>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:boolean</code>, <emph>SV</emph> is
-                                    converted to <code>1.0E0</code> if <emph>SV</emph> is
-                                    <code>true</code> and to <code>0.0E0</code> if <emph>SV</emph>
+                        <p>If <var>ST</var> is <code>xs:boolean</code>, <var>SV</var> is
+                                    converted to <code>1.0E0</code> if <var>SV</var> is
+                                    <code>true</code> and to <code>0.0E0</code> if <var>SV</var>
                                     is <code>false</code> and the conversion is complete.</p>
                      </item>
                      <item>
-                        <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                        <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                     or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>.</p>
                         <note><p>XSD 1.1 adds the value <code>+INF</code> to the lexical space,
@@ -9954,161 +10081,89 @@ characters except the first "P" and the optional negative sign in <emph>TDT</emp
                </div4>
                <div4 id="casting-to-decimal">
                   <head>Casting to xs:decimal</head>
-                  <p>When a value of any simple type is cast as <code>xs:decimal</code>, the
-                            <code>xs:decimal</code> value <emph>TV</emph> is derived from
-                            <emph>ST</emph> and <emph>SV</emph> as follows: </p>
+                  
+                  <p>This section defines the rules for casting to the primitive type <code>xs:decimal</code>.
+                     The rules are also invoked implicitly as part of the process of converting to types
+                     derived from <code>xs:decimal</code>. There are special rules, however, if the
+                     target type <var>TT</var> is <code>xs:integer</code>, or a type derived from
+                     <code>xs:integer</code>: those rules are given in <specref ref="casting-to-integer"/>.</p>
+                  
+                  <p>When the target type <var>TT</var> is <code>xs:decimal</code>, the
+                            resulting <code>xs:decimal</code> value <var>TV</var> is derived from
+                            <var>ST</var> and <var>SV</var> as follows: </p>
                   <ulist>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:decimal</code>,
-                                    <code>xs:integer</code> or a type derived from them, then
-                                    <emph>TV</emph> is <emph>SV</emph>, converted to an
-                                    <code>xs:decimal</code> value if need be, and the conversion is complete.</p>
+                        <p>If <var>ST</var> is <code>xs:decimal</code> or a subtype thereof 
+                           (including <code>xs:integer</code>), then
+                                    the result <var>TV</var> has the same <termref def="dt-datum"/> as <var>SV</var>.
+                           The type annotation <rfc2119>may</rfc2119> be <code>xs:decimal</code> or any
+                           subtype of <code>xs:decimal</code> for which this is a valid instance, including
+                           the original type <code>ST</code>.</p>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:float</code> or
-                                    <code>xs:double</code>, then <emph>TV</emph> is the
+                        <p>If <var>ST</var> is <code>xs:float</code> or
+                                    <code>xs:double</code>, then <var>TV</var> is the
                                     <code>xs:decimal</code> value, within the set of
                                     <code>xs:decimal</code> values that the implementation is
                                     capable of representing, that is numerically closest to
-                                    <emph>SV</emph>. If two values are equally close, then the one
-                                    that is closest to zero is chosen. If <emph>SV</emph> is too
+                                    <var>SV</var>. If two values are equally close, then the one
+                                    that is closest to zero is chosen. If <var>SV</var> is too
                                     large to be accommodated as an <code>xs:decimal</code>, (see
                                         <bibref ref="xmlschema-2"/> for <termref def="implementation-defined"/> limits on
-                           numeric values) a dynamic error is raised <errorref class="CA" code="0001"/>. If <emph>SV</emph> is one of the special
+                           numeric values) a dynamic error is raised <errorref class="CA" code="0001"/>. If <var>SV</var> is one of the special
                                     <code>xs:float</code> or <code>xs:double</code> values
                            <code>NaN</code>, <code>INF</code>, or <code>-INF</code>, a dynamic
                                     error is raised <errorref class="CA" code="0002"/>.</p>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:boolean</code>, <emph>SV</emph> is
-                                    converted to <code>1.0</code> if <emph>SV</emph> is
+                        <p>If <var>ST</var> is <code>xs:boolean</code>, the result <var>TV</var> is
+                                    <code>1.0</code> if <var>SV</var> is
                                     <code>1</code> or <code>true</code> and to <code>0.0</code> if
-                                    <emph>SV</emph> is <code>0</code> or <code>false</code> and the
-                                    conversion is complete.</p>
+                                    <var>SV</var> is <code>0</code> or <code>false</code>.
+                        The type annotation of the result may be any subtype of <code>xs:decimal</code>
+                        whose value space includes the integer values <code>0</code> and <code>1</code>.</p>
                      </item>
                      <item>
-                        <p>If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                        <p>If <var>ST</var> is <code>xs:untypedAtomic</code>
                                     or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>.</p>
                      </item>
                   </ulist>
                </div4>
-               <div4 id="casting-to-integer">
-                  <head>Casting to xs:integer</head>
-                  <p>When a value of any simple type is cast as <code>xs:integer</code>, the
-                            <code>xs:integer</code> value <emph>TV</emph> is derived from
-                            <emph>ST</emph> and <emph>SV</emph> as follows:</p>
-                  <ulist>
-                     <item>
-                        <p>If <emph>ST</emph> is <code>xs:integer</code>, or a type derived
-                                    from <code>xs:integer</code>, then <emph>TV</emph> is
-                                    <emph>SV</emph>, converted to an <code>xs:integer</code> value
-                                    if need be, and the conversion is complete.</p>
-                     </item>
-                     <item>
-                        <p>If <emph>ST</emph> is
-                                    <code>xs:decimal</code>, <code>xs:float</code> or
-                                    <code>xs:double</code>, then <emph>TV</emph> is <emph>SV</emph>
-                                    with the fractional part discarded and the value converted to
-                                    <code>xs:integer</code>. Thus, casting <code>3.1456</code>
-                                    returns <code>3</code> and <code>-17.89</code> returns
-                                    <code>-17</code>. Casting <code>3.124E1</code>
-                                    returns <code>31</code>. If <emph>SV</emph> is too large to be
-                                    accommodated as an integer, (see <bibref ref="xmlschema-2"/> for
-                           <termref def="implementation-defined"/> limits on numeric values) a 
-                           dynamic error is
-                                    raised <errorref class="CA" code="0003"/>. If <emph>SV</emph> is
-                                    one of the special <code>xs:float</code> or
-                                    <code>xs:double</code> values <code>NaN</code>,
-                           <code>INF</code>, or <code>-INF</code>, a dynamic error is raised
-                                        <errorref class="CA" code="0002"/>.</p>
-                     </item>
-                     <item>
-                        <p>If <emph>ST</emph> is <code>xs:boolean</code>, <emph>SV</emph> is
-                                    converted to <code>1</code> if <emph>SV</emph> is <code>1</code>
-                                    or <code>true</code> and to <code>0</code> if <emph>SV</emph> is
-                                    <code>0</code> or <code>false</code> and the conversion is complete.</p>
-                     </item>
-                     <item>
-                        <p>If <emph>ST</emph> is <code>xs:untypedAtomic</code>
-                                    or <code>xs:string</code>, see 
-                                    <specref ref="casting-from-strings"/>.</p>
-                     </item>
-                     <!--    <item>
-                                <p>If <emph>TT</emph> is a subtype of <code>xs:integer</code>, then
-                                    <emph>TV</emph> is calculated as described above, and is then
-                                    cast to <emph>TT</emph> as described in <specref
-                                    ref="casting-within-branch"/>. This involves checking the value
-                                    against the facets of <emph>TT</emph>.</p>
-                            </item>  --></ulist>
-               </div4>
+               
             </div3>
             <div3 id="casting-to-durations">
                <head>Casting to duration types</head>
-               <p>When a value of type <code>xs:untypedAtomic</code>, <code>xs:string</code>,
-                        a type derived from <code>xs:string</code>,
-                        <code>xs:yearMonthDuration</code> or <code>xs:dayTimeDuration</code> is
-                        cast as <code>xs:duration</code>, <code>xs:yearMonthDuration</code> or
-                        <code>xs:dayTimeDuration</code>, <emph>TV</emph> is derived from
-                        <emph>ST</emph> and <emph>SV</emph> as follows:</p>
+               
+               <p>This section defines the rules for casting to the primitive duration type <code>xs:duration</code>. 
+                  Rules for casting to the derived types
+               <code>xs:yearMonthDuration</code> and <code>xs:dayTimeDuration</code> 
+                  are given in <specref ref="casting-to-duration-subtypes"/>.</p>
+               
+               
+               
                <ulist>
                   <item>
-                     <p>If <emph>ST</emph> is the same as <emph>TT</emph>, then
-                                <emph>TV</emph> is <emph>SV</emph>. </p>
+                     <p>If the source value <var>SV</var> is an instance of <code>xs:duration</code>
+                        (including instances of subtypes such as <code>xs:yearMonthDuration</code>
+                        and <code>xs:dayTimeDuration</code>, then the datum of the result 
+                        <var>TV</var> is the same as the datum of <var>SV</var>, and the
+                       type annotation is <code>xs:duration</code> or any subtype thereof that
+                       includes this datum in its value space (in particular, it <rfc2119>may</rfc2119>
+                        be the same as the type annotation of <var>SV</var>).</p>
                   </item>
                   <item>
-                     <p>If <emph>ST</emph> is <code>xs:duration</code>, or a type derived
-                                from <code>xs:duration</code>, but not
-                                <code>xs:dayTimeDuration</code> or a type derived from
-                                <code>xs:dayTimeDuration</code>, and <emph>TT</emph> is
-                                <code>xs:yearMonthDuration</code>, then <emph>TV</emph> is derived
-                                from <emph>SV</emph> by removing the day, hour, minute and second
-                                components from <emph>SV</emph>.</p>
-                  </item>
-                  <item>
-                     <p>If <emph>ST</emph> is <code>xs:duration</code>, or a type derived
-                                from <code>duration</code>, but not
-                                <code>xs:yearMonthDuration</code> or a type derived from
-                                <code>xs:yearMonthDuration</code>, and <emph>TT</emph> is
-                                <code>xs:dayTimeDuration</code>, then <emph>TV</emph> is derived
-                                from <emph>SV</emph> by removing the year and month components from <emph>SV</emph>.</p>
-                  </item>
-                  <item>
-                     <p>If <emph>ST</emph> is <code>xs:yearMonthDuration</code>
-                                or <code>xs:dayTimeDuration</code>, and <emph>TT</emph> is
-                                <code>xs:duration</code>, then <emph>TV</emph> is derived from
-                                <emph>SV</emph> as defined in <specref ref="casting-from-derived-to-parent"/>.</p>
-                  </item>
-                  <item>
-                     <p>If <emph>ST</emph> is <code>xs:yearMonthDuration</code>
-                                and <emph>TT</emph> is
-                                <code>xs:dayTimeDuration</code>, the cast is permitted and
-                                returns a <code>xs:dayTimeDuration</code> with value
-                                <code>0.0</code> seconds.</p>
-                  </item>
-                  <item>
-                     <p>If <emph>ST</emph> is <code>xs:dayTimeDuration</code>
-                                and <emph>TT</emph> is
-                                <code>xs:yearMonthDuration</code>, the cast is permitted and
-                                returns a <code>xs:yearMonthDuration</code> with value
-                                <code>0</code> months.</p>
-                  </item>
-                  <item>
-                     <p>If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                     <p>If <var>ST</var> is <code>xs:untypedAtomic</code>
                                 or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>.</p>
                   </item>
                </ulist>
-               <p>Note that casting from <code>xs:duration</code> to
-                        <code>xs:yearMonthDuration</code> or <code>xs:dayTimeDuration</code> loses
-                        information. To avoid this, users can cast the <code>xs:duration</code>
-                        value to both an <code>xs:yearMonthDuration</code> and an
-                        <code>xs:dayTimeDuration</code> and work with both values.</p>
+ 
             </div3>
             <div3 id="casting-to-datetimes">
                <head>Casting to date and time types</head>
                <p>In several situations, casting to date and time types requires the extraction
-                        of a component from <emph>SV</emph> or from the result of
+                        of a component from <var>SV</var> or from the result of
                         <code>fn:current-dateTime</code> and converting it to an
                         <code>xs:string</code>. These conversions must follow certain rules. For
                         example, converting an <code>xs:integer</code> year value requires
@@ -10155,7 +10210,7 @@ declare function eg:convertTZtoString($tz as xs:dayTimeDuration?) as xs:string {
        return concat($plusMinus, $tzhString, ":", $tzmString)
 };]]></eg>
                <!--End of text replaced by erratum E6--><p>Conversion from 
-                  <termref def="dt-cast-primitive-type">primitive types</termref> to date and time types follows the rules below.</p>
+                  <termref def="dt-primitive-type">primitive types</termref> to date and time types follows the rules below.</p>
                <olist><!--    <item>
                             <p>When a value of any primitive type is cast as
                                 <code>xs:dateTime</code>, <code>xs:time</code>,
@@ -10176,19 +10231,19 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                         </item> --><item>
                      <p>When a value of any primitive type is cast as
                                 <code>xs:dateTime</code>, the <code>xs:dateTime</code> value
-                                <emph>TV</emph> is derived from <emph>ST</emph> and <emph>SV</emph>
+                                <var>TV</var> is derived from <var>ST</var> and <var>SV</var>
                                 as follows:</p>
                      <ulist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then
-                                        <emph>TV</emph> is <emph>SV</emph>. </p>
+                           <p>If <var>ST</var> is <code>xs:dateTime</code>, then
+                                        <var>TV</var> is <var>SV</var>. </p>
                         </item>
                         <!--		<item>
-								<p>If <emph>ST</emph> is <code>xs:time</code>, then let <emph>SHR</emph> be <code>eg:convertTo2CharString( hours-from-time(</code>
-									<emph>SV</emph>	<code>)) </code>, let <emph>SMI</emph> be <code>eg:convertTo2CharString( minutes-from-time(</code>
-									<emph>SV</emph><code>))</code>, let <emph>SSE</emph> be <code>eg:convertSecondsToString( seconds-from-time(</code>
-									<emph>SV</emph><code>))</code> and let <emph>STZ</emph> be <code>eg:convertTZtoString( timezone-from-time(</code><emph>SV</emph><code>))</code>
-; <emph>TV</emph> is <code>xs:dateTime( concat(</code>
+								<p>If <var>ST</var> is <code>xs:time</code>, then let <emph>SHR</emph> be <code>eg:convertTo2CharString( hours-from-time(</code>
+									<var>SV</var>	<code>)) </code>, let <emph>SMI</emph> be <code>eg:convertTo2CharString( minutes-from-time(</code>
+									<var>SV</var><code>))</code>, let <emph>SSE</emph> be <code>eg:convertSecondsToString( seconds-from-time(</code>
+									<var>SV</var><code>))</code> and let <emph>STZ</emph> be <code>eg:convertTZtoString( timezone-from-time(</code><var>SV</var><code>))</code>
+; <var>TV</var> is <code>xs:dateTime( concat(</code>
 									<emph>CYR</emph>
 									<code>, '-', </code>
 									<emph>CMO</emph>
@@ -10202,19 +10257,19 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
 									<emph>SSE, STZ</emph> 
 									<code>) )</code>. </p>
 							</item> --><item>
-                           <p>If <emph>ST</emph> is <code>xs:date</code>, then let
+                           <p>If <var>ST</var> is <code>xs:date</code>, then let
                                         <emph>SYR</emph> be <code>eg:convertYearToString( year-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>, let <emph>SMO</emph> be
                                             <code>eg:convertTo2CharString( month-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>, let <emph>SDA</emph> be
                                             <code>eg:convertTo2CharString( day-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-date(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:dateTime( concat(</code>
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:dateTime( concat(</code>
                                         <emph>SYR</emph>
                                         <code>, '-', </code>
                                         <emph>SMO</emph>
@@ -10224,7 +10279,7 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                                         <code>) )</code>. </p>
                         </item>
                         <item>
-                           <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code> or
+                           <p> If <var>ST</var> is <code>xs:untypedAtomic</code> or
                                         <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>.</p>
                         </item>
@@ -10232,28 +10287,28 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   </item>
                   <item>
                      <p>When a value of any primitive type is cast as <code>xs:time</code>,
-                                the <code>xs:time</code> value <emph>TV</emph> is derived from
-                                <emph>ST</emph> and <emph>SV</emph> as follows:</p>
+                                the <code>xs:time</code> value <var>TV</var> is derived from
+                                <var>ST</var> and <var>SV</var> as follows:</p>
                      <ulist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:time</code>, then
-                                        <emph>TV</emph> is <emph>SV</emph>. </p>
+                           <p>If <var>ST</var> is <code>xs:time</code>, then
+                                        <var>TV</var> is <var>SV</var>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then
-                                        <emph>TV</emph> is <code>xs:time( concat(
+                           <p>If <var>ST</var> is <code>xs:dateTime</code>, then
+                                        <var>TV</var> is <code>xs:time( concat(
                                             eg:convertTo2CharString( hours-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>)), ':', eg:convertTo2CharString( minutes-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>)), ':', eg:convertSecondsToString( seconds-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>)), eg:convertTZtoString( timezone-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>)) ))</code>. </p>
                         </item>
                         <item>
-                           <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                           <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                         or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>. </p>
                         </item>
@@ -10261,26 +10316,26 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   </item>
                   <item>
                      <p>When a value of any primitive type is cast as <code>xs:date</code>,
-                                the <code>xs:date</code> value <emph>TV</emph> is derived from
-                                <emph>ST</emph> and <emph>SV</emph> as follows:</p>
+                                the <code>xs:date</code> value <var>TV</var> is derived from
+                                <var>ST</var> and <var>SV</var> as follows:</p>
                      <ulist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:date</code>, then
-                                        <emph>TV</emph> is <emph>SV</emph>. </p>
+                           <p>If <var>ST</var> is <code>xs:date</code>, then
+                                        <var>TV</var> is <var>SV</var>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
+                           <p>If <var>ST</var> is <code>xs:dateTime</code>, then let
                                         <emph>SYR</emph> be <code>eg:convertYearToString( year-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>, let <emph>SMO</emph> be
                                             <code>eg:convertTo2CharString( month-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>, let <emph>SDA</emph> be
                                             <code>eg:convertTo2CharString( day-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be <code>eg:convertTZtoString(timezone-from-dateTime(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:date( concat(</code>
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:date( concat(</code>
                                         <emph>SYR</emph>
                                         <code>, '-', </code>
                                         <emph>SMO</emph>
@@ -10289,7 +10344,7 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                                         <code>) )</code>. </p>
                         </item>
                         <item>
-                           <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                           <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                         or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>. </p>
                         </item>
@@ -10298,47 +10353,47 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   <item>
                      <p>When a value of any primitive type is cast as
                                 <code>xs:gYearMonth</code>, the <code>xs:gYearMonth</code> value
-                                <emph>TV</emph> is derived from <emph>ST</emph> and <emph>SV</emph>
+                                <var>TV</var> is derived from <var>ST</var> and <var>SV</var>
                                 as follows:</p>
                      <ulist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:gYearMonth</code>, then
-                                        <emph>TV</emph> is <emph>SV</emph>. </p>
+                           <p>If <var>ST</var> is <code>xs:gYearMonth</code>, then
+                                        <var>TV</var> is <var>SV</var>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
+                           <p>If <var>ST</var> is <code>xs:dateTime</code>, then let
                                         <emph>SYR</emph> be <code>eg:convertYearToString( year-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>, let <emph>SMO</emph> be
                                             <code>eg:convertTo2CharString( month-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-dateTime(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( concat(</code>
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gYearMonth( concat(</code>
                                         <emph>SYR</emph>
                                         <code>, '-', </code>
                                         <emph>SMO</emph>, <emph>STZ</emph>
                                         <code>) )</code>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:date</code>, then let
+                           <p>If <var>ST</var> is <code>xs:date</code>, then let
                                         <emph>SYR</emph> be <code>eg:convertYearToString( year-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>, let <emph>SMO</emph> be
                                             <code>eg:convertTo2CharString( month-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-date(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( concat(</code>
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gYearMonth( concat(</code>
                                         <emph>SYR</emph>
                                         <code>, '-', </code>
                                         <emph>SMO</emph>, <emph>STZ</emph>
                                         <code>) )</code>. </p>
                         </item>
                         <item>
-                           <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                           <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                         or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>. </p>
                         </item>
@@ -10346,37 +10401,37 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   </item>
                   <item>
                      <p>When a value of any primitive type is cast as <code>xs:gYear</code>,
-                                the <code>xs:gYear</code> value <emph>TV</emph> is derived from
-                                <emph>ST</emph> and <emph>SV</emph> as follows:</p>
+                                the <code>xs:gYear</code> value <var>TV</var> is derived from
+                                <var>ST</var> and <var>SV</var> as follows:</p>
                      <ulist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:gYear</code>, then
-                                        <emph>TV</emph> is <emph>SV</emph>. </p>
+                           <p>If <var>ST</var> is <code>xs:gYear</code>, then
+                                        <var>TV</var> is <var>SV</var>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:dateTime</code>, let
+                           <p>If <var>ST</var> is <code>xs:dateTime</code>, let
                                         <emph>SYR</emph> be <code>eg:convertYearToString( year-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-dateTime(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYear(concat(</code>
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gYear(concat(</code>
                                         <emph>SYR</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:date</code>, let
+                           <p>If <var>ST</var> is <code>xs:date</code>, let
                                         <emph>SYR</emph> be <code>eg:convertYearToString( year-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>; and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-date(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYear(concat(</code>
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gYear(concat(</code>
                                         <emph>SYR</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
-                           <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                           <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                         or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>. </p>
                         </item>
@@ -10385,24 +10440,24 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   <item>
                      <p>When a value of any primitive type is cast as
                                 <code>xs:gMonthDay</code>, the <code>xs:gMonthDay</code> value
-                                <emph>TV</emph> is derived from <emph>ST</emph> and <emph>SV</emph>
+                                <var>TV</var> is derived from <var>ST</var> and <var>SV</var>
                                 as follows:</p>
                      <ulist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:gMonthDay</code>, then
-                                        <emph>TV</emph> is <emph>SV</emph>. </p>
+                           <p>If <var>ST</var> is <code>xs:gMonthDay</code>, then
+                                        <var>TV</var> is <var>SV</var>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
+                           <p>If <var>ST</var> is <code>xs:dateTime</code>, then let
                                         <emph>SMO</emph> be <code>eg:convertTo2CharString( month-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>, let <emph>SDA</emph> be
                                             <code>eg:convertTo2CharString( day-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-dateTime(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( concat(</code>
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gYearMonth( concat(</code>
                                         <code> '--', </code>
                                         <emph>SMO</emph>
                                         <code> '-', </code>
@@ -10410,16 +10465,16 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                                         <code>) )</code>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:date</code>, then let
+                           <p>If <var>ST</var> is <code>xs:date</code>, then let
                                         <emph>SMO</emph> be <code>eg:convertTo2CharString( month-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code>, let <emph>SDA</emph> be
                                             <code>eg:convertTo2CharString( day-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-date(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gYearMonth( concat(</code>
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gYearMonth( concat(</code>
                                         <code> '--', </code>
                                         <emph>SMO</emph>
                                         <code>, '-', </code>
@@ -10427,7 +10482,7 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                                         <code>) )</code>. </p>
                         </item>
                         <item>
-                           <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                           <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                         or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>.</p>
                         </item>
@@ -10435,37 +10490,37 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   </item>
                   <item>
                      <p>When a value of any primitive type is cast as <code>xs:gDay</code>,
-                                the <code>xs:gDay</code> value <emph>TV</emph> is derived from
-                                <emph>ST</emph> and <emph>SV</emph> as follows:</p>
+                                the <code>xs:gDay</code> value <var>TV</var> is derived from
+                                <var>ST</var> and <var>SV</var> as follows:</p>
                      <ulist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:gDay</code>, then
-                                        <emph>TV</emph> is <emph>SV</emph>. </p>
+                           <p>If <var>ST</var> is <code>xs:gDay</code>, then
+                                        <var>TV</var> is <var>SV</var>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
+                           <p>If <var>ST</var> is <code>xs:dateTime</code>, then let
                                         <emph>SDA</emph> be <code>eg:convertTo2CharString( day-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-dateTime(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gDay(
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gDay(
                                             concat( '---'</code>, <emph>SDA</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:date</code>, then let
+                           <p>If <var>ST</var> is <code>xs:date</code>, then let
                                         <emph>SDA</emph> be <code>eg:convertTo2CharString( day-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-date(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gDay(
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gDay(
                                             concat( '---'</code>, <emph>SDA</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
-                           <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                           <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                         or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>. </p>
                         </item>
@@ -10473,37 +10528,37 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                   </item>
                   <item>
                      <p>When a value of any primitive type is cast as <code>xs:gMonth</code>,
-                                the <code>xs:gMonth</code> value <emph>TV</emph> is derived from
-                                <emph>ST</emph> and <emph>SV</emph> as follows:</p>
+                                the <code>xs:gMonth</code> value <var>TV</var> is derived from
+                                <var>ST</var> and <var>SV</var> as follows:</p>
                      <ulist>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:gMonth</code>, then
-                                        <emph>TV</emph> is <emph>SV</emph>. </p>
+                           <p>If <var>ST</var> is <code>xs:gMonth</code>, then
+                                        <var>TV</var> is <var>SV</var>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:dateTime</code>, then let
+                           <p>If <var>ST</var> is <code>xs:dateTime</code>, then let
                                         <emph>SMO</emph> be <code>eg:convertTo2CharString( month-from-dateTime(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-dateTime(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gMonth(
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gMonth(
                                             concat( '--' </code>, <emph>SMO</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
-                           <p>If <emph>ST</emph> is <code>xs:date</code>, then let
+                           <p>If <var>ST</var> is <code>xs:date</code>, then let
                                         <emph>SMO</emph> be <code>eg:convertTo2CharString( month-from-date(</code>
-                                        <emph>SV</emph>
+                                        <var>SV</var>
                                         <code>))</code> and let <emph>STZ</emph> be
                                             <code>eg:convertTZtoString( timezone-from-date(</code>
-                                        <emph>SV</emph>
-                                        <code>))</code>; <emph>TV</emph> is <code>xs:gMonth(
+                                        <var>SV</var>
+                                        <code>))</code>; <var>TV</var> is <code>xs:gMonth(
                                             concat( '--'</code>, <emph>SMO</emph>, <emph>STZ</emph>
                                         <code>))</code>. </p>
                         </item>
                         <item>
-                           <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                           <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                         or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>.</p>
                         </item>
@@ -10512,37 +10567,35 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                </olist>
             </div3>
             <div3 id="casting-boolean">
-               <head>Casting to xs:boolean </head>
-               <p>When a value of any <termref def="dt-cast-primitive-type">primitive type</termref> is cast as <code>xs:boolean</code>, the
-                        <code>xs:boolean</code> value <emph>TV</emph> is derived from
-                        <emph>ST</emph> and <emph>SV</emph> as follows:</p>
+               <head>Casting to <code>xs:boolean</code></head>
+               <p>When the target type <var>TT</var> is <code>xs:boolean</code>, the
+                        resulting <code>xs:boolean</code> value <var>TV</var> is derived from
+                        the source value <var>SV</var> as follows:</p>
                <ulist>
                   <item>
-                     <p>If <emph>ST</emph> is <code>xs:boolean</code>, then <emph>TV</emph>
-                                is <emph>SV</emph>.</p>
+                     <p>If <var>SV</var> is an instance of <code>xs:boolean</code>, then <var>TV</var>
+                                is <var>SV</var>.</p>
                   </item>
                   <item>
-                     <p>If <emph>ST</emph> is <code>xs:float</code>, <code>xs:double</code>,
-                                <code>xs:decimal</code> or <code>xs:integer</code> and
-                                <emph>SV</emph> is <code>0</code>, <code>+0</code>, <code>-0</code>,
+                     <p>If <var>SV</var> is an instance of <code>xs:numeric</code> and
+                                <var>SV</var> is <code>0</code>, <code>+0</code>, <code>-0</code>,
                                 <code>0.0</code>, <code>0.0E0</code> or <code>NaN</code>, then
-                                <emph>TV</emph> is <code>false</code>. </p>
+                                <var>TV</var> is <code>false</code>. </p>
                   </item>
                   <item>
-                     <p>If <emph>ST</emph> is <code>xs:float</code>, <code>xs:double</code>,
-                                <code>xs:decimal</code> or <code>xs:integer</code> and
-                                <emph>SV</emph> is not one of the above values, then <emph>TV</emph>
+                     <p>If <var>ST</var> is is an instance of <code>xs:numeric</code> and
+                                <var>SV</var> is not one of the above values, then <var>TV</var>
                                 is <code>true</code>. </p>
                   </item>
                   <item>
-                     <p> If <emph>ST</emph> is <code>xs:untypedAtomic</code>
+                     <p> If <var>ST</var> is <code>xs:untypedAtomic</code>
                                 or <code>xs:string</code>, see 
                                     <specref ref="casting-from-strings"/>. </p>
                   </item>
                </ulist>
             </div3>
             <div3 id="casting-to-binary">
-               <head>Casting to xs:base64Binary and xs:hexBinary</head>
+               <head>Casting to <code>xs:base64Binary</code> and <code>xs:hexBinary</code></head>
                <p>Values of type <code>xs:base64Binary</code> can be cast as
                         <code>xs:hexBinary</code> and vice versa, since the two types have the same
                         value space. Casting to <code>xs:base64Binary</code> and
@@ -10554,12 +10607,12 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                <head>Casting to xs:anyURI</head>
                <p>Casting to <code>xs:anyURI</code> is supported only from the same type,
                         <code>xs:untypedAtomic</code> or <code>xs:string</code>.</p>
-               <p>When a value of any <termref def="dt-cast-primitive-type">primitive type</termref> is cast as <code>xs:anyURI</code>, the
-                        <code>xs:anyURI</code> value <emph>TV</emph> is derived from the
-                        <emph>ST</emph> and <emph>SV</emph> as follows:</p>
+               <p>When a value of any <termref def="dt-primitive-type">primitive type</termref> is cast as <code>xs:anyURI</code>, the
+                        <code>xs:anyURI</code> value <var>TV</var> is derived from the
+                        <var>ST</var> and <var>SV</var> as follows:</p>
                <ulist>
                   <item>
-                     <p>If <emph>ST</emph> is <code>xs:untypedAtomic</code> or <code>xs:string</code> see 
+                     <p>If <var>ST</var> is <code>xs:untypedAtomic</code> or <code>xs:string</code> see 
                                     <specref ref="casting-from-strings"/>.
                              </p>
                   </item>
@@ -10647,8 +10700,8 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
                namespace-sensitive type among its members, and any list type having a namespace-sensitive type
                as its item type. For details, see <specref ref="constructor-qname-notation"/>.</p>
             
-            <note><p>This version of the specification allows casting between <code>xs:QName</code>
-               and <code>xs:NOTATION</code> in either direction; this was not permitted in the previous Recommendation. This version also removes
+            <note><p>Since version 3.0 of this specification, casting has been allowed between <code>xs:QName</code>
+               and <code>xs:NOTATION</code> in either direction; this was not permitted in previous Recommendations. Version 3.0 also removed
                the rule that only a string literal (rather than a dynamic string) may be cast to an <code>xs:QName</code></p></note>
             
             <p>When casting to a numeric type:</p>
@@ -10701,38 +10754,134 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
             This section defines how other casts to non-primitive types operate, including casting
             to types derived by restriction, to union types, and to list types.</p>
             
-            <note>
-               <p>A <term>non-primitive type</term> here means any type that is not a
-                  <termref def="dt-cast-primitive-type">primitive type</termref> according
-               to the extended definition used in <specref ref="casting"/>.</p>
-            </note>
+            
          
          <div3 id="casting-to-derived-types">
             
             <head>Casting to derived types</head>
-            <p>Casting a value to a derived type can be separated into four cases. In these rules:</p>
+            <p>Casting a value to a derived type can be separated into a number of cases. In these rules:</p>
             <ulist>
-               <item><p>The types <code>xs:untypedAtomic</code>, <code>xs:integer</code>, <code>xs:yearMonthDuration</code>,
-               and <code>xs:dayTimeDuration</code> are treated as primitive types (alongside the 19 primitive types defined in XSD).</p></item>
-               <item><p>For any atomic type <var>T</var>, let <var>P(T)</var> denote the most specific primitive type
+               <item><p>The types <code>xs:integer</code>, <code>xs:yearMonthDuration</code>,
+               and <code>xs:dayTimeDuration</code> are treated as quasi-primitive types 
+                  (alongside the 20 truly <termref def="dt-primitive-type">primitive types</termref>).</p></item>
+               <item><p>For any atomic type <var>T</var>, let <var>P(T)</var> denote the most specific primitive or quasi-primitive type
                such that <code>itemType-subtype(T, P(T))</code> is <code>true</code>.</p></item>
             </ulist>
             <p>The rules are then:</p>
             <olist>
                <item>
-                  <p>When <var>ST</var> is the same type as <var>TT</var>: this case always succeeds, returning <var>SV</var> unchanged.</p>
+                  <p>When the source type <var>ST</var> is the same type as the target type <var>TT</var>: 
+                     this case always succeeds, returning the source value <var>SV</var> unchanged.</p>
                </item>
                <item>
-                  <p>When <code>itemType-subtype(ST, TT)</code> is <code>true</code>: This case is described in <specref ref="casting-from-derived-to-parent"/>. </p>
+                  <p>When <code>itemType-subtype(ST, TT)</code> is <code>true</code>: 
+                     see <specref ref="casting-from-derived-to-parent"/>. </p>
                </item>
                <item>
-                  <p>When <var>P(ST)</var> is the same type as <var>P(TT)</var>: This case is described in <specref ref="casting-within-branch"/>.</p>
+                  <p>When <var>TT</var> is the quasi-primitive type <code>xs:integer</code> 
+                     and <code>SV</code> is an instance of <code>xs:numeric</code>:
+                  see <specref ref="casting-to-integer"/>.</p>
                </item>
                <item>
-                  <p>Otherwise (<var>P(ST)</var> is not the same type as <var>P(TT)</var>): This case is described in <specref ref="casting-across-hierarchy"/>.</p>
+                  <p>When <var>TT</var> is the quasi-primitive type <code>xs:yearMonthDuration</code> 
+                     or <code>xs:dayTimeDuration</code> and <code>SV</code> is an instance of <code>xs:duration</code>:
+                  see <specref ref="casting-to-duration-subtypes"/>.</p>
+               </item>
+               <item>
+                  <p>When <var>P(ST)</var> is the same type as <var>P(TT)</var>: 
+                     see <specref ref="casting-within-branch"/>.</p>
+               </item>
+               <item>
+                  <p>Otherwise (<var>P(ST)</var> is not the same type as <var>P(TT)</var>): 
+                     see <specref ref="casting-across-hierarchy"/>.</p>
                </item>
             </olist>
          </div3>
+            
+         <div3 id="casting-to-integer">
+                  <head>Casting to xs:integer</head>
+                  <p>When an atomic value <code>SV</code> is cast as <code>xs:integer</code>, the
+                            resulting <code>xs:integer</code> value <var>TV</var> is obtained as follows:</p>
+                  <ulist>
+ <!--                    <item>
+                        <p>If <var>ST</var> is <code>xs:integer</code>, or a type derived
+                                    from <code>xs:integer</code>, then the <termref def="dt-datum"/> of <var>TV</var> is
+                                    the same as the datum of <var>SV</var>, and the type annotation
+                           of <var>TV</var> is <code>xs:integer</code> or any subtype of <code>xs:integer</code>
+                           that includes this datum in its value space (in particular, the original type annotation
+                        of <code>SV</code> <rfc2119>may</rfc2119> be retained).</p>
+                     </item>-->
+                     <item>
+                        <p>If <var>ST</var> is
+                                    <code>xs:decimal</code>, <code>xs:float</code> or
+                                    <code>xs:double</code>, then <var>TV</var> is <var>SV</var>
+                                    with the fractional part discarded and the value converted to
+                                    <code>xs:integer</code>. Thus, casting <code>3.1456</code>
+                                    returns <code>3</code> while <code>-17.89</code> returns
+                                    <code>-17</code>. Casting <code>3.124E1</code>
+                                    returns <code>31</code>. If <var>SV</var> is too large to be
+                                    accommodated as an integer, (see <bibref ref="xmlschema-2"/> for
+                           <termref def="implementation-defined"/> limits on numeric values) a 
+                           dynamic error is
+                                    raised <errorref class="CA" code="0003"/>. If <var>SV</var> is
+                                    one of the special <code>xs:float</code> or
+                                    <code>xs:double</code> values <code>NaN</code>,
+                           <code>INF</code>, or <code>-INF</code>, a dynamic error is raised
+                                        <errorref class="CA" code="0002"/>.</p>
+                     </item>
+                     <item>
+                        <p>In all other cases, the general rules of <specref ref="casting-to-derived-types"/> apply.</p>
+                     </item>
+                     <!--<item>
+                        <p>If <var>ST</var> is <code>xs:boolean</code>, <var>SV</var> is
+                                    converted to <code>1</code> if <var>SV</var> is <code>1</code>
+                                    or <code>true</code> and to <code>0</code> if <var>SV</var> is
+                                    <code>0</code> or <code>false</code> and the conversion is complete.</p>
+                     </item>
+                     <item>
+                        <p>If <var>ST</var> is <code>xs:untypedAtomic</code>
+                                    or <code>xs:string</code>, see 
+                                    <specref ref="casting-from-strings"/>.</p>
+                     </item>-->
+                     </ulist>
+            <note><p>When casting to a subtype of <code>xs:integer</code> (for example, <code>xs:long</code>), the 
+            rules in <specref ref="casting-to-derived-types"/> apply. Note, however, that these rules
+            treat <code>xs:integer</code> as a quasi-primitive type.</p></note>
+               </div3>
+            
+            <div3 id="casting-to-duration-subtypes">
+               <head>Casting to <code>xs:yearMonthDuration</code> and <code>xs:dayTimeDuration</code></head>
+               
+               <p>When the source value <var>SV</var> is an instance of <code>xs:duration</code> (including
+               any subtype of <code>xs:duration</code>), then:</p>
+               
+               <ulist>
+                  <item><p>If the target type <var>TT</var> is <code>xs:yearMonthDuration</code>, the result
+                  is an instance of <code>xs:yearMonthDuration</code> whose <code>months</code> component
+                  is equal to the <code>months</code> component of <var>SV</var>. The <code>seconds</code>
+                  component of <var>SV</var> is ignored.</p></item>
+                  <item><p>If the target type <var>TT</var> is <code>xs:dayTimeDuration</code>, the result
+                  is an instance of <code>xs:dayTimeDuration</code> whose <code>seconds</code> component
+                  is equal to the <code>seconds</code> component of <var>SV</var>. The <code>months</code>
+                  component of <var>SV</var> is ignored.</p></item>
+               </ulist>
+               
+               <p>In all other cases, the general rules of <specref ref="casting-to-derived-types"/> apply.</p>
+               
+               <note>
+                  <p>In general, casting to <code>xs:yearMonthDuration</code> or <code>xs:dayTimeDuration</code>
+                  loses information.</p>
+               </note>
+               
+               
+               <note><p>When casting to a subtype of <code>xs:dayTimeDuration</code> or 
+                  <code>xs:yearMonthDuration</code>, the 
+            rules in <specref ref="casting-to-derived-types"/> apply. Note, however, that these rules
+            treat <code>xs:dayTimeDuration</code> and <code>xs:yearMonthDuration</code> as quasi-primitive types.</p></note>
+               
+               
+            </div3>
+            
          <div3 id="casting-from-derived-to-parent">
             <head>Casting from derived types to parent types</head>
             
@@ -10769,9 +10918,9 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
          </div3>
          <div3 id="casting-within-branch">
             <head>Casting within a branch of the type hierarchy</head>
-            <p>It is possible to cast an <emph>SV</emph> to a <emph>TT</emph> if the type of the
-                    <emph>SV</emph> and the <emph>TT</emph> type are both derived by restriction
-               (directly or indirectly) from the same <termref def="dt-cast-primitive-type">primitive type</termref>, provided that the
+            <p>It is possible to cast an <var>SV</var> to a <var>TT</var> if the type of the
+                    <var>SV</var> and the <var>TT</var> type are both derived by restriction
+               (directly or indirectly) from the same <termref def="dt-primitive-type">primitive type</termref>, provided that the
                     supplied value conforms to the constraints implied by the facets of the target
                     type.  This includes the case where the target type is derived from the type of the supplied value,
                     as well as the case where the type of the supplied value is derived from the target type.  For example, an instance of <code>xs:byte</code> can be cast as
@@ -10779,10 +10928,10 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
             <p>If the value does not conform to the facets defined for the target type, then a dynamic
                     error is raised <errorref class="RG" code="0001"/>. See <bibref ref="xmlschema-2"/>.
                     In the case of the pattern facet (which applies to the lexical space rather than
-                    the value space), the pattern is tested against the canonical lexical
+                    the value space), the pattern is tested against the canonical 
                     representation of the value, as defined for the source type (or the result
                     of casting the value to an <code>xs:string</code>, in the case of types that have no canonical
-                    lexical representation defined for them).</p>
+                     representation defined for them).</p>
             <p>Note that this will cause casts to fail if the pattern excludes the canonical
                     lexical representation of the source type. For example, if the type
                     <code>my:distance</code> is defined as a restriction of <code>xs:decimal</code>
@@ -10797,36 +10946,36 @@ let <emph>CTZ</emph> be <code>eg:convertTZtoString(
          </div3>
          <div3 id="casting-across-hierarchy">
             <head>Casting across the type hierarchy</head>
-            <p>When the <emph>ST</emph> and the <emph>TT</emph> are derived, directly or
-               indirectly, from different <termref def="dt-cast-primitive-type">primitive types</termref>, this is called casting across the
+            <p>When the <var>ST</var> and the <var>TT</var> are derived, directly or
+               indirectly, from different <termref def="dt-primitive-type">primitive types</termref>, this is called casting across the
                     type hierarchy. Casting across the type hierarchy is logically equivalent to
                     three separate steps performed in order. Errors can occur in either of the
                     latter two steps.</p>
             <olist>
                <item>
-                  <p>Cast the <emph>SV</emph>, up the hierarchy, to the <termref def="dt-cast-primitive-type">primitive type</termref> of the
+                  <p>Cast the <var>SV</var>, up the hierarchy, to the <termref def="dt-primitive-type">primitive type</termref> of the
                             source, as described in <specref ref="casting-from-derived-to-parent"/>.</p>
                   <olist>
                      <item>
                         <p>
-If <emph>SV</emph> is an instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>, check its value against the 
-                           pattern facet of <emph>TT</emph>, and raise a dynamic error <errorref class="RG" code="0001"/> if the check fails.</p>
+If <var>SV</var> is an instance of <code>xs:string</code> or <code>xs:untypedAtomic</code>, check its value against the 
+                           pattern facet of <var>TT</var>, and raise a dynamic error <errorref class="RG" code="0001"/> if the check fails.</p>
                      </item>
                   </olist>
                </item>
                <item>
-                  <p>Cast the value to the <termref def="dt-cast-primitive-type">primitive type</termref> of <emph>TT</emph>, as described in
-                                <specref ref="casting-from-primitive-to-primitive"/>.</p>
-                  <ulist>
-                     <item>
-                        <p>If <emph>TT</emph> is derived from <code>xs:NOTATION</code>, assume for the
-purposes of this rule that casting to <code>xs:NOTATION</code> succeeds.
-</p>
-                     </item>
-                  </ulist>
+                  <p>Let <var>P(TT)</var> be the most specific primitive or quasi-primitive type of which <var>TT</var>
+                  is a subtype, as described in <specref ref="casting-to-derived-types"/>.</p>
+                  <p>Cast the value to <var>P(TT)</var>, as described in
+                                <specref ref="casting-from-primitive-to-primitive"/> if <var>P(TT)</var>
+                     is primitive, or as described in <specref ref="casting-to-derived-types"/> if <var>P(TT)</var>
+                     is quasi-primitive.</p>
+
+                        <p>If <var>TT</var> is derived from <code>xs:NOTATION</code>, assume for the
+                        purposes of this rule that casting to <code>xs:NOTATION</code> succeeds.</p>
                </item>
                <item>
-                  <p>Cast the value down to the <emph>TT</emph>, as described in <specref ref="casting-within-branch"/>
+                  <p>Cast the value down to the target type <var>TT</var>, as described in <specref ref="casting-within-branch"/>
                         </p>
                </item>
             </olist>


### PR DESCRIPTION
Fix #1401

The main changes are:

- The three derived types xs:integer, xs:dayTimeDuration, and xs:yearMonthDuration are no longer treated as primitive for the purpose of this section. They are now treated as derived types, but given special status where necessary as "quasi-primitive".
- In places where the F+O rules give the same result as the canonical representation in XSD 1.1, we now defer to XSD 1.1 rather than replicating the rules. Many of the rules originate with XPath 2.0, which was published before XSD 1.1, but which anticipated some of the changes in XSD 1.1, for example the use of a seven-component model for dates/times, and a two-component model for durations. XPath 3.0/3.1 failed to take advantage of the resulting opportunity for rationalisation.
- Generally the language is a bit less terse, with more notes and examples
- The rules have more to say about the type annotation of the result. In some places the spec appeared to imply that the type annotation on the result must be the target type; in others it appeared to imply that the type annotation must be unchanged from the source (for example 19.1.1 "If ST is xs:string or a type derived from xs:string, TV is SV. [presumably with unchanged type annotation]). The spec is now hopefully clearer that the result TV MUST be an instance of TT and MAY be an instance of some other type derived from TT, especially in the case where the value is unchanged.