### PR TITLE
1474 xml-to-json: ensure numbers are JSON conformant

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24542,27 +24542,6 @@ return json-to-xml($json, $options)]]></eg>
                   </fos:value>
                </fos:values>
             </fos:option>
-            <!--<fos:option key="number-formatter" diff="add" at="A">
-               <fos:meaning>Determines how numeric values should be formatted.</fos:meaning>
-               <fos:type>(fn(xs:string) as xs:string)?</fos:type>
-               <fos:default>()</fos:default>
-               <fos:values>
-                     <fos:value value="User-supplied function">
-                        The supplied function is called to process the string value of all <code>fn:number</code>
-                        elements in the input. For example, setting the value to <code>fn:identity#1</code>
-                        causes the value to be output unchanged. There is no requirement that the result should
-                        be valid JSON.
-                     </fos:value>
-                     <fos:value value="()">
-                        If no function is supplied, numbers are formatted by converting the string value of
-                        the <code>fn:number</code> element to an <code>xs:double</code>, and then converting
-                        the result to a string using the casting rules. Note that this will result in exponential
-                        notation being used for values outside the range
-                        <code>1e-6</code> to <code>1e+6</code>. A dynamic error occurs for values
-                        such as infinity and <code>NaN</code> where the resulting JSON would be invalid.
-                     </fos:value>
-               </fos:values>
-            </fos:option>-->
          </fos:options>
 
  
@@ -24658,10 +24637,19 @@ return json-to-xml($json, $options)]]></eg>
             </item>
             <item diff="chg" at="A">
                <p>An element <code>$E</code> named <code>number</code> is processed by copying the string
-                  value of <code>$E</code> to the output, removing any redundant leading zero digits to ensure
-                  that the result is a valid JSON number.</p>
+                  value of <code>$E</code> to the output, making any changes that are necessary to ensure
+                  that the result is a valid JSON number. Such changes include:</p>
+               
+                  <ulist>
+                     <item><p>Removing leading and trailing whitespace.</p></item>
+                     <item><p>Removing a leading plus sign.</p></item>
+                     <item><p>Removing redundant leading zero digits.</p></item>
+                     <item><p>Adding a zero digit before or after a decimal point that is not preceded and
+                        followed by a digit.</p></item>
+                  </ulist>
                
                <note>
+                  <p>The output uses exponential notation if and only if the input uses exponential notation.</p>
                   <p>The rules have changed since version 3.1 of this specification. In previous versions, the supplied
                      number was cast to an <code>xs:double</code>, and then serialized using the rules of the 
                      <code>fn:string</code> function. This resulted in JSON numbers using exponential notation
@@ -24815,9 +24803,9 @@ return json-to-xml($json, $options)]]></eg>
       </fos:examples>
       <fos:changes>
          <fos:change issue="1347" PR="1353"><p>An option has been added to suppress the escaping 
-            of the solidus (forwards slash) character</p></fos:change>
-         <fos:change issue="1445" PR="1455"><p>Numbers now retain their original lexical form, except that
-         any redundant leading zeroes are stripped to satisfy JSON syntax rules.</p></fos:change>
+            of the solidus (forwards slash) character.</p></fos:change>
+         <fos:change issue="1445" PR="1455"><p>Numbers now retain their original lexical form, except for
+         any changes needed to satisfy JSON syntax rules (for example, stripping leading zero digits).</p></fos:change>
       </fos:changes>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -12017,9 +12017,14 @@ ISBN 0 521 77752 6.</bibl>
 	              are now defined in terms of two functions (for each data type): <code role="example">op:XX-equal</code>,
 	              and <code role="example">op:XX-less-than</code>. The entries for <code role="example">op:XX-greater-than</code>
 	           have therefore been removed.</p></item>
-	           <item><p>The names of arguments appearing in function signatures have been changed. This
+	           <item><p>The names of parameters appearing in function signatures have been changed. This
 	           is to reflect the introduction of keyword arguments in XPath 4.0; the names chosen
-	           for arguments are now more consistent across the function library.</p></item>
+	           for parameters are now more consistent across the function library.</p>
+	           
+	           <p>In 3.1 and earlier versions, the keywords used in the specification were for documentation
+	           purposes only, so these changes do not affect backwards compatibility.</p>
+	           
+	           </item>
 	           <item><p>Where appropriate, the phrase "the value of <code>$x</code>" has been replaced
 	           by the simpler <code>$x</code>. No change in meaning is intended.</p></item>
 	           <item><p>For functions that take a variable number of arguments, wherever possible
@@ -12087,6 +12092,13 @@ ISBN 0 521 77752 6.</bibl>
                  comments and processing instructions, so the elements <code><![CDATA[<a>abc<!--note1-->def</code>]]></code>
                  and <code><![CDATA[<a>abcde<!--note2-->f</code>]]></code> were considered non-equal. In version 4.0, 
                  the text nodes are now merged prior to comparison, so these two elements compare equal.</p>
+           </item>
+           <item diff="add" at="2024-10-01">
+              <p>The format of numeric values in the output of <code>fn:xml-to-json</code> may be different. 
+                 In version 3.1, the supplied value was parsed as an <code>xs:double</code> and then serialized
+                 using the casting rules, resulting in an input value of 10000000 being output as <code>1e7</code>.
+                 In version 4.0, the value is output <emph>as is</emph>, except for any changes (such as stripping
+                 of leading zeroes or a leading plus sign) that might be needed to ensure the result is valid JSON.</p>
            </item>
            <item diff="add" at="2023-03-06">
               <p>In version 4.0, the function signature of <code>fn:namespace-uri-for-prefix</code> constrains the


### PR DESCRIPTION
Fix #1474

Describes the changes that might be needed to supplied numbers to ensure the output conforms with JSON syntax.

Independently, adds a note to appendix to G.4 to affirm that changes to argument keywords have no backwards compatibility implication, satisfying action  QT4CG-091-01