### PR TITLE
Add to changes metadata

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -2834,7 +2834,7 @@ would raise an error because it has an <code>id</code> child whose value is not 
             <head>Guarded Expressions</head>
             
             <changes>
-               <change>
+               <change issue="71" PR="230" date="2022-11-15">
                   The rules for “errors and optimization” have been tightened up to disallow
                   many cases of optimizations that alter error behavior. In particular
                   there are restrictions on reordering the operands of <code>and</code> and <code>or</code>,
@@ -4299,7 +4299,7 @@ the schema type named <code>us:address</code>.</p>
                <head>Enumeration Types</head>
 
                <changes>
-                  <change>Enumeration types are added as a new kind of <code>ItemType</code>, constraining
+                  <change issue="688" PR="691" date="2023-10-10">Enumeration types are added as a new kind of <code>ItemType</code>, constraining
                      the value space of strings.</change>
                </changes>
                
@@ -4368,11 +4368,11 @@ the schema type named <code>us:address</code>.</p>
                <head>Node Types</head>
                
                <changes>
-                  <change>
+                  <change issue="107" PR="286" date="2023-01-17">
                      Element and attribute tests can include alternative names: <code>element(chapter|section)</code>,
                      <code>attribute(role|class)</code>.
                   </change>
-                  <change>
+                  <change issue="107" PR="286" date="2023-01-17">
                      The <code>NodeTest</code> in an <code>AxisStep</code> now allows alternatives: 
                      <code>ancestor::(section|appendix)</code>
                   </change>
@@ -4513,7 +4513,7 @@ the schema type named <code>us:address</code>.</p>
                <head>Element Test</head>
                
                <changes>
-                  <change>
+                  <change issue="107" PR="286" date="2023-01-17">
                      Element and attribute tests of the form <code>element(N)</code>
                      and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
                      including a wildcard. The forms <code>element(A|B)</code> and <code>attribute(A|B)</code>
@@ -4841,7 +4841,7 @@ in the following two situations:
                <head>Attribute Test</head>
                
                <changes>
-                  <change>
+                  <change issue="107" PR="286" date="2023-01-17">
                      Element and attribute tests of the form <code>element(N)</code>
                      and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
                      including a wildcard. The forms <code>element(A|B)</code> and <code>attribute(A|B)</code>
@@ -5867,7 +5867,7 @@ declare record Particle (
             <head>Subtype Relationships</head>
             
             <changes>
-               <change>The presentation of the rules for the subtype relationship between 
+               <change issue="196" PR="202" date="2022-10-25">The presentation of the rules for the subtype relationship between 
                   sequence types and item types has been substantially
                   rewritten to improve clarity; no change to the semantics is intended.</change>
             </changes>
@@ -6909,13 +6909,21 @@ declare record Particle (
                <head>Coercion Rules</head>
             
             <changes>
-               <change>
+               <change PR="254" date="2022-11-29">
                   The term "function conversion rules" used in 3.1 has been replaced by the term "coercion rules".
                </change>
                <change issue="117" PR="254" date="2022-11-29">
                   The coercion rules allow “relabeling” of a supplied atomic item where
                   the required type is a derived atomic type: for example, it is now permitted to supply
                   the value 3 when calling a function that expects an instance of <code>xs:positiveInteger</code>.
+               </change>
+               <change issue="980" PR="911" date="2024-01-30">
+                  The coercion rules now allow any numeric type to be implicitly converted to any other, for example
+                  an <code>xs:double</code> is accepted where the required type is <code>xs:double</code>.
+               </change>
+               <change issue="130 480" PR="815" date="2023-11-07">
+                  The coercion rules now allow conversion in either direction between <code>xs:hexBinary</code>
+                  and <code>xs:base64Binary</code>.
                </change>
             </changes>
 
@@ -7354,7 +7362,7 @@ declare record Particle (
                      greater than <var>N</var> is expected. For example this allows the function <code>true#0</code> 
                      to be supplied where a predicate function is required.
                   </change>
-                  <change>
+                  <change issue="1020" PR="1023 1128" date="2024-04-09">
                      It has been clarified that function coercion applies even when the supplied function item
                      matches the required function type. This is to ensure that arguments supplied when calling
                      the function are checked against the signature of the required function type, which might
@@ -10419,7 +10427,8 @@ return $a("A")]]></eg>
                   In inline function expressions, the keyword <code>function</code> may be abbreviated
                   as <code>fn</code>.
                </change>
-               <change>New abbreviated syntax is introduced (<termref def="dt-focus-function"/>) 
+               <change issue="503" PR="521" date="2023-05-30">New abbreviated syntax is introduced 
+                     (<termref def="dt-focus-function"/>) 
                      for simple inline functions taking a single argument. 
                      An example is <code>fn { ../@code }</code>
                </change>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7369,7 +7369,6 @@ declare record Particle (
                      be stricter than the signature of the supplied function item.
                   </change>
                </changes>
-
                <p>
         Function coercion is a transformation applied to <termref def="dt-function-item"
                      >function items</termref> during application of the

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -480,11 +480,11 @@ return (
     
     <changes>
  
-      <change>In previous versions the interpretation of location hints in 
+      <change issue="647" PR="659" date="2023-10-24">In previous versions the interpretation of location hints in 
         <code>import schema</code> declarations was entirely at the discretion of the processor. To
         improve interoperability, XQuery 4.0 recommends (but does not mandate)
         a specific strategy for interpreting these hints.</change>
-      <change>The rules for the consistency of schemas imported by different query modules,
+      <change issue="451" PR="635">The rules for the consistency of schemas imported by different query modules,
         and for consistency between imported schemas and those used for validating input documents, have
         been defined with greater precision. It is now recognized that these schemas will not always be
         identical, and that validation with respect to different schemas may produce different outcomes,
@@ -1417,7 +1417,7 @@ declare function local:f() { $b }; </eg>
     <head>Context Value Declaration</head>
     
     <changes>
-      <change>
+      <change issue="129" PR="368" date="2023-07-21">
         The concept of the context item has been generalized, so it is now a context value. That is,
         it is no longer constrained to be a single item.
       </change>


### PR DESCRIPTION
No issue raised.

Adds links from change metadata in the spec to issue and PR numbers in GitHub in many cases where these were previously missing.