### PR TITLE
1538 Add XSLT support for json-lines

### DIFF
--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1867,6 +1867,11 @@
             <e:data-type name="string"/>
          </e:attribute-value-template>
       </e:attribute>
+      <e:attribute name="json-lines">
+         <e:attribute-value-template>
+            <e:data-type name="boolean"/>
+         </e:attribute-value-template>
+      </e:attribute>
       <e:attribute name="json-node-output-method">
          <e:attribute-value-template>
             <e:constant value="xml"/>
@@ -1986,6 +1991,9 @@
       </e:attribute>
       <e:attribute name="item-separator">
          <e:data-type name="string"/>
+      </e:attribute>
+      <e:attribute name="json-lines">
+         <e:data-type name="boolean"/>
       </e:attribute>
       <e:attribute name="json-node-output-method">
          <e:constant value="xml"/>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -1434,6 +1434,7 @@ of problems processing the schema using various tools
           <xs:attribute name="include-content-type" type="xsl:yes-or-no"/>
           <xs:attribute name="indent" type="xsl:yes-or-no"/>
           <xs:attribute name="item-separator" type="xs:string"/>
+          <xs:attribute name="json-lines" type="xsl:yes-or-no"/>
           <xs:attribute name="json-node-output-method" type="xsl:method"/>
           <xs:attribute name="media-type" type="xs:string"/>
           <xs:attribute name="normalization-form" type="xs:NMTOKEN"/>
@@ -1653,6 +1654,7 @@ of problems processing the schema using various tools
           <xs:attribute name="include-content-type" type="xsl:avt"/>
           <xs:attribute name="indent" type="xsl:avt"/>
           <xs:attribute name="item-separator" type="xsl:avt"/>
+          <xs:attribute name="json-lines" type="xsl:avt"/>
           <xs:attribute name="json-node-output-method" type="xsl:avt"/>
           <xs:attribute name="media-type" type="xsl:avt"/>
           <xs:attribute name="normalization-form" type="xsl:avt"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -38323,6 +38323,12 @@ return ($m?price - $m?discount)</eg>
                </note>
             </item>
             <item>
+               <p>The value of the <code>json-lines</code> attribute determines whether the JSON
+                  output method should output multiple JSON values in json-lines format (one
+                  value per line). The default value is <code>no</code>.
+               </p>
+            </item>
+            <item>
                <p> The value of the <code>media-type</code> attribute provides the value of the
                      <code>media-type</code> parameter to the serialization method. The default
                   value is <code>text/xml</code> in the case of the <code>xml</code> output method,

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -36992,7 +36992,8 @@ return ($m?price - $m?discount)</eg>
                   <code>doctype-system</code>, <code>encoding</code>,
                <code diff="add" at="2023-03-31">escape-solidus</code>
                   <code>escape-uri-attributes</code>, <code>html-version</code>, <code>indent</code>, <code>item-separator</code>,
-               <code diff="add" at="2024-11-09">json-lines</code>, <code>json-node-output-method</code>,
+               <code diff="add" at="2024-11-01">json-lines</code>,
+               <code>json-node-output-method</code>,
                   <code>media-type</code>, <code>normalization-form</code>,
                   <code>omit-xml-declaration</code>, <code>standalone</code>, <code>suppress-indentation</code>,
                <!-- see bug 6535 -->

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -655,6 +655,10 @@ is performed. <termref def="host-language">Host languages</termref> <rfc2119>MAY
 they are not <rfc2119>REQUIRED</rfc2119> to be able to do so. However, the <termref def="host-language">host language</termref>
 specification <rfc2119>MUST</rfc2119> specify how the values of all applicable parameters are to be
 determined. </p>
+  <p>Host languages may also define alternative representations of the values of serialization parameters. For example, both XSLT
+  and XQuery allow the boolean values <code>true</code> and <code>false</code> to be written as <code>1</code>/<code>0</code>
+  or <code>yes</code>/<code>no</code>. The <code>$options</code> map passed to the <code>fn:serialize</code> function,
+  by contrast, requires an <code>xs:boolean</code> value.</p>
 <p>It is a <termref def="serial-err">serialization error</termref> <errorref code="0016" class="PM"/> if a parameter value is invalid for the given parameter.   It
 is the responsibility of the <termref def="host-language">host language</termref> to specify how invalid values should be handled at the level of that language.</p>
 <p>The following serialization parameters are defined:</p>
@@ -668,15 +672,14 @@ is the responsibility of the <termref def="host-language">host language</termref
 <tbody>
 <tr>
 <td rowspan="1" colspan="1"><code>allow-duplicate-names</code></td>
-<td rowspan="1" colspan="1">One of the enumerated values
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+<td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 This parameter indicates
 whether a map item serialized as a JSON object using the JSON output method is 
-allowed to contain duplicate member names.  If the value <code>no</code>, <code>false</code> or <code>0</code>
+allowed to contain duplicate member names.  If the value <code>false</code>
 is specified, a serialization error <errorref code="0022" class="RE"/> may be raised under certain conditions.</td>
 </tr>
-<tr><td rowspan="1" colspan="1"><code>byte-order-mark</code></td><td rowspan="1" colspan="1">One of the enumerated values
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+<tr><td rowspan="1" colspan="1"><code>byte-order-mark</code></td><td rowspan="1" colspan="1">A boolean value, 
+  <code>true</code> or <code>false</code>.
           This parameter indicates
           whether the serialized sequence of octets is to be preceded by
           a Byte Order Mark  (See Section 5.1 of
@@ -710,29 +713,25 @@ This parameter <rfc2119>MAY</rfc2119> be absent.</td>
 
   <tr diff="add" at="2023-03-31">
     <td rowspan="1" colspan="1"><code>escape-solidus</code></td>
-    <td rowspan="1" colspan="1">One of the enumerated values 
-      <code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+    <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
     </td></tr>
 
 <tr>
 <td rowspan="1" colspan="1"><code>escape-uri-attributes</code></td>
-<td rowspan="1" colspan="1">One of the enumerated values 
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+<td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
 <tr>
 <td rowspan="1" colspan="1"><code>html-version</code></td>
 <td rowspan="1" colspan="1">A decimal value.  This parameter <rfc2119>MAY</rfc2119> be absent.</td></tr>
-<tr><td rowspan="1" colspan="1"><code>include-content-type</code></td><td rowspan="1" colspan="1">One of the enumerated values 
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+<tr><td rowspan="1" colspan="1"><code>include-content-type</code></td>
+  <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
-<tr><td rowspan="1" colspan="1"><code>indent</code></td><td rowspan="1" colspan="1">One of the enumerated values 
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+<tr><td rowspan="1" colspan="1"><code>indent</code></td><td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
 <tr><td rowspan="1" colspan="1"><code>item-separator</code></td><td rowspan="1" colspan="1">A string of Unicode characters.  This
 parameter <rfc2119>MAY</rfc2119> be absent.</td></tr>
 
-<tr><td rowspan="1" colspan="1"><code>json-lines</code></td><td rowspan="1" colspan="1">One of the enumerated values 
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+<tr><td rowspan="1" colspan="1"><code>json-lines</code></td><td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
 
 <tr>
@@ -785,11 +784,11 @@ output method; its behavior is not specified by this document.</td>
           <termref def="impdef">implementation-defined</termref> value
          of type
          <code>NMTOKEN</code>.</td></tr>
-<tr><td rowspan="1" colspan="1"><code>omit-xml-declaration</code></td><td rowspan="1" colspan="1">One of the enumerated values 
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+<tr><td rowspan="1" colspan="1"><code>omit-xml-declaration</code></td>
+  <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
-<tr><td rowspan="1" colspan="1"><code>standalone</code></td><td rowspan="1" colspan="1">One of the enumerated values 
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code>, <code>0</code>
+<tr><td rowspan="1" colspan="1"><code>standalone</code></td>
+  <td rowspan="1" colspan="1">Either a boolean value, <code>true</code> or <code>false</code>, or the value
 or <code>omit</code>.</td></tr>
 <tr>
 <td rowspan="1" colspan="1"><code>suppress-indentation</code></td>
@@ -797,8 +796,7 @@ or <code>omit</code>.</td></tr>
 </tr>
 <tr>
 <td rowspan="1" colspan="1"><code>undeclare-prefixes</code></td>
-<td rowspan="1" colspan="1">One of the enumerated values 
-<code>yes</code>, <code>no</code>, <code>true</code>, <code>false</code>, <code>1</code> or <code>0</code>.
+<td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
 <tr>
 <td rowspan="1" colspan="1"><code>use-character-maps</code></td>
@@ -862,7 +860,7 @@ that this specification leaves the output <termref def="impdef">implementation-d
 namespace declarations on an element are written before or after the
 attributes of the element, or they might define the number of space or tab
 characters to be inserted when the <code>indent</code> parameter is set to 
-<code>yes</code>, <code>true</code> or <code>1</code>; but they
+<code>true</code>; but they
 could not instruct the <termref def="serializer">serializer</termref>
 to suppress the error that occurs when the
 HTML output method encounters
@@ -1263,7 +1261,7 @@ serialization parameters in an
 and processed using the mechanism described in this section,
 would specify the settings of the <code>method</code>, <code>version</code>
 and <code>indent</code> serialization parameters with the values
-<code>xml</code>, <code>1.0</code> and <code>yes</code>, respectively.
+<code>xml</code>, <code>1.0</code> and <code>true</code>, respectively.
 </p>
 <eg xml:space="preserve"><![CDATA[
 <output:serialization-parameters 
@@ -1593,7 +1591,7 @@ See <xspecref spec="DM40" ref="const-infoset-element"/> and
 for additional information.
 </p></item>
 <item><p>If the <code>indent</code> parameter has
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
 </p><ulist><item><p>additional text nodes consisting of
 whitespace characters <rfc2119>MAY</rfc2119> be present in the <termref def="reconstructed-tree">reconstructed tree</termref>; and</p></item>
 <item><p>text nodes in the <termref def="result-tree">result tree</termref> that contained only whitespace
@@ -1791,7 +1789,7 @@ reference.  If a comment node contains the same character, a
 <termref def="serializer">serializer</termref> <rfc2119>MAY</rfc2119> adjust the whitespace
 in the serialized result so that a person will find it easier to read.
 If the <code>indent</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
 the <termref def="serializer">serializer</termref> <rfc2119>MAY</rfc2119> output whitespace characters in
   addition to the whitespace characters in the <termref def="dt-input-tree"/>.  
   It <rfc2119>MAY</rfc2119> also elide from the output whitespace
@@ -1813,10 +1811,10 @@ of that element.</termdef>
 <!--End of text changed for Bug 6808 under comment 12-->
 
 <p>If the
-<code>indent</code> parameter has the value <code>no</code>, <code>false</code> or <code>0</code>, the
+<code>indent</code> parameter has the value <code>false</code>, the
 <termref def="serializer">serializer</termref> <rfc2119>MUST NOT</rfc2119> add, elide
 or replace whitespace characters in the output. If the <code>indent</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
 the <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119>
 use an algorithm for dealing with whitespace characters that satisfies
 all of the following constraints.
@@ -1933,12 +1931,12 @@ have been explicitly requested by the user, either by using the
 attempts to preserve CDATA sections present in the source
 document.</p></note><imp-def-feature>A <termref def="serializer">serializer</termref> <rfc2119>MAY</rfc2119> provide an <termref def="impdef">implementation-defined</termref> mechanism to place CDATA sections in the <termref def="result-tree">result tree</termref>.</imp-def-feature></div3>
 <div3 id="XML_OMIT-XML-DECLARATION"><head>XML Output Method: the <code>omit-xml-declaration</code> and <code>standalone</code> Parameters</head><p>The XML output method
-<rfc2119>MUST</rfc2119> output an XML declaration if the <code>omit-xml-declaration</code> parameter has the value <code>no</code>, <code>false</code> or <code>0</code>.   
+<rfc2119>MUST</rfc2119> output an XML declaration if the <code>omit-xml-declaration</code> parameter has the value <code>false</code>.   
 The XML declaration <rfc2119>MUST</rfc2119> include both version information and an encoding declaration. 
 If the <code>standalone</code> parameter has 
-one of the values <code>yes</code>, <code>true</code>, <code>1</code>, <code>no</code>, <code>false</code> or <code>0</code>,
-the XML declaration <rfc2119>MUST</rfc2119> include a standalone document declaration with the same value as the value of the <code>standalone</code> parameter.
-
+the value <code>true</code> or <code>false</code>,
+the XML declaration <rfc2119>MUST</rfc2119> include a standalone document declaration 
+  with the value of the <code>standalone</code> parameter set accordingly to <code>yes</code> or <code>no</code>.
 If the <code>standalone</code> parameter has
 the value <code>omit</code>, the XML declaration
 <rfc2119>MUST NOT</rfc2119> include a standalone document declaration; this ensures
@@ -1947,7 +1945,7 @@ document entity) and a text declaration (allowed at the beginning of
 an external general parsed entity).</p>
 <p>A <termref def="serial-err">serialization error</termref> <errorref code="0009" class="PM"/> results if the
 <code>omit-xml-declaration</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>, and</p>
+the value <code>true</code>, and</p>
 <ulist><item><p>the <code>standalone</code> parameter has a value other than
 <code>omit</code>; or
 </p></item>
@@ -1958,7 +1956,7 @@ parameter is specified.</p></item></ulist>
 </p>
 <p>Otherwise, if the
 <code>omit-xml-declaration</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the <code>true</code>,
  the XML output method
 
 <rfc2119>MUST NOT</rfc2119> output an XML declaration.</p></div3>
@@ -1984,12 +1982,12 @@ have a child element node that does
 not bind that same prefix. In <emph>Namespaces in XML 1.1</emph> (<bibref ref="xml-names11"/>), this can be represented accurately by undeclaring
 prefixes.  For the undeclaring prefix of the child element node,  
 if the <code>undeclare-prefixes</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
 the output method is XML or XHTML, and the <code>version</code> 
 parameter value is greater than <code>1.0</code>,
 the <termref def="serializer">serializer</termref>
 <rfc2119>MUST</rfc2119> undeclare its namespace.  If the
-<code>undeclare-prefixes</code> parameter has the value <code>no</code>, <code>false</code> or <code>0</code> and the output method is XML or
+<code>undeclare-prefixes</code> parameter has the value <code>false</code> and the output method is XML or
 XHTML, then the undeclaration of prefixes <rfc2119>MUST NOT</rfc2119> occur.</p><example><p>Consider an element <code>x:foo</code> with four in-scope namespaces
 that associate prefixes with URIs as follows:
 </p><ulist><item><p><code>x</code> is associated with
@@ -2012,7 +2010,7 @@ that associate prefixes with URIs as follows:
        
 &lt;/x:foo&gt;</eg></example><p>In <emph>Namespaces in XML</emph> 1.0 (<bibref ref="xml-names"/>), prefix undeclaration is not possible.
 If the output method is XML or XHTML, the value of the <code>undeclare-prefixes</code> parameter is 
-one of <code>yes</code>, <code>true</code> or <code>1</code>,
+<code>true</code>,
 and the value of the <code>version</code> parameter is <code>1.0</code>,
 a <termref def="serial-err">serialization error</termref> <errorref code="0010" class="PM"/> results; the
 <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> raise the error.</p></div3>
@@ -2067,7 +2065,7 @@ applicable to the XML output method.  See
 <specref ref="serparam"/> for more information.</p><note><p>The byte order mark may be undesirable under certain circumstances, 
 for example, to concatenate resulting XML fragments without additional processing to remove the byte order mark. 
 Therefore this specification does not mandate the <code>byte-order-mark</code> parameter to have 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>
+the value <code>true</code>
 when the encoding is UTF-16, 
 even though the XML 1.0 and XML 1.1 specifications state that entities encoded in UTF-16 <rfc2119>MUST</rfc2119> begin with a byte order mark.  
 Consequently, this specification does not guarantee that the resulting XML fragment, 
@@ -2429,7 +2427,7 @@ or the requirements of <bibref ref="xhtml1"/> and <bibref ref="xhtml11"/>.</p>
 <head>XHTML Output Method: the <code>indent</code> and <code>suppress-indentation</code> Parameters</head>
 <!--Text replaced by erratum E9 change 1"-->
 <p>If the <code>indent</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>, the
+the value <code>true</code>, the
 <termref def="serializer">serializer</termref> <rfc2119>MAY</rfc2119> add or remove whitespace as it serializes the
 <termref def="result-tree">result tree</termref>,
 if it observes the following constraints.</p>
@@ -2539,7 +2537,7 @@ name of the element.</p>
   <div3 id="XHTML_ESCAPE-URI-ATTRIBUTES"><head>XHTML Output Method: the <code>escape-uri-attributes</code> Parameter</head><p>
 
 If the <code>escape-uri-attributes</code> parameter has
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
  the XHTML output method 
 <rfc2119>MUST</rfc2119> apply <termref def="uri-escaping">URI escaping</termref> to 
 <termref def="uri-attribute-values">URI attribute values</termref>, except that relative URIs <rfc2119>MUST NOT</rfc2119> be absolutized.</p><note><p>This escaping is deliberately confined to non-ASCII characters,
@@ -2548,14 +2546,14 @@ example when URIs or URI fragments are interpreted locally by the HTML
 user agent. Even in the case of non-ASCII characters, escaping can
 sometimes cause problems. More precise control of <termref def="uri-escaping">URI escaping</termref> is
 therefore available by setting <code>escape-uri-attributes</code> to
-<code>no</code>, and controlling the escaping of URIs by using methods defined in
+<code>false</code>, and controlling the escaping of URIs by using methods defined in
 <xspecref spec="FO40" ref="func-encode-for-uri"/> and <xspecref spec="FO40" ref="func-iri-to-uri"/>.</p></note></div3>
 <div3 id="XHTML_INCLUDE-CONTENT-TYPE"><head>XHTML Output Method: the <code>include-content-type</code> Parameter</head>
   <p>If the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> includes a <code>head</code> element
 <termref def="recognized-as-HTML">recognized as
 an HTML element</termref>,
 and the <code>include-content-type</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
 the XHTML output method
 <rfc2119>MUST</rfc2119>
 add a <code>meta</code> element as the first child element of the
@@ -3064,7 +3062,7 @@ raise a <termref def="serial-err">serialization error</termref> <errorref code="
 <head>HTML Output Method: the <code>indent</code> and <code>suppress-indentation</code> Parameters</head>
 <!--Text replaced by erratum E9 change 3"-->
 <p>If the <code>indent</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
 then the
 HTML output method <rfc2119>MAY</rfc2119> add or remove whitespace as it
 serializes the <termref def="result-tree">result tree</termref>,
@@ -3188,7 +3186,7 @@ applicable to the HTML output method.  See
    
 <div3 id="HTML_ESCAPE-URI-ATTRIBUTES"><head>HTML Output Method: the <code>escape-uri-attributes</code> Parameter</head><p>
 If the <code>escape-uri-attributes</code> parameter
-has one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+has the value <code>true</code>,
 the HTML output method <rfc2119>MUST</rfc2119>
 apply <termref def="uri-escaping">URI escaping</termref> to 
 <termref def="uri-attribute-values">URI attribute values</termref>, except that relative URIs <rfc2119>MUST NOT</rfc2119> be absolutized.
@@ -3198,11 +3196,11 @@ example when URIs or URI fragments are interpreted locally by the HTML
 user agent. Even in the case of non-ASCII characters, escaping can
 sometimes cause problems. More precise control of <termref def="uri-escaping">URI escaping</termref> is
 therefore available by setting <code>escape-uri-attributes</code> to
-<code>no</code>, and controlling the escaping of URIs by using methods defined in
+<code>false</code>, and controlling the escaping of URIs by using methods defined in
 <xspecref spec="FO40" ref="func-encode-for-uri"/> and <xspecref spec="FO40" ref="func-iri-to-uri"/>.</p></note></div3>
 <div3 id="HTML_INCLUDE-CONTENT-TYPE"><head>HTML Output Method: the <code>include-content-type</code> Parameter</head><p>If there is a <code>head</code> element,
 and the <code>include-content-type</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
 the HTML output method
 <rfc2119>MUST</rfc2119> add a <code>meta</code> element
 as the first child element
@@ -3420,12 +3418,14 @@ is described in <specref ref="serdm"/>.</p>
 
   <ulist>
     <item>
-      <p>If the value is one of <code>yes</code>, <code>true</code> or <code>1</code>,
-        each item of the input value becomes a separate list entry.
+      <p>If the value is <code>true</code>,
+        each item of the input value becomes a separate list entry. If the input value
+        is an empty sequence, the serialized result is empty.
       </p>
     </item>
     <item>
-      <p>For all other values, the input value becomes a single list entry.</p>
+      <p>If the value is <code>false</code>, the input value becomes a single list entry. If
+      the input value is an empty sequence, the serialized result is the string <code>null</code>.</p>
     </item>
   </ulist>
 
@@ -3462,7 +3462,7 @@ serialized output is
 <termref def="dt-string-value">string value</termref>,
 serialization error <errorref code="0022" class="RE"/> is raised,
 unless the <code>allow-duplicate-names</code> parameter has
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>.
+the value <code>true</code>.
 </p>
 </item>
 
@@ -3472,7 +3472,7 @@ is serialized <termref def="to-a-json-string">to a JSON string</termref> by outp
 the result of serializing the node using the method specified by the 
 <code>json-node-output-method</code> parameter.  
 The node is serialized with the serialization parameter <code>omit-xml-declaration</code> set
- to <code>yes</code> and with no other serialization parameters set.
+ to <code>true</code> and with no other serialization parameters set.
 
 </p></item>
 
@@ -3553,8 +3553,8 @@ range 1-31 or 127-159 by an escape in the form <code>\uHHHH</code>
 where <code>HHHH</code> is the hexadecimal representation of the codepoint value.
   <phrase diff="add" at="2023-05-31">Escaping further replaces the solidus character (<code>/</code>)
   by the escape sequence <code>\/</code> if the <code>escape-solidus</code> parameter
-  is set to <code>true</code>, <code>yes</code>, or <code>1</code>, but not if it is
-  set to <code>false</code>, <code>no</code>, or <code>0</code>.</phrase>
+  is set to <code>true</code>, but not if it is
+  set to <code>false</code>.</phrase>
 Escaping is also applied to any characters that cannot be represented in the selected encoding.
 </p></item>
 <item><p>The resulting string is enclosed in double quotation marks.</p></item>
@@ -3572,7 +3572,7 @@ converts the character stream produced by the preceding rules into an octet stre
 When nodes are serialized using the JSON output method, 
 serialization is delegated to the output method specified by the 
 <code>json-node-output-method</code> serialization parameter.  The 
-<code>omit-xml-declaration</code> parameter is set to <code>yes</code>, and no other 
+<code>omit-xml-declaration</code> parameter is set to <code>true</code>, and no other 
 serialization parameters are passed down to the serialization 
 method responsible for serializing the node.
 </p>
@@ -3618,13 +3618,13 @@ definition of JSON in <bibref ref="rfc7159"/>.</p>
 </div3>
 
 <div3 id="JSON_INDENT">
-<head>JSON Output Method: the <code>indent</code> and <code>suppress-indentation</code> Parameters</head>
+<head>JSON Output Method: the <code>indent</code> Parameter</head>
 
 <p>The <code>indent</code> parameter
 controls whether the <termref def="serializer">serializer</termref>
 adjusts the whitespace in the serialized result so that a person will
 find it easier to read. If the <code>indent</code> parameter has 
-one of the values <code>yes</code>, <code>true</code> or <code>1</code>,
+the value <code>true</code>,
 the <termref
 def="serializer">serializer</termref> <rfc2119>MAY</rfc2119> output
 additional whitespace characters adjacent to the JSON structural
@@ -3632,8 +3632,8 @@ tokens. For all other values, the <termref def="serializer">serializer</termref>
 <rfc2119>MUST</rfc2119> output no whitespace characters adjacent to
 the JSON structural tokens.
 </p>
-<p>If <code>json-lines</code> has one of the values <code>yes</code>, <code>true</code> or
-<code>1</code>, indentation is allowed, but the output whitespace characters may not contain
+<p>If <code>indent</code> and <code>json-lines</code> are both <code>true</code>, 
+  additional whitespace is allowed, but it <rfc2119>MUST NOT</rfc2119> include
 the character <char>U+000A</char>.</p>
 
 </div3>
@@ -3676,9 +3676,9 @@ the byte-order mark).</p>
   
   <div3 id="JSON_ESCAPE-SOLIDUS" diff="add" at="2023-05-31"><head>JSON Output Method: the <code>escape-solidus</code> Parameter</head>
     <p>The <code>escape-solidus</code> parameter is
-      applicable to the JSON output method. If the value is <code>yes</code>, <code>true</code>, or <code>1</code>,
+      applicable to the JSON output method. If the value is <code>true</code>,
       then the solidus character (<code>"/"</code>) appearing in a string is escaped with a backslash
-      (as <code>"\/"</code>). If the value is <code>no</code>, <code>false</code>, or <code>0</code>,
+      (as <code>"\/"</code>). If the value is <code>false</code>,
     then it is not escaped.</p>
   
   <note><p>In previous versions of this specification, the solidus was always escaped. Although JSON does not require
@@ -3693,10 +3693,10 @@ determines whether the presence of multiple keys in a map item
 with the same string value (e.g. the date 2014-10-01 and the string
 "<code>2014-10-01</code>") will or will not raise serialization error
 <errorref code="0022" class="RE"/>.  If the value is 
-one of, <code>yes</code>, <code>true</code> or <code>1</code>,
+<code>true</code>,
 such duplicate keys will result in duplicate object-member names in
 the JSON output and no error will be raised because of the duplicate names.
-If the value is <code>no</code>, <code>false</code> or <code>0</code>,
+If the value is <code>false</code>,
 such duplicate keys are an error 
 (<errorref code="0022" class="RE"/>).</p>
 </div3>
@@ -3710,7 +3710,7 @@ If the value is one of <code>xml</code>, <code>xhtml</code>, <code>html</code> o
 then the node is converted <termref def="to-a-json-string">to a JSON string</termref> by serializing the node using the output method 
 specified by this parameter.  If the value is <code>xml</code> or <code>xhtml</code> then 
 the node is serialised with the additional serialization parameter <code>omit-xml-declaration</code> 
-set to <code>yes</code>.
+set to <code>true</code>.
 </p>
 </div3>
 


### PR DESCRIPTION
Fix #1538

I also did some editorial cleanup of the serialization spec, in particular parameters like `indent` now have the value `true` or `false`, while recognizing that some host languages may allow alternative representations such as yes/no or 1/0.