### PR TITLE
Correct return type for fn:siblings

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -13930,7 +13930,7 @@ return empty($break)
    
    <fos:function name="siblings" prefix="fn">
       <fos:signatures>
-         <fos:proto name="siblings" return-type="xs:boolean">
+         <fos:proto name="siblings" return-type="node()*">
             <fos:arg name="node" type="node()?" default="." usage="navigation"/>
          </fos:proto>
       </fos:signatures>


### PR DESCRIPTION
As noted during the review at yesterday's meeting. (I was supposed to correct it before applying the PR, but pressed the wrong key...)