### PR TITLE
1507 Make format-integer spec legible

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -2949,12 +2949,14 @@ format-number(12345, '0,###^0', {
       </fos:rules>
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
 let $alphabet := characters("0123456789abcdefghijklmnopqrstuvwxyz")
-let $preprocessed-value := translate($value, "_ &#x9;&#xa;&#xd;", "")
-let $digits := translate($preprocessed-value, "+-", "")
+let $preprocessed := translate($value, 
+                               codepoints-to-string((9, 10, 13, 32, 95)), 
+                               "")
+let $digits := translate($preprocessed, "+-", "")
 let $abs := sum(
   for $char at $p in reverse(characters(lower-case($digits)))
   return (index-of($alphabet, $char) - 1) * xs:integer(math:pow($radix, $p - 1)))
-return if (starts-with($preprocessed-value, "-")) then -$abs else +$abs                 
+return if (starts-with($preprocessed, "-")) then -$abs else +$abs                 
       </fos:equivalent>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="RG" code="0011"/>


### PR DESCRIPTION
Fix #1507 

Make the "formal spec" of fn:parse-integer legible (and portable between XPath and XQuery) by avoiding use of XML character references in the code.