### PR TITLE
1493 Expand the rules for handling numbers in xml-to-json

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -25238,17 +25238,33 @@ return json-to-xml($json, $options)]]></eg>
                <p>An element <code>$E</code> named <code>boolean</code> results in the output <code>true</code> or <code>false</code>
             depending on the result of <phrase><code>xs:boolean(fn:string($E))</code></phrase>.</p>
             </item>
-            <item diff="chg" at="A">
-               <p>An element <code>$E</code> named <code>number</code> is processed by copying the string
-                  value of <code>$E</code> to the output, making any changes that are necessary to ensure
-                  that the result is a valid JSON number. Such changes include:</p>
+            <item>
+               <p>An element <code>$E</code> named <code>number</code> is processed as follows.</p>
                
+               <p>The input is required to conform to the XSD rules defining a valid instance of <code>xs:double</code>
+               (excluding infinity and <code>NaN</code>), while the output is required to conform to the
+               JSON rules defining a valid JSON number. These rules are slightly different.</p>
+               
+               <p>Specifically, the XSD rules require the value (after removing leading and trailing whitespace)
+                  to match the regular expression:</p>
+               
+               <eg>(\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)([Ee](\+|-)?[0-9]+)?</eg>
+               
+               <p>while the JSON rules require:</p>
+               
+               <eg>-?(0|[1-9][0-9]*)(\.[0-9]+)?([Ee](\+|-)?[0-9]+)?</eg>
+               
+               <p>If the input value does not match the required JSON format, it must therefore be adjusted
+               by applying the following steps:</p>
                   <ulist>
-                     <item><p>Removing leading and trailing whitespace.</p></item>
-                     <item><p>Removing a leading plus sign.</p></item>
-                     <item><p>Removing redundant leading zero digits.</p></item>
-                     <item><p>Adding a zero digit before or after a decimal point that is not preceded and
-                        followed by a digit.</p></item>
+                     <item><p>Remove leading and trailing whitespace.</p></item>
+                     <item><p>Remove any leading plus sign.</p></item>
+                     <item><p>Remove any leading zero digits in the integer part, while ensuring that at
+                        least one digit remains.</p></item>
+                     <item><p>If there is a decimal point that is not preceded by a digit, add a zero digit 
+                        before the decimal point.</p></item>
+                     <item><p>If there is a decimal point that is not followed by a digit, add a zero digit 
+                        after the decimal point.</p></item>
                   </ulist>
                
                <note>


### PR DESCRIPTION
I have (a) added more explanation of why the conversion is needed, and (b) described the conversions more prescriptively.

Fix #1493