### PR TITLE
1403 Align type tests

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2892,7 +2892,7 @@ ErrorVal ::= "$" VarName
   <g:production name="AnyMapTest" if="xpath40 xquery40 xslt40-patterns">
     <g:string>map</g:string>
     <g:string>(</g:string>
-    <g:string>*</g:string>
+    <g:optional><g:string>*</g:string></g:optional>
     <g:string>)</g:string>
   </g:production>
 

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2995,7 +2995,7 @@ ErrorVal ::= "$" VarName
   <g:production name="AnyArrayTest" if="xpath40 xquery40 xslt40-patterns">
     <g:string>array</g:string>
     <g:string>(</g:string>
-    <g:string>*</g:string>
+    <g:optional><g:string>*</g:string></g:optional>
     <g:string>)</g:string>
   </g:production>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5223,8 +5223,8 @@ name.</p>
 
 
 
-               <p>The <nt def="MapTest">MapTest</nt>
-                  <code>map(*)</code> matches any map. The <nt def="MapTest">MapTest</nt>
+               <p>The <nt def="AnyMapTest">AnyMapTest</nt>
+                  <code>map()</code> or <code>map(*)</code> matches any map. The <nt def="TypedMapTest">TypedMapTest</nt>
                   <code>map(K, V)</code> matches any map where <phrase diff="del" at="issue730">the type of </phrase>every key
                   is an instance of <code>K</code> and <phrase diff="del" at="issue730">the type of </phrase>every value is an
   instance of <code>V</code>.</p>
@@ -5243,6 +5243,11 @@ name.</p>
   </p>
 
                <ulist>
+                  <item>
+                     <p>
+                        <code>$M instance of map()</code>  returns <code>true()</code>
+                     </p>
+                  </item>
                   <item>
                      <p>
                         <code>$M instance of map(*)</code>  returns <code>true()</code>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5651,7 +5651,7 @@ name.</p>
 
 
                <p>The <nt def="AnyArrayTest">AnyArrayTest</nt>
-                  <code>array(*)</code> matches any
+                  <code>array()</code> or <code>array(*)</code> matches any
   array. The <nt def="TypedArrayTest"
                      >TypedArrayTest</nt>
                   <code>array(X)</code> matches any array
@@ -5662,6 +5662,11 @@ name.</p>
                <p>Examples:</p>
 
                <ulist>
+                  <item>
+                     <p>
+                        <code>[ 1, 2 ] instance array()</code> returns <code>true()</code>
+                     </p>
+                  </item>
                   <item>
                      <p>
                         <code>[ 1, 2 ] instance array(*)</code> returns <code>true()</code>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5214,6 +5214,12 @@ name.</p>
 
             <div4 id="id-map-test">
                <head>Map Test</head>
+               <changes>
+                  <change issue="1403" PR="1429" date="2024-01-10">
+                     The syntax <code>map()</code> is allowed; it matches any map.
+                  </change>
+               </changes>
+
                <scrap headstyle="show">
                   <head/>
                   <prodrecap id="MapTest" ref="MapTest"/>
@@ -5646,6 +5652,11 @@ name.</p>
 
             <div4 id="id-array-test">
                <head>Array Test</head>
+               <changes>
+                  <change issue="1403" PR="1429" date="2024-01-10">
+                     The syntax <code>array()</code> is allowed; it matches any array.
+                  </change>
+               </changes>
 
                <scrap>
                   <head/>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5656,25 +5656,22 @@ name.</p>
 
 
                <p>The <nt def="AnyArrayTest">AnyArrayTest</nt>
-                  <code>array()</code> or <code>array(*)</code> matches any
-  array. The <nt def="TypedArrayTest"
-                     >TypedArrayTest</nt>
-                  <code>array(X)</code> matches any array
-  in which every array member matches the <nt
-                     def="SequenceType">SequenceType</nt>
-                  <code>X</code>.</p>
+                  <code>array()</code> or <code>array(*)</code> matches any array.
+                  The <nt def="TypedArrayTest">TypedArrayTest</nt> <code>array(X)</code> matches any array
+                  in which every array member matches the <nt def="SequenceType">SequenceType</nt><code>X</code>.
+               </p>
 
                <p>Examples:</p>
 
                <ulist>
                   <item>
                      <p>
-                        <code>[ 1, 2 ] instance array()</code> returns <code>true()</code>
+                        <code>[ 1, 2 ] instance of array()</code> returns <code>true()</code>
                      </p>
                   </item>
                   <item>
                      <p>
-                        <code>[ 1, 2 ] instance array(*)</code> returns <code>true()</code>
+                        <code>[ 1, 2 ] instance of array(*)</code> returns <code>true()</code>
                      </p>
                   </item>
                   <item>
@@ -6512,13 +6509,16 @@ name.</p>
                         <item>
                            <p>Both of the following are true:</p>
                            <olist>
-                              <item><p><var>A</var> is <code>map(<var>K</var>, <var>V</var>)</code>,
-                                 for any <var>K</var> and <var>V</var></p></item>
-                              <item><p><var>B</var> is <code>map(*)</code></p></item>
+                              <item><p><var>A</var> is a <nt def="TypedMapTest">TypedMapTest</nt> (that is, <code>map(<var>K</var>, <var>V</var>)</code>
+                                 for any <var>K</var> and <var>V</var>)</p></item>
+                              <item><p><var>B</var> is an <nt def="AnyMapTest">AnyMapTest</nt> (that is, <code>map()</code> or <code>map(*)</code>)</p></item>
                            </olist>
                            <example>
-                              <head>Example:</head>
-                              <p><code>map(xs:integer, item()*) ⊆ map(*)</code></p>
+                              <head>Examples:</head>
+                              <ulist>
+                                 <item><p><code>map(xs:integer, item()*) ⊆ map()</code></p></item>
+                                 <item><p><code>map(xs:string, xs:decimal+) ⊆ map(*)</code></p></item>
+                              </ulist>
                            </example>
                         </item>
                         
@@ -6539,27 +6539,35 @@ name.</p>
                         <item>
                            <p>Both the following are true:</p>
                            <olist>
-                              <item><p><var>A</var> is <code>map(*)</code>
-                                 (or, because of the transitivity rules, any other map type)</p></item>
+                              <item><p><var>A</var> is an <nt def="AnyMapTest">AnyMapTest</nt>
+                                 (or a <nt def="TypedMapTest">TypedMapTest</nt>, because of the transitivity rules)</p></item>
                               <item><p><var>B</var> is <code>function(*)</code></p></item>
                            </olist>
                            <example>
-                              <head>Example:</head>
-                              <p><code>map(xs:long, xs:string?) ⊆ function(*)</code></p>
+                              <head>Examples:</head>
+                              <ulist>
+                                 <item><p><code>map() ⊆ function(*)</code></p></item>
+                                 <item><p><code>map(*) ⊆ function(*)</code></p></item>
+                                 <item><p><code>map(xs:long, xs:string?) ⊆ function(*)</code></p></item>
+                              </ulist>
                            </example>
                         </item>
                         
                         <item>
                            <p>Both the following are true:</p>
                            <olist>
-                              <item><p><var>A</var> is <code>map(*)</code>
-                                 (or, because of the transitivity rules, any other map type)</p></item>
+                              <item><p><var>A</var> is <nt def="AnyMapTest">AnyMapTest</nt>
+                                 (or a <nt def="TypedMapTest">TypedMapTest</nt>, because of the transitivity rules)</p></item>
                               <item><p><var>B</var> is 
                                  <code>function(xs:anyAtomicType) as item()*</code></p></item>
                            </olist>
                            <example>
-                              <head>Example:</head>
-                              <p><code>map(xs:long, xs:string?) ⊆ function(xs:anyAtomicType) as item()*</code></p>
+                              <head>Examples:</head>
+                              <ulist>
+                                 <item><p><code>map() ⊆ function(xs:anyAtomicType) as item()*</code></p></item>
+                                 <item><p><code>map(*) ⊆ function(xs:anyAtomicType) as item()*</code></p></item>
+                                 <item><p><code>map(xs:string, xs:long+) ⊆ function(xs:anyAtomicType) as item()*</code></p></item>
+                              </ulist>
                            </example>
                         </item>
                         
@@ -6590,18 +6598,21 @@ name.</p>
                <div4 id="id-item-subtype-arrays">
                   <head>Arrays</head>
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
-                  
-                     <olist>   
-                        
+
+                     <olist>
                         <item>
                            <p>Both the following are true:</p>
                            <olist>
-                              <item><p><var>A</var> is <code>array(<var>X</var>)</code></p></item>
-                              <item><p><var>B</var> is <code>array(*)</code></p></item>
+                              <item><p><var>A</var> is a <nt def="TypedArrayTest">TypedArrayTest</nt> (that is, <code>array(<var>X</var>)</code>)</p></item>
+                              <item><p><var>B</var> is an <nt def="AnyArrayTest">AnyArrayTest</nt> (that is, <code>array()</code> or <code>array(*)</code>)</p></item>
                            </olist>
                            <example>
-                              <head>Example:</head>
-                              <p><code>array(xs:integer) ⊆ array(*)</code></p></example>
+                              <head>Examples:</head>
+                              <ulist>
+                                 <item><p><code>array(xs:integer) ⊆ array()</code></p></item>
+                                 <item><p><code>array(xs:string+) ⊆ array(*)</code></p></item>
+                              </ulist>
+                           </example>
                         </item>
                         
                         <item>
@@ -6613,39 +6624,48 @@ name.</p>
                            </olist>
                            <example>
                               <head>Example:</head>
-                              <p><code>array(xs:integer) ⊆ array(xs:decimal+)</code></p></example>
-                        </item>
-                        
-                        <item>
-                           <p>Both the following are true:</p>
-                           <olist>
-                              <item><p><var>A</var> is <code>array(*)</code>
-                                 (or, because of the transitivity rules, any other array type)</p></item>
-                              <item><p><var>B</var> is <code>function(*)</code></p></item>
-                           </olist>
-                           <example>
-                              <head>Example:</head>
-                              <p><code>array(xs:integer) ⊆ function(*)</code></p>
+                              <p><code>array(xs:integer) ⊆ array(xs:decimal+)</code></p>
                            </example>
                         </item>
                         
                         <item>
                            <p>Both the following are true:</p>
                            <olist>
-                              <item><p><var>A</var> is <code>array(*)</code>
-                                 (or, because of the transitivity rules, any other array type)</p></item>
+                              <item><p><var>A</var> is an <nt def="AnyArrayTest">AnyArrayTest</nt>
+                                 (or a <nt def="TypedArrayTest">TypedArrayTest</nt>, because of the transitivity rules)</p></item>
+                              <item><p><var>B</var> is <code>function(*)</code></p></item>
+                           </olist>
+                           <example>
+                              <head>Examples:</head>
+                              <ulist>
+                                 <item><p><code>array() ⊆ function(*)</code></p></item>
+                                 <item><p><code>array(*) ⊆ function(*)</code></p></item>
+                                 <item><p><code>array(xs:integer) ⊆ function(*)</code></p></item>
+                              </ulist>
+                           </example>
+                        </item>
+                        
+                        <item>
+                           <p>Both the following are true:</p>
+                           <olist>
+                              <item><p><var>A</var> is an <nt def="AnyArrayTest">AnyArrayTest</nt>
+                                 (or a <nt def="TypedArrayTest">TypedArrayTest</nt>, because of the transitivity rules)</p></item>
                               <item><p><var>B</var> is <code>function(xs:integer) as item()*</code></p></item>
                            </olist>
                            <example>
-                              <head>Example:</head>
-                              <p><code>array(*) ⊆ function(xs:integer) as item()*</code></p>
+                              <head>Examples:</head>
+                              <ulist>
+                                 <item><p><code>array() ⊆ function(xs:integer) as item()*</code></p></item>
+                                 <item><p><code>array(*) ⊆ function(xs:integer) as item()*</code></p></item>
+                                 <item><p><code>array(xs:integer) ⊆ function(xs:integer) as item()*</code></p></item>
+                              </ulist>
                            </example>
                         </item>
                       
                         <item>
                            <p>Both the following are true:</p>
                            <olist>
-                              <item><p><var>A</var> is <code>array(<var>X</var>)</code></p></item>
+                              <item><p><var>A</var> is a <nt def="TypedArrayTest">TypedArrayTest</nt> (that is, <code>array(<var>X</var>)</code>)</p></item>
                               <item><p><var>B</var> is <code>function(xs:integer) as <var>X</var></code></p></item>
                            </olist>
                            <example>
@@ -6670,9 +6690,11 @@ name.</p>
                         </olist>
                         <example>
                            <head>Examples:</head>
-                           <p><code>record(longitude, latitude)</code> ⊆ <code>map(*)</code></p>
-                           <p><code>record(longitude, latitude, *)</code> ⊆ <code>record(*)</code></p>
-                           <p><code>record(*)</code> ⊆ <code>map(*)</code></p>
+                           <ulist>
+                              <item><p><code>record(longitude, latitude)</code> ⊆ <code>map(*)</code></p></item>
+                              <item><p><code>record(longitude, latitude, *)</code> ⊆ <code>record(*)</code></p></item>
+                              <item><p><code>record(*)</code> ⊆ <code>map(*)</code></p></item>
+                           </ulist>
                         </example>
                      </item>
                      


### PR DESCRIPTION
fixes #1403

Allow Array and Map tests to omit the asterisk to match any array or map.

- `array()` <> `array(*)`
- `map()` <> `map(*)`