### PR TITLE
69 Add default for current-merge-group $source

### DIFF
--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -297,7 +297,7 @@
    <fos:function name="current-merge-group">
       <fos:signatures>
          <fos:proto name="current-merge-group" return-type="item()*">
-            <fos:arg name="source" type="xs:string?"/>
+            <fos:arg name="source" type="xs:string?" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>


### PR DESCRIPTION
I found that the two functions mentioned in the issue (document and function-available) had been updated as suggested. However I also checked all the XSLT-specific functions, and found that for current-merge-group(), the prose has been updated to say what happens if the argument is omitted, but the signature does not actually define a default. I have corrected this.

Fix #69