### PR TITLE
CSS tweaks for productions

### DIFF
--- a/specifications/css/qtspecs.css
+++ b/specifications/css/qtspecs.css
@@ -150,7 +150,7 @@ td.castOther     { background-color: yellow;
                    vertical-align: middle;
                  }
                  
-td.prodComment   { background-color: #ffdddd;
+td.prodComment   { background-color: #f5f5f5;
                    font-style: italic;
                    color: black;
                    text-align: right;
@@ -173,6 +173,11 @@ table.scrap td {
 	 vertical-align: baseline;
 	 text-align: left;
 	 padding-left: 10px;
+}
+
+table.scrap td code {
+    border: none;
+    background-color: inherit;
 }
 
 table.data table.index {


### PR DESCRIPTION
1. Make the productions a little easier to read by removing the border and background on `code` elements in production tables.
2. Make the background color for production notes a little less ... intense.