### PR TITLE
1394 Add new default priority rules

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4516,7 +4516,8 @@ the schema type named <code>us:address</code>.</p>
                   <change>
                      Element and attribute tests of the form <code>element(N)</code>
                      and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
-                     including a wildcard.
+                     including a wildcard. The forms <code>element(A|B)</code> and <code>attribute(A|B)</code>
+                     are also allowed.
                   </change>
                   <change>
                      Setting the default namespace for elements and types to the special value
@@ -4642,7 +4643,7 @@ type annotation.</p>
                   
                   <item diff="add" at="A">
                      <p><code role="parse-test"
-                        >element(xhtml:*|svg:*|mathml|*)</code> matches any element node whose name is one of the
+                        >element(xhtml:*|svg:*|mathml:*)</code> matches any element node whose name is one of the
                         three namespaces identified, specifically the namespaces bound to the prefixes
                         <code>xhtml</code>, <code>svg</code>, and <code>mathml</code>.</p>
                   </item>
@@ -4709,6 +4710,11 @@ matches any nilled or non-nilled element node whose type annotation is
                   node may contain children or descendants that the <termref def="dt-issd"/>
                   would not allow.
                </p>
+               
+               <note><p>Technically, <code>element(p|q)</code> is not the same type as
+               the choice item type <code>(element(p)|element(q))</code>. However, (a)
+               they match exactly the same set of element nodes, and (b) each is a subtype
+               of the other, so in practice they are indistinguishable.</p></note>
 
             </div4>
                
@@ -4838,7 +4844,8 @@ in the following two situations:
                   <change>
                      Element and attribute tests of the form <code>element(N)</code>
                      and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
-                     including a wildcard.
+                     including a wildcard. The forms <code>element(A|B)</code> and <code>attribute(A|B)</code>
+                     are also allowed.
                   </change>
                </changes>
 
@@ -4987,6 +4994,11 @@ name.</p>
                   few problems arise if the attribute was validated using a different
                   schema. This is because simple types can never be derived by extension,
                   and attributes do not have substitution groups.</p>
+               
+               <note><p>Technically, <code>attribute(p|q)</code> is not the same type as
+               the choice item type <code>(attribute(p)|attribute(q))</code>. However, (a)
+               they match exactly the same set of attribute nodes, and (b) each is a subtype
+               of the other, so in practice they are indistinguishable.</p></note>
             </div4>
 
             <div4 id="id-schema-attribute-test">
@@ -6241,7 +6253,8 @@ name.</p>
                      <item><p><var>N</var> is the <nt def="Wildcard">Wildcard</nt> <code>*</code>.</p></item>
                   </olist>
                   
-                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply.</p>
+                  <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> 
+                     is true if any of the following apply.</p>
                   
                   <olist>
                      <item>
@@ -6350,6 +6363,21 @@ name.</p>
                                    block substitution of elements whose type is derived by extension, while <var>P</var> does not.</p>
                            </note>
                         </item>
+                     
+                        <item>
+                           <p><var>A</var> is <code>element(<var>A/1</var>|<var>A/2</var>|..., <var>T</var>)</code> 
+                              (where <var>T</var> may be absent),
+                           and for each <var>A/n</var>, <code>element(<var>A/n</var>, <var>T</var>) ⊆ <var>B</var></code>.</p>
+                           <example>
+                              <head>Examples:</head>
+                              <ulist>
+                                 <item><p><code>element(a|b) ⊆ (element(a)|element(b)|element(c))</code></p></item>
+                                 <item><p><code>element(a|b, xs:integer) ⊆ (element(a, xs:decimal) | element(b, xs:integer))</code></p></item>
+  
+                              </ulist>
+                           </example>
+
+                        </item>
                   </olist>
                </div4>
                <div4 id="id-item-subtype-attributes">
@@ -6434,6 +6462,17 @@ name.</p>
                                  >expanded QName</termref> of <var>B/n</var></p></item>
        
                            </olist>
+                        </item>
+                       <item>
+                           <p><var>A</var> is <code>attribute(<var>A/1</var>|<var>A/2</var>|..., <var>T</var>)</code> (where <var>T</var> may be absent),
+                           and for each <var>A/n</var>, <code>attribute(<var>A/n</var>, <var>T</var>) ⊆ <var>B</var></code>.</p>
+                          <example>
+                              <head>Examples:</head>
+                              <ulist>
+                                 <item><p><code>attribute(a|b) ⊆ (attribute(a)|attribute(b)|attribute(c))</code></p></item>
+                                 <item><p><code>attribute(a|b, xs:integer) ⊆ (attribute(a, xs:decimal) | attribute(b))</code></p></item>
+                              </ulist>
+                           </example>
                         </item>
                      </olist>
                </div4>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12931,14 +12931,37 @@ and <code>version="1.0"</code> otherwise.</p>
                         template rules (which affects the result of <elcode>xsl:next-match</elcode>
                         if the alternatives have the same default priority) is the order of
                         alternatives in the <nt def="UnionExprP">UnionExprP</nt>.</p>
-                  <p diff="add" at="2022-12-13">Similarly, if the top-level pattern takes the form
+                  <p diff="add" at="2022-12-13">Similarly:</p>
+                  <ulist><item><p>If the top-level pattern takes the form
                      of a <xnt spec="XP40" ref="UnionNodeTest">UnionNodeTest</xnt> preceded by
                      an axis name or abbreviation, it is treated equivalently to a set of template rules, one
                      for each alternative. For example, a rule with <code>match="@(a|b)"</code> is treated
-                     as if there were one rule with <code>match="@a"</code> and another with <code>match="@b"</code> </p>
+                     as if there were one rule with <code>match="@a"</code> and another with <code>match="@b"</code>. </p>
+                     </item>
+                  <item><p>If the top-level pattern takes the form
+                     of an <xnt spec="XP40" ref="ElementTest">ElementTest</xnt> 
+                     or <xnt spec="XP40" ref="AttributeTest">AttributeTest</xnt>
+                     containing a <xnt spec="XP40" ref="NameTestUnion">NameTestUnion</xnt> with
+                     multiple alternatives, optionally preceded by a <nt def="ForwardAxisP">ForwardAxisP</nt>,
+                     it is treated equivalently to a set of template rules, one
+                     for each alternative. For example, a rule with <code>match="element(a|b)"</code> is treated
+                     as if there were one rule with <code>match="element(a)"</code> and another with 
+                     <code>match="element(b)"</code>, while a rule with <code>match="attribute(a|b, xs:integer)"</code> 
+                     is treated as a pair of rules specifying <code>match="attribute(a, xs:integer)"</code> and
+                     <code>match="attribute(b, xs:integer)"</code> respectively</p></item>
+                  </ulist>
                   <note>
                      <p>The splitting of a template rule into multiple rules occurs only if there is
                         no explicit <code>priority</code> attribute.</p>
+                     
+                     <p>Splitting the template rule has two effects: firstly, the two match patterns
+                        may have different default priority. Secondly, an <elcode>xsl:next-match</elcode>
+                        instruction within the template body may result in the other template rule being
+                        invoked.</p>
+                     <p>In practice, this means that the splitting has no effect if 
+                        (a) the alternatives have the same default priority,
+                        and (b) the alternatives are disjoint &mdash; which is the case for some
+                        of the examples given above.</p>
                   </note>
                </item>
                <item>
@@ -12971,19 +12994,17 @@ and <code>version="1.0"</code> otherwise.</p>
                </item>
                <item>
                   <p>If the pattern is a <nt def="PathExprP">PathExprP</nt> taking the form of an
-                        <xnt spec="XP40" ref="prod-xpath40-ElementTest">ElementTest</xnt> or <xnt spec="XP40" ref="prod-xpath40-AttributeTest">AttributeTest</xnt>, optionally
+                        <xnt spec="XP40" ref="prod-xpath40-ElementTest">ElementTest</xnt> 
+                     or <xnt spec="XP40" ref="prod-xpath40-AttributeTest">AttributeTest</xnt>, optionally
                      preceded by a <nt def="ForwardAxisP">ForwardAxisP</nt>, then the priority is as
                      shown in the table below. In this table:</p>
                      <ulist>
                            <item><p>The symbols <var>E</var>,
                         <var>A</var>, and <var>T</var> represent an arbitrary element name, attribute
                         name, and type name respectively;</p></item>
-                           <item><p>The symbol <var>W</var> represents either a 
+                           <item><p>The symbol <var>W</var> represents a 
                         <xnt spec="XP40" ref="prod-xpath40-Wildcard">Wildcard</xnt> other than <code>*</code>
-                        (for example <code>prefix:*</code> or <code>*:local</code>),
-                           or a <xnt spec="XP40" ref="prod-xpath40-NameTestUnion">NameTestUnion</xnt> 
-                           containing more than one <xnt spec="XP40" ref="prod-xpath40-NameTest">NameTest</xnt>
-                           (for example <code>a|b</code>);</p></item>
+                        (for example <code>prefix:*</code> or <code>*:local</code>);</p></item>
                            <item><p>The symbol <code>*</code> represents
                         itself.</p></item>
                      </ulist>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12906,7 +12906,7 @@ and <code>version="1.0"</code> otherwise.</p>
          <div2 id="default-priority">
             <head>Default Priority for Template Rules</head>
             <changes>
-               <change issue="1394" date="2024-09-15">
+               <change issue="1394" PR="1442" date="2024-09-15">
                   Default priorities are added for new forms of <code>ElementTest</code> and <code>AttributeTest</code>,
                   for example <code>element(p:*)</code> and <code>element(a|b)</code>.
                </change>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -12905,6 +12905,12 @@ and <code>version="1.0"</code> otherwise.</p>
          </div2>
          <div2 id="default-priority">
             <head>Default Priority for Template Rules</head>
+            <changes>
+               <change issue="1394" date="2024-09-15">
+                  Default priorities are added for new forms of <code>ElementTest</code> and <code>AttributeTest</code>,
+                  for example <code>element(p:*)</code> and <code>element(a|b)</code>.
+               </change>
+            </changes>
             <p><termdef id="dt-default-priority" term="default priority">If no <code>priority</code>
                   attribute is specified on an <elcode>xsl:template</elcode> element, a
                      <term>default priority</term> is computed, based on the syntax of the <termref def="dt-pattern">pattern</termref> supplied in the <code>match</code>
@@ -12967,10 +12973,21 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>If the pattern is a <nt def="PathExprP">PathExprP</nt> taking the form of an
                         <xnt spec="XP40" ref="prod-xpath40-ElementTest">ElementTest</xnt> or <xnt spec="XP40" ref="prod-xpath40-AttributeTest">AttributeTest</xnt>, optionally
                      preceded by a <nt def="ForwardAxisP">ForwardAxisP</nt>, then the priority is as
-                     shown in the table below. In this table, the symbols <var>E</var>,
-                     <var>A</var>, and <var>T</var> represent an arbitrary element name, attribute
-                     name, and type name respectively, while the symbol <code>*</code> represents
-                     itself. The presence or absence of the symbol <code>?</code> following a type
+                     shown in the table below. In this table:</p>
+                     <ulist>
+                           <item><p>The symbols <var>E</var>,
+                        <var>A</var>, and <var>T</var> represent an arbitrary element name, attribute
+                        name, and type name respectively;</p></item>
+                           <item><p>The symbol <var>W</var> represents either a 
+                        <xnt spec="XP40" ref="prod-xpath40-Wildcard">Wildcard</xnt> other than <code>*</code>
+                        (for example <code>prefix:*</code> or <code>*:local</code>),
+                           or a <xnt spec="XP40" ref="prod-xpath40-NameTestUnion">NameTestUnion</xnt> 
+                           containing more than one <xnt spec="XP40" ref="prod-xpath40-NameTest">NameTest</xnt>
+                           (for example <code>a|b</code>);</p></item>
+                           <item><p>The symbol <code>*</code> represents
+                        itself.</p></item>
+                     </ulist>
+                  <p>The presence or absence of the symbol <code>?</code> following a type
                      name does not affect the priority.</p>
                   <table class="data">
                      <caption>Default Priority of Patterns</caption>
@@ -13012,6 +13029,20 @@ and <code>version="1.0"</code> otherwise.</p>
                         </tr>
                         <tr>
                            <td rowspan="1" colspan="1">
+                              <code>element(W)</code>
+                           </td>
+                           <td rowspan="1" colspan="1">−0.25</td>
+                           <td rowspan="1" colspan="1"></td>
+                        </tr>
+                        <tr>
+                           <td rowspan="1" colspan="1">
+                              <code>attribute(W)</code>
+                           </td>
+                           <td rowspan="1" colspan="1">−0.25</td>
+                           <td rowspan="1" colspan="1"></td>
+                        </tr>
+                        <tr>
+                           <td rowspan="1" colspan="1">
                               <code>element(<var>E</var>)</code>
                            </td>
                            <td rowspan="1" colspan="1">0</td>
@@ -13040,6 +13071,13 @@ and <code>version="1.0"</code> otherwise.</p>
                         </tr>
                         <tr>
                            <td rowspan="1" colspan="1">
+                              <code>element(<var>W</var>,<var>T</var>)</code>
+                           </td>
+                           <td rowspan="1" colspan="1">0.125</td>
+                           <td rowspan="1" colspan="1"></td>
+                        </tr>
+                        <tr>
+                           <td rowspan="1" colspan="1">
                               <code>element(<var>E</var>,<var>T</var>)</code>
                            </td>
                            <td rowspan="1" colspan="1">0.25</td>
@@ -13051,6 +13089,13 @@ and <code>version="1.0"</code> otherwise.</p>
                            </td>
                            <td rowspan="1" colspan="1">0.25</td>
                            <td rowspan="1" colspan="1">(matches by substitution group and type)</td>
+                        </tr>
+                        <tr>
+                           <td rowspan="1" colspan="1">
+                              <code>attribute(<var>W</var>,<var>T</var>)</code>
+                           </td>
+                           <td rowspan="1" colspan="1">0.125</td>
+                           <td rowspan="1" colspan="1"></td>
                         </tr>
                         <tr>
                            <td rowspan="1" colspan="1">


### PR DESCRIPTION
Adds rules for the default priority of new match pattern options such as `element(p:*)` and `element(p|q)`.

Fix #1394