### PR TITLE
Fix markup error

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -21144,15 +21144,12 @@ and raises a <termref
          <head>Try/Catch Expressions</head>
          
          <changes>
-            <change issue="32" PR="493" date="2023-05-16">
-               A new variable <code>err:map</code> is available, capturing all error information in one place.
-            </change>
-         </changes>
-
-         <changes>
             <change issue="32" date="2023-05-23">
                <code>$err:map</code> contains entries for all values that are bound to the
                   single variables.
+            </change>
+            <change issue="32" PR="493" date="2023-05-16">
+               A new variable <code>err:map</code> is available, capturing all error information in one place.
             </change>
             <change issue="689" date="2024-10-01">
                <code>$err:stack-trace</code> provides information about the current state of execution.


### PR DESCRIPTION
Merging allowed a `changes` block to become split into two blocks, which isn't allowed.