### PR TITLE
1379 Initializing expression: Allow self references

### DIFF
--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1322,7 +1322,7 @@ return $node/xx:bing]]>
         declaration includes an expression (<code>VarValue</code> or <code>VarDefaultValue</code>),
         the expression is called an <term>initializing expression.</term> The static context for an
         initializing expression includes all functions, variables, and namespaces that are declared
-        or imported anywhere in the Prolog, other than the variable being declared.</termdef>
+        or imported anywhere in the Prolog.</termdef>
     </p>
     
     <p diff="add" at="2022-11-17">If a required type is defined, then the value obtained by 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1169,6 +1169,10 @@ return $node/xx:bing]]>
         and means that the rules for binding to variables are the same as the rules for binding
         to function parameters.
       </change>
+      <change issue="1379" PR="1432" date="2024-09-12">
+         In earlier versions, the static context for the <termref def="dt-initializing-expression"/>
+         excluded the variable being declared. This restriction has been lifted.
+      </change>
     </changes>
 
     <scrap>


### PR DESCRIPTION
With function declarations, recursive functions can be declared:

```xquery
declare function local:factorial($x) {
  if($x > 1) then $x + local:factorial($x - 1) else $x
};
local:factorial(5)
```

We should allow the same for variable declarations:

```xquery
declare variable $factorial := fn($x) {
  if($x > 1) then $x + $factorial($x - 1) else $x
};
$factorial(5)
```

I believe it is sufficient to simplify the definition of *initializing expressions* and drop the exception “other than the variable being declared”.

Related: https://www.w3.org/Bugs/Public/show_bug.cgi?id=15791 (the static dependency check was given up before due to `fn:function-lookup`).

Closes #1379