### PR TITLE
1323b Function parameters names: $uri → $source

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -5955,7 +5955,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
             printable characters of the US-ASCII coded character set, specifically the <termref
                def="codepoint"
                >codepoints</termref> between 32 and 126 (decimal) inclusive. Each
-            character in <code>$uri</code> to be escaped is replaced by an escape sequence, which is
+            character in <code>$value</code> to be escaped is replaced by an escape sequence, which is
             formed by encoding the character as a sequence of octets in UTF-8, and then representing
             each of these octets in the form %HH, where HH is the hexadecimal representation of the
             octet. This function must always generate hexadecimal values using the upper-case
@@ -7336,7 +7336,7 @@ some $t in $value ! tokenize(.) satisfies
    <fos:function name="resolve-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="resolve-uri" return-type="xs:anyURI?">
-            <fos:arg name="uri" type="xs:string?"/>
+            <fos:arg name="href" type="xs:string?"/>
             <fos:arg name="base" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -7365,11 +7365,11 @@ some $t in $value ! tokenize(.) satisfies
 
          <olist>
             <item>
-               <p>If <code>$uri</code> is the empty sequence, the function returns the empty
+               <p>If <code>$href</code> is the empty sequence, the function returns the empty
                sequence.</p>
             </item>
             <item>
-               <p>If <code>$uri</code> is an absolute IRI (as defined above), then it is returned
+               <p>If <code>$href</code> is an absolute IRI (as defined above), then it is returned
                unchanged.</p>
             </item>
             <item>
@@ -7387,7 +7387,7 @@ some $t in $value ! tokenize(.) satisfies
                </olist>
             </item>
             <item>
-               <p>The function resolves the relative IRI reference <code>$uri</code>
+               <p>The function resolves the relative IRI reference <code>$href</code>
                against the base IRI <code>$base</code> using the algorithm defined in <bibref
                      ref="rfc3986"/>, adapted by treating any <termref def="character"
                      >character</termref>
@@ -7397,13 +7397,13 @@ some $t in $value ! tokenize(.) satisfies
          </olist>
       </fos:rules>
       <fos:errors>
-         <p>The first form of this function resolves <code>$uri</code> against the value of the
+         <p>The first form of this function resolves <code>$href</code> against the value of the
             base-uri property from the static context. A dynamic error is raised <errorref
                class="NS" code="0005"
             /> if the base-uri property is not initialized in the static
             context. </p>
          <p>A dynamic error is raised <errorref class="RG" code="0002"
-            /> if <code>$uri</code>
+            /> if <code>$href</code>
             is not a valid IRI according to the rules of RFC3987, extended with an
             implementation-defined subset of the extensions permitted in LEIRI, or if it is not a
             suitable relative reference to use as input to the RFC3986 resolution algorithm extended
@@ -17456,7 +17456,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="doc" prefix="fn">
       <fos:signatures>
          <fos:proto name="doc" return-type="document-node()?">
-            <fos:arg name="uri" type="xs:string?"/>
+            <fos:arg name="source" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17469,8 +17469,8 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             corresponding document node.</p>
       </fos:summary>
       <fos:rules>
-         <p>If <code>$uri</code> is the empty sequence, the result is an empty sequence.</p>
-         <p>If <code>$uri</code> is a relative URI reference, it is resolved relative to the value
+         <p>If <code>$source</code> is the empty sequence, the result is an empty sequence.</p>
+         <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
             of the <term>static base URI</term> property from the static context. The resulting absolute URI is
             promoted to an <code>xs:string</code>.</p>
          <p>If the <term>available documents</term> described in <xspecref spec="XP31"
@@ -17501,7 +17501,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                class="DC" code="0003"/>.</p>
 
          <note>
-            <p>If <code>$uri</code> is read from a source document, it is generally appropriate to
+            <p>If <code>$source</code> is read from a source document, it is generally appropriate to
                resolve it relative to the base URI property of the relevant node in the source
                document. This can be achieved by calling the <code>fn:resolve-uri</code> function,
                and passing the resulting absolute URI as an argument to the <code>fn:doc</code>
@@ -17580,7 +17580,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:errors>
          <p>A dynamic error <rfc2119>may</rfc2119> be raised <errorref class="DC" code="0005"
                /> if
-               <code>$uri</code> is not a valid URI <phrase>reference</phrase>.</p>
+               <code>$source</code> is not a valid URI <phrase>reference</phrase>.</p>
          <p>A dynamic error is raised <errorref class="DC" code="0002"
             /> if a relative URI reference
          is supplied, and the base-URI property in the static context is absent.</p>
@@ -17599,7 +17599,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="doc-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="doc-available" return-type="xs:boolean">
-            <fos:arg name="uri" type="xs:string?"/>
+            <fos:arg name="source" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17608,18 +17608,18 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>The function returns <code>true</code> if and only if the function call <code>fn:doc($uri)</code>
+         <p>The function returns <code>true</code> if and only if the function call <code>fn:doc($source)</code>
             would return a document node.</p>
       </fos:summary>
       <fos:rules>
-         <p>If <code>$uri</code> is an empty sequence, this function returns <code>false</code>.</p>
-         <p>If a call on <code>fn:doc($uri)</code> would return a document node, this function
+         <p>If <code>$source</code> is an empty sequence, this function returns <code>false</code>.</p>
+         <p>If a call on <code>fn:doc($source)</code> would return a document node, this function
             returns <code>true</code>.</p>
          <p>In all other cases this function returns <code>false</code>. <phrase>This
          includes the case where <phrase>an invalid URI is supplied, and also the case where </phrase>
             a valid relative URI reference is supplied, and cannot be resolved,
          for example because the static base URI is absent.</phrase></p>
-         <p>If this function returns <code>true</code>, then calling <code>fn:doc($uri)</code>
+         <p>If this function returns <code>true</code>, then calling <code>fn:doc($source)</code>
             within the same <termref
                def="execution-scope"
                /> must return a document node. However,
@@ -17630,7 +17630,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="collection" prefix="fn">
       <fos:signatures>
          <fos:proto name="collection" return-type="item()*">
-            <fos:arg name="uri" type="xs:string?" default="()"/>
+            <fos:arg name="source" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17644,7 +17644,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:summary>
       <fos:rules>
          <p>This function takes an <code>xs:string</code> as argument and returns a sequence of
-            <phrase>items</phrase> obtained by interpreting <code>$uri</code> as an <code>xs:anyURI</code> and
+            <phrase>items</phrase> obtained by interpreting <code>$source</code> as an <code>xs:anyURI</code> and
             resolving it according to the mapping specified in <term>available 
                collections</term> described in <xspecref
                spec="XP31" ref="id-xp-evaluation-context-components"/>.</p>
@@ -17652,12 +17652,12 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             sequence of items, the function returns that sequence. If <term>available 
                collections</term> maps the string to an empty sequence, then the function returns an
             empty sequence.</p>
-         <p>If <code>$uri</code> is not specified, the function returns the sequence of <phrase>items</phrase> in
+         <p>If <code>$source</code> is not specified, the function returns the sequence of <phrase>items</phrase> in
             the default collection in the dynamic context. See <xspecref
                spec="XP31" ref="id-xp-evaluation-context-components"/>. </p>
-         <p>If <code>$uri</code> is a relative <code>xs:anyURI</code>, it is resolved
+         <p>If <code>$source</code> is a relative <code>xs:anyURI</code>, it is resolved
             against the value of the base-URI property from the static context. </p>
-         <p>If <code>$uri</code> is the empty sequence, the function behaves as if it had been
+         <p>If <code>$source</code> is the empty sequence, the function behaves as if it had been
             called without an argument. See above.</p>
          <p>By default, this function is <termref def="dt-deterministic"
                >deterministic</termref>. This
@@ -17687,7 +17687,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                /> if <term>available node
                collections</term> provides no mapping for the absolutized URI.</p>
          <p>A dynamic error <phrase><rfc2119>may</rfc2119> be</phrase> raised <errorref class="DC"
-               code="0004"/> if <code>$uri</code> is not
+               code="0004"/> if <code>$source</code> is not
             a valid <code>xs:anyURI</code>.</p>
       </fos:errors>
       <fos:notes>
@@ -17707,7 +17707,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="uri-collection" prefix="fn">
       <fos:signatures>
          <fos:proto name="uri-collection" return-type="xs:anyURI*">
-            <fos:arg name="uri" type="xs:string?" default="()"/>
+            <fos:arg name="source" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17723,9 +17723,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p>The zero-argument form of the function returns the URIs in the <term>default URI
                collection</term> described in <xspecref
                spec="XP31" ref="id-xp-evaluation-context-components"/>.</p>
-         <p>If <code>$uri</code> is a relative <code>xs:anyURI</code>, it is resolved
+         <p>If <code>$source</code> is a relative <code>xs:anyURI</code>, it is resolved
             against the value of the base-URI property from the static context. </p>
-         <p>If <code>$uri</code> is the empty sequence, the function behaves as if it had been
+         <p>If <code>$source</code> is the empty sequence, the function behaves as if it had been
             called without an argument. See above.</p>
          <p>The single-argument form of the function returns the sequence of URIs corresponding to
             the supplied URI in the <term>available URI collections</term> described in
@@ -17760,7 +17760,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                /> if <term>available resource
                collections</term> provides no mapping for the absolutized URI.</p>
          <p>A dynamic error <phrase><rfc2119>may</rfc2119> be</phrase> raised <errorref class="DC"
-               code="0004"/> if <code>$uri</code> is not
+               code="0004"/> if <code>$source</code> is not
             a valid <code>xs:anyURI</code>.</p>
       </fos:errors>
       <fos:notes>
@@ -17832,7 +17832,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="unparsed-text" prefix="fn">
       <fos:signatures>
          <fos:proto name="unparsed-text" return-type="xs:string?">
-            <fos:arg name="uri" type="xs:string?"/>
+            <fos:arg name="source" type="xs:string?"/>
             <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -17846,7 +17846,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             file) and returns a string representation of the resource.</p>
       </fos:summary>
       <fos:rules>
-         <p>The <code>$uri</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
+         <p>The <code>$source</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
             reference, which <rfc2119>must</rfc2119> contain no fragment identifier, and
                <rfc2119>must</rfc2119> identify a resource for which a string representation is
             available. If the URI is a relative URI reference, then it is resolved relative to the
@@ -17886,7 +17886,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                spec="XP31" ref="dt-available-text-resources"
                >available text
                resources</xtermref> component of the dynamic context.</p>
-         <p>If the <code>$uri</code> argument is an empty sequence, the function
+         <p>If the <code>$source</code> argument is an empty sequence, the function
             returns an empty sequence.</p>
          <p>The <code>encoding</code> option, if present 
             <phrase diff="add" at="2022-12-19"> and non-empty</phrase>, is the name of an encoding. The values
@@ -17931,7 +17931,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="UT" code="1170"
-               /> if the <code>$uri</code> argument
+               /> if the <code>$source</code> argument
             contains a fragment identifier, <phrase>or if it cannot be resolved
             to an absolute URI (for example, because the base-URI property in the static context is absent), 
             </phrase>or if it cannot be used to retrieve the string
@@ -18085,7 +18085,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
         
          <p>The result of the function is the same as the result of the expression:</p>
          
-         <eg>(fn:unparsed-text($uri, map:put($options, 'normalize-newlines', true()))
+         <eg>(fn:unparsed-text($source, map:put($options, 'normalize-newlines', true()))
    => fn:tokenize('\n'))
    [not(position()=last() and .='')]
          </eg>
@@ -26252,7 +26252,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
    <fos:function name="json-doc" prefix="fn">
       <fos:signatures>
          <fos:proto name="json-doc" return-type="item()?">
-            <fos:arg name="uri" type="xs:string?" example="'JSONTestSuite/test_parsing/y_number.json'"/>
+            <fos:arg name="source" type="xs:string?" example="'JSONTestSuite/test_parsing/y_number.json'"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}"/>
          </fos:proto>
       </fos:signatures>
@@ -26293,7 +26293,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             </item>
          </olist>
 
-         <p>If <code>$uri</code> is the empty sequence, the function returns the empty sequence.</p>
+         <p>If <code>$source</code> is the empty sequence, the function returns the empty sequence.</p>
 
 
 
@@ -32501,12 +32501,12 @@ return $result
       <fos:notes>
          <p>The effect of calling <code>pin</code> on a map or array is that subsequent retrieval operations
          within the pinned map or array return labeled results, whose labels contain useful information about
-         where the results were found. For example, an expression such as <code>json-doc($uri)??name</code>
+         where the results were found. For example, an expression such as <code>json-doc($source)??name</code>
          will return the values of all entries in the JSON tree having the key <code>"name"</code>; but very little
          can be done with this information because the result is simply a sequence of (typically) strings 
-         with no context. By contrast, the result of <code>pin(json-doc($uri))??name</code> is the same set
+         with no context. By contrast, the result of <code>pin(json-doc($source))??name</code> is the same set
          of strings, labeled with information about where they were found. For example, if <code>$result</code>
-            is the result of the expression <code>pin(json-doc($uri))??name</code>, then:</p>
+            is the result of the expression <code>pin(json-doc($source))??name</code>, then:</p>
          
          <ulist>
             <item><p><code>$result => label()?parent?ssn</code> locates the map that contained each

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18048,7 +18048,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="unparsed-text-lines" prefix="fn">
       <fos:signatures>
          <fos:proto name="unparsed-text-lines" return-type="xs:string*">
-            <fos:arg name="uri" type="xs:string?"/>
+            <fos:arg name="source" type="xs:string?"/>
             <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -18117,7 +18117,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="unparsed-text-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="unparsed-text-available" return-type="xs:boolean">
-            <fos:arg name="uri" type="xs:string?"/>
+            <fos:arg name="source" type="xs:string?"/>
             <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
          </fos:proto>
       </fos:signatures>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -7336,7 +7336,7 @@ some $t in $value ! tokenize(.) satisfies
    <fos:function name="resolve-uri" prefix="fn">
       <fos:signatures>
          <fos:proto name="resolve-uri" return-type="xs:anyURI?">
-            <fos:arg name="href" type="xs:string?"/>
+            <fos:arg name="uri" type="xs:string?"/>
             <fos:arg name="base" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -7365,11 +7365,11 @@ some $t in $value ! tokenize(.) satisfies
 
          <olist>
             <item>
-               <p>If <code>$href</code> is the empty sequence, the function returns the empty
+               <p>If <code>$uri</code> is the empty sequence, the function returns the empty
                sequence.</p>
             </item>
             <item>
-               <p>If <code>$href</code> is an absolute IRI (as defined above), then it is returned
+               <p>If <code>$uri</code> is an absolute IRI (as defined above), then it is returned
                unchanged.</p>
             </item>
             <item>
@@ -7387,7 +7387,7 @@ some $t in $value ! tokenize(.) satisfies
                </olist>
             </item>
             <item>
-               <p>The function resolves the relative IRI reference <code>$href</code>
+               <p>The function resolves the relative IRI reference <code>$uri</code>
                against the base IRI <code>$base</code> using the algorithm defined in <bibref
                      ref="rfc3986"/>, adapted by treating any <termref def="character"
                      >character</termref>
@@ -7397,13 +7397,13 @@ some $t in $value ! tokenize(.) satisfies
          </olist>
       </fos:rules>
       <fos:errors>
-         <p>The first form of this function resolves <code>$href</code> against the value of the
+         <p>The first form of this function resolves <code>$uri</code> against the value of the
             base-uri property from the static context. A dynamic error is raised <errorref
                class="NS" code="0005"
             /> if the base-uri property is not initialized in the static
             context. </p>
          <p>A dynamic error is raised <errorref class="RG" code="0002"
-            /> if <code>$href</code>
+            /> if <code>$uri</code>
             is not a valid IRI according to the rules of RFC3987, extended with an
             implementation-defined subset of the extensions permitted in LEIRI, or if it is not a
             suitable relative reference to use as input to the RFC3986 resolution algorithm extended
@@ -17456,7 +17456,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="doc" prefix="fn">
       <fos:signatures>
          <fos:proto name="doc" return-type="document-node()?">
-            <fos:arg name="href" type="xs:string?"/>
+            <fos:arg name="uri" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17469,8 +17469,8 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             corresponding document node.</p>
       </fos:summary>
       <fos:rules>
-         <p>If <code>$href</code> is the empty sequence, the result is an empty sequence.</p>
-         <p>If <code>$href</code> is a relative URI reference, it is resolved relative to the value
+         <p>If <code>$uri</code> is the empty sequence, the result is an empty sequence.</p>
+         <p>If <code>$uri</code> is a relative URI reference, it is resolved relative to the value
             of the <term>static base URI</term> property from the static context. The resulting absolute URI is
             promoted to an <code>xs:string</code>.</p>
          <p>If the <term>available documents</term> described in <xspecref spec="XP31"
@@ -17501,7 +17501,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                class="DC" code="0003"/>.</p>
 
          <note>
-            <p>If <code>$href</code> is read from a source document, it is generally appropriate to
+            <p>If <code>$uri</code> is read from a source document, it is generally appropriate to
                resolve it relative to the base URI property of the relevant node in the source
                document. This can be achieved by calling the <code>fn:resolve-uri</code> function,
                and passing the resulting absolute URI as an argument to the <code>fn:doc</code>
@@ -17580,7 +17580,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:errors>
          <p>A dynamic error <rfc2119>may</rfc2119> be raised <errorref class="DC" code="0005"
                /> if
-               <code>$href</code> is not a valid URI <phrase>reference</phrase>.</p>
+               <code>$uri</code> is not a valid URI <phrase>reference</phrase>.</p>
          <p>A dynamic error is raised <errorref class="DC" code="0002"
             /> if a relative URI reference
          is supplied, and the base-URI property in the static context is absent.</p>
@@ -17599,7 +17599,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="doc-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="doc-available" return-type="xs:boolean">
-            <fos:arg name="href" type="xs:string?"/>
+            <fos:arg name="uri" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -17608,18 +17608,18 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>The function returns <code>true</code> if and only if the function call <code>fn:doc($href)</code>
+         <p>The function returns <code>true</code> if and only if the function call <code>fn:doc($uri)</code>
             would return a document node.</p>
       </fos:summary>
       <fos:rules>
-         <p>If <code>$href</code> is an empty sequence, this function returns <code>false</code>.</p>
-         <p>If a call on <code>fn:doc($href)</code> would return a document node, this function
+         <p>If <code>$uri</code> is an empty sequence, this function returns <code>false</code>.</p>
+         <p>If a call on <code>fn:doc($uri)</code> would return a document node, this function
             returns <code>true</code>.</p>
          <p>In all other cases this function returns <code>false</code>. <phrase>This
          includes the case where <phrase>an invalid URI is supplied, and also the case where </phrase>
             a valid relative URI reference is supplied, and cannot be resolved,
          for example because the static base URI is absent.</phrase></p>
-         <p>If this function returns <code>true</code>, then calling <code>fn:doc($href)</code>
+         <p>If this function returns <code>true</code>, then calling <code>fn:doc($uri)</code>
             within the same <termref
                def="execution-scope"
                /> must return a document node. However,
@@ -17832,7 +17832,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="unparsed-text" prefix="fn">
       <fos:signatures>
          <fos:proto name="unparsed-text" return-type="xs:string?">
-            <fos:arg name="href" type="xs:string?"/>
+            <fos:arg name="uri" type="xs:string?"/>
             <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -17846,7 +17846,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             file) and returns a string representation of the resource.</p>
       </fos:summary>
       <fos:rules>
-         <p>The <code>$href</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
+         <p>The <code>$uri</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
             reference, which <rfc2119>must</rfc2119> contain no fragment identifier, and
                <rfc2119>must</rfc2119> identify a resource for which a string representation is
             available. If the URI is a relative URI reference, then it is resolved relative to the
@@ -17886,7 +17886,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                spec="XP31" ref="dt-available-text-resources"
                >available text
                resources</xtermref> component of the dynamic context.</p>
-         <p>If the <code>$href</code> argument is an empty sequence, the function
+         <p>If the <code>$uri</code> argument is an empty sequence, the function
             returns an empty sequence.</p>
          <p>The <code>encoding</code> option, if present 
             <phrase diff="add" at="2022-12-19"> and non-empty</phrase>, is the name of an encoding. The values
@@ -17931,7 +17931,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="UT" code="1170"
-               /> if the <code>$href</code> argument
+               /> if the <code>$uri</code> argument
             contains a fragment identifier, <phrase>or if it cannot be resolved
             to an absolute URI (for example, because the base-URI property in the static context is absent), 
             </phrase>or if it cannot be used to retrieve the string
@@ -18048,7 +18048,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="unparsed-text-lines" prefix="fn">
       <fos:signatures>
          <fos:proto name="unparsed-text-lines" return-type="xs:string*">
-            <fos:arg name="href" type="xs:string?"/>
+            <fos:arg name="uri" type="xs:string?"/>
             <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -18085,7 +18085,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
         
          <p>The result of the function is the same as the result of the expression:</p>
          
-         <eg>(fn:unparsed-text($href, map:put($options, 'normalize-newlines', true()))
+         <eg>(fn:unparsed-text($uri, map:put($options, 'normalize-newlines', true()))
    => fn:tokenize('\n'))
    [not(position()=last() and .='')]
          </eg>
@@ -18117,7 +18117,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
    <fos:function name="unparsed-text-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="unparsed-text-available" return-type="xs:boolean">
-            <fos:arg name="href" type="xs:string?"/>
+            <fos:arg name="uri" type="xs:string?"/>
             <fos:arg name="options" type="(xs:string | map(*))?" default="()"/>
          </fos:proto>
       </fos:signatures>
@@ -19877,9 +19877,9 @@ serialize(
          <fos:example>
             <p>The expression
          <eg>let $f := function-lookup(xs:QName('zip:binary-entry'), 2)
-return if (exists($f)) then $f($href, $entry) else ()</eg>
+return if (exists($f)) then $f($uri, $entry) else ()</eg>
 returns the result of
-               calling <code>zip:binary-entry($href, $entry)</code> if the function is available, or
+               calling <code>zip:binary-entry($uri, $entry)</code> if the function is available, or
                an empty sequence otherwise.</p>
          </fos:example>
       </fos:examples>
@@ -26252,7 +26252,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
    <fos:function name="json-doc" prefix="fn">
       <fos:signatures>
          <fos:proto name="json-doc" return-type="item()?">
-            <fos:arg name="href" type="xs:string?" example="'JSONTestSuite/test_parsing/y_number.json'"/>
+            <fos:arg name="uri" type="xs:string?" example="'JSONTestSuite/test_parsing/y_number.json'"/>
             <fos:arg name="options" type="map(*)?" usage="inspection" default="{}"/>
          </fos:proto>
       </fos:signatures>
@@ -26293,7 +26293,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             </item>
          </olist>
 
-         <p>If <code>$href</code> is the empty sequence, the function returns the empty sequence.</p>
+         <p>If <code>$uri</code> is the empty sequence, the function returns the empty sequence.</p>
 
 
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19877,9 +19877,9 @@ serialize(
          <fos:example>
             <p>The expression
          <eg>let $f := function-lookup(xs:QName('zip:binary-entry'), 2)
-return if (exists($f)) then $f($uri, $entry) else ()</eg>
+return if (exists($f)) then $f($source, $entry) else ()</eg>
 returns the result of
-               calling <code>zip:binary-entry($uri, $entry)</code> if the function is available, or
+               calling <code>zip:binary-entry($source, $entry)</code> if the function is available, or
                an empty sequence otherwise.</p>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11675,7 +11675,7 @@ ISBN 0 521 77752 6.</bibl>
             <error class="UT" code="1170" label="Invalid URI reference."
                type="dynamic">
                <p>Raised by <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>
-                  if the <code>$uri</code> argument contains a fragment identifier,
+                  if the <code>$source</code> argument contains a fragment identifier,
                   or if it cannot be resolved to an absolute URI (for example, because the
                   base-URI property in the static context is absent), or if it cannot be used to
                   retrieve the string representation of a resource.</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -11675,7 +11675,7 @@ ISBN 0 521 77752 6.</bibl>
             <error class="UT" code="1170" label="Invalid URI reference."
                type="dynamic">
                <p>Raised by <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>
-                  if the <code>$href</code> argument contains a fragment identifier,
+                  if the <code>$uri</code> argument contains a fragment identifier,
                   or if it cannot be resolved to an absolute URI (for example, because the
                   base-URI property in the static context is absent), or if it cannot be used to
                   retrieve the string representation of a resource.</p>


### PR DESCRIPTION
Second attempt. Closes #1323 and #1436.

In addition, includes a change to `fn:json-doc($uri)`, and fixed an editorial bug for the `fn:escape-html-uri` function.