### PR TITLE
767 Fix reference to HTML5 spec

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6236,7 +6236,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                                     <termref def="implementation-defined">implementation-defined</termref>
                                     replacement string is used. The result must be a valid <code>NCName</code>.</p>
                                  <note>
-                                    <p><bibref ref="dom-ls"/> section 13.2.9
+                                    <p><bibref ref="html5"/> section 13.2.9
                                        <emph>Coercing an HTML DOM into an infoset</emph> uses a
                                        <code>Unnnnnn</code> escape sequence. That would map <code>:</code>
                                        to <code>U00003A</code>.</p>


### PR DESCRIPTION
The reference to §13.2.9 of the WhatWG DOM spec should be a reference to §13.2.9 of the WhatWG HTML spec.

Fix #767