### PR TITLE
Markup fix

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -5450,6 +5450,8 @@ return normalize-unicode(concat($v1, $v2))</eg>
                <fos:expression><eg>hash("ABC", { "algorithm": "sha-256" })
 => string()</eg></fos:expression>
                <fos:result>"B5D4045C3F466FA91FE2CC6ABE79232A1A57CDF104F7A26E716E0A1E2789DF78"</fos:result>
+            </fos:test>
+            <fos:test>
                <fos:expression><eg>hash("ABC", { "algorithm": "sha-256" })</eg></fos:expression>
                <fos:result>xs:hexBinary("B5D4045C3F466FA91FE2CC6ABE79232A1A57CDF104F7A26E716E0A1E2789DF78")</fos:result>
             </fos:test>


### PR DESCRIPTION
There's a markup error in the hash function that breaks the automatic test build. This PR fixes that.

(I'm just going to merge this straight away.)