### PR TITLE
Update RELAX NG grammar for XSLT

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -1,18 +1,30 @@
-# XSLT 3.0 Relax NG Schema
+# XSLT 4.0 Relax NG Schema
 # 
 # Copyright (c) 2010-2016, Mohamed ZERGAOUI (Innovimax)
+# Portions © 2024, XQuery and XSLT Extensions Community Group
 # 
 # All rights reserved.
 # 
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-# Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-# Neither the name of the Mohamed ZERGAOUI or Innovimax nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer. Redistributions in binary
+# form must reproduce the above copyright notice, this list of conditions and
+# the following disclaimer in the documentation and/or other materials provided
+# with the distribution. Neither the name of the Mohamed ZERGAOUI or Innovimax
+# nor the names of its contributors may be used to endorse or promote products
+# derived from this software without specific prior written permission.
 # 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # 
 namespace local = ""
 default namespace xsl = "http://www.w3.org/1999/XSL/Transform"
@@ -135,9 +147,11 @@ global.atts.except.version =
    attribute xpath-default-namespace { uri.datatype }?,
    attribute _xpath-default-namespace { avt.datatype }?
    
+# In XSLT 4.0, prefixes can be defined with the fixed-namespaces attribute
+# on the xsl:stylesheet, so we can't rely on XML declarations for QNames.
+qname.strict = xsd:token { pattern = "[\i-[:]][\c-[:]]*:[\i-[:]][\c-[:]]*" }
+qname.datatype = xsd:NCName | qname.strict
 
-
-qname.datatype = xsd:QName
 # Extract from XPath 3.0
 #[94]   EQName           ::= QName | URIQualifiedName
 #[104]  QName            ::= [http://www.w3.org/TR/REC-xml-names/#NT-QName]Names
@@ -146,8 +160,7 @@ qname.datatype = xsd:QName
 #[100]  BracedURILiteral ::= "Q" "{" [^{}]* "}"
 
 uri.qualified.name = xsd:token { pattern = "Q\{[^\{\}]*\}[\i-[:]][\c-[:]]*" } 
-qname.strict = xsd:token { pattern = "[\i-[:]][\c-[:]]:[\i-[:]][\c-[:]]" }
-eqname.datatype = xsd:QName | uri.qualified.name | qname.strict 
+eqname.datatype = qname.datatype | uri.qualified.name
 qnames.datatype = list { qname.datatype* }
 eqnames.datatype = list { eqname.datatype* }
 ncname.datatype = xsd:NCName
@@ -173,6 +186,14 @@ qname-but-not-ncname.datatype = xsd:QName { pattern = ".*:.*" }
 xs_schema.element = element xs:schema { anyElement* }
 item-type.datatype = text
 sequence-type.datatype = text
+
+# #standard or NCName or prefix=URI or URI
+fixed-namespaces.datatype = xsd:string
+
+select-or-sequence-constructor.model =
+  ((attribute select { expression.datatype }
+    | attribute _select { avt.datatype })+
+   | sequence-constructor.model)
 
 declaration.category =
    use-package.element
@@ -205,6 +226,7 @@ instruction.category =
  | break.element
  | if.element
  | choose.element
+ | switch.element
  | try.element
  | variable.element
  | call-template.element
@@ -232,6 +254,8 @@ instruction.category =
  | source-document.element
  | map.element
  | map-entry.element
+ | array.element
+ | array-member.element
  | message.element
  | assert.element
  | fallback.element
@@ -267,6 +291,8 @@ package.element =
       attribute _use-when { avt.datatype }?,
       attribute xpath-default-namespace { uri.datatype }?,
       attribute _xpath-default-namespace { avt.datatype }?,
+      attribute fixed-namespaces { fixed-namespaces.datatype }?,
+      attribute _fixed-namespaces { fixed-namespaces.datatype }?,
       ((expose.element | declarations.model)*)
    }
 use-package.element =
@@ -334,6 +360,8 @@ stylesheet.element =
       attribute _use-when { avt.datatype }?,
       attribute xpath-default-namespace { uri.datatype }?,
       attribute _xpath-default-namespace { avt.datatype }?,
+      attribute fixed-namespaces { fixed-namespaces.datatype }?,
+      attribute _fixed-namespaces { fixed-namespaces.datatype }?,
       (declarations.model)
    }
 transform.element =
@@ -361,6 +389,8 @@ transform.element =
       attribute _use-when { avt.datatype }?,
       attribute xpath-default-namespace { uri.datatype }?,
       attribute _xpath-default-namespace { avt.datatype }?,
+      attribute fixed-namespaces { fixed-namespaces.datatype }?,
+      attribute _fixed-namespaces { fixed-namespaces.datatype }?,
       (declarations.model)
    }
 include.element =
@@ -461,6 +491,8 @@ apply-templates.element =
       attribute _select { avt.datatype }?,
       attribute mode { (eqname.datatype | '#unnamed' | '#default' | '#current') }?,
       attribute _mode { avt.datatype }?,
+      attribute separator { avt.datatype }?,
+      attribute _separator { avt.datatype }?,
       (sort.element | with-param.element)*
    }
 mode.element =
@@ -471,7 +503,7 @@ mode.element =
       attribute _name { avt.datatype }?,
       attribute streamable { boolean.datatype }?,
       attribute _streamable { avt.datatype }?,
-      attribute on-no-match { "deep-copy" | "shallow-copy" | "deep-skip" | "shallow-skip" | "text-only-copy" | "fail" }?,
+      attribute on-no-match { "deep-copy" | "shallow-copy" | "shallow-copy-all" | "deep-skip" | "shallow-skip" | "text-only-copy" | "fail" }?,
       attribute _on-no-match { avt.datatype }?,
       attribute on-multiple-match { "use-last" | "fail" }?,
       attribute _on-multiple-match { avt.datatype }?,
@@ -577,14 +609,24 @@ when.element =
       global.atts,
       (attribute test { expression.datatype }
       | attribute _test { avt.datatype })+,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 otherwise.element =
    element otherwise {
       extension.atts,
       global.atts,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
+
+switch.element =
+  element switch {
+    extension.atts,
+    global.atts,
+    (attribute select { expression.datatype }
+    | attribute _select { avt.datatype })+,
+    (when.element+, otherwise.element?, fallback.element*)
+  }
+
 try.element =
    element try {
       extension.atts,
@@ -601,9 +643,7 @@ catch.element =
       global.atts,
       attribute errors { tokens.datatype }?,
       attribute _errors { avt.datatype }?,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 variable.element =
    element variable {
@@ -611,15 +651,13 @@ variable.element =
       global.atts,
       (attribute name { eqname.datatype }
       | attribute _name { avt.datatype })+,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
       attribute as { sequence-type.datatype }?,
       attribute _as { avt.datatype }?,
       attribute static { boolean.datatype }?,
       attribute _static { avt.datatype }?,
       attribute visibility { "public" | "private" | "final" | "abstract" }?,
       attribute _visibility { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 param.element =
    element param {
@@ -627,8 +665,6 @@ param.element =
       global.atts,
       (attribute name { eqname.datatype }
       | attribute _name { avt.datatype })+,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
       attribute as { sequence-type.datatype }?,
       attribute _as { avt.datatype }?,
       attribute required { boolean.datatype }?,
@@ -637,7 +673,7 @@ param.element =
       attribute _tunnel { avt.datatype }?,
       attribute static { boolean.datatype }?,
       attribute _static { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 with-param.element =
    element with-param {
@@ -645,13 +681,11 @@ with-param.element =
       global.atts,
       (attribute name { eqname.datatype }
       | attribute _name { avt.datatype })+,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
       attribute as { sequence-type.datatype }?,
       attribute _as { avt.datatype }?,
       attribute tunnel { boolean.datatype }?,
       attribute _tunnel { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 call-template.element =
    element call-template {
@@ -753,15 +787,13 @@ attribute.element =
       | attribute _name { avt.datatype })+,
       attribute namespace { uri.datatype | avt.datatype }?,
       attribute _namespace { avt.datatype }?,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
       attribute separator { string.datatype | avt.datatype }?,
       attribute _separator { avt.datatype }?,
       ((attribute type { eqname.datatype }?,
       attribute _type { avt.datatype }?) |
       (attribute validation { "strict" | "lax" | "preserve" | "strip" }?,
       attribute _validation { avt.datatype }? )), # type and validation are mutually exclusive
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 text.element =
    element text {
@@ -775,13 +807,11 @@ value-of.element =
    element value-of {
       extension.atts,
       global.atts,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
       attribute separator { string.datatype | avt.datatype }?,
       attribute _separator { avt.datatype }?,
       attribute disable-output-escaping { boolean.datatype }?,
       attribute _disable-output-escaping { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 document.element =
    element document {
@@ -799,9 +829,7 @@ processing-instruction.element =
       global.atts,
       (attribute name { ncname.datatype | avt.datatype }
       | attribute _name { avt.datatype })+,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 namespace.element =
    element namespace {
@@ -809,24 +837,18 @@ namespace.element =
       global.atts,
       (attribute name { ncname.datatype | avt.datatype }
       | attribute _name { avt.datatype })+,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 comment.element =
    element comment {
       extension.atts,
       global.atts,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 copy.element =
    element copy {
       extension.atts,
       global.atts,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
       attribute copy-namespaces { boolean.datatype }?,
       attribute _copy-namespaces { avt.datatype }?,
       attribute inherit-namespaces { boolean.datatype }?,
@@ -859,9 +881,9 @@ sequence.element =
    element sequence {
       extension.atts,
       global.atts,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      attribute as { sequence-type.datatype }?,
+      attribute _as { avt.datatype }?,
+      select-or-sequence-constructor.model
    }
 where-populated.element =
    element where-populated {
@@ -873,17 +895,13 @@ on-empty.element =
    element on-empty {
       extension.atts,
       global.atts,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 on-non-empty.element =
    element on-non-empty {
       extension.atts,
       global.atts,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 number.element =
    element number {
@@ -919,8 +937,6 @@ sort.element =
    element sort {
       extension.atts,
       global.atts,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
       attribute lang { language.datatype | avt.datatype }?,
       attribute _lang { avt.datatype }?,
       attribute order { "ascending" | "descending" | avt.datatype }?,
@@ -933,7 +949,7 @@ sort.element =
       attribute _case-order { avt.datatype }?,
       attribute data-type { "text" | "number" | eqname.datatype | avt.datatype }?,
       attribute _data-type { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 perform-sort.element =
    element perform-sort {
@@ -1041,13 +1057,13 @@ matching-substring.element =
    element matching-substring {
       extension.atts,
       global.atts,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 non-matching-substring.element =
    element non-matching-substring {
       extension.atts,
       global.atts,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 source-document.element =
    element source-document {
@@ -1087,9 +1103,7 @@ accumulator-rule.element =
       attribute _match { avt.datatype })+,
       attribute phase { "start" | "end" }?,
       attribute _phase { avt.datatype }?,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 key.element =
    element key {
@@ -1119,21 +1133,32 @@ map-entry.element =
       global.atts,
       (attribute key { expression.datatype }
       | attribute _key { avt.datatype }),
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
+
+array.element =
+  element array {
+    extension.atts,
+    global.atts,
+    select-or-sequence-constructor.model
+  }
+
+array-member.element =
+  element array-member {
+    extension.atts,
+    global.atts,
+    select-or-sequence-constructor.model
+  }
+
 message.element =
    element message {
       extension.atts,
       global.atts,
-      attribute select { expression.datatype }?,
-      attribute _select { avt.datatype }?,
       attribute terminate { boolean.datatype | avt.datatype }?,
       attribute _terminate { avt.datatype }?,
       attribute error-code { eqname.datatype | avt.datatype }?,
       attribute _error-code { avt.datatype }?,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
 assert.element =
    element assert {


### PR DESCRIPTION
This PR updates the RELAX NG grammar to be (more) consistent with the XSD grammar (and consequently more correct for XSLT 4.0)

1. Relaxes the definition of QNames so that prefixes declared with `fixed-namespaces` can be supported
2. Adds the `fixed-namespaces` attribute to `xsl:stylesheet`, `xsl:transform`, and `xsl:package`
3. Adds the `xsl:switch` element
4. Adds the `xsl:array` and `xsl:array-member` elements
5. Adds `shallow-copy-all` to the possible values for `on-no-match`
6. Adds `separator` to `xsl:apply-templates`
7. Removes `select` attribute from `xsl:copy`
8. Adds `as` attribute to `xsl:sequence`
9. Updated the declarations for `xsl:accumulator-rule`, `xsl:array`, `xsl:array-member`, `xsl:attribute`, `xsl:catch`, `xsl:comment`, `xsl:map-entry`, `xsl:matching-substring`, `xsl:message`, `xsl:namespace`, `xsl:non-matching-substring`, `xsl:on-empty`, `xsl:on-non-empty`, `xsl:otherwise`, `xsl:param`, `xsl:processing-instruction`, `xsl:sequence`, `xsl:sort`, `xsl:value-of`, `xsl:variable`, `xsl:when`, and `xsl:with-param` so that they accept *either* a `select` attribute or a sequence constructor

More changes may also be required. A comprehensive comparision of the RNC and XSD schemas is needed, #1584 