### PR TITLE
Modest editorial corrections to XSLT specs through 2.7

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -133,17 +133,7 @@
          <p>This specification defines the syntax and semantics of XSLT 4.0, a language designed
                primarily for transforming XML documents into other XML documents.</p>
          <p>XSLT 4.0 is a revised version of the XSLT 3.0 Recommendation <bibref ref="xslt-30"/>
-            published on 8 June 2017.</p>
-         <p>The changes in this version of the language are relatively minor usability enhancements. There
-         are no changes to the data model or processing model. Instead, the specification attempts to fill
-         a number of gaps in functionality resulting from feedback from XSLT 3.0 users. The main areas
-         covered are:</p>
-         <ulist>
-            <item><p>Enhancements to the type system to allow more expressive constraints, especially
-            for maps and atomic items.</p></item>
-            <item><p>Additional functionality for processing arrays.</p></item>
-            <item><p>Exploitation of the power afforded by first-class function items.</p></item>
-         </ulist>
+            published on 8 June 2017. Changes are presented in <specref ref="whats-new-in-xslt4"/>. </p>
          <p>XSLT 4.0 is designed to be used in conjunction with XPath 4.0, which is defined in
                <bibref ref="xpath-40"/>. XSLT shares the same data model as XPath 4.0, which is
             defined in <bibref ref="xpath-datamodel-30"/>, and it uses the library of functions and
@@ -189,13 +179,13 @@
                (see <bibref ref="xsl11"/>), or into another presentation-oriented format such as
                HTML, XHTML, or SVG. However, XSLT is used for a wide range of transformation tasks,
                not exclusively for formatting and presentation applications.</p>
-            <p>A transformation expressed in XSLT describes rules for transforming  input data into output data. The inputs and outputs
+            <p>A transformation expressed in XSLT describes rules for transforming input data into output data. The inputs and outputs
                   will all be instances of the XDM data model, described in <bibref ref="xpath-datamodel-30"/>. In the simplest and most common case, the input is
-                  an XML document referred to as the source tree, and the output is an XML document
-                  referred to as the result tree. It is also possible to process multiple source
+                  an XML document referred to as the source document or <termref def="dt-source-tree">source tree</termref>, and the output is an XML document
+                  referred to as the <termref def="dt-result-tree">result tree</termref>. It is also possible to process multiple source
                   documents, to generate multiple result documents, and to handle formats other than
-                  XML.
-                The transformation is achieved by a set of
+                  XML.</p>
+            <p>The transformation is achieved by a set of
                   <termref def="dt-template-rule">template rules</termref>. A template rule
                associates a <termref def="dt-pattern">pattern</termref>, which typically matches nodes in the source document, with a
                   <termref def="dt-sequence-constructor">sequence constructor</termref>. In many
@@ -203,12 +193,13 @@
                which can be used to produce part of a result tree. The structure of the result trees
                can be completely different from the structure of the source trees. In constructing a
                result tree, nodes from the source trees can be filtered and reordered, and arbitrary
-               structure can be added. This mechanism allows a <termref def="dt-stylesheet">stylesheet</termref> to be applicable to a wide class of documents that have
-               similar source tree structures.</p>
+               structure can be added. Because <termref def="dt-pattern">pattern</termref>s can
+               point to nodes according to typological features, a <termref def="dt-stylesheet">stylesheet</termref> 
+               can be applicable to a wide class of source documents that have similar tree structures.</p>
 
 
 
-            <p>Stylesheets have a modular structure; they may contain several packages developed
+            <p>Stylesheets are modular; they may contain several packages developed
                independently of each other, and each package may consist of several stylesheet
                modules. </p>
 
@@ -291,7 +282,8 @@
                   and namespaces.</termdef>
             </p>
                <note>
-                  <p>The use of the term <term>tree</term> in this document does not imply the use
+                  <p>The use of the term <term>tree</term> in this document in phrases such as <term>source
+                     tree</term>, <term>result tree</term>, and <term>temporary tree</term> does not imply the use
                      of a data structure in memory that holds the entire contents of the document at
                      one time. It implies rather a logical view of the XML input and output in which
                      elements have a hierarchic relationship to each other. When a source document
@@ -358,14 +350,15 @@
                      tree</term> means any tree that is neither a <termref def="dt-source-tree">source tree</termref> nor a <termref def="dt-final-result-tree">final result
                      tree</termref>.</termdef> Temporary trees are used to hold intermediate results
                during the execution of the transformation.</p>
-            <p>The use of the term “tree” in phrases such as <term>source
+            <!-- Duplicates the note just above. -->
+            <p><!--The use of the term “tree” in phrases such as <term>source
                   tree</term>, <term>result tree</term>, and <term>temporary tree</term> is not
                confined to documents that the processor materializes in memory in their entirety.
                The processor <rfc2119>may</rfc2119>, and in some cases <rfc2119>must</rfc2119>, use
                streaming techniques to limit the amount of memory used to hold source and result
                documents. When streaming is used, the nodes of the tree may never all be in memory
                at the same time, but at an abstract level the information is still modeled as a tree
-               of nodes, and the document is therefore still described as a tree. Unless otherwise stated, the term “tree” refers to a tree rooted
+               of nodes, and the document is therefore still described as a tree. -->Unless otherwise stated, the term “tree” refers to a tree rooted
                   at a parentless node: that is, the term does not include subtrees of larger trees.
                   Every node therefore belongs to exactly one tree.</p>
             <p>In this specification the phrases <rfc2119>must</rfc2119>, <rfc2119>must
@@ -464,9 +457,11 @@
                         expression: in the case of XSLT it typically means either a <termref def="dt-stylesheet-function"/>,
                         or a built-in function such as those defined in <bibref ref="xpath-functions-40"/></termdef>
                   </p>
+               </item>
+               <item>
                   <p>
                      <termdef id="dt-arity-range" term="arity range">A <termref def="dt-function-definition"/>
-                        has an <term>arity range</term> which defines the minimum and maximum number of arguments
+                        has an <term>arity range</term>, which defines the minimum and maximum number of arguments
                         that must be supplied in a call to the function. The static context can contain multiple
                         <termref def="dt-function-definition">function definitions</termref> with the same name, 
                         provided that their <term>arity ranges</term> do not overlap.</termdef>
@@ -533,13 +528,13 @@
                      <gitem>
                         <label><code>string</code></label>
                         <def>
-                           <p>Any string</p>
+                           <p>Any string.</p>
                         </def>
                      </gitem>
                      <gitem>
                         <label><code>expression</code></label>
                         <def>
-                           <p>An XPath <termref def="dt-expression">expression</termref></p>
+                           <p>An XPath <termref def="dt-expression">expression</termref>.</p>
                         </def>
                      </gitem>
                      <gitem>
@@ -567,27 +562,27 @@
                         <label><code>uri; uris</code></label>
                         <def>
                            <p>A URI, for example a namespace URI or a collation URI; a
-                              whitespace-separated list of URIs</p>
+                              whitespace-separated list of URIs.</p>
                         </def>
                      </gitem>
                      <gitem>
                         <label><code>qname</code></label>
                         <def>
                            <p>A <termref def="dt-lexical-qname">lexical QName</termref> as defined
-                              in <specref ref="qname"/></p>
+                              in <specref ref="qname"/>.</p>
                         </def>
                      </gitem>
                      <gitem>
                         <label><code>eqname; eqnames</code></label>
                         <def>
-                           <p>An <termref def="dt-eqname">EQName</termref> as defined in <specref ref="qname"/>; a whitespace-separated list of EQNames</p>
+                           <p>An <termref def="dt-eqname">EQName</termref> as defined in <specref ref="qname"/>; a whitespace-separated list of EQNames.</p>
                         </def>
                      </gitem>
                      <gitem>
                         <label><code>token; tokens</code></label>
                         <def>
                            <p>A string containing no significant whitespace; a whitespace-separated
-                              list of such strings</p>
+                              list of such strings.</p>
                         </def>
                      </gitem>
                      <gitem>
@@ -601,7 +596,7 @@
                      <gitem>
                         <label><code>char</code></label>
                         <def>
-                           <p>A string comprising a single Unicode character</p>
+                           <p>A string comprising a single Unicode character.</p>
                         </def>
                      </gitem>
                      <gitem diff="add" at="2023-04-18">
@@ -613,22 +608,22 @@
                      <gitem>
                         <label><code>integer</code></label>
                         <def>
-                           <p>An integer, that is a string <phrase diff="chg" at="2022-11-01">that is castable to</phrase> the schema type
-                                 <code>xs:integer</code></p>
+                           <p>An integer, that is, a string <phrase diff="chg" at="2022-11-01">that is castable to</phrase> the schema type
+                                 <code>xs:integer</code>.</p>
                         </def>
                      </gitem>
                      <gitem>
                         <label><code>decimal</code></label>
                         <def>
-                           <p>A decimal value, that is a string <phrase diff="chg" at="2022-11-01">that is castable to</phrase> the schema
-                              type <code>xs:decimal</code></p>
+                           <p>A decimal value, that is, a string <phrase diff="chg" at="2022-11-01">that is castable to</phrase> the schema
+                              type <code>xs:decimal</code>.</p>
                         </def>
                      </gitem>
                      <gitem>
-                        <label><code>ncname;</code> <phrase diff="add" at="2022-01-01"><code>ncnames</code></phrase></label>
+                        <label><code>ncname</code>; <phrase diff="add" at="2022-01-01"><code>ncnames</code></phrase></label>
                         <def>
                            <p>An unprefixed name: a string <phrase diff="chg" at="2022-11-01">that is castable to</phrase> the schema type
-                                 <code>xs:NCName</code>; <phrase diff="add" at="2022-01-01">a whitespace-separated list of such strings</phrase></p>
+                                 <code>xs:NCName</code>; <phrase diff="add" at="2022-01-01">a whitespace-separated list of such strings</phrase>.</p>
                         </def>
                      </gitem>
                      <gitem>
@@ -643,7 +638,7 @@
                         <label><code>id</code></label>
                         <def>
                            <p>An <code>xs:NCName</code> used as a unique identifier for an element
-                              in the containing XML document</p>
+                              in the containing XML document.</p>
                         </def>
                      </gitem>
                   </glist>
@@ -668,14 +663,14 @@
                   is applicable; if an attribute is not permitted to appear in the particular context,
                   then its default value should be ignored. (For example, the <code>stable</code>
                      attribute of <elcode>xsl:sort</elcode> is shown as having a default value
-                     of <code>'yes'</code>, but the attribute is only allowed to appear on the
+                     of <code>'yes'</code>, but the attribute is allowed only on the
                      first of a sequence of adjacent <elcode>xsl:sort</elcode> elements.) 
                      The quotation marks around a default value are not part of the value.</p>
                </item>
                <item>
                   <p>Unless the element is <rfc2119>required</rfc2119> to be empty, the model
                      element contains a comment specifying the allowed content. The allowed content
-                     is specified in a similar way to an element type declaration in XML;
+                     is specified in a way similar to an element type declaration in XML;
                         <emph>sequence constructor</emph> means that any mixture of text nodes,
                         <termref def="dt-literal-result-element">literal result elements</termref>,
                         <termref def="dt-extension-instruction">extension instructions</termref>,
@@ -686,7 +681,7 @@
                <item>
                   <p>The element is prefaced by comments indicating if it belongs to the
                         <code>instruction</code> category or <code>declaration</code> category or
-                     both. The category of an element only affects whether it is allowed in the
+                     both. The category of an element affects only whether it is allowed in the
                      content of elements that allow a <termref def="dt-sequence-constructor">sequence constructor</termref> or <emph>other-declarations</emph>.</p>
                </item>
             </ulist>
@@ -738,7 +733,8 @@
                         the value can be defined as an <termref def="dt-attribute-value-template">attribute value template</termref>, allowing a value such as
                            <code>validation="{ $val }"</code>, where the <termref def="dt-variable">variable</termref>
                         <code>val</code> is evaluated to yield <code>"strict"</code> or
-                           <code>"lax"</code> at run-time.</p>
+                        <code>"lax"</code> at run-time. The value <code>strict</code> in tortoise-shell
+                        brackets indicates the default value, if the attribute is not present.</p>
                   </item>
                </olist>
                <p>The content of an <code>xsl:example-element</code> instruction is defined to be a
@@ -834,8 +830,8 @@
                and dynamic evaluation. Static analysis consists of those tasks that can be performed
                by inspection of the stylesheet alone, including the
                   binding of <termref def="dt-static-variable">static variables</termref>,
-               the evaluation of <code>[xsl:]use-when</code> expressions (see <specref ref="conditional-inclusion"/>), and shadow attributes
-                  (see <specref ref="shadow-attributes"/>) and detection of <termref def="dt-static-error">static errors</termref>. Dynamic evaluation consists of
+               the evaluation of <code>[xsl:]use-when</code> expressions (see <specref ref="conditional-inclusion"/>) and shadow attributes
+                  (see <specref ref="shadow-attributes"/>), and the detection of <termref def="dt-static-error">static errors</termref>. Dynamic evaluation consists of
                tasks which in general cannot be carried out until a source document is
                available.</p>
             <p>Dynamic evaluation is further divided into two activities:
@@ -945,8 +941,8 @@
                   </item>
                   <item>
                      <p>
-                        <termdef id="dt-global-context-item" term="global context item">An item that acts as the <term>global
-                                 context item</term> for the transformation. This item acts
+                        <termdef id="dt-global-context-item" term="global context item">An item that is the <term>global
+                                 context item</term> for the transformation acts
                            as the <termref def="dt-context-item"/> when evaluating
                             the <code>select</code> expression or <termref def="dt-sequence-constructor"/> of a
                                  <termref def="dt-global-variable"/> <phrase diff="chg" at="2022-01-01">whose declaration is</phrase>
@@ -1022,9 +1018,9 @@
                      <note>
                         <p>For maximum reusability of code, it is best to avoid use of the context
                            item when initializing global variables and parameters. Instead, all
-                           external information should be supplied using named <termref def="dt-stylesheet-parameter">stylesheet parameters</termref>.
-                           Especially when these use namespaces to avoid conflicts, there is then no
-                           risk of confusion between the information supplied externally to
+                           external information should be supplied using named <termref def="dt-stylesheet-parameter">stylesheet parameters</termref>,
+                           ideally with namespaces, to avoid confusion and conflicts
+                           in the information supplied externally to
                            different packages.</p>
                         <p>When a stylesheet parameter is defined in a library package, it is
                            possible for a using package to supply a value for the parameter by
@@ -1248,8 +1244,8 @@
                   <p>A <termref def="dt-stylesheet">stylesheet</termref> can process further source
                      documents in addition to those supplied when the transformation is invoked.
                      These additional documents can be loaded using the functions
-                        <function>document</function> (see <specref ref="func-document"/>) or
-                        <xfunction>doc</xfunction> or <xfunction>collection</xfunction> (see <bibref ref="xpath-functions-40"/>), or using the
+                        <function>document</function> (see <specref ref="func-document"/>); or
+                     <xfunction>doc</xfunction>, <xfunction>unparsed-text</xfunction>, <xfunction>unparsed-text-lines</xfunction>, or <xfunction>collection</xfunction> (see <bibref ref="xpath-functions-40"/>); or using the
                            <elcode>xsl:source-document</elcode> instruction; alternatively, they can
                      be supplied as <termref def="dt-stylesheet-parameter">stylesheet
                         parameters</termref> (see <specref ref="global-variables"/>), or returned as
@@ -1464,7 +1460,7 @@
                   representation such as the W3C Document Object Model (DOM) (see <bibref ref="DOM-Level-2-Core"/>),
                      adapted to the data structures offered by the programming language in which the API is defined.
                   To deliver a raw result, processors need to define a representation not only of XDM nodes but
-                  also of sequences, atomic items, maps and even functions. As with the return of a simple tree, 
+                  also of sequences, atomic items, maps, arrays, and even functions. As with the return of a simple tree, 
                   this may involve a trade-off between strict fidelity to the XDM data model and usability in the particular 
                   programming language environment. It is <emph>not</emph> a requirement that an API should return results 
                      in a way that exposes every property of the XDM data model; for example there may be APIs that do not expose
@@ -1765,7 +1761,7 @@
    &lt;h1&gt;{.}&lt;/h1&gt;
  &lt;/xsl:template&gt;
  
- &lt;xsl:template match="PERSONA[count(tokenize(., ',') = 2]"&gt;
+ &lt;xsl:template match="PERSONA[count(tokenize(., ',')) = 2]"&gt;
    &lt;p&gt;&lt;b&gt;{substring-before(., ',')}&lt;/b&gt;: {substring-after(., ',')}&lt;/p&gt;
  &lt;/xsl:template&gt; 
 
@@ -1795,9 +1791,10 @@
                   <item><p>The template rule for the <code>TITLE</code> element outputs an <code>h1</code> element
                   to the HTML result document, and populates this with the value of <code>.</code>, the context item. That is,
                   it copies the text content of the <code>TITLE</code> element to the output <code>h1</code> element.</p></item>
-                  <item><p>The last two rules match <code>PERSONA</code> element. The first rule matches <code>PERSONA</code>
+                  <item><p>The last two rules match <code>PERSONA</code> elements. The first rule matches <code>PERSONA</code>
                   elements whose text content contains exactly one comma; the second rule matches all <code>PERSONA</code> elements,
-                     but it has lower priority than the first rule, so in practice it only applies to <code>PERSONA</code>
+                     but it has lower priority than the first rule (see <specref ref="default-priority"/>), so in practice it 
+                     applies only to <code>PERSONA</code>
                   elements that contain no comma or multiple commas.</p>
                   <p>For both rules the body of the rule is a sequence constructor containing a single literal result element,
                   the <code>p</code> element. These literal result elements contain


### PR DESCRIPTION
* Two largish sections had duplicate prose nearby;
* Some punctuation rendered consistently;
* Some substantive insertions/edits for clarification, when it seemed clear to me.

Let me know if any of these changes are misfires.