### PR TITLE
1527 Move record types into separate sections

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17,6 +17,19 @@
       <fos:variable id="v-item3" name="item3" select="$po/line-item[3]"/>
    </fos:global-variables>
    
+   <fos:record-type id="key-value-pair" extensible="true">
+      <fos:field name="key" type="xs:anyAtomicType" required="true">
+         <fos:meaning>
+            <p>A key suitable for use in a map entry.</p>
+         </fos:meaning>
+      </fos:field>
+      <fos:field name="value" type="item()*" required="true">
+         <fos:meaning>
+            <p>The value corresponding to the key.</p>
+         </fos:meaning>
+      </fos:field>
+   </fos:record-type>
+   
    <fos:record-type id="uri-structure-record" extensible="true">
       <fos:field name="uri" type="xs:string?" required="false">
          <fos:meaning>
@@ -22885,7 +22898,7 @@ return fold-left($maps, {},
       <fos:signatures>
          <fos:proto name="of-pairs" return-type="map(*)">
             <fos:arg name="input" 
-                     type="record(key as xs:anyAtomicType, value as item()*)*" 
+                     type-ref="key-value-pair" type-ref-occurs="*"
                      usage="inspection"
                      example="{ 'key':'n','value':false() }, { 'key':'y','value':true() }"/>
             <fos:arg name="combine" type="(fn(item()*, item()*) as item()*)?" usage="inspection" default="fn:op(',')"/>
@@ -23257,7 +23270,7 @@ return map:keys-where($birthdays, fn($name, $date) {
 
    <fos:function name="pairs" prefix="map">
       <fos:signatures>
-         <fos:proto name="pairs" return-type="record(key as xs:anyAtomicType, value as item()*)*">
+         <fos:proto name="pairs" return-type-ref="key-value-pair" return-type-ref-occurs="*">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -23753,7 +23766,7 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
 
    <fos:function name="pair" prefix="map">
       <fos:signatures>
-         <fos:proto name="pair" return-type="record(key as xs:anyAtomicType, value as item()*)">
+         <fos:proto name="pair" return-type-ref="key-value-pair">
             <fos:arg name="key" type="xs:anyAtomicType"/>
             <fos:arg name="value" type="item()*" usage="navigation"/>
          </fos:proto>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -25767,10 +25767,8 @@ return json-to-xml($json, $options)]]></eg>
             </fos:option>
          </fos:options>
 
-         <p>The result of the function is a <code>parsed-csv-structure-record</code>, which is defined as
-            follows:</p>
-         
-         <?record-description parsed-csv-structure-record?>
+         <p>The result of the function is a <code>parsed-csv-structure-record</code>, as
+         defined in <specref ref="parsed-csv-structure-record"/>.</p>
          
 
 
@@ -29551,9 +29549,7 @@ declare function array:flatten(
 
   
          <p>The result of the function is a map
-         <var>R</var> with two entries:</p>
-
-         <?record-description load-xquery-module-record?>
+         <var>R</var> with two entries, as defined in <specref ref="load-xquery-module-record"/>.</p>
 
          
          <p>The static and dynamic context of the library module are established according to the rules in 
@@ -30455,9 +30451,9 @@ return $result?output//body
       <fos:rules>
          <p diff="chg" at="2022-12-19"
                >The function returns a random number generator. A random number generator is represented as a value of type 
-            <code>random-number-generator-record</code>, defined as follows:</p>
-         
-          <?record-description random-number-generator-record?>
+            <code>random-number-generator-record</code>, defined in
+         <specref ref="random-number-generator-record"/>.</p>
+        
 
    
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7569,6 +7569,7 @@ return <table>
             <item><p><termdef id="dt-key-value-pair-map" term="key-value pair map">A <term>key-value pair map</term> is a map containing two
             entries, one (with the key <code>"key"</code>) containing the key part of a key value pair, the other (with the key <code>"value"</code>)
             containing the value part of a key value pair.</termdef></p>
+               <p>The record type for a <termref def="dt-key-value-pair-map"/> is defined in <specref ref="key-value-pair"/>.</p>
                <p>For example
                   the map <code>{ "x": 1, "y": 2 }</code> can be decomposed as 
                   <code>({ "key": "x", "value": 1 }, { "key": "y", "value": 2 })</code></p>
@@ -7615,6 +7616,10 @@ return <table>
                </tr>
             </tbody>
          </table>
+            
+            <div3 id="key-value-pair">
+               <head><?record-description key-value-pair?></head>
+            </div3>
          
          </div2>
          

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -2540,6 +2540,11 @@ string conversion of the number as obtained above, and the appropriate <var>suff
          <div2 id="random-numbers">
             <head>Random Numbers</head>
             <?local-function-index?>
+            
+            <p>The function makes use of the record structure defined in the next section.</p>
+            <div3 id="random-number-generator-record">
+               <head><?record-description random-number-generator-record?></head>
+            </div3>
             <div3 id="func-random-number-generator">
                <head><?function fn:random-number-generator?></head>
             </div3>
@@ -3537,11 +3542,12 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 
          <?local-function-index?>
 
-           <p>The structured representation of a URI is described by the
-           <loc href="#uri-structure-record">uri-structure-record</loc>, whose parts are:</p>
+           <p>Both functions use a structured representation of a URI as defined in the next section.</p>
             
-            <?record-description uri-structure-record?>
-
+            
+           <div3 id="uri-structure-record">
+              <head><?record-description uri-structure-record?></head>
+              
            <p>The segmented forms of the path and query parameters provide
            convenient access to commonly used information.</p>
 
@@ -3566,6 +3572,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
            is repeated in the query string, the map will contain a
            sequence of values for that key, as seen for <code>a</code>
            in this example.</p>
+           </div3>
 
            <div3 id="func-parse-uri">
              <head><?function fn:parse-uri?></head>
@@ -7104,6 +7111,9 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                
 
             </div3>
+            <div3 id="parsed-csv-structure-record">
+               <head><?record-description parsed-csv-structure-record?></head>
+            </div3>
             <div3 id="func-parse-csv">
                <head><?function fn:parse-csv?></head>
             </div3>
@@ -7485,6 +7495,9 @@ return <table>
             <p>The following functions allow dynamic loading and evaluation of XQuery queries, XSLT stylesheets,
                and XPath binary operators.</p>
             <?local-function-index?>
+            <div3 id="load-xquery-module-record">
+              <head><?record-description load-xquery-module-record?></head>
+            </div3>
             <div3 id="func-load-xquery-module">
                <head><?function fn:load-xquery-module?></head>
             </div3>
@@ -9139,7 +9152,7 @@ return <table>
          <p>The structured representation of a schema type is described by the
            <loc href="#schema-type-record">schema-type-record</loc>, whose parts are:</p>
             
-            <?record-description schema-type-record?>
+            <p>?record-description schema-type-record?</p>
          
          <note>
             <p>Simple properties of a schema type that can be expressed as strings or booleans are
@@ -9157,6 +9170,10 @@ return <table>
         
          
          <?local-function-index?>
+            
+            <div3 id="schema-type-record">
+              <head><?record-description schema-type-record?></head>
+            </div3>
             
             <div3 id="func-schema-type">
                <head><?function fn:schema-type?></head>


### PR DESCRIPTION
Changes the rendition of record type definitions so each is now defined in a section of its own, extracted from the function catalog into the narrative spec by means of a processing instruction, following the precedent of function definitions. Record type definitions can therefore be cross-referenced using a specref, but they are automatically cross-referenced if named in a function signature.

Fix #1527