### PR TITLE
1561 Correct the schema for XSLT 4.0

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -77,6 +77,12 @@
            which is beyond the scope of XSD.
         </li>
         <li>
+           The XSLT specification allows <code>xsl:note</code> elements to appear
+           anywhere, with arbitrary content. This schema does not: for example, it does
+           not allow <code>xsl:note</code> as a child of an element such as <code>xsl:text</code>
+           or <code>xsl:strip-space</code>.
+        </li>
+        <li>
            The schema imports the schema for XSD 1.0 schema documents. In
            stylesheets that contain an inline XSD 1.1 schema, this import should be
            replaced with one for the schema for XSD 1.1 schema documents.
@@ -458,7 +464,7 @@ of problems processing the schema using various tools
             <xs:element ref="xsl:with-param"/>
           </xs:choice>
           <xs:attribute name="select" type="xsl:expression" default="child::node()"/>
-          <xs:attribute name="separator" type="xsl:expression"/>
+          <xs:attribute name="separator" type="xsl:avt"/>
           <xs:attribute name="mode" type="xsl:mode"/>
           <xs:attribute name="_select" type="xs:string"/>
           <xs:attribute name="_separator" type="xs:string"/>
@@ -480,17 +486,13 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
   
-  <xs:element name="array" substitutionGroup="xsl:instruction">
-    <xs:complexType>
-      <xs:complexContent mixed="true">
-        <xs:extension base="xsl:sequence-constructor-or-select">
-          <xs:attribute name="use" type="xsl:expression"/>
-          <xs:attribute name="_use" type="xs:string"/>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-  </xs:element>
+  <xs:element name="array"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor-or-select"/>
   
+  <xs:element name="array-member"
+              substitutionGroup="xsl:instruction"
+              type="xsl:sequence-constructor-or-select"/>
   
   <xs:element name="assert" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -848,7 +850,7 @@ of problems processing the schema using various tools
                       maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
-          <xs:attribute name="separator" type="xsl:expression"/>
+          <xs:attribute name="separator" type="xsl:avt"/>
           <xs:attribute name="_select" type="xs:string"/>
           <xs:attribute name="_separator" type="xs:string"/>
           <xs:assert test="every $e in subsequence(xsl:sort, 2) 
@@ -911,7 +913,7 @@ of problems processing the schema using various tools
           <xs:assert test="count(((@group-by|@_group-by)[1], 
                                   (@group-adjacent|@_group-adjacent)[1], 
                                   (@group-starting-with|@_group-starting-with)[1], 
-                                  (@group-ending-with|@_group-ending-with)[1]),
+                                  (@group-ending-with|@_group-ending-with)[1],
                                   (@split-when|@_split-when)[1])) = 1">
             <xs:annotation>
               <xs:documentation>
@@ -1159,7 +1161,7 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="matching-substring" type="xsl:sequence-constructor"/>
+  <xs:element name="matching-substring" type="xsl:sequence-constructor-or-select"/>
 
   <xs:element name="merge" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1349,7 +1351,7 @@ of problems processing the schema using various tools
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="non-matching-substring" type="xsl:sequence-constructor"/>
+  <xs:element name="non-matching-substring" type="xsl:sequence-constructor-or-select"/>
   
   <xs:element name="note" type="xs:anyType"/>
 
@@ -1699,8 +1701,16 @@ of problems processing the schema using various tools
   </xs:element>
   
   <xs:element name="sequence"
-              substitutionGroup="xsl:instruction"
-              type="xsl:sequence-constructor-or-select"/>
+              substitutionGroup="xsl:instruction">
+    <xs:complexType>
+      <xs:complexContent mixed="true">
+        <xs:extension base="xsl:sequence-constructor-or-select">
+          <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="_as" type="xs:string"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
 
   <xs:element name="sort">
     <xs:complexType>
@@ -1772,6 +1782,7 @@ of problems processing the schema using various tools
           <xs:sequence>
             <xs:element ref="xsl:when" maxOccurs="unbounded"/>
             <xs:element ref="xsl:otherwise" minOccurs="0"/>
+            <xs:element ref="xsl:fallback" minOccurs="0" maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
           <xs:attribute name="_select" type="xsl:avt"/>
@@ -2330,27 +2341,22 @@ of problems processing the schema using various tools
     </xs:annotation>
     <xs:list>
       <xs:simpleType>
-        <xs:union>
-          <!-- Option 1: #default -->
-          <xs:simpleType>
-            <xs:restriction base="xs:string">
-              <xs:enumeration value="#default"/>
-            </xs:restriction>
-          </xs:simpleType>
-          <!-- Option 2: NCName -->
-          <xs:simpleType ref="xs:NCName"/>
-          <!-- Option 3: prefix=namespace -->
-          <xs:simpleType>
-            <xs:restriction base="xs:string">
-              <xs:pattern value="([\i-[:]][\c-[:]]*:)=.+"/>
-            </xs:restriction>
-          </xs:simpleType>
-          <!-- Option 4: anyURI -->
-          <xs:simpleType ref="xs:anyURI"/>
-        </xs:union>
+        <xs:union memberTypes="xsl:fixed-namespaces-type-default xs:NCName xsl:fixed-namespaces-type-prefix-binding xs:anyURI"/>
       </xs:simpleType>
     </xs:list>
  
+  </xs:simpleType>
+  
+  <xs:simpleType name="fixed-namespaces-type-default">
+    <xs:restriction base="xs:string">
+       <xs:enumeration value="#default"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="fixed-namespaces-type-prefix-binding">
+    <xs:restriction base="xs:string">
+       <xs:pattern value="([\i-[:]][\c-[:]]*:)=.+"/>
+    </xs:restriction>
   </xs:simpleType>
 
   <xs:simpleType name="item-type">
@@ -2538,6 +2544,7 @@ of problems processing the schema using various tools
     <xs:restriction base="xs:token">
       <xs:enumeration value="deep-copy"/>
       <xs:enumeration value="shallow-copy"/>
+      <xs:enumeration value="shallow-copy-all"/>
       <xs:enumeration value="deep-skip"/>
       <xs:enumeration value="shallow-skip"/>
       <xs:enumeration value="text-only-copy"/>
@@ -2645,19 +2652,22 @@ of problems processing the schema using various tools
            or a prefixed QName, or a name written using the extended QName notation
            <code>Q{uri}local</code>
         </p>
-        <p>
-           Although <code>xs:QName</code> would define the correct validation on these
-           attributes, a schema processor would expand unprefixed QNames
-           incorrectly when constructing the PSVI, because (as defined in XML
-           Schema errata) an unprefixed <code>xs:QName</code> is assumed to be in the default
-           namespace, which is not the correct assumption for XSLT. The datatype is
-           therefore defined as a union of NCName and QName, so that an unprefixed
-           name will be validated as an NCName and will therefore not be treated as
-           having the semantics of an unprefixed xs:QName.
-        </p>
+        <p>In XSLT 4.0, where a QName is used in the <code>name</code> attribute
+        of (say) <code>xsl:template</code> or <code>xsl:call-template</code>, the prefix
+        does not have to be bound in an XML namespace declaration; rather it can be bound
+        in a <code>fixed-namespaces</code> attribute on the <code>xsl:stylesheet</code>
+        element. Therefore, the built-in <code>xs:QName</code> type cannot be used.
+        This schema does not attempt to verify that namespace prefixes have been
+        properly declared.</p>
+        
       </xs:documentation>
     </xs:annotation>
-    <xs:union memberTypes="xs:NCName xs:QName">
+    <xs:union memberTypes="xs:NCName">
+      <xs:simpleType>
+        <xs:restriction base="xs:token">
+          <xs:pattern value="[\i-[:]][\c-[:]]*:[\i-[:]][\c-[:]]*"/>
+        </xs:restriction>
+      </xs:simpleType>
       <xs:simpleType>
         <xs:restriction base="xs:token">
           <xs:pattern value="Q\{[^{}]*\}[\i-[:]][\c-[:]]*"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -39767,9 +39767,8 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
       <inform-div1 id="schema-for-xslt">
          <head>Schemas for XSLT 4.0 Stylesheets</head>
          
-         <p diff="add" at="2022-01-01">TODO: the two schemas need to be updated for XSLT 4.0</p>
          
-         <p>For convenience, schemas are provided for validation of XSLT 3.0 stylesheets
+         <p>For convenience, schemas are provided for validation of XSLT 4.0 stylesheets
          using the XSD 1.1 and Relax NG schema languages. These are non-normative. Neither will detect
          every static error that might arise in an XSLT 4.0 stylesheet (for example, there is no attempt
          to check the syntax of XPath expressions); in addition, these schemas may reject some stylesheets
@@ -39778,12 +39777,22 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
          <div2 id="xsd11-schema-for-xslt">
             <head>XSD 1.1 Schema for XSLT Stylesheets</head>
 
-         <p>The following XSD 1.1 schema describes the structure of an XSLT stylesheet module. It
+         <p>The following XSD 1.1 schema describes the structure of an XSLT stylesheet module. 
+            There are some limitations:</p>
+            
+            <ulist>
+               <item><p>It
             does not define all the constraints that apply to a stylesheet (for example, it does not
             attempt to define a datatype that precisely represents attributes containing XPath
-               <termref def="dt-expression">expressions</termref>). However, every valid stylesheet
-            module conforms to this schema, unless it contains elements that invoke <termref def="dt-forwards-compatible-behavior"/>.</p>
-         <p>A copy of this schema is available at <phrase diff="chg" at="2023-04-18"><loc href="schema-for-xslt40.xsd">schema-for-xslt40.xsd</loc></phrase>
+               <termref def="dt-expression">expressions</termref>).</p></item>
+               <item><p>Stylesheets that use <termref def="dt-forwards-compatible-behavior"/> 
+                  (an <code>[xsl:]version</code> attribute greater than
+                  4.0), or that have sections excluded using <code>[xsl:]use-when</code>
+                  attributes, are not required to conform to the schema.</p></item>
+               <item><p>The specification allows <elcode>xsl:note</elcode> elements to appear anywhere,
+               but this schema is more restrictive.</p></item>
+            </ulist>
+            <p>A copy of this schema is available at <phrase diff="chg" at="2023-04-18"><loc href="schema-for-xslt40.xsd">schema-for-xslt40.xsd</loc></phrase>
          </p>
 
          <note>


### PR DESCRIPTION
Fix #1561 

Test case catalog-005 now passes, showing that all the non-error stylesheets in the test suite are valid against the schema.