### PR TITLE
1548 Clarify default for xsl:output/@indent

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -20202,7 +20202,7 @@ serialize(
          <p>Returns the value of the default collation property from the 
             <phrase diff="chg" at="2023-05-19">dynamic</phrase> context context. Components
             of the dynamic context are described in <xspecref
-               spec="XP40" ref="id-eval-context"/>.</p>
+               spec="XP40" ref="eval_context"/>.</p>
       </fos:rules>
       <fos:notes>
          <p>The default collation property can never be absent. If it is not explicitly defined, a

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19098,9 +19098,8 @@ processing with JSON processing.</p>
   and arrays, especially constructors and lookup.</p>
 
             <p>Some of the functionality typically needed for maps and
-  arrays is provided by functions defined in <xspecref
-                  spec="FO40" ref="maps-and-arrays"
-               />, including functions used to
+  arrays is provided by functions defined in <xspecref spec="FO40" ref="maps"/>
+               and <xspecref spec="FO40" ref="arrays"/>, including functions used to
   read JSON to create maps and arrays, serialize maps and arrays to
   JSON, combine maps to create a new map, remove map entries to create
   a new map, iterate over the keys of a map, convert an array to

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -25,8 +25,6 @@
          <loc href="Overview-diff.html">HTML with revision markings (non-normative)</loc>
          <loc href="schema-for-xslt40.xsd">XSD 1.1 Schema for XSLT 4.0 Stylesheets (non-normative)</loc>
          <loc href="schema-for-xslt40.rnc">Relax-NG Schema for XSLT 4.0 Stylesheets (non-normative)</loc>
-         <loc href="schema-for-json.xsd">XSD 1.0 Schema for the XML representation of JSON used by
-            fn:json-to-xml (non-normative)</loc>
          <loc href="xml-to-json.xsl">Stylesheet for XML-to-JSON conversion (non-normative)</loc>
       </altlocs>
       <latestloc>
@@ -36227,7 +36225,8 @@ return ($m?price - $m?discount)</eg>
                call the <function>xml-to-json</function> function; or transform it to JSON directly
                by using custom template rules.</p>
 
-            <p>To assist with the second approach, a stylesheet is provided in <specref ref="xml-to-json-stylesheet"/>. This stylesheet includes a function
+            <p>To assist with the second approach, a stylesheet is provided in <specref ref="json-in-xml"/>. 
+               This stylesheet includes a function
                   <code>j:xml-to-json</code> which, apart from being in a different namespace, is
                functionally very similar to the <function>xml-to-json</function> function described in
                the previous section. (It differs in doing less validation
@@ -39237,26 +39236,20 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
       </div1>
       <div1 id="json-in-xml">
          <head>XML Representation of JSON</head>
-         <p>This appendix contains the schema for the XML representation of JSON described in
-               <specref ref="json-to-xml-mapping"/>, together with the stylesheets used for
-            converting from this XML representation to strings matching the JSON grammar.</p>
-         <p>These schema documents and stylesheets are also available as separate resources (links
+         <p>This appendix a stylesheet that can be used for converting the XML representation of JSON described in
+               <xspecref spec="FO40" ref="json-to-xml-mapping"/> into strings matching the JSON grammar.</p>
+         <p>This stylesheet as also available as a separate resource (links
             are listed at the top of this document).</p>
-         <div2 id="schema-for-json">
-            <head>Schema for the XML Representation of JSON</head>
-            <p>The schema is reproduced below:</p>
-            <?doc schema-for-json.xsd?>
-         </div2>
-         <div2 id="xml-to-json-stylesheet">
-            <head>Stylesheet for converting XML to JSON</head>
-            <p>This stylesheet contains the implementation of a function very similar to
+         <p>The schema for this XML representation of JSON is described at 
+            <xspecref spec="FO40" ref="json-to-xml-mapping"/>.</p>
+         
+            <p>The stylesheet contains the implementation of a function very similar to
                   <function>xml-to-json</function>, but implemented in XSLT so that it can be
                customized and extended. This stylesheet is provided for the benefit of users and
                there are no conformance requirements associated with it; there is no requirement
                that processors should make this stylesheet available. The stylesheet is reproduced
                below:</p>
             <?doc xml-to-json.xsl?>
-         </div2>
       </div1>
       <inform-div1 id="glossary">
          <head>Glossary</head>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -39236,9 +39236,9 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
       </div1>
       <div1 id="json-in-xml">
          <head>XML Representation of JSON</head>
-         <p>This appendix a stylesheet that can be used for converting the XML representation of JSON described in
+         <p>This appendix contains a stylesheet that can be used for converting the XML representation of JSON described in
                <xspecref spec="FO40" ref="json-to-xml-mapping"/> into strings matching the JSON grammar.</p>
-         <p>This stylesheet as also available as a separate resource (links
+         <p>This stylesheet is also available as a separate resource (links
             are listed at the top of this document).</p>
          <p>The schema for this XML representation of JSON is described at 
             <xspecref spec="FO40" ref="json-to-xml-mapping"/>.</p>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -39663,6 +39663,11 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                   prescriptive about which schema is used for validation. The rules may differ from
                   the conventions adopted by implementations of XSLT 3.0.</p>
             </item>
+            <item>
+               <p>XSLT 3.0 failed to specify a default value for the serialization parameter <code>indent</code>
+               where the serialization method is <code>json</code> or <code>adaptive</code>. XSLT 4.0 specifies
+               a default value of <code>no</code>.</p>
+            </item>
          </olist>
          
          <p>See also <bibref ref="xpath-40"/>, <bibref ref="xpath-functions-40"/>, and

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -37934,30 +37934,33 @@ return ($m?price - $m?discount)</eg>
       <div1 id="serialization">
          <head>Serialization</head>
          
-         <changes>
-            <change issue="530" PR="534" date="2023-06-09">
-               A new serialization parameter <code>escape-solidus</code> is provided to control
-               whether the character <code>/</code> is escaped as <code>\/</code> by the
-               JSON serialization method.
-            </change>
-            <change issue="1548" date="2024-11-09">
-               The default value for the <code>indent</code> parameter is now defined to be
-               <code>no</code> for all output methods other than <code>html</code> and <code>xhtml</code>.
-            </change>
-         </changes>
+        
          
          <p>A <termref def="dt-processor">processor</termref>
             <rfc2119>may</rfc2119> output a <termref def="dt-final-result-tree">final result
                tree</termref> as a sequence of octets, although it is not
                <rfc2119>required</rfc2119> to be able to do so (see <specref ref="conformance"/>).
+            This process is described as <term>serialization</term>.
             Stylesheet authors can use <elcode>xsl:output</elcode> declarations to specify how they
             wish result trees to be serialized. If a processor serializes a final result tree, it
                <rfc2119>must</rfc2119> do so as specified by these declarations.</p>
-         <p>The rules governing the output of the serializer are defined in <bibref ref="xslt-xquery-serialization-30"/>. The serialization is controlled using a number
+         <p>The rules governing the output of the serializer are defined in <bibref ref="xslt-xquery-serialization-30"/>. 
+            The serialization is controlled using a number
             of serialization parameters. The values of these serialization parameters may be set
             within the <termref def="dt-stylesheet">stylesheet</termref>, using the
                <elcode>xsl:output</elcode>, <elcode>xsl:result-document</elcode>, and
                <elcode>xsl:character-map</elcode> declarations.</p>
+         
+         <div2 id="id-xsl-output-declaration">
+            <head>The <code>xsl:output</code> declaration</head>
+            <changes>
+               <change issue="530" PR="534" date="2023-06-09">
+                  A new serialization parameter <code>escape-solidus</code> is provided to control
+                  whether the character <code>/</code> is escaped as <code>\/</code> by the
+                  JSON serialization method.
+               </change>
+            </changes>
+         
          <?element xsl:output?>
          <p>The <elcode>xsl:output</elcode> declaration is optional; if used, it
                <rfc2119>must</rfc2119> always appear as a <termref def="dt-top-level">top-level</termref> element within a stylesheet module.</p>
@@ -38036,14 +38039,7 @@ return ($m?price - $m?discount)</eg>
                   attribute. </p>
             </error>
          </p>
-         <p diff="del" at="2022-01-01">The <code>build-tree</code> attribute controls whether the
-            raw <termref def="dt-principal-result"/> or <termref def="dt-secondary-result"/> is
-            converted to a <termref def="dt-final-result-tree"/>. The default depends on the value
-            of the <code>method</code> attribute: the default is <code>yes</code> if the
-               <code>method</code> attribute specifies <code>xml</code>, <code>html</code>,
-               <code>xhtml</code>, or <code>text</code>, or if it is omitted; the default is <code>no</code> if the <code>method</code> attribute
-               specifies <code>json</code> or <code>adaptive</code>. A <termref def="dt-final-result-tree"/> may be constructed whether or not it is subsequently
-            serialized.</p>
+         
          <p diff="add" at="2022-01-01">
             If the result is not serialized, then the decision whether to return the raw result 
             or to construct a tree depends on the <termref def="dt-effective-value"/> of the <code>build-tree</code> attribute. 
@@ -38059,13 +38055,15 @@ return ($m?price - $m?discount)</eg>
                methods or for serialization methods introduced in future versions of this
                specification.</p>
          </note>
-         <p diff="del" at="2022-01-01">Unless the processor implements the XPath 3.1 feature, the 
-            <code>method</code> values <code>json</code> and
-               <code>adaptive</code>
-            <rfc2119>must</rfc2119> be rejected as invalid, and the attributes
-               <code>allow-duplicate-names</code> and <code>json-node-output-method</code>
-            <rfc2119>must</rfc2119> be ignored. The meaning of these output methods and
-            serialization parameters is defined in <bibref ref="xslt-xquery-serialization-40"/>.</p>
+         </div2>
+         <div2 id="id-default-serialization-parameters">
+            <head>Defaults for serialization parameters</head>
+            <changes>
+               <change issue="1548" date="2024-11-09">
+                  The default value for the <code>indent</code> parameter is now defined to be
+                  <code>no</code> for all output methods other than <code>html</code> and <code>xhtml</code>.
+               </change>
+            </changes>
          <p>If none of the <elcode>xsl:output</elcode> declarations within an <termref def="dt-output-definition">output definition</termref> specifies a value for a
             particular attribute, then the corresponding serialization parameter takes a default
             value. The default value depends on the chosen output method.</p>
@@ -38323,7 +38321,8 @@ return ($m?price - $m?discount)</eg>
          <p>If the processor performs serialization, then it must raise any  serialization errors that occur. These have the same
             effect as <termref def="dt-dynamic-error"> dynamic errors</termref>: that is, the processor must
             raise the error and must not finish as if the transformation had been successful.</p>
-         <div2 id="character-maps">
+         </div2>
+            <div2 id="character-maps">
             <head>Character Maps</head>
             <p>
                <termdef id="dt-character-map" term="character map">A <term>character map</term>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -36217,291 +36217,12 @@ return ($m?price - $m?discount)</eg>
                arrays.</p>
          </note>
 
-         <div2 id="json-to-xml-mapping" diff="del" at="2022-01-01">
-            <head>XML Representation of JSON</head>
-
-
-            <p>This specification defines a mapping from JSON data to XML (specifically, to XDM
-               instances). A function <function>json-to-xml</function> is provided to take a JSON
-               string as input and convert it to the XML representation. Two stylesheet modules are
-               provided to perform the reverse transformation: one produces JSON in compact linear
-               form, the other in indented form suitable for display, editing, or printing.</p>
-
-            <p>The XML representation is designed to be capable of representing any valid JSON text
-               other than one that uses characters which are not valid in XML. The transformation is
-               lossless: that is, distinct JSON texts convert to distinct XML representations. When
-               converting JSON to XML, options are provided to reject unsupported characters, to
-               replace them with a substitute character, or to leave them in backslash-escaped
-               form.</p>
-
-            <p>The following example demonstrates the correspondence of a JSON text and the
-               corresponding XML representation. </p>
-
-            <example>
-               <head>A JSON Text and its XML Representation</head>
-               <p>Consider the following JSON text:</p>
-               <eg role="json" xml:space="preserve">
-{
-  "desc"    : "Distances between several cities, in kilometers.",
-  "updated" : "2014-02-04T18:50:45",
-  "uptodate": true,
-  "author"  : null,
-  "cities"  : {
-    "Brussels": [
-      { "to": "London",    "distance": 322 },
-      { "to": "Paris",     "distance": 265 },
-      { "to": "Amsterdam", "distance": 173 }
-    ],
-    "London": [
-      { "to": "Brussels",  "distance": 322 },
-      { "to": "Paris",     "distance": 344 },
-      { "to": "Amsterdam", "distance": 358 }
-    ],
-    "Paris": [
-      { "to": "Brussels",  "distance": 265 },
-      { "to": "London",    "distance": 344 },
-      { "to": "Amsterdam", "distance": 431 }
-    ],
-    "Amsterdam": [
-      { "to": "Brussels",  "distance": 173 },
-      { "to": "London",    "distance": 358 },
-      { "to": "Paris",     "distance": 431 }
-    ]
-  }
-}
-               </eg>
-               <p>The XML representation of this text is as follows. Whitespace is included in the
-                  XML representation for purposes of illustration, and is ignored by the stylesheets
-                  that convert XML to JSON, but it will not be present in the output of the
-                     <function>json-to-xml</function> function.</p>
-               <eg role="xml" xml:space="preserve">
-  &lt;map xmlns="http://www.w3.org/2005/xpath-functions"&gt;
-    &lt;string key='desc'&gt;Distances between several cities, in kilometers.&lt;/string&gt;
-    &lt;string key='updated'&gt;2014-02-04T18:50:45&lt;/string&gt;
-    &lt;boolean key="uptodate"&gt;true&lt;/boolean&gt;
-    &lt;null key="author"/&gt;
-    &lt;map key='cities'&gt;
-      &lt;array key="Brussels"&gt;
-        &lt;map&gt;
-            &lt;string key="to"&gt;London&lt;/string&gt;
-            &lt;number key="distance"&gt;322&lt;/number&gt;
-        &lt;/map&gt; 
-        &lt;map&gt;
-            &lt;string key="to"&gt;Paris&lt;/string&gt;
-            &lt;number key="distance"&gt;265&lt;/number&gt;
-        &lt;/map&gt; 
-        &lt;map&gt;
-            &lt;string key="to"&gt;Amsterdam&lt;/string&gt;
-            &lt;number key="distance"&gt;173&lt;/number&gt;
-        &lt;/map&gt; 
-      &lt;/array&gt;
-      &lt;array key="London"&gt;
-        &lt;map&gt;
-            &lt;string key="to"&gt;Brussels&lt;/string&gt;
-            &lt;number key="distance"&gt;322&lt;/number&gt;
-        &lt;/map&gt; 
-        &lt;map&gt;
-            &lt;string key="to"&gt;Paris&lt;/string&gt;
-            &lt;number key="distance"&gt;344&lt;/number&gt;
-        &lt;/map&gt; 
-        &lt;map&gt;
-            &lt;string key="to"&gt;Amsterdam&lt;/string&gt;
-            &lt;number key="distance"&gt;358&lt;/number&gt;
-        &lt;/map&gt; 
-      &lt;/array&gt;
-      &lt;array key="Paris"&gt;
-        &lt;map&gt;
-            &lt;string key="to"&gt;Brussels&lt;/string&gt;
-            &lt;number key="distance"&gt;265&lt;/number&gt;
-        &lt;/map&gt; 
-        &lt;map&gt;
-            &lt;string key="to"&gt;London&lt;/string&gt;
-            &lt;number key="distance"&gt;344&lt;/number&gt;
-        &lt;/map&gt; 
-        &lt;map&gt;
-            &lt;string key="to"&gt;Amsterdam&lt;/string&gt;
-            &lt;number key="distance"&gt;431&lt;/number&gt;
-        &lt;/map&gt;  
-      &lt;/array&gt;
-      &lt;array key="Amsterdam"&gt;
-        &lt;map&gt;
-            &lt;string key="to"&gt;Brussels&lt;/string&gt;
-            &lt;number key="distance"&gt;173&lt;/number&gt;
-        &lt;/map&gt; 
-        &lt;map&gt;
-            &lt;string key="to"&gt;London&lt;/string&gt;
-            &lt;number key="distance"&gt;358&lt;/number&gt;
-        &lt;/map&gt; 
-        &lt;map&gt;
-            &lt;string key="to"&gt;Paris&lt;/string&gt;
-            &lt;number key="distance"&gt;431&lt;/number&gt;
-        &lt;/map&gt;
-      &lt;/array&gt;
-    &lt;/map&gt;  
-  &lt;/map&gt;</eg>
-            </example>
-
-            <p>An XSD 1.0 schema for the XML representation is provided in <specref ref="schema-for-json"/>. It is not necessary to import this schema (using
-                  <elcode>xsl:import-schema</elcode>) unless the stylesheet makes explicit reference
-               to the components defined in the schema. If the stylesheet does import a schema for
-               the namespace <code>http://www.w3.org/2005/xpath-functions</code>, then:</p>
-
-            <olist>
-               <item>
-                  <p>The processor (if it is schema-aware) <rfc2119>must</rfc2119> recognize an
-                        <elcode>xsl:import-schema</elcode> declaration for this namespace, whether
-                     or not the <code>schema-location</code> is supplied.</p>
-               </item>
-               <item>
-                  <p>If a <code>schema-location</code> is provided, then the schema document at that
-                     location <rfc2119>must</rfc2119> be equivalent to the schema document at
-                        <specref ref="schema-for-json"/>; the effect if it is not is <termref def="dt-implementation-dependent"/></p>
-               </item>
-            </olist>
-
-            <p>The rules governing the mapping from JSON to XML are as follows. In these rules, the
-               phrase “an element named N” is to be interpreted as meaning “an element node whose
-               local name is N and whose namespace URI is
-               <code>http://www.w3.org/2005/xpath-functions</code>”.</p>
-
-            <olist>
-               <item>
-                  <p>The JSON value <code>null</code> is represented by an element named
-                        <code>null</code>, with empty content.</p>
-               </item>
-               <item>
-                  <p>The JSON values <code>true</code> and <code>false</code> are represented by an
-                     element named <code>boolean</code>, with content conforming to the type
-                        <code>xs:boolean</code>.</p>
-               </item>
-               <item>
-                  <p>A JSON number is represented by an element named <code>number</code>, with
-                     content conforming to the type <code>xs:double</code>, with the additional
-                     restriction that the value must not be positive or negative infinity, nor
-                        <code>NaN</code>.</p>
-               </item>
-               <item>
-                  <p>A JSON string is represented by an element named <code>string</code>, with
-                     content conforming to the type <code>xs:string</code>.</p>
-               </item>
-               <item>
-                  <p>A JSON array is represented by an element named <code>array</code>. The content
-                     is a sequence of child elements representing the members of the array in order,
-                     each such element being the representation of the array member obtained by
-                     applying these rules recursively.</p>
-               </item>
-               <item>
-                  <p>A JSON object is represented by an element named <code>map</code>. The content
-                     is a sequence of child elements each of which represents one of the name/value
-                     pairs in the object. The representation of the name/value pair <var>N:V</var>
-                     is obtained by taking the element that represents the value <var>V</var> (by
-                     applying these rules recursively) and adding an attribute with name
-                        <code>key</code> (in no namespace), whose value is <var>N</var> as an
-                     instance of <code>xs:string</code>.</p>
-               </item>
-
-            </olist>
-
-            <p>The attribute <code>escaped="true"</code> may be specified on a <code>string</code>
-               element to indicate that the string value contains backslash-escaped characters that
-               are to be interpreted according to the JSON rules. The attribute
-                  <code>escaped-key="true"</code> may be specified on any element with a
-                  <code>key</code> attribute to indicate that the key contains backslash-escaped
-               characters that are to be interpreted according to the JSON rules. Both attributes
-               have the default value <code>false</code>.</p>
-
-            <p>The JSON grammar for <code>number</code> is a subset of
-               the lexical space of the XSD type <code>xs:double</code>. The mapping from JSON
-                  <code>number</code> values to <code>xs:double</code> values is defined by the
-               XPath rules for casting from <code>xs:string</code> to <code>xs:double</code>. Note
-               that these rules will never generate an error for out-of-range values; instead very
-               large or very small values will be converted to <code>+INF</code> or
-                  <code>-INF</code>. Since JSON does not impose limits on the range or precision of
-               numbers, the conversion is not guaranteed to be lossless.</p>
-
-            <p>Although the order of entries in a JSON object is generally considered to have no
-               significance, the function <code>json-to-xml</code> and the stylesheets that perform
-               the reverse transformation both retain order.</p>
-
-            <p>The XDM representation of a JSON value may either be untyped (all elements annotated
-               as <code>xs:untyped</code>, attributes as <code>xs:untypedAtomic</code>), or it may
-               be typed. If it is typed, then it <rfc2119>must</rfc2119> have the type annotations
-               obtained by validating the untyped representation against the schema given in
-                  <specref ref="schema-for-json"/>. If it is untyped, then it
-                  <rfc2119>must</rfc2119> be an XDM instance such that validation against this
-               schema would succeed.</p>
-         </div2>
-         
-         <div2 id="options"  diff="del" at="2022-01-01">
-            <head>Option Parameter Conventions</head>
-            <p><emph>This section describes conventions which in principle can be adopted by the specification
-            of any function. At the time of writing, the function which invoke these conventions are 
-               <function>xml-to-json</function> and <function>json-to-xml</function>.</emph></p>
-            <p>As a matter of convention, a number of functions defined in this document take
-               a parameter whose value is a map, defining options controlling the detail of how
-               the function is evaluated. Maps are a new data type introduced in XSLT 3.0.</p>
-            <p>For example, the function <code>fn:xml-to-json</code> has an options parameter
-               allowing specification of whether the output is to be indented. A call might be written:</p>
-            <eg role="xpath" xml:space="preserve">xml-to-json($input, { 'indent': true() })</eg>
-            <p><termdef id="option-parameter-conventions" term="option parameter conventions">Functions
-               that take an options parameter adopt common conventions on how the
-               options are used. These are referred to as the <term>option parameter conventions</term>. These
-               rules apply only to functions that explicitly refer to them.</termdef></p>
-            <p>Where a function adopts the <termref def="option-parameter-conventions"/>, the following rules
-               apply:</p>
-            <olist>
-               <item><p>The value of the relevant argument must be a map. The entries in the map are
-                  referred to as options: the key of the entry is called the option name, and the
-                  associated value is the option value. Option names defined in this specification
-                  are always strings (single <code>xs:string</code> values). Option values may
-                  be of any type.</p></item>
-               <item><p>The type of the options parameter in the function signature is always
-                  given as <code>map(*)</code>.</p></item>
-               <item><p>Although option names are described above as strings, the actual key may be
-                  any value that compares equal to the required string (using the <code>eq</code> operator
-                  with Unicode codepoint collation). For example, instances of <code>xs:untypedAtomic</code>
-                  or <code>xs:anyURI</code> are equally acceptable.</p>
-                  <note><p>This means that the implementation of the function can check for the
-                     presence and value of particular options using the functions <code>map:contains</code>
-                     and/or <code>map:get</code>.</p></note></item>
-               <item><p>It is not an error if the options map contains options with names other than those
-                  described in this specification. Implementations <rfc2119>may</rfc2119> attach an 
-                  <termref def="dt-implementation-defined">implementation-defined</termref> meaning to such entries,
-                  and <rfc2119>may</rfc2119> define errors that arise if such entries are present with invalid values.
-                  Implementations <rfc2119>must</rfc2119> ignore such entries unless they have a specific 
-                  <termref def="dt-implementation-defined">implementation-defined</termref> meaning.
-                  Implementations that define additional options in this way <rfc2119>should</rfc2119>
-                  use values of type <code>xs:QName</code> as the option names, using an appropriate namespace.</p></item>
-               <item><p>All entries in the options map are optional, and supplying an empty map has the same
-                  effect as omitting the relevant argument in the function call, assuming this is permitted.</p></item>
-               <item><p>For each named option, the function
-                  specification defines a required type for the option value. The value that is actually
-                  supplied in the map is converted to this required type using the 
-                  <termref def="dt-coercion-rules"/>. 
-                  A type error <xerrorref spec="XP40" class="TY" code="0004" type="type"/> occurs
-                     if conversion of the supplied value to the required type is not possible, or if this conversion
-                     delivers a coerced function whose invocation fails with a type error.
-                  A dynamic error occurs if the supplied value 
-                  after conversion is not one of the permitted values for the option in question: the error codes
-                  for this error are defined in the specification of each function.</p>
-                  <note><p>It is the responsibility of each function implementation to invoke this conversion; it
-                     does not happen automatically as a consequence of the function calling rules.</p></note></item>
-               <item><p>In cases where an option is list-valued, by convention the value may be supplied
-                  either as a sequence or as an array. Accepting a sequence is convenient if the
-                  value is generated programmatically using an XPath expression; while accepting an array 
-                  allows the options to be held in an external file in JSON format, to be read using
-                  a call on the <code>fn:json-doc</code> function.</p></item>
-               <item><p>In cases where the value of an option is itself a map, the specification
-                  of the particular function must indicate whether or not these rules apply recursively 
-                  to the contents of that map.</p></item>
-            </olist>
-         </div2>
-
+        
 
          <div2 id="xml-to-json-transformation">
             <head>Transforming XML to JSON</head>
             <p>Given an XML structure that does not use the XML representation of JSON defined in
-                  <specref ref="json-to-xml-mapping"/>, there are two practical ways to convert it
+                  <xspecref spec="FO40" ref="json-to-xml-mapping"/>, there are two practical ways to convert it
                to JSON: either perform a transformation to the XML representation of JSON and then
                call the <function>xml-to-json</function> function; or transform it to JSON directly
                by using custom template rules.</p>
@@ -37194,7 +36915,7 @@ return ($m?price - $m?discount)</eg>
                   <code>doctype-system</code>, <code>encoding</code>,
                <code diff="add" at="2023-03-31">escape-solidus</code>
                   <code>escape-uri-attributes</code>, <code>html-version</code>, <code>indent</code>, <code>item-separator</code>,
-               <code>json-node-output-method</code>,
+               <code diff="add" at="2024-11-09">json-lines</code>, <code>json-node-output-method</code>,
                   <code>media-type</code>, <code>normalization-form</code>,
                   <code>omit-xml-declaration</code>, <code>standalone</code>, <code>suppress-indentation</code>,
                <!-- see bug 6535 -->
@@ -37255,7 +36976,8 @@ return ($m?price - $m?discount)</eg>
                   and <code>suppress-indentation</code>, an
                   unprefixed element name is expanded using the default namespace. In the case of
                   the <code>method</code> attribute, if the method is not one of the system-defined
-                  methods (xml, html, xhtml, text) then the expanded name must have a non-absent
+                  methods (<code>xml</code>, <code>html</code>, <code>xhtml</code>, 
+                  <code>text</code>, <code>json</code>, <code>adaptive</code>) then the expanded name must have a non-absent
                   namespace.</p>
             </note>
             <p diff="del" at="2022-01-01">Unless the processor implements the XPath 3.1 feature, the 
@@ -38218,6 +37940,10 @@ return ($m?price - $m?discount)</eg>
                whether the character <code>/</code> is escaped as <code>\/</code> by the
                JSON serialization method.
             </change>
+            <change issue="1548" date="2024-11-09">
+               The default value for the <code>indent</code> parameter is now defined to be
+               <code>no</code> for all output methods other than <code>html</code> and <code>xhtml</code>.
+            </change>
          </changes>
          
          <p>A <termref def="dt-processor">processor</termref>
@@ -38503,7 +38229,7 @@ return ($m?price - $m?discount)</eg>
                <p> The value of the <code>indent</code> attribute provides the value of the
                      <code>indent</code> parameter to the serialization method. The default value is
                      <code>yes</code> in the case of the <code>html</code> and <code>xhtml</code>
-                  output methods, <code>no</code> in the case of the <code>xml</code> output method.
+                  output methods, <code>no</code> in the case of all other output methods.
                </p>
             </item>
             <item>


### PR DESCRIPTION
Fix #1548

XSLT 3.0 specified no default for xsl:output/@indent in the case of the JSON and Adaptive output methods. This PR sets the default to "no".

I believe this is sufficient to close #1548.