### PR TITLE
Dispose of action QT4CG-080-05, add absolute to parse-uri

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30591,6 +30591,10 @@ fold-left($input, false(), fn($result, $item, $pos) {
             </item>
          </ulist>
 
+         <p>If the <emph>scheme</emph> is not empty and the <emph>fragment</emph> is empty,
+         <emph>absolute</emph> is true. Otherwise, <emph>absolute</emph> is the empty
+         sequence. (But see the discussion of hierarchical URIs, below.)</p>
+
          <p>If <emph>scheme</emph> is the empty sequence or <code>file</code>:</p>
          <ulist>
             <item>
@@ -30633,6 +30637,9 @@ fold-left($input, false(), fn($result, $item, $pos) {
          <code>false</code> otherwise.</p>
             </item>
          </ulist>
+
+         <p>If the URI is not <emph>hierarchical</emph>, <emph>absolute</emph>
+         is the empty sequence.</p>
 
          <p>Identify the remaining components according to the scheme and whether
          or not the URI is hierarchical.</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3493,6 +3493,12 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
       </fos:meaning>
       <fos:type>xs:string?</fos:type>
    </fos:option>
+   <fos:option key="absolute">
+      <fos:meaning>
+         <p>The URI is an absolute URI.</p>
+      </fos:meaning>
+      <fos:type>xs:boolean?</fos:type>
+   </fos:option>
    <fos:option key="hierarchical">
       <fos:meaning>
          <p>Whether the URI is hierarchical or not.</p>


### PR DESCRIPTION
This PR disposes of my action to add `absolute` to the output of `fn:parse-uri`.

The rules that define an absolute URI: "has a scheme", "does not have a fragment identifier", "is a hierarchical scheme" don't fit neatly into a single place, so there are two different places where the setting is considered.

Because of this, I think it's simpler to set `absolute` to `true` when the URI is absolute, but not to `false` when it isn't. That could be rectified with a bit more prose.