### PR TITLE
1468 Revise the xsl:array instruction

### DIFF
--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1687,7 +1687,15 @@
       <e:attribute name="select" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="use" required="no" default=".">
+      <e:model name="sequence-constructor"/>
+      <e:allowed-parents>
+         <e:parent-category name="sequence-constructor"/>
+      </e:allowed-parents>
+   </e:element-syntax>
+   
+   <e:element-syntax name="array-member">
+      <e:in-category name="instruction"/>
+      <e:attribute name="select" required="no">
          <e:data-type name="expression"/>
       </e:attribute>
       <e:model name="sequence-constructor"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -1655,6 +1655,7 @@
                </item>
                <item>
                   <p>instructions that construct maps and arrays: <elcode>xsl:array</elcode>,
+                     <elcode>xsl:array-member</elcode>,
                      <elcode>xsl:map</elcode>, <elcode>xsl:map-entry</elcode>;</p>
                </item>
                <item>
@@ -21844,7 +21845,8 @@ and <code>version="1.0"</code> otherwise.</p>
                   <p>For the elements <elcode>xsl:sequence</elcode>, <elcode>xsl:on-empty</elcode>,
                      <elcode>xsl:on-non-empty</elcode>, <elcode>xsl:when</elcode>,
                      <elcode>xsl:otherwise</elcode>, <elcode>xsl:matching-substring</elcode>,
-                     and <elcode>xsl:non-matching-substring</elcode>,
+                     <elcode>xsl:non-matching-substring</elcode>, <elcode>xsl:array</elcode>,
+                     and <elcode>xsl:array-member</elcode>,
                      it is a <termref def="dt-static-error">static error</termref> if the
                         <code>select</code> attribute is present
                      and the instruction has children other than <elcode>xsl:fallback</elcode>.</p>
@@ -35909,76 +35911,75 @@ return ($m?price - $m?discount)</eg>
             
             <p>If the <elcode>xsl:array</elcode> instruction has a <code>select</code> attribute then
             the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
-            (which an XSLT 4.0 processor ignores).</p>
+            (which an XSLT 4.0 processor ignores) <errorref spec="XT" class="SE" code="3185"/>.</p>
             
             <p>If the <elcode>xsl:array-member</elcode> instruction has a <code>select</code> attribute then
             the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
-            (which an XSLT 4.0 processor ignores).</p>
+            (which an XSLT 4.0 processor ignores) <errorref spec="XT" class="SE" code="3185"/>.</p>
             
             <p>The content of the array is constructed by the following steps:</p>
             
             <olist>
-               <item><p>The expression in the <code>select</code> attribute, or the contained 
-               <termref def="dt-sequence-constructor"/>, is evaluated. Call the result <var>S</var>.</p></item>
-               <item><p>The value of <var>S</var> must be one of the following:</p>
+               <item><p>The expression in the <code>select</code> attribute of the <elcode>xsl:array</elcode> 
+                  instruction, or its contained 
+               <termref def="dt-sequence-constructor"/>, is evaluated. Call the result <code>$seq</code>.</p></item>
+               <item><p>The value of <code>$seq</code> must be one of the following:</p>
                
                <olist>
-                  <item><p>An empty sequence. In this case the result is an empty array.</p></item>
+                  <item><p>An empty sequence. In this case the result of the <elcode>xsl:array</elcode>
+                     instruction is an empty array.</p></item>
                   <item><p>A sequence of one or more atomic items, that is, an instance of
-                  <code>xs:anyAtomicValue+</code>. In this case the result is the value of the
-                  expression <code>array{<var>S</var>}</code>: namely, an array whose members
+                  <code>xs:anyAtomicType+</code>. In this case the result of the instruction is the value of the
+                  expression <code>array{$seq}</code>: namely, an array whose members
                   are all single atomic items.</p></item>
                   <item><p>A sequence of one or more nodes, that is, an instance of
                   <code>node()+</code>. In this case the result is the value of the
-                  expression <code>array{<var>S</var>}</code>: namely, an array whose members
+                  expression <code>array{$seq}</code>: namely, an array whose members
                   are all single nodes.</p></item>
+                  <item><p>A sequence of one or more <term>value records</term>, or more specifically, an instance of
+                  <code>record(value as item()*, *)+</code>. In this case the result is the value of the
+                  expression <code>array:build($seq, fn{?value})</code>. Value records
+                  can be conveniently constructed using the <elcode>array:member</elcode>
+                  instruction, or using the function <xfunction>array:members</xfunction> applied
+                  to an existing array.</p></item>
                   <item><p>A sequence of one or more arrays, that is, an instance of
                   <code>array(*)+</code>. In this case the result is obtained by converting the sequence
                      of arrays to an array of sequences: specifically, the result is the value of the
-                  expression <code>array:build{<var>S</var>, fn{?*}}</code>.</p></item>
-                  <item><p>A sequence of one or more <term>value records</term>, that is, an instance of
-                  <code>record(value as item()*)+</code>. In this case the result is the value of the
-                  expression <code>array:build(<var>S</var>, fn{?value})</code>. Value records
-                  can be conveniently constructed using the <elcode>array:member</elcode>
-                  instruction, or using the function <xfunction>array:members</xfunction>. applied
-                  to an existing array.</p></item>
+                  expression <code>array:build($seq, fn{?*})</code>.</p></item>
                </olist>
                </item>
             </olist>
             
+            <p>
+                     <error spec="XT" type="type" class="TE" code="4045">
+                        <p>A <termref def="dt-type-error">type error</termref> is raised if the
+                           result of evaluating the <code>select</code> expression or contained
+                           <termref def="dt-sequence-constructor"/> of an <elcode>xsl:array</elcode>
+                           instruction is not an instance of one of the following sequence types:
+                           <code>empty-sequence()</code>, <code>xs:anyAtomicType+</code>, <code>node()+</code>,
+                           <code>record(value as item()*, *)+</code>, or <code>array(*)+</code>. As
+                           with other type errors, the error <rfc2119>may</rfc2119> be raised
+                           statically if it can be detected statically. </p>
+                     </error>
+                  </p>
+            
             <p>The <elcode>array:member</elcode> instruction evaluates the expression in its 
                <code>select</code> attribute, or its contained <termref def="dt-sequence-constructor"/>, to
-            produce a value <var>V</var>, and then returns the result of the expression <code>{value: <var>V</var>}</code>.
-            That is, it returns a value record that wraps the value <var>V</var>, constructing an item that is
+            produce a value <code>$val</code>, and then returns the result of the expression <code>{value: $val}</code>.
+            That is, it returns a value record that wraps the value <code>$val</code>, thereby constructing an item that is
             suitable for input to the <elcode>xsl:array</elcode> instruction.</p>
             
-            <!--<p diff="chg" at="2023-03-22">If the <code>use</code> attribute is omitted, the resulting
-            array has one singleton member for each item returned by the <code>select</code> attribute or
-            sequence constructor. For example <code>&lt;xsl:array select="1 to 5"/></code> returns
-            an array with five members: <code>[ 1, 2, 3, 4, 5 ]</code>.</p>
-            <p diff="chg" at="2023-03-22">If the <code>use</code> attribute is present then it is evaluated
-               once for each item in the sequence returned by the <code>select</code> attribute or
-               sequence constructor, with a <termref def="dt-singleton-focus"/> based on that item,
-               to produce the value of the corresponding array member.</p>
-            <p diff="chg" at="2023-03-22">For example, <code>&lt;xsl:array select="'red', 'green', 'blue'" use="characters(.)"/></code>
-               returns an array with three members: <code>[ ("r", "e", "d"), ("g", "r", "e", "e", "n"), ("b", "l", "u", "e") ]</code>.</p>
-            <p diff="chg" at="2023-03-22">A useful convention is to construct each array member as a <term>value record</term>
-               (a singleton map whose single entry has the key <code>"value"</code>): 
-               <code>&lt;xsl:array select="map:entry('value', 1 to 3), map:entry('value': 8 to 10)" use="?value"/></code>
-            returns an array with two members: <code>[ (1, 2, 3), (8, 9, 10) ]</code>. This is essentially equivalent to
-            the effect of the <function>array:of-members</function> function.</p>
-            <p>The <code>select</code> attribute and the contained sequence constructor are mutually
-            exclusive: if the <code>select</code> attribute is present, then the only permitted child
-            element is <elcode>xsl:fallback</elcode>.</p>
-            <p diff="del" at="2023-03-22">For convenience and readability, the instruction <code>xsl:array-member</code>
-            can be used to construct a zero-arity function suitable for use with <elcode>xsl:array</elcode>.</p>-->
-            
+            <note><p>Although <elcode>array:member</elcode> is designed primarily for use in conjunction
+            with <elcode>xsl:array</elcode>, it is not an error to use it outside this context. In principle
+            it could be used for purposes that have nothing to do with array construction.</p></note>
             
             
             <example>
                <head>Constructing an array whose members are single items</head>
                <p>The following example constructs the array <code>[1, 2, 3, 4, 5</code>:</p>
                <eg><![CDATA[<xsl:array select="1 to 5"/>]]></eg>
+               <p>The following example constructs an array of text nodes:</p>
+               <eg><![CDATA[<xsl:array select=".//text()"/>]]></eg>
                <p>The following example constructs an array by tokenizing a string:</p>
                <eg><![CDATA[<xsl:array select="tokenize('The cat sat on the mat')"/>]]></eg>
                <p>The result is the array <code>[ "The", "cat", "sat", "on", "the", "mat" ]</code>.</p>
@@ -36005,39 +36006,19 @@ return ($m?price - $m?discount)</eg>
                <p>The following example delivers the same result in a different way:</p>
                <eg><![CDATA[<xsl:array>
    <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
-     <xsl:sequence select="array{current-group#0}"/>
+     <xsl:sequence select="array{current-group()}"/>
    </xsl:for-each-group>
 </xsl:array>]]></eg>
-               <p>In this approach, the member sequence is captured in an array, and the <elcode>xsl:array</elcode>
+               <p>In this approach, the member sequence is captured in an array using the XPath 
+                  <code>array{}</code> constructor, and the <elcode>xsl:array</elcode>
                   instruction converts the sequence of arrays to an array of sequences.
                </p>
-               <note><p>TODO: this example only works if we fix issue #407. Without that fix, calling <code>current-group#0</code> 
-                  raises XTDE1061.</p></note>
                         
-            </example>
-            <example>
-               <head>Constructing an array based on an existing array</head>
-               <p>The <elcode>xsl:array</elcode> instruction can be used in conjunction with
-               the <xfunction>array:members</xfunction> function to construct an array from the members
-               of an existing array. For example, the following code combines two arrays and sorts the result:</p>
-               <eg><![CDATA[<xsl:array>
-   <xsl:perform-sort select="array:members($input-1), array:members($input-2)">
-      <xsl:sort select="count(?value)"/>
-   </xsl:perform-sort>
-</xsl:array>]]></eg>
-               <p>The following code inverts a nested array (such as <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]</code>)
-               so the result is organized by columns rather than rows (<code>[ [ 1, 4, 7 ], [ 2, 5, 8 ], [ 3, 6, 9 ] ]</code>):</p>
-               <eg><![CDATA[<xsl:array>
-   <xsl:for-each select="1 to array:size($input?1)">
-      <xsl:variable name="index" select="."/>
-      <xsl:array select="array:members($input)?value?($index)"/>
-   </xsl:for-each>
-</xsl:array>]]></eg>
             </example>
             
             <example>
                <head>Constructing nested arrays</head>
-               <p>The <elcode>xsl:array</elcode> instruction can be nested. For example</p>
+               <p>The <elcode>xsl:array</elcode> instruction can be nested. For example:</p>
                <eg><![CDATA[<xsl:array>
    <xsl:for-each select="1 to 4">
       <xsl:array-member>
@@ -36055,8 +36036,98 @@ return ($m?price - $m?discount)</eg>
               
             </example>
             
-            <ednote><edtext>Add error condition when the sequence evaluated by xsl:array is not one of the
-            permitted types.</edtext></ednote>
+            <example>
+               <head>Constructing arrays using template rules</head>
+               <p>The <elcode>xsl:array-member</elcode> instruction does not need to be lexically
+               contained within the <elcode>xsl:array</elcode> instruction. For example, given
+               a book containing chapters which in turn contain sections, the following code
+               produces a nested array representing the (crude) word counts of the sections
+               within each chapter:</p>
+               <eg><![CDATA[<xsl:mode name="word-counts" on-no-match="shallow-skip">   
+    <xsl:template match="book">
+        <xsl:array>
+            <xsl:apply-templates/>
+        </xsl:array>
+    </xsl:template>
+    <xsl:template match="chapter">
+        <xsl:array-member>
+           <xsl:array>
+              <xsl:apply-templates/>
+           </xsl:array>   
+        </xsl:array-member>
+    </xsl:template>
+    <xsl:template match="section">
+        <xsl:array-member select="tokenize(.) => count()"/>
+    </xsl:template>
+</xsl:mode>]]></eg>
+               <p>The result might be an array of the form <code>[[842, 316], [450, 217], ...]</code>
+               indicating that the first section of the second chapter has a word count of 450.</p>
+            </example>
+            <example>
+               <head>Constructing an array based on an existing array</head>
+               <p>The <elcode>xsl:array</elcode> instruction can be used in conjunction with
+               the <xfunction>array:members</xfunction> function to construct an array from the members
+               of an existing array. For example, the following code combines two arrays <code>$A1</code>
+                  and <code>$A2</code>, and sorts the result:</p>
+               <eg><![CDATA[<xsl:array>
+   <xsl:perform-sort select="array:members($A1), array:members($A2)">
+      <xsl:sort select="count(?value)"/>
+   </xsl:perform-sort>
+</xsl:array>]]></eg>
+               <p>The following code inverts a nested array (such as <code>[ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]</code>)
+               so the result is organized by columns rather than rows (<code>[ [ 1, 4, 7 ], [ 2, 5, 8 ], [ 3, 6, 9 ] ]</code>):</p>
+               <eg><![CDATA[<xsl:array>
+   <xsl:for-each select="1 to array:size($input?1)">
+      <xsl:variable name="index" select="."/>
+      <xsl:array select="array:members($input)?value?$index"/>
+   </xsl:for-each>
+</xsl:array>]]></eg>
+            </example>
+            
+            
+            
+            <example>
+               <head>An error case</head>
+               <p>The following code raises an type error because the result of the <code>select</code> 
+               expression is not one of the permitted types:</p>
+               <eg><![CDATA[<xsl:array select="1, 2, 3, [], 4"/>]]></eg>
+               <p>If the intention is to create the array <code>[1, 2, 3, [], 4]</code>, this can be achieved
+               by writing:
+               <eg><![CDATA[<xsl:array select="(1, 2, 3, [], 4) ! map{value:.}"/>]]></eg>
+               </p>
+               <p>Simple cases like this can be readily handled using XPath
+               array constructors, although some users might feel that using <elcode>xsl:sequence</elcode>
+               to construct an array is easily misread:</p>
+               <eg><![CDATA[<xsl:sequence select="[1, 2, 3, [], 4]"/>]]></eg>
+               <p>The following example produces a different and probably unintended effect:</p>
+               <eg><![CDATA[<xsl:array select="[1, 2, 3, [], 4]"/>]]></eg>
+               <p>This results in a single-member array <code>[(1, 2, 3, [], 4)]</code></p>
+               <p>The <elcode>xsl:array</elcode> instruction comes into its own primarily when array
+               members are constructed using nested XSLT instructions.</p>
+               <p>The following code, while a little verbose, has the benefit of clarity:</p>
+               <eg><![CDATA[<xsl:array>
+   <xsl:array-member select="1"/>
+   <xsl:array-member select="2"/>
+   <xsl:array-member select="3"/>
+   <xsl:array-member select="[]"/>
+   <xsl:array-member select="4"/>
+</xsl:array>]]></eg>
+            </example>
+            
+            <note>
+               <p>Although the <elcode>xsl:array</elcode> instruction is highly versatile, following
+               some simple conventions will to keep code easy to read and understand:</p>
+               
+               <ulist>
+                  <item><p>When creating a simple array of atomic items or nodes, use
+                  <elcode>xsl:array</elcode> with a <code>select</code> attribute.</p></item>
+                  <item><p>When creating anything more complex (for example, a nested array
+                  structure, or an array whose contents are heterogeous), use 
+                     <elcode>xsl:array</elcode> with a contained sequence constructor,
+                  and use <elcode>xsl:array-member</elcode> to construct the individual members
+                  of the array.</p></item>
+               </ulist>
+            </note>
             
             
             

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35905,7 +35905,54 @@ return ($m?price - $m?discount)</eg>
             
             <p>The instruction <elcode>xsl:array</elcode> constructs and returns a new array.</p>
             <?element xsl:array?>
-            <p diff="chg" at="2023-03-22">If the <code>use</code> attribute is omitted, the resulting
+            <?element xsl:array-member?>
+            
+            <p>If the <elcode>xsl:array</elcode> instruction has a <code>select</code> attribute then
+            the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
+            (which an XSLT 4.0 processor ignores).</p>
+            
+            <p>If the <elcode>xsl:array-member</elcode> instruction has a <code>select</code> attribute then
+            the sequence constructor must be empty, except for any <elcode>xsl:fallback</elcode> instructions
+            (which an XSLT 4.0 processor ignores).</p>
+            
+            <p>The content of the array is constructed by the following steps:</p>
+            
+            <olist>
+               <item><p>The expression in the <code>select</code> attribute, or the contained 
+               <termref def="dt-sequence-constructor"/>, is evaluated. Call the result <var>S</var>.</p></item>
+               <item><p>The value of <var>S</var> must be one of the following:</p>
+               
+               <olist>
+                  <item><p>An empty sequence. In this case the result is an empty array.</p></item>
+                  <item><p>A sequence of one or more atomic items, that is, an instance of
+                  <code>xs:anyAtomicValue+</code>. In this case the result is the value of the
+                  expression <code>array{<var>S</var>}</code>: namely, an array whose members
+                  are all single atomic items.</p></item>
+                  <item><p>A sequence of one or more nodes, that is, an instance of
+                  <code>node()+</code>. In this case the result is the value of the
+                  expression <code>array{<var>S</var>}</code>: namely, an array whose members
+                  are all single nodes.</p></item>
+                  <item><p>A sequence of one or more arrays, that is, an instance of
+                  <code>array(*)+</code>. In this case the result is obtained by converting the sequence
+                     of arrays to an array of sequences: specifically, the result is the value of the
+                  expression <code>array:build{<var>S</var>, fn{?*}}</code>.</p></item>
+                  <item><p>A sequence of one or more <term>value records</term>, that is, an instance of
+                  <code>record(value as item()*)+</code>. In this case the result is the value of the
+                  expression <code>array:build(<var>S</var>, fn{?value})</code>. Value records
+                  can be conveniently constructed using the <elcode>array:member</elcode>
+                  instruction, or using the function <xfunction>array:members</xfunction>. applied
+                  to an existing array.</p></item>
+               </olist>
+               </item>
+            </olist>
+            
+            <p>The <elcode>array:member</elcode> instruction evaluates the expression in its 
+               <code>select</code> attribute, or its contained <termref def="dt-sequence-constructor"/>, to
+            produce a value <var>V</var>, and then returns the result of the expression <code>{value: <var>V</var>}</code>.
+            That is, it returns a value record that wraps the value <var>V</var>, constructing an item that is
+            suitable for input to the <elcode>xsl:array</elcode> instruction.</p>
+            
+            <!--<p diff="chg" at="2023-03-22">If the <code>use</code> attribute is omitted, the resulting
             array has one singleton member for each item returned by the <code>select</code> attribute or
             sequence constructor. For example <code>&lt;xsl:array select="1 to 5"/></code> returns
             an array with five members: <code>[ 1, 2, 3, 4, 5 ]</code>.</p>
@@ -35924,12 +35971,14 @@ return ($m?price - $m?discount)</eg>
             exclusive: if the <code>select</code> attribute is present, then the only permitted child
             element is <elcode>xsl:fallback</elcode>.</p>
             <p diff="del" at="2023-03-22">For convenience and readability, the instruction <code>xsl:array-member</code>
-            can be used to construct a zero-arity function suitable for use with <elcode>xsl:array</elcode>.</p>
+            can be used to construct a zero-arity function suitable for use with <elcode>xsl:array</elcode>.</p>-->
             
             
             
             <example>
                <head>Constructing an array whose members are single items</head>
+               <p>The following example constructs the array <code>[1, 2, 3, 4, 5</code>:</p>
+               <eg><![CDATA[<xsl:array select="1 to 5"/>]]></eg>
                <p>The following example constructs an array by tokenizing a string:</p>
                <eg><![CDATA[<xsl:array select="tokenize('The cat sat on the mat')"/>]]></eg>
                <p>The result is the array <code>[ "The", "cat", "sat", "on", "the", "mat" ]</code>.</p>
@@ -35945,39 +35994,33 @@ return ($m?price - $m?discount)</eg>
             <example>
                <head>Constructing an array whose members are arbitrary sequences</head>
                <p>The following example constructs an array whose members are sequences:</p>
-               <eg><![CDATA[<xsl:array use="?value">
+               <eg><![CDATA[<xsl:array>
    <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
-     <xsl:map-entry key="'value'" select="current-group()"/>
+     <xsl:array-member select="current-group()"/>
    </xsl:for-each-group>
 </xsl:array>]]></eg>
                <p>The result is the array <code>[ (0, 1, 2, 3), (4, 5, 6, 7), (8, 9, 10, 11), (12, 13, 14, 15), (16, 17, 18, 19) ]</code>.</p>
-               <p>The technique used here is to capture each member sequence in a singleton map (known as a <term>value record</term>)
-               with the conventional key <code>"value"</code>.</p> 
+               <p>The way this works is that each member sequence is captured in a <term>value record</term> by the
+                  <elcode>xsl:array-member</elcode> instruction.</p> 
                <p>The following example delivers the same result in a different way:</p>
-               <eg><![CDATA[<xsl:array use=".()">
+               <eg><![CDATA[<xsl:array>
    <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
-     <xsl:sequence select="current-group#0"/>
+     <xsl:sequence select="array{current-group#0}"/>
    </xsl:for-each-group>
 </xsl:array>]]></eg>
-               <p>In this approach, the member sequence is captured in the value of the zero-arity function
-                  <code>current-group#0</code>, which is then applied using the expression <code>.()</code> 
-                  to yield the actual value.
+               <p>In this approach, the member sequence is captured in an array, and the <elcode>xsl:array</elcode>
+                  instruction converts the sequence of arrays to an array of sequences.
                </p>
                <note><p>TODO: this example only works if we fix issue #407. Without that fix, calling <code>current-group#0</code> 
                   raises XTDE1061.</p></note>
-               <p>A third approach would be to capture the member sequences as arrays:</p>
-               <eg><![CDATA[<xsl:array use="?*">
-   <xsl:for-each-group select="0 to 19" group-adjacent=". idiv 4">
-     <xsl:array select="current-group()"/>
-   </xsl:for-each-group>
-</xsl:array>]]></eg>               
+                        
             </example>
             <example>
                <head>Constructing an array based on an existing array</head>
                <p>The <elcode>xsl:array</elcode> instruction can be used in conjunction with
                the <xfunction>array:members</xfunction> function to construct an array from the members
                of an existing array. For example, the following code combines two arrays and sorts the result:</p>
-               <eg><![CDATA[<xsl:array use="?value">
+               <eg><![CDATA[<xsl:array>
    <xsl:perform-sort select="array:members($input-1), array:members($input-2)">
       <xsl:sort select="count(?value)"/>
    </xsl:perform-sort>
@@ -35992,79 +36035,34 @@ return ($m?price - $m?discount)</eg>
 </xsl:array>]]></eg>
             </example>
             
+            <example>
+               <head>Constructing nested arrays</head>
+               <p>The <elcode>xsl:array</elcode> instruction can be nested. For example</p>
+               <eg><![CDATA[<xsl:array>
+   <xsl:for-each select="1 to 4">
+      <xsl:array-member>
+         <xsl:array select="(.*10 to .*10 + 2)"/>
+      </xsl:array-member>
+   </xsl:for-each>
+</xsl:array>]]></eg>
+               <p>The result is <code>[ [ 10, 11, 12], [ 20, 21, 22 ], [ 30, 31, 32 ], [ 40, 41, 42 ]</code>.</p>
+               <p>The same effect can be achieved by combining XSLT and XPath array construction:</p>
+               <eg><![CDATA[<xsl:array>
+   <xsl:for-each select="1 to 4">
+      <xsl:array-member select="array{.*10 to .*10 + 2}"/>
+   </xsl:for-each>
+</xsl:array>]]></eg>
+              
+            </example>
+            
+            <ednote><edtext>Add error condition when the sequence evaluated by xsl:array is not one of the
+            permitted types.</edtext></ednote>
+            
             
             
          </div2>
          
-         <!--<div2 id="array-iteration">
-            <head>Iterating over the Members of an Array</head>
-            <p>The instruction <elcode>for-each-member</elcode> is available to iterate over the members of an
-            array.</p>
-            <?element xsl:for-each-member?>
          
-            <p>The <code>select</code> attribute is <rfc2119>required</rfc2119>, and its value <rfc2119>must</rfc2119>
-            be a single array item. The contained sequence constructor is evaluated once for each member in the array.</p>
-            <p>If the <code>composite</code> attribute is absent or has the value <code>no</code>, then each member of the array
-               must be a single item. In this case the sequence constructor is evaluated (once for each member) with 
-               the context item being the single item comprising the array member, the context position being the
-               position of the member within the array, and the context size being the number of members in the array.</p>
-            
-            <p>It is a <termref def="dt-type-error"/> [TBA] if the <elcode>xsl:for-each-member</elcode> instruction is evaluated
-            for an array that has a member which is not a singleton item.</p>
-            
-            <p>If the <code>composite</code> attribute is present with the value <code>yes</code>, then the sequence
-               constructor is evaluated (once for each member) with the context item being an anonymous zero-arity 
-               function that wraps the actual
-               value of the array member. The context position is again the
-               position of the member within the array, and the context size is the number of members in the array.</p>
-            
-            <example>
-               <head>Processing an array of singleton items</head>
-               <p>Given an array <code>$in</code> containing <code>[ 1, 5, 6, 10 ]</code> the following example might output the sequence
-               <code>('i', 'v', 'vi', 'x')</code>:</p>
-               <eg><![CDATA[
-<xsl:for-each-member select="$in">
-  <xsl:sequence select="format-integer(., 'i')"/>
-</xsl:for-each-member>  
-]]></eg>
-               <p>To obtain the output as an array, <code>('i', 'v', 'vi', 'x')</code>, the iteration can be combined with
-               array construction:</p>
-               <eg><![CDATA[
-<xsl:array>
-  <xsl:for-each-member select="$in">
-    <xsl:array-item select="format-integer(., 'i')"/>
-  </xsl:for-each-member>
-</xsl:array>  
-]]></eg>
-               
-            </example>
-            <example>
-               <head>Processing an array of sequence-valued items</head>
-               <p>Given an array <code>$in</code> containing <code>[ (1, 2), (), (3, 4, 5) ]</code>, the following example
-               outputs the sum of the integers in each member, that is, <code>(3, 0, 12)</code>.</p>
-               <eg><![CDATA[
-<xsl:for-each-member select="$in" composite="yes">
-  <xsl:sequence select="sum(.())"/>
-</xsl:for-each-member>  
-]]></eg>
-               <p>The sequence constructor is evaluated three times, with the context item being set successively
-               to a function that delivers <code>(1,2)</code>, a function that delivers the empty sequence 
-                  <code>()</code>, and finally a function that delivers the sequence <code>(3,4,5)</code>.</p>
-               <p>Because <elcode>xsl:for-each-member</elcode> represents array members in the same way that
-               <elcode>xsl:array</elcode> expects them, array iteration and array construction can conveniently
-               be combined. The following example copies selected items of an array into a new array:</p>
-               <eg><![CDATA[
-<xsl:variable name="items-to-copy" select="1, 5, 8"/>
-<xsl:array>
-  <xsl:for-each-member select="$in" composite="yes">
-    <xsl:if test="position() = $items-to-copy" then="."/>
-  </xsl:for-each-member>
-</xsl:array>  
-]]></eg>
-            </example>
-            
- 
-         </div2>-->
          
       </div1>
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35939,7 +35939,7 @@ return ($m?price - $m?discount)</eg>
                   <item><p>A sequence of one or more <term>value records</term>, or more specifically, an instance of
                   <code>record(value as item()*, *)+</code>. In this case the result is the value of the
                   expression <code>array:build($seq, fn{?value})</code>. Value records
-                  can be conveniently constructed using the <elcode>array:member</elcode>
+                  can be conveniently constructed using the <elcode>xsl:array-member</elcode>
                   instruction, or using the function <xfunction>array:members</xfunction> applied
                   to an existing array.</p></item>
                   <item><p>A sequence of one or more arrays, that is, an instance of
@@ -35963,20 +35963,20 @@ return ($m?price - $m?discount)</eg>
                      </error>
                   </p>
             
-            <p>The <elcode>array:member</elcode> instruction evaluates the expression in its 
+            <p>The <elcode>xsl:array-member</elcode> instruction evaluates the expression in its 
                <code>select</code> attribute, or its contained <termref def="dt-sequence-constructor"/>, to
             produce a value <code>$val</code>, and then returns the result of the expression <code>{value: $val}</code>.
             That is, it returns a value record that wraps the value <code>$val</code>, thereby constructing an item that is
             suitable for input to the <elcode>xsl:array</elcode> instruction.</p>
             
-            <note><p>Although <elcode>array:member</elcode> is designed primarily for use in conjunction
+            <note><p>Although <elcode>xsl:array-member</elcode> is designed primarily for use in conjunction
             with <elcode>xsl:array</elcode>, it is not an error to use it outside this context. In principle
             it could be used for purposes that have nothing to do with array construction.</p></note>
             
             
             <example>
                <head>Constructing an array whose members are single items</head>
-               <p>The following example constructs the array <code>[1, 2, 3, 4, 5</code>:</p>
+               <p>The following example constructs the array <code>[1, 2, 3, 4, 5]</code>:</p>
                <eg><![CDATA[<xsl:array select="1 to 5"/>]]></eg>
                <p>The following example constructs an array of text nodes:</p>
                <eg><![CDATA[<xsl:array select=".//text()"/>]]></eg>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35965,7 +35965,7 @@ return ($m?price - $m?discount)</eg>
             
             <p>The <elcode>xsl:array-member</elcode> instruction evaluates the expression in its 
                <code>select</code> attribute, or its contained <termref def="dt-sequence-constructor"/>, to
-            produce a value <code>$val</code>, and then returns the result of the expression <code>{value: $val}</code>.
+            produce a value <code>$val</code>, and then returns the result of the expression <code>{"value": $val}</code>.
             That is, it returns a value record that wraps the value <code>$val</code>, thereby constructing an item that is
             suitable for input to the <elcode>xsl:array</elcode> instruction.</p>
             
@@ -36093,7 +36093,7 @@ return ($m?price - $m?discount)</eg>
                <eg><![CDATA[<xsl:array select="1, 2, 3, [], 4"/>]]></eg>
                <p>If the intention is to create the array <code>[1, 2, 3, [], 4]</code>, this can be achieved
                by writing:
-               <eg><![CDATA[<xsl:array select="(1, 2, 3, [], 4) ! map{value:.}"/>]]></eg>
+               <eg><![CDATA[<xsl:array select="(1, 2, 3, [], 4) ! map{'value':.}"/>]]></eg>
                </p>
                <p>Simple cases like this can be readily handled using XPath
                array constructors, although some users might feel that using <elcode>xsl:sequence</elcode>


### PR DESCRIPTION
Attempts an improved (more intuitive) specification for the xsl:array instruction.

Fix #1468