### PR TITLE
Update the changed/new marks in the ToC

### DIFF
--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -5,7 +5,7 @@
 }
 
 #toc .toc-new::after {
-    content: " Δ➕";
+    content: " ➕";
     font-weight: normal;
     color: blue;
 }

--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -4,6 +4,18 @@
   padding-top: 4em ! important;
 }
 
+#toc .toc-new::after {
+    content: " Δ➕";
+    font-weight: normal;
+    color: blue;
+}
+
+#toc .toc-chg::after {
+    content: " Δ";
+    font-weight: normal;
+    color: blue;
+}
+
 #function-finder {
   position: fixed;
   background-color: rgb(247, 248, 249);

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -231,7 +231,8 @@ for transition to Proposed Recommendation. </p>'>
          
          <changes>
             <change>Use the arrows to browse significant changes since the 3.1 version of this specification.</change>
-            <change>Sections with significant changes are marked Δ in the table of contents.</change>
+            <change>Sections with significant changes are marked Δ in the table of contents.
+            New functions introduced in this version are marked ➕ in the table of contents.</change>
           </changes>
           
                 

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -47,6 +47,7 @@
 
 <xsl:output method="html" version="5.0" encoding="UTF-8" indent="yes" />
 
+<xsl:variable name="fo31" select="doc('../build/etc/FO31.xml')"/>
 
 <!--
   <xsl:output method="html"
@@ -2797,19 +2798,26 @@
   </xsl:template>
 
   <xsl:template name="toc-entry-class">
-    <xsl:attribute name="class">
+    <xsl:variable name="isnew"
+                  select="if ((self::div2 or self::div3 or self::div4 or self::div5)
+                              and starts-with(@id, 'func-'))
+                          then not(exists(key('ids', @id, $fo31)))
+                          else false()"/>
+
+    <xsl:variable name="classes" as="xs:string*">
+      <xsl:sequence select="'content'"/>
+      <xsl:sequence select="@role/string()"/>
       <xsl:choose>
-        <xsl:when test="@role">
-          <xsl:sequence select="'content ' || @role"/>
+        <xsl:when test="$isnew">
+          <xsl:sequence select="'toc-new'"/>
         </xsl:when>
-        <xsl:otherwise>
-          <xsl:sequence select="'content'"/>
-        </xsl:otherwise>
+        <xsl:when test="child::changes">
+          <xsl:sequence select="'toc-chg'"/>
+        </xsl:when>
       </xsl:choose>
-    </xsl:attribute>
-    <xsl:if test="child::changes">
-      <span class="tocDelta"> Δ </span>
-    </xsl:if>
+    </xsl:variable>
+
+    <xsl:attribute name="class" select="string-join($classes, ' ')"/>
   </xsl:template>
 
   <xsl:template name="css">


### PR DESCRIPTION
Fix #1357 

This is a purely cosmetic PR. I think @ChristianGruen is right that it is unfortunate that we've lost the distinction between "new" and "only updated" functions. I'm trying to make that work again, in a way that's more visually distinct.

I have:

1. Use `Δ` for changed sections. 
2. Use `Δ➕` for new functions. (I'm making no effort to determine if non-function sections are new or changed; I doubt that it's either worth the effort or likely to be correct. One could argue that `➕` alone is sufficient, but I liked the consistency this way. Even new functions do change between drafts.)
3. Per @michaelhkay, a function is "new" if it doesn't appear on F&O 3.1.
4. I found it distracting that the delta symbol preceded the ToC entry. That's purely aesthetic, I guess, but I've put them at the end.

You can see the results here: https://qt4cgtest.nwalsh.com/branch/iss-1357/xpath-functions-40/Overview.html
