### PR TITLE
1461 Generate correct tests for functions involving named record types

### DIFF
--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -20,11 +20,12 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="fos:global-variables"/>
-        <xs:element ref="fos:type" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="fos:record-type" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="fos:function" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  
   <xs:element name="global-variables">
     <xs:complexType>
       <xs:sequence>
@@ -32,33 +33,30 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="type">
-    <xs:complexType>
-      <xs:choice>
-        <xs:element ref="fos:record"/>
-        <!-- No other options currently -->
-      </xs:choice>
-      <xs:attribute name="id" type="xs:ID" use="required"/>
-      <xs:attributeGroup ref="fos:diff-markup"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="record">
+
+  <xs:element name="record-type">
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="fos:field" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="id" type="xs:ID" use="required"/>
       <xs:attribute name="extensible" use="required" type="xs:boolean"/>
       <xs:attributeGroup ref="fos:diff-markup"/>
     </xs:complexType>
   </xs:element>
+  
   <xs:element name="field">
     <xs:complexType>
+      <xs:sequence>
+        <xs:element name="meaning" type="xs:anyType" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
       <xs:attribute name="name" use="required" type="xs:NCName"/>
       <xs:attribute name="required" use="required" type="xs:boolean"/>
       <xs:attribute name="type" use="required" type="xs:string"/>
       <xs:attributeGroup ref="fos:diff-markup"/>
     </xs:complexType>
   </xs:element>
+  
   <xs:element name="function">
     <xs:complexType>
       <xs:sequence>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17,19 +17,31 @@
       <fos:variable id="v-item3" name="item3" select="$po/line-item[3]"/>
    </fos:global-variables>
 
-   <!-- Not used, but needed for IDREF in this file -->
    <fos:type id="uri-structure-record">
       <fos:record extensible="true">
          <fos:field name="uri" type="xs:string?" required="false"/>
-         <!-- ... -->
+         <fos:field name="scheme" type="xs:string?" required="false"/>
+         <fos:field name="absolute" type="xs:boolean?" required="false"/>
+         <fos:field name="hierarchical" type="xs:boolean?" required="false"/>
+         <fos:field name="authority" type="xs:string?" required="false"/>
+         <fos:field name="userinfo" type="xs:string?" required="false"/>
+         <fos:field name="host" type="xs:string?" required="false"/>
+         <fos:field name="port" type="xs:integer?" required="false"/>
+         <fos:field name="path" type="xs:string?" required="false"/>
+         <fos:field name="query" type="xs:string?" required="false"/>
+         <fos:field name="fragment" type="xs:string?" required="false"/>
+         <fos:field name="path-segments" type="xs:string*" required="false"/>
+         <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false"/>
+         <fos:field name="filepath" type="xs:string?" required="false"/>
       </fos:record>
    </fos:type>
 
-   <!-- Not used, but needed for IDREF in this file -->
    <fos:type id="parse-html-options">
       <fos:record extensible="true">        
          <fos:field name="method" type="xs:string" required="false"/>
-         <!-- ... -->
+         <fos:field name="html-version" type="(enum('LS'), xs:decimal)" required="false" />
+         <fos:field name="encoding" type="xs:string?" required="false"/>
+         <fos:field name="include-template-content" type="xs:boolean?" required="false"/>
       </fos:record>
    </fos:type>
 
@@ -37,7 +49,9 @@
    <fos:type id="parsed-csv-structure-record">
       <fos:record extensible="false">
          <fos:field name="columns" type="xs:string*" required="true"/>
-         <!-- ... -->
+         <fos:field name="columnsindex" type="map(xs:string,xs:integer)?" required="true"/>
+         <fos:field name="rows" type="array(xs:string)*" required="true"/>
+         <fos:field name="get" type="function(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string?" required="true"/>
       </fos:record>
    </fos:type>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24651,7 +24651,9 @@ return json-to-xml($json, $options)]]></eg>
          <glist>
             <gitem>
                <label>columns</label>
-               <def><p>This entry holds a sequence of strings containing column names.
+               <def>
+                  <p><emph>Type: </emph> <code>xs:string*</code></p>
+                  <p>This entry holds a sequence of strings containing column names.
                   The content depends on the setting of the <code>header</code>
                   entry in <code>$options</code>:</p>
                
@@ -24681,7 +24683,9 @@ return json-to-xml($json, $options)]]></eg>
           
             <gitem>
                <label>column-index</label>
-               <def><p>This entry holds a map from column names (as strings) to
+               <def>
+                  <p><emph>Type: </emph> <code>map(xs:string, xs:integer)?</code></p>
+                  <p>This entry holds a map from column names (as strings) to
                   column positions (as 1-based positive integers).
                   The content depends on the setting of the <code>header</code>
                   entry in <code>$options</code>:</p>
@@ -24721,7 +24725,9 @@ return json-to-xml($json, $options)]]></eg>
             <gitem>
                <label>rows</label>
             
-               <def><p>This entry is a sequence of arrays of strings, holding the parsed
+               <def>
+                  <p><emph>Type: </emph> <code>array(xs:string)*</code></p>
+                  <p>This entry is a sequence of arrays of strings, holding the parsed
                   rows of the CSV data. The format is the same as the result of the
                   <code>fn:csv-to-arrays</code> function, except that the first row
                   is omitted in the case where the <code>header</code>
@@ -24731,7 +24737,9 @@ return json-to-xml($json, $options)]]></eg>
             </gitem>
             <gitem>
                <label>get</label>
-               <def><p>This entry holds a function that takes two arguments: an integer
+               <def>
+                  <p><emph>Type: </emph> <code>function($row as xs:integer, $column as union(xs:string, xs:integer)) as xs:string?</code></p>
+                  <p>This entry holds a function that takes two arguments: an integer
                   row number (1-based), and a string or integer used to identify a column.
                   Except in error cases (described below), 
                   the function call <code>$csv?get($R, $C)</code>, where <code>$C</code>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17,62 +17,294 @@
       <fos:variable id="v-item3" name="item3" select="$po/line-item[3]"/>
    </fos:global-variables>
 
-   <fos:type id="uri-structure-record">
-      <fos:record extensible="true">
-         <fos:field name="uri" type="xs:string?" required="false"/>
-         <fos:field name="scheme" type="xs:string?" required="false"/>
-         <fos:field name="absolute" type="xs:boolean?" required="false"/>
-         <fos:field name="hierarchical" type="xs:boolean?" required="false"/>
-         <fos:field name="authority" type="xs:string?" required="false"/>
-         <fos:field name="userinfo" type="xs:string?" required="false"/>
-         <fos:field name="host" type="xs:string?" required="false"/>
-         <fos:field name="port" type="xs:integer?" required="false"/>
-         <fos:field name="path" type="xs:string?" required="false"/>
-         <fos:field name="query" type="xs:string?" required="false"/>
-         <fos:field name="fragment" type="xs:string?" required="false"/>
-         <fos:field name="path-segments" type="xs:string*" required="false"/>
-         <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false"/>
-         <fos:field name="filepath" type="xs:string?" required="false"/>
-      </fos:record>
-   </fos:type>
+   <fos:record-type id="uri-structure-record" extensible="true">
+      <fos:field name="uri" type="xs:string?" required="false">
+         <fos:meaning>
+            <p>The original URI. This element is returned by <code>fn:parse-uri</code>,
+            but ignored by <code>fn:build-uri</code>.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="scheme" type="xs:string?" required="false">
+         <fos:meaning>
+            <p>The URI scheme (e.g., “https” or “file”).</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="absolute" type="xs:boolean?" required="false">
+         <fos:meaning>
+            <p>The URI is an absolute URI.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="hierarchical" type="xs:boolean?" required="false">
+         <fos:meaning>
+            <p>Whether the URI is hierarchical or not.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="authority" type="xs:string?" required="false">
+         <fos:meaning>
+            <p>The authority portion of the URI (e.g., “example.com:8080”).</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="userinfo" type="xs:string?" required="false">
+         <fos:meaning><p>Any userinfo that was passed as part of the authority.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="host" type="xs:string?" required="false">
+         <fos:meaning><p>The host passed as part of the authority (e.g., “example.com”). </p></fos:meaning>
+      </fos:field>
+      <fos:field name="port" type="xs:integer?" required="false">
+         <fos:meaning><p>The port passed as part of the authority (e.g., “8080”).</p></fos:meaning>
+      </fos:field>
+      <fos:field name="path" type="xs:string?" required="false">
+         <fos:meaning><p>The path portion of the URI.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="query" type="xs:string?" required="false">
+         <fos:meaning><p>Any query string.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="fragment" type="xs:string?" required="false">
+         <fos:meaning><p>Any fragment identifier.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="path-segments" type="xs:string*" required="false">
+         <fos:meaning><p>Parsed and unescaped path segments.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false">
+         <fos:meaning><p>Parsed and unescaped query key-value pairs.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="filepath" type="xs:string?" required="false">
+         <fos:meaning><p>The path of the URI, treated as a filepath.</p></fos:meaning>
+      </fos:field>
+   </fos:record-type>
 
-   <fos:type id="parse-html-options">
-      <fos:record extensible="true">        
-         <fos:field name="method" type="xs:string" required="false"/>
-         <fos:field name="html-version" type="(enum('LS'), xs:decimal)" required="false" />
-         <fos:field name="encoding" type="xs:string?" required="false"/>
-         <fos:field name="include-template-content" type="xs:boolean?" required="false"/>
-      </fos:record>
-   </fos:type>
+   
+   
+   <fos:record-type id="parsed-csv-structure-record" extensible="false">
+      <fos:field name="columns" type="xs:string*" required="true">
+         <fos:meaning>
+               <p>This entry holds a sequence of strings containing column names.
+                  The content depends on the setting of the <code>header</code>
+                  entry in <code>$options</code>:</p>
+               
+                  <ulist>
+                     <item><p>With <code>"header":false()</code> (which is the default),
+                     then the value is an empty sequence.</p></item>
+                     <item><p>With <code>"header":true()</code>, the value is a sequence
+                     of strings taken from the first row of the data. The strings have
+                     leading and trailing whitespace trimmed, regardless of the value of the
+                     <code>trim-whitespace</code> option. The sequence
+                     of strings will potentially be truncated if the <code>number-of-columns</code>
+                     option is specified, and it will potentially be reordered if the
+                     <code>filter-columns</code> option is specified. Any strings that are
+                     zero-length or duplicated are retained <emph>as-is</emph>.</p>
+                    </item>
+                     <item><p>If the value of the <code>header</code> option is a sequence
+                     of strings, then the value is taken from the supplied sequence.</p>
+                     <p>The order of names is <emph>not</emph> adjusted based on the 
+                        <code>select-columns</code> 
+                        option; the supplied list of names is expected to refer to columns
+                        in the result, not to columns in the input.</p></item>
+                  </ulist>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="column-index" type="map(xs:string,xs:integer)?" required="true">
+         <fos:meaning>
+         
+         <p>This entry holds a map from column names (as strings) to
+                  column positions (as 1-based positive integers).
+                  The content depends on the setting of the <code>header</code>
+                  entry in <code>$options</code>:</p>
+               
+               <ulist>
+                  <item><p>With <code>"header":false()</code> (which is the default),
+                     the value is an empty map.</p></item>
+                  <item><p>With <code>"header":true()</code>, the map
+                     contains entries based on the contents of the first row of the data. 
+                     The strings have
+                     leading and trailing whitespace trimmed, regardless of the value of the
+                     <code>trim-whitespace</code> option. Any string appearing in the header
+                     row that is non-zero-length and is not equal (using codepoint collation) to
+                     any previous string appearing in the header results in an entry
+                     pairing that string to its 1-based position in the header row.</p>
+                     <p>If the <code>select-columns</code> 
+                     option is present then the entries are adjusted (or removed) to
+                     reflect their position in the adjusted data rows.</p>
+                     
+                    
+                  
+                  </item>
+                  <item><p>If the value of the <code>header</code> option is a 
+                     sequence of strings, then the map contains entries based on the supplied value.
+                     Any string appearing in the option value that is non-zero-length and 
+                     is not equal (using codepoint collation) to
+                     any previous string results in an entry
+                     pairing that string to its 1-based position in the sequence.
+                  </p>
+                     <p>The allocation of column numbers is <emph>not</emph> adjusted based on the 
+                        <code>select-columns</code> 
+                        option; the supplied list of names is expected to refer to columns
+                        in the result, not to columns in the input.</p>
+                  </item>
+               </ulist>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="rows" type="array(xs:string)*" required="true">
+         <fos:meaning><p>This entry is a sequence of arrays of strings, holding the parsed
+                  rows of the CSV data. The format is the same as the result of the
+                  <code>fn:csv-to-arrays</code> function, except that the first row
+                  is omitted in the case where the <code>header</code>
+                  option is <code>true</code>. If there are no data rows in the CSV, the
+                  value will be an empty sequence.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="get" type="function(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string?" required="true">
+         <fos:meaning><p>A function providing ready access to a given field in a given
+      row. The <code>get</code> function has signature:</p>
+                     <eg>function($row as xs:integer, $column as union(xs:string, xs:integer)) as xs:string?</eg>
+                     <p>The function takes two arguments: the first is an
+                     integer giving the row number (1-based), the second
+                     identifies a column either by its name or by its 1-based
+                     position.</p>
+         
+         <p>Except in error cases (described below), 
+                  the function call <code>$csv?get($R, $C)</code>, where <code>$C</code>
+                  is an integer, returns the value of <code>$csv?rows[$R] => array:get($C, fn{""})</code>,
+                  and the function call <code>$csv?get($R, $K)</code>, where <code>$K</code>
+                  is a string, returns the value of <code>$csv?get($R, $csv?column-numbers($K))</code>.</p>
 
-   <!-- Not used, but needed for IDREF in this file -->
-   <fos:type id="parsed-csv-structure-record">
-      <fos:record extensible="false">
-         <fos:field name="columns" type="xs:string*" required="true"/>
-         <fos:field name="columnsindex" type="map(xs:string,xs:integer)?" required="true"/>
-         <fos:field name="rows" type="array(xs:string)*" required="true"/>
-         <fos:field name="get" type="function(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string?" required="true"/>
-      </fos:record>
-   </fos:type>
+               <p>The properties of the function are as follows:</p>
+                  <glist>
+                     <gitem>
+                        <label>Name</label>
+                        <def><p>Absent</p></def>
+                     </gitem>
+                     <gitem>
+                        <label>Parameter names</label>
+                        <def><p>(<var>$row</var>, <var>$col</var>)</p></def>
+                     </gitem>
+                     <gitem>
+                        <label>Signature</label>
+                        <def><p><code>(xs:positiveInteger, (xs:positiveInteger | xs:string)) => xs:string?</code></p></def>
+                     </gitem>
+                     <gitem>
+                        <label>Non-local variable bindings</label>
+                        <def><p>None</p></def>
+                     </gitem>
+                     <gitem>
+                        <label>Body</label>
+                        <def><p>As described in the specification above</p></def>
+                     </gitem>
+                     <gitem>
+                        <label>Errors</label>
+                        <def><p>A dynamic error <errorref class="CV" code="0004"/> occurs if the
+                           supplied <var>$key</var> is a string and does not occur in the map of column
+                           names.</p></def>
+                     </gitem>
+                     <gitem>
+                        <label>Rules</label>
+                        <def>
+                           <p>The function returns a field in the result.</p>
+                           <p>The first argument <code>$row</code> selects a row within the sequence of rows
+                              returned as <var>rows</var> by position (one-based). If the value is out of range for the number
+                              of rows returned, the <code>get</code> function returns a zero-length
+                              string.</p>
+                           <p>The second argument <code>$col</code> may be either an integer or a string.</p>
+                           <p>If <code>$col</code> is an integer then it selects a field within the
+                              selected row by position (one-based). If the value is out of range for the number
+                              of fields in the selected row, the <code>get</code> function returns a zero-length
+                              string.</p>
+                           <p>If <code>$col</code> is a string, the string is mapped to an integer using the
+                              map in the returned <var>column-index</var>. If the string is not present
+                              in this map, then an error is raised <errorref class="CV" code="0004"/>. The resulting
+                              integer is then used as if it were supplied as <code>$col</code> directly.</p>
 
- <!--  <!-\- MP - FIXUP -\->
-   <fos:type id="common-csv-options">
-      <fos:record extensible="false">
-         <fos:field name="row-delimiter" type="xs:string" required="false"/>
-         <fos:field name="column-delimiter" type="xs:string" required="false"/>
-         <fos:field name="quote-character" type="xs:string" required="false"/>
-      </fos:record>
-   </fos:type>-->
+                        </def>
+                     </gitem>
+                  </glist>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
+   
 
- <!--  <fos:type id="csv-parsing-options">
-      <fos:record extensible="false">
-         <fos:field name="row-delimiter" type="xs:string" required="false"/>
-         <fos:field name="column-delimiter" type="xs:string" required="false"/>
-         <fos:field name="quote-character" type="xs:string" required="false"/>
-         <fos:field name="trim-whitespace" type="xs:boolean" required="false"/>
-      </fos:record>
-   </fos:type>-->
+   <fos:record-type id="load-xquery-module-record" extensible="false">
+      <fos:field name="variables" type="map(xs:QName, item()*)" required="true">
+         <fos:meaning>
+                  <p>This map (<var>V</var> ) contains one entry for each public
+                  global variable declared in the library module. The key of the
+                  entry is the name of the variable, as an <code>xs:QName</code>
+                  value; the associated value is the value of the variable.</p>
+         </fos:meaning>        
+      </fos:field>
+      <fos:field name="functions" type="map(xs:QName, map(xs:integer, function(*)))" required="true">
+         <fos:meaning>
+            <p>This map (<var>F</var> ) contains one entry for each distinct QName
+            <var>Q</var> that represents the name of a public and non-external
+            function declared in the library module. The key of the entry is
+            <var>Q</var>, as an <code>xs:QName</code> value; the associated value
+            is a map <var>A</var>. This map (<var>A</var>) contains one entry for
+            each arity <var>N</var> within the arity range of any of the function
+            declarations with the given name; its key is <var>N</var>, as an
+            <code>xs:integer</code> value, and its associated value is a function
+            item obtained as if by evaluating a named function reference
+            <code>Q#N</code>, using the static and dynamic context of the call on
+            <code>fn:load-xquery-module</code>. The function item can be invoked
+            using the rules for dynamic function invocation.</p>
+         </fos:meaning>         
+      </fos:field>
+   </fos:record-type>
+   
+   
 
+   <fos:record-type id="random-number-generator-record" extensible="true">
+      <fos:field name="number" type="xs:double" required="true">
+         <fos:meaning><p>An <code>xs:double</code> greater than or equal
+               to zero (0.0e0), and less than one (1.0e0).</p></fos:meaning>
+      </fos:field>
+      <fos:field name="next" type="fn() as random-number-generator-record" required="true">
+         <fos:meaning>
+               <p>A zero-arity function that can be called to return another random number
+            generator.</p>
+               <p>The properties of this function are as follows:</p>
+               <ulist>
+                  <item>
+                     <p>name: absent</p>
+                  </item>
+                  <item>
+                     <p>parameter names: ()</p>
+                  </item>
+                  <item>
+                     <p>signature: <code>() => map(xs:string, item())</code></p>
+                  </item>
+                  <item>
+                     <p>non-local variable bindings: none</p>
+                  </item>
+                  <item>
+                     <p>implementation: implementation-dependent</p>
+                  </item>
+               </ulist>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="permute" type="function(item()*) as item()*" required="true">
+         <fos:meaning>
+               <p>A function with arity 1 (one), which takes an arbitrary sequence
+            as its argument, and returns a random permutation of that sequence.</p>
+               <p>The properties of this function are as follows:</p>
+               <ulist>
+                  <item>
+                     <p>name: absent</p>
+                  </item>
+                  <item>
+                     <p>parameter names: <code>"arg"</code></p>
+                  </item>
+                  <item>
+                     <p>signature: <code>(item()*) => item()*</code></p>
+                  </item>
+                  <item>
+                     <p>non-local variable bindings: none</p>
+                  </item>
+                  <item>
+                     <p>body: implementation-dependent</p>
+                  </item>
+               </ulist>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
+   
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="node-name" return-type="xs:QName?">
@@ -19012,10 +19244,10 @@ serialize(
       <fos:signatures>
          <fos:proto name="parse-html" return-type="document-node(element(*:html))?">
             <fos:arg name="html" type="(xs:string | xs:hexBinary | xs:base64Binary)?"/>
-            <fos:arg name="options" type-ref="parse-html-options"
+            <fos:arg name="options" type="map(*)"
                      default="{
                                  &quot;method&quot;: &quot;html&quot;,
-                                 &quot;html-version&quot;: &quot;5&quot;
+                                 &quot;html-version&quot;: 5
                               }"/>
          </fos:proto>
       </fos:signatures>
@@ -19030,6 +19262,100 @@ serialize(
       </fos:summary>
       <fos:rules>
          <p>If <code>$html</code> is the empty sequence the function returns the empty sequence.</p>
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         
+         <fos:options>
+            <fos:option key="method">
+               <fos:meaning>
+                                    <p>The approach used to parse the HTML document into XDM nodes.</p>
+                                    <note>
+                                       <p>An implementation may use this to specify a specific algorithm, tool, or
+                                          library that is used, such as <code>tidy</code> or <code>tagsoup</code>.</p>
+                                       <p>An implementation may also use this to specify a non-standard variant of
+                                          HTML to support, such as <code>word</code> for the Microsoft Word HTML variant.</p>
+                                    </note>
+               </fos:meaning>
+               <fos:type>xs:string</fos:type>
+            </fos:option>
+            <fos:option key="html-version">
+               <fos:meaning>
+                                    <p>The version of HTML to support when parsing HTML strings or sequences of octets.</p>
+                                    <p>Valid values an implementation must support for the <code>html</code> method are:</p>
+                                    <olist>
+                                       <item>
+                                          <p><code>3</code>, <code>3.2</code> for HTML 3.2 W3C Recommendation, 14 January 1997</p>
+                                       </item>
+                                       <item>
+                                          <p><code>4</code>, <code>4.01</code> for HTML 4.01 W3C Recommendation, 24 December 1999</p>
+                                       </item>
+                                       <item>
+                                          <p><code>5.0</code> for HTML5 W3C Recommendation, 28 October 2014</p>
+                                       </item>
+                                       <item>
+                                          <p><code>5.1</code> for HTML 5.1 W3C Recommendation, 1 November 2016</p>
+                                       </item>
+                                       <item>
+                                          <p><code>5.2</code> for HTML 5.2 W3C Recommendation, 14 December 2017</p>
+                                       </item>
+                                       <item>
+                                          <p><code>LS</code> for HTML Living Standard, WHATWG</p>
+                                       </item>
+                                       <item>
+                                          <p><code>5</code> may be equivalent to any of <code>5.0</code>, <code>5.1</code>, <code>5.2</code>, or <code>LS</code></p>
+                                       </item>
+                                    </olist>
+                                    <p>Valid values an implementation must support for the <code>xhtml</code> method are:</p>
+                                    <olist>
+                                       <item>
+                                          <p><code>1.0</code> for XHTML 1.0 W3C Recommendation, 26 January 2000</p>
+                                       </item>
+                                       <item>
+                                          <p><code>1.1</code> for XHTML 1.1 W3C Recommendation, 31 May 2001</p>
+                                       </item>
+                                    </olist>
+                                    <p>Any other <code>method</code> and <code>html-version</code> combinations are
+                                       <termref def="implementation-defined">implementation-defined</termref>.</p>
+               </fos:meaning>
+               <fos:type>(enum('LS') | xs:decimal)</fos:type>
+            </fos:option>
+            <fos:option key="encoding">
+               <fos:meaning>
+                  <p>The character encoding to use to decode a sequence of octets that
+                  represents an HTML document.</p>
+               </fos:meaning>
+               <fos:type>xs:string?</fos:type>
+            </fos:option>
+            <fos:option key="include-template-content">
+               <fos:meaning>
+                                    <p>Defines how to handle elements in the <code>HTMLTemplateElement.content</code>
+                                       property.</p>
+                                    <p>If this option is <code>true</code>, the <code>template</code> element’s
+                                       children are the children of the <code>content</code> property’s document
+                                       fragment node.</p>
+                                    <p>If this option is <code>false</code>, the <code>template</code> element’s
+                                       children are the empty sequence.</p>
+                                    <p>The default behaviour is
+                                       <termref def="implementation-defined">implementation-defined</termref>.</p>
+                                    <note>
+                                       <p>This allows an implementation to support the behaviour defined in
+                                          <bibref ref="html5"/> section 4.12.3.1, <emph>Interaction of
+                                          <code>template</code> elements with XSLT and XPath</emph>:</p>
+                                       <olist>
+                                          <item>
+                                             <p>This option would default to <code>true</code> for an XSLT processor
+                                                operating on an HTML DOM constructed from an XHTML document.</p>
+                                          </item>
+                                          <item>
+                                             <p>This option would default to <code>false</code> for an XPath processor
+                                                using the <bibref ref="dom-ls"/> section 8, <emph>XPath</emph> APIs.</p>
+                                          </item>
+                                       </olist>
+                                    </note>
+               </fos:meaning>
+               <fos:type>xs:boolean?</fos:type>
+            </fos:option>
+         </fos:options>
+         
          <p>If <code>$html</code> is not the empty sequence, an input byte stream is constructed as follows:</p>
          <olist>
             <item>
@@ -24658,161 +24984,11 @@ return json-to-xml($json, $options)]]></eg>
             </fos:option>
          </fos:options>
 
-         <p>The result of the function is a <code>parsed-csv-structure-record</code>, a map with
-            string-valued keys containing four entries: <code>columns</code>, 
-            <code>column-index</code>, <code>rows</code>, and <code>get</code>.
-            The values of these entries are set as follows:</p>
-         <glist>
-            <gitem>
-               <label>columns</label>
-               <def>
-                  <p><emph>Type: </emph> <code>xs:string*</code></p>
-                  <p>This entry holds a sequence of strings containing column names.
-                  The content depends on the setting of the <code>header</code>
-                  entry in <code>$options</code>:</p>
-               
-                  <ulist>
-                     <item><p>With <code>"header":false()</code> (which is the default),
-                     then the value is an empty sequence.</p></item>
-                     <item><p>With <code>"header":true()</code>, the value is a sequence
-                     of strings taken from the first row of the data. The strings have
-                     leading and trailing whitespace trimmed, regardless of the value of the
-                     <code>trim-whitespace</code> option. The sequence
-                     of strings will potentially be truncated if the <code>number-of-columns</code>
-                     option is specified, and it will potentially be reordered if the
-                     <code>filter-columns</code> option is specified. Any strings that are
-                     zero-length or duplicated are retained <emph>as-is</emph>.</p>
-                    </item>
-                     <item><p>If the value of the <code>header</code> option is a sequence
-                     of strings, then the value is taken from the supplied sequence.</p>
-                     <p>The order of names is <emph>not</emph> adjusted based on the 
-                        <code>select-columns</code> 
-                        option; the supplied list of names is expected to refer to columns
-                        in the result, not to columns in the input.</p></item>
-                  </ulist></def>
-            </gitem>
-                  
-                  
-            
-          
-            <gitem>
-               <label>column-index</label>
-               <def>
-                  <p><emph>Type: </emph> <code>map(xs:string, xs:integer)?</code></p>
-                  <p>This entry holds a map from column names (as strings) to
-                  column positions (as 1-based positive integers).
-                  The content depends on the setting of the <code>header</code>
-                  entry in <code>$options</code>:</p>
-               
-               <ulist>
-                  <item><p>With <code>"header":false()</code> (which is the default),
-                     the value is an empty map.</p></item>
-                  <item><p>With <code>"header":true()</code>, the map
-                     contains entries based on the contents of the first row of the data. 
-                     The strings have
-                     leading and trailing whitespace trimmed, regardless of the value of the
-                     <code>trim-whitespace</code> option. Any string appearing in the header
-                     row that is non-zero-length and is not equal (using codepoint collation) to
-                     any previous string appearing in the header results in an entry
-                     pairing that string to its 1-based position in the header row.</p>
-                     <p>If the <code>select-columns</code> 
-                     option is present then the entries are adjusted (or removed) to
-                     reflect their position in the adjusted data rows.</p>
-                     
-                    
-                  
-                  </item>
-                  <item><p>If the value of the <code>header</code> option is a 
-                     sequence of strings, then the map contains entries based on the supplied value.
-                     Any string appearing in the option value that is non-zero-length and 
-                     is not equal (using codepoint collation) to
-                     any previous string results in an entry
-                     pairing that string to its 1-based position in the sequence.
-                  </p>
-                     <p>The allocation of column numbers is <emph>not</emph> adjusted based on the 
-                        <code>select-columns</code> 
-                        option; the supplied list of names is expected to refer to columns
-                        in the result, not to columns in the input.</p>
-                  </item>
-               </ulist></def>
-            </gitem>
-            <gitem>
-               <label>rows</label>
-            
-               <def>
-                  <p><emph>Type: </emph> <code>array(xs:string)*</code></p>
-                  <p>This entry is a sequence of arrays of strings, holding the parsed
-                  rows of the CSV data. The format is the same as the result of the
-                  <code>fn:csv-to-arrays</code> function, except that the first row
-                  is omitted in the case where the <code>header</code>
-                  option is <code>true</code>. If there are no data rows in the CSV, the
-                  value will be an empty sequence.</p></def>
-               
-            </gitem>
-            <gitem>
-               <label>get</label>
-               <def>
-                  <p><emph>Type: </emph> <code>function($row as xs:integer, $column as union(xs:string, xs:integer)) as xs:string?</code></p>
-                  <p>This entry holds a function that takes two arguments: an integer
-                  row number (1-based), and a string or integer used to identify a column.
-                  Except in error cases (described below), 
-                  the function call <code>$csv?get($R, $C)</code>, where <code>$C</code>
-                  is an integer, returns the value of <code>$csv?rows[$R] => array:get($C, fn{""})</code>,
-                  and the function call <code>$csv?get($R, $K)</code>, where <code>$K</code>
-                  is a string, returns the value of <code>$csv?get($R, $csv?column-numbers($K))</code>.</p>
-
-               <p>The properties of the function are as follows:</p>
-                  <glist>
-                     <gitem>
-                        <label>Name</label>
-                        <def><p>Absent</p></def>
-                     </gitem>
-                     <gitem>
-                        <label>Parameter names</label>
-                        <def><p>(<var>$row</var>, <var>$col</var>)</p></def>
-                     </gitem>
-                     <gitem>
-                        <label>Signature</label>
-                        <def><p><code>(xs:positiveInteger, (xs:positiveInteger | xs:string)) => xs:string?</code></p></def>
-                     </gitem>
-                     <gitem>
-                        <label>Non-local variable bindings</label>
-                        <def><p>None</p></def>
-                     </gitem>
-                     <gitem>
-                        <label>Body</label>
-                        <def><p>As described in the specification above</p></def>
-                     </gitem>
-                     <gitem>
-                        <label>Errors</label>
-                        <def><p>A dynamic error <errorref class="CV" code="0004"/> occurs if the
-                           supplied <var>$key</var> is a string and does not occur in the map of column
-                           names.</p></def>
-                     </gitem>
-                     <gitem>
-                        <label>Rules</label>
-                        <def>
-                           <p>The function returns a field in the result.</p>
-                           <p>The first argument <code>$row</code> selects a row within the sequence of rows
-                              returned as <var>rows</var> by position (one-based). If the value is out of range for the number
-                              of rows returned, the <code>get</code> function returns a zero-length
-                              string.</p>
-                           <p>The second argument <code>$col</code> may be either an integer or a string.</p>
-                           <p>If <code>$col</code> is an integer then it selects a field within the
-                              selected row by position (one-based). If the value is out of range for the number
-                              of fields in the selected row, the <code>get</code> function returns a zero-length
-                              string.</p>
-                           <p>If <code>$col</code> is a string, the string is mapped to an integer using the
-                              map in the returned <var>column-index</var>. If the string is not present
-                              in this map, then an error is raised <errorref class="CV" code="0004"/>. The resulting
-                              integer is then used as if it were supplied as <code>$col</code> directly.</p>
-
-                        </def>
-                     </gitem>
-                  </glist>
-               </def>
-            </gitem>
-         </glist>
+         <p>The result of the function is a <code>parsed-csv-structure-record</code>, which is defined as
+            follows:</p>
+         
+         <?record-description parsed-csv-structure-record?>
+         
 
 
       </fos:rules>
@@ -28595,36 +28771,8 @@ declare function array:flatten(
          <p>The result of the function is a map
          <var>R</var> with two entries:</p>
 
-<fos:record-description id="load-xquery-module-record" extensible="true">
-   <fos:option key="variables">
-      <fos:meaning>
-               <p>This map (<var>V</var> ) contains one entry for each public
-               global variable declared in the library module. The key of the
-               entry is the name of the variable, as an <code>xs:QName</code>
-               value; the associated value is the value of the variable.</p>
-      </fos:meaning>
-      <fos:type>map(xs:QName, item()*)</fos:type>
-      <!-- REQUIRED -->
-   </fos:option>
-   <fos:option key="functions">
-      <fos:meaning>
-         <p>This map (<var>F</var> ) contains one entry for each distinct QName
-         <var>Q</var> that represents the name of a public and non-external
-         function declared in the library module. The key of the entry is
-         <var>Q</var>, as an <code>xs:QName</code> value; the associated value
-         is a map <var>A</var>. This map (<var>A</var>) contains one entry for
-         each arity <var>N</var> within the arity range of any of the function
-         declarations with the given name; its key is <var>N</var>, as an
-         <code>xs:integer</code> value, and its associated value is a function
-         item obtained as if by evaluating a named function reference
-         <code>Q#N</code>, using the static and dynamic context of the call on
-         <code>fn:load-xquery-module</code>. The function item can be invoked
-         using the rules for dynamic function invocation.</p>
-      </fos:meaning>
-      <fos:type>map(xs:QName, map(xs:integer, function(*)))</fos:type>
-      <!-- REQUIRED -->
-   </fos:option>
-</fos:record-description>
+         <?record-description load-xquery-module-record?>
+
          
          <p>The static and dynamic context of the library module are established according to the rules in 
             <xspecref
@@ -29523,67 +29671,9 @@ return $result?output//body
                >The function returns a random number generator. A random number generator is represented as a value of type 
             <code>random-number-generator-record</code>, defined as follows:</p>
          
+          <?record-description random-number-generator-record?>
 
-   <fos:record-description id="random-number-generator-record" extensible="true">
-      <fos:option key="number">
-         <fos:meaning><p>An <code>xs:double</code> greater than or equal
-               to zero (0.0e0), and less than one (1.0e0).</p></fos:meaning>
-         <fos:type>xs:double</fos:type>
-         <fos:required>true</fos:required>
-      </fos:option>
-      <fos:option key="next">
-         <fos:meaning>
-               <p>A zero-arity function that can be called to return another random number
-            generator.</p>
-               <p>The properties of this function are as follows:</p>
-               <ulist>
-                  <item>
-                     <p>name: absent</p>
-                  </item>
-                  <item>
-                     <p>parameter names: ()</p>
-                  </item>
-                  <item>
-                     <p>signature: <code>() => map(xs:string, item())</code></p>
-                  </item>
-                  <item>
-                     <p>non-local variable bindings: none</p>
-                  </item>
-                  <item>
-                     <p>implementation: implementation-dependent</p>
-                  </item>
-               </ulist>
-         </fos:meaning>
-         <fos:type>function() as random-number-generator-record</fos:type>
-         <fos:required>true</fos:required>
-      </fos:option>
-      <fos:option key="permute">
-         <fos:meaning>
-               <p>A function with arity 1 (one), which takes an arbitrary sequence
-            as its argument, and returns a random permutation of that sequence.</p>
-               <p>The properties of this function are as follows:</p>
-               <ulist>
-                  <item>
-                     <p>name: absent</p>
-                  </item>
-                  <item>
-                     <p>parameter names: <code>"arg"</code></p>
-                  </item>
-                  <item>
-                     <p>signature: <code>(item()*) => item()*</code></p>
-                  </item>
-                  <item>
-                     <p>non-local variable bindings: none</p>
-                  </item>
-                  <item>
-                     <p>implementation: implementation-dependent</p>
-                  </item>
-               </ulist>
-         </fos:meaning>
-         <fos:type>function(item()*) as item()*</fos:type>
-         <fos:required>true</fos:required>
-      </fos:option>
-   </fos:record-description>
+   
 
          <p>Calling the <code>fn:random-number-generator</code> function with no arguments is equivalent to calling the single-argument
          form of the function with an implementation-dependent seed.</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -143,8 +143,7 @@ for transition to Proposed Recommendation. </p>'>
 
 <!--
 <head><?xml-stylesheet type="text/xsl" href="E:\XMLdocs\XML Query Language (XQuery)\Functions and Operators\Current Functions and Operators Build Files\xquery-operators.xsl"?></head> -->
-<spec id="spec-top" w3c-doctype="&doc.w3c-doctype;" status="ext-review"
-      xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace">
+<spec id="spec-top" w3c-doctype="&doc.w3c-doctype;" status="ext-review">
     <header>
         <title>&language;</title>
         <version>&version;</version>
@@ -3526,81 +3525,9 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
          <?local-function-index?>
 
            <p>The structured representation of a URI is described by the
-           <code>uri-structure-record</code>:</p>
-
-           <p>The parts of this structure are:</p>
-
-<fos:record-description id="uri-structure-record"
-                        extensible="true"
-                        xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace" >
-   <fos:option key="uri">
-      <fos:meaning>
-         <p>The original URI. This element is returned by <code>fn:parse-uri</code>,
-         but ignored by <code>fn:build-uri</code>.</p>
-      </fos:meaning>
-      <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="scheme">
-      <fos:meaning>
-         <p>The URI scheme (e.g., “https” or “file”).</p>
-      </fos:meaning>
-      <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="absolute">
-      <fos:meaning>
-         <p>The URI is an absolute URI.</p>
-      </fos:meaning>
-      <fos:type>xs:boolean?</fos:type>
-   </fos:option>
-   <fos:option key="hierarchical">
-      <fos:meaning>
-         <p>Whether the URI is hierarchical or not.</p>
-      </fos:meaning>
-      <fos:type>xs:boolean?</fos:type>
-   </fos:option>
-   <fos:option key="authority">
-     <fos:meaning>
-       <p>The authority portion of the URI (e.g., “example.com:8080”).</p>
-     </fos:meaning>
-     <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="userinfo">
-     <fos:meaning>Any userinfo that was passed as part of the authority.</fos:meaning>
-     <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="host">
-     <fos:meaning>The host passed as part of the authority (e.g., “example.com”). </fos:meaning>
-     <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="port">
-     <fos:meaning>The port passed as part of the authority (e.g., “8080”).</fos:meaning>
-     <fos:type>xs:integer?</fos:type>
-   </fos:option>
-   <fos:option key="path">
-     <fos:meaning>The path portion of the URI.</fos:meaning>
-     <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="query">
-     <fos:meaning>Any query string.</fos:meaning>
-     <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="fragment">
-     <fos:meaning>Any fragment identifier.</fos:meaning>
-     <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="path-segments">
-     <fos:meaning>Parsed and unescaped path segments.</fos:meaning>
-     <fos:type>xs:string*</fos:type>
-   </fos:option>
-   <fos:option key="query-parameters">
-     <fos:meaning>Parsed and unescaped query key-value pairs.</fos:meaning>
-     <fos:type>map(xs:string, xs:string*)?</fos:type>
-   </fos:option>
-   <fos:option key="filepath">
-     <fos:meaning>The path of the URI, treated as a filepath.</fos:meaning>
-     <fos:type>xs:string?</fos:type>
-   </fos:option>
-</fos:record-description>
+           <loc href="#uri-structure-record">uri-structure-record</loc>, whose parts are:</p>
+            
+            <?record-description uri-structure-record?>
 
            <p>The segmented forms of the path and query parameters provide
            convenient access to commonly used information.</p>
@@ -6668,97 +6595,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <p>This section describes the record structure used to pass options to the
                <code>fn:parse-html</code> function.</p>
 
-<fos:record-description id="parse-html-options" extensible="true">
-   <fos:option key="method">
-      <fos:meaning>
-                           <p>The approach used to parse the HTML document into XDM nodes.</p>
-                           <note>
-                              <p>An implementation may use this to specify a specific algorithm, tool, or
-                                 library that is used, such as <code>tidy</code> or <code>tagsoup</code>.</p>
-                              <p>An implementation may also use this to specify a non-standard variant of
-                                 HTML to support, such as <code>word</code> for the Microsoft Word HTML variant.</p>
-                           </note>
-      </fos:meaning>
-      <fos:type>xs:string</fos:type>
-   </fos:option>
-   <fos:option key="html-version">
-      <fos:meaning>
-                           <p>The version of HTML to support when parsing HTML strings or sequences of octets.</p>
-                           <p>Valid values an implementation must support for the <code>html</code> method are:</p>
-                           <olist>
-                              <item>
-                                 <p><code>3</code>, <code>3.2</code> for HTML 3.2 W3C Recommendation, 14 January 1997</p>
-                              </item>
-                              <item>
-                                 <p><code>4</code>, <code>4.01</code> for HTML 4.01 W3C Recommendation, 24 December 1999</p>
-                              </item>
-                              <item>
-                                 <p><code>5.0</code> for HTML5 W3C Recommendation, 28 October 2014</p>
-                              </item>
-                              <item>
-                                 <p><code>5.1</code> for HTML 5.1 W3C Recommendation, 1 November 2016</p>
-                              </item>
-                              <item>
-                                 <p><code>5.2</code> for HTML 5.2 W3C Recommendation, 14 December 2017</p>
-                              </item>
-                              <item>
-                                 <p><code>LS</code> for HTML Living Standard, WHATWG</p>
-                              </item>
-                              <item>
-                                 <p><code>5</code> may be equivalent to any of <code>5.0</code>, <code>5.1</code>, <code>5.2</code>, or <code>LS</code></p>
-                              </item>
-                           </olist>
-                           <p>Valid values an implementation must support for the <code>xhtml</code> method are:</p>
-                           <olist>
-                              <item>
-                                 <p><code>1.0</code> for XHTML 1.0 W3C Recommendation, 26 January 2000</p>
-                              </item>
-                              <item>
-                                 <p><code>1.1</code> for XHTML 1.1 W3C Recommendation, 31 May 2001</p>
-                              </item>
-                           </olist>
-                           <p>Any other <code>method</code> and <code>html-version</code> combinations are
-                              <termref def="implementation-defined">implementation-defined</termref>.</p>
-      </fos:meaning>
-      <fos:type>(enum('LS') | xs:decimal)</fos:type>
-   </fos:option>
-   <fos:option key="encoding">
-      <fos:meaning>
-         <p>The character encoding to use to decode a sequence of octets that
-         represents an HTML document.</p>
-      </fos:meaning>
-      <fos:type>xs:string?</fos:type>
-   </fos:option>
-   <fos:option key="include-template-content">
-      <fos:meaning>
-                           <p>Defines how to handle elements in the <code>HTMLTemplateElement.content</code>
-                              property.</p>
-                           <p>If this option is <code>true()</code>, the <code>template</code> element’s
-                              children are the children of the <code>content</code> property’s document
-                              fragment node.</p>
-                           <p>If this option is <code>false()</code>, the <code>template</code> element’s
-                              children are the empty sequence.</p>
-                           <p>The default behaviour is
-                              <termref def="implementation-defined">implementation-defined</termref>.</p>
-                           <note>
-                              <p>This allows an implementation to support the behaviour defined in
-                                 <bibref ref="html5"/> section 4.12.3.1, <emph>Interaction of
-                                 <code>template</code> elements with XSLT and XPath</emph>:</p>
-                              <olist>
-                                 <item>
-                                    <p>This option would default to <code>true()</code> for an XSLT processor
-                                       operating on an HTML DOM constructed from an XHTML document.</p>
-                                 </item>
-                                 <item>
-                                    <p>This option would default to <code>false()</code> for an XPath processor
-                                       using the <bibref ref="dom-ls"/> section 8, <emph>XPath</emph> APIs.</p>
-                                 </item>
-                              </olist>
-                           </note>
-      </fos:meaning>
-      <fos:type>xs:boolean?</fos:type>
-   </fos:option>
-</fos:record-description>
+
 
    <p>Additional <termref def="implementation-defined"/> parser options are allowed.</p>
                            <example>
@@ -7261,38 +7098,9 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                   names may be taken either from the first row of the CSV data, or from
                   data supplied by the caller in the <code>options</code> parameter.</p>
                   
- <!--                 <p>The function returns a
-                  <code>parsed-csv-structure-record</code>:</p>
+                 
+               
 
-               <p>The record has four parts, which are always present (though potentially empty):</p>
-
-<fos:record-description id="parsed-csv-structure-record">
-   <fos:option key="columns">
-      <fos:meaning><p>The list of column names, in order.</p></fos:meaning>
-      <fos:type>xs:string*</fos:type>
-   </fos:option>
-   <fos:option key="columns-index">
-      <fos:meaning><p>A map from column names to the 1-based integer position of the column.</p></fos:meaning>
-      <fos:type>map(xs:string,xs:integer)?</fos:type>
-   </fos:option>
-   <fos:option key="rows">
-      <fos:meaning><p>The contents of the non-header rows in the CSV data, as a
-      sequence of arrays of <code>xs:string</code> values; each array represents
-      one row of the CSV data.</p></fos:meaning>
-      <fos:type>array(xs:string)*</fos:type>
-   </fos:option>
-   <fos:option key="get">
-      <fos:meaning><p>A function providing ready access to a given field in a given
-      row. The <code>get</code> function has signature:</p>
-                     <eg>function($row as xs:integer, $column as union(xs:string, xs:integer)) as xs:string?</eg>
-                     <p>The function takes two arguments: the first is an
-                     integer giving the row number (1-based), the second
-                     identifies a column either by its name or by its 1-based
-                     position.</p></fos:meaning>
-      <fos:type>function(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string?</fos:type>
-   </fos:option>
-</fos:record-description>
--->
             </div3>
             <div3 id="func-parse-csv">
                <head><?function fn:parse-csv?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7261,7 +7261,7 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                   names may be taken either from the first row of the CSV data, or from
                   data supplied by the caller in the <code>options</code> parameter.</p>
                   
-                  <p>The function returns a
+ <!--                 <p>The function returns a
                   <code>parsed-csv-structure-record</code>:</p>
 
                <p>The record has four parts, which are always present (though potentially empty):</p>
@@ -7292,7 +7292,7 @@ Field 2A,Field 2B,Field 2C,Field 2D'
       <fos:type>function(xs:positiveInteger, (xs:positiveInteger | xs:string)) as xs:string?</fos:type>
    </fos:option>
 </fos:record-description>
-
+-->
             </div3>
             <div3 id="func-parse-csv">
                <head><?function fn:parse-csv?></head>

--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -13,6 +13,8 @@
    <xsl:output method="xml" indent="yes"/>
    <xsl:strip-space elements="*"/>
    
+   <xsl:key name="type-ref" match="type" use="@id"/>
+   
    <xsl:template match="/">
      <xsl:comment> ************************************************** </xsl:comment>
      <xsl:text>&#10;</xsl:text>
@@ -72,14 +74,38 @@
             <xsl:text>instance of function(</xsl:text>
             <xsl:for-each select="arg">
               <xsl:if test="position() != 1">, </xsl:if>
-              <xsl:text>{@type}</xsl:text>
+              <xsl:apply-templates select="(@type, @type-ref)[1]"/>
             </xsl:for-each>
-            <xsl:text>) as {(@return-type, 'item()*')[1]}</xsl:text>
+            <xsl:text>) as </xsl:text>
+            <xsl:apply-templates select="(@return-type, @return-type-ref)[1]"/>
          </test>
          <result>
             <assert-true/>
          </result>
       </test-case>
+   </xsl:template>
+   
+   <xsl:template match="@type | @return-type">
+      <xsl:text>{.}</xsl:text>
+   </xsl:template>
+   
+   <xsl:template match="@type-ref | @return-type-ref">
+      <xsl:variable name="type" select="key('type-ref', .)"/>
+      <xsl:apply-templates select="$type/*"/>
+   </xsl:template>
+   
+   <xsl:template match="type/record">
+      <xsl:text>record(</xsl:text>
+      <xsl:for-each select="field">
+         <xsl:if test="position() ne 1">, </xsl:if>
+         <xsl:apply-templates select="."/>
+      </xsl:for-each>
+      <xsl:if test="xs:boolean(@extensible)">, *</xsl:if>
+      <xsl:text>)</xsl:text>
+   </xsl:template>
+   
+   <xsl:template match="field">
+      <xsl:text>{@name}{if (xs:boolean(@required)) then "" else "?"} as {@type}</xsl:text>
    </xsl:template>
    
  


### PR DESCRIPTION
This PR addresses issue #1461 in a fairly narrow way, without attempting to tackle the deeper problem identified in issue #1336.

This involves expanding the `fos:type` entries for types such as `uri-structure-record` that are referenced in function signatures, resulting in some duplication with the `fos:record-description` entries that describe the same types in a different place.: hopefully the resolution to #1336 will resolve that duplication.