### PR TITLE
Emergency fix to test generator stylesheet

### DIFF
--- a/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-qt3-test-set.xsl
@@ -105,7 +105,13 @@
             <xsl:choose>
               <xsl:when test="fos:result/@normalize-space eq true()">
                <xsl:variable name="stripped">
-                 <xsl:apply-templates select="parse-xml(fos:result)" mode="strip-space"/>
+                 <xsl:try>
+                   <xsl:apply-templates select="parse-xml(fos:result)" mode="strip-space"/>
+                   <xsl:catch>
+                     <xsl:message expand-text="1">** Failure in parse-xml on fos:result of {$fos-function/@name}-{$n}</xsl:message>
+                     <substitute-for-unparseable-result-xml/>
+                   </xsl:catch>
+                 </xsl:try>
                </xsl:variable>
                 <assert-xml ignore-prefixes="{(fos:result/@ignore-prefixes, false())[1]}">{serialize($stripped)}</assert-xml>
               </xsl:when>


### PR DESCRIPTION
There's a parse-xml() call in the test generator stylesheet that's failing to process some of the test examples, for reasons that aren't entirely clear. This is causing the entire build to fail. This PR adds a try/catch around the parse-xml() call so that a failure only affects the individual tests, not the entire build.