### PR TITLE
1590 Drop draft current-mode function from catalog

### DIFF
--- a/specifications/xslt-40/src/function-catalog.xml
+++ b/specifications/xslt-40/src/function-catalog.xml
@@ -537,47 +537,6 @@
       </fos:notes>
    </fos:function>
    
-   <fos:function name="current-mode">
-      <fos:signatures>
-         <fos:proto name="current-mode" return-type="xs:QName?"/>
-      </fos:signatures>
-      <fos:properties>
-         <fos:property>deterministic</fos:property>
-         <fos:property>focus-independent</fos:property>
-         <fos:property>context-dependent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Returns the value of the <termref def="dt-current-mode"/>.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>The function returns the name of the <termref def="dt-current-mode"/>. If the current mode
-            is <termref def="dt-absent"/>, or if it is the
-            <termref def="dt-unnamed-mode"/>, the function returns an empty sequence.</p>
-         
-         <p>If the function is called while evaluating the <code>match</code> pattern of a template
-         rule, the function returns the name of the mode used in the calling <elcode>xsl:apply-templates</elcode>
-         instruction (or, if the pattern is evaluated in the course of an <elcode></elcode></p>
-         <p>During execution of an <elcode>xsl:result-document</elcode> instruction with an <code>href</code>
-            attribute, the current output URI changes to the absolute URI obtained by resolving the <termref def="dt-effective-value"/>
-            of the <code>href</code> attribute against the base output URI.</p>
-         
-         <p>The current output URI is cleared (set to <termref def="dt-absent"/>) while evaluating stylesheet functions, 
-            dynamic function calls, evaluation of global variables, stylesheet parameters, and patterns. 
-            If the function is called when the current output URI is absent, the function returns the empty sequence.
-         </p>
-         
-         <p>The current output URI may also be <termref def="dt-absent"/> in the event that a stylesheet is invoked without supplying a
-            <termref def="dt-base-output-uri"/>.</p>
-      </fos:rules>
-      <fos:notes>
-         <p>The current output URI is not cleared when evaluating a local variable, even though <elcode>xsl:result-document</elcode>
-            cannot be used while evaluating a local variable. 
-            The reason for this is to allow the value of <code>current-output-uri</code> to be set as the value of a 
-            tunnel parameter, so that the original
-            base output URI is accessible even when writing nested result documents.</p>
-      </fos:notes>
-   </fos:function>
-   
    <fos:function name="regex-group">
       <fos:signatures>
          <fos:proto name="regex-group" return-type="xs:string">


### PR DESCRIPTION
Fix #1590.

A draft spec for this function is in the function-catalog, but it has never been referenced in the published spec and the draft is incomplete.

This PR has no impact on the published specs, only on processes that access the function catalog.