### PR TITLE
1491 Empty record types

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -773,9 +773,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>record</g:string>
     <g:ref name="EQName"/>
     <g:string>(</g:string>
-    <g:oneOrMore separator=",">
+    <g:zeroOrMore separator=",">
       <g:ref name="ExtendedFieldDeclaration"/>
-    </g:oneOrMore>
+    </g:zeroOrMore>
     <g:optional>
       <g:ref name="ExtensibleFlag"/>
     </g:optional>
@@ -2801,9 +2801,9 @@ ErrorVal ::= "$" VarName
   <g:production name="TypedRecordType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>record</g:string>
     <g:string>(</g:string>
-    <g:oneOrMore separator=",">
+    <g:zeroOrMore separator=",">
       <g:ref name="FieldDeclaration"/>
-    </g:oneOrMore>
+    </g:zeroOrMore>
     <g:optional>
       <g:ref name="ExtensibleFlag"/>
     </g:optional>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8034,9 +8034,9 @@ return <table>
                  <xtermref spec="XP40" ref="dt-named-item-type">named item types</xtermref>.
               </p>
                  <p>These constructor functions always take a single argument.</p></item>
-              <item><p>Record tests defined as 
+              <item><p>Record types defined as 
                  <xtermref spec="XP40" ref="dt-named-item-type">named item types</xtermref>.</p>
-              <p>These take one argument for each named field of the record test.
+              <p>These take one argument for each named field of the record type.
               Constructor functions for record types are defined in 
                  <specref ref="id-constructors-for-record-tests"/>.
               </p></item>
@@ -8627,7 +8627,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
             </div2>
            
            <div2 diff="add" at="issue617" id="id-constructors-for-record-tests">
-              <head>Constructor functions for named record tests</head>
+              <head>Constructor functions for named record types</head>
               
               <changes>
                  <change issue="617" PR="953" date="2024-02-20">
@@ -8635,14 +8635,14 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                  </change>
               </changes>
               
-              <p>For every named item type in the static context (See <xspecref spec="XP31"
-                    ref="static_context"/>) whose expansion is a record test, there is a
-                 constructor function whose name is the same as the name of the 
-                 type, and whose parameters correspond to the fields defined in the record test.</p>
+              <p>Both XQuery 4.0 and XSLT 4.0 provide syntax to declare named record types;
+                 such a declaration implicitly adds a constructor function for values of that
+                 type to the (See <xspecref spec="XP31"
+                    ref="static_context"/>).</p>
               
               <p>For example, if there is a named item type with the XQuery definition:</p>
               
-              <eg>declare item type my:location as record(
+              <eg>declare record my:location (
   latitude  as xs:double,
   longitude as xs:double
 )</eg>
@@ -8658,7 +8658,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
               <p>Equivalently using XSLT syntax, if there is a named item type with the
               XSLT definition:</p>
               
-              <eg><![CDATA[<xsl:item-type name="my:location"
+              <eg><![CDATA[<xsl:record name="my:location"
   as="record(latitude as xs:double, longitude as xs:double)"/>]]></eg>
               
               <p>then there will be a function definition equivalent to:</p>
@@ -8672,76 +8672,13 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
   </xsl:map>
 </xsl:function>]]></eg>
               
+              
               <p>The rules defining the relationship of the function definition to the
-              record test are as follows:</p>
+              record type are given for XQuery 4.0 in <xspecref spec="XQ40" ref="named-records-as-functions"/>.</p>
               
-              <olist>
-                 <item><p>The name of the function is the same as the name of the
-                 named item type. A static error occurs if this clashes with the name and arity
-                 of other function definitions in the static context.</p></item>
-                 <item><p>For every named field in the record test, in order,
-                 there is is one parameter defined as follows:</p>
-                 <olist>
-                    <item><p>If the name of the field is an <code>NCName</code>, then
-                    the name of the parameter is the name of the field.</p></item>
-                    <item><p>Otherwise, the name of the parameter is <code>argNZ</code>,
-                    where <code>arg</code> is the literal string <code>"arg"</code>,
-                    <code>N</code> is the ordinal position of the field, counting from 1 (one),
-                    and <code>Z</code> is an implementation-defined suffix, added only when
-                    needed to make the parameter name unique.</p></item>
-                    <item><p>The declared type of the parameter is the same as the declared
-                    type of the field, but if the field is declared optional, then the
-                    occurrence indicator is adjusted to <code>?</code> or <code>*</code>
-                    if needed to make the empty sequence a valid value for the parameter.</p></item>
-                    <item><p>If the field is optional and if all subsequent fields are optional,
-                    then the parameter is declared as optional with a default value of <code>()</code>
-                    (the empty sequence). In all other cases the parameter is declared as required.</p></item>
-                 </olist>
-                 </item>
-                 <item><p>It is immaterial whether the record test is extensible; the constructor
-                 function cannot be used to create entries in the resulting map other than entries
-                 corresponding to named fields.</p></item>
-                 <item><p>The return type of the constructor function is the record test (with
-                 no occurrence indicator).</p></item>
-                 <item><p>The body of the function constructs a map having one entry for
-                 each mandatory field in the record test, and one entry for each optional field
-                 in the record test for which an actual value other than the empty sequence
-                 is supplied in the arguments of the function call. The key of the entry
-                 is the field name as an instance of <code>xs:string</code>, and the corresponding
-                 value is the value supplied in the arguments to the constructor function call,
-                 after applying the coercion rules.</p></item>
-              </olist>
+              <ednote><edtext>TODO: Add cross-reference to XSLT here. 
+                 Anticipates resolution of issue #1485. </edtext></ednote>
               
-              <example id="record-constructor-with-optional-fields">
-                 <head>Record constructor with optional fields</head>
-                 <p>Consider the record test (in XQuery syntax):</p>
-                 <eg>declare item type p:person as record(
-  "1st-title"? as xs:string,
-  "2nd-title"? as xs:string,
-  first        as xs:string,
-  middle?      as xs:string,
-  last         as xs:string,
-  suffix?      as xs:string,
-  *)</eg>
-                 <p>This will result in an implicit function declaration equivalent to:</p>
-                 <eg>declare function p:person (
-  $arg1   as xs:string?,
-  $arg2   as xs:string?,
-  $first  as xs:string,
-  $middle as xs:string?,
-  $last   as xs:string,
-  $suffix as xs:string? := ()
-) as p:person {
-  map:merge((
-    { "1st-title", $arg1 }[exists($arg1)],
-    { "2nd-title", $arg2 }[exists($arg2)],
-    { "first", $first },
-    { "middle", $middle }[exists($middle)],
-    { "last", $last },
-    { "suffix", $suffix }[exists($suffix)]
-  ))
-};</eg>
-              </example>
               
            </div2>
         </div1>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5494,6 +5494,9 @@ name.</p>
                   <change issue="52" PR="728" date="2023-10-10">
                      The syntax <code>record(*)</code> is allowed; it matches any map.
                   </change>
+                  <change issue="1491">
+                     The syntax <code>record()</code> is allowed; the only thing it matches is an empty map.
+                  </change>
                </changes>
                <scrap headstyle="show">
                   <head/>
@@ -5522,13 +5525,17 @@ name.</p>
 		             matches a map if it has an entry with key <code>"e"</code> whose value matches <code>element(Employee)</code>,
 		             regardless what other entries the map might contain.</p>
                
-               <p>For generality, the syntax <code>record(*)</code> defines an extensible record type that has no explicit
-                  field declarations. The item type denoted by <code>record(*)</code> is equivalent to the item type
-                  <code>map(*)</code>: that is, it allows any map.
-               </p>
+               <p>For generality:</p>
+               <ulist>
+                  <item><p>The syntax <code>record()</code> defines a record type that has no explicit fields and that
+                  is not extensible. The only thing it matches is an empty map.</p></item>
+                  <item><p>The syntax <code>record(*)</code> defines an extensible record type that has no explicit
+                  field declarations. It is equivalent to the item type
+                  <code>map(*)</code>: that is, it allows any map.</p></item>
+               </ulist>
                
                <p>A record type can constrain only those entries whose keys are strings, but when the record
-		             type is marked as extensible, then other entries may be present in the map with non-string keys.
+		             type is marked as extensible, then other entries may be present in the map with either string or non-string keys.
 		             Entries whose key is a string can be expressed using an (unquoted) NCName if the key conforms to
 		             NCName syntax, or using a (quoted) string literal otherwise.</p>
 


### PR DESCRIPTION
As well as allowing `record()` for an empty record type as proposed in #1491, this PR also allows named record declarations in XQuery to have no fields. In the course of implementing this I discovered there was old text in the F&O "Constructors" section which duplicated but had become out of sync with the XQuery spec, so much of this has been deleted and replaced with a cross-reference. Named record definitions for XSLT have not yet been defined, this is unfinished business.

Fix #1491