### PR TITLE
1516(B) Fix problems with testing examples

### DIFF
--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" 
            targetNamespace="http://www.w3.org/xpath-functions/spec/namespace" 
 		   xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace"
-   xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+       xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
   <xs:attributeGroup name="diff-markup">
     <xs:attribute name="diff" use="optional">
@@ -346,14 +346,27 @@
       <xs:sequence>
         <xs:element ref="fos:expression"/>
         <xs:choice>
-          <xs:element ref="fos:result" minOccurs="1" maxOccurs="unbounded"/>
+          <xs:element ref="fos:result" minOccurs="1" maxOccurs="1"/>
           <xs:element ref="fos:error-result"/>
         </xs:choice>
+        <xs:element name="test-assertion" minOccurs="0" maxOccurs="1">
+          <!-- A 'result' element to be used in the generated test, for use in cases where the result as presented
+            in the spec cannot be used as-is in the test, for example because (a) it uses XQuery, or (b) because there
+            are variations documented in the postamble -->
+          <!-- We avoid bringing in the schema for the qt3 test suite because it's too much hassle. --> 
+            <xs:complexType>
+              <xs:sequence>
+                <xs:any namespace="http://www.w3.org/2010/09/qt-fots-catalog" processContents="skip"/>
+              </xs:sequence>
+              <xs:assert test="local-name(*) eq 'result'"/>
+            </xs:complexType>           
+        </xs:element>
         <xs:element ref="fos:postamble" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="use" type="xs:IDREFS"/>
       <xs:attribute name="default-collation" type="xs:anyURI"/>
       <xs:attribute name="implicit-timezone" type="xs:duration"/>
+      <xs:attribute name="schema-aware" type="xs:boolean"/>
       <xs:attribute name="xslt-version" type="xs:decimal"/>
       <xs:attribute name="spec" default="XPath">
         <xs:simpleType>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22305,7 +22305,9 @@ let $type := node-type-annotation($n23)
 return ($type?name, 
         $type?base-type()?name, 
         $type?base-type()?base-type()?name)]]></eg></fos:expression>
-               <fos:result>xs:QName('fn:numberType'), xs:QName('fn:finiteNumberType'), xs:QName('xs:double')</fos:result>
+               <fos:result><eg>xs:QName('fn:numberType'), 
+xs:QName('fn:finiteNumberType'), 
+xs:QName('xs:double')</eg></fos:result>
             </fos:test>
          </fos:example>
          
@@ -24504,7 +24506,7 @@ return map:build($titles/title, fn($title) { $title/ix })
             </fos:test>
             <fos:test>
                <fos:expression>collation({ 'lang': 'de', 'strength': 'primary' })</fos:expression>
-               <fos:result>"http://www.w3.org/2013/collation/UCA?lang=de;strength=primary ZZZZ"</fos:result>
+               <fos:result>"http://www.w3.org/2013/collation/UCA?lang=de;strength=primary"</fos:result>
                <fos:test-assertion>
                   <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
                      <any-of>
@@ -25967,7 +25969,9 @@ return (
                <fos:result><eg>{
   "columns": ("Person", "", "Amount"),
   "column-index": { "Person": 1, "Amount": 3 },
-  "rows": (["Alice", "2023-07-20", "15.00" ], [ "Bob", "2023-07-19", "10.00" ], ["Charlie", "2023-07-20", "15.00"]),
+  "rows": ([ "Alice", "2023-07-20", "15.00" ], 
+           [ "Bob", "2023-07-19", "10.00" ], 
+           [ "Charlie", "2023-07-20", "15.00" ]),
   "get": "(: function :)"                  
 },
 "Bob",
@@ -26024,7 +26028,8 @@ return (
   $result?get(3, "original amount")
 )</eg></fos:expression>
                <fos:result><eg>{
-  "columns": ("date", "name", "city", "amount", "currency", "original amount"),
+  "columns": ("date", "name", "city", 
+              "amount", "currency", "original amount"),
   "column-index": {
     "date": 1, "name": 2, "city": 3, "amount": 4,
     "currency": 5, "original amount": 6
@@ -26446,7 +26451,8 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
          <fos:example>
             <p>With defaults for delimiters and quotes, recognizing headers:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression><eg>csv-to-xml($csv-string, { "header": true(), "normalize-newlines": true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml($csv-string, 
+         { "header": true(), "normalize-newlines": true() })</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
   <columns>
@@ -26478,7 +26484,10 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml(
   $csv-uneven-cols, 
-  { "header": true(), "select-columns": (2, 1, 4), "normalize-newlines": true() }
+  { "header": true(), 
+    "select-columns": (2, 1, 4), 
+    "normalize-newlines": true() 
+  }
 )</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -26561,7 +26570,10 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml(
   $csv-uneven-cols, 
-  { "header": true(), "trim-rows": true(), "normalize-newlines": true() }
+  { "header": true(), 
+    "trim-rows": true(), 
+    "normalize-newlines": true() 
+  }
 )</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -26612,7 +26624,10 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml(
   $csv-uneven-cols, 
-  { "header": true(), "select-columns": 1 to 6, "normalize-newlines": true() }
+  { "header": true(), 
+    "select-columns": 1 to 6, 
+    "normalize-newlines": true() 
+  }
 )</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -20466,20 +20466,6 @@ function-annotations(local:inc#1)</eg></fos:expression>
          <fos:example>
             <fos:test>
                <fos:expression><eg>
-declare %private %variadic 
-        function local:sum($c as xs:integer*) { sum($c) };
-function-annotations(local:sum#3)</eg></fos:expression>
-               <fos:result><eg>{ "key": QName("http://www.w3.org/2012/xquery", "private"),
-  "value": () 
-},
-{ "key": QName("http://www.w3.org/2012/xquery", "variadic"),
-  "value": () 
-}</eg></fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>
 let $old := %local:deprecated('0.1', '0.2') fn() {}
 let $ann := function-annotations($old)
 return map:of-pairs($ann)
@@ -22293,22 +22279,33 @@ return atomic-type-annotation($x)?matches($y)</eg></fos:expression>
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[let $e := parse-xml("<e/>")/*
-return node-type-annotation($e)]]></eg></fos:expression>
+return node-type-annotation($e)?name]]></eg></fos:expression>
                <fos:result>xs:QName('xs:untyped')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <fos:test>
                <fos:expression><eg><![CDATA[let $a := parse-xml("<e a='3'/>")//@a
-return node-type-annotation($a)]]></eg></fos:expression>
+return node-type-annotation($a)?name]]></eg></fos:expression>
                <fos:result>xs:QName('xs:untypedAtomic')</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
-            <fos:test>
+            <fos:test schema-aware="true">
                <fos:expression><eg><![CDATA[let $x := json-to-xml('[23, 24]', { 'validate': true() })
-return node-type-annotation($x/*)]]></eg></fos:expression>
+return node-type-annotation($x/*)?name]]></eg></fos:expression>
                <fos:result>xs:QName('fn:arrayType')</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test schema-aware="true">
+               <fos:expression><eg><![CDATA[let $x := json-to-xml('[23, 24]', { 'validate': true() })
+let $n23 := $x//fn:number[. = 23]                  
+let $type := node-type-annotation($n23)
+return ($type?name, 
+        $type?base-type()?name, 
+        $type?base-type()?base-type()?name)]]></eg></fos:expression>
+               <fos:result>xs:QName('fn:numberType'), xs:QName('fn:finiteNumberType'), xs:QName('xs:double')</fos:result>
             </fos:test>
          </fos:example>
          
@@ -23295,6 +23292,14 @@ return map:keys-where($birthdays, fn($name, $date) {
   { 1: "Y", 2: "N" }
 )</eg></fos:expression>
                <fos:result allow-permutation="true"><eg>({ "key": 1, "value": "Y" }, { "key": 2, "value": "N" })</eg></fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <any-of>
+                        <assert-deep-eq>{ "key": 1, "value": "Y" }, { "key": 2, "value": "N" }</assert-deep-eq>
+                        <assert-deep-eq>{ "key": 2, "value": "N" }, { "key": 1, "value": "Y" }</assert-deep-eq>
+                     </any-of>
+                  </result>
+               </fos:test-assertion>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
@@ -24252,7 +24257,7 @@ fold-left($input, {}, fn($map, $item, $pos) {
                <fos:postamble>Returns an inverted index for the input sequence with the 
                   string stored as key and the position stored as value.</fos:postamble>
             </fos:test>
-            <fos:test>
+            <fos:test spec="XQuery">
                <fos:expression><eg><![CDATA[
 let $titles := <titles>
   <title>A Beginner’s Guide to <ix>Java</ix></title>
@@ -24271,6 +24276,16 @@ return map:build($titles/title, fn($title) { $title/ix })
     <title>Using <ix>XML</ix> with <ix>Java</ix></title>
   )
 }]]></eg></fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <all-of>
+                        <assert><![CDATA[?Java[1][self::title][ix='Java'][string(.)="A Beginner’s Guide to Java"]]]></assert>
+                        <assert><![CDATA[?Java[2][self::title][ix='XML'][ix='Java'][string(.)="Using XML with Java"]]]></assert>
+                        <assert><![CDATA[?XML[1][self::title][ix='XML'][string(.)="Learning XML"]]]></assert>
+                        <assert><![CDATA[?XML[2][self::title][ix='XML'][ix='Java'][string(.)="Using XML with Java"]]]></assert>
+                     </all-of>
+                  </result>
+               </fos:test-assertion>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -24489,7 +24504,15 @@ return map:build($titles/title, fn($title) { $title/ix })
             </fos:test>
             <fos:test>
                <fos:expression>collation({ 'lang': 'de', 'strength': 'primary' })</fos:expression>
-               <fos:result>"http://www.w3.org/2013/collation/UCA?lang=de;strength=primary"</fos:result>
+               <fos:result>"http://www.w3.org/2013/collation/UCA?lang=de;strength=primary ZZZZ"</fos:result>
+               <fos:test-assertion>
+                  <result xmlns="http://www.w3.org/2010/09/qt-fots-catalog">
+                     <any-of>
+                        <assert-string-value>http://www.w3.org/2013/collation/UCA?lang=de;strength=primary</assert-string-value>
+                        <assert-string-value>http://www.w3.org/2013/collation/UCA?strength=primary;lang=de;</assert-string-value>
+                     </any-of>
+                  </result>
+               </fos:test-assertion>
                <fos:postamble>The order of query parameters may vary.</fos:postamble>
             </fos:test>
             
@@ -25568,7 +25591,7 @@ return json-to-xml($json, $options)]]></eg>
     <list>
       <item value='1'/>
       <item value='2'/>
-    </foo>
+    </list>
   ")/*)]]></eg></fos:expression>
                <fos:result><eg>{ "list": [ 
     { "@value": "1" },
@@ -25580,7 +25603,7 @@ return json-to-xml($json, $options)]]></eg>
     <name>
       <first>Jane</first>
       <last>Smith</last>
-    </foo>
+    </name>
   ")/*)]]></eg></fos:expression>
                <fos:result><eg>{ "name": { 
     "first": "Jane",
@@ -25857,7 +25880,7 @@ return (
   "quote-character": "|"
 }
 let $input := "|name|;|city|§|Bob|;|Berlin|§|Alice|;|Aachen|"
-let $result := parse-csv($csv, $options)
+let $result := parse-csv($input, $options)
 return (
   $result => $display(),
   $result?get(3, 1)
@@ -25907,7 +25930,7 @@ let $options := {
 let $result := parse-csv($input, $options)
 return (
   $result => $display(),
-  $result?get(2, "city")
+  $result?get(2, "amount")
 )</eg></fos:expression>
                <fos:result><eg>{
   "columns": ("name", "date", "amount"),
@@ -25919,19 +25942,19 @@ return (
   ),
   "get": "(: function :)"                  
 },
-"Aachen"</eg></fos:result>
+"15.00"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>Filtering columns, with supplied column map</p>
             <fos:test use="csv-display">
                <fos:expression><eg>let $input := string-join((
+  "2023-07-20,Alice,Aachen,15.00",                  
   "2023-07-19,Bob,Berlin,10.00,USD,13.99",
-  "2023-07-20,Alice,Aachen,15.00",
   "2023-07-20,Charlie,Celle,15.00,GBP,11.99,cake,not a lie"
 ), char('\n'))
 let $options := { 
-  "header": { "Person": 1, "Amount": 3 }, 
+  "header": ( "Person", "", "Amount" ),
   "select-columns": (2, 1, 4)
 }
 let $result := parse-csv($input, $options)
@@ -25944,11 +25967,11 @@ return (
                <fos:result><eg>{
   "columns": ("Person", "", "Amount"),
   "column-index": { "Person": 1, "Amount": 3 },
-  "rows": ([ "Alice", "Aachen" ], [ "Bob", "Berlin" ]),
+  "rows": (["Alice", "2023-07-20", "15.00" ], [ "Bob", "2023-07-19", "10.00" ], ["Charlie", "2023-07-20", "15.00"]),
   "get": "(: function :)"                  
 },
-"Alice",
-"15.00"</eg></fos:result>
+"Bob",
+"10.00"</eg></fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -25981,7 +26004,7 @@ return (
   ),
   "get": "(: function :)"                  
 },
-"15:00"</eg></fos:result>
+"15.00"</eg></fos:result>
                
             </fos:test>
          </fos:example>
@@ -26399,7 +26422,6 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
                <fos:expression><eg>csv-to-xml("", { "header": true() })</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
-  <columns/>
   <rows/>
 </csv>
 ]]></eg></fos:result>
@@ -26424,7 +26446,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
          <fos:example>
             <p>With defaults for delimiters and quotes, recognizing headers:</p>
             <fos:test use="escaped-crlf-3 csv-string-2">
-               <fos:expression><eg>csv-to-xml($csv-string, { "header": true() })</eg></fos:expression>
+               <fos:expression><eg>csv-to-xml($csv-string, { "header": true(), "normalize-newlines": true() })</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
   <columns>
@@ -26456,7 +26478,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml(
   $csv-uneven-cols, 
-  { "header": true(), "select-columns": (2, 1, 4) }
+  { "header": true(), "select-columns": (2, 1, 4), "normalize-newlines": true() }
 )</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -26491,7 +26513,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml(
   $csv-uneven-cols, 
-  { "header": true() }
+  { "header": true(), "normalize-newlines": true() }
 )</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -26539,7 +26561,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml(
   $csv-uneven-cols, 
-  { "header": true(), "trim-rows": true() }
+  { "header": true(), "trim-rows": true(), "normalize-newlines": true() }
 )</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -26590,7 +26612,7 @@ return <csv xmlns="http://www.w3.org/2005/xpath-functions"> {
             <fos:test use="escaped-crlf-3 uneven-cols-csv-string-2">
                <fos:expression><eg>csv-to-xml(
   $csv-uneven-cols, 
-  { "header": true(), "select-columns": 1 to 6 }
+  { "header": true(), "select-columns": 1 to 6, "normalize-newlines": true() }
 )</eg></fos:expression>
                <fos:result normalize-space="true"><eg><![CDATA[
 <csv xmlns="http://www.w3.org/2005/xpath-functions">
@@ -33317,7 +33339,7 @@ return $result
   "fr": { "capital": "Paris", "languages": [ "French" ] }, 
   "de": { "capital": "Berlin", "languages": [ "German" ] }
 }
-return pin($data)??languages[. = 'German'] ! label()?path()[1]</eg></fos:expression>
+return pin($data)??languages[. = 'German'] ! label(.)?path()[1]</eg></fos:expression>
                <fos:result>"de"</fos:result>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -17521,13 +17521,13 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
   }
 }]]></fos:variable>
          <fos:example>
-            <fos:test xslt-version="3.0" use="v-id-emp" spec="XQuery">
+            <fos:test xslt-version="3.0" use="v-id-emp" spec="XQuery" schema-aware="true">
                <fos:expression><eg>$emp/id('ID21256')/name()</eg></fos:expression>
                <fos:result>"employee"</fos:result>
                <fos:postamble>The <code>xml:id</code> attribute has the <code>is-id</code> property,
                   so the employee element is selected.</fos:postamble>
             </fos:test>
-            <fos:test xslt-version="3.0" use="v-id-emp" spec="XQuery">
+            <fos:test xslt-version="3.0" use="v-id-emp" spec="XQuery" schema-aware="true">
                <fos:expression><eg>$emp/id('E21256')/name()</eg></fos:expression>
                <fos:result>"empnr"</fos:result>
                <fos:postamble>Assuming the <code>empnr</code> element is given the type
@@ -17694,7 +17694,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 }]]>
          </fos:variable>
          <fos:example>
-            <fos:test xslt-version="3.0" use="v-element-with-id-emp" spec="XQuery">
+            <fos:test xslt-version="3.0" use="v-element-with-id-emp" spec="XQuery" schema-aware="true">
                <fos:expression><eg>$emp/element-with-id('ID21256')/name()</eg></fos:expression>
                <fos:result>"employee"</fos:result>
                <fos:postamble>The <code>xml:id</code> attribute has the <code>is-id</code> property,
@@ -17702,7 +17702,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </fos:test>
          </fos:example>
          <fos:example>
-            <fos:test xslt-version="3.0" use="v-element-with-id-emp" spec="XQuery">
+            <fos:test xslt-version="3.0" use="v-element-with-id-emp" spec="XQuery" schema-aware="true">
                <fos:expression>$emp/element-with-id('E21256')/name()</fos:expression>
                <fos:result>"employee"</fos:result>
                <fos:postamble>Assuming the <code>empnr</code> element is given the type
@@ -17855,7 +17855,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 }]]>
          </fos:variable>
          <fos:example>
-            <fos:test xslt-version="3.0" use="v-idref-emp" spec="XQuery">
+            <fos:test xslt-version="3.0" use="v-idref-emp" spec="XQuery" schema-aware="true">
                <fos:expression><eg>$emp/(
   element-with-id('ID21256')/@xml:id => idref()
 )/ancestor::employee/last
@@ -17867,7 +17867,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </fos:test>
          </fos:example>
          <fos:example>
-            <fos:test xslt-version="3.0" use="v-idref-emp" spec="XQuery">
+            <fos:test xslt-version="3.0" use="v-idref-emp" spec="XQuery" schema-aware="true">
                <fos:expression><eg>$emp/(
   element-with-id('E30561')/empnr => idref()
 )/ancestor::employee/last

--- a/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
+++ b/specifications/xpath-functions-40/style/generate-keyword-test-set.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0"
    xmlns="http://www.w3.org/2010/09/qt-fots-catalog"
    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   xmlns:f="http://local.functions/"
    xpath-default-namespace="http://www.w3.org/xpath-functions/spec/namespace"
    exclude-result-prefixes="#all"
    expand-text="yes">
@@ -13,7 +14,7 @@
    <xsl:output method="xml" indent="yes"/>
    <xsl:strip-space elements="*"/>
    
-   <xsl:key name="type-ref" match="type" use="@id"/>
+   <xsl:key name="type-ref" match="record-type" use="@id"/>
    
    <xsl:template match="/">
      <xsl:comment> ************************************************** </xsl:comment>
@@ -90,8 +91,8 @@
    </xsl:template>
    
    <xsl:template match="@type-ref | @return-type-ref">
-      <xsl:variable name="type" select="key('type-ref', .)"/>
-      <xsl:apply-templates select="$type/*"/>
+      <!-- For the moment, assume the named types will become built-in types in the fn namespace -->
+      <xsl:text>fn:{.}</xsl:text>
    </xsl:template>
    
    <xsl:template match="type/record">


### PR DESCRIPTION
Fix #1516 

1. Fixes some examples in the spec where the expected results were apparently incorrect
2. Introduces a mechanism for giving a test assertion for an example that is separate from the published result, for example where alternative results are possible
3. Marks some tests as schema-aware so a non-schema-aware processor won't attempt to run them

All the tests for features that are implemented in Saxon now run successfully.