### PR TITLE
1415 Add to lists of XSLT declarations and instructions

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -1644,6 +1644,10 @@
                      <elcode>xsl:namespace</elcode>;</p>
                </item>
                <item>
+                  <p>instructions that construct maps and arrays: <elcode>xsl:array</elcode>,
+                     <elcode>xsl:map</elcode>, <elcode>xsl:map-entry</elcode>;</p>
+               </item>
+               <item>
                   <p>instructions that copy nodes: <elcode>xsl:copy</elcode>,
                      <elcode>xsl:copy-of</elcode>;</p>
                </item>
@@ -6518,12 +6522,13 @@ and <code>version="1.0"</code> otherwise.</p>
                   <elcode>xsl:include</elcode>
                </sitem>
                <sitem>
-                  <elcode>xsl:key</elcode>
+                  <elcode>xsl:item-type</elcode>
                </sitem>
                <sitem>
-                  
-                     <elcode>xsl:mode</elcode>
-                  
+                  <elcode>xsl:key</elcode>
+               </sitem>
+               <sitem>                 
+                  <elcode>xsl:mode</elcode>                 
                </sitem>
                <sitem>
                   <elcode>xsl:namespace-alias</elcode>


### PR DESCRIPTION
Fix #1415

Adds xsl:item-type to the list of declarations.
Adds xsl:array. xsl:map, and xsl:map-entry to the list of instructions.