### PR TITLE
1387 Another tweak to build-uri

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31614,7 +31614,7 @@ path with an explicit <code>file:</code> scheme.</p>
            <item><p>If the <code>path-segments</code> key exists in the map,
            then the path is constructed from the segments.</p>
 
-           <p>To construct the path, each
+           <p>To construct the path, if the URI is hierarchical, each
            segment is encoded, then they are joined together, separated by <code>/</code> (solidus)
            characters, to form the path.
            The encoding performed replaces any control characters (codepoints less than 0x20)
@@ -31624,6 +31624,8 @@ path with an explicit <code>file:</code> scheme.</p>
            <code>#</code> (number sign), <code>+</code> (plus sign),
            <code>[</code> (left square bracket), and <code>]</code> (right
            square bracket). That is “<code>[#0-#20%/\?\#\+\[\]]</code>”.</p>
+           <p>If the scheme is not hierarchical, the path is the (unencoded) string value of
+           the first segment.</p>
         </item>
         <item>
            <p>Otherwise the value of the <code>path</code> key is used.</p>
@@ -31709,7 +31711,7 @@ path with an explicit <code>file:</code> scheme.</p>
          in meeting 042.</fos:version>
       </fos:history>-->
       <fos:changes>
-         <fos:change date="2022-10-17" issue="72 389 390"><p>New in 4.0</p></fos:change>
+         <fos:change date="2022-10-17" issue="72 389 390" PR="1423 1413"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -30989,25 +30989,8 @@ fold-left($input, false(), fn($result, $item, $pos) {
          forward slashes in the path <rfc2119>may</rfc2119> be
          replaced with backslashes.</p>
 
-         <p>The following map is returned:</p>
-
-         <eg>{
-  "uri": $value,
-  "scheme": <emph>scheme</emph>,
-  "hierarchical": <emph>hierarchical</emph>,
-  "authority": <emph>authority</emph>,
-  "userinfo": <emph>userinfo</emph>,
-  "host": <emph>host</emph>,
-  "port": <emph>port</emph>,
-  "path": <emph>path</emph>,
-  "query": <emph>query</emph>,
-  "fragment": <emph>fragment</emph>,
-  "path-segments": <emph>path-segments</emph>,
-  "query-parameters": <emph>query-parameters</emph>,
-  "filepath": <emph>filepath</emph>
-}</eg>
-
-         <p>The map should be populated with only those keys that have a non-empty value (keys
+         <p>A <loc href="#uri-structure-record">uri-structure-record</loc> is returned.
+         The record should be populated with only those keys that have a non-empty value (keys
          whose value is the empty sequence <rfc2119>should</rfc2119>
          be omitted).</p>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31046,6 +31046,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "authority": "www.ietf.org",
   "hierarchical": true(),
+  "absolute": true(),
   "host": "www.ietf.org",
   "path": "/rfc/rfc2396.txt",
   "path-segments": ("", "rfc", "rfc2396.txt"),
@@ -31065,6 +31066,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
   "path-segments": ("", "path", "to", "file"),
   "host": "example.com",
   "hierarchical": true(),
+  "absolute": true(),
   "uri": "https://example.com/path/to/file"
 }</eg></fos:result>
 </fos:test>
@@ -31076,6 +31078,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "authority": "example.com:8080",
   "hierarchical": true(),
+  "absolute": true(),
   "host": "example.com",
   "path": "/path",
   "path-segments": ("", "path"),
@@ -31097,6 +31100,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "authority": "user@example.com",
   "hierarchical": true(),
+  "absolute": true(),
   "host": "example.com",
   "path": "/path/to/file",
   "path-segments": ("", "path", "to", "file"),
@@ -31113,6 +31117,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "authority": "ftp.is.co.za",
   "hierarchical": true(),
+  "absolute": true(),
   "host": "ftp.is.co.za",
   "path": "/rfc/rfc1808.txt",
   "path-segments": ("", "rfc", "rfc1808.txt"),
@@ -31128,6 +31133,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "filepath": "/uncname/path/to/file",
   "hierarchical": true(),
+  "absolute": true(),
   "path": "/uncname/path/to/file",
   "path-segments": ("", "uncname", "path", "to", "file"),
   "scheme": "file",
@@ -31142,6 +31148,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "filepath": "c:/path/to/file",
   "hierarchical": true(),
+  "absolute": true(),
   "path": "/c:/path/to/file",
   "path-segments": ("", "c:", "path", "to", "file"),
   "scheme": "file",
@@ -31156,6 +31163,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "filepath": "C:/Program Files/test.jar",
   "hierarchical": true(),
+  "absolute": true(),
   "path": "/C:/Program%20Files/test.jar",
   "path-segments": ("", "C:", "Program Files", "test.jar"),
   "scheme": "file",
@@ -31170,6 +31178,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "filepath": "c:/path/to/file",
   "hierarchical": true(),
+  "absolute": true(),
   "path": "/c:/path/to/file",
   "path-segments": ("", "c:", "path", "to", "file"),
   "scheme": "file",
@@ -31184,6 +31193,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "filepath": "c:/path/to/file",
   "hierarchical": true(),
+  "absolute": true(),
   "path": "/c:/path/to/file",
   "path-segments": ("", "c:", "path", "to", "file"),
   "scheme": "file",
@@ -31248,6 +31258,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "authority": "[2001:db8::7]",
   "hierarchical": true(),
+  "absolute": true(),
   "host": "[2001:db8::7]",
   "path": "/c=GB",
   "path-segments": ("", "c=GB"),
@@ -31306,6 +31317,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
 <fos:result><eg>map {
   "authority": "192.0.2.16:80",
   "hierarchical": true(),
+  "absolute": true(),
   "host": "192.0.2.16",
   "path": "/",
   "path-segments": ("", ""),
@@ -31379,42 +31391,13 @@ description of <code>fn:resolve-uri</code>.</p>
 <fos:result><eg>map {
   "authority": "www.example.org",
   "hierarchical": true(),
+  "absolute": true(),
   "host": "www.example.org",
   "path": "/Dürst",
   "path-segments": ("", "Dürst"),
   "scheme": "http",
   "uri": "http://www.example.org/Dürst"
 }</eg></fos:result>
-</fos:test>
-</fos:example>
-
-<fos:example>
-<p>This example demonstrates a non-standard query separator.</p>
-<fos:test>
-<fos:expression><eg>parse-uri("https://example.com:8080/path?s=%22hello world%22;sort=relevance", { "query-separator": ";" })</eg></fos:expression>
-<fos:result><eg>map {
-  "authority": "example.com:8080",
-  "hierarchical": true(),
-  "host": "example.com",
-  "path": "/path",
-  "path-segments": ("", "path"),
-  "port": "8080",
-  "query": "s=%22hello world%22;sort=relevance",
-  "query-parameters":map {
-    "s": """hello world""",
-    "sort": "relevance"
-  },
-  "scheme": "https",
-  "uri": "https://example.com:8080/path?s=%22hello world%22;sort=relevance"
-}</eg></fos:result>
-</fos:test>
-</fos:example>
-
-<fos:example>
-<p>This example uses an invalid query separator so raises an error.</p>
-<fos:test>
-<fos:expression><eg>parse-uri("https://example.com:8080/path?s=%22hello world%22;;sort=relevance", { "query-separator": ";;" } )</eg></fos:expression>
-<fos:error-result error-code="FOUR0002"/>
 </fos:test>
 </fos:example>
 
@@ -31442,6 +31425,7 @@ path with an explicit <code>file:</code> scheme.</p>
 <fos:result><eg>map {
   "filepath": "c:/path/to/file",
   "hierarchical": true(),
+  "absolute": true(),
   "path": "/c:/path/to/file",
   "path-segments": ("", "c:", "path", "to", "file"),
   "scheme": "file",
@@ -31673,7 +31657,7 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:examples role="wide">
          <fos:example>
             <fos:test>
-               <fos:expression><eg>build-uri({
+               <fos:expression><eg>build-uri(map {
   "scheme": "https",
   "host": "qt4cg.org",
   "port": (),

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31578,21 +31578,39 @@ path with an explicit <code>file:</code> scheme.</p>
         <code>query-parameters</code> keys out of the map.</p>
 
         <ulist>
-           <item><p>If the <code>path-segments</code> key exists in the map,
-           then the path is constructed from the segments.</p>
+           <item><p>If the <code>path-segments</code> key exists in
+           the map, then the path is constructed from the segments. To
+           construct the path, the possibly encoded segments are
+           concatentated together, separated by
+           <code>/</code> (solidus) characters.</p>
 
-           <p>To construct the path, if the URI is hierarchical, each
-           segment is encoded, then they are joined together, separated by <code>/</code> (solidus)
-           characters, to form the path.
-           The encoding performed replaces any control characters (codepoints less than 0x20)
+           <p>The rules for encoding the path segments are different
+           for hierarchical and non-hierarchical URIs. If a
+           <code>scheme</code> is provided and that scheme is known to
+           be non-hierarchical, or if <code>hierarchical</code> is
+           provided and is explicitly <code>false()</code>, then no
+           encoding is performed on the segments. Otherwise,
+           each segment is encoded by replacing any control characters (codepoints less than 0x20)
            and exclusively the following characters with their
            percent-escaped forms: <code> </code> (space) <code>%</code> (percent
            sign), <code>/</code> (solidus), <code>?</code> (question mark),
            <code>#</code> (number sign), <code>+</code> (plus sign),
            <code>[</code> (left square bracket), and <code>]</code> (right
            square bracket). That is “<code>[#0-#20%/\?\#\+\[\]]</code>”.</p>
-           <p>If the scheme is not hierarchical, the path is the (unencoded) string value of
-           the first segment.</p>
+
+           <note>
+              <p>Encoding is performed unless the URI is known to be non-hierarchical;
+              in other words, encoding is the default. This heuristic improves the
+              reliability of using <code>fn:build-uri()</code> on the output of
+              <code>fn:parse-uri()</code>. (For example,
+              <code>fn:parse-uri('a+b/c') => fn:build-uri()</code> will return 
+              <code>a+b/c</code>.)</p>
+              <p>It’s necessary to avoid encoding non-hierarchical schemes because there is more
+              variation in them (for example, the <code>tel:</code> scheme
+              uses a “<code>+</code>” that must not be escaped). Users working with
+              non-hierarchical schemes may need to address the encoding issue directly
+              bearing in mind the encoding requirements of the particular schemes in use.</p>
+           </note>
         </item>
         <item>
            <p>Otherwise the value of the <code>path</code> key is used.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -31585,10 +31585,8 @@ path with an explicit <code>file:</code> scheme.</p>
            <code>/</code> (solidus) characters.</p>
 
            <p>The rules for encoding the path segments are different
-           for hierarchical and non-hierarchical URIs. If a
-           <code>scheme</code> is provided and that scheme is known to
-           be non-hierarchical, or if <code>hierarchical</code> is
-           provided and is explicitly <code>false()</code>, then no
+           for hierarchical and non-hierarchical URIs. If the URI is
+           non-hierarchical, no
            encoding is performed on the segments. Otherwise,
            each segment is encoded by replacing any control characters (codepoints less than 0x20)
            and exclusively the following characters with their
@@ -31607,7 +31605,7 @@ path with an explicit <code>file:</code> scheme.</p>
               <code>a+b/c</code>.)</p>
               <p>It’s necessary to avoid encoding non-hierarchical schemes because there is more
               variation in them (for example, the <code>tel:</code> scheme
-              uses a “<code>+</code>” that must not be escaped). Users working with
+              uses a “<code>+</code>” that must not be encoded). Users working with
               non-hierarchical schemes may need to address the encoding issue directly
               bearing in mind the encoding requirements of the particular schemes in use.</p>
            </note>


### PR DESCRIPTION
In #1387 @ChristianGruen observes that the `+` seems to be a special case in the `tel:` scheme. In fact, I think we concluded that the special case is that you shouldn't encode the path segment of a non-hierarchical URI.

This PR attempts to implement that.