### PR TITLE
Actions QT4CG-095-01 and -02 - follow-up on computed node constructors

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2426,11 +2426,11 @@ ErrorVal ::= "$" VarName
     </g:choice>
   </g:production>
   
-  <g:production name="UnreservedName"  xgc-id="unreserved-name">
+  <g:production name="UnreservedName"  xgc-id="unreserved-name"  if="xquery40">
     <g:ref name="EQName"/>
   </g:production>
   
-  <g:production name="UnreservedNCName"  xgc-id="unreserved-name">
+  <g:production name="UnreservedNCName"  xgc-id="unreserved-name"  if="xquery40">
     <g:ref name="NCName"/>
   </g:production>
 

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1501,6 +1501,14 @@ See
       in 3.1, but will output <code>"1621"</code> (1234 in base 9) with 4.0. As a workaround, this can be rewritten as 
       <code>format-integer(1234, "0^000")</code>.</p>
     
+    <p role="xquery">In computed node constructors, the node name must now be written in quotation marks
+    if it matches certain language keywords. For example <code>element div {}</code> must now be
+    written <code>element "div" {}</code>. (Alternatively, <code>element {"div"} {}</code>
+    and <code>element Q{}div {}</code> are permitted by both XQuery 3.1 and XQuery 4.0.)
+    This change is made because <code>{}</code> is now a valid expression representing an
+    empty map, so expressions such as <code>element otherwise {}</code> could (without this rule) be 
+    parsed in two different ways.</p>
+    
     <p>In &language;, certain expressions are classified as <termref def="dt-implausible"/>: an example
     is <code>@code/text()</code>, which will always return an empty sequence. A processor may report
     a static error when such expressions are encountered; however, processors are <rfc2119>required</rfc2119>
@@ -1584,145 +1592,5 @@ See
   
 
   <?change-log?>
-<!--
-<p role="xquery">This appendix lists the changes that have been made to this
-specification since the publication of the XQuery 3.1 Recommendation.</p>
 
-<p role="xpath">This appendix lists the changes that have been made to this
-specification since the publication of XPath 3.1 Recommendation.</p>
-
-<div2 id="id-changes-since-3.1">
-  <head>Changes since version 3.1</head>
-  <div3 id="id-substantive-changes-since-3.1">
-    <head>Substantive Changes</head>
-  
-  <p>The following changes have been made:</p>
-    <olist>
-      <item><p>The concept of the context item has been generalized, so it is now a context value. That is,
-      it is no longer constrained to be a single item.</p></item>
-      <item><p>Function definitions in the static context may now have optional parameters,
-      provided this does not cause ambiguity across multiple function definitions with the same name.
-      Optional parameters are given a default value, which can be any expression, including one that
-      depends on the context of the caller (so an argument can default to the context value).</p></item>
-      <item><p>In a static function call, arguments can be specified either positionally or by keyword,
-      or a combination of both.</p></item>
-      <item><p>An <code>otherwise</code> operator is introduced: <code>A otherwise B</code> returns the
-        value of <code>A</code>, unless it is an empty sequence, in which case it returns the value of <code>B</code>.</p></item>
-      <item><p>Alternative syntax for conditional expressions is available: <code>if (condition) {X} else {Y}</code>,
-      with the <code>else</code> part being optional.</p></item>
-      <item><p>In map constructors, the keyword <code>map</code> is now optional, so 
-        <code>map { 0: false(), 1: true() }</code> can now be written <code>{ 0: false(), 1: true() }</code>.</p></item>
-      <item><p>The syntax <code>for $x in X for $y in Y return Z</code> is now accepted in XPath as well as in XQuery.</p></item>
-      <item><p>The <code>NodeTest</code> in an <code>AxisStep</code> now allows alternatives: 
-        <code>ancestor::(section|appendix)</code>.</p></item>
-      <item><p>Element and attribute tests can include alternative names: <code>element(chapter|section)</code>,
-      <code>attribute(role|class)</code>.</p></item>
-      <item><p>String templates provide a new way of constructing strings: for example <code>`{$greeting}, {$planet}!`</code>
-      is equivalent to <code>$greeting || ', ' || $planet || '!'</code></p></item>
-      <item><p>In inline function expressions, the keyword <code>function</code> may be abbreviated
-      as <code>fn</code>.</p></item>
-      <item><p>New abbreviated syntax is introduced (<termref def="dt-focus-function"/>) 
-        for simple inline functions taking a single argument. 
-        An example is <code>fn { ../@code }</code></p></item>
-      <item><p>The arrow operator <code>=></code> is now complemented by a “mapping arrow” operator <code>=!></code>
-        which applies a the supplied function to each item in the input sequence independently.</p></item>
-      <item><p>The “function conversion rules” are now renamed “coercion rules”.</p></item>
-      <item><p>The coercion rules allow “relabeling” of a supplied atomic item where
-        the required type is a derived atomic type: for example, it is now permitted to supply
-        the value 3 when calling a function that expects an instance of <code>xs:positiveInteger</code>.</p></item>
-      <item><p>In XQuery, the coercion rules are now used when binding values to variables (both
-        global variable declarations and local variable bindings). This aligns XQuery with XSLT,
-        and means that the rules for binding to variables are the same as the rules for binding
-        to function parameters.</p></item>
-      <item><p>Function coercion allows a function with arity <var>N</var> to be supplied where a function of arity 
-        greater than <var>N</var> is expected. For example this allows the function <code>true#0</code> 
-        to be supplied where a predicate function is required.</p></item>
-      <item><p>The rules for “errors and optimization” have been tightened up to disallow
-        many cases of optimizations that alter error behavior. In particular
-        there are restrictions on reordering the operands of <code>and</code> and <code>or</code>,
-        and of predicates in filter expressions, in a way that might allow the processor to raise dynamic
-        errors that the author intended to prevent.
-      </p></item>
-      <item><p>Support for higher-order functions is now a mandatory feature (in 3.1 it was optional).</p></item>
-      <item role="xquery"><p>Switch expressions now allow a <code>case</code> clause to match multiple atomic items.</p></item>
-      <item><p>Numeric literals can now be written in hexadecimal or binary notation; and underscores can be included
-      for readability.</p></item>
-      <item role="xquery"><p>Switch and typeswitch expressions can now be written with curly braces,
-        to improve readability.</p></item>
-      <item role="xquery"><p>The comparand expression in a switch expression can be omitted, allowing
-        the switch cases to be provided as arbitrary boolean expressions.</p></item>
-      <item><p>The symbols <code>×</code> and <code>÷</code> can be used for multiplication and division,
-        and operators such as <code>&lt;</code> and <code>&gt;</code> can use the full-width forms
-        <code>&#xFF1C;</code> and <code>&#xFF1E;</code> to avoid the need for XML escaping.</p></item>
-      <item role="xquery"><p>The <code>start</code> clause in window expressions has become optional, as well as
-      the <code>when</code> keyword and its associated expression.</p></item>
-      <item role="xquery"><p>The values <code>true()</code> and <code>false()</code> are allowed
-      in function annotations, and negated numeric literals are also allowed.</p></item>
-      <item role="xquery"><p>All implementations must now predeclare the namespace prefixes
-      <code>math</code>, <code>map</code>, <code>array</code>, and <code>err</code>. In XQuery 3.1 it was permitted
-        but not required to predeclare these namespaces.</p></item>
-
-      <item role="xquery"><p>In previous versions the interpretation of location hints in 
-        <code>import schema</code> declarations was entirely at the discretion of the processor. To
-        improve interoperability, XQuery 4.0 recommends (but does not mandate)
-        a specific strategy for interpreting these hints.</p></item>
-
-
-      <item role="xquery"><p>The rules for the consistency of schemas imported by different query modules,
-      and for consistency between imported schemas and those used for validating input documents, have
-      been defined with greater precision. It is now recognized that these schemas will not always be
-      identical, and that validation with respect to different schemas may produce different outcomes,
-      even if the components of one are a subset of the components of the other.</p></item>
-
-      <item><p>Element and attribute tests of the form <code>element(N)</code>
-        and <code>attribute(N)</code> now allow <code>N</code> to be any <code>NameTest</code>,
-        including a wildcard.</p></item>
-      <item role="xquery"><p>The <termref def="dt-default-namespace-elements-and-types"/> can now be declared to be fixed
-      for a query module, meaning it is unaffected by a namespace declaration appearing on a direct
-      element constructor.</p></item>
-      
-      <item><p>The rules for reporting type errors during static analysis have been changed
-        so that a processor has more freedom to report errors in respect of constructs that
-        are evidently wrong, such as <code>@price/@value</code>, even though dynamic evaluation
-        is defined to return an empty sequence rather than an error.</p></item>
-      <item><p>Record types are added as a new kind of <code>ItemType</code>, constraining
-        the value space of maps.</p></item>
-      <item><p>Local union types are added as a new kind of <code>ItemType</code>, constraining
-        the value space of atomic items.</p></item>
-      <item><p>Enumeration types are added as a new kind of <code>ItemType</code>, constraining
-        the value space of strings.</p></item>
-      
-      
-      
-      
-      <item><p>The lookup operator <code>?</code> can now be followed by a string literal, for cases where
-        map keys are strings other than NCNames.</p></item>
-      
-      
-      <item><p>The rules for value comparisons when comparing values of different types (for example, decimal and double)
-        have changed to be transitive. A decimal value is no longer converted to double, instead the double is converted
-        to a decimal without loss of precision. This may affect compatibility in edge cases involving comparison of
-        values that are numerically very close.</p></item>
-      <item><p>A <code>for member</code> clause is added to FLWOR expressions to allow iteration over
-        an array.</p></item>
-
-    </olist>
-   
-
-  </div3>
-  <div3 id="id-editorial-changes-since-3.1">
-    <head>Editorial Changes</head>
-    
-    <olist>
-      <item><p>The presentation of the rules for the subtype relationship between sequence types and item types has been substantially
-        rewritten to improve clarity; no change to the semantics is intended.</p></item>
-      <item><p>The operator mapping table has been simplified by removing entries for the operators <code>ne</code>,
-      <code>le</code>, <code>gt</code>, and <code>ge</code>; these are now defined by reference to the
-      rules for the operators <code>eq</code> and <code>lt</code>.</p></item>
-      <item><p>Recommended rules for processing an <code>import schema</code> declaration with multiple
-      location hints are now provided, though they are not binding on implementers.</p></item>
-
-    </olist>
-  </div3>
-</div2>-->
 </inform-div1>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -199,7 +199,7 @@
             /</code>, on the other hand, is syntactically valid without parentheses.</p>
       </constraintnote>
       
-      <constraintnote id="parse-note-unreserved-name" type="xgc">
+      <constraintnote id="parse-note-unreserved-name" type="xgc" role="xquery">
         <head>unreserved-name</head>
         <p>In a computed node constructor of the form
         <code>element <var>NNN</var> {}</code>, <code>attribute <var>NNN</var> {}</code>,

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -15085,12 +15085,11 @@ be created: <code>element</code>, <code>attribute</code>,
 <code>processing-instruction</code>, <code>comment</code>, or
 <code>namespace</code>.</p>
 
-            <p>For those kinds of nodes that have names (element, attribute, and
-processing instruction nodes), the keyword that specifies the node
+            <p>For those kinds of nodes that have names (element, attribute, 
+processing instruction, and namespace nodes), the keyword that specifies the node
 kind is followed by the name of the node to be created. This name may
 be specified either as an EQName or as an expression enclosed in
-braces. <termdef
-                  term="name expression" id="dt-name-expression"
+braces. <termdef term="name expression" id="dt-name-expression"
                      >When
 an expression is used to specify the name of a constructed node, that
 expression is called the <term>name expression</term> of the
@@ -15111,6 +15110,28 @@ same result as the first example in <specref
     element last { "Johnson" }
   }
 }]]></eg>
+            
+            <note><p>XQuery 4.0 allows the node name to be written in quotation
+            marks (for example, <code>element "book" {}</code>, and at the same
+            time it disallows the use of a defined set of language keywords
+            without quotes: for example <code>element div {}</code> was allowed
+            in XQuery 3.1 but must now be written <code>element "div" {}</code> or
+            <code>element {"div"} {}</code>. The reason for this incompatible
+            change is that allowing map constructors to omit the <code>map</code>
+            keyword would otherwise create an ambiguity: consider for example the
+            expression <code>element otherwise {}</code>.</p>
+            
+            <p>Because the list of reserved keywords may be extended in future
+            versions of this specification, the safest strategy is to always to
+            use quotation marks (for example <code>element "div"</code>) 
+            when the node name is a simple <code>NCName</code>. To avoid
+            any dependency on the default namespace context, the form
+            <code>element Q{}div</code> might also be used.</p>
+               
+            <p>To write code that is portable between XQuery 3.1 and XQuery 4.0,
+            the best advice is to use either the form <code>element {"div"}</code>
+            or the form <code>element Q{}div</code>.</p>
+            </note>
 
             <div4 id="id-computedElements">
                <head>Computed Element Constructors</head>


### PR DESCRIPTION
1. Adds advice and guidance on avoiding reserved words
2. Drops XQuery-specific material from the XPath spec
3. Adds a paragraph to the incompatibilities appendix