### PR TITLE
148 New functions to get type information

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17,61 +17,109 @@
       <fos:variable id="v-item3" name="item3" select="$po/line-item[3]"/>
    </fos:global-variables>
 
-   <fos:record-type id="uri-structure-record" extensible="true">
-      <fos:field name="uri" type="xs:string?" required="false">
+   <fos:record-type id="schema-type-record" extensible="true">
+      <fos:field name="name" type="xs:QName?" required="false">
          <fos:meaning>
-            <p>The original URI. This element is returned by <code>fn:parse-uri</code>,
-            but ignored by <code>fn:build-uri</code>.</p>
+            <p>The name of the type. Absent in the case of an anonymous type. Corresponds to
+            {name} and {target namespace} in the XSD component model for simple and complex type
+            components.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="scheme" type="xs:string?" required="false">
+      <fos:field name="is-simple" type="xs:boolean" required="true">
          <fos:meaning>
-            <p>The URI scheme (e.g., “https” or “file”).</p>
+            <p>True for a simple type, false for a complex type.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="absolute" type="xs:boolean?" required="false">
+      <fos:field name="base-type" type="schema-type-record" required="false">
          <fos:meaning>
-            <p>The URI is an absolute URI.</p>
+            <p>The base type (the type from which this type is derived by restriction or extension). Absent
+            in the case of the type <code>xs:anyType</code>. Corresponds to the {base type definition} property
+            in the XSD component model.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="hierarchical" type="xs:boolean?" required="false">
+      <fos:field name="primitive-type" type="schema-type-record" required="false">
          <fos:meaning>
-            <p>Whether the URI is hierarchical or not.</p>
+            <p>For an atomic type, the primitive type from which this type is ultimately derived. Corresponds
+               to {primitive type definition} in the XSD component model for simple types. Absent
+            if the type is non atomic, or if it is the simple type <code>xs:anyAtomicType</code>.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="authority" type="xs:string?" required="false">
+      <fos:field name="variety" required="true" type='enum("atomic", "list", "union", "empty", "simple",
+         "element-only", "mixed")'>
          <fos:meaning>
-            <p>The authority portion of the URI (e.g., “example.com:8080”).</p>
+            <p>For a simple type, one of <code>"atomic"</code>, <code>"list"</code>, or <code>"union"</code>, corresponding to the
+               {variety} of the simple type in the XSD component model. For a complex type, one of
+            <code>"empty"</code>, <code>"simple"</code>, <code>"element-only"</code>, or <code>"mixed"</code>, 
+               corresponding to the {content type}.{variety} of the complex type in the XSD component model.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="userinfo" type="xs:string?" required="false">
-         <fos:meaning><p>Any userinfo that was passed as part of the authority.</p></fos:meaning>
+      <fos:field name="members" required="false" type="function() as schema-record-type*">
+         <fos:meaning>
+            <p>For a simple type with variety <code>"union"</code>, a function that returns a sequence of
+               records representing the member types of the union, in order, corresponding to the
+               {member type definitions} property in the XSD component model. 
+               For a simple type with variety <code>"list"</code>,
+            a function that returns a record representing the item type of the list type, corresponding to
+            the {item type definition} property in the XSD component model. In all other cases, absent.</p>
+         </fos:meaning>
       </fos:field>
-      <fos:field name="host" type="xs:string?" required="false">
-         <fos:meaning><p>The host passed as part of the authority (e.g., “example.com”). </p></fos:meaning>
+      <fos:field name="simple-content-type" required="false" type="function() as schema-record-type">
+         <fos:meaning>
+            <p>For a complex type with variety <code>"simple"</code> (that is, a complex type with simple content), 
+               a function that returns a record representing the relevant simple type, corresponding to 
+               the {content type}{simple type definition} property in the XSD complex type component. 
+               In all other cases, absent.</p>
+         </fos:meaning>
       </fos:field>
-      <fos:field name="port" type="xs:integer?" required="false">
-         <fos:meaning><p>The port passed as part of the authority (e.g., “8080”).</p></fos:meaning>
+      <fos:field name="matches" type="function(xs:anyAtomicType) as xs:boolean" required="false">
+         <fos:meaning>
+            <p>For an atomic type, a function item that can be called to establish whether the supplied atomic value
+               is an instance of this atomic type. In all other cases, absent.</p>
+         </fos:meaning>
       </fos:field>
-      <fos:field name="path" type="xs:string?" required="false">
-         <fos:meaning><p>The path portion of the URI.</p></fos:meaning>
-      </fos:field>
-      <fos:field name="query" type="xs:string?" required="false">
-         <fos:meaning><p>Any query string.</p></fos:meaning>
-      </fos:field>
-      <fos:field name="fragment" type="xs:string?" required="false">
-         <fos:meaning><p>Any fragment identifier.</p></fos:meaning>
-      </fos:field>
-      <fos:field name="path-segments" type="xs:string*" required="false">
-         <fos:meaning><p>Parsed and unescaped path segments.</p></fos:meaning>
-      </fos:field>
-      <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false">
-         <fos:meaning><p>Parsed and unescaped query key-value pairs.</p></fos:meaning>
-      </fos:field>
-      <fos:field name="filepath" type="xs:string?" required="false">
-         <fos:meaning><p>The path of the URI, treated as a filepath.</p></fos:meaning>
+      <fos:field name="constructor" type="function(xs:anyAtomicType) as xs:anyAtomicType" required="false">
+         <fos:meaning>
+            <p>For a simple type, a function item that can be used to construct instances of this type. In the case of a named
+             type, the result is the same function as returned by <code>fn:function-lookup</code> applied
+            to the type name (with arity one). For details see <specref ref="constructor-functions-for-xsd-types"/>
+               and <specref ref="constructor-functions-for-user-defined-types"/>. 
+               However, constructor functions are also available for
+            anonymous types. The field is absent for complex types and for the abstract types <code>xs:anyAtomicType</code> and
+               <code>xs:NOTATION</code>. It is also absent for all namespace-sensitive types, that is, types
+               derived from <code>xs:QName</code> or <code>xs:NOTATION</code>.
+            </p>
+         </fos:meaning>
       </fos:field>
    </fos:record-type>
+   
+   <fos:record-type id="load-xquery-module-record" extensible="false">
+      <fos:field name="variables" type="map(xs:QName, item()*)" required="true">
+         <fos:meaning>
+                  <p>This map (<var>V</var> ) contains one entry for each public
+                  global variable declared in the library module. The key of the
+                  entry is the name of the variable, as an <code>xs:QName</code>
+                  value; the associated value is the value of the variable.</p>
+         </fos:meaning>        
+      </fos:field>
+      <fos:field name="functions" type="map(xs:QName, map(xs:integer, function(*)))" required="true">
+         <fos:meaning>
+            <p>This map (<var>F</var> ) contains one entry for each distinct QName
+            <var>Q</var> that represents the name of a public and non-external
+            function declared in the library module. The key of the entry is
+            <var>Q</var>, as an <code>xs:QName</code> value; the associated value
+            is a map <var>A</var>. This map (<var>A</var>) contains one entry for
+            each arity <var>N</var> within the arity range of any of the function
+            declarations with the given name; its key is <var>N</var>, as an
+            <code>xs:integer</code> value, and its associated value is a function
+            item obtained as if by evaluating a named function reference
+            <code>Q#N</code>, using the static and dynamic context of the call on
+            <code>fn:load-xquery-module</code>. The function item can be invoked
+            using the rules for dynamic function invocation.</p>
+         </fos:meaning>         
+      </fos:field>
+   </fos:record-type>
+   
+   
 
    
    
@@ -403,6 +451,90 @@
          </fos:example>
       </fos:examples>
    </fos:function>
+   
+   <fos:function name="node-kind" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="node-kind" return-type="enum('document', 'element', 'attribute', 'text', 'comment', processing-instruction', 'namespace')?">
+            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties arity="0">
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-dependent</fos:property>
+         <fos:property>focus-dependent</fos:property>
+      </fos:properties>
+      <fos:properties arity="1">
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns the kind of node, for example <code>"element"</code> or <code>"attribute"</code>.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>If the argument is omitted, it defaults to the context value (<code>.</code>).</p>
+         <p>If <code>$node</code> is the empty sequence, the empty sequence is returned.</p>
+         <p>Otherwise, the function returns the kind of the supplied node.</p>
+      </fos:rules>
+      <fos:equivalent style="xpath-expression" covers-error-cases="false">
+$node ! (
+  if (self::document-node()) then "document"
+  else if (self::element()) then "element"
+  else if (self::attribute()) then "attribute"
+  else if (self::text()) then "text"
+  else if (self::comment()) then "comment"
+  else if (self::processing-instruction()) then "processing-instruction"
+  else "namespace")
+      </fos:equivalent>
+      <fos:errors>
+         <p>The following errors may be raised when <code>$node</code> is omitted:</p>
+         <ulist>
+            <item>
+               <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
+                     >absent</xtermref>,
+                  type error <xerrorref spec="XP"
+                     class="DY" code="0002" type="type"/>.</p>
+            </item>
+            <item>
+               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+                     code="0004" type="type"/>.</p>
+            </item>
+         </ulist>
+
+      </fos:errors>
+ 
+      <fos:examples>
+         <fos:variable name="e" id="v-node-kind-e"><![CDATA[<doc>
+  <p id="alpha" xml:id="beta">One</p>
+  <p id="gamma" xmlns="http://example.com/ns">Two</p>
+  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</ex:p>
+  <?pi 3.14159?>
+</doc>]]>
+         </fos:variable>
+         <fos:example>
+            <fos:test use="v-node-kind-e" spec="XQuery">
+               <fos:expression>node-kind($e//*[@id = 'alpha'])</fos:expression>
+               <fos:result>"element</fos:result>
+            </fos:test>
+            <fos:test use="v-node-kind-e" spec="XQuery">
+               <fos:expression>node-kind($e//@id[. = 'gamma'])</fos:expression>
+               <fos:result>"attribute"</fos:result>
+            </fos:test>
+            <fos:test use="v-node-kind-e" spec="XQuery">
+               <fos:expression>node-kind($e//node()[.='3.14159'])</fos:expression>
+               <fos:result>"processing-instruction</fos:result>
+            </fos:test>
+            <fos:test use="v-node-kind-e" spec="XQuery">
+               <fos:expression>node-kind($e//no-such-node</fos:expression>
+               <fos:result>()</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:changes>
+         <fos:change issue="148"><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+   
    <fos:function name="nilled" prefix="fn">
       <fos:signatures>
          <fos:proto name="nilled" return-type="xs:boolean?">
@@ -21920,6 +22052,101 @@ declare function transitive-closure (
       </fos:examples>
       <fos:changes>
          <fos:change issue="83" PR="173" date="2022-10-11"><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+   
+   <fos:function name="atomic-type" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="atomic-type" return-type="atomic-type-record">
+            <fos:arg name="value" type="xs:anyAtomicType"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+         
+      </fos:properties>
+      <fos:summary>
+         <p>Returns a record containing information about the type of an atomic value.</p>
+      </fos:summary>
+      <fos:rules>        
+         <p>Given an atomic value, the function returns an <code>atomic-type-record</code>
+         containing information about the atomic type represented by its type annotation.</p>
+      </fos:rules>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>atomic-type(23)?name</fos:expression>
+               <fos:result>xs:QName('xs:integer')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>let $x := 23, $y := 93.7 return atomic-type($x)?matches($y)</fos:expression>
+               <fos:result>false</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>atomic-type(23)?relationship(atomic-type(93.7))</fos:expression>
+               <fos:result>"subtype"</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:changes>
+         <fos:change issue="148"><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+   
+   <fos:function name="schema-type" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="schema-type" return-type="schema-type-record?">
+            <fos:arg name="name" type="xs:QName"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-dependent</fos:property>
+         <fos:property>focus-independent</fos:property>
+         
+      </fos:properties>
+      <fos:summary>
+         <p>Returns a record containing information about a named schema type in the static context.</p>
+      </fos:summary>
+      <fos:rules>        
+         <p>If the static context includes a schema type whose name matches <code>$name</code>, 
+            the function returns a <code>schema-type-record</code>
+         containing information about that schema type. If not, it returns an empty sequence.</p>
+      </fos:rules>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>schema-type(xs:QName('xs:integer'))?name</fos:expression>
+               <fos:result>xs:QName('xs:integer')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>schema-type(xs:QName('xs:long'))?primitive-type?name</fos:expression>
+               <fos:result>xs:QName('xs:decimal')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>schema-type(xs:QName('xs:positiveInteger'))?base-type?name</fos:expression>
+               <fos:result>xs:QName('xs:integer')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>schema-type(xs:QName('xs:integer'))?matches(23)</fos:expression>
+               <fos:result>true</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:changes>
+         <fos:change issue="148"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -74,9 +74,9 @@
    </fos:record-type>
 
    <fos:record-type id="schema-type-record" extensible="true">
-      <fos:field name="name" type="xs:QName?" required="false">
+      <fos:field name="name" type="xs:QName?" required="true">
          <fos:meaning>
-            <p>The name of the type. Absent in the case of an anonymous type. Corresponds to
+            <p>The name of the type. Empty in the case of an anonymous type. Corresponds to
             {name} and {target namespace} in the XSD component model for simple and complex type
             components.</p>
          </fos:meaning>
@@ -86,18 +86,21 @@
             <p>True for a simple type, false for a complex type.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="base-type" type="schema-type-record" required="false">
+      <fos:field name="base-type" type="fn() as schema-type-record?" required="true">
          <fos:meaning>
-            <p>The base type (the type from which this type is derived by restriction or extension). Absent
-            in the case of the type <code>xs:anyType</code>. Corresponds to the {base type definition} property
+            <p>Function item returning the base type (the type from which this type is derived by restriction 
+               or extension). The function is always present, and returns an empty sequence
+               in the case of the type <code>xs:anyType</code>. Corresponds to the {base type definition} property
             in the XSD component model.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="primitive-type" type="schema-type-record" required="false">
+      <fos:field name="primitive-type" type="fn() as schema-type-record" required="false">
          <fos:meaning>
-            <p>For an atomic type, the primitive type from which this type is ultimately derived. Corresponds
-               to {primitive type definition} in the XSD component model for simple types. Absent
-            if the type is non atomic, or if it is the simple type <code>xs:anyAtomicType</code>.</p>
+            <p>For an atomic type, a function item returning the primitive type from which this 
+               type is ultimately derived. Corresponds to {primitive type definition} in the XSD 
+               component model for simple types. Absent if the type is non atomic, or if it is 
+               the simple type <code>xs:anyAtomicType</code>. If this is a primitive type, the
+               function item is idempotent.</p>
          </fos:meaning>
       </fos:field>
       <fos:field name="variety" 
@@ -110,7 +113,7 @@
                corresponding to the {content type}.{variety} of the complex type in the XSD component model.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="members" required="false" type="function() as schema-record-type*">
+      <fos:field name="members" required="false" type="fn() as schema-type-record*">
          <fos:meaning>
             <p>For a simple type with variety <code>"union"</code>, a function that returns a sequence of
                records representing the member types of the union, in order, corresponding to the
@@ -120,7 +123,7 @@
             the {item type definition} property in the XSD component model. In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="simple-content-type" required="false" type="function() as schema-record-type">
+      <fos:field name="simple-content-type" required="false" type="fn() as schema-type-record">
          <fos:meaning>
             <p>For a complex type with variety <code>"simple"</code> (that is, a complex type with simple content), 
                a function that returns a record representing the relevant simple type, corresponding to 
@@ -128,13 +131,13 @@
                In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="matches" type="function(xs:anyAtomicType) as xs:boolean" required="false">
+      <fos:field name="matches" type="fn(xs:anyAtomicType) as xs:boolean" required="false">
          <fos:meaning>
-            <p>For an atomic type, a function item that can be called to establish whether the supplied atomic value
+            <p>For an atomic type, a function item that can be called to establish whether the supplied atomic item
                is an instance of this atomic type. In all other cases, absent.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="constructor" type="function(xs:anyAtomicType) as xs:anyAtomicType" required="false">
+      <fos:field name="constructor" type="fn(xs:anyAtomicType) as xs:anyAtomicType" required="false">
          <fos:meaning>
             <p>For a simple type, a function item that can be used to construct instances of this type. In the case of a named
              type that is present in the dynamic context, the result is the same function as returned by 
@@ -148,7 +151,7 @@
             </p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="validate" type="function((document-node()|element())) as (document-node()|element())" required="true">
+      <fos:field name="validate" type="fn((document-node()|element())) as (document-node()|element())" required="true">
          <fos:meaning>
             <p>A function item that can be called to validate a supplied document or element node against this type.
             The effect is equivalent to the XQuery expression <code>validate type T {$node}</code> where <var>T</var>
@@ -158,7 +161,7 @@
             not support schema validation) then an error is raised, as with the equivalent XQuery expression.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="valid" type="function((document-node()|element())) as xs:boolean" required="true">
+      <fos:field name="valid" type="fn((document-node()|element())) as xs:boolean" required="true">
          <fos:meaning>
             <p>A function item that can be called to validate a supplied document or element node against this type,
             returning <code>true</code> if validation succeeds, or <code>false</code> if it fails. The function
@@ -23410,6 +23413,9 @@ return if (exists($entry))
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change><p>A third argument is added, allowing user control of how absent keys should be handled.</p></fos:change>
+      </fos:changes>
    </fos:function>
 
    <fos:function name="find" prefix="map">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22143,8 +22143,7 @@ declare function transitive-closure (
       <fos:properties>
          <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-         
+         <fos:property>focus-independent</fos:property>        
       </fos:properties>
       <fos:summary>
          <p>Returns a record containing information about the type annotation of an atomic value.</p>
@@ -22156,7 +22155,21 @@ declare function transitive-closure (
       <fos:notes>
          <p>The result will always have <code>?is-simple = true()</code> and <code>?variety = "atomic"</code>. In a non-schema-aware
          environment the type will always be a built-in atomic type in the <code>xs</code> namespace: see
-         <specref ref="atomic-type-hierarchy"/>.</p>
+         <specref ref="atomic-type-hierarchy"/>. Where a schema is in use, however, the result may be an atomic type defined
+         in the schema, which may be an anonymous type.</p>
+         
+         <p>This function should not be used as a substitute for an <code>instance of</code> test. The precise type annotation
+         of the result of an expression is not always predictable, because processors are free to deliver a more specific type
+         than is mandated by the specification. For example, if <code>$n</code> is of type <code>xs:positiveInteger</code>,
+         then the result of <code>abs($n)</code> is guaranteed to be an instance of <code>xs:integer</code>, but an 
+         implementation might reasonably return the supplied value unchanged: that is, a value whose actual type 
+         annotation is <code>xs:positiveInteger</code>. Similarly the type annotation of the value returned by
+         <code>position()</code> might have a type annotation of <code>xs:long</code> rather than <code>xs:integer</code>.</p>
+         
+         <p>Implementations <rfc2119>should</rfc2119>, however, refrain from exposing types that are purely internal.
+         For example, an implementation might have an optimized internal representation for strings consisting entirely
+         of ASCII characters, or for single-character strings; if this is the case then the type annotation returned by this function
+         should be a user-visible supertype such as <code>xs:string</code>.</p>
       </fos:notes>
       <fos:examples role="wide">
          <fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -601,13 +601,13 @@ $node ! (
                <fos:result>"processing-instruction"</fos:result>
             </fos:test>
             <fos:test use="v-node-kind-e" spec="XQuery">
-               <fos:expression>node-kind($e//no-such-node</fos:expression>
+               <fos:expression>node-kind($e//no-such-node)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="148"><p>New in 4.0</p></fos:change>
+         <fos:change issue="148" PR="1523" date="2024-10-22"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    
@@ -22177,7 +22177,7 @@ return atomic-type-annotation($x)?matches($y)</eg></fos:expression>
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="148"><p>New in 4.0</p></fos:change>
+         <fos:change issue="148" PR="1523" date="2024-10-22"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    
@@ -22232,7 +22232,7 @@ return node-type-annotation($x/*)]]></eg></fos:expression>
          
       </fos:examples>
       <fos:changes>
-         <fos:change issue="148"><p>New in 4.0</p></fos:change>
+         <fos:change issue="148" PR="1523" date="2024-10-22"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    
@@ -22296,7 +22296,7 @@ return node-type-annotation($x/*)]]></eg></fos:expression>
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="148"><p>New in 4.0</p></fos:change>
+         <fos:change issue="148" PR="1523" date="2024-10-22"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16,6 +16,62 @@
       <fos:variable id="v-item2" name="item2" select="$po/line-item[2]"/>
       <fos:variable id="v-item3" name="item3" select="$po/line-item[3]"/>
    </fos:global-variables>
+   
+   <fos:record-type id="uri-structure-record" extensible="true">
+      <fos:field name="uri" type="xs:string?" required="false">
+         <fos:meaning>
+            <p>The original URI. This element is returned by <code>fn:parse-uri</code>,
+            but ignored by <code>fn:build-uri</code>.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="scheme" type="xs:string?" required="false">
+         <fos:meaning>
+            <p>The URI scheme (e.g., “https” or “file”).</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="absolute" type="xs:boolean?" required="false">
+         <fos:meaning>
+            <p>The URI is an absolute URI.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="hierarchical" type="xs:boolean?" required="false">
+         <fos:meaning>
+            <p>Whether the URI is hierarchical or not.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="authority" type="xs:string?" required="false">
+         <fos:meaning>
+            <p>The authority portion of the URI (e.g., “example.com:8080”).</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="userinfo" type="xs:string?" required="false">
+         <fos:meaning><p>Any userinfo that was passed as part of the authority.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="host" type="xs:string?" required="false">
+         <fos:meaning><p>The host passed as part of the authority (e.g., “example.com”). </p></fos:meaning>
+      </fos:field>
+      <fos:field name="port" type="xs:integer?" required="false">
+         <fos:meaning><p>The port passed as part of the authority (e.g., “8080”).</p></fos:meaning>
+      </fos:field>
+      <fos:field name="path" type="xs:string?" required="false">
+         <fos:meaning><p>The path portion of the URI.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="query" type="xs:string?" required="false">
+         <fos:meaning><p>Any query string.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="fragment" type="xs:string?" required="false">
+         <fos:meaning><p>Any fragment identifier.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="path-segments" type="xs:string*" required="false">
+         <fos:meaning><p>Parsed and unescaped path segments.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="query-parameters" type="map(xs:string, xs:string*)?" required="false">
+         <fos:meaning><p>Parsed and unescaped query key-value pairs.</p></fos:meaning>
+      </fos:field>
+      <fos:field name="filepath" type="xs:string?" required="false">
+         <fos:meaning><p>The path of the URI, treated as a filepath.</p></fos:meaning>
+      </fos:field>
+   </fos:record-type>
 
    <fos:record-type id="schema-type-record" extensible="true">
       <fos:field name="name" type="xs:QName?" required="false">
@@ -44,8 +100,9 @@
             if the type is non atomic, or if it is the simple type <code>xs:anyAtomicType</code>.</p>
          </fos:meaning>
       </fos:field>
-      <fos:field name="variety" required="true" type='enum("atomic", "list", "union", "empty", "simple",
-         "element-only", "mixed")'>
+      <fos:field name="variety" 
+                 required="true" 
+                 type='enum("atomic", "list", "union", "empty", "simple", "element-only", "mixed")'>
          <fos:meaning>
             <p>For a simple type, one of <code>"atomic"</code>, <code>"list"</code>, or <code>"union"</code>, corresponding to the
                {variety} of the simple type in the XSD component model. For a complex type, one of
@@ -80,14 +137,33 @@
       <fos:field name="constructor" type="function(xs:anyAtomicType) as xs:anyAtomicType" required="false">
          <fos:meaning>
             <p>For a simple type, a function item that can be used to construct instances of this type. In the case of a named
-             type, the result is the same function as returned by <code>fn:function-lookup</code> applied
-            to the type name (with arity one). For details see <specref ref="constructor-functions-for-xsd-types"/>
+             type that is present in the dynamic context, the result is the same function as returned by 
+               <code>fn:function-lookup</code> applied to the type name (with arity one). For details see <specref ref="constructor-functions-for-xsd-types"/>
                and <specref ref="constructor-functions-for-user-defined-types"/>. 
-               However, constructor functions are also available for
-            anonymous types. The field is absent for complex types and for the abstract types <code>xs:anyAtomicType</code> and
+               Constructor function items are also available for
+               anonymous types, and for types that might not be present in the dynamic context. 
+               The field is absent for complex types and for the abstract types <code>xs:anyAtomicType</code> and
                <code>xs:NOTATION</code>. It is also absent for all namespace-sensitive types, that is, types
                derived from <code>xs:QName</code> or <code>xs:NOTATION</code>.
             </p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="validate" type="function((document-node()|element())) as (document-node()|element())" required="true">
+         <fos:meaning>
+            <p>A function item that can be called to validate a supplied document or element node against this type.
+            The effect is equivalent to the XQuery expression <code>validate type T {$node}</code> where <var>T</var>
+            is this type, and <code>$node</code> is the node supplied as the argument to the function. 
+               (See <xspecref spec="XQ40" ref="id-validate"/>.) If validation succeeds,
+            the validated node is returned; if it fails (for any reason, including the fact that the processor does
+            not support schema validation) then an error is raised, as with the equivalent XQuery expression.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="valid" type="function((document-node()|element())) as xs:boolean" required="true">
+         <fos:meaning>
+            <p>A function item that can be called to validate a supplied document or element node against this type,
+            returning <code>true</code> if validation succeeds, or <code>false</code> if it fails. The function
+            call <code>$type?valid($node)</code> is equivalent to the XQuery expression:</p>
+            <eg>try { exists( $type?validate($node) ) } catch * { false() }</eg>
          </fos:meaning>
       </fos:field>
    </fos:record-type>
@@ -269,7 +345,7 @@
    </fos:record-type>
    
 
-   <fos:record-type id="load-xquery-module-record" extensible="false">
+   <!--<fos:record-type id="load-xquery-module-record" extensible="false">
       <fos:field name="variables" type="map(xs:QName, item()*)" required="true">
          <fos:meaning>
                   <p>This map (<var>V</var> ) contains one entry for each public
@@ -295,7 +371,7 @@
          </fos:meaning>         
       </fos:field>
    </fos:record-type>
-   
+   -->
    
 
    <fos:record-type id="random-number-generator-record" extensible="true">
@@ -514,7 +590,7 @@ $node ! (
          <fos:example>
             <fos:test use="v-node-kind-e" spec="XQuery">
                <fos:expression>node-kind($e//*[@id = 'alpha'])</fos:expression>
-               <fos:result>"element</fos:result>
+               <fos:result>"element"</fos:result>
             </fos:test>
             <fos:test use="v-node-kind-e" spec="XQuery">
                <fos:expression>node-kind($e//@id[. = 'gamma'])</fos:expression>
@@ -522,7 +598,7 @@ $node ! (
             </fos:test>
             <fos:test use="v-node-kind-e" spec="XQuery">
                <fos:expression>node-kind($e//node()[.='3.14159'])</fos:expression>
-               <fos:result>"processing-instruction</fos:result>
+               <fos:result>"processing-instruction"</fos:result>
             </fos:test>
             <fos:test use="v-node-kind-e" spec="XQuery">
                <fos:expression>node-kind($e//no-such-node</fos:expression>
@@ -22055,9 +22131,9 @@ declare function transitive-closure (
       </fos:changes>
    </fos:function>
    
-   <fos:function name="atomic-type" prefix="fn">
+   <fos:function name="atomic-type-annotation" prefix="fn">
       <fos:signatures>
-         <fos:proto name="atomic-type" return-type="atomic-type-record">
+         <fos:proto name="atomic-type-annotation" return-type-ref="schema-type-record">
             <fos:arg name="value" type="xs:anyAtomicType"/>
          </fos:proto>
       </fos:signatures>
@@ -22068,29 +22144,35 @@ declare function transitive-closure (
          
       </fos:properties>
       <fos:summary>
-         <p>Returns a record containing information about the type of an atomic value.</p>
+         <p>Returns a record containing information about the type annotation of an atomic value.</p>
       </fos:summary>
       <fos:rules>        
-         <p>Given an atomic value, the function returns an <code>atomic-type-record</code>
-         containing information about the atomic type represented by its type annotation.</p>
+         <p>Given an atomic value, the function returns a <loc href="#schema-type-record">schema-type-record</loc>
+         containing information about the atomic type represented by its <xtermref spec="DM40" ref="dt-type-annotation"/>.</p>
       </fos:rules>
-      <fos:examples>
+      <fos:notes>
+         <p>The result will always have <code>?is-simple = true()</code> and <code>?variety = "atomic"</code>. In a non-schema-aware
+         environment the type will always be a built-in atomic type in the <code>xs</code> namespace: see
+         <specref ref="atomic-type-hierarchy"/>.</p>
+      </fos:notes>
+      <fos:examples role="wide">
          <fos:example>
             <fos:test>
-               <fos:expression>atomic-type(23)?name</fos:expression>
+               <fos:expression><eg>atomic-type-annotation(23)?name</eg></fos:expression>
                <fos:result>xs:QName('xs:integer')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>let $x := 23, $y := 93.7 return atomic-type($x)?matches($y)</fos:expression>
-               <fos:result>false</fos:result>
+               <fos:expression><eg>let $x := 23, $y := 93.7 
+return atomic-type-annotation($x)?matches($y)</eg></fos:expression>
+               <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
-               <fos:expression>atomic-type(23)?relationship(atomic-type(93.7))</fos:expression>
-               <fos:result>"subtype"</fos:result>
+               <fos:expression><eg>atomic-type-annotation(xs:numeric('23.2'))?name</eg></fos:expression>
+               <fos:result>xs:QName('xs:double')</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -22099,9 +22181,64 @@ declare function transitive-closure (
       </fos:changes>
    </fos:function>
    
+   <fos:function name="node-type-annotation" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="node-type-annotation" return-type-ref="schema-type-record">
+            <fos:arg name="node" type="(element() | attribute())"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+         
+      </fos:properties>
+      <fos:summary>
+         <p>Returns a record containing information about the type annotation of an element or attribute node.</p>
+      </fos:summary>
+      <fos:rules>        
+         <p>Given an element or attribute node, the function returns a <loc href="#schema-type-record">schema-type-record</loc>
+         containing information about the schema type represented by its <xtermref spec="DM40" ref="dt-type-annotation"/>.</p>
+         
+      </fos:rules>
+      <fos:notes>
+         <p>For an element that has not been schema-validated, the type annotation is always <code>xs:untyped</code>.</p>
+         <p>For an attribute that has not been schema-validated, the type annotation is always <code>xs:untypedAtomic</code>.</p>
+         <p>The type annotation of an attribute node is always a simple type; the type annotation of an element node may
+         be simple or complex.</p>
+      </fos:notes>
+      <fos:examples role="wide">
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[let $e := parse-xml("<e/>")/*
+return node-type-annotation($e)]]></eg></fos:expression>
+               <fos:result>xs:QName('xs:untyped')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[let $a := parse-xml("<e a='3'/>")//@a
+return node-type-annotation($a)]]></eg></fos:expression>
+               <fos:result>xs:QName('xs:untypedAtomic')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg><![CDATA[let $x := json-to-xml('[23, 24]', {'validate':true()})
+return node-type-annotation($x/*)]]></eg></fos:expression>
+               <fos:result>xs:QName('fn:arrayType')</fos:result>
+            </fos:test>
+         </fos:example>
+         
+      </fos:examples>
+      <fos:changes>
+         <fos:change issue="148"><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+   
    <fos:function name="schema-type" prefix="fn">
       <fos:signatures>
-         <fos:proto name="schema-type" return-type="schema-type-record?">
+         <fos:proto name="schema-type" return-type-ref="schema-type-record" return-type-ref-occurs="?">
             <fos:arg name="name" type="xs:QName"/>
          </fos:proto>
       </fos:signatures>
@@ -22115,11 +22252,12 @@ declare function transitive-closure (
          <p>Returns a record containing information about a named schema type in the static context.</p>
       </fos:summary>
       <fos:rules>        
-         <p>If the static context includes a schema type whose name matches <code>$name</code>, 
-            the function returns a <code>schema-type-record</code>
+         <p>If the static context (specifically, the <xtermref spec="XP40" ref="dt-is-types">in-scope schema types</xtermref>) 
+            includes a schema type whose name matches <code>$name</code>, 
+            the function returns a <loc href="#schema-type-record">schema-type-record</loc>
          containing information about that schema type. If not, it returns an empty sequence.</p>
       </fos:rules>
-      <fos:examples>
+      <fos:examples role="wide">
          <fos:example>
             <fos:test>
                <fos:expression>schema-type(xs:QName('xs:integer'))?name</fos:expression>
@@ -22141,7 +22279,19 @@ declare function transitive-closure (
          <fos:example>
             <fos:test>
                <fos:expression>schema-type(xs:QName('xs:integer'))?matches(23)</fos:expression>
-               <fos:result>true</fos:result>
+               <fos:result>true()</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>schema-type(xs:QName('xs:numeric'))?variety</fos:expression>
+               <fos:result>"union"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression>schema-type(xs:QName('xs:numeric'))?members()?name</fos:expression>
+               <fos:result>xs:QName('xs:double'), xs:QName('xs:float'), xs:QName('xs:decimal')</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1415,6 +1415,9 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                </tbody>
             </table>
             <?local-function-index?>
+            <div3 id="func-node-kind">
+               <head><?function fn:node-kind?></head>
+            </div3>
             <div3 id="func-node-name">
                <head><?function fn:node-name?></head>
             </div3>
@@ -7928,6 +7931,36 @@ return <table>
               </ulist>
             </div3>
          </div2>
+         
+      </div1>
+      
+      <div1 id="functions-on-types">
+         <head>Functions on types</head>
+         <changes>
+              <change issue="148">
+                 New functions are provided to obtain information about built-in types and types defined in an
+                 imported schema.
+              </change>
+           </changes>
+         
+         <p>The functions in this section deliver information about schema types (including simple types and complex
+         types). These may represent built-in types (such as <code>xs:dateTime</code>), 
+            user-defined types found in the static context (typically because they appear in an imported schema),
+         or types used as type annotations on schema-validated nodes.</p>
+         
+         <p>The structured representation of a schema type is described by the
+           <loc href="#schema-type-record">schema-type-record</loc>, whose parts are:</p>
+            
+            <?record-description schema-type-record?>
+         
+         <?local-function-index?>
+            
+            <div2 id="func-schema-type">
+               <head><?function schema-type?></head>
+            </div2>
+            <div2 id="func-atomic-type">
+               <head><?function atomic-type?></head>
+            </div2>
          
       </div1>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7948,19 +7948,33 @@ return <table>
             user-defined types found in the static context (typically because they appear in an imported schema),
          or types used as type annotations on schema-validated nodes.</p>
          
+         <p>For more information on schema types, see <specref ref="schema-type-hierarchy"/>. The properties
+         of a schema type are described in terms of the properties of a Simple Type Definition 
+         or Complex Type Definition component as described in <xspecref spec="XS11-1" ref="Simple_Type_Definition_details"/>
+         and <xspecref spec="XS11-1" ref="Complex_Type_Definition_details"/> respectively. Not all properties are exposed.</p>
+         
          <p>The structured representation of a schema type is described by the
            <loc href="#schema-type-record">schema-type-record</loc>, whose parts are:</p>
             
             <?record-description schema-type-record?>
          
+         <div2 id="functions-returning-type-information">
+            <head>Functions returning type information</head>
+        
+         
          <?local-function-index?>
             
-            <div2 id="func-schema-type">
-               <head><?function schema-type?></head>
-            </div2>
-            <div2 id="func-atomic-type">
-               <head><?function atomic-type?></head>
-            </div2>
+            <div3 id="func-schema-type">
+               <head><?function fn:schema-type?></head>
+            </div3>
+            <div3 id="func-atomic-type-annotation">
+               <head><?function fn:atomic-type-annotation?></head>
+            </div3>
+            <div3 id="func-node-type-annotation">
+               <head><?function fn:node-type-annotation?></head>
+            </div3>
+            
+         </div2>
          
       </div1>
 


### PR DESCRIPTION
Provides four new functions:

- node-kind
- schema-type
- atomic-type-annotation
- node-type-annotation

to return type information using a new record structure schema-record-type.

Fix #148
Partial Fix for #1271