### PR TITLE
1387b Clarify parse-uri/build-uri encoding rules, and remove options

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -6418,7 +6418,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
          <p>This is different from the behavior of patterns in <bibref ref="xmlschema-2"
                />, where
             regular expressions are <emph>implicitly</emph> anchored.</p>
-         <p>Regular expression matching is defined on the basis of Unicode code points; it takes no
+         <p>Regular expression matching is defined on the basis of Unicode codepoints; it takes no
             account of collations.</p>
       </fos:notes>
       <fos:examples>
@@ -31562,7 +31562,7 @@ path with an explicit <code>file:</code> scheme.</p>
            <p>To construct the path, each
            segment is encoded, then they are joined together, separated by <code>/</code> (solidus)
            characters, to form the path.
-           The encoding performed replaces any control characters (code points less than 0x20)
+           The encoding performed replaces any control characters (codepoints less than 0x20)
            and exclusively the following characters with their
            percent-escaped forms: <code> </code> (space) <code>%</code> (percent
            sign), <code>/</code> (solidus), <code>?</code> (question mark),
@@ -31585,7 +31585,7 @@ path with an explicit <code>file:</code> scheme.</p>
 
         <p>To construct the string, each <emph>key</emph> and <emph>value</emph>
         is encoded.
-        The encoding performed replaces any control characters (code points less than 0x20)
+        The encoding performed replaces any control characters (codepoints less than 0x20)
         and exclusively the following characters with their
         percent-escaped forms: <code> </code> (space) <code>%</code> (percent
         sign), <code>=</code> (equals sign), <code>&amp;</code> (ampersand),
@@ -31617,7 +31617,7 @@ path with an explicit <code>file:</code> scheme.</p>
         the value of that key is encoded and added to the URI with a
         preceding hash mark (<code>#</code>).
 
-        The encoding performed replaces any control characters (code points less than 0x20)
+        The encoding performed replaces any control characters (codepoints less than 0x20)
         and exclusively the following characters with their
         percent-escaped forms: <code> </code> (space) <code>%</code> (percent
         sign),

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31389,7 +31389,7 @@ description of <code>fn:resolve-uri</code>.</p>
 <p>This example uses an invalid query separator so raises an error.</p>
 <fos:test>
 <fos:expression><eg>parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance", { "query-separator": ";;" } )</eg></fos:expression>
-<fos:error-result error-code="FOXX0000"/>
+<fos:error-result error-code="FOUR0002"/>
 </fos:test>
 </fos:example>
 
@@ -31560,9 +31560,28 @@ path with an explicit <code>file:</code> scheme.</p>
         is made to determine if a password or standard port are present,
         the <code>authority</code> value is simply added to the string.)</p>
 
+        <p>The <code>fn:parse-uri</code> function removes
+        percent-escaping when it constructs the
+        <code>path-segments</code>, <code>query-parameters</code>, and
+        <code>fragment</code> properties. That’s often the most
+        convenient behavior but, in order to reconstruct a URI from them,
+        special escaping rules apply. These rules protect delimiters
+        without encoding additional characters unnecessarily.
+        The rules for <code>path-segments</code>,
+        <code>query-parameters</code>, and <code>fragment</code>s are
+        slightly different because the URI encoding conventions are
+        slightly different in each case.</p>
+
+        <p>An application with more stringent requirements can
+        construct a <code>path</code> or <code>query</code> that
+        satisfies the requirements and leave the
+        <code>path-segments</code> and/or
+        <code>query-parameters</code> keys out of the map.</p>
+
         <ulist>
            <item><p>If the <code>path-segments</code> key exists in the map,
            then the path is constructed from the segments.</p>
+
            <p>To construct the path, each
            segment is encoded, then they are joined together, separated by the path
            separator, to form the path.
@@ -31573,20 +31592,6 @@ path with an explicit <code>file:</code> scheme.</p>
            <code>#</code> (number sign), <code>+</code> (plus sign),
            <code>[</code> (left square bracket), and <code>]</code> (right
            square bracket).</p>
-
-           <p>This is a compromise. The <code>fn:parse-uri</code> function removes
-           percent-escaping when it constructs the path segments because that
-           behavior is often most convenient when dealing with
-           common cases involving <code>file:</code> URIs. But the decoding process is not lossless (consider
-           that both “<code>%3D</code>” and “<code>=</code>” will be realized as
-           <code>=</code> in the path segments).</p>
-
-           <p>The escaping described here protects the delimiters used in
-           hierarchical URIs because leaving those unescaped would change the
-           interpretation of the URI.
-           An application with more stringent requirements can construct a <code>path</code>
-           that satisfies the requirements and leave the <code>path-segments</code> key out of the
-           map.</p>
         </item>
         <item>
            <p>Otherwise the value of the <code>path</code> key is used.</p>
@@ -31596,40 +31601,55 @@ path with an explicit <code>file:</code> scheme.</p>
         </item>
         </ulist>
 
-        <note>
-           <p>The compromise encoding used for the <code>path-segments</code> does not
-           apply to the query parameters or fragment identifier. Those values are encoded
-           with <code>encode-for-uri</code>. The compromise encoding isn’t appropriate
-           because those fields can contain additional characters that must be encoded.
-           Adopting a <emph>different</emph> compromise encoding for those values
-           seems unnecessary in practice.</p>
-        </note>
-
         <p>The path is added to the URI.</p>
 
         <p>If the <code>query-parameters</code> key exists in the map, its value
-        must be a map. A sequence of strings is constructed from the values in the map.
+        must be a map. A sequence of strings is constructed from the values in the map.</p>
+
+        <p>To construct the string, each <emph>key</emph> and <emph>value</emph>
+        is encoded.
+        The encoding performed replaces any control characters (code points less than 0x20)
+        and exclusively the following characters with their
+        percent-escaped forms: <code> </code> (space) <code>%</code> (percent
+        sign), <code>#</code> (number sign), <code>+</code> (plus sign),
+        <code>[</code> (left square bracket), <code>]</code> (right
+        square bracket), <code>=</code> (equal sign), <code>&amp;</code> (ampersand),
+        and the <emph>query-separator</emph> character.
+        (this differs from the path encoding in that it includes
+        <code>=</code> (equal sign), <code>&amp;</code> (ampersand), and the
+        <emph>query-separator</emph> and excludes
+        <code>/</code> (solidus) and <code>?</code> (question mark).
         For each <emph>key</emph> and each <emph>value</emph> associated with
         that key in turn:</p>
 
         <ulist>
            <item><p>If the <emph>key</emph> is the empty string, the string constructed
-           is the <emph>value</emph> encoded with <code>encode-for-uri</code>.</p></item>
+           is the encoded <emph>value</emph>.</p></item>
            <item><p>Otherwise, the string constructed is the value of the
            <emph>key</emph>, encoded, followed by an equal sign (<code>=</code>),
            followed by the <emph>value</emph>, encoded.</p></item>
         </ulist>
 
         <p>The query is constructed by joining the resulting
-        strings into a single string, separated by <code>$options?query-separator</code>).
+        strings into a single string, separated by <code nobreak="true">$options?query-separator</code>).
         If the <code>query-parameters</code> key does not exist in the map, but
         the <code>query</code> key does, then the query is the value of the
-        <code>query</code> key. If there is a query, it is added to the URI with
-        a preceding question mark (<code>?</code>).</p>
+        <code>query</code> key.</p>
+        <p>If there is a query, it is added to the URI with
+        a preceding <code>?</code> (question mark).</p>
 
         <p>If the <code>fragment</code> key exists in the map, then
-        the value of that key is encoded with <code>encode-for-uri</code> and added to the URI with
-        a preceding hash mark (<code>#</code>).</p>
+        the value of that key is encoded and added to the URI with a
+        preceding hash mark (<code>#</code>).
+        The encoding performed for the fragment replaces any control characters (code points less than 0x20)
+        and exclusively the following characters with their
+        percent-escaped forms: <code> </code> (space) <code>%</code> (percent
+        sign),
+        <code>#</code> (number sign), <code>+</code> (plus sign),
+        <code>[</code> (left square bracket), and <code>]</code> (right
+        square bracket).
+        (this differs from the path encoding in that it excludes
+        <code>/</code> (solidus) and <code>?</code> (question mark).</p>
 
         <p>The resulting URI is returned.</p>
       </fos:rules>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31568,7 +31568,7 @@ path with an explicit <code>file:</code> scheme.</p>
         special escaping rules apply. These rules protect delimiters
         without encoding additional characters unnecessarily.
         The rules for <code>path-segments</code>,
-        <code>query-parameters</code>, and <code>fragment</code>s are
+        <code>query-parameters</code>, and <code>fragment</code> are
         slightly different because the URI encoding conventions are
         slightly different in each case.</p>
 
@@ -31615,7 +31615,7 @@ path with an explicit <code>file:</code> scheme.</p>
         <code>[</code> (left square bracket), <code>]</code> (right
         square bracket), <code>=</code> (equal sign), <code>&amp;</code> (ampersand),
         and the <emph>query-separator</emph> character.
-        (this differs from the path encoding in that it includes
+        (This differs from the path encoding in that it includes
         <code>=</code> (equal sign), <code>&amp;</code> (ampersand), and the
         <emph>query-separator</emph> and excludes
         <code>/</code> (solidus) and <code>?</code> (question mark).
@@ -31648,7 +31648,7 @@ path with an explicit <code>file:</code> scheme.</p>
         <code>#</code> (number sign), <code>+</code> (plus sign),
         <code>[</code> (left square bracket), and <code>]</code> (right
         square bracket).
-        (this differs from the path encoding in that it excludes
+        (This differs from the path encoding in that it excludes
         <code>/</code> (solidus) and <code>?</code> (question mark).</p>
 
         <p>The resulting URI is returned.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30619,16 +30619,6 @@ fold-left($input, false(), fn($result, $item, $pos) {
          <p>The following options are available:</p>
 
          <fos:options>
-            <fos:option key="path-separator">
-               <fos:meaning>Identifies the path separator</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>/</fos:default>
-            </fos:option>
-            <fos:option key="query-separator">
-               <fos:meaning>Identifies the query separator</fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>&amp;</fos:default>
-            </fos:option>
             <fos:option key="allow-deprecated-features">
                <fos:meaning>Indicates that deprecated URI
                features should be returned</fos:meaning>
@@ -30885,12 +30875,9 @@ fold-left($input, false(), fn($result, $item, $pos) {
          is the whole <emph>string</emph>. If the <emph>scheme</emph> is 
          the empty sequence, <emph>filepath</emph> is also the whole <emph>string</emph>.</p>
 
-         <p>The <emph>path separator</emph> is the value of the
-         <code>path-separator</code> option. A
-         <emph>path-segments</emph> sequence is constructed by
-         tokenizing the <emph>string</emph> on the <emph>path
-         separator</emph> and applying <emph>uri decoding</emph> on each
-         token.</p>
+         <p>A <emph>path-segments</emph> sequence is constructed by tokenizing
+         the <emph>string</emph> on <code>/</code> (solidus) and applying
+         <emph>uri decoding</emph> on each token.</p>
 
          <note>
          <p>The <emph>path</emph> and <emph>path-segments</emph> properties both contain
@@ -30909,27 +30896,27 @@ fold-left($input, false(), fn($result, $item, $pos) {
          reconstructing the path with the syntactic ones.</p>
 
          <p>A consequence of constructing the <emph>path-segments</emph> this
-         way is that an empty string appears before the first
-         <emph>path-separator</emph>, if the path begins with a
-         <emph>path-separator</emph>, after the last
-         <emph>path-separator</emph>, if the path ends with a
-         <emph>path-separator</emph>, and between consecutive
-         <emph>path-separator</emph>. (If the path consists of a single <emph>path-separator</emph>,
-         that <emph>path-separator</emph> counts as <emph>both</emph> the first and last <emph>path-separator</emph>,
-         producing a segment list containing two empty strings.)</p> <p>The
+         way is that an empty string appears before the first <code>/</code>,
+         if the path begins with a
+         <code>/</code>, after the last
+         <code>/</code>, if the path ends with a
+         <code>/</code>, and between consecutive
+         <code>/</code> characters. (If the path consists of a single <code>/</code>,
+         that <code>/</code> counts as <emph>both</emph> the first and last <code>/</code>,
+         producing a segment list containing two empty strings.)</p>
+
+         <p>The
          empty strings may seem unnecessary at first glance, but they assure
          that the path can be reconstructed by joining the segments together
          again without having to handle the presence or absence of a leading or
-         trailing <emph>path-separator</emph> as special cases.</p></note>
+         trailing <code>/</code> as special cases.</p></note>
 
          <p>Applying <emph>uri decoding</emph> is equivalent to
          calling <code>fn:decode-from-uri</code> on the string.</p>
 
-         <p>The <emph>query separator</emph> is the value of the
-         <code>query-separator</code> option, and is used to construct
-         a <emph>query-parameters</emph> value as follows.
+         <p>The <emph>query-parameters</emph> value is constructed as follows.
          Start with an empty map. Tokenize the <emph>query</emph> on
-         the <emph>query separator</emph>. For each token, identify
+         the <code>&amp;</code> (ampersand). For each token, identify
          the <emph>key</emph> and the <emph>value</emph>. If the token
          contains an equal sign (<code>=</code>), the <emph>key</emph>
          is the string that precedes the first equal sign, uri
@@ -31470,16 +31457,6 @@ path with an explicit <code>file:</code> scheme.</p>
         <p>The following options are available:</p>
 
         <fos:options>
-           <fos:option key="path-separator">
-              <fos:meaning>Identifies the path separator</fos:meaning>
-              <fos:type>xs:string</fos:type>
-              <fos:default>/</fos:default>
-           </fos:option>
-           <fos:option key="query-separator">
-              <fos:meaning>Identifies the query separator</fos:meaning>
-              <fos:type>xs:string</fos:type>
-              <fos:default>&amp;</fos:default>
-           </fos:option>
            <fos:option key="allow-deprecated-features">
               <fos:meaning>Indicates that deprecated URI
               features should be returned</fos:meaning>
@@ -31583,15 +31560,15 @@ path with an explicit <code>file:</code> scheme.</p>
            then the path is constructed from the segments.</p>
 
            <p>To construct the path, each
-           segment is encoded, then they are joined together, separated by the path
-           separator, to form the path.
+           segment is encoded, then they are joined together, separated by <code>/</code> (solidus)
+           characters, to form the path.
            The encoding performed replaces any control characters (code points less than 0x20)
            and exclusively the following characters with their
            percent-escaped forms: <code> </code> (space) <code>%</code> (percent
            sign), <code>/</code> (solidus), <code>?</code> (question mark),
            <code>#</code> (number sign), <code>+</code> (plus sign),
            <code>[</code> (left square bracket), and <code>]</code> (right
-           square bracket).</p>
+           square bracket). That is “<code>[#0-#20%/\?\#\+\[\]]</code>”.</p>
         </item>
         <item>
            <p>Otherwise the value of the <code>path</code> key is used.</p>
@@ -31611,14 +31588,12 @@ path with an explicit <code>file:</code> scheme.</p>
         The encoding performed replaces any control characters (code points less than 0x20)
         and exclusively the following characters with their
         percent-escaped forms: <code> </code> (space) <code>%</code> (percent
-        sign), <code>#</code> (number sign), <code>+</code> (plus sign),
-        <code>[</code> (left square bracket), <code>]</code> (right
-        square bracket), <code>=</code> (equal sign), <code>&amp;</code> (ampersand),
-        and the <emph>query-separator</emph> character.
-        (This differs from the path encoding in that it includes
-        <code>=</code> (equal sign), <code>&amp;</code> (ampersand), and the
-        <emph>query-separator</emph> and excludes
-        <code>/</code> (solidus) and <code>?</code> (question mark).
+        sign), <code>=</code> (equals sign), <code>&amp;</code> (ampersand),
+        <code>#</code> (number sign), <code>+</code> (plus sign),
+        <code>[</code> (left square bracket), and <code>]</code> (right
+        square bracket). That is “<code>[#0-#20%=&amp;\#\+\[\]]</code>”.
+        (This differs from the path encoding in that it excludes <code>/</code>
+        and <code>?</code> but includes <code>=</code> and <code>&amp;</code>.)
         For each <emph>key</emph> and each <emph>value</emph> associated with
         that key in turn:</p>
 
@@ -31631,7 +31606,7 @@ path with an explicit <code>file:</code> scheme.</p>
         </ulist>
 
         <p>The query is constructed by joining the resulting
-        strings into a single string, separated by <code nobreak="true">$options?query-separator</code>).
+        strings into a single string, separated by <code>&amp;</code> (ampersand) characters.
         If the <code>query-parameters</code> key does not exist in the map, but
         the <code>query</code> key does, then the query is the value of the
         <code>query</code> key.</p>
@@ -31641,15 +31616,16 @@ path with an explicit <code>file:</code> scheme.</p>
         <p>If the <code>fragment</code> key exists in the map, then
         the value of that key is encoded and added to the URI with a
         preceding hash mark (<code>#</code>).
-        The encoding performed for the fragment replaces any control characters (code points less than 0x20)
+
+        The encoding performed replaces any control characters (code points less than 0x20)
         and exclusively the following characters with their
         percent-escaped forms: <code> </code> (space) <code>%</code> (percent
         sign),
         <code>#</code> (number sign), <code>+</code> (plus sign),
         <code>[</code> (left square bracket), and <code>]</code> (right
-        square bracket).
-        (This differs from the path encoding in that it excludes
-        <code>/</code> (solidus) and <code>?</code> (question mark).</p>
+        square bracket). That is “<code>[#0-#20%\#\+\[\]]</code>”.
+        (This differs from the path encoding in that it excludes <code>/</code>
+        and <code>?</code>.)</p>
 
         <p>The resulting URI is returned.</p>
       </fos:rules>


### PR DESCRIPTION
This is a slightly more radical alternative to #1388 

In addition to clarifying the encoding rules (maintaining slightly different rules for path segments, query parameters, and fragment identifiers), it removes the `path-separator` and `query-separator` options.