### PR TITLE
557 Add fn:unparsed-binary function

### DIFF
--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -179,6 +179,7 @@
                   <xs:simpleType>
                     <xs:restriction base="xs:string">
                       <xs:enumeration value="collations"/>
+                      <xs:enumeration value="executable-base-uri"/>
                       <xs:enumeration value="static-base-uri"/>
                       <xs:enumeration value="available-documents"/>
                       <xs:enumeration value="available-collections"/>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -7971,7 +7971,7 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -8006,8 +8006,9 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
                   <phrase diff="add" at="2022-12-19">or is supplied as an empty sequence</phrase> then:</p>
                <olist>
                   <item>
-                     <p>If the static base URI in the static context is not absent, it is used as the effective
-               value of <code>$base</code>.</p>
+                     <p>If the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> 
+                        in the dynamic context is not absent, it is used as the effective
+                        value of <code>$base</code>.</p>
                   </item>
                   <item>
                      <p>Otherwise, a dynamic error is raised: <phrase><errorref class="NS"
@@ -8181,7 +8182,7 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
       <fos:rules>
          <p>The function computes the effective boolean value of a sequence, defined according to
             the following rules. See also <xspecref
-               spec="XP31" ref="id-ebv"/>.</p>
+               spec="XP40" ref="id-ebv"/>.</p>
          <ulist>
             <item>
                <p>If <code>$input</code> is the empty sequence, <function>fn:boolean</function> returns
@@ -11424,7 +11425,7 @@ represented by the <code>$value</code> argument took place or will take place.
          <p>If either <code>$arg1</code> or <code>$arg2</code> do not contain an explicit timezone
             then, for the purpose of the operation, the implicit timezone provided by the dynamic
             context (See <xspecref
-               spec="XP31" ref="id-xp-evaluation-context-components"
+               spec="XP40" ref="id-xp-evaluation-context-components"
             />.) is
             assumed to be present as part of the value.</p>
          <p>The function returns the elapsed time between the date/time instant <code>arg2</code>
@@ -11476,7 +11477,7 @@ represented by the <code>$value</code> argument took place or will take place.
          <p>If either <code>$arg1</code> or <code>$arg2</code> do not contain an explicit timezone
             then, for the purpose of the operation, the implicit timezone provided by the dynamic
             context (See <xspecref
-               spec="XP31" ref="id-xp-evaluation-context-components"
+               spec="XP40" ref="id-xp-evaluation-context-components"
             />.) is
             assumed to be present as part of the value.</p>
          <p>The starting instant of an <code>xs:date</code> is the <code>xs:dateTime</code> at
@@ -18438,6 +18439,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </fos:example>
       </fos:examples>
    </fos:function>
+   
    <fos:function name="doc" prefix="fn">
       <fos:signatures>
          <fos:proto name="doc" return-type="document-node()?">
@@ -18447,7 +18449,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="available-documents static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="available-documents executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -18457,9 +18459,12 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:rules>
          <p>If <code>$source</code> is the empty sequence, the result is an empty sequence.</p>
          <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
-            of the <term>static base URI</term> property from the static context. The resulting absolute URI is
-            cast to an <code>xs:string</code>.</p>
-         <p>If the <term>available documents</term> described in <xspecref spec="XP31"
+
+            of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 
+            from the dynamic context of the caller. The resulting absolute URI is
+            promoted to an <code>xs:string</code>.</p>
+         <p>If the <term>available documents</term> described in <xspecref spec="XP40"
+
                ref="eval_context"
             /> provides a mapping from this string to a document node, the
             function returns that document node.</p>
@@ -18753,7 +18758,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="available-documents static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="available-documents executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -18778,7 +18783,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          function provides no guarantees regarding the outcome of a call on <function>fn:doc</function> with 
          the same explicit and implicit arguments.</p>
          
-         
+
       </fos:rules>
       <fos:changes>
          <fos:change issue="1021" PR="1910" date="2025-04-06">
@@ -18797,7 +18802,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="available-collections static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="available-collections executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -18809,16 +18814,18 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             <phrase>items</phrase> obtained by interpreting <code>$source</code> as an <code>xs:anyURI</code> and
             resolving it according to the mapping specified in <term>available 
                collections</term> described in <xspecref
-               spec="XP31" ref="id-xp-evaluation-context-components"/>.</p>
+               spec="XP40" ref="id-xp-evaluation-context-components"/>.</p>
          <p>If <phrase><term>available collections</term></phrase> provides a mapping from this string to a
             sequence of items, the function returns that sequence. If <term>available 
                collections</term> maps the string to an empty sequence, then the function returns an
             empty sequence.</p>
          <p>If <code>$source</code> is not specified, the function returns the sequence of <phrase>items</phrase> in
             the default collection in the dynamic context. See <xspecref
-               spec="XP31" ref="id-xp-evaluation-context-components"/>. </p>
-         <p>If <code>$source</code> is a relative <code>xs:anyURI</code>, it is resolved
-            against the value of the base-URI property from the static context. </p>
+               spec="XP40" ref="id-xp-evaluation-context-components"/>. </p>
+         <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
+            of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 
+            from the dynamic context of the caller. The resulting absolute URI is
+            promoted to an <code>xs:string</code>.</p>
          <p>If <code>$source</code> is the empty sequence, the function behaves as if it had been
             called without an argument. See above.</p>
          <p>By default, this function is <termref def="dt-deterministic"
@@ -18874,7 +18881,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="available-uri-collections static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="available-uri-collections executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -18884,15 +18891,17 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:rules>
          <p>The zero-argument form of the function returns the URIs in the <term>default URI
                collection</term> described in <xspecref
-               spec="XP31" ref="id-xp-evaluation-context-components"/>.</p>
-         <p>If <code>$source</code> is a relative <code>xs:anyURI</code>, it is resolved
-            against the value of the base-URI property from the static context. </p>
+               spec="XP40" ref="id-xp-evaluation-context-components"/>.</p>
+         <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
+            of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 
+            from the dynamic context of the caller. The resulting absolute URI is
+            promoted to an <code>xs:string</code>.</p>
          <p>If <code>$source</code> is the empty sequence, the function behaves as if it had been
             called without an argument. See above.</p>
          <p>The single-argument form of the function returns the sequence of URIs corresponding to
             the supplied URI in the <term>available URI collections</term> described in
                <xspecref
-               spec="XP31" ref="id-xp-evaluation-context-components"/>.</p>
+               spec="XP40" ref="id-xp-evaluation-context-components"/>.</p>
          <p>By default, this function is <termref def="dt-deterministic"
                >deterministic</termref>. This
             means that repeated calls on the function with the same argument will return the same
@@ -18934,11 +18943,6 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          items that do not have any URI; or a URI collection might contain URIs that cannot be dereferenced to return any 
          resource.</p>
 
-         <!-- Marked for deletion; assumes a collection() that returns only document nodes. -->
-         <p diff="del" at="2023-12-26">Thus, some implementations might ensure that calling <function>fn:uri-collection</function> and then
-            applying <function>fn:doc</function> to each of the returned URIs delivers the same result as
-            calling <function>fn:collection</function> with the same argument; however, this is not
-            guaranteed.</p>
 
          <p>In the case where <function>fn:uri-collection</function> returns the URIs of resources that
             could also be retrieved directly using <function>fn:collection</function>, there are several reasons why it 
@@ -19000,7 +19004,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -19011,8 +19015,12 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p>The <code>$source</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
             reference, which <rfc2119>must</rfc2119> contain no fragment identifier, and
                <rfc2119>must</rfc2119> identify a resource for which a string representation is
-            available. If the URI is a relative URI reference, then it is resolved relative to the
-            <term>static base URI</term> property from the static context.</p>
+            available.</p>
+         <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
+            of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 
+            from the dynamic context of the caller. The resulting absolute URI is
+            promoted to an <code>xs:string</code>.</p>
+         
          <p>The <code>$options</code> argument, for backwards compatibility reasons, may be supplied
          either as a map, or as a string. Supplying a value <code>$S</code> that is not a map
             is equivalent to supplying the map <code>{ "encoding": $S }</code>.
@@ -19045,7 +19053,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                 
          <p>The mapping of URIs to the string representation of a resource is the mapping defined in
             the <xtermref
-               spec="XP31" ref="dt-available-text-resources"
+               spec="XP40" ref="dt-available-text-resources"
                >available text
                resources</xtermref> component of the dynamic context.</p>
          <p>If the <code>$source</code> argument is an empty sequence, the function
@@ -19113,7 +19121,8 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:errors>
 
       <fos:notes>
-         <p>If it is appropriate to use a base URI other than the dynamic base URI (for example,
+         <p>If it is appropriate to use a base URI other than the 
+            <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> (for example,
             when resolving a relative URI reference read from a source document) then it is
             advisable to resolve the relative URI reference using the <function>fn:resolve-uri</function>
             function before passing it to the <function>fn:unparsed-text</function> function.</p>
@@ -19141,6 +19150,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             <item>
                <p>The handling of media types is implementation-defined.</p>
             </item>
+            <item>
+               <p>Implementations may provide user options that relax the requirement for the function
+               to return deterministic results.</p>
+            </item>
 
             <item>
                <p>Implementations may provide user-defined error handling options that allow
@@ -19148,11 +19161,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                   its content. When errors have been handled in this way, the function may return a
                   fallback document provided by the error handler.</p>
             </item>
-            <item>
-               <p>For backwards compatibility reasons, implementations may provide 
-                  configuration options that alter the default for the <code>deterministic</code>
-                  option.</p>
-            </item>
+            
          </ulist>
 
          <p>The rules for determining the encoding are chosen for consistency with <bibref
@@ -19216,7 +19225,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -19276,6 +19285,7 @@ return $lines[not(position() = last() and . = '')]
          </fos:change>
       </fos:changes>
    </fos:function>
+   
    <fos:function name="unparsed-text-available" prefix="fn">
       <fos:signatures>
          <fos:proto name="unparsed-text-available" return-type="xs:boolean">
@@ -19285,7 +19295,7 @@ return $lines[not(position() = last() and . = '')]
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -19345,6 +19355,176 @@ return $lines[not(position() = last() and . = '')]
       </fos:changes>
 
    </fos:function>
+   
+   
+   <fos:function name="binary-resource" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="binary-resource" return-type="xs:base64Binary">
+            <fos:arg name="source" type="xs:string?"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>The <code>fn:binary-resource</code> function reads an external resource (for example, a
+            file) and returns its contents in binary.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The <code>$source</code> argument <rfc2119>must</rfc2119> be a string in the form of a URI
+            reference, which <rfc2119>must</rfc2119> contain no fragment identifier, and
+               <rfc2119>must</rfc2119> identify a resource for which a binary representation is
+            available.</p>
+         
+         <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
+            of the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> property 
+            from the dynamic context of the caller. The resulting absolute URI is
+            promoted to an <code>xs:string</code>.</p>
+         
+         
+         
+
+                
+         <p>The mapping of URIs to the string representation of a resource is the mapping defined in
+            the <xtermref
+               spec="XP40" ref="dt-available-binary-resources"
+               >available text
+               resources</xtermref> component of the dynamic context.</p>
+         <p>If the <code>$source</code> argument is an empty sequence, the function
+            returns an empty sequence.</p>
+         
+         <p>The result of the function is an atomic item of type <code>xs:base64Binary</code> 
+            containing the binary representation of the
+            resource retrieved using the URI.</p>
+         
+         
+         
+      </fos:rules>
+      <fos:errors>
+         <p>A dynamic error is raised <errorref class="UT" code="1170"
+               /> if the <code>$source</code> argument
+            contains a fragment identifier, <phrase>or if it cannot be resolved
+            to an absolute URI (for example, because the base-URI property in the static context is absent), 
+            </phrase>or if it cannot be used to retrieve the binary
+            representation of a resource. </p>
+         
+      </fos:errors>
+
+      <fos:notes>
+         <p>If it is appropriate to use a base URI other than the 
+            <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> (for example,
+            when resolving a relative URI reference read from a source document) then it is
+            advisable to resolve the relative URI reference using the <code>fn:resolve-uri</code>
+            function before passing it to the <code>fn:unparsed-text</code> function.</p>
+         <p>There is no essential relationship between the sets of URIs accepted by the 
+            function <code>fn:binary-resource</code> and other functions such as
+            <code>fn:doc</code> and <code>fn:unparsed-text</code>  (a URI accepted by one
+            may or may not be accepted by the others), and if a URI is accepted by more than 
+            one of these functions then there is no
+            essential relationship between the results (different resource representations are
+            permitted by the architecture of the web).</p>
+         <p>There are no constraints on the MIME type of the resource.</p>
+
+
+         <p>The fact that the resolution of URIs is defined by a mapping in the dynamic context
+            means that in effect, various aspects of the behavior of this function are <termref
+               def="implementation-defined"
+            >implementation-defined</termref>. Implementations may provide external configuration
+            options that allow any aspect of the processing to be controlled by the user. In
+            particular:</p>
+         <ulist>
+            <item>
+               <p>The set of URI schemes that the implementation recognizes is
+                  implementation-defined. Implementations may allow the mapping of URIs to resources
+                  to be configured by the user, using mechanisms such as catalogs or user-written
+                  URI handlers.</p>
+            </item>
+            <item>
+               <p>The handling of media types is implementation-defined.</p>
+            </item>
+            <item>
+               <p>Implementations may provide user options that relax the requirement for the function
+               to return deterministic results.</p>
+            </item>
+
+            <item>
+               <p>Implementations may provide user-defined error handling options that allow
+                  processing to continue following an error in retrieving a resource, or in reading
+                  its content. When errors have been handled in this way, the function may return a
+                  fallback document provided by the error handler.</p>
+            </item>
+            
+         </ulist>
+
+         <p>The rules for determining the encoding are chosen for consistency with <bibref
+               ref="xinclude"
+            />. Files with an XML media type are treated specially because there
+            are use cases for this function where the retrieved text is to be included as unparsed
+            XML within a CDATA section of a containing document, and because processors are likely
+            to be able to reuse the code that performs encoding detection for XML external
+            entities.</p>
+         <p>If the text file contains characters such as <code>&lt;</code> and <code>&amp;</code>,
+            these will typically be output as <code>&amp;lt;</code> and <code>&amp;amp;</code> if
+            the string is serialized as XML or HTML. If these characters actually represent markup
+            (for example, if the text file contains HTML), then an XSLT stylesheet can attempt to
+            write them as markup to the output file using the <code>disable-output-escaping</code>
+            attribute of the <code>xsl:value-of</code> instruction. Note, however, that XSLT
+            implementations are not required to support this feature.</p>
+         <p>There is no function (analogous to <code>fn:doc-available</code> or <code>fn:unparsed-text-available</code>)
+            to determine whether a suitable resource is available. In XQuery and XSLT, try/catch
+            constructs are available to catch the error.</p>
+         <p>The choice of <code>xs:base64Binary</code> rather than <code>xs:hexBinary</code> for the
+            result is arbitrary. The two types have the same value space and are interchangeable for nearly
+            all purposes, the notable exception being conversion to <code>xs:string</code>.</p>
+         <p>A comprehensive set of functions for manipulating binary data is available in the
+            EXPath binary module: see <bibref ref="expath"/>. In addition, the EXPath file module
+            provides a function <code>file:read-binary</code> with similar functionality to
+            <code>fn:binary-resource</code>, the notable differences being (a) that it takes
+            a file name rather than a URI, and (b) that it is defined to be nondeterministic.
+          </p>
+      </fos:notes>
+
+
+
+      <!--
+      <imp-def-feature>The set of encodings recognized by the
+         <function>unparsed-text</function> function, other than <code>utf-8</code> and
+         <code>utf-16</code>, is <termref def="implementation-defined"
+            >implementation-defined</termref>.</imp-def-feature>
+      
+      <imp-def-feature>If no encoding is specified on a call to the
+         <function>unparsed-text</function> function, the processor
+         <rfc2119>may</rfc2119> use <termref def="implementation-defined"
+            >implementation-defined</termref> heuristics to determine the likely
+         encoding.</imp-def-feature>-->
+
+      <fos:examples>
+         <fos:example>
+            <p>The following XQuery, adapted from an example in the EXPath binary module <bibref ref="expath"/>,
+               reads a JPEG image and determines its size in pixels:</p>
+            
+            <eg><![CDATA[declare namespace bin = "http://expath.org/ns/binary";
+let $content := fn:binary-resource("image.jpeg")
+let $int16-at := bin:unpack-unsigned-integer(
+                    $content, ?, 2, 'most-significant-first')
+let $loc := bin:find($content, 0, bin:hex('FFC0'))
+return { "width": $int16-at($loc + 5),
+         "height": $int16-at($loc + 7) }]]></eg>
+            
+            <p>The example assumes that the functions in the EXPath binary module are available.</p>
+         </fos:example>
+      </fos:examples>
+      <fos:changes>
+         <fos:change issue="557"  date="2024-11-18">
+            <p>New in 4.0</p>
+         </fos:change>
+      </fos:changes>
+   </fos:function>
+   
+   
+   
    <fos:function name="environment-variable" prefix="fn">
       <fos:signatures>
          <fos:proto name="environment-variable" return-type="xs:string?">
@@ -19360,7 +19540,7 @@ return $lines[not(position() = last() and . = '')]
          <p>Returns the value of a system environment variable, if it exists.</p>
       </fos:summary>
       <fos:rules>
-         <p>The set of available <xtermref spec="XP31" ref="dt-environment-variables"
+         <p>The set of available <xtermref spec="XP40" ref="dt-environment-variables"
                >environment
                variables</xtermref> is a set of (name, value) pairs forming part of the dynamic
             context, in which the name is unique within the set of pairs. The name and value are
@@ -19611,7 +19791,7 @@ return $lines[not(position() = last() and . = '')]
       </fos:signatures>
       <fos:properties>
          <fos:property>nondeterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -19858,7 +20038,7 @@ return $lines[not(position() = last() and . = '')]
       </fos:signatures>
       <fos:properties>
          <fos:property>nondeterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -20795,7 +20975,7 @@ serialize(
          <p>Returns the context position from the dynamic context.</p>
       </fos:summary>
       <fos:rules>
-         <p>Returns the context position from the dynamic context. (See <xspecref spec="XP31"
+         <p>Returns the context position from the dynamic context. (See <xspecref spec="XP40"
                ref="id-xp-evaluation-context-components"/>.)</p>
       </fos:rules>
       <fos:errors>
@@ -20819,7 +20999,7 @@ serialize(
          <p>Returns the context size from the dynamic context.</p>
       </fos:summary>
       <fos:rules>
-         <p>Returns the context size from the dynamic context. (See <xspecref spec="XP31"
+         <p>Returns the context size from the dynamic context. (See <xspecref spec="XP40"
                ref="id-xp-evaluation-context-components"/>.)</p>
       </fos:rules>
       <fos:errors>
@@ -20855,7 +21035,7 @@ serialize(
       </fos:summary>
       <fos:rules>
          <p>Returns the current dateTime (with timezone) from the dynamic context. (See <xspecref
-               spec="XP31" ref="id-xp-evaluation-context-components"
+               spec="XP40" ref="id-xp-evaluation-context-components"
                />.) This is an
                <code>xs:dateTime</code> that is current at some time during the evaluation of a
             query or transformation in which <function>fn:current-dateTime</function> is executed.</p>
@@ -20963,7 +21143,7 @@ serialize(
       <fos:rules>
          <p>Returns the value of the implicit timezone property from the dynamic context. Components
             of the dynamic context are described in <xspecref
-               spec="XP31" ref="id-xp-evaluation-context-components"/>.</p>
+               spec="XP40" ref="id-xp-evaluation-context-components"/>.</p>
       </fos:rules>
    </fos:function>
    <fos:function name="default-collation" prefix="fn">
@@ -21012,7 +21192,7 @@ serialize(
       <fos:rules>
          <p>Returns the value of the default language property from the dynamic context. Components
             of the dynamic context are described in <xspecref
-               spec="XP31" ref="eval_context"/>.</p>
+               spec="XP40" ref="eval_context"/>.</p>
       </fos:rules>
       <fos:notes>
          <p>The default language property can never be absent. The functions <function>fn:format-integer</function>,
@@ -21027,7 +21207,7 @@ serialize(
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -26012,7 +26192,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:signatures>
       <fos:properties>
          <fos:property>nondeterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -26240,7 +26420,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
             >implementation-dependent</termref> whether the same node is returned on both
             occasions.</p>
 
-         <p>The base URI of the returned document node is taken from the static base URI of the
+         <p>The base URI of the returned document node is taken from the 
+            <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> of the
             function call.</p>
 
          <p>The choice of namespace prefix (or absence of a prefix) in the names of constructed
@@ -27585,7 +27766,7 @@ return csv-to-arrays(
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -28341,7 +28522,7 @@ return document {
       </fos:signatures>
       <fos:properties>
          <fos:property>deterministic</fos:property>
-         <fos:property dependency="static-base-uri">context-dependent</fos:property>
+         <fos:property dependency="executable-base-uri">context-dependent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
@@ -30740,7 +30921,8 @@ declare function array:flatten(
             <fos:option key="content">
                <fos:meaning>The content of the query module as a string. When this option is used, the 
                   <code>location-hints</code> option is ignored. The static base URI of the dynamically loaded
-                  module is the same as the static base URI of the caller.</fos:meaning>
+                  module is the same as the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> 
+                  of the caller.</fos:meaning>
                <fos:type>xs:string?</fos:type>
                <fos:default>Empty sequence</fos:default>
             </fos:option>
@@ -31211,7 +31393,11 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                <fos:applies-to>1.0, 2.0, 3.0</fos:applies-to>
                <fos:meaning>The URI of the principal result document; also used as the base URI for
             resolving relative URIs of secondary result documents. If the value is a relative 
-            reference, it is resolved against the static base URI of the <function>fn:transform</function> 
+
+            reference, it is resolved against the 
+                  <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> 
+                  of the <code>fn:transform</code> 
+
             function call. </fos:meaning>
 
                <fos:type>xs:string</fos:type>
@@ -31478,14 +31664,20 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                      def="implementation-defined"
                      >implementation-defined</termref> whether this
             parameter has any effect. If the value is a relative reference, it is resolved against
-            the static base URI of the <function>fn:transform</function> function call.</fos:meaning>
+
+            the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> 
+                  of the <code>fn:transform</code> function call.</fos:meaning>
+
                <fos:type>xs:string</fos:type>
                <fos:default-description>n/a</fos:default-description>
             </fos:option>
             <fos:option key="stylesheet-location">
                <fos:applies-to>1.0, 2.0, 3.0</fos:applies-to>
                <fos:meaning>URI that can be used to locate the principal stylesheet module. If relative, it
-            is resolved against the static base URI of the <function>fn:transform</function> function call.
+
+            is resolved against the <xtermref spec="XP40" ref="dt-executable-base-uri">executable base URI</xtermref> 
+                  of the <code>fn:transform</code> function call.
+
             The value also acts as the default for stylesheet-base-uri.</fos:meaning>
                <fos:type>xs:string</fos:type>
                <fos:default-description>n/a</fos:default-description>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19369,7 +19369,7 @@ return $lines[not(position() = last() and . = '')]
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>The <code>fn:binary-resource</code> function reads an external resource (for example, a
+         <p>The <code>fn:unparsed-binary</code> function reads an external resource (for example, a
             file) and returns its contents in binary.</p>
       </fos:summary>
       <fos:rules>
@@ -19389,9 +19389,7 @@ return $lines[not(position() = last() and . = '')]
                 
          <p>The mapping of URIs to the binary representation of a resource is the mapping defined in
             the <xtermref
-               spec="XP40" ref="dt-available-binary-resources"
-               >available text
-               resources</xtermref> component of the dynamic context.</p>
+               spec="XP40" ref="dt-available-binary-resources"/> component of the dynamic context.</p>
          <p>If the <code>$source</code> argument is an empty sequence, the function
             returns an empty sequence.</p>
          

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19504,7 +19504,7 @@ return { "width": $int16-at($loc + 5),
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="557"  date="2024-11-18">
+         <fos:change issue="557" PR="1587" date="2024-11-18">
             <p>New in 4.0</p>
          </fos:change>
       </fos:changes>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19357,9 +19357,9 @@ return $lines[not(position() = last() and . = '')]
    </fos:function>
    
    
-   <fos:function name="binary-resource" prefix="fn">
+   <fos:function name="unparsed-binary" prefix="fn">
       <fos:signatures>
-         <fos:proto name="binary-resource" return-type="xs:base64Binary">
+         <fos:proto name="unparsed-binary" return-type="xs:base64Binary">
             <fos:arg name="source" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
@@ -19387,7 +19387,7 @@ return $lines[not(position() = last() and . = '')]
          
 
                 
-         <p>The mapping of URIs to the string representation of a resource is the mapping defined in
+         <p>The mapping of URIs to the binary representation of a resource is the mapping defined in
             the <xtermref
                spec="XP40" ref="dt-available-binary-resources"
                >available text
@@ -19458,20 +19458,7 @@ return $lines[not(position() = last() and . = '')]
             
          </ulist>
 
-         <p>The rules for determining the encoding are chosen for consistency with <bibref
-               ref="xinclude"
-            />. Files with an XML media type are treated specially because there
-            are use cases for this function where the retrieved text is to be included as unparsed
-            XML within a CDATA section of a containing document, and because processors are likely
-            to be able to reuse the code that performs encoding detection for XML external
-            entities.</p>
-         <p>If the text file contains characters such as <code>&lt;</code> and <code>&amp;</code>,
-            these will typically be output as <code>&amp;lt;</code> and <code>&amp;amp;</code> if
-            the string is serialized as XML or HTML. If these characters actually represent markup
-            (for example, if the text file contains HTML), then an XSLT stylesheet can attempt to
-            write them as markup to the output file using the <code>disable-output-escaping</code>
-            attribute of the <code>xsl:value-of</code> instruction. Note, however, that XSLT
-            implementations are not required to support this feature.</p>
+         
          <p>There is no function (analogous to <code>fn:doc-available</code> or <code>fn:unparsed-text-available</code>)
             to determine whether a suitable resource is available. In XQuery and XSLT, try/catch
             constructs are available to catch the error.</p>
@@ -19481,7 +19468,7 @@ return $lines[not(position() = last() and . = '')]
          <p>A comprehensive set of functions for manipulating binary data is available in the
             EXPath binary module: see <bibref ref="expath"/>. In addition, the EXPath file module
             provides a function <code>file:read-binary</code> with similar functionality to
-            <code>fn:binary-resource</code>, the notable differences being (a) that it takes
+            <code>fn:unparsed-binary</code>, the notable differences being (a) that it takes
             a file name rather than a URI, and (b) that it is defined to be nondeterministic.
           </p>
       </fos:notes>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6120,8 +6120,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-unparsed-text-available">
                <head><?function fn:unparsed-text-available?></head>
             </div3>
-            <div3 id="func-binary-resource">
-               <head><?function fn:binary-resource?></head>
+            <div3 id="func-unparsed-binary">
+               <head><?function fn:unparsed-binary?></head>
             </div3>
             <div3 id="func-environment-variable">
                <head><?function fn:environment-variable?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6120,6 +6120,9 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="func-unparsed-text-available">
                <head><?function fn:unparsed-text-available?></head>
             </div3>
+            <div3 id="func-binary-resource">
+               <head><?function fn:binary-resource?></head>
+            </div3>
             <div3 id="func-environment-variable">
                <head><?function fn:environment-variable?></head>
             </div3>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1728,7 +1728,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                         <term>Available binary resources</term>. 
   This is a mapping of strings to binary resources. Each string
   represents the absolute URI of a resource. The resource is returned
-  by the <code>fn:binary-resource</code> function when applied to that
+  by the <code>fn:unparsed-binary</code> function when applied to that
   URI.</termdef> The set of available binary resources may be empty.</p>
                </item>
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1721,6 +1721,16 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
   by the <function>fn:unparsed-text</function> function when applied to that
   URI.</termdef> The set of available text resources may be empty.</p>
                </item>
+               
+               <item>
+                  <p>
+                     <termdef id="dt-available-binary-resources" term="available binary resources">
+                        <term>Available binary resources</term>. 
+  This is a mapping of strings to binary resources. Each string
+  represents the absolute URI of a resource. The resource is returned
+  by the <code>fn:binary-resource</code> function when applied to that
+  URI.</termdef> The set of available binary resources may be empty.</p>
+               </item>
 
 
                <item>


### PR DESCRIPTION
Adds the function `fn:binary-resource`

Also fixes some inconstencies in the handling of static/executable base URI in other resource access functions.

Fix #557