### PR TITLE
1651 Ordered Maps

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1511,7 +1511,7 @@ must equal the function’s arity.
   <changes>
     <change issue="1335" date="2024-07-20">Constructors are added, and the single accessor function
     is now an iterator over the key/value pairs in the map.</change>
-    <change issue="564" date="2024-11-25">Ordered maps are introduced.</change>
+    <change issue="564" PR="1609" date="2024-11-25">Ordered maps are introduced.</change>
   </changes>
 
 <p><termdef term="map item" id="dt-map-item">A <term>map item</term>
@@ -1523,32 +1523,49 @@ to which it is equal) and has associated with it a value that is a sequence
 of zero or more items. There is no uniqueness constraint on
 values, only on keys. The semantics of equality when comparing keys are described in
 <xspecref spec="FO40" ref="func-atomic-equal"/>.</p>
+  
+  <note>
+<p>Maps have no intrinsic identity separate from their content. A map can be given
+  a transient identity, represented by an <code>id</code> property in its label, by applying the
+  <code>fn:pin</code> function. This property is expected to be used in defining
+  operations for deep update of maps.
+</p>
+</note>
+
 
 <p><termdef term="ordering" id="dt-map-ordering">A <termref def="dt-map-item"/> has
 a property called its <term>ordering</term>, which takes one of the three values
 <code>undefined</code>, <code>sorted</code>, or <code>insertion</code>.</termdef></p>
   
   <ulist>
-    <item><p><term>Random</term> ordering means that the order of entries
-    in the map is <termref def="dt-implementation-dependent"/>.</p></item>
-    <item><p><term>Sorted</term> ordering means that the keys in the map
-    are considered to be sorted, and entries are retrieved in order of their keys.</p></item>
-    <item><p><term>Insertion</term> ordering (first-in, first-out) means that the map
-    maintains an ordering of entries based on the order in which entries were added,
-    with new entries being added at the end, after existing entries.</p></item>
+    <item><p><termdef id="dt-map-ordering-undefined" term="undefined">When
+      the <termref def="dt-map-ordering"/> of a map is <term>undefined</term>,
+      the order of entries in the map is <termref def="dt-implementation-dependent"/>;
+      in a typical implementation it might depend on the result of a randomizing hash 
+      function.</termdef></p></item>
+    <item><p><termdef id="dt-map-ordering-sorted" term="sorted">When
+      the <termref def="dt-map-ordering"/> of a map is <term>sorted</term>,
+      the entries in the map are retrieved in order of their keys,
+      which must be comparable so that the order is well defined.</termdef></p></item>
+    <item><p><termdef id="dt-map-ordering-insertion" term="insertion">When
+      the <termref def="dt-map-ordering"/> of a map is <term>insertion</term>,
+      the map maintains an ordering of entries (first-in, first-out) based on 
+      the order in which entries were added,
+     with new entries being added at the end, after existing entries.</termdef></p></item>
   </ulist>
   
   <p><termdef id="dt-entry-order" term="entry order">The order of entries in a map
-            (which is dependent on its <termref def="dt-map-ordering">ordering</termref>
-            property) is referred to as <term>entry order</term>.</termdef></p>
-
+            (which is dependent on its <termref def="dt-map-ordering"/>
+            property) is referred to as <term>entry order</term>.</termdef>
+  The entry order affects the result of functions such as <function>map:keys</function>
+  and <function>map:for-each</function>, and also determines the order of entries
+  when a map is serialized using the JSON output method.</p>
 
 <note>
-<p>Maps have no intrinsic identity separate from their content. A map can be given
-  a transient identity, represented by an <code>id</code> property in its label, by applying the
-  <code>fn:pin</code> function. This property is expected to be used in defining
-  operations for deep update of maps.
-</p>
+  <p>Note the distinction between the <termref def="dt-map-ordering"/> property of
+  a map, which determines the policy for where new entries are added, and the
+  <termref def="dt-entry-order"/> of the map, which determines the sequence in which
+  existing entries are retrieved. The two things are of course closely related.</p>
 </note>
 
 <p>Constructor and accessor functions for maps are defined in the following sections.</p>
@@ -1567,9 +1584,11 @@ a property called its <term>ordering</term>, which takes one of the three values
     value of the <code>$ordering</code> argument.</p>
     
     <p>In XPath an empty map constructor, written as <code>{}</code>
-    or <code>map {}</code>, creates a map with <code>ordering=undefined</code>. An empty map with
-    ordering <code>sorted</code> or <code>insertion</code> can be constructed using functions such as
-    <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code>.</p>
+    or <code>map {}</code>, creates a map whose <termref def="dt-map-ordering"/>. is
+      <termref def="dt-map-ordering-undefined"/>. An empty map with
+    ordering <termref def="dt-map-ordering-sorted"/> or <termref def="dt-map-ordering-insertion"/> 
+      can be constructed using functions such as
+    <function>map:build</function>, <function>map:merge</function>, or <function>map:of-pairs</function>.</p>
   </div4>
   
   <div4 id="dm-map-put">
@@ -1596,12 +1615,13 @@ a property called its <term>ordering</term>, which takes one of the three values
     <p>The detailed effect of the function depends on the ordering property, as follows:</p>
     
     <ulist>
-      <item><p>If the ordering is <code>undefined</code>, the order of entries in the returned
+      <item><p>If the ordering is <termref def="dt-map-ordering-undefined"/>, 
+        the <termref def="dt-entry-order"/> in the returned
       map is <termref def="dt-implementation-dependent"/>, and bears no necessary relationship
-      to the ordering of entries in the supplied <code>$map</code>.</p></item>
-      <item><p>If the ordering is <code>sorted</code>, the key of the new entry must be
+      to the <termref def="dt-entry-order"/> in the supplied <code>$map</code>.</p></item>
+      <item><p>If the ordering is <termref def="dt-map-ordering-sorted"/>, the key of the new entry must be
         <termref def="dt-strictly-comparable"/> with the keys of existing entries (a dynamic error occurs if this is not
-        the case), and the ordering of entries in the returned map is such that an entry with key <var>K1</var>
+        the case), and the <termref def="dt-entry-order"/> in the returned map is such that an entry with key <var>K1</var>
         precedes an entry with key <var>K2</var> if and only 
         if <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC) lt 0</code>,
         where <code>$CC</code> is the Unicode codepoint collation.</p>
@@ -1610,13 +1630,14 @@ a property called its <term>ordering</term>, which takes one of the three values
         (a) the function call <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC)</code> (where <code>$CC</code>
         is the Unicode codepoint collation) does not fail with a type error, and (b) either both of the values
         have a timezone component, or neither of them has a timezone component.</termdef></p></item>
-      <item><p>If the ordering is <code>insertion</code>, then the order of entries in the returned
-      map reflects the order of entries in the supplied <code>$map</code>. If the key of
+      <item><p>If the ordering is <termref def="dt-map-ordering-insertion"/>, then the 
+        <termref def="dt-entry-order"/> in the returned
+      map reflects the <termref def="dt-entry-order"/> in the supplied <code>$map</code>. If the key of
       the new entry was present in <code>$map</code> then the new entry replaces that entry retaining
       its current position; otherwise, the new entry is added after all existing entries.</p></item>
     </ulist>
     
-    <p>The function is exposed in XPath through the function <code>map:put</code>.</p>
+    <p>The function is exposed in XPath through the function <function>map:put</function>.</p>
   </div4>
 
   <div4 id="dm-iterate-map">
@@ -1632,11 +1653,11 @@ a property called its <term>ordering</term>, which takes one of the three values
     <p>The <code>dm:iterate-map</code> accessor calls the supplied <code>$action</code>
       function once for each key/value pair in <code>$map</code>, in order,
       and returns the sequence concenation of the results. The order in which entries
-    are processed reflects the <termref def="dt-map-ordering"/> property of the map.</p>
+    are processed is the <termref def="dt-entry-order"/> of the map.</p>
       
-      <p>The function is exposed in XPath most directly through the function <code>map:for-each</code>, but
-      it also underpins all other functions giving access to maps, such as <code>map:size</code>,
-      <code>map:contains</code>, and <code>map:get</code>.</p>
+      <p>The function is exposed in XPath most directly through the function <function>map:for-each</function>, but
+      it also underpins all other functions giving access to maps, such as <function>map:size</function>,
+      <function>map:contains</function>, and <function>map:get</function>.</p>
     
   </div4>
 

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1526,7 +1526,7 @@ values, only on keys. The semantics of equality when comparing keys are describe
 
 <p><termdef term="ordering" id="dt-map-ordering">A <termref def="dt-map-item"/> has
 a property called its <term>ordering</term>, which takes one of the three values
-<code>random</code>, <code>sorted</code>, or <code>insertion</code>.</termdef></p>
+<code>undefined</code>, <code>sorted</code>, or <code>insertion</code>.</termdef></p>
   
   <ulist>
     <item><p><term>Random</term> ordering means that the order of entries
@@ -1557,7 +1557,7 @@ a property called its <term>ordering</term>, which takes one of the three values
     <head><code>empty-map</code> Constructor</head>
     <example role="signature">
       <proto class="dm" name="empty-map" return-type="map(*)" returnSeq="no">
-        <arg name="ordering" type="enum('random', 'sorted', 'insertion')"/>
+        <arg name="ordering" type="enum('undefined', 'sorted', 'insertion')"/>
       </proto>
     </example>
     
@@ -1567,7 +1567,7 @@ a property called its <term>ordering</term>, which takes one of the three values
     value of the <code>$ordering</code> argument.</p>
     
     <p>In XPath an empty map constructor, written as <code>{}</code>
-    or <code>map {}</code>, creates a map with <code>ordering=random</code>. An empty map with
+    or <code>map {}</code>, creates a map with <code>ordering=undefined</code>. An empty map with
     ordering <code>sorted</code> or <code>insertion</code> can be constructed using functions such as
     <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code>.</p>
   </div4>
@@ -1596,7 +1596,7 @@ a property called its <term>ordering</term>, which takes one of the three values
     <p>The detailed effect of the function depends on the ordering property, as follows:</p>
     
     <ulist>
-      <item><p>If the ordering is <code>random</code>, the order of entries in the returned
+      <item><p>If the ordering is <code>undefined</code>, the order of entries in the returned
       map is <termref def="dt-implementation-dependent"/>, and bears no necessary relationship
       to the ordering of entries in the supplied <code>$map</code>.</p></item>
       <item><p>If the ordering is <code>sorted</code>, the key of the new entry must be

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1533,7 +1533,7 @@ a property called its <term>ordering</term>, which takes one of the three values
     in the map is <termref def="dt-implementation-dependent"/>.</p></item>
     <item><p><term>Sorted</term> ordering means that the keys in the map
     are considered to be sorted, and entries are retrieved in order of their keys.</p></item>
-    <item><p><term>Fifo</term> (first-in, first-out) order means that the map
+    <item><p><term>Insertion</term> ordering (first-in, first-out) means that the map
     maintains an ordering of entries based on the order in which entries were added,
     with new entries being added at the end, after existing entries.</p></item>
   </ulist>
@@ -1608,8 +1608,8 @@ a property called its <term>ordering</term>, which takes one of the three values
         <p><termdef id="dt-strictly-comparable" term="strictly comparable">Two atomic items
         <var>K1</var> and <var>K2</var> are <term>strictly comparable</term> if
         (a) the function call <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC)</code> (where <code>$CC</code>
-        is the Unicode codepoint collation) does not fail with a type error, and (b) if one of the values
-        has a timezone component, then the other also has a timezone component.</termdef></p></item>
+        is the Unicode codepoint collation) does not fail with a type error, and (b) either both of the values
+        have a timezone component, or neither of them has a timezone component.</termdef></p></item>
       <item><p>If the ordering is <code>insertion</code>, then the order of entries in the returned
       map reflects the order of entries in the supplied <code>$map</code>. If the key of
       the new entry was present in <code>$map</code> then the new entry replaces that entry retaining

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1526,7 +1526,7 @@ values, only on keys. The semantics of equality when comparing keys are describe
 
 <p><termdef term="ordering" id="dt-map-ordering">A <termref def="dt-map-item"/> has
 a property called its <term>ordering</term>, which takes one of the three values
-<code>random</code>, <code>sorted</code>, or <code>fifo</code>.</termdef></p>
+<code>random</code>, <code>sorted</code>, or <code>insertion</code>.</termdef></p>
   
   <ulist>
     <item><p><term>Random</term> ordering means that the order of entries
@@ -1557,7 +1557,7 @@ a property called its <term>ordering</term>, which takes one of the three values
     <head><code>empty-map</code> Constructor</head>
     <example role="signature">
       <proto class="dm" name="empty-map" return-type="map(*)" returnSeq="no">
-        <arg name="ordering" type="enum('random', 'sorted', 'fifo')"/>
+        <arg name="ordering" type="enum('random', 'sorted', 'insertion')"/>
       </proto>
     </example>
     
@@ -1568,7 +1568,7 @@ a property called its <term>ordering</term>, which takes one of the three values
     
     <p>In XPath an empty map constructor, written as <code>{}</code>
     or <code>map {}</code>, creates a map with <code>ordering=random</code>. An empty map with
-    ordering <code>sorted</code> or <code>fifo</code> can be constructed using functions such as
+    ordering <code>sorted</code> or <code>insertion</code> can be constructed using functions such as
     <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code>.</p>
   </div4>
   
@@ -1610,7 +1610,7 @@ a property called its <term>ordering</term>, which takes one of the three values
         (a) the function call <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC)</code> (where <code>$CC</code>
         is the Unicode codepoint collation) does not fail with a type error, and (b) if one of the values
         has a timezone component, then the other also has a timezone component.</termdef></p></item>
-      <item><p>If the ordering is <code>fifo</code>, then the order of entries in the returned
+      <item><p>If the ordering is <code>insertion</code>, then the order of entries in the returned
       map reflects the order of entries in the supplied <code>$map</code>. If the key of
       the new entry was present in <code>$map</code> then the new entry replaces that entry retaining
       its current position; otherwise, the new entry is added after all existing entries.</p></item>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1511,18 +1511,36 @@ must equal the function’s arity.
   <changes>
     <change issue="1335" date="2024-07-20">Constructors are added, and the single accessor function
     is now an iterator over the key/value pairs in the map.</change>
+    <change issue="564" date="2024-11-25">Ordered maps are introduced.</change>
   </changes>
 
 <p><termdef term="map item" id="dt-map-item">A <term>map item</term>
 is a value that represents a map (in other languages this is sometimes 
 called a hash, dictionary, or associative array).</termdef> 
-  A map is logically a collection of
+  A map is logically a sequence of
 key/value pairs. Each key in the map is unique (there is no other key
 to which it is equal) and has associated with it a value that is a sequence 
 of zero or more items. There is no uniqueness constraint on
-values. The semantics of equality are described in
+values, only on keys. The semantics of equality when comparing keys are described in
 <xspecref spec="FO40" ref="func-atomic-equal"/>.</p>
 
+<p><termdef term="ordering" id="dt-map-ordering">A <termref def="dt-map-item"/> has
+a property called its <term>ordering</term>, which takes one of the three values
+<code>random</code>, <code>sorted</code>, or <code>fifo</code>.</termdef></p>
+  
+  <ulist>
+    <item><p><term>Random</term> ordering means that the order of entries
+    in the map is <termref def="dt-implementation-dependent"/>.</p></item>
+    <item><p><term>Sorted</term> ordering means that the keys in the map
+    are considered to be sorted, and entries are retrieved in order of their keys.</p></item>
+    <item><p><term>Fifo</term> (first-in, first-out) order means that the map
+    maintains an ordering of entries based on the order in which entries were added,
+    with new entries being added at the end, after existing entries.</p></item>
+  </ulist>
+  
+  <p><termdef id="dt-entry-order" term="entry order">The order of entries in a map
+            (which is dependent on its <termref def="dt-map-ordering">ordering</termref>
+            property) is referred to as <term>entry order</term>.</termdef></p>
 
 
 <note>
@@ -1538,13 +1556,20 @@ values. The semantics of equality are described in
   <div4 id="dm-empty-map">
     <head><code>empty-map</code> Constructor</head>
     <example role="signature">
-      <proto class="dm" name="empty-map" return-type="map(*)" returnSeq="no"/>
+      <proto class="dm" name="empty-map" return-type="map(*)" returnSeq="no">
+        <arg name="ordering" type="enum('random', 'sorted', 'fifo')"/>
+      </proto>
     </example>
     
     <p>The <code>dm:empty-map</code> constructor returns a map containing no key/value pairs.</p>
     
-    <p>The function is exposed in XPath as an empty map constructor, which may be written <code>{}</code>
-    or <code>map {}</code>.</p>
+    <p>The <termref def="dt-map-ordering">ordering</termref> property of the map is based on the
+    value of the <code>$ordering</code> argument.</p>
+    
+    <p>In XPath an empty map constructor, written as <code>{}</code>
+    or <code>map {}</code>, creates a map with <code>ordering=random</code>. An empty map with
+    ordering <code>sorted</code> or <code>fifo</code> can be constructed using functions such as
+    <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code>.</p>
   </div4>
   
   <div4 id="dm-map-put">
@@ -1565,6 +1590,32 @@ values. The semantics of equality are described in
       <item><p>One key/value pair whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p></item>
     </ulist>
     
+    <p>The <termref def="dt-map-ordering">ordering</termref> property of the returned map is the same
+    as the <termref def="dt-map-ordering">ordering</termref> of the supplied <code>$map</code>.</p>
+    
+    <p>The detailed effect of the function depends on the ordering property, as follows:</p>
+    
+    <ulist>
+      <item><p>If the ordering is <code>random</code>, the order of entries in the returned
+      map is <termref def="dt-implementation-dependent"/>, and bears no necessary relationship
+      to the ordering of entries in the supplied <code>$map</code>.</p></item>
+      <item><p>If the ordering is <code>sorted</code>, the key of the new entry must be
+        <termref def="dt-strictly-comparable"/> with the keys of existing entries (a dynamic error occurs if this is not
+        the case), and the ordering of entries in the returned map is such that an entry with key <var>K1</var>
+        precedes an entry with key <var>K2</var> if and only 
+        if <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC) lt 0</code>,
+        where <code>$CC</code> is the Unicode codepoint collation.</p>
+        <p><termdef id="dt-strictly-comparable" term="strictly comparable">Two atomic items
+        <var>K1</var> and <var>K2</var> are <term>strictly comparable</term> if
+        (a) the function call <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC)</code> (where <code>$CC</code>
+        is the Unicode codepoint collation) does not fail with a type error, and (b) if one of the values
+        has a timezone component, then the other also has a timezone component.</termdef></p></item>
+      <item><p>If the ordering is <code>fifo</code>, then the order of entries in the returned
+      map reflects the order of entries in the supplied <code>$map</code>. If the key of
+      the new entry was present in <code>$map</code> then the new entry replaces that entry retaining
+      its current position; otherwise, the new entry is added after all existing entries.</p></item>
+    </ulist>
+    
     <p>The function is exposed in XPath through the function <code>map:put</code>.</p>
   </div4>
 
@@ -1578,9 +1629,10 @@ values. The semantics of equality are described in
       </proto>
     </example>
     
-    <p>The <function>dm:iterate-map</function> accessor calls the supplied <code>$action</code>
-      function once for each key/value pair in <code>$map</code>, in implementation-dependent order,
-      and returns the sequence concenation of the results.</p>
+    <p>The <code>dm:iterate-map</code> accessor calls the supplied <code>$action</code>
+      function once for each key/value pair in <code>$map</code>, in order,
+      and returns the sequence concenation of the results. The order in which entries
+    are processed reflects the <termref def="dt-map-ordering"/> property of the map.</p>
       
       <p>The function is exposed in XPath most directly through the function <code>map:for-each</code>, but
       it also underpins all other functions giving access to maps, such as <code>map:size</code>,

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1515,11 +1515,12 @@ must equal the function’s arity.
   </changes>
 
 <p><termdef term="map item" id="dt-map-item">A <term>map item</term>
-is a value that represents a map (in other languages this is sometimes 
-called a hash, dictionary, or associative array).</termdef> 
-  A map is logically a sequence of
-key/value pairs. Each key in the map is unique (there is no other key
-to which it is equal) and has associated with it a value that is a sequence 
+is an item that represents a (possibly ordered) set of key/value pairs,
+in which the keys are unique.</termdef> 
+  In other languages this is sometimes 
+called a hash, dictionary, or associative array.
+  The keys are atomic items, and each key in the map is unique (there is no other key
+to which it is equal). Each key is associated with a value that may be any sequence 
 of zero or more items. There is no uniqueness constraint on
 values, only on keys. The semantics of equality when comparing keys are described in
 <xspecref spec="FO40" ref="func-atomic-equal"/>.</p>

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1534,36 +1534,21 @@ values, only on keys. The semantics of equality when comparing keys are describe
 </note>
 
 
-<p><termdef term="ordering" id="dt-map-ordering">A <termref def="dt-map-item"/> has
-a property called its <term>ordering</term>, which takes one of the three values
-<code>undefined</code>, <code>sorted</code>, or <code>insertion</code>.</termdef></p>
+<p><termdef term="ordered" id="dt-map-ordered">A <termref def="dt-map-item"/> has
+a boolean property called <term>ordered</term>: if a map is ordered, then there is
+  a defined order for the entries in the map, and new entries are added at the end.</termdef></p>
   
-  <ulist>
-    <item><p><termdef id="dt-map-ordering-undefined" term="undefined">When
-      the <termref def="dt-map-ordering"/> of a map is <term>undefined</term>,
-      the order of entries in the map is <termref def="dt-implementation-dependent"/>;
-      in a typical implementation it might depend on the result of a randomizing hash 
-      function.</termdef></p></item>
-    <item><p><termdef id="dt-map-ordering-sorted" term="sorted">When
-      the <termref def="dt-map-ordering"/> of a map is <term>sorted</term>,
-      the entries in the map are retrieved in order of their keys,
-      which must be comparable so that the order is well defined.</termdef></p></item>
-    <item><p><termdef id="dt-map-ordering-insertion" term="insertion">When
-      the <termref def="dt-map-ordering"/> of a map is <term>insertion</term>,
-      the map maintains an ordering of entries (first-in, first-out) based on 
-      the order in which entries were added,
-     with new entries being added at the end, after existing entries.</termdef></p></item>
-  </ulist>
   
   <p><termdef id="dt-entry-order" term="entry order">The order of entries in a map
-            (which is dependent on its <termref def="dt-map-ordering"/>
-            property) is referred to as <term>entry order</term>.</termdef>
+            is referred to as <term>entry order</term>.</termdef>
   The entry order affects the result of functions such as <function>map:keys</function>
   and <function>map:for-each</function>, and also determines the order of entries
-  when a map is serialized using the JSON output method.</p>
+  when a map is serialized using the JSON output method. If the <termref def="dt-map-ordered"/>
+  property of a map is <code>false</code>, then the entry order is 
+  <termref def="dt-implementation-dependent"/>.</p>
 
 <note>
-  <p>Note the distinction between the <termref def="dt-map-ordering"/> property of
+  <p>Note the distinction between the <termref def="dt-map-ordered"/> property of
   a map, which determines the policy for where new entries are added, and the
   <termref def="dt-entry-order"/> of the map, which determines the sequence in which
   existing entries are retrieved. The two things are of course closely related.</p>
@@ -1575,19 +1560,18 @@ a property called its <term>ordering</term>, which takes one of the three values
     <head><code>empty-map</code> Constructor</head>
     <example role="signature">
       <proto class="dm" name="empty-map" return-type="map(*)" returnSeq="no">
-        <arg name="ordering" type="enum('undefined', 'sorted', 'insertion')"/>
+        <arg name="ordered" type="xs:boolean"/>
       </proto>
     </example>
     
     <p>The <code>dm:empty-map</code> constructor returns a map containing no key/value pairs.</p>
     
-    <p>The <termref def="dt-map-ordering">ordering</termref> property of the map is based on the
-    value of the <code>$ordering</code> argument.</p>
+    <p>The <termref def="dt-map-ordered">ordered</termref> property of the map is based on the
+    value of the <code>$ordered</code> argument.</p>
     
     <p>In XPath an empty map constructor, written as <code>{}</code>
-    or <code>map {}</code>, creates a map whose <termref def="dt-map-ordering"/>. is
-      <termref def="dt-map-ordering-undefined"/>. An empty map with
-    ordering <termref def="dt-map-ordering-sorted"/> or <termref def="dt-map-ordering-insertion"/> 
+    or <code>map {}</code>, creates a map whose <termref def="dt-map-ordered"/> property is
+      <code>false</code>. An ordered map 
       can be constructed using functions such as
     <function>map:build</function>, <function>map:merge</function>, or <function>map:of-pairs</function>.</p>
   </div4>
@@ -1610,28 +1594,17 @@ a property called its <term>ordering</term>, which takes one of the three values
       <item><p>One key/value pair whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p></item>
     </ulist>
     
-    <p>The <termref def="dt-map-ordering">ordering</termref> property of the returned map is the same
-    as the <termref def="dt-map-ordering">ordering</termref> of the supplied <code>$map</code>.</p>
+    <p>The <termref def="dt-map-ordered">ordered</termref> property of the returned map is the same
+    as the <termref def="dt-map-ordered">ordered</termref> of the supplied <code>$map</code>.</p>
     
-    <p>The detailed effect of the function depends on the ordering property, as follows:</p>
+    <p>The detailed effect of the function depends on this property, as follows:</p>
     
     <ulist>
-      <item><p>If the ordering is <termref def="dt-map-ordering-undefined"/>, 
+      <item><p>If the map is unordered, 
         the <termref def="dt-entry-order"/> in the returned
       map is <termref def="dt-implementation-dependent"/>, and bears no necessary relationship
       to the <termref def="dt-entry-order"/> in the supplied <code>$map</code>.</p></item>
-      <item><p>If the ordering is <termref def="dt-map-ordering-sorted"/>, the key of the new entry must be
-        <termref def="dt-strictly-comparable"/> with the keys of existing entries (a dynamic error occurs if this is not
-        the case), and the <termref def="dt-entry-order"/> in the returned map is such that an entry with key <var>K1</var>
-        precedes an entry with key <var>K2</var> if and only 
-        if <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC) lt 0</code>,
-        where <code>$CC</code> is the Unicode codepoint collation.</p>
-        <p><termdef id="dt-strictly-comparable" term="strictly comparable">Two atomic items
-        <var>K1</var> and <var>K2</var> are <term>strictly comparable</term> if
-        (a) the function call <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC)</code> (where <code>$CC</code>
-        is the Unicode codepoint collation) does not fail with a type error, and (b) either both of the values
-        have a timezone component, or neither of them has a timezone component.</termdef></p></item>
-      <item><p>If the ordering is <termref def="dt-map-ordering-insertion"/>, then the 
+      <item><p>If the map is ordered, then the 
         <termref def="dt-entry-order"/> in the returned
       map reflects the <termref def="dt-entry-order"/> in the supplied <code>$map</code>. If the key of
       the new entry was present in <code>$map</code> then the new entry replaces that entry retaining

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -408,7 +408,7 @@
                      <p>parameter names: ()</p>
                   </item>
                   <item>
-                     <p>signature: <code>() => map(xs:string, item())</code></p>
+                     <p>signature: <code>() => random-number-generator-record</code></p>
                   </item>
                   <item>
                      <p>non-local variable bindings: none</p>
@@ -12741,7 +12741,7 @@ else QName("", $value)</eg>
             instance of <code>xs:NCName</code>. For the default namespace, which has no prefix, the key is
             the zero-length string as an instance of <code>xs:string</code>.</p>
 
-
+         <p>The ordering of the returned map is <termref def="implementation-dependent"/>.</p>
 
       </fos:rules>
       <fos:notes>
@@ -22915,7 +22915,7 @@ xs:QName('xs:double')</eg></fos:result>
                      </fos:values>
                   </fos:option>
                   <fos:option key="ordering">
-                     <fos:meaning>Determines the ordering, and the 
+                     <fos:meaning>Determines the <xtermref spec="DM40" ref="dt-map-ordering"/>, and the 
                         <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
                         entries in the returned map.
                      </fos:meaning>
@@ -22923,18 +22923,21 @@ xs:QName('xs:double')</eg></fos:result>
                      <fos:default>undefined</fos:default>
                      <fos:values>
                         <fos:value value="undefined">
-                           The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
+                           The <code>ordering</code> property of the returned map is 
+                           <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                            is <termref def="implementation-dependent"/>.
                         </fos:value>
                         <fos:value value="sorted">
-                           The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
+                           The <code>ordering</code> property of the returned map is 
+                           <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                            is sorted by key. A dynamic error occurs
                            if the keys are not <termref def="dt-strictly-comparable"/>.
                         </fos:value>
                         <fos:value value="insertion">
-                           The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
+                           The <code>ordering</code> property of the returned map is 
+                           <xtermref spec="DM40" ref="dt-map-insertion"/>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                            reflects the order of the maps supplied in <code>$maps</code>,
                            and within each input map, the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
@@ -23144,7 +23147,7 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
                <fos:default>fn:op(',')</fos:default>
             </fos:option>
             <fos:option key="ordering">
-               <fos:meaning>Determines the ordering, and the 
+               <fos:meaning>Determines the <xtermref spec="DM40" ref="dt-map-ordering"/>, and the 
                   <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
                   entries in the returned map.
                </fos:meaning>
@@ -23152,18 +23155,21 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
                <fos:default>undefined</fos:default>
                <fos:values>
                   <fos:value value="undefined">
-                     The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
+                     The <code>ordering</code> property of the returned map is 
+                     <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, and its
                      <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                      is <termref def="implementation-dependent"/>.
                   </fos:value>
                   <fos:value value="sorted">
-                     The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
+                     The <code>ordering</code> property of the returned map is 
+                     <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, and its
                      <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                      is sorted by key. A dynamic error occurs
                      if the keys are not <termref def="dt-strictly-comparable"/>.
                   </fos:value>
                   <fos:value value="insertion">
-                     The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
+                     The <code>ordering</code> property of the returned map is 
+                     <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>, and its
                      <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                      reflects the order of the items supplied in <code>$input</code>.
                   </fos:value>
@@ -23190,7 +23196,8 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
 
       <fos:notes>
          <p>If the input is an empty sequence, the result is an empty map.</p>
-         <p>There is no requirement that the supplied key-value pairs should have the same or compatible
+         <p>Except when <code>ordering=sorted</code>, 
+            there is no requirement that the supplied key-value pairs should have the same or compatible
             types. The type of a map (for example <code>map(xs:integer, xs:string)</code>) is
             descriptive of the entries it currently contains, but is not a constraint on how the map
             may be combined with other maps.</p>
@@ -23301,7 +23308,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>nondeterministic-wrt-ordering</fos:property>
+         <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -23313,11 +23320,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
             <termref def="dt-map">map</termref> as its <code>$map</code> argument and returns
             the keys that are present in the map as a sequence of atomic items, 
             in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
-         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
-            (see <specref
-               ref="properties-of-functions"
-            />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>-->
+         
       </fos:rules>
       <fos:equivalent style="xpath-expression">
          map:for-each($map, fn($key, $value) { $key })
@@ -23356,7 +23359,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>nondeterministic-wrt-ordering</fos:property>
+         <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -23368,9 +23371,11 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
             <termref def="dt-map">map</termref> as its <code>$map</code> argument. The
             <code>$predicate</code> function takes the key and the value of the corresponding
             map entry as an argument, and the result is a sequence containing the keys of those
-            entries for which the predicate function returns <code>true</code> in 
-            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.
-         A return value of <code>()</code> is treated as <code>false</code>.</p>
+            entries for which the predicate function returns <code>true</code>, in 
+            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
+         
+         <p>A return value of <code>()</code> from the predicate function is 
+            treated as <code>false</code>.</p>
          
          <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
@@ -23447,7 +23452,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>nondeterministic-wrt-ordering</fos:property>
+         <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -23459,11 +23464,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             >map</termref>
             as its <code>$map</code> argument and returns the values that are present in the map as
             a sequence, in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
-         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
-            (see <specref
-               ref="properties-of-functions"
-            />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>-->
+         
          <p>The effect of the function is equivalent to <code>$map?*</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -23501,7 +23502,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>nondeterministic-wrt-ordering</fos:property>
+         <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -23516,11 +23517,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             a sequence of <termref def="dt-singleton-map">singleton maps</termref>, in 
             <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
          
-         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
-            (see <specref
-               ref="properties-of-functions"
-            />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>-->
+         
 
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -23557,7 +23554,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>nondeterministic-wrt-ordering</fos:property>
+         <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
@@ -23574,11 +23571,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>A key-value pair map is an instance of type <code>record(key as xs:anyAtomicType, value as item()*)</code>:
          that is a map with two entries, one (with key <code>"key"</code>) holding the key,
          and the other (with key <code>"value"</code>) holding the value.</p>
-         <p>The function is <term>nondeterministic with respect to ordering</term>
-            (see <specref
-               ref="properties-of-functions"
-            />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>
+         
       </fos:rules>
       <fos:equivalent style="xpath-expression">
          map:for-each($map, map:pair#2)
@@ -23623,8 +23616,11 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>Returns the ordering property of a map.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function returns the value of the <code>ordering</code> property of a map:
-         one of <code>undefined</code>, <code>sorted</code>, or <code>insertion</code>.</p>
+         <p>The function returns the value of the 
+            <xtermref spec="DM40" ref="dt-map-ordering"/> property of a map:
+         one of <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, 
+            <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, or 
+            <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
@@ -23990,22 +23986,23 @@ declare function map:find($input as item()*,
                >same key</termref> as <code>$key</code>, together with a new
          entry whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p>
          
-         <p>The <code>ordering</code> property of the returned map is the same as the <code>ordering</code>
+         <p>The <xtermref spec="DM40" ref="dt-map-ordering"/> property of the returned map 
+            is the same as the <xtermref spec="DM40" ref="dt-map-ordering"/>
          property of <code>$map</code>.</p>
          
          <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
             of the entries in the returned map is as follows:</p>
          
          <ulist>
-            <item><p>If the ordering is <code>undefined</code>, then the 
+            <item><p>If the ordering is <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, then the 
                <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
             <termref def="implementation-dependent"/>, and has no necessary relationship with the
             <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of <code>$map</code>.</p></item>
-            <item><p>If the ordering is <code>sorted</code>, then the 
+            <item><p>If the ordering is <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, then the 
                <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
             sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
             <item>
-               <p>If the ordering is <code>insertion</code> then:</p>
+               <p>If the ordering is <xtermref spec="DM40" ref="dt-map-ordering-insertion"/> then:</p>
                <ulist>
                   <item><p>If the input <code>$map</code> contains an entry whose</p></item>
                </ulist>
@@ -24043,9 +24040,13 @@ declare function map:find($input as item()*,
       </fos:equivalent>
       
       <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the <code>ordering</code>
-         property has the value <code>sorted</code> is requested, and the keys of the entries to be included in the result are not 
-         <termref def="dt-strictly-comparable"/>.</p>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the 
+            <xtermref spec="DM40" ref="dt-map-ordering"/>
+         property of <code>$map</code> has the value 
+            <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, 
+            and the <code>$key</code> is not 
+         <termref def="dt-strictly-comparable"/>
+            with every key present in <code>$map</code>.</p>
       </fos:errors>
 
       <fos:notes>
@@ -24117,7 +24118,8 @@ declare function map:find($input as item()*,
             entry. The key of the entry in the new map is
                <code>$key</code>, and its associated value is <code>$value</code>.</p>
          
-         <p>The <code>ordering</code> property of the returned map is <code>undefined</code>.</p>
+         <p>The <xtermref spec="DM40" ref="dt-map-ordering"/> property 
+            of the returned map is <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>.</p>
 
 
       </fos:rules>
@@ -24176,7 +24178,8 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
             >map</termref> which contains two entries, one (with the key <code>"key"</code>)
             containing <code>$key</code> and the other (with the key <code>"value"</code>)
             containing <code>$value</code>.</p>
-         <p>The <code>ordering</code> property of the returned map is <code>undefined</code>.</p>
+         <p>The <xtermref spec="DM40" ref="dt-map-ordering"/> property of the returned 
+            map is <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 {}
@@ -24287,7 +24290,7 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
          </fos:proto>
       </fos:signatures>
       <fos:properties>
-         <fos:property>nondeterministic-wrt-ordering</fos:property>
+         <fos:property>deterministic</fos:property>
          <fos:property>context-independent</fos:property>
          <fos:property>focus-independent</fos:property>
          
@@ -24301,11 +24304,7 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map, in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>; the result is the <xtermref spec="XP40" ref="dt-sequence-concatenation"/> 
             of the results of these function calls.</p>
-         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
-            (see <specref
-               ref="properties-of-functions"
-            />). This means that two calls with the same arguments
-            are not guaranteed to process the map entries in the same order.</p>-->
+         
          <p>The function supplied as <code>$action</code> takes two arguments. It is called
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
@@ -24394,9 +24393,11 @@ return <box>{
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
          
-         <p>The <code>ordering</code> property of the returned map is the same as the 
-         <code>ordering</code> property of <code>$map</code>, and in the case of <code>sorted</code>
-         or <code>insertion</code> ordering the relative order of entries in the returned map
+         <p>The <xtermref spec="DM40" ref="dt-map-ordering"/> property of the returned map is the same as the 
+         <xtermref spec="DM40" ref="dt-map-ordering"/> property of <code>$map</code>, and in the case of 
+            <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>
+         or <xtermref spec="DM40" ref="dt-map-ordering-insertion"/> 
+            ordering the relative order of entries in the returned map
          is the same as their relative order in <code>$map</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -24633,7 +24634,7 @@ else map:put($map, $key, $action(()))
                      <fos:default>fn:op(',')</fos:default>
                   </fos:option>
                   <fos:option key="ordering">
-                     <fos:meaning>Determines the ordering, and the 
+                     <fos:meaning>Determines the <xtermref spec="DM40" ref="dt-map-ordering"/>, and the 
                         <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
                         entries in the returned map.
                      </fos:meaning>
@@ -24641,17 +24642,20 @@ else map:put($map, $key, $action(()))
                      <fos:default>undefined</fos:default>
                      <fos:values>
                         <fos:value value="undefined">
-                           The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
+                           The <code>ordering</code> property of the returned map is 
+                           <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is 
                            <termref def="implementation-dependent"/>.
                         </fos:value>
                         <fos:value value="sorted">
-                           The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
+                           The <code>ordering</code> property of the returned map is 
+                           <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is sorted by key. A dynamic error occurs
                            if the keys are not <termref def="dt-strictly-comparable"/>.
                         </fos:value>
                         <fos:value value="insertion">
-                           The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
+                           The <code>ordering</code> property of the returned map is 
+                           <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                            reflects the order of the items supplied in <code>$input</code>,
                            and within each of those items, the order of the keys returned by the <code>$keys</code> function.
@@ -33899,6 +33903,8 @@ return $result
                is derived from <var>V</var> by applying the function <code>derived-value(M', K, V)</code>,
                   defined below.</p>
                </item>
+               <item><p>The <xtermref spec="DM40" ref="dt-map-ordering"/> and <xtermref spec="DM40" ref="dt-entry-order"/>
+               of <var>M</var> are retained in <var>M'</var>.</p></item>
             </olist>
             </item>
             <item><p>If <code>$input</code> is an array <var>A</var>, the result is an array <var>A'</var>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22916,7 +22916,7 @@ xs:QName('xs:double')</eg></fos:result>
                      <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
                         entries in the returned map.
                      </fos:meaning>
-                     <fos:type>enum("random", "sorted", "fifo")</fos:type>
+                     <fos:type>enum("random", "sorted", "insertion")</fos:type>
                      <fos:default>random</fos:default>
                      <fos:values>
                         <fos:value value="random">
@@ -22928,8 +22928,8 @@ xs:QName('xs:double')</eg></fos:result>
                            <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
                            if the keys are not <termref def="dt-strictly-comparable"/>.
                         </fos:value>
-                        <fos:value value="fifo">
-                           The <code>ordering</code> property of the returned map is <code>fifo</code>, and its
+                        <fos:value value="insertion">
+                           The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
                            <termref def="dt-entry-order"/> reflects the order of the maps supplied in <code>$maps</code>,
                            and within each input map, the <termref def="dt-entry-order"/> of the entries in that map.
                         </fos:value>
@@ -23083,7 +23083,7 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "random"),
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:merge(({ "red": 0 }, { "green": 1}, { "blue": 2 }),
-    { "ordering": "fifo" } => map:keys()</eg></fos:expression>
+    { "ordering": "insertion" } => map:keys()</eg></fos:expression>
                <fos:result>"red", "green", "blue"</fos:result>
                <fos:postamble>The keys are in first-in, first-out order.</fos:postamble>
             </fos:test>
@@ -23140,7 +23140,7 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "random"),
                <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
                   entries in the returned map.
                </fos:meaning>
-               <fos:type>enum("random", "sorted", "fifo")</fos:type>
+               <fos:type>enum("random", "sorted", "insertion")</fos:type>
                <fos:default>random</fos:default>
                <fos:values>
                   <fos:value value="random">
@@ -23152,8 +23152,8 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "random"),
                      <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
                      if the keys are not <termref def="dt-strictly-comparable"/>.
                   </fos:value>
-                  <fos:value value="fifo">
-                     The <code>ordering</code> property of the returned map is <code>fifo</code>, and its
+                  <fos:value value="insertion">
+                     The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
                      <termref def="dt-entry-order"/> reflects the order of the items supplied in <code>$input</code>.
                   </fos:value>
                </fos:values>
@@ -23271,7 +23271,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
             
             <fos:test>
                <fos:expression><eg>map:of-pairs((map:pair("red": 0), map:pair("green": 1), map:pair("blue": 2 )),
-    { "ordering": "fifo" } => map:keys()</eg></fos:expression>
+    { "ordering": "insertion" } => map:keys()</eg></fos:expression>
                <fos:result>"red", "green", "blue"</fos:result>
                <fos:postamble>The keys are in first-in, first-out order.</fos:postamble>
             </fos:test>
@@ -23329,9 +23329,9 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
                <fos:postamble>The map is sorted, so the result is in sorted order.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:keys(map:merge(({"red": 0}, {"blue": 1}, {"green": 2}), {"ordering": "fifo"}))</fos:expression>
+               <fos:expression>map:keys(map:merge(({"red": 0}, {"blue": 1}, {"green": 2}), {"ordering": "insertion"}))</fos:expression>
                <fos:result>("red", "blue", "green")</fos:result>
-               <fos:postamble>The map has <code>fifo</code> ordering, so the order of keys is predictable.</fos:postamble>
+               <fos:postamble>The map has <code>insertion</code> ordering, so the order of keys is predictable.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -23945,7 +23945,7 @@ declare function map:find($input as item()*,
             <item><p>If the ordering is <code>sorted</code>, then the <termref def="dt-entry-order"/> is
             sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
             <item>
-               <p>If the ordering is <code>fifo</code> then:</p>
+               <p>If the ordering is <code>insertion</code> then:</p>
                <ulist>
                   <item><p>If the input <code>$map</code> contains an entry whose</p></item>
                </ulist>
@@ -23993,7 +23993,7 @@ declare function map:find($input as item()*,
             there is no requirement that the type of <code>$key</code> and <code>$value</code> be consistent with the types
          of any existing keys and values in the supplied map.</p>
          
-         <p>With <code>ordering=fifo</code>, you can force the new entry to go at the end of the sequence by calling
+         <p>With <code>ordering=insertion</code>, you can force the new entry to go at the end of the sequence by calling
          <code>map:remove</code> before calling <code>map:put</code>.</p>
 
       </fos:notes>
@@ -24016,14 +24016,14 @@ declare function map:find($input as item()*,
                <fos:expression><eg>map:put(parse-json('{ "red": 0, "green": 1, "blue" 2 }),
         "yellow", -1) => map:keys()</eg></fos:expression>
                <fos:result>"red", "green", "blue", "yellow"</fos:result>
-               <fos:postamble>The result of <code>fn:parse-json</code> has <code>ordering=fifo</code>,
+               <fos:postamble>The result of <code>fn:parse-json</code> has <code>ordering=insertion</code>,
                so the new entry is added at the end of the list.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:put(parse-json('{ "red": 0, "green": 1, "blue" 2 }),
         "red", -1) => map:keys()</eg></fos:expression>
                <fos:result>"red", "green", "blue"</fos:result>
-               <fos:postamble>The result of <code>fn:parse-json</code> has <code>ordering=fifo</code>,
+               <fos:postamble>The result of <code>fn:parse-json</code> has <code>ordering=insertion</code>,
                changing the value for an existing key does not change the order of the keys.</fos:postamble>
             </fos:test>
          </fos:example>
@@ -24178,7 +24178,7 @@ map:of-pairs((
          <p>No failure occurs <phrase>if an item in <code>$keys</code> does not correspond to any entry in <code>$map</code>;
             that key value is simply ignored</phrase>.</p>
          <p>The <code>ordering</code> property of the returned map is the same as the <code>ordering</code> property
-         of <code>$map</code>, and in the case of ordering <code>sorted</code> or <code>fifo</code>, the relative
+         of <code>$map</code>, and in the case of ordering <code>sorted</code> or <code>insertion</code>, the relative
          position of retained entries in the result map is the same as their relative position in <code>$map</code>.</p>
         
       </fos:rules>
@@ -24335,7 +24335,7 @@ return <box>{
          
          <p>The <code>ordering</code> property of the returned map is the same as the 
          <code>ordering</code> property of <code>$map</code>, and in the case of <code>sorted</code>
-         or <code>fifo</code> ordering the relative order of entries in the returned map
+         or <code>insertion</code> ordering the relative order of entries in the returned map
          is the same as their relative order in <code>$map</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -24422,7 +24422,7 @@ map:for-each($map, fn($key, $value) {
             <item><p>If the ordering is <code>sorted</code>, then the <termref def="dt-entry-order"/> is
             sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
             <item>
-               <p>If the ordering is <code>fifo</code> then:</p>
+               <p>If the ordering is <code>insertion</code> then:</p>
                <ulist>
                   <item><p>If the input <code>$map</code> contains an entry whose</p></item>
                </ulist>
@@ -24572,7 +24572,7 @@ else map:put($map, $key, $action(()))
                      <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
                         entries in the returned map.
                      </fos:meaning>
-                     <fos:type>enum("random", "sorted", "fifo")</fos:type>
+                     <fos:type>enum("random", "sorted", "insertion")</fos:type>
                      <fos:default>random</fos:default>
                      <fos:values>
                         <fos:value value="random">
@@ -24584,8 +24584,8 @@ else map:put($map, $key, $action(()))
                            <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
                            if the keys are not <termref def="dt-strictly-comparable"/>.
                         </fos:value>
-                        <fos:value value="fifo">
-                           The <code>ordering</code> property of the returned map is <code>fifo</code>, and its
+                        <fos:value value="insertion">
+                           The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
                            <termref def="dt-entry-order"/> reflects the order of the items supplied in <code>$input</code>,
                            and within each of those items, the order of the keys returned by the <code>$keys</code> function.
                         </fos:value>
@@ -27372,7 +27372,7 @@ return document {
                   <fos:value value="false">Any maps resulting from parsing of JSON objects have the <code>ordering</code>
                   property set to <code>random</code>.</fos:value>
                   <fos:value value="true">Any maps resulting from parsing of JSON objects have the <code>ordering</code>
-                  property set to <code>fifo</code>, and the <termref def="dt-entry-order"/> retains the order
+                  property set to <code>insertion</code>, and the <termref def="dt-entry-order"/> retains the order
                   of entries in the input.</fos:value>
                </fos:values>
             </fos:option>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22914,30 +22914,22 @@ xs:QName('xs:double')</eg></fos:result>
                         </fos:value>
                      </fos:values>
                   </fos:option>
-                  <fos:option key="ordering">
-                     <fos:meaning>Determines the <xtermref spec="DM40" ref="dt-map-ordering"/>, and the 
-                        <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
-                        entries in the returned map.
+                  <fos:option key="retain-order">
+                     <fos:meaning>Determines the 
+                        <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of the
+                        entries in the returned map, as well as the value of the map's 
+                        <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref> property.
                      </fos:meaning>
-                     <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
-                     <fos:default>undefined</fos:default>
+                     <fos:type>xs:boolean</fos:type>
+                     <fos:default>false</fos:default>
                      <fos:values>
-                        <fos:value value="undefined">
-                           The <code>ordering</code> property of the returned map is 
-                           <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, and its
+                        <fos:value value="false">
+                           The <code>ordered</code> property of the returned map is <code>false</code>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                            is <termref def="implementation-dependent"/>.
                         </fos:value>
-                        <fos:value value="sorted">
-                           The <code>ordering</code> property of the returned map is 
-                           <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, and its
-                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                           is sorted by key. A dynamic error occurs
-                           if the keys are not <termref def="dt-strictly-comparable"/>.
-                        </fos:value>
                         <fos:value value="insertion">
-                           The <code>ordering</code> property of the returned map is 
-                           <xtermref spec="DM40" ref="dt-map-insertion"/>, and its
+                           The <code>ordering</code> property of the returned map is <code>true</code>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                            reflects the order of the maps supplied in <code>$maps</code>,
                            and within each input map, the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
@@ -22982,9 +22974,7 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
                /> if the value of 
           <code>$options</code> includes an entry whose key is defined 
           in this specification, and whose value is not a permitted value for that key.</p>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the option
-         <code>ordering=sorted</code> is requested, and the keys of the entries to be included in the result are not 
-         <termref def="dt-strictly-comparable"/>.</p>
+         
       </fos:errors>
 
       <fos:notes>
@@ -23013,7 +23003,7 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
          <p>If the input is an empty sequence, the result is an empty map.</p>
          <p>If the input is a sequence of length one, the result map is 
             <phrase>indistinguishable from the supplied map</phrase>.</p>
-         <p>Except when <code>ordering=sorted</code>, there is no requirement that 
+         <p>There is no requirement that 
             the supplied input maps should have the same or compatible
             types. The type of a map (for example <code>map(xs:integer, xs:string)</code>) is
             descriptive of the entries it currently contains, but is not a constraint on how the map
@@ -23085,15 +23075,10 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
                   entry that appears in the result is the <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> of the entries
                   in the input maps, retaining order.</fos:postamble>
             </fos:test>
+           
             <fos:test>
                <fos:expression><eg>map:merge(({ "red": 0 }, { "green": 1}, { "blue": 2 }),
-    { "ordering": "sorted" } => map:keys()</eg></fos:expression>
-               <fos:result>"blue", "green", "red"</fos:result>
-               <fos:postamble>The result is in sorted order.</fos:postamble>
-            </fos:test>
-            <fos:test>
-               <fos:expression><eg>map:merge(({ "red": 0 }, { "green": 1}, { "blue": 2 }),
-    { "ordering": "insertion" } => map:keys()</eg></fos:expression>
+    { "retain-order": true() } => map:keys()</eg></fos:expression>
                <fos:result>"red", "green", "blue"</fos:result>
                <fos:postamble>The keys are in first-in, first-out order.</fos:postamble>
             </fos:test>
@@ -23146,32 +23131,24 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
                <fos:type>(fn(item()*, item()*) as item()*)?</fos:type>
                <fos:default>fn:op(',')</fos:default>
             </fos:option>
-            <fos:option key="ordering">
-               <fos:meaning>Determines the <xtermref spec="DM40" ref="dt-map-ordering"/>, and the 
-                  <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
-                  entries in the returned map.
+            <fos:option key="retain-order">
+               <fos:meaning>Determines the 
+                  <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of the
+                  entries in the returned map, as well as value of the map's
+                  <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref> property.
                </fos:meaning>
-               <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
-               <fos:default>undefined</fos:default>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
                <fos:values>
-                  <fos:value value="undefined">
-                     The <code>ordering</code> property of the returned map is 
-                     <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, and its
+                  <fos:value value="false">
+                     The <code>ordered</code> property of the returned map is <code>false</code>, and its
                      <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                      is <termref def="implementation-dependent"/>.
                   </fos:value>
-                  <fos:value value="sorted">
-                     The <code>ordering</code> property of the returned map is 
-                     <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, and its
+                  <fos:value value="true">
+                     The <code>ordered</code> property of the returned map is <code>true</code>, and its
                      <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                     is sorted by key. A dynamic error occurs
-                     if the keys are not <termref def="dt-strictly-comparable"/>.
-                  </fos:value>
-                  <fos:value value="insertion">
-                     The <code>ordering</code> property of the returned map is 
-                     <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>, and its
-                     <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                     reflects the order of the items supplied in <code>$input</code>.
+                     retains the order of the items supplied in <code>$input</code>.
                   </fos:value>
                </fos:values>
             </fos:option>
@@ -23185,9 +23162,7 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
 map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
       </fos:equivalent>
       <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the option
-         <code>ordering=sorted</code> is requested, and the keys of the entries to be included in the result are not 
-         <termref def="dt-strictly-comparable"/>.</p>
+         
          
          <p>The function can be made to fail with a dynamic error in the event that
          duplicate keys are present in the input sequence by supplying a <code>$combine</code>
@@ -23282,16 +23257,16 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
             
             <fos:test>
                <fos:expression><eg>map:of-pairs((map:pair("red": 0), map:pair("green": 1), map:pair("blue": 2 )),
-    { "ordering": "sorted" } => map:keys()</eg></fos:expression>
-               <fos:result>"blue", "green", "red"</fos:result>
-               <fos:postamble>The result is in sorted order.</fos:postamble>
+    { "retain-order": true() } => map:keys()</eg></fos:expression>
+               <fos:result>"red", "green", "blue"</fos:result>
+               <fos:postamble>The keys are returned in the order supplied.</fos:postamble>
             </fos:test>
             
             <fos:test>
                <fos:expression><eg>map:of-pairs((map:pair("red": 0), map:pair("green": 1), map:pair("blue": 2 )),
-    { "ordering": "insertion" } => map:keys()</eg></fos:expression>
-               <fos:result>"red", "green", "blue"</fos:result>
-               <fos:postamble>The keys are in first-in, first-out order.</fos:postamble>
+    { "retain-order": true() } => map:put("yellow": -1) => map:keys()</eg></fos:expression>
+               <fos:result>"red", "green", "blue", "yellow"</fos:result>
+               <fos:postamble>Because the map is ordered, new entries are added at the end.</fos:postamble>
             </fos:test>
 
          </fos:example>
@@ -23328,6 +23303,9 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
       <fos:notes>
          <p>The number of items in the result will be the same as the number of entries in the map,
             and the result sequence will contain no duplicate values.</p>
+         <p>If the map is ordered, then the order of the result sequence is predictable and reflects
+         the order in which entries in the map were added. If the map is unordered, then the order
+         of the result sequence is <termref def="implementation-dependent"/>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -23338,14 +23316,9 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
                      >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:keys({ 1: "yes", 0: "no" } => map:sort())</fos:expression>
-               <fos:result>(0, 1)</fos:result>
-               <fos:postamble>The map is sorted, so the result is in sorted order.</fos:postamble>
-            </fos:test>
-            <fos:test>
-               <fos:expression>map:keys(map:merge(({"red": 0}, {"blue": 1}, {"green": 2}), {"ordering": "insertion"}))</fos:expression>
+               <fos:expression>map:keys(map:merge(({"red": 0}, {"blue": 1}, {"green": 2}), {"retain-order": true()}))</fos:expression>
                <fos:result>("red", "blue", "green")</fos:result>
-               <fos:postamble>The map has <code>insertion</code> ordering, so the order of keys is predictable.</fos:postamble>
+               <fos:postamble>The map is ordered, so the order of keys is predictable.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -23533,13 +23506,6 @@ return map:keys-where($birthdays, fn($name, $date) {
                <fos:postamble>The result sequence is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
             </fos:test>
-            <fos:test>
-               <fos:expression><eg>map:entries(
-  { 1: "yes", 0: "no" } => map:sort(), 
-)</eg></fos:expression>
-               <fos:result>({ 0: "no" }, { 1: "yes" })</fos:result>
-               <fos:postamble>The result sequence is in key order.</fos:postamble>
-            </fos:test>
          </fos:example>
       </fos:examples>
       <fos:changes>
@@ -23601,9 +23567,9 @@ return map:keys-where($birthdays, fn($name, $date) {
       </fos:changes>
    </fos:function>
    
-   <fos:function name="ordering" prefix="map">
+   <fos:function name="ordered" prefix="map">
       <fos:signatures>
-         <fos:proto name="ordering" return-type="enum('undefined', 'sorted', 'insertion')">
+         <fos:proto name="ordered" return-type="xs:boolean">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
          </fos:proto>
       </fos:signatures>
@@ -23613,35 +23579,27 @@ return map:keys-where($birthdays, fn($name, $date) {
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Returns the ordering property of a map.</p>
+         <p>Returns the <code>ordered</code> property of a map.</p>
       </fos:summary>
       <fos:rules>
          <p>The function returns the value of the 
-            <xtermref spec="DM40" ref="dt-map-ordering"/> property of a map:
-         one of <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, 
-            <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, or 
-            <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>.</p>
+            <xtermref spec="DM40" ref="dt-map-ordered"/> property of a map.</p>
       </fos:rules>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression><eg>map:ordering({ 1: "Y", 2: "N" })</eg></fos:expression>
-               <fos:result>"undefined"</fos:result>
+               <fos:expression><eg>map:ordered({ 1: "Y", 2: "N" })</eg></fos:expression>
+               <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>
+
          <fos:example>
             <fos:test>
-               <fos:expression><eg>map:ordering(map:sort({ 1: "Y", 2: "N" }))</eg></fos:expression>
-               <fos:result>"sorted"</fos:result>
-            </fos:test>
-         </fos:example>
-         <fos:example>
-            <fos:test>
-               <fos:expression><eg>map:ordering(
+               <fos:expression><eg>map:ordered(
    map:merge(({ 1: "Y" }, { 2: "N" }), 
-   { "ordering" : "insertion" })
+   { "retain-order" : true() })
 )</eg></fos:expression>
-               <fos:result>"insertion"</fos:result>
+               <fos:result>true()</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -23986,25 +23944,24 @@ declare function map:find($input as item()*,
                >same key</termref> as <code>$key</code>, together with a new
          entry whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p>
          
-         <p>The <xtermref spec="DM40" ref="dt-map-ordering"/> property of the returned map 
-            is the same as the <xtermref spec="DM40" ref="dt-map-ordering"/>
+         <p>The <xtermref spec="DM40" ref="dt-map-ordered"/> property of the returned map 
+            has the same value as the <xtermref spec="DM40" ref="dt-map-ordered"/>
          property of <code>$map</code>.</p>
          
          <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
             of the entries in the returned map is as follows:</p>
          
          <ulist>
-            <item><p>If the ordering is <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, then the 
+            <item><p>If <code>$map</code> has <code>ordered=false</code>, then the 
                <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
             <termref def="implementation-dependent"/>, and has no necessary relationship with the
             <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of <code>$map</code>.</p></item>
-            <item><p>If the ordering is <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, then the 
-               <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
-            sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
             <item>
-               <p>If the ordering is <xtermref spec="DM40" ref="dt-map-ordering-insertion"/> then:</p>
+               <p>If <code>$map</code> has <code>ordered=true</code> then:</p>
                <ulist>
-                  <item><p>If the input <code>$map</code> contains an entry whose</p></item>
+                  <item><p>If <code>$map</code> contains an entry whose key is <code>$key</code>,
+                  then the new value replaces the old value and the position of the entry is not changed.</p></item>
+                  <item><p>Otherwise, the new entry is added after all existing entries.</p></item>
                </ulist>
             
             </item>
@@ -24039,22 +23996,13 @@ declare function map:find($input as item()*,
           dm:map-put($map, $key, $value)
       </fos:equivalent>
       
-      <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the 
-            <xtermref spec="DM40" ref="dt-map-ordering"/>
-         property of <code>$map</code> has the value 
-            <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, 
-            and the <code>$key</code> is not 
-         <termref def="dt-strictly-comparable"/>
-            with every key present in <code>$map</code>.</p>
-      </fos:errors>
+
 
       <fos:notes>
-         <p>Except when <code>ordering</code> is sorted, 
-            there is no requirement that the type of <code>$key</code> and <code>$value</code> be consistent with the types
+         <p>There is no requirement that the type of <code>$key</code> and <code>$value</code> be consistent with the types
          of any existing keys and values in the supplied map.</p>
          
-         <p>With <code>ordering=insertion</code>, you can force the new entry to go at the end of the sequence by calling
+         <p>With an ordered map, you can force the new entry to go at the end of the sequence by calling
          <code>map:remove</code> before calling <code>map:put</code>.</p>
 
       </fos:notes>
@@ -24118,8 +24066,8 @@ declare function map:find($input as item()*,
             entry. The key of the entry in the new map is
                <code>$key</code>, and its associated value is <code>$value</code>.</p>
          
-         <p>The <xtermref spec="DM40" ref="dt-map-ordering"/> property 
-            of the returned map is <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>.</p>
+         <p>The <xtermref spec="DM40" ref="dt-map-ordered"/> property 
+            of the returned map is <code>false</code>.</p>
 
 
       </fos:rules>
@@ -24178,8 +24126,8 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
             >map</termref> which contains two entries, one (with the key <code>"key"</code>)
             containing <code>$key</code> and the other (with the key <code>"value"</code>)
             containing <code>$value</code>.</p>
-         <p>The <xtermref spec="DM40" ref="dt-map-ordering"/> property of the returned 
-            map is <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>.</p>
+         <p>The <xtermref spec="DM40" ref="dt-map-ordered"/> property of the returned 
+            map is <code>false</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 {}
@@ -24242,8 +24190,8 @@ map:of-pairs((
             <code>$keys</code>.</p>
          <p>No failure occurs <phrase>if an item in <code>$keys</code> does not correspond to any entry in <code>$map</code>;
             that key value is simply ignored</phrase>.</p>
-         <p>The <code>ordering</code> property of the returned map is the same as the <code>ordering</code> property
-         of <code>$map</code>, and in the case of ordering <code>sorted</code> or <code>insertion</code>, the relative
+         <p>The <code>ordered</code> property of the returned map is the same as the <code>ordered</code> property
+         of <code>$map</code>, and in the case of an ordered map, the relative
          position of retained entries in the result map is the same as their relative position in <code>$map</code>.</p>
         
       </fos:rules>
@@ -24309,9 +24257,15 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
       </fos:rules>
+      
       <fos:equivalent style="dm-primitive">
         dm:iterate-map($map, $action)
       </fos:equivalent>
+      <fos:notes>
+         <p>If the map is ordered, then the order in which entries are processed is predictable and reflects
+         the order in which entries in the map were added. If the map is unordered, then the order
+         of processing is <termref def="implementation-dependent"/>.</p>
+      </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -24393,10 +24347,9 @@ return <box>{
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
          
-         <p>The <xtermref spec="DM40" ref="dt-map-ordering"/> property of the returned map is the same as the 
-         <xtermref spec="DM40" ref="dt-map-ordering"/> property of <code>$map</code>, and in the case of 
-            <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>
-         or <xtermref spec="DM40" ref="dt-map-ordering-insertion"/> 
+         <p>The <xtermref spec="DM40" ref="dt-map-ordered"/> property of the returned map is the same as the 
+         <xtermref spec="DM40" ref="dt-map-ordered"/> property of <code>$map</code>, and in the case of 
+            an ordered map, 
             ordering the relative order of entries in the returned map
          is the same as their relative order in <code>$map</code>.</p>
       </fos:rules>
@@ -24426,16 +24379,7 @@ map:for-each($map, fn($key, $value) {
 )</eg></fos:expression>
                <fos:result><eg>{ 1: "Sunday", 7: "Saturday" }</eg></fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression><eg>map:filter(
-  { "Sunday": false(), "Monday": true(), "Tuesday": true(), "Wednesday": true(),
-    "Thursday": true(), "Friday": true(), "Saturday": false() } => map:sort(),
-  fn($k, $v) { $v }
-)</eg></fos:expression>
-               <fos:result><eg>{ "Friday": true(), "Monday": true(), "Thursday": true(),
-   "Tuesday": true(), "Wednesday": true()}</eg></fos:result>
-               <fos:postamble>The result is sorted because the input is sorted.</fos:postamble>
-            </fos:test>
+ 
 
          </fos:example>
 
@@ -24476,21 +24420,17 @@ map:for-each($map, fn($key, $value) {
          property of <code>$map</code>.</p>
          
          <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-            of the entries in the returned map is as follows:</p>
+            of the entries depends on teh map's <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
+            property, as follows:</p>
          
          <ulist>
-            <item><p>If the ordering is <code>undefined</code>, then the 
+            <item><p>If the map is unordered, then the 
                <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
             <termref def="implementation-dependent"/>, and has no necessary relationship with the
             <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of <code>$map</code>.</p></item>
-            <item><p>If the ordering is <code>sorted</code>, then the 
-               <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
-            sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
             <item>
-               <p>If the ordering is <code>insertion</code> then:</p>
-               <ulist>
-                  <item><p>If the input <code>$map</code> contains an entry whose</p></item>
-               </ulist>
+               <p>If the map is ordered, then the new entry replaces the old in its existing position,
+                  and the relative order of other entries in the map is retained.</p>
             
             </item>
          </ulist>
@@ -24500,11 +24440,6 @@ if (map:contains($map, $key))
 then map:put($map, $key, $action(map:get($map, $key)))
 else map:put($map, $key, $action(()))        
       </fos:equivalent>
-      <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the option
-         <code>ordering=sorted</code> is requested, and the keys of the entries to be included in the result are not 
-         <termref def="dt-strictly-comparable"/>.</p>
-      </fos:errors>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -24633,29 +24568,23 @@ else map:put($map, $key, $action(()))
                      <fos:type>(fn(item()*, item()*) as item()*)?</fos:type>
                      <fos:default>fn:op(',')</fos:default>
                   </fos:option>
-                  <fos:option key="ordering">
-                     <fos:meaning>Determines the <xtermref spec="DM40" ref="dt-map-ordering"/>, and the 
+                  <fos:option key="retain-order">
+                     <fos:meaning>Determines the 
                         <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
-                        entries in the returned map.
+                        entries in the returned map, and the value of the returned map's 
+                        <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref> property.
                      </fos:meaning>
-                     <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
-                     <fos:default>undefined</fos:default>
+                     <fos:type>xs:boolean</fos:type>
+                     <fos:default>false</fos:default>
                      <fos:values>
-                        <fos:value value="undefined">
-                           The <code>ordering</code> property of the returned map is 
-                           <xtermref spec="DM40" ref="dt-map-ordering-undefined"/>, and its
+                        <fos:value value="false">
+                           The <code>ordered</code> property of the returned map is <code>false</code>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is 
                            <termref def="implementation-dependent"/>.
                         </fos:value>
-                        <fos:value value="sorted">
-                           The <code>ordering</code> property of the returned map is 
-                           <xtermref spec="DM40" ref="dt-map-ordering-sorted"/>, and its
-                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is sorted by key. A dynamic error occurs
-                           if the keys are not <termref def="dt-strictly-comparable"/>.
-                        </fos:value>
-                        <fos:value value="insertion">
-                           The <code>ordering</code> property of the returned map is 
-                           <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>, and its
+             
+                        <fos:value value="true">
+                           The <code>ordered</code> property of the returned map is <code>true</code>, and its
                            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
                            reflects the order of the items supplied in <code>$input</code>,
                            and within each of those items, the order of the keys returned by the <code>$keys</code> function.
@@ -24679,11 +24608,7 @@ fold-left($input, {}, fn($map, $item, $pos) {
   })
 })            
       </fos:equivalent>
-      <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the option
-         <code>ordering=sorted</code> is requested, and the keys of the entries to be included in the result are not 
-         <termref def="dt-strictly-comparable"/>.</p>
-      </fos:errors>
+      
       
       <fos:notes>
          <!--<p>Although defined to process the input sequence in order, this is only relevant when combining the entries
@@ -24862,7 +24787,7 @@ return map:build($titles/title, fn($title) { $title/ix })
       </fos:examples>
    </fos:function>
    
-   <fos:function name="sort" prefix="map">
+   <!--<fos:function name="sort" prefix="map">
       <fos:signatures>
          <fos:proto name="sort" return-type="map(*)">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
@@ -24910,9 +24835,9 @@ return map:build($titles/title, fn($title) { $title/ix })
       <fos:changes>
          <fos:change issue="564" PR="1609" date="2024-11-27"><p>New in 4.0</p></fos:change>
       </fos:changes>
-   </fos:function>
+   </fos:function>-->
    
-   <fos:function name="range" prefix="map">
+   <!--<fos:function name="range" prefix="map">
       <fos:signatures>
          <fos:proto name="range" return-type="xs:integer">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
@@ -25011,7 +24936,7 @@ return
       <fos:changes>
          <fos:change issue="564" PR="1609" date="2024-11-27"><p>New in 4.0</p></fos:change>
       </fos:changes>
-   </fos:function>
+   </fos:function>-->
 
    <fos:function name="collation" prefix="fn">
       <fos:signatures>
@@ -33903,7 +33828,8 @@ return $result
                is derived from <var>V</var> by applying the function <code>derived-value(M', K, V)</code>,
                   defined below.</p>
                </item>
-               <item><p>The <xtermref spec="DM40" ref="dt-map-ordering"/> and <xtermref spec="DM40" ref="dt-entry-order"/>
+               <item><p>The <xtermref spec="DM40" ref="dt-map-ordered"/> property 
+                  and <xtermref spec="DM40" ref="dt-entry-order"/>
                of <var>M</var> are retained in <var>M'</var>.</p></item>
             </olist>
             </item>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16356,6 +16356,8 @@ declare function equal-strings(
                      </olist>
                   </item>
                </olist>
+               <note><p>It is not required that both maps have the same <code>ordering</code> property, 
+                  nor that the order of entries matches.</p></note>
              </item>
             <item>
                <p>All the following conditions are true:</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23598,6 +23598,52 @@ return map:keys-where($birthdays, fn($name, $date) {
          <fos:change><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
+   
+   <fos:function name="ordering" prefix="map">
+      <fos:signatures>
+         <fos:proto name="ordering" return-type="enum('undefined', 'sorted', 'insertion')">
+            <fos:arg name="map" type="map(*)" usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns the ordering property of a map.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function returns the value of the <code>ordering</code> property of a map:
+         one of <code>undefined</code>, <code>sorted</code>, or <code>insertion</code>.</p>
+      </fos:rules>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>map:ordering({ 1: "Y", 2: "N" })</eg></fos:expression>
+               <fos:result>"undefined"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>map:ordering(map:sort({ 1: "Y", 2: "N" }))</eg></fos:expression>
+               <fos:result>"sorted"</fos:result>
+            </fos:test>
+         </fos:example>
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>map:ordering(
+   map:merge(({ 1: "Y" }, { 2: "N" }), 
+   { "ordering" : "insertion" })
+)</eg></fos:expression>
+               <fos:result>"insertion"</fos:result>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:changes>
+         <fos:change><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
 
    <fos:function name="contains" prefix="map">
       <fos:signatures>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23904,7 +23904,7 @@ declare function map:find($input as item()*,
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+         <fos:change issue="564" PR="1609" date="2024-11-27"><p>Enhanced to allow for ordered maps.</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -24013,23 +24013,25 @@ declare function map:find($input as item()*,
   4: "Donnerstag", 5: "Freitag", 6: "Samstag", -1: "Unbekannt" }</eg></fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>map:put(parse-json('{ "red": 0, "green": 1, "blue" 2 }),
-        "yellow", -1) => map:keys()</eg></fos:expression>
+               <fos:expression><eg>parse-json('{ "red": 0, "green": 1, "blue" 2 }', {'retain-order': true()})
+  => map:put("yellow", -1) 
+  => map:keys()</eg></fos:expression>
                <fos:result>"red", "green", "blue", "yellow"</fos:result>
-               <fos:postamble>The result of <code>fn:parse-json</code> has <code>ordering=insertion</code>,
+               <fos:postamble>The result of <code>fn:parse-json</code> is in insertion order,
                so the new entry is added at the end of the list.</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression><eg>map:put(parse-json('{ "red": 0, "green": 1, "blue" 2 }),
-        "red", -1) => map:keys()</eg></fos:expression>
+               <fos:expression><eg>parse-json('{ "red": 0, "green": 1, "blue" 2 }', {'retain-order': true()})
+  => map:put("red", -1) 
+  => map:keys()</eg></fos:expression>
                <fos:result>"red", "green", "blue"</fos:result>
-               <fos:postamble>The result of <code>fn:parse-json</code> has <code>ordering=insertion</code>,
-               changing the value for an existing key does not change the order of the keys.</fos:postamble>
+               <fos:postamble>The result of <code>fn:parse-json</code> is in insertion order,
+               so changing the value for an existing key does not change the order of the keys.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+         <fos:change issue="564" PR="1609" date="2024-11-27"><p>Enhanced to allow for ordered maps.</p></fos:change>
       </fos:changes>
    </fos:function>
    
@@ -24213,7 +24215,7 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+         <fos:change issue="564" PR="1609" date="2024-11-27"><p>Enhanced to allow for ordered maps.</p></fos:change>
       </fos:changes>
    </fos:function>
    <fos:function name="for-each" prefix="map">
@@ -24302,7 +24304,7 @@ return <box>{
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+         <fos:change issue="564" PR="1609" date="2024-11-27"><p>Enhanced to allow for ordered maps.</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -24383,7 +24385,7 @@ map:for-each($map, fn($key, $value) {
          <fos:change issue="1171" PR="1182" date="2024-05-07">
             <p>The <code>$predicate</code> callback function may return an empty sequence (meaning <code>false</code>).</p>
          </fos:change>
-         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+         <fos:change issue="564" PR="1609" date="2024-11-27"><p>Enhanced to allow for ordered maps.</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -24837,7 +24839,7 @@ return map:build($titles/title, fn($title) { $title/ix })
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="564"><p>New in 4.0</p></fos:change>
+         <fos:change issue="564" PR="1609" date="2024-11-27"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
    
@@ -24938,7 +24940,7 @@ return
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="564"><p>New in 4.0</p></fos:change>
+         <fos:change issue="564" PR="1609" date="2024-11-27"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -25403,19 +25405,6 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                   </fos:value>
                </fos:values>
             </fos:option>
-            
-            <fos:option key="retain-order">
-               <fos:meaning>Determines whether the XML representation of a JSON object should retain the order
-                  of entries in the input.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>true</fos:default>
-               <fos:values>
-                  <fos:value value="false">The children of any <code>fn:map</code> element in the output will be
-                     in <termref def="implementation-dependent"/> order.</fos:value>
-                  <fos:value value="true">The children of any <code>fn:map</code> element in the output will be
-                     in the same order as the corresponding entries in the JSON input.</fos:value>
-               </fos:values>
-            </fos:option>
 
             <fos:option key="validate">
                <fos:meaning>Determines whether the generated XML tree is schema-validated.</fos:meaning>
@@ -25575,8 +25564,8 @@ return $M(collation-key("a", $C))</eg></fos:expression>
          <p>The XDM tree returned by the function does not contain any
          unnecessary (albeit valid) nodes such as whitespace text nodes, comments, or processing instructions.
          It does not include any whitespace in the value of <code>number</code> or <code>boolean</code> 
-            element nodes, <phrase>or in the value of <code>escaped</code> or <code>escaped-key</code>
-         attribute nodes.</phrase></p>
+            element nodes, nor in the value of <code>escaped</code> or <code>escaped-key</code>
+         attribute nodes.</p>
 
 
          <p>If the result is typed, every element named <code>string</code> will have an attribute named 
@@ -27663,6 +27652,9 @@ return document {
             <p>The default for the <code>escape</code> option has been changed to <code>false</code>. The 3.1
             specification gave the default value as <code>true</code>, but this appears to have been an error,
             since it was inconsistent with examples given in the specification and with tests in the test suite.</p>
+         </fos:change>
+         <fos:change issue="564" PR="1609" date="2024-11-27">
+            <p>An option is provided to retain the order of entries in maps.</p>
          </fos:change>
       </fos:changes>
    </fos:function>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24845,11 +24845,9 @@ return map:build($titles/title, fn($title) { $title/ix })
       <fos:signatures>
          <fos:proto name="range" return-type="xs:integer">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
-            <fos:arg name="min-inclusive" type="xs:anyAtomicType?" usage="absorption" default="()"/>
-            <fos:arg name="min-exclusive" type="xs:anyAtomicType?" usage="absorption" default="()"/>
-            <fos:arg name="max-inclusive" type="xs:anyAtomicType?" usage="absorption" default="()"/>
-            <fos:arg name="max-exclusive" type="xs:anyAtomicType?" usage="absorption" default="()"/>
-            <fos:arg name="limit" type="xs:integer?"  usage="absorption" default="()"/>
+            <fos:arg name="min" type="xs:anyAtomicType?" usage="absorption" default="()"/>
+            <fos:arg name="max" type="xs:anyAtomicType?" usage="absorption" default="()"/>
+            <fos:arg name="count" type="xs:integer?"  usage="absorption" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24863,29 +24861,39 @@ return map:build($titles/title, fn($title) { $title/ix })
       <fos:rules>
          <p>The function filters the supplied <code>$map</code> to return those entries that are
          within a given range of values.</p>
-         <p>The entries selected are those, up to a maximum count of <code>$limit</code> if specified, where the
+         <p>The function first selects those entries whose
             key <var>K</var> satisfies all the following conditions:</p>
        
          <ulist>
-            <item><p>If <code>$min-inclusive</code> is supplied, then <var>K</var> is 
-               greater than or equal to <code>$min-inclusive</code></p></item>
-            <item><p>If <code>$min-exclusive</code> is supplied, then <var>K</var> is 
-               greater than <code>$min-exclusive</code></p></item>
-            <item><p>If <code>$max-inclusive</code> is supplied, then <var>K</var> is 
-               less than or equal to <code>$max-inclusive</code></p></item>
-            <item><p>If <code>$max-exclusive</code> is supplied, then <var>K</var> is 
-               less than <code>$max-exclusive</code></p></item>
+            <item><p>If <code>$min</code> is supplied, then <var>K</var> is 
+               greater than or equal to <code>$min</code>.</p></item>
+            <item><p>If <code>$max</code> is supplied, then <var>K</var> is 
+               less than <code>$max</code>.</p></item>
          </ulist>
+         
+         <p>If <code>$count</code> is specified, then:</p>
+         <ulist>
+            <item><p>If <code>$count</code> is positive and is less than the number of selected
+            entries, it then selects the first <code>$count</code> of these entries, in key order.</p></item>
+            <item><p>If <code>$count</code> is negative and <code>-$count</code> is less than the number of selected
+            entries, it then selects the last <code>-$count</code> of these entries, in key order.</p></item>
+         </ulist>
+         
+         <p>For example, specifying <code>count := 1</code> selects the first qualifying entry, while
+         <code>count := -1</code> selects the last.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 let $CC := "http://www.w3.org/2005/xpath-functions/collation/codepoint"         
-return map:pairs(map:sort($map)) [
-   (empty($min-inclusive) or compare(?key, $min-inclusive, $CC) ge 0) and  
-   (empty($min-exclusive) or compare(?key, $min-exclusive, $CC) gt 0) and
-   (empty($max-inclusive) or compare(?key, $max-exclusive, $CC) le 0) and 
-   (empty($max-inclusive) or compare(?key, $max-exclusive, $CC) le 0)
-] => subsequence(1, $limit otherwise xs:double('+INF'))
-  => map:of-pairs({ "ordering": "sorted" })
+let $pairs := map:pairs(map:sort($map)) [
+   (empty($min) or compare(?key, $min, $CC) ge 0) and  
+   (empty($max) or compare(?key, $max, $CC) lt 0)
+]
+let $slice := 
+  if ($count gt 0) then slice($pairs, 1, $count)
+  else if ($count lt 0) then slice($pairs, -$count, -1)
+  else $pairs
+return
+  map:of-pairs($slice, { "ordering": "sorted" })
 </fos:equivalent>
       <fos:errors>
          <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if 
@@ -24896,22 +24904,35 @@ return map:pairs(map:sort($map)) [
          <p>The function is intended primarily to take advantage of efficiencies that
             become possible when the supplied <code>$map</code> has <code>ordering=sorted</code>,
             but it still works if the input is not sorted. </p>
-         <p>It would be unusual to supply both <code>$min-inclusive</code> and <code>$min-exclusive</code>,
-         or both <code>$max-inclusive</code> and <code>$max-exclusive</code>, but all combinations are permitted.</p>
+         <p>Note that <code>$min</code> is an inclusive bound, while <code>$max</code> is exclusive.
+         If <code>$min</code> is omitted, the selection starts at the first entry in <code>$map</code>,
+         and if <code>$max</code> is omitted, the selection ends at the last entry.</p>
       </fos:notes>
-      <fos:examples>
+      <fos:examples role="wide">
          <fos:example>
             <fos:test>
-               <fos:expression>map:sort({ "a": 1, "b": 2, "c": 3 }) => map:range(max-inclusive:="b") </fos:expression>
-               <fos:result>{ "a": 1, "b": 2 }</fos:result>
+               <fos:expression><eg>map:sort({ "a": 1, "c": 3, "b": 2 }) => map:range(count:=1) </eg></fos:expression>
+               <fos:result><eg>{ "a": 1 }</eg></fos:result>
+               <fos:postamble>Selects the first entry in the map, in key order</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:sort({ "a": 1, "b": 2, "c": 3 }) => map:range(min-inclusive:="b", max-exclusive="d") </fos:expression>
-               <fos:result>{ "b": 2, "c": 3 }</fos:result>
+               <fos:expression><eg>map:sort({ "a": 1, "c": 3, "b": 2 }) => map:range(count:=-1) </eg></fos:expression>
+               <fos:result><eg>{ "c": 3 }</eg></fos:result>
+               <fos:postamble>Selects the last entry in the map, in key order</fos:postamble>
             </fos:test>
             <fos:test>
-               <fos:expression>map:sort({ "aa": 1, "bb": 2, "cc": 3 }) => map:range(min-inclusive:="b", limit:=1) => map:keys() </fos:expression>
-               <fos:result>"bb"</fos:result>
+               <fos:expression><eg>map:sort({ "a": 1, "c": 3, "b": 2 }) => map:range(max:="b") </eg></fos:expression>
+               <fos:result><eg>{ "a": 1, "b": 2 }</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eeg>map:sort({ "a": 1, "c": 3, "b": 2 }) => map:range(min:="b", max="d") </eeg></fos:expression>
+               <fos:result><eg>{ "b": 2, "c": 3 }</eg></fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:sort({ "aa": 1, "cc": 3, "bb": 2 }) 
+  => map:range(min:="b", count:=1) 
+  => map:keys() </eg></fos:expression>
+               <fos:result><eg>"bb"</eg></fos:result>
                <fos:postamble>Returns the first key greater than or equal to the supplied value.</fos:postamble>
             </fos:test>
          </fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22918,11 +22918,11 @@ xs:QName('xs:double')</eg></fos:result>
                      <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
                         entries in the returned map.
                      </fos:meaning>
-                     <fos:type>enum("random", "sorted", "insertion")</fos:type>
-                     <fos:default>random</fos:default>
+                     <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
+                     <fos:default>undefined</fos:default>
                      <fos:values>
-                        <fos:value value="random">
-                           The <code>ordering</code> property of the returned map is <code>random</code>, and its
+                        <fos:value value="undefined">
+                           The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
                            <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
                         </fos:value>
                         <fos:value value="sorted">
@@ -22961,7 +22961,7 @@ let $combine := fn($A as map(*), $B as map(*), $deduplicator as fn(*)) {
     else map:put($z, $k, $B($k))
   })
 }
-return fold-left($maps, dm:empty-map($options?ordering otherwise "random"),
+return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
   $combine(?, ?, $duplicates-handler($options?duplicates otherwise "use-first"))
 )        
       </fos:equivalent>
@@ -23142,11 +23142,11 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "random"),
                <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
                   entries in the returned map.
                </fos:meaning>
-               <fos:type>enum("random", "sorted", "insertion")</fos:type>
-               <fos:default>random</fos:default>
+               <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
+               <fos:default>undefined</fos:default>
                <fos:values>
-                  <fos:value value="random">
-                     The <code>ordering</code> property of the returned map is <code>random</code>, and its
+                  <fos:value value="undefined">
+                     The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
                      <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
                   </fos:value>
                   <fos:value value="sorted">
@@ -23941,7 +23941,7 @@ declare function map:find($input as item()*,
          <p>The <termref def="dt-entry-order"/> of the entries in the returned map is as follows:</p>
          
          <ulist>
-            <item><p>If the ordering is <code>random</code>, then the <termref def="dt-entry-order"/> is
+            <item><p>If the ordering is <code>undefined</code>, then the <termref def="dt-entry-order"/> is
             <termref def="implementation-dependent"/>, and has no necessary relationship with the
             <termref def="dt-entry-order"/> of <code>$map</code>.</p></item>
             <item><p>If the ordering is <code>sorted</code>, then the <termref def="dt-entry-order"/> is
@@ -24059,7 +24059,7 @@ declare function map:find($input as item()*,
             entry. The key of the entry in the new map is
                <code>$key</code>, and its associated value is <code>$value</code>.</p>
          
-         <p>The <code>ordering</code> property of the returned map is <code>random</code>.</p>
+         <p>The <code>ordering</code> property of the returned map is <code>undefined</code>.</p>
 
 
       </fos:rules>
@@ -24118,7 +24118,7 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
             >map</termref> which contains two entries, one (with the key <code>"key"</code>)
             containing <code>$key</code> and the other (with the key <code>"value"</code>)
             containing <code>$value</code>.</p>
-         <p>The <code>ordering</code> property of the returned map is <code>random</code>.</p>
+         <p>The <code>ordering</code> property of the returned map is <code>undefined</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 {}
@@ -24420,7 +24420,7 @@ map:for-each($map, fn($key, $value) {
          <p>The <termref def="dt-entry-order"/> of the entries in the returned map is as follows:</p>
          
          <ulist>
-            <item><p>If the ordering is <code>random</code>, then the <termref def="dt-entry-order"/> is
+            <item><p>If the ordering is <code>undefined</code>, then the <termref def="dt-entry-order"/> is
             <termref def="implementation-dependent"/>, and has no necessary relationship with the
             <termref def="dt-entry-order"/> of <code>$map</code>.</p></item>
             <item><p>If the ordering is <code>sorted</code>, then the <termref def="dt-entry-order"/> is
@@ -24576,11 +24576,11 @@ else map:put($map, $key, $action(()))
                      <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
                         entries in the returned map.
                      </fos:meaning>
-                     <fos:type>enum("random", "sorted", "insertion")</fos:type>
-                     <fos:default>random</fos:default>
+                     <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
+                     <fos:default>undefined</fos:default>
                      <fos:values>
-                        <fos:value value="random">
-                           The <code>ordering</code> property of the returned map is <code>random</code>, and its
+                        <fos:value value="undefined">
+                           The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
                            <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
                         </fos:value>
                         <fos:value value="sorted">
@@ -27361,7 +27361,7 @@ return document {
                <fos:default>false</fos:default>
                <fos:values>
                   <fos:value value="false">Any maps resulting from parsing of JSON objects have the <code>ordering</code>
-                  property set to <code>random</code>.</fos:value>
+                  property set to <code>undefined</code>.</fos:value>
                   <fos:value value="true">Any maps resulting from parsing of JSON objects have the <code>ordering</code>
                   property set to <code>insertion</code>, and the <termref def="dt-entry-order"/> retains the order
                   of entries in the input.</fos:value>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22912,6 +22912,29 @@ xs:QName('xs:double')</eg></fos:result>
                         </fos:value>
                      </fos:values>
                   </fos:option>
+                  <fos:option key="ordering">
+                     <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
+                        entries in the returned map.
+                     </fos:meaning>
+                     <fos:type>enum("random", "sorted", "fifo")</fos:type>
+                     <fos:default>random</fos:default>
+                     <fos:values>
+                        <fos:value value="random">
+                           The <code>ordering</code> property of the returned map is <code>random</code>, and its
+                           <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
+                        </fos:value>
+                        <fos:value value="sorted">
+                           The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
+                           <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
+                           if the keys are not <termref def="dt-strictly-comparable"/>.
+                        </fos:value>
+                        <fos:value value="fifo">
+                           The <code>ordering</code> property of the returned map is <code>fifo</code>, and its
+                           <termref def="dt-entry-order"/> reflects the order of the maps supplied in <code>$maps</code>,
+                           and within each input map, the <termref def="dt-entry-order"/> of the entries in that map.
+                        </fos:value>
+                     </fos:values>
+                  </fos:option>
                </fos:options>
 
                
@@ -22936,7 +22959,7 @@ let $combine := fn($A as map(*), $B as map(*), $deduplicator as fn(*)) {
     else map:put($z, $k, $B($k))
   })
 }
-return fold-left($maps, {},
+return fold-left($maps, dm:empty-map($options?ordering otherwise "random"),
   $combine(?, ?, $duplicates-handler($options?duplicates otherwise "use-first"))
 )        
       </fos:equivalent>
@@ -22949,6 +22972,9 @@ return fold-left($maps, {},
                /> if the value of 
           <code>$options</code> includes an entry whose key is defined 
           in this specification, and whose value is not a permitted value for that key.</p>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the option
+         <code>ordering=sorted</code> is requested, and the keys of the entries to be included in the result are not 
+         <termref def="dt-strictly-comparable"/>.</p>
       </fos:errors>
 
       <fos:notes>
@@ -22977,7 +23003,8 @@ return fold-left($maps, {},
          <p>If the input is an empty sequence, the result is an empty map.</p>
          <p>If the input is a sequence of length one, the result map is 
             <phrase>indistinguishable from the supplied map</phrase>.</p>
-         <p>There is no requirement that the supplied input maps should have the same or compatible
+         <p>Except when <code>ordering=sorted</code>, there is no requirement that 
+            the supplied input maps should have the same or compatible
             types. The type of a map (for example <code>map(xs:integer, xs:string)</code>) is
             descriptive of the entries it currently contains, but is not a constraint on how the map
             may be combined with other maps.</p>
@@ -23048,6 +23075,18 @@ return fold-left($maps, {},
                   entry that appears in the result is the <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> of the entries
                   in the input maps, retaining order.</fos:postamble>
             </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:merge(({ "red": 0 }, { "green": 1}, { "blue": 2 }),
+    { "ordering": "sorted" } => map:keys()</eg></fos:expression>
+               <fos:result>"blue", "green", "red"</fos:result>
+               <fos:postamble>The result is in sorted order.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:merge(({ "red": 0 }, { "green": 1}, { "blue": 2 }),
+    { "ordering": "fifo" } => map:keys()</eg></fos:expression>
+               <fos:result>"red", "green", "blue"</fos:result>
+               <fos:postamble>The keys are in first-in, first-out order.</fos:postamble>
+            </fos:test>
 
          </fos:example>
       </fos:examples>
@@ -23060,7 +23099,7 @@ return fold-left($maps, {},
                      type-ref="key-value-pair" type-ref-occurs="*"
                      usage="inspection"
                      example="{ 'key':'n','value':false() }, { 'key':'y','value':true() }"/>
-            <fos:arg name="combine" type="(fn(item()*, item()*) as item()*)?" usage="inspection" default="fn:op(',')"/>
+            <fos:arg name="options" type="map(*)" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23080,9 +23119,48 @@ return fold-left($maps, {},
             <code>$input</code>
             argument.</p>
          
-         <p>The optional <code>$combine</code> argument can be used to define how
-         duplicate keys should be handled. The default is to form the sequence concatenation 
-         of the corresponding values, retaining their order in the input sequence.</p>
+         <p>The <code>$options</code> argument can be used to control the ordering of the result, 
+            and the way in which duplicate keys are handled.
+            The <termref def="option-parameter-conventions">option parameter conventions</termref> apply.
+         </p>
+ 
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+
+         <fos:options>
+            <fos:option key="combine">
+               <fos:meaning>A function that is used to combine two different values that are supplied
+                  for the same key. The default is to combine the two values using
+                  <xtermref spec="XP40" ref="dt-sequence-concatenation"/>, retaining their order
+                  in the input sequence.
+               </fos:meaning>
+               <fos:type>(fn(item()*, item()*) as item()*)?</fos:type>
+               <fos:default>fn:op(',')</fos:default>
+            </fos:option>
+            <fos:option key="ordering">
+               <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
+                  entries in the returned map.
+               </fos:meaning>
+               <fos:type>enum("random", "sorted", "fifo")</fos:type>
+               <fos:default>random</fos:default>
+               <fos:values>
+                  <fos:value value="random">
+                     The <code>ordering</code> property of the returned map is <code>random</code>, and its
+                     <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
+                  </fos:value>
+                  <fos:value value="sorted">
+                     The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
+                     <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
+                     if the keys are not <termref def="dt-strictly-comparable"/>.
+                  </fos:value>
+                  <fos:value value="fifo">
+                     The <code>ordering</code> property of the returned map is <code>fifo</code>, and its
+                     <termref def="dt-entry-order"/> reflects the order of the items supplied in <code>$input</code>.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+         </fos:options>
+
+
         
 
       </fos:rules>
@@ -23090,6 +23168,10 @@ return fold-left($maps, {},
 map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
       </fos:equivalent>
       <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the option
+         <code>ordering=sorted</code> is requested, and the keys of the entries to be included in the result are not 
+         <termref def="dt-strictly-comparable"/>.</p>
+         
          <p>The function can be made to fail with a dynamic error in the event that
          duplicate keys are present in the input sequence by supplying a <code>$combine</code>
          function that invokes the <code>fn:error</code> function.</p>
@@ -23179,6 +23261,20 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
                <fos:postamble>In the result map, the value for key <code>6</code> is obtained by concatenating the values
                   from the two input maps, with a separator character.</fos:postamble>
             </fos:test>
+            
+            <fos:test>
+               <fos:expression><eg>map:of-pairs((map:pair("red": 0), map:pair("green": 1), map:pair("blue": 2 )),
+    { "ordering": "sorted" } => map:keys()</eg></fos:expression>
+               <fos:result>"blue", "green", "red"</fos:result>
+               <fos:postamble>The result is in sorted order.</fos:postamble>
+            </fos:test>
+            
+            <fos:test>
+               <fos:expression><eg>map:of-pairs((map:pair("red": 0), map:pair("green": 1), map:pair("blue": 2 )),
+    { "ordering": "fifo" } => map:keys()</eg></fos:expression>
+               <fos:result>"red", "green", "blue"</fos:result>
+               <fos:postamble>The keys are in first-in, first-out order.</fos:postamble>
+            </fos:test>
 
          </fos:example>
       </fos:examples>
@@ -23204,13 +23300,13 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
       <fos:rules>
          <p>Informally, the function <code>map:keys</code> takes any
             <termref def="dt-map">map</termref> as its <code>$map</code> argument and returns
-            the keys that are present in the map as a sequence of atomic items, in <termref
-               def="implementation-dependent">implementation-dependent</termref> order.</p>
-         <p>The function is <term>nondeterministic with respect to ordering</term>
+            the keys that are present in the map as a sequence of atomic items, 
+            in <termref def="dt-entry-order"/>.</p>
+         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
             />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>
+            are not guaranteed to produce the results in the same order.</p>-->
       </fos:rules>
       <fos:equivalent style="xpath-expression">
          map:for-each($map, fn($key, $value) { $key })
@@ -23222,10 +23318,20 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>map:keys({ 1: "yes", 2: "no" })</fos:expression>
-               <fos:result allow-permutation="true">(1, 2)</fos:result>
+               <fos:expression>map:keys({ 1: "yes", 0: "no" })</fos:expression>
+               <fos:result allow-permutation="true">(1, 0)</fos:result>
                <fos:postamble>The result is in <termref def="implementation-dependent"
                      >implementation-dependent</termref> order.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:keys({ 1: "yes", 0: "no" } => map:sort())</fos:expression>
+               <fos:result>(0, 1)</fos:result>
+               <fos:postamble>The map is sorted, so the result is in sorted order.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:keys(map:merge(({"red": 0}, {"blue": 1}, {"green": 2}), {"ordering": "fifo"}))</fos:expression>
+               <fos:result>("red", "blue", "green")</fos:result>
+               <fos:postamble>The map has <code>fifo</code> ordering, so the order of keys is predictable.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -23251,15 +23357,15 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
             <termref def="dt-map">map</termref> as its <code>$map</code> argument. The
             <code>$predicate</code> function takes the key and the value of the corresponding
             map entry as an argument, and the result is a sequence containing the keys of those
-            entries for which the predicate function returns <code>true</code> in <termref
-               def="implementation-dependent">implementation-dependent</termref> order.
+            entries for which the predicate function returns <code>true</code> in 
+            <termref def="dt-entry-order"/>.
          A return value of <code>()</code> is treated as <code>false</code>.</p>
          
-         <p>The function is <term>nondeterministic with respect to ordering</term>
+         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
             />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>
+            are not guaranteed to produce the results in the same order.</p>-->
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 map:for-each($map, fn($key, $value) {
@@ -23341,13 +23447,12 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>The function <code>map:values</code> takes any <termref def="dt-map"
             >map</termref>
             as its <code>$map</code> argument and returns the values that are present in the map as
-            a sequence, in <termref
-               def="implementation-dependent">implementation-dependent</termref> order.</p>
-         <p>The function is <term>nondeterministic with respect to ordering</term>
+            a sequence, in <termref def="dt-entry-order"/>.</p>
+         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
             />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>
+            are not guaranteed to produce the results in the same order.</p>-->
          <p>The effect of the function is equivalent to <code>$map?*</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -23398,13 +23503,13 @@ return map:keys-where($birthdays, fn($name, $date) {
             >map</termref>
             as its <code>$map</code> argument and returns the key-value pairs that are present in the map as
             a sequence of <termref def="dt-singleton-map">singleton maps</termref>, in <termref
-               def="implementation-dependent">implementation-dependent</termref> order.</p>
+               def="dt-entry-order"/>.</p>
          
-         <p>The function is <term>nondeterministic with respect to ordering</term>
+         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
             />). This means that two calls with the same argument
-            are not guaranteed to produce the results in the same order.</p>
+            are not guaranteed to produce the results in the same order.</p>-->
 
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -23414,11 +23519,18 @@ return map:keys-where($birthdays, fn($name, $date) {
          <fos:example>
             <fos:test>
                <fos:expression><eg>map:entries(
-  { 1: "yes", 2: "no" }
+  { 1: "yes", 0: "no" }
 )</eg></fos:expression>
-               <fos:result allow-permutation="true">({ 1: "yes" }, { 2: "no" })</fos:result>
+               <fos:result allow-permutation="true">({ 1: "yes" }, { 0: "no" })</fos:result>
                <fos:postamble>The result sequence is in <termref def="implementation-dependent"
                   >implementation-dependent</termref> order.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:entries(
+  { 1: "yes", 0: "no" } => map:sort(), 
+)</eg></fos:expression>
+               <fos:result>({ 0: "no" }, { 1: "yes" })</fos:result>
+               <fos:postamble>The result sequence is in key order.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -23447,7 +23559,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             >map</termref>
             as its <code>$map</code> argument and returns the keys that are present in the map as
             a sequence of <termref def="dt-key-value-pair-map">key-value pair maps</termref>, in <termref
-               def="implementation-dependent">implementation-dependent</termref> order.</p>
+               def="dt-entry-order"/>.</p>
          <p>A key-value pair map is an instance of type <code>record(key as xs:anyAtomicType, value as item()*)</code>:
          that is a map with two entries, one (with key <code>"key"</code>) holding the key,
          and the other (with key <code>"value"</code>) holding the value.</p>
@@ -23713,9 +23825,7 @@ return (
             </item>
             <item>
                <p>To process an item that is a map, then for each key-value entry (<var>K</var>, <var>V</var>)
-               in the map (in <termref
-                     def="implementation-dependent"
-                  >implementation-dependent</termref> order)
+               in the map (in <termref def="dt-entry-order"/>)
                perform both of the following steps, in order:</p>
                <olist>
                   <item>
@@ -23793,6 +23903,9 @@ declare function map:find($input as item()*,
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+      </fos:changes>
    </fos:function>
 
    <fos:function name="put" prefix="map">
@@ -23819,6 +23932,26 @@ declare function map:find($input as item()*,
                def="dt-same-key"
                >same key</termref> as <code>$key</code>, together with a new
          entry whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p>
+         
+         <p>The <code>ordering</code> property of the returned map is the same as the <code>ordering</code>
+         property of <code>$map</code>.</p>
+         
+         <p>The <termref def="dt-entry-order"/> of the entries in the returned map is as follows:</p>
+         
+         <ulist>
+            <item><p>If the ordering is <code>random</code>, then the <termref def="dt-entry-order"/> is
+            <termref def="implementation-dependent"/>, and has no necessary relationship with the
+            <termref def="dt-entry-order"/> of <code>$map</code>.</p></item>
+            <item><p>If the ordering is <code>sorted</code>, then the <termref def="dt-entry-order"/> is
+            sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
+            <item>
+               <p>If the ordering is <code>fifo</code> then:</p>
+               <ulist>
+                  <item><p>If the input <code>$map</code> contains an entry whose</p></item>
+               </ulist>
+            
+            </item>
+         </ulist>
 
          <!--<p>The effect of the function call <code>map:put($MAP, $KEY, $VALUE)</code> is equivalent
          to the result of the following steps:</p>
@@ -23848,10 +23981,20 @@ declare function map:find($input as item()*,
       <fos:equivalent style="dm-primitive">
           dm:map-put($map, $key, $value)
       </fos:equivalent>
+      
+      <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the <code>ordering</code>
+         property has the value <code>sorted</code> is requested, and the keys of the entries to be included in the result are not 
+         <termref def="dt-strictly-comparable"/>.</p>
+      </fos:errors>
 
       <fos:notes>
-         <p>There is no requirement that the type of <code>$key</code> and <code>$value</code> be consistent with the types
+         <p>Except when <code>ordering</code> is sorted, 
+            there is no requirement that the type of <code>$key</code> and <code>$value</code> be consistent with the types
          of any existing keys and values in the supplied map.</p>
+         
+         <p>With <code>ordering=fifo</code>, you can force the new entry to go at the end of the sequence by calling
+         <code>map:remove</code> before calling <code>map:put</code>.</p>
 
       </fos:notes>
 
@@ -23869,8 +24012,25 @@ declare function map:find($input as item()*,
                <fos:result><eg>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
   4: "Donnerstag", 5: "Freitag", 6: "Samstag", -1: "Unbekannt" }</eg></fos:result>
             </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:put(parse-json('{ "red": 0, "green": 1, "blue" 2 }),
+        "yellow", -1) => map:keys()</eg></fos:expression>
+               <fos:result>"red", "green", "blue", "yellow"</fos:result>
+               <fos:postamble>The result of <code>fn:parse-json</code> has <code>ordering=fifo</code>,
+               so the new entry is added at the end of the list.</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:put(parse-json('{ "red": 0, "green": 1, "blue" 2 }),
+        "red", -1) => map:keys()</eg></fos:expression>
+               <fos:result>"red", "green", "blue"</fos:result>
+               <fos:postamble>The result of <code>fn:parse-json</code> has <code>ordering=fifo</code>,
+               changing the value for an existing key does not change the order of the keys.</fos:postamble>
+            </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+      </fos:changes>
    </fos:function>
    
    <fos:function name="entry" prefix="map">
@@ -23891,9 +24051,11 @@ declare function map:find($input as item()*,
       </fos:summary>
       <fos:rules>
          <p>The function <code>map:entry</code> returns a <termref def="dt-map"
-               >map</termref> which  contains a single
+               >map</termref> which contains a single
             entry. The key of the entry in the new map is
                <code>$key</code>, and its associated value is <code>$value</code>.</p>
+         
+         <p>The <code>ordering</code> property of the returned map is <code>random</code>.</p>
 
 
       </fos:rules>
@@ -23952,6 +24114,7 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
             >map</termref> which contains two entries, one (with the key <code>"key"</code>)
             containing <code>$key</code> and the other (with the key <code>"value"</code>)
             containing <code>$value</code>.</p>
+         <p>The <code>ordering</code> property of the returned map is <code>random</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 {}
@@ -24014,6 +24177,9 @@ map:of-pairs((
             <code>$keys</code>.</p>
          <p>No failure occurs <phrase>if an item in <code>$keys</code> does not correspond to any entry in <code>$map</code>;
             that key value is simply ignored</phrase>.</p>
+         <p>The <code>ordering</code> property of the returned map is the same as the <code>ordering</code> property
+         of <code>$map</code>, and in the case of ordering <code>sorted</code> or <code>fifo</code>, the relative
+         position of retained entries in the result map is the same as their relative position in <code>$map</code>.</p>
         
       </fos:rules>
       <fos:equivalent style="xpath-expression">
@@ -24046,6 +24212,9 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+      </fos:changes>
    </fos:function>
    <fos:function name="for-each" prefix="map">
       <fos:signatures>
@@ -24069,14 +24238,13 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
          <p>The function <code>map:for-each</code> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map, in <termref
-               def="implementation-dependent"
-            >implementation-dependent</termref> order; the result is the sequence obtained by
-            concatenating the results of these function calls.</p>
-         <p>The function is <term>nondeterministic with respect to ordering</term>
+               def="dt-entry-order"/>; the result is the <xtermref spec="XP40" ref="dt-sequence-concatenation"/> 
+            of the results of these function calls.</p>
+         <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
             />). This means that two calls with the same arguments
-            are not guaranteed to process the map entries in the same order.</p>
+            are not guaranteed to process the map entries in the same order.</p>-->
          <p>The function supplied as <code>$action</code> takes two arguments. It is called
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
@@ -24133,6 +24301,9 @@ return <box>{
                   depth="5"/></code>.</p>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
+      </fos:changes>
    </fos:function>
 
    <fos:function name="filter" prefix="map">
@@ -24161,6 +24332,11 @@ return <box>{
          <p>The function supplied as <code>$predicate</code> takes two arguments. It is called
             supplying the key of the map entry as the first argument, and the associated value as
             the second argument.</p>
+         
+         <p>The <code>ordering</code> property of the returned map is the same as the 
+         <code>ordering</code> property of <code>$map</code>, and in the case of <code>sorted</code>
+         or <code>fifo</code> ordering the relative order of entries in the returned map
+         is the same as their relative order in <code>$map</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 map:for-each($map, fn($key, $value) {
@@ -24188,6 +24364,16 @@ map:for-each($map, fn($key, $value) {
 )</eg></fos:expression>
                <fos:result><eg>{ 1: "Sunday", 7: "Saturday" }</eg></fos:result>
             </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:filter(
+  { "Sunday": false(), "Monday": true(), "Tuesday": true(), "Wednesday": true(),
+    "Thursday": true(), "Friday": true(), "Saturday": false() } => map:sort(),
+  fn($k, $v) { $v }
+)</eg></fos:expression>
+               <fos:result><eg>{ "Friday": true(), "Monday": true(), "Thursday": true(),
+   "Tuesday": true(), "Wednesday": true()}</eg></fos:result>
+               <fos:postamble>The result is sorted because the input is sorted.</fos:postamble>
+            </fos:test>
 
          </fos:example>
 
@@ -24197,6 +24383,7 @@ map:for-each($map, fn($key, $value) {
          <fos:change issue="1171" PR="1182" date="2024-05-07">
             <p>The <code>$predicate</code> callback function may return an empty sequence (meaning <code>false</code>).</p>
          </fos:change>
+         <fos:change issue="564"><p>Enhanced to allow for ordered maps.</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -24223,14 +24410,36 @@ map:for-each($map, fn($key, $value) {
          the supplied <code>$action</code> to the existing value associated with that key.</p>
          <p>Otherwise, the returned map contains an entry for the supplied <code>$key</code> whose value is
             obtained by applying the supplied <code>$action</code> to an empty sequence.</p>
-
-
+<p>The <code>ordering</code> property of the returned map is the same as the <code>ordering</code>
+         property of <code>$map</code>.</p>
+         
+         <p>The <termref def="dt-entry-order"/> of the entries in the returned map is as follows:</p>
+         
+         <ulist>
+            <item><p>If the ordering is <code>random</code>, then the <termref def="dt-entry-order"/> is
+            <termref def="implementation-dependent"/>, and has no necessary relationship with the
+            <termref def="dt-entry-order"/> of <code>$map</code>.</p></item>
+            <item><p>If the ordering is <code>sorted</code>, then the <termref def="dt-entry-order"/> is
+            sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
+            <item>
+               <p>If the ordering is <code>fifo</code> then:</p>
+               <ulist>
+                  <item><p>If the input <code>$map</code> contains an entry whose</p></item>
+               </ulist>
+            
+            </item>
+         </ulist>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 if (map:contains($map, $key)) 
 then map:put($map, $key, $action(map:get($map, $key)))
 else map:put($map, $key, $action(()))        
       </fos:equivalent>
+      <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the option
+         <code>ordering=sorted</code> is requested, and the keys of the entries to be included in the result are not 
+         <termref def="dt-strictly-comparable"/>.</p>
+      </fos:errors>
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -24316,7 +24525,7 @@ else map:put($map, $key, $action(()))
             <fos:arg name="input" type="item()*"/>
             <fos:arg name="keys" type="(fn(item(), xs:integer) as xs:anyAtomicType*)?" default="fn:identity#1"/>
             <fos:arg name="value" type="(fn(item(), xs:integer) as item()*)?" default="fn:identity#1"/>
-            <fos:arg name="combine" type="(fn(item()*, item()*) as item()*)?" default="fn:op(',')"/>
+            <fos:arg name="options" type="map(*)" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24335,11 +24544,57 @@ else map:put($map, $key, $action(()))
             Then, for each key value:</p>
          <ulist>
             <item><p>If the key is not already present in the target map, the processor adds a
-               new key-value pair to the map, with that key  and that value. </p></item>
-            <item><p>If the key is already present, the processor calls the <code>$combine</code>
-               function to combine the existing value for the key with the new value,
+               new key-value pair to the map, with that key and that value. </p></item>
+            <item><p>If the key is already present, the processor calls the <code>combine</code>
+               function in the <code>$options</code> argument to combine the existing value for the key with the new value,
                and replaces the entry with this combined value.</p></item>
          </ulist>
+         
+         <p>The <code>$options</code> argument can be used to control the ordering of the result, 
+            and the way in which duplicate keys are handled.
+               The <termref
+                     def="option-parameter-conventions"
+                  >option parameter conventions</termref> apply.
+            </p>
+ 
+               <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+
+               <fos:options>
+                  <fos:option key="combine">
+                     <fos:meaning>A function that is used to combine two different values that are supplied
+                        for the same key. The default is to combine the two values using
+                        <xtermref spec="XP40" ref="dt-sequence-concatenation"/>.
+                     </fos:meaning>
+                     <fos:type>(fn(item()*, item()*) as item()*)?</fos:type>
+                     <fos:default>fn:op(',')</fos:default>
+                  </fos:option>
+                  <fos:option key="ordering">
+                     <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
+                        entries in the returned map.
+                     </fos:meaning>
+                     <fos:type>enum("random", "sorted", "fifo")</fos:type>
+                     <fos:default>random</fos:default>
+                     <fos:values>
+                        <fos:value value="random">
+                           The <code>ordering</code> property of the returned map is <code>random</code>, and its
+                           <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
+                        </fos:value>
+                        <fos:value value="sorted">
+                           The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
+                           <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
+                           if the keys are not <termref def="dt-strictly-comparable"/>.
+                        </fos:value>
+                        <fos:value value="fifo">
+                           The <code>ordering</code> property of the returned map is <code>fifo</code>, and its
+                           <termref def="dt-entry-order"/> reflects the order of the items supplied in <code>$input</code>,
+                           and within each of those items, the order of the keys returned by the <code>$keys</code> function.
+                        </fos:value>
+                     </fos:values>
+                  </fos:option>
+               </fos:options>
+
+         
+         
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 fold-left($input, {}, fn($map, $item, $pos) {
@@ -24353,10 +24608,15 @@ fold-left($input, {}, fn($map, $item, $pos) {
   })
 })            
       </fos:equivalent>
+      <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if the option
+         <code>ordering=sorted</code> is requested, and the keys of the entries to be included in the result are not 
+         <termref def="dt-strictly-comparable"/>.</p>
+      </fos:errors>
       
       <fos:notes>
-         <p>Although defined to process the input sequence in order, this is only relevant when combining the entries
-            for duplicate keys.</p>
+         <!--<p>Although defined to process the input sequence in order, this is only relevant when combining the entries
+            for duplicate keys.</p>-->
          <p>The default function for both <code>$keys</code> and <code>$value</code> is the identity function.
             Although it is permitted to default both, this serves little purpose: usually at least one of these arguments
             will be supplied.</p>
@@ -24416,7 +24676,7 @@ fold-left($input, {}, fn($map, $item, $pos) {
   ("apple", "apricot", "banana", "blueberry", "cherry"), 
   substring(?, 1, 1),
   string-length#1,
-  op("+")
+  { "combine": op("+") }
 )</eg></fos:expression>
                <fos:result>{ "a": 12, "b": 15, "c": 6 }</fos:result>
                <fos:postamble>Constructs a map where the key is the first character of an input item, and where the corresponding value
@@ -24472,7 +24732,7 @@ return map:build($titles/title, fn($title) { $title/ix })
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values represent the number of employees at each distinct location. Any employees that
                lack an <code>@location</code> attribute will be excluded from the result.</p>
-            <eg>map:build(//employee, fn { @location }, fn { 1 }, op("+"))</eg>
+            <eg>map:build(//employee, fn { @location }, fn { 1 }, { "combine": op("+") })</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
@@ -24529,6 +24789,136 @@ return map:build($titles/title, fn($title) { $title/ix })
             </fos:test>
          </fos:example>
       </fos:examples>
+   </fos:function>
+   
+   <fos:function name="sort" prefix="map">
+      <fos:signatures>
+         <fos:proto name="sort" return-type="map(*)">
+            <fos:arg name="map" type="map(*)" usage="inspection"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns a sorted map with the same entries as a supplied map.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function <code>map:sort</code> takes any <termref def="dt-map"
+               >map</termref>
+            as its <code>$map</code> argument and returns a sorted map containing the
+            same entries.</p>
+      </fos:rules>
+      <fos:equivalent style="xpath-expression">
+         map:of-pairs(map:pairs($map), {'ordering': 'sorted'})
+      </fos:equivalent>
+      <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if 
+            the keys in <code>$map</code> are not 
+         <termref def="dt-strictly-comparable"/>.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>If the <code>ordering</code> property of <code>$map</code> is <code>sorted</code>,
+         then <code>$map</code> is returned unchanged.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>map:sort({ "a": 0, "z": 0, "q": 0 }) => map:keys()</fos:expression>
+               <fos:result>"a", "q", "z"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:sort({}) => map:put("x", 0) => map:put("a", 0) => map:keys()</fos:expression>
+               <fos:result>"a", "x"</fos:result>
+               <fos:postamble>Adding entries to a sorted map, even if it is empty, produces a sorted map</fos:postamble>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:changes>
+         <fos:change issue="564"><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+   
+   <fos:function name="range" prefix="map">
+      <fos:signatures>
+         <fos:proto name="range" return-type="xs:integer">
+            <fos:arg name="map" type="map(*)" usage="inspection"/>
+            <fos:arg name="min-inclusive" type="xs:anyAtomicType?" usage="absorption" default="()"/>
+            <fos:arg name="min-exclusive" type="xs:anyAtomicType?" usage="absorption" default="()"/>
+            <fos:arg name="max-inclusive" type="xs:anyAtomicType?" usage="absorption" default="()"/>
+            <fos:arg name="max-exclusive" type="xs:anyAtomicType?" usage="absorption" default="()"/>
+            <fos:arg name="limit" type="xs:integer?"  usage="absorption" default="()"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Returns a sorted map containing a subset of the entries of a supplied map.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function filters the supplied <code>$map</code> to return those entries that are
+         within a given range of values.</p>
+         <p>The entries selected are those, up to a maximum count of <code>$limit</code> if specified, where the
+            key <var>K</var> satisfies all the following conditions:</p>
+       
+         <ulist>
+            <item><p>If <code>$min-inclusive</code> is supplied, then <var>K</var> is 
+               greater than or equal to <code>$min-inclusive</code></p></item>
+            <item><p>If <code>$min-exclusive</code> is supplied, then <var>K</var> is 
+               greater than <code>$min-exclusive</code></p></item>
+            <item><p>If <code>$max-inclusive</code> is supplied, then <var>K</var> is 
+               less than or equal to <code>$max-inclusive</code></p></item>
+            <item><p>If <code>$max-exclusive</code> is supplied, then <var>K</var> is 
+               less than <code>$max-exclusive</code></p></item>
+         </ulist>
+      </fos:rules>
+      <fos:equivalent style="xpath-expression">
+let $CC := "http://www.w3.org/2005/xpath-functions/collation/codepoint"         
+return map:pairs(map:sort($map)) [
+   (empty($min-inclusive) or compare(?key, $min-inclusive, $CC) ge 0) and  
+   (empty($min-exclusive) or compare(?key, $min-exclusive, $CC) gt 0) and
+   (empty($max-inclusive) or compare(?key, $max-exclusive, $CC) le 0) and 
+   (empty($max-inclusive) or compare(?key, $max-exclusive, $CC) le 0)
+] => subsequence(1, $limit otherwise xs:double('+INF'))
+  => map:of-pairs({ "ordering": "sorted" })
+</fos:equivalent>
+      <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0008"/> if 
+            the keys in <code>$map</code> are not 
+         <termref def="dt-strictly-comparable"/>.</p>
+      </fos:errors>
+      <fos:notes>
+         <p>The function is intended primarily to take advantage of efficiencies that
+            become possible when the supplied <code>$map</code> has <code>ordering=sorted</code>,
+            but it still works if the input is not sorted. </p>
+         <p>It would be unusual to supply both <code>$min-inclusive</code> and <code>$min-exclusive</code>,
+         or both <code>$max-inclusive</code> and <code>$max-exclusive</code>, but all combinations are permitted.</p>
+      </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test>
+               <fos:expression>map:sort({ "a": 1, "b": 2, "c": 3 }) => map:range(max-inclusive:="b") </fos:expression>
+               <fos:result>{ "a": 1, "b": 2 }</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:sort({ "a": 1, "b": 2, "c": 3 }) => map:range(min-inclusive:="b", max-exclusive="d") </fos:expression>
+               <fos:result>{ "b": 2, "c": 3 }</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>map:sort({ "aa": 1, "bb": 2, "cc": 3 }) => map:range(min-inclusive:="b", limit:=1) => map:keys() </fos:expression>
+               <fos:result>"bb"</fos:result>
+               <fos:postamble>Returns the first key greater than or equal to the supplied value.</fos:postamble>
+            </fos:test>
+         </fos:example>
+      </fos:examples>
+      <fos:changes>
+         <fos:change issue="564"><p>New in 4.0</p></fos:change>
+      </fos:changes>
    </fos:function>
 
    <fos:function name="collation" prefix="fn">
@@ -24990,6 +25380,19 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      it invalid against the schema). This value is therefore incompatible with the option <code>validate=true</code>
                      <errorref class="JS" code="0005"/>
                   </fos:value>
+               </fos:values>
+            </fos:option>
+            
+            <fos:option key="retain-order">
+               <fos:meaning>Determines whether the XML representation of a JSON object should retain the order
+                  of entries in the input.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>true</fos:default>
+               <fos:values>
+                  <fos:value value="false">The children of any <code>fn:map</code> element in the output will be
+                     in <termref def="implementation-dependent"/> order.</fos:value>
+                  <fos:value value="true">The children of any <code>fn:map</code> element in the output will be
+                     in the same order as the corresponding entries in the JSON input.</fos:value>
                </fos:values>
             </fos:option>
 
@@ -25502,7 +25905,8 @@ return json-to-xml($json, $options)]]></eg>
                the children of the <code>map</code> element, enclosed between curly braces and separated by commas. 
                Each entry comprises the value of the <code>key</code> attribute of the child element, enclosed in quotation marks 
                and escaped as described below, followed by a colon, followed by the result of processing the child element 
-               by applying these rules recursively.</p>
+               by applying these rules recursively. The order of properties in the output JSON representation retains the order
+               of the children of the <code>map</code> element.</p>
             </item>
             <item>
                <p>Comments, processing instructions, and whitespace text node children of <code>map</code> and <code>array</code>
@@ -26938,6 +27342,19 @@ return document {
                   </fos:value>
                </fos:values>
             </fos:option>
+            
+            <fos:option key="retain-order">
+               <fos:meaning>Determines whether maps resulting from parsing of JSON objects should retain the input order.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="false">Any maps resulting from parsing of JSON objects have the <code>ordering</code>
+                  property set to <code>random</code>.</fos:value>
+                  <fos:value value="true">Any maps resulting from parsing of JSON objects have the <code>ordering</code>
+                  property set to <code>fifo</code>, and the <termref def="dt-entry-order"/> retains the order
+                  of entries in the input.</fos:value>
+               </fos:values>
+            </fos:option>
 
             <fos:option key="escape">
                <fos:meaning>Determines whether special characters are represented in the XDM output in backslash-escaped form.</fos:meaning>
@@ -27071,6 +27488,7 @@ return document {
                      <code>{ "x": 2, "y": 5 }</code>.</p>
                <p>If duplicate keys are encountered in a JSON <emph>object</emph>, they are handled
                   as determined by the <code>duplicates</code> option defined above.</p>
+               <p>The order of entries is retained if the <code>retain-order</code> option is set to true.</p>
             </item>
             <item>
                <p>A JSON <emph>array</emph> is transformed to an array whose members are the result of converting

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22915,7 +22915,8 @@ xs:QName('xs:double')</eg></fos:result>
                      </fos:values>
                   </fos:option>
                   <fos:option key="ordering">
-                     <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
+                     <fos:meaning>Determines the ordering, and the 
+                        <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
                         entries in the returned map.
                      </fos:meaning>
                      <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
@@ -22923,17 +22924,21 @@ xs:QName('xs:double')</eg></fos:result>
                      <fos:values>
                         <fos:value value="undefined">
                            The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
-                           <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
+                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+                           is <termref def="implementation-dependent"/>.
                         </fos:value>
                         <fos:value value="sorted">
                            The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
-                           <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
+                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+                           is sorted by key. A dynamic error occurs
                            if the keys are not <termref def="dt-strictly-comparable"/>.
                         </fos:value>
                         <fos:value value="insertion">
                            The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
-                           <termref def="dt-entry-order"/> reflects the order of the maps supplied in <code>$maps</code>,
-                           and within each input map, the <termref def="dt-entry-order"/> of the entries in that map.
+                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+                           reflects the order of the maps supplied in <code>$maps</code>,
+                           and within each input map, the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+                           of the entries in that map.
                         </fos:value>
                      </fos:values>
                   </fos:option>
@@ -23139,7 +23144,8 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
                <fos:default>fn:op(',')</fos:default>
             </fos:option>
             <fos:option key="ordering">
-               <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
+               <fos:meaning>Determines the ordering, and the 
+                  <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
                   entries in the returned map.
                </fos:meaning>
                <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
@@ -23147,16 +23153,19 @@ return fold-left($maps, dm:empty-map($options?ordering otherwise "undefined"),
                <fos:values>
                   <fos:value value="undefined">
                      The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
-                     <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
+                     <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+                     is <termref def="implementation-dependent"/>.
                   </fos:value>
                   <fos:value value="sorted">
                      The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
-                     <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
+                     <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+                     is sorted by key. A dynamic error occurs
                      if the keys are not <termref def="dt-strictly-comparable"/>.
                   </fos:value>
                   <fos:value value="insertion">
                      The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
-                     <termref def="dt-entry-order"/> reflects the order of the items supplied in <code>$input</code>.
+                     <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+                     reflects the order of the items supplied in <code>$input</code>.
                   </fos:value>
                </fos:values>
             </fos:option>
@@ -23303,7 +23312,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
          <p>Informally, the function <code>map:keys</code> takes any
             <termref def="dt-map">map</termref> as its <code>$map</code> argument and returns
             the keys that are present in the map as a sequence of atomic items, 
-            in <termref def="dt-entry-order"/>.</p>
+            in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
          <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
@@ -23360,7 +23369,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
             <code>$predicate</code> function takes the key and the value of the corresponding
             map entry as an argument, and the result is a sequence containing the keys of those
             entries for which the predicate function returns <code>true</code> in 
-            <termref def="dt-entry-order"/>.
+            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.
          A return value of <code>()</code> is treated as <code>false</code>.</p>
          
          <!--<p>The function is <term>nondeterministic with respect to ordering</term>
@@ -23449,7 +23458,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>The function <code>map:values</code> takes any <termref def="dt-map"
             >map</termref>
             as its <code>$map</code> argument and returns the values that are present in the map as
-            a sequence, in <termref def="dt-entry-order"/>.</p>
+            a sequence, in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
          <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
                ref="properties-of-functions"
@@ -23504,8 +23513,8 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>The function <code>map:entries</code> takes any <termref def="dt-map"
             >map</termref>
             as its <code>$map</code> argument and returns the key-value pairs that are present in the map as
-            a sequence of <termref def="dt-singleton-map">singleton maps</termref>, in <termref
-               def="dt-entry-order"/>.</p>
+            a sequence of <termref def="dt-singleton-map">singleton maps</termref>, in 
+            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
          
          <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
@@ -23560,8 +23569,8 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>The function <code>map:pairs</code> takes any <termref def="dt-map"
             >map</termref>
             as its <code>$map</code> argument and returns the keys that are present in the map as
-            a sequence of <termref def="dt-key-value-pair-map">key-value pair maps</termref>, in <termref
-               def="dt-entry-order"/>.</p>
+            a sequence of <termref def="dt-key-value-pair-map">key-value pair maps</termref>, in 
+            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
          <p>A key-value pair map is an instance of type <code>record(key as xs:anyAtomicType, value as item()*)</code>:
          that is a map with two entries, one (with key <code>"key"</code>) holding the key,
          and the other (with key <code>"value"</code>) holding the value.</p>
@@ -23873,7 +23882,7 @@ return (
             </item>
             <item>
                <p>To process an item that is a map, then for each key-value entry (<var>K</var>, <var>V</var>)
-               in the map (in <termref def="dt-entry-order"/>)
+               in the map (in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>)
                perform both of the following steps, in order:</p>
                <olist>
                   <item>
@@ -23984,13 +23993,16 @@ declare function map:find($input as item()*,
          <p>The <code>ordering</code> property of the returned map is the same as the <code>ordering</code>
          property of <code>$map</code>.</p>
          
-         <p>The <termref def="dt-entry-order"/> of the entries in the returned map is as follows:</p>
+         <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+            of the entries in the returned map is as follows:</p>
          
          <ulist>
-            <item><p>If the ordering is <code>undefined</code>, then the <termref def="dt-entry-order"/> is
+            <item><p>If the ordering is <code>undefined</code>, then the 
+               <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
             <termref def="implementation-dependent"/>, and has no necessary relationship with the
-            <termref def="dt-entry-order"/> of <code>$map</code>.</p></item>
-            <item><p>If the ordering is <code>sorted</code>, then the <termref def="dt-entry-order"/> is
+            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of <code>$map</code>.</p></item>
+            <item><p>If the ordering is <code>sorted</code>, then the 
+               <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
             sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
             <item>
                <p>If the ordering is <code>insertion</code> then:</p>
@@ -24287,8 +24299,7 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
       <fos:rules>
          <p>The function <code>map:for-each</code> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
-            to each entry in the map, in <termref
-               def="dt-entry-order"/>; the result is the <xtermref spec="XP40" ref="dt-sequence-concatenation"/> 
+            to each entry in the map, in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>; the result is the <xtermref spec="XP40" ref="dt-sequence-concatenation"/> 
             of the results of these function calls.</p>
          <!--<p>The function is <term>nondeterministic with respect to ordering</term>
             (see <specref
@@ -24463,13 +24474,16 @@ map:for-each($map, fn($key, $value) {
 <p>The <code>ordering</code> property of the returned map is the same as the <code>ordering</code>
          property of <code>$map</code>.</p>
          
-         <p>The <termref def="dt-entry-order"/> of the entries in the returned map is as follows:</p>
+         <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+            of the entries in the returned map is as follows:</p>
          
          <ulist>
-            <item><p>If the ordering is <code>undefined</code>, then the <termref def="dt-entry-order"/> is
+            <item><p>If the ordering is <code>undefined</code>, then the 
+               <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
             <termref def="implementation-dependent"/>, and has no necessary relationship with the
-            <termref def="dt-entry-order"/> of <code>$map</code>.</p></item>
-            <item><p>If the ordering is <code>sorted</code>, then the <termref def="dt-entry-order"/> is
+            <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of <code>$map</code>.</p></item>
+            <item><p>If the ordering is <code>sorted</code>, then the 
+               <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is
             sorted by key. A dynamic error occurs if the keys are not <termref def="dt-strictly-comparable"/>.</p></item>
             <item>
                <p>If the ordering is <code>insertion</code> then:</p>
@@ -24619,7 +24633,8 @@ else map:put($map, $key, $action(()))
                      <fos:default>fn:op(',')</fos:default>
                   </fos:option>
                   <fos:option key="ordering">
-                     <fos:meaning>Determines the ordering, and the <termref def="dt-entry-order"/>, of the
+                     <fos:meaning>Determines the ordering, and the 
+                        <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
                         entries in the returned map.
                      </fos:meaning>
                      <fos:type>enum("undefined", "sorted", "insertion")</fos:type>
@@ -24627,16 +24642,18 @@ else map:put($map, $key, $action(()))
                      <fos:values>
                         <fos:value value="undefined">
                            The <code>ordering</code> property of the returned map is <code>undefined</code>, and its
-                           <termref def="dt-entry-order"/> is <termref def="implementation-dependent"/>.
+                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is 
+                           <termref def="implementation-dependent"/>.
                         </fos:value>
                         <fos:value value="sorted">
                            The <code>ordering</code> property of the returned map is <code>sorted</code>, and its
-                           <termref def="dt-entry-order"/> is sorted by key. A dynamic error occurs
+                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is sorted by key. A dynamic error occurs
                            if the keys are not <termref def="dt-strictly-comparable"/>.
                         </fos:value>
                         <fos:value value="insertion">
                            The <code>ordering</code> property of the returned map is <code>insertion</code>, and its
-                           <termref def="dt-entry-order"/> reflects the order of the items supplied in <code>$input</code>,
+                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
+                           reflects the order of the items supplied in <code>$input</code>,
                            and within each of those items, the order of the keys returned by the <code>$keys</code> function.
                         </fos:value>
                      </fos:values>
@@ -27409,7 +27426,8 @@ return document {
                   <fos:value value="false">Any maps resulting from parsing of JSON objects have the <code>ordering</code>
                   property set to <code>undefined</code>.</fos:value>
                   <fos:value value="true">Any maps resulting from parsing of JSON objects have the <code>ordering</code>
-                  property set to <code>insertion</code>, and the <termref def="dt-entry-order"/> retains the order
+                  property set to <code>insertion</code>, and the 
+                     <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> retains the order
                   of entries in the input.</fos:value>
                </fos:values>
             </fos:option>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7588,7 +7588,7 @@ return <table>
                   all have a timezone, or all have no timezone.</p></note>
                </item>
                
-               <item><p><term>Fifo</term> (first-in, first-out) ordering maintains and delivers the
+               <item><p><term>Insertion</term> ordering maintains and delivers the
                entries in a map in the order they were added: new entries are added at the end. The detailed
                rules are determined by the <code>map:put</code> function.</p></item>
             </ulist>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7523,12 +7523,13 @@ return <table>
       <div1 id="maps">
          <head>Maps</head>
          
+         
          <p>Maps were introduced as a new datatype in XDM 3.1. This section describes functions that
          operate on maps.</p>
          
-         <p>A map is an additional kind of item.</p>
+         <p>A map is a kind of item.</p>
          
-         <p><termdef id="dt-map" term="map">A <term>map</term> consists of a set of entries, also known
+         <p><termdef id="dt-map" term="map">A <term>map</term> consists of a sequence of entries, also known
             as key-value pairs. Each entry comprises a key 
             which is an arbitrary atomic item, and an arbitrary sequence called the associated value.</termdef></p>
          
@@ -7555,6 +7556,73 @@ return <table>
             <code>$books-by-isbn("0470192747")</code> returns the <code>book</code> element with the given ISBN.
             The fact that a map is a function item allows it to be passed as an argument to higher-order functions 
             that expect a function item as one of their arguments.</p>
+         
+         <div2 id="map-ordering">
+            <head>Ordering of Maps</head>
+            
+            <changes>
+               <change issue="564" date="2024-11-25">Ordered maps are introduced.</change>
+            </changes>
+            
+            <p>A map has a property called its <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>,
+            which takes one of the values <code>random</code>, <code>sorted</code>, or <code>fifo</code>.</p>
+            
+            <ulist>
+               <item><p><term>Random</term> is the default ordering, and was the only value available in
+               earlier versions of this specification. With random ordering, the order of entries in the
+               map is <termref def="implementation-dependent"/>: with many implementations, it is likely
+               to be entirely unpredictable, based on some internal hashing function applied to the keys.</p></item>
+               
+               <item><p><term>Sorted</term> ordering maintains and delivers the entries in a map in ascending
+               order of the keys. This imposes a constraint that the keys must be <termref def="dt-strictly-comparable"/>.</p>
+                  <p><termdef id="dt-strictly-comparable" term="strictly comparable">A set of keys
+                  is <term>strictly comparable</term> if for every pair of keys <var>K1</var>
+                  and <var>K2</var>, (a) the function <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC)</code>,
+                  where <code>$CC</code> is the Unicode Codepoint Collation, can be evaluated without raising a type error,
+                  and (b) if either <var>K1</var> or <var>K2</var> has a timezone component, then both have
+                  a timezone component.</termdef></p>
+                  <note><p>This disallows types such as <code>xs:QName</code> for which no ordering is defined,
+                  and also disallows mixing of types such as <code>xs:string</code> and <code>xs:integer</code>
+                  in the same map. The ordering chosen in context-independent, which means that strings
+                  are always compared using the Unicode codepoint collation, and date/time values must either
+                  all have a timezone, or all have no timezone.</p></note>
+               </item>
+               
+               <item><p><term>Fifo</term> (first-in, first-out) ordering maintains and delivers the
+               entries in a map in the order they were added: new entries are added at the end. The detailed
+               rules are determined by the <code>map:put</code> function.</p></item>
+            </ulist>
+            
+            <p>A sorted map may be constructed using the <code>map:sort</code> function. Adding or removing
+            entries to a sorted map will maintain the sort order. In some cases it is convenient to 
+            construct an empty map with the property <code>ordering=sorted</code> using the
+            expression <code>map:sort({})</code>, and then build the map by adding entries incrementally.
+            Alternatively, a sorted map may be constructed by calling any of the functions
+            <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code> with
+            the option <code>ordering=sorted</code>.</p>
+            
+            <p>A map with ordering <code>fifo</code> may be constructed by calling any of the functions
+            <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code> with
+            the option <code>ordering=fifo</code>. These functions may be used to construct an empty
+            map with this ordering property, to which entries can then be added incrementally; or they
+            may be used to construct a map in which the order of entries reflect the order of items
+            in the sequence supplied as input.</p>
+            
+            <p>Maps with ordering <code>fifo</code> are also constructed by certain operations such
+            as <code>parse-json</code> and <code>xml-to-json</code>.</p>
+            
+            <p><termdef id="dt-entry-order" term="entry order">The order of entries in a map
+            (which is dependent on its <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
+            property) is referred to as <term>entry order</term>.</termdef></p>
+            <p>The <termref def="dt-entry-order"/> of the entries in a map is 
+               respected by functions such as <code>map:entries</code>,
+               <code>map:keys</code>, <code>map:values</code>, <code>map:pairs</code>, <code>map:for-each</code>, and 
+            <code>json-to-xml</code>. It also affects the result of the expression 
+               <code>for key $k value $v return <var>EXPR</var></code>, and the output
+            of the <code>json</code> and <code>adaptive</code> serialization methods.</p>
+         
+            
+         </div2>
          
          <div2 id="map-composition-decomposition" diff="add" at="2023-04-19">
             <head>Composing and Decomposing Maps</head>
@@ -7637,7 +7705,7 @@ return <table>
             <head>Formal Specification of Maps</head>
             <p>The XDM data model (<bibref ref="xpath-datamodel-40"/>) defines three primitive operations on maps:</p>
             <ulist>
-               <item><p><code>dm:empty-map</code> constructs an empty map.</p></item>
+               <item><p><code>dm:empty-map</code> constructs an empty map with a given ordering property.</p></item>
                <item><p><code>dm:map-put</code> adds or replaces an entry in a map.</p></item>
                <item><p><code>dm:iterate-map</code> applies a supplied function to every entry in a map.</p></item>
             </ulist>
@@ -13046,6 +13114,12 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised by <code>fn:xml-to-json</code> if the XML input uses the attribute
                   <code>escaped="true"</code> or <code>escaped-key="true"</code>, and the corresponding string
                   or key contains an invalid JSON escape sequence.</p>
+            </error>
+            
+            <error class="JS" code="0008" label="Non-comparable keys for sorted map" type="dynamic">
+               <p>Raised by various functions if an attempt is made to construct a map with the <code>ordering</code>
+                  property set to <code>sorted</code> when the keys to be included in the map
+                  are not <termref def="dt-strictly-comparable"/>.</p>
             </error>
             
             

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7561,11 +7561,14 @@ return <table>
             <head>Ordering of Maps</head>
             
             <changes>
-               <change issue="564" date="2024-11-25">Ordered maps are introduced.</change>
+               <change issue="564" PR="1609" date="2024-11-25">Ordered maps are introduced.</change>
             </changes>
             
             <p>A map has a property called its <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>,
-            which takes one of the values <code>undefined</code>, <code>sorted</code>, or <code>insertion</code>.</p>
+            which takes one of the values 
+               <xtermref spec="DM40" ref="dt-map-ordering-undefined">undefined</xtermref>, 
+               <xtermref spec="DM40" ref="dt-map-ordering-sorted">sorted</xtermref>, or 
+               <xtermref spec="DM40" ref="dt-map-ordering-insertion">insertion</xtermref>.</p>
             
             <ulist>
                <item><p><term>Undefined</term> is the default ordering, and was the only value available in
@@ -7593,34 +7596,111 @@ return <table>
                rules are determined by the <code>map:put</code> function.</p></item>
             </ulist>
             
-            <p>A sorted map may be constructed using the <code>map:sort</code> function. Adding or removing
-            entries to a sorted map will maintain the sort order. In some cases it is convenient to 
-            construct an empty map with the property <code>ordering=sorted</code> using the
-            expression <code>map:sort({})</code>, and then build the map by adding entries incrementally.
-            Alternatively, a sorted map may be constructed by calling any of the functions
-            <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code> with
-            the option <code>ordering=sorted</code>.</p>
-            
-            <p>A map with ordering <code>insertion</code> may be constructed by calling any of the functions
-            <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code> with
-            the option <code>ordering=insertion</code>. These functions may be used to construct an empty
-            map with this ordering property, to which entries can then be added incrementally; or they
-            may be used to construct a map in which the order of entries reflect the order of items
-            in the sequence supplied as input.</p>
-            
-            <p>Maps with ordering <code>insertion</code> are also constructed by certain operations such
-            as <code>parse-json</code> and <code>xml-to-json</code>.</p>
-            
-            <p><termdef id="dt-entry-order" term="entry order">The order of entries in a map
+            <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of a map
             (which is dependent on its <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
-            property) is referred to as <term>entry order</term>.</termdef></p>
-            <p>The <termref def="dt-entry-order"/> of the entries in a map is 
+            property) is referred to as <term>entry order</term>.</p>
+            <p>The entry order of the entries in a map is 
                respected by functions such as <code>map:entries</code>,
                <code>map:keys</code>, <code>map:values</code>, <code>map:pairs</code>, <code>map:for-each</code>, and 
             <code>json-to-xml</code>. It also affects the result of the expression 
                <code>for key $k value $v return <var>EXPR</var></code>, and the output
             of the <code>json</code> and <code>adaptive</code> serialization methods.</p>
-         
+            
+            <p>Maps with ordering <term>sorted</term> or <term>insertion</term> are
+            described in more detail in the following sections.</p>
+            
+            <div3 id="id-sorted-maps">
+               <head>Using Sorted Maps</head>
+               
+               <p>A sorted map can be constructed either by applying the <code>map:sort</code> function
+               to an existing map, or by constructing an empty map with the sorted property, and then adding
+               entries to it incrementally. The simplest way to construct an empty map with
+               the sorted property is with the function call <code>map:sort({})</code>. Sorted
+               maps can also be constructed using the <code>map:build</code>, <code>map:of-pairs</code>,
+               or <code>map:merge</code> functions with the option <code>{ "ordering" : "sorted" }</code>.</p>
+               
+               <p>There are a number of possible reasons for using sorted maps (which in most implementations
+               are likely to incur some overhead, in space and time, relative to maps whose ordering
+               is undefined).</p>
+               
+               <ulist>
+                  <item><p>One reason is to achieve sorted output. For example, serializing a sorted map
+                  using the JSON output method will output the entries in key order. Although the order
+                  of entries in a JSON object typically has no semantic meaning, there are many operations
+                  that retain order when JSON is parsed and this may be useful, for example, when generating
+                  reports.</p>
+                  <p>Similarly, the expression <code>for key $key value $value return <var>EXPR</var></code>
+                  will process a sorted map in key order, which may be useful when generating an output
+                  report.</p>
+                  <p>The <function>json-to-xml</function> function also preserves the order of entries
+                  in JSON objects in the generated XML.</p>
+                  <p>There is of course no guarantee that putting data into a sorted map and then iterating
+                  over the map will be faster than using <code>fn:sort</code> (or other constructs) to
+                  sort the data. But if the sorted data is required repeatedly, then it makes sense to
+                  maintain the data in sorted order rather than performing repeated sorts.</p>   
+                  </item>
+                  <item><p>A second reason is to enable range searching. The function <function>map:range</function>
+                  can be used to select all the entries from a sorted map where the key is in a given
+                  range of values. For example, if a map holds information about events with the date and time
+                  of the event as a key value, a range search enables all the events in a given week to
+                  found efficiently; it also enables finding the first event after or before 
+                  a given date and time.</p>
+                  <p>(The <function>map:range</function> function will also work on an input map that is not
+                  sorted, but it is likely to be much less efficient in this case.)</p></item>
+                  
+               </ulist>
+
+            
+            <p>Adding or removing entries to a sorted map will maintain the sort order, as will
+            calls to functions such as <function>map:filter</function> and <function>map:find</function>.</p>
+               
+            </div3>
+            <div3 id="id-insertion-maps">
+               <head>Using Maps with Insertion Ordering</head>
+            
+            <p>Maps with ordering <xtermref spec="DM40" ref="dt-map-ordering-insertion">insertion</xtermref>
+            have two main uses:</p>
+               
+               <ulist>
+                  <item><p>When a map is constructed in a single operation, for example
+                  by parsing JSON, by converting XML, or by a function such as <code>map:build</code>,
+                  it can be useful if the order of entries in the map retains the order of the
+                  relevant input sequence. For example, there might be no semantic information
+                  in the ordering of a JSON input file, but if a small change is being made to a large
+                  file, then it can be useful if the order of entries in the output is the same as
+                  the order of entries in the input, as this enables easy visual checking that the
+                  change has been made correctly.</p></item>
+                  <item><p>When a map is constructed incrementally in a sequence of operations,
+                  it can be useful if iterating over the map entries reflects the order in which
+                  the entries were added to the map.</p></item>
+               </ulist>
+                  
+            <p>In the first case the map will typically be constructed using a function such as
+            <function>map:build</function>, <function>map:of-pairs</function>, or <function>map:merge</function>
+            with the option <code>{ 'ordering': 'insertion' }</code>. 
+               The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of the map
+            will then reflect the order of items in the original input sequence.</p>
+                  
+            <p>In the second case, an empty map with insertion ordering will typically be created
+            using a function call such as <code>map:build({}, { 'ordering': 'insertion' })</code>,
+            and entries will then be added incrementally by successive calls on <function>map:put</function>,
+            often within a processing loop controlled using <function>fn:fold-left</function>,
+            or in XSLT <code>xsl:iterate</code>.</p>
+                  
+            <p>A map constructor expression such as <code>{ "first": 1, "second": 2 }</code>
+            returns a map in which the order of entries in the constructor is lost; this mechanism
+            cannot therefore be used to construct a map with predictable order of entries.
+            Instead, the required effect can be achieved with the expression 
+               <code>map:merge(({ "first": 1 }, { "second": 2 }), { 'ordering': 'insertion' })</code>.</p>      
+            
+   
+            
+            <p>Maps with ordering <xtermref spec="DM40" ref="dt-map-ordering-insertion">insertion</xtermref> 
+               can also be constructed by certain operations such
+            as <function>parse-json</function> and <function>xml-to-json</function>.</p>
+            
+               
+            </div3>
             
          </div2>
          

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7568,102 +7568,33 @@ return <table>
                <change issue="564" PR="1609" date="2024-11-25">Ordered maps are introduced.</change>
             </changes>
             
-            <p>A map has a property called its <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>,
-            which takes one of the values 
-               <xtermref spec="DM40" ref="dt-map-ordering-undefined">undefined</xtermref>, 
-               <xtermref spec="DM40" ref="dt-map-ordering-sorted">sorted</xtermref>, or 
-               <xtermref spec="DM40" ref="dt-map-ordering-insertion">insertion</xtermref>.</p>
+            <p>A map has a property called <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref>,
+            which takes the value <code>true</code> or <code>false</code>.</p>
             
             <ulist>
-               <item><p><term>Undefined</term> is the default ordering, and was the only value available in
-               earlier versions of this specification. With undefined ordering, the order of entries in the
-               map is <termref def="implementation-dependent"/>: with many implementations, it is likely
+               <item><p>By default, the <code>ordered</code> propery is <code>false</code>,
+                  in which case the map is said to be unordered. The order of entries in an unordered map 
+               is <termref def="implementation-dependent"/>: with many implementations, it is likely
                to be entirely unpredictable, based on some internal hashing function applied to the keys.</p></item>
                
-               <item><p><term>Sorted</term> ordering maintains and delivers the entries in a map in ascending
-               order of the keys. This imposes a constraint that the keys must be <termref def="dt-strictly-comparable"/>.</p>
-                  <p><termdef id="dt-strictly-comparable" term="strictly comparable">A set of keys
-                  is <term>strictly comparable</term> if for every pair of keys <var>K1</var>
-                  and <var>K2</var>, (a) the function <code>fn:compare(<var>K1</var>, <var>K2</var>, $CC)</code>,
-                  where <code>$CC</code> is the Unicode Codepoint Collation, can be evaluated without raising a type error,
-                  and (b) if either <var>K1</var> or <var>K2</var> has a timezone component, then both have
-                  a timezone component.</termdef></p>
-                  <note><p>This disallows types such as <code>xs:QName</code> for which no ordering is defined,
-                  and also disallows mixing of types such as <code>xs:string</code> and <code>xs:integer</code>
-                  in the same map. The ordering chosen in context-independent, which means that strings
-                  are always compared using the Unicode codepoint collation, and date/time values must either
-                  all have a timezone, or all have no timezone.</p></note>
-               </item>
-               
-               <item><p><term>Insertion</term> ordering maintains and delivers the
-               entries in a map in the order they were added: new entries are added at the end. The detailed
+               <item><p>In a map whose <code>ordered</code> propery is <code>true</code>, 
+                  entries in a map are delivered in the order they were added: 
+                  new entries are added at the end. The detailed
                rules are determined by the <code>map:put</code> function.</p></item>
             </ulist>
             
             <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of a map
-            (which is dependent on its <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
-            property) is referred to as <term>entry order</term>.</p>
+            is referred to as <term>entry order</term>.</p>
             <p>The entry order of the entries in a map is 
                respected by functions such as <code>map:entries</code>,
-               <code>map:keys</code>, <code>map:values</code>, <code>map:pairs</code>, <code>map:for-each</code>, and 
+               <code>map:keys</code>, <code>map:values</code>, <code>map:pairs</code>, 
+               <code>map:for-each</code>, and 
             <code>json-to-xml</code>. It also affects the result of the expression 
                <code>for key $k value $v return <var>EXPR</var></code>, and the output
             of the <code>json</code> and <code>adaptive</code> serialization methods.</p>
             
-            <p>Maps with ordering <term>sorted</term> or <term>insertion</term> are
-            described in more detail in the following sections.</p>
             
-            <div3 id="id-sorted-maps">
-               <head>Using Sorted Maps</head>
-               
-               <p>A sorted map can be constructed either by applying the <code>map:sort</code> function
-               to an existing map, or by constructing an empty map with the sorted property, and then adding
-               entries to it incrementally. The simplest way to construct an empty map with
-               the sorted property is with the function call <code>map:sort({})</code>. Sorted
-               maps can also be constructed using the <code>map:build</code>, <code>map:of-pairs</code>,
-               or <code>map:merge</code> functions with the option <code>{ "ordering" : "sorted" }</code>.</p>
-               
-               <p>There are a number of possible reasons for using sorted maps (which in most implementations
-               are likely to incur some overhead, in space and time, relative to maps whose ordering
-               is undefined).</p>
-               
-               <ulist>
-                  <item><p>One reason is to achieve sorted output. For example, serializing a sorted map
-                  using the JSON output method will output the entries in key order. Although the order
-                  of entries in a JSON object typically has no semantic meaning, there are many operations
-                  that retain order when JSON is parsed and this may be useful, for example, when generating
-                  reports.</p>
-                  <p>Similarly, the expression <code>for key $key value $value return <var>EXPR</var></code>
-                  will process a sorted map in key order, which may be useful when generating an output
-                  report.</p>
-                  <p>The <function>json-to-xml</function> function also preserves the order of entries
-                  in JSON objects in the generated XML.</p>
-                  <p>There is of course no guarantee that putting data into a sorted map and then iterating
-                  over the map will be faster than using <code>fn:sort</code> (or other constructs) to
-                  sort the data. But if the sorted data is required repeatedly, then it makes sense to
-                  maintain the data in sorted order rather than performing repeated sorts.</p>   
-                  </item>
-                  <item><p>A second reason is to enable range searching. The function <function>map:range</function>
-                  can be used to select all the entries from a sorted map where the key is in a given
-                  range of values. For example, if a map holds information about events with the date and time
-                  of the event as a key value, a range search enables all the events in a given week to
-                  found efficiently; it also enables finding the first event after or before 
-                  a given date and time.</p>
-                  <p>(The <function>map:range</function> function will also work on an input map that is not
-                  sorted, but it is likely to be much less efficient in this case.)</p></item>
-                  
-               </ulist>
-
-            
-            <p>Adding or removing entries to a sorted map will maintain the sort order, as will
-            calls to functions such as <function>map:filter</function> and <function>map:find</function>.</p>
-               
-            </div3>
-            <div3 id="id-insertion-maps">
-               <head>Using Maps with Insertion Ordering</head>
-            
-            <p>Maps with ordering <xtermref spec="DM40" ref="dt-map-ordering-insertion">insertion</xtermref>
-            have two main uses:</p>
+            <p>Ordered maps have two main uses:</p>
                
                <ulist>
                   <item><p>When a map is constructed in a single operation, for example
@@ -7681,12 +7612,12 @@ return <table>
                   
             <p>In the first case the map will typically be constructed using a function such as
             <function>map:build</function>, <function>map:of-pairs</function>, or <function>map:merge</function>
-            with the option <code>{ 'ordering': 'insertion' }</code>. 
+            with the option <code>{ 'retain-order': true() }</code>. 
                The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of the map
             will then reflect the order of items in the original input sequence.</p>
                   
-            <p>In the second case, an empty map with insertion ordering will typically be created
-            using a function call such as <code>map:build({}, { 'ordering': 'insertion' })</code>,
+            <p>In the second case, an empty ordered map will typically be created
+            using a function call such as <code>map:build({}, { 'retain-order': true() })</code>,
             and entries will then be added incrementally by successive calls on <function>map:put</function>,
             often within a processing loop controlled using <function>fn:fold-left</function>,
             or in XSLT <code>xsl:iterate</code>.</p>
@@ -7695,16 +7626,14 @@ return <table>
             returns a map in which the order of entries in the constructor is lost; this mechanism
             cannot therefore be used to construct a map with predictable order of entries.
             Instead, the required effect can be achieved with the expression 
-               <code>map:merge(({ "first": 1 }, { "second": 2 }), { 'ordering': 'insertion' })</code>.</p>      
+               <code>map:merge(({ "first": 1 }, { "second": 2 }), { 'ordered': true() })</code>.</p>      
             
    
             
-            <p>Maps with ordering <xtermref spec="DM40" ref="dt-map-ordering-insertion">insertion</xtermref> 
-               can also be constructed by certain operations such
+            <p>Ordered maps can also be constructed by certain operations such
             as <function>parse-json</function> and <function>xml-to-json</function>.</p>
             
                
-            </div3>
             
          </div2>
          
@@ -7871,8 +7800,8 @@ return <table>
             <div3 id="func-map-of-pairs" diff="add" at="2023-04-03">
                <head><?function map:of-pairs?></head>
             </div3>
-            <div3 id="func-map-ordering">
-               <head><?function map:ordering?></head>
+            <div3 id="func-map-ordered">
+               <head><?function map:ordered?></head>
             </div3>
             <div3 id="func-map-pair">
                <head><?function map:pair?></head>
@@ -7883,9 +7812,6 @@ return <table>
             <div3 id="func-map-put">
                <head><?function map:put?></head>
             </div3>
-            <div3 id="func-map-range" diff="add" at="A">
-               <head><?function map:range?></head>
-            </div3>
             <div3 id="func-map-remove">
                <head><?function map:remove?></head>
             </div3>
@@ -7895,9 +7821,7 @@ return <table>
             <div3 id="func-map-size">
                <head><?function map:size?></head>
             </div3>
-            <div3 id="func-map-sort" diff="add" at="A">
-               <head><?function map:sort?></head>
-            </div3>
+            
             <!--<div3 id="func-map-substitute" diff="add" at="A">
                <head><?function map:substitute?></head>
             </div3>-->
@@ -13209,12 +13133,7 @@ ISBN 0 521 77752 6.</bibl>
                   or key contains an invalid JSON escape sequence.</p>
             </error>
             
-            <error class="JS" code="0008" label="Non-comparable keys for sorted map" type="dynamic">
-               <p>Raised by various functions if an attempt is made to construct a map with the <code>ordering</code>
-                  property set to <code>sorted</code> when the keys to be included in the map
-                  are not <termref def="dt-strictly-comparable"/>.</p>
-            </error>
-            
+
             
             
             <error class="NS" code="0004" label="No namespace found for prefix." type="dynamic">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7565,7 +7565,7 @@ return <table>
             </changes>
             
             <p>A map has a property called its <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>,
-            which takes one of the values <code>random</code>, <code>sorted</code>, or <code>fifo</code>.</p>
+            which takes one of the values <code>random</code>, <code>sorted</code>, or <code>insertion</code>.</p>
             
             <ulist>
                <item><p><term>Random</term> is the default ordering, and was the only value available in
@@ -7601,14 +7601,14 @@ return <table>
             <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code> with
             the option <code>ordering=sorted</code>.</p>
             
-            <p>A map with ordering <code>fifo</code> may be constructed by calling any of the functions
+            <p>A map with ordering <code>insertion</code> may be constructed by calling any of the functions
             <code>map:build</code>, <code>map:merge</code>, or <code>map:of-pairs</code> with
-            the option <code>ordering=fifo</code>. These functions may be used to construct an empty
+            the option <code>ordering=insertion</code>. These functions may be used to construct an empty
             map with this ordering property, to which entries can then be added incrementally; or they
             may be used to construct a map in which the order of entries reflect the order of items
             in the sequence supplied as input.</p>
             
-            <p>Maps with ordering <code>fifo</code> are also constructed by certain operations such
+            <p>Maps with ordering <code>insertion</code> are also constructed by certain operations such
             as <code>parse-json</code> and <code>xml-to-json</code>.</p>
             
             <p><termdef id="dt-entry-order" term="entry order">The order of entries in a map

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7787,6 +7787,9 @@ return <table>
             <div3 id="func-map-of-pairs" diff="add" at="2023-04-03">
                <head><?function map:of-pairs?></head>
             </div3>
+            <div3 id="func-map-ordering">
+               <head><?function map:ordering?></head>
+            </div3>
             <div3 id="func-map-pair">
                <head><?function map:pair?></head>
             </div3>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7565,11 +7565,11 @@ return <table>
             </changes>
             
             <p>A map has a property called its <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>,
-            which takes one of the values <code>random</code>, <code>sorted</code>, or <code>insertion</code>.</p>
+            which takes one of the values <code>undefined</code>, <code>sorted</code>, or <code>insertion</code>.</p>
             
             <ulist>
-               <item><p><term>Random</term> is the default ordering, and was the only value available in
-               earlier versions of this specification. With random ordering, the order of entries in the
+               <item><p><term>Undefined</term> is the default ordering, and was the only value available in
+               earlier versions of this specification. With undefined ordering, the order of entries in the
                map is <termref def="implementation-dependent"/>: with many implementations, it is likely
                to be entirely unpredictable, based on some internal hashing function applied to the keys.</p></item>
                

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -802,6 +802,7 @@ for transition to Proposed Recommendation. </p>'>
                
                <item><p>All entries in the options map are optional, and supplying an empty map has the same
                effect as omitting the relevant argument in the function call, assuming this is permitted.</p></item>
+               <item><p>The ordering of the options map is immaterial.</p></item>
                <item><p>For each named option, the function
                specification defines a required type for the option value. The value that is actually
                supplied in the map is converted to this required type using the 
@@ -862,16 +863,19 @@ the relationship of various item types.</p>
       in declaring the types of variables or the argument types and result types of functions.</p>
       
       
-<p>Item types in the data model form a directed graph, rather than a
+<p>In XDM, item types include node types,
+function types, and built-in atomic types. 
+Item types form a directed graph, rather than a
 hierarchy or lattice: in the relationship defined by the
 <code>derived-from(A, B)</code> function, some types are derived from
 more than one other type. Examples include functions
 (<code>function(xs:string) as xs:int</code> is substitutable for
 <code>function(xs:NCName) as xs:int</code> and also for
-<code>function(xs:string) as xs:decimal</code>), and union types
-(<code>A</code> is substitutable for the union type <code>(A | B)</code> and also
-for <code>(A | C)</code>. In XDM, item types include node types,
-function types, and built-in atomic types. The diagram, which shows
+<code>function(xs:string) as xs:decimal</code>), and choice types
+(<code>A</code> is substitutable for the choice type <code>(A | B)</code> and also
+for <code>(A | C)</code>. Record types provide an alternative way of categorizing
+   maps: the instances of <code>record(longitude, latitude)</code> overlap with
+   the instances of <code>map(xs:string, xs:double)</code>. The diagram, which shows
 only hierarchic relationships, is therefore a simplification of the
 full model.</p>
 
@@ -7797,7 +7801,7 @@ return <table>
             to be specified by reference to this function library, without risk of circularity.</p>
             
             <p>There is one exception to this rule: for convenience, the notation <code>{}</code> is used to represent
-            an empty map, in preference to a call on <code>dm:empty-map()</code>.</p>
+            an empty map, in preference to a call on <code>dm:empty-map(ordering := 'undefined')</code>.</p>
             
             <p>The formal equivalents are not intended to provide a realistic way of implementating the
             functions (in particular, any real implementation might be expected to implement <code>map:get</code>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7796,6 +7796,9 @@ return <table>
             <div3 id="func-map-put">
                <head><?function map:put?></head>
             </div3>
+            <div3 id="func-map-range" diff="add" at="A">
+               <head><?function map:range?></head>
+            </div3>
             <div3 id="func-map-remove">
                <head><?function map:remove?></head>
             </div3>
@@ -7804,6 +7807,9 @@ return <table>
             </div3> 
             <div3 id="func-map-size">
                <head><?function map:size?></head>
+            </div3>
+            <div3 id="func-map-sort" diff="add" at="A">
+               <head><?function map:sort?></head>
             </div3>
             <!--<div3 id="func-map-substitute" diff="add" at="A">
                <head><?function map:substitute?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -6865,7 +6865,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      of numbers, the conversion is not guaranteed to retain full precision.</p>
                   
                   <p>Although the order of entries in a JSON object is generally considered to have no significance, the functions
-                     <code>json-to-xml</code> and <code>json-to-xml</code> both retain order.</p>
+                     <code>json-to-xml</code> and <code>xml-to-json</code> both retain order.</p>
                   
                   <p>The XDM representation of a JSON value may either be untyped (all elements annotated as <code>xs:untyped</code>, attributes
                      as <code>xs:untypedAtomic</code>), or it may be typed. If it is typed, then it <rfc2119>must</rfc2119> have the type

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19136,7 +19136,7 @@ processing with JSON processing.</p>
             see <xspecref spec="FO40" ref="maps"/>.</p>
             
             <note>
-               <p>Maps in &language; have a property called <xspecref spec="DM40" ref="dt-map-ordered"/>,
+               <p>Maps in &language; have a property called <xtermref spec="DM40" ref="dt-map-ordered"/>,
                which takes the value <code>true</code> or <code>false</code>; a map
                   is accordingly said to be <term>ordered</term> or <term>unordered</term>.
                   The effect of this property is explained 
@@ -19874,9 +19874,8 @@ processing with JSON processing.</p>
                           <note>
                               <p>The order of entries in the result sequence in this case 
                                  reflects the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>
-                                 of the map. In the default case where the <code>ordering</code> of the
-                                 map is <code>undefined</code>, the order of entries in the result sequence 
-                                 is implementation-dependent.</p>
+                                 of the map. In the default case where the map is unordered, 
+                                 the order of entries in the result sequence is implementation-dependent.</p>
                            </note>
                         </item>
                         <!--<item>
@@ -20502,10 +20501,9 @@ return $array?[count(.) ge 2]</eg>
                and the context size is the number of entries in the map. The result
                of the expression is a map containing those entries of the input map for which
                the <termref def="dt-predicate-truth-value"/> of the <code><var>FILTER</var></code> expression is true.
-               The <code>ordering</code> property of the result is the same as the <code>ordering</code>
-               property of the input map, and in the case of <code>sorted</code> or <code>insertion</code>
-               ordering the relative order of entries in the result retains the relative order of entries
-               in the input.
+               The <code>ordered</code> property of the result is the same as the <code>ordered</code>
+               property of the input map, and in the case of an ordered map, the relative order of 
+               entries in the result retains the relative order of entries in the input.
             </p>
             
             <p>For example, the following expression:</p>
@@ -20519,9 +20517,10 @@ return $map?[?key ge 2]</eg>
             
             <note>
                <p>Filtering of maps based on numeric positions is not generally useful when
-                  the <code>ordering</code> of the map is <code>undefined</code>, 
-                  because the order of entries in a map is unpredictable; but it is available 
-                  in the interests of orthogonality. </p>
+                  the map is unordered, because the order of entries is unpredictable; but it is available 
+                  in the interests of orthogonality.</p>
+               <p>With an ordered map, a filter expression such as <code>$map?[last()-1, last()]</code>
+                  might be used to return the last two entries.</p>
             </note>
          </div3>
          

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5271,7 +5271,7 @@ name.</p>
                   is an instance of <code>K</code> and every value is an
                   instance of <code>V</code>.</p>
                
-               <p>The <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
+               <p>The <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref>
                and <xtermref spec="DM40" ref="dt-entry-order">entry-order</xtermref>
                properties of a map have no effect on whether the map matches a particular
                map type.</p>
@@ -5495,7 +5495,7 @@ name.</p>
                <p>Although constructors for named record types produce a map in which the
                   <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> reflects
                   the order of field definitions in the record type definition,
-                  the <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
+                  the <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref>
                   and <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>
                   properties of a map have no effect on whether the map matches a particular
                   record type: the entries in a map do not have to be in any particular order.</p>
@@ -19136,24 +19136,17 @@ processing with JSON processing.</p>
             see <xspecref spec="FO40" ref="maps"/>.</p>
             
             <note>
-               <p>Maps in &language; have a property called <xspecref spec="DM40" ref="dt-map-ordering"/>,
-               which takes three possible values: <code>undefined</code>, <code>sorted</code>,
-               and <code>insertion</code>. The effect of these three options is explained 
+               <p>Maps in &language; have a property called <xspecref spec="DM40" ref="dt-map-ordered"/>,
+               which takes the value <code>true</code> or <code>false</code>; a map
+                  is accordingly said to be <term>ordered</term> or <term>unordered</term>.
+                  The effect of this property is explained 
                   in <xspecref spec="DM40" ref="map-items"/>. In summary:</p>
                <ulist>
-                  <item><p>The value <code>undefined</code> means that the order of entries
+                  <item><p>In an unordered map, the order of entries
                   in the map is <termref def="dt-implementation-dependent"/>; it may, for example,
                   be the result of a randomized hashing algorithm.</p></item>
-                  <item><p>The value <code>sorted</code> means that the map maintains entries
-                  sorted in key order. If this option is chosen then it is required that the
-                  keys be mutually comparable: an error will result if there is a key whose
-                  data type does not define ordering (for example, <code>xs:QName</code>), or if
-                  there are two keys whose data types are not mutually comparable (for example,
-                  <code>xs:integer</code> and <code>xs:string</code>). Strings are sorted
-                  using the Unicode Codepoint Collation.</p></item>
-                  <item><p>The value <code>insertion</code> means that the map will retain entries
-                  in the order of the initial sequence that results from evaluation of the
-                  contained sequence constructor.</p></item>
+                  <item><p>In an ordered map, the order of entries is predictable
+                  and depends on the order in which they were added to the map.</p></item>
                </ulist>
             </note>
 
@@ -19283,17 +19276,14 @@ processing with JSON processing.</p>
     
     </p>
                
-               <p>The <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref> 
+               <p>The <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref> 
                   property of a map constructed using a map constructor expression
-               is <xtermref spec="DM40" ref="dt-map-ordering-undefined">undefined</xtermref>.</p>
+               is <code>false</code>.</p>
                
                <note>
-                  <p>A map with <xtermref spec="DM40" ref="dt-map-ordering-sorted">sorted</xtermref> 
-                     ordering can be created by applying the <function>map:sort</function> function.</p>
-                  <p>A map with <xtermref spec="DM40" ref="dt-map-ordering-insertion">insertion</xtermref> 
-                     ordering can be created by use of the functions <function>map:build</function>,
+                  <p>An ordered map can be created by use of the functions <function>map:build</function>,
                   <function>map:merge</function>, or <function>map:of-pairs</function> 
-                     with the option <code>{ "ordering": "insertion" }</code>.</p>
+                     with the option <code>{ "retain-order": true() }</code>.</p>
                </note>
 
       <example>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19134,6 +19134,28 @@ processing with JSON processing.</p>
                see <xspecref spec="DM40" ref="map-items"/>. For an overview
             of the functions available for processing maps,
             see <xspecref spec="FO40" ref="maps"/>.</p>
+            
+            <note>
+               <p>Maps in &language; have a property called <xspecref spec="DM40" ref="dt-map-ordering"/>,
+               which takes three possible values: <code>undefined</code>, <code>sorted</code>,
+               and <code>insertion</code>. The effect of these three options is explained 
+                  in <xspecref spec="DM40" ref="map-items"/>. In summary:</p>
+               <ulist>
+                  <item><p>The value <code>undefined</code> means that the order of entries
+                  in the map is <termref def="dt-implementation-dependent"/>; it may, for example,
+                  be the result of a randomized hashing algorithm.</p></item>
+                  <item><p>The value <code>sorted</code> means that the map maintains entries
+                  sorted in key order. If this option is chosen then it is required that the
+                  keys be mutually comparable: an error will result if there is a key whose
+                  data type does not define ordering (for example, <code>xs:QName</code>), or if
+                  there are two keys whose data types are not mutually comparable (for example,
+                  <code>xs:integer</code> and <code>xs:string</code>). Strings are sorted
+                  using the Unicode Codepoint Collation.</p></item>
+                  <item><p>The value <code>insertion</code> means that the map will retain entries
+                  in the order of the initial sequence that results from evaluation of the
+                  contained sequence constructor.</p></item>
+               </ulist>
+            </note>
 
             <div4 id="id-map-constructors">
                <head>Map Constructors</head>
@@ -19353,9 +19375,11 @@ processing with JSON processing.</p>
                   <item><p><code>map:of-pairs(//employee ! {'key':@id, 'value':.})</code></p></item>
                </ulist>
                
-               <p>All three functions also provide control over how duplicate keys are handled,
-               allowing them to be used to create a map in which items are grouped according
-               to the value of a grouping key.</p>
+               <p>All three functions also provide control over:</p>
+               <ulist>
+                  <item><p>The way in which duplicate keys are handled, and </p></item>
+                  <item><p>The ordering of entries in the resulting map.</p></item>
+               </ulist>
 
             </div4>
             <div4 id="id-map-lookup">
@@ -19972,7 +19996,8 @@ processing with JSON processing.</p>
 }</eg>
 
                      <p>then <code>?*[. instance of record(street, postcode)]?postcode</code>
-                        returns <code>("MK12 2EX", "EX8 9AA")</code> (or some permutation thereof).</p>
+                        returns <code>("MK12 2EX", "EX8 9AA")</code> (or some permutation thereof,
+                        depending on the <xtermref spec="DM40" ref="dt-entry-order"/> of the map).</p>
                      <note><p>Writing <code>?*?postcode</code> would raise a type error, because the result of the initial
                         step <code>?*</code> includes an item (the string <code>"John Smith"</code>) that is neither
                         a map nor an array.</p></note>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5271,6 +5271,11 @@ name.</p>
                   is an instance of <code>K</code> and every value is an
                   instance of <code>V</code>.</p>
                
+               <p>The <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
+               and <xtermref spec="DM40" ref="dt-entry-order">entry-order</xtermref>
+               properties of a map have no effect on whether the map matches a particular
+               map type.</p>
+               
                
                
                <p diff="add" at="A">Although the grammar for <code>TypedMapType</code>
@@ -5486,6 +5491,14 @@ name.</p>
 		             type is marked as extensible, then other entries may be present in the map with either string or non-string keys.
 		             Entries whose key is a string can be expressed using an (unquoted) NCName if the key conforms to
 		             NCName syntax, or using a (quoted) string literal otherwise.</p>
+               
+               <p>Although constructors for named record types produce a map in which the
+                  <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> reflects
+                  the order of field definitions in the record type definition,
+                  the <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
+                  and <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>
+                  properties of a map have no effect on whether the map matches a particular
+                  record type: the entries in a map do not have to be in any particular order.</p>
 
                <note>
                   <p>Lookup expressions have been extended in 4.0 so that non-NCName keys can be used without
@@ -19096,7 +19109,11 @@ processing with JSON processing.</p>
 
          <div3 id="id-maps">
             <head>Maps</head>
-
+            
+            <changes>
+               <change issue="564" PR="1609" date="2024-11-25">Ordered maps are introduced.</change>
+            </changes>
+            
             <p>
                <termdef term="map" id="dt-map"
                   >A <term>map</term> is a function
@@ -19112,6 +19129,11 @@ processing with JSON processing.</p>
   associated with a given key is called the <term>associated
   value</term> of the key.</termdef>
             </p>
+            
+            <p>Maps and their properties are defined in the data model:
+               see <xspecref spec="DM40" ref="map-items"/>. For an overview
+            of the functions available for processing maps,
+            see <xspecref spec="FO40" ref="maps"/>.</p>
 
             <div4 id="id-map-constructors">
                <head>Map Constructors</head>
@@ -19239,14 +19261,17 @@ processing with JSON processing.</p>
     
     </p>
                
-               <p>The <code>ordering</code> property of a map constructed using a map constructor expression
-               is <code>undefined</code>.</p>
+               <p>The <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref> 
+                  property of a map constructed using a map constructor expression
+               is <xtermref spec="DM40" ref="dt-map-ordering-undefined">undefined</xtermref>.</p>
                
                <note>
-                  <p>A map with <code>sorted</code> ordering can be created by applying the <code>map:sort</code>
-                  function.</p>
-                  <p>A map with <code>insertion</code> ordering can be created by use of the functions <code>map:build</code>,
-                  <code>map:merge</code>, or <code>map:of-pairs</code> with the option <code>{ "ordering": "insertion" }</code>.</p>
+                  <p>A map with <xtermref spec="DM40" ref="dt-map-ordering-sorted">sorted</xtermref> 
+                     ordering can be created by applying the <function>map:sort</function> function.</p>
+                  <p>A map with <xtermref spec="DM40" ref="dt-map-ordering-insertion">insertion</xtermref> 
+                     ordering can be created by use of the functions <function>map:build</function>,
+                  <function>map:merge</function>, or <function>map:of-pairs</function> 
+                     with the option <code>{ "ordering": "insertion" }</code>.</p>
                </note>
 
       <example>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19240,7 +19240,7 @@ processing with JSON processing.</p>
     </p>
                
                <p>The <code>ordering</code> property of a map constructed using a map constructor expression
-               is <code>random</code>.</p>
+               is <code>undefined</code>.</p>
                
                <note>
                   <p>A map with <code>sorted</code> ordering can be created by applying the <code>map:sort</code>
@@ -19836,7 +19836,7 @@ processing with JSON processing.</p>
                               <p>The order of entries in the result sequence in this case 
                                  reflects the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>
                                  of the map. In the default case where the <code>ordering</code> of the
-                                 map is <code>random</code>, the order of entries in the result sequence 
+                                 map is <code>undefined</code>, the order of entries in the result sequence 
                                  is implementation-dependent.</p>
                            </note>
                         </item>
@@ -20479,7 +20479,7 @@ return $map?[?key ge 2]</eg>
             
             <note>
                <p>Filtering of maps based on numeric positions is not generally useful when
-                  the <code>ordering</code> of the map is <code>random</code>, 
+                  the <code>ordering</code> of the map is <code>undefined</code>, 
                   because the order of entries in a map is unpredictable; but it is available 
                   in the interests of orthogonality. </p>
             </note>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16816,7 +16816,7 @@ let $z := g($x, $y)]]></eg>
                <item><p>When a <nt def="ForItemBinding">ForEntryBinding</nt> is used (that is, when either
                   or both of the keywords <code>key</code> and <code>value</code> are used), 
                   the <code>key</code> range variable (if present) is bound in turn to each key in the map 
-                  (in <termref def="dt-implementation-dependent"/> order), and the <code>value</code>
+                  (in <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>), and the <code>value</code>
                   range variable (if present) is bound to the corresponding value.</p>
                   <p>In this case the corresponding <code>ExprSingle</code>
                   must evaluate to a single map, otherwise a type error is raised <errorref
@@ -19238,6 +19238,16 @@ processing with JSON processing.</p>
 
     
     </p>
+               
+               <p>The <code>ordering</code> property of a map constructed using a map constructor expression
+               is <code>random</code>.</p>
+               
+               <note>
+                  <p>A map with <code>sorted</code> ordering can be created by applying the <code>map:sort</code>
+                  function.</p>
+                  <p>A map with <code>fifo</code> ordering can be created by use of the functions <code>map:build</code>,
+                  <code>map:merge</code>, or <code>map:of-pairs</code> with the option <code>{ "ordering": "fifo" }</code>.</p>
+               </note>
 
       <example>
          <head>Constructing a fixed map</head>
@@ -19824,6 +19834,9 @@ processing with JSON processing.</p>
                               the result is the same as <code>$V?pairs::(map:keys($V))</code>.</p>
                           <note>
                               <p>The order of entries in the result sequence in this case 
+                                 reflects the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>
+                                 of the map. In the default case where the <code>ordering</code> of the
+                                 map is <code>random</code>, the order of entries in the result sequence 
                                  is implementation-dependent.</p>
                            </note>
                         </item>
@@ -20448,7 +20461,12 @@ return $array?[count(.) ge 2]</eg>
                The context position is the position of the entry in the map (in an arbitrary ordering),
                and the context size is the number of entries in the map. The result
                of the expression is a map containing those entries of the input map for which
-               the <termref def="dt-predicate-truth-value"/> of the <code><var>FILTER</var></code> expression is true.</p>
+               the <termref def="dt-predicate-truth-value"/> of the <code><var>FILTER</var></code> expression is true.
+               The <code>ordering</code> property of the result is the same as the <code>ordering</code>
+               property of the input map, and in the case of <code>sorted</code> or <code>fifo</code>
+               ordering the relative order of entries in the result retains the relative order of entries
+               in the input.
+            </p>
             
             <p>For example, the following expression:</p>
             
@@ -20460,8 +20478,10 @@ return $map?[?key ge 2]</eg>
             <eg>{ 2: "beta", 3: "gamma" }</eg>
             
             <note>
-               <p>Filtering of maps based on numeric positions is not generally useful, because the order of entries
-               in a map is unpredictable; but it is available in the interests of orthogonality. </p>
+               <p>Filtering of maps based on numeric positions is not generally useful when
+                  the <code>ordering</code> of the map is <code>random</code>, 
+                  because the order of entries in a map is unpredictable; but it is available 
+                  in the interests of orthogonality. </p>
             </note>
          </div3>
          

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19245,8 +19245,8 @@ processing with JSON processing.</p>
                <note>
                   <p>A map with <code>sorted</code> ordering can be created by applying the <code>map:sort</code>
                   function.</p>
-                  <p>A map with <code>fifo</code> ordering can be created by use of the functions <code>map:build</code>,
-                  <code>map:merge</code>, or <code>map:of-pairs</code> with the option <code>{ "ordering": "fifo" }</code>.</p>
+                  <p>A map with <code>insertion</code> ordering can be created by use of the functions <code>map:build</code>,
+                  <code>map:merge</code>, or <code>map:of-pairs</code> with the option <code>{ "ordering": "insertion" }</code>.</p>
                </note>
 
       <example>
@@ -20463,7 +20463,7 @@ return $array?[count(.) ge 2]</eg>
                of the expression is a map containing those entries of the input map for which
                the <termref def="dt-predicate-truth-value"/> of the <code><var>FILTER</var></code> expression is true.
                The <code>ordering</code> property of the result is the same as the <code>ordering</code>
-               property of the input map, and in the case of <code>sorted</code> or <code>fifo</code>
+               property of the input map, and in the case of <code>sorted</code> or <code>insertion</code>
                ordering the relative order of entries in the result retains the relative order of entries
                in the input.
             </p>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2132,7 +2132,7 @@ local:depth(doc("partlist.xml"))
   map:merge((
     { "r": $r },
     { "i": $i }
-  ), { "ordering" : "insertion" })
+  ), { "retain-order" : true() })
 };
        </eg>
       
@@ -2163,7 +2163,7 @@ local:depth(doc("partlist.xml"))
   map:merge((
     { "r": $r },
     if (exists($i)) { { "i": $i } }
-  ), { "ordering" : "insertion" })
+  ), { "retain-order" : true() })
 };
        </eg>
       
@@ -2192,7 +2192,7 @@ local:depth(doc("partlist.xml"))
     { "last": $last },
     $options
   ),
-  { "duplicates": "use-first", "ordering" : "insertion" }
+  { "duplicates": "use-first", "retain-order" : true() }
  };
       </eg>
       
@@ -2251,7 +2251,7 @@ local:depth(doc("partlist.xml"))
            <item><p>The optional final subexpression, if present, takes the form <code>$options</code>,
            where <code>$options</code> is the name allocated to the final parameter.</p></item>
            <item><p>The second argument in the call of the function <code>map:merge</code>
-           is the map <code>{ "duplicates": "use-first", "ordering": "insertion" }</code>.</p></item>
+           is the map <code>{ "duplicates": "use-first", "retain-order": true() }</code>.</p></item>
          </ulist>
        </item>  
  

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2143,7 +2143,7 @@ local:depth(doc("partlist.xml"))
       <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>, so the order of entries corresponds
       to the order of field declarations in the record type. This means, for example, that when
       the map is serialized using the JSON output method, the order of entries in the output will
-      be predictable.</p>
+      correspond to the order of field declarations.</p>
       
       <p>If a field is declared as optional, by including a question mark after the name, and if it has no initializer,
       then the initializer <code>:= ()</code> is added implicitly. If the declared type of an optional field does

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2132,12 +2132,18 @@ local:depth(doc("partlist.xml"))
   map:merge((
     { "r": $r },
     { "i": $i }
-  ))
+  ), { "ordering" : "insertion" })
 };
        </eg>
       
       <p>So the call <code>cx:complex(3, 2)</code> produces the value <code>{ "r": 3e0, "i": 2e0 }</code>,
       while the call <code>cx:complex(3)</code> produces the value <code>{ "r": 3e0, "i": 0e0 }</code></p>
+      
+      <p>The resulting map has its <xtermref spec="DM40" ref="dt-map-ordering"/> property set to
+      <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>, so the order of entries corresponds
+      to the order of field declarations in the record type. This means, for example, that when
+      the map is serialized using the JSON output method, the order of entries in the output will
+      be predictable.</p>
       
       <p>If a field is declared as optional, by including a question mark after the name, and if it has no initializer,
       then the initializer <code>:= ()</code> is added implicitly. If the declared type of an optional field does
@@ -2157,7 +2163,7 @@ local:depth(doc("partlist.xml"))
   map:merge((
     { "r": $r },
     if (exists($i)) { { "i": $i } }
-  ))
+  ), { "ordering" : "insertion" })
 };
        </eg>
       
@@ -2186,13 +2192,16 @@ local:depth(doc("partlist.xml"))
     { "last": $last },
     $options
   ),
-  { "duplicates": "use-first" }
+  { "duplicates": "use-first", "ordering" : "insertion" }
  };
       </eg>
       
       <p>The effect of the <code>duplicates</code> option here is that when two values are supplied for the same field,
       one as a direct argument in the function call and the other in the <code>options</code> map, the value supplied
-      as a direct argument is used in preference.</p>
+      as a direct argument is used in preference. The effect of the <code>ordering</code> option is that the resulting
+      map has an <xtermref spec="DM40" ref="dt-entry-order"/> in which the named fields appear first, in order of
+      declaration, followed by the extension entries supplied in <code>$options</code>, retaining the 
+        <xtermref spec="DM40" ref="dt-entry-order"/> of the <code>$options</code> map.</p>
       
       <p>If the name <code>options</code> is already in use for one of the fields, then the first available name from the
       sequence <code>("options1", "options2", ...)</code> is used instead for the additional function parameter.</p>
@@ -2242,8 +2251,7 @@ local:depth(doc("partlist.xml"))
            <item><p>The optional final subexpression, if present, takes the form <code>$options</code>,
            where <code>$options</code> is the name allocated to the final parameter.</p></item>
            <item><p>The second argument in the call of the function <code>map:merge</code>
-           is the map <code>{ "duplicates": "use-first" }</code>. This can be omitted if the record is not
-           extensible, because in this case duplicate field names cannot arise.</p></item>
+           is the map <code>{ "duplicates": "use-first", "ordering": "insertion" }</code>.</p></item>
          </ulist>
        </item>  
  
@@ -2272,6 +2280,13 @@ local:depth(doc("partlist.xml"))
              the constructed map will always have an entry for <code>altitude</code>.</p>
          </item>
        </ulist>
+      
+      <note>
+        <p>Although the constructor function for a named record type produces a map in which the
+        order of entries corresponds to the order of field declarations in the record type, the order
+        of entries in a map is immaterial when testing whether a map matches the record type: the entries
+        can be in any order.</p>
+      </note>
       
     </div3>
     <div3 id="id-functions-as-fields">

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2139,8 +2139,8 @@ local:depth(doc("partlist.xml"))
       <p>So the call <code>cx:complex(3, 2)</code> produces the value <code>{ "r": 3e0, "i": 2e0 }</code>,
       while the call <code>cx:complex(3)</code> produces the value <code>{ "r": 3e0, "i": 0e0 }</code></p>
       
-      <p>The resulting map has its <xtermref spec="DM40" ref="dt-map-ordering"/> property set to
-      <xtermref spec="DM40" ref="dt-map-ordering-insertion"/>, so the order of entries corresponds
+      <p>The resulting map has its <xtermref spec="DM40" ref="dt-map-ordered"/> property set to
+      <code>true</code>, so the order of entries corresponds
       to the order of field declarations in the record type. This means, for example, that when
       the map is serialized using the JSON output method, the order of entries in the output will
       correspond to the order of field declarations.</p>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1662,11 +1662,9 @@
       <e:attribute name="on-duplicates" required="no" default="error(xs:QName(err:XTDE3365))">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="ordering" default="undefined">
+      <e:attribute name="ordered" default="no">
          <e:attribute-value-template>
-            <e:constant value="undefined"/>
-            <e:constant value="sorted"/>
-            <e:constant value="insertion"/>
+            <e:data-type name="boolean"/>
          </e:attribute-value-template>
       </e:attribute>
       <e:model name="sequence-constructor"/>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1662,6 +1662,13 @@
       <e:attribute name="on-duplicates" required="no" default="error(xs:QName(err:XTDE3365))">
          <e:data-type name="expression"/>
       </e:attribute>
+      <e:attribute name="ordering" default="random">
+         <e:attribute-value-template>
+            <e:constant value="random"/>
+            <e:constant value="sorted"/>
+            <e:constant value="fifo"/>
+         </e:attribute-value-template>
+      </e:attribute>
       <e:model name="sequence-constructor"/>
       <e:allowed-parents>
          <e:parent-category name="sequence-constructor"/>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1666,7 +1666,7 @@
          <e:attribute-value-template>
             <e:constant value="random"/>
             <e:constant value="sorted"/>
-            <e:constant value="fifo"/>
+            <e:constant value="insertion"/>
          </e:attribute-value-template>
       </e:attribute>
       <e:model name="sequence-constructor"/>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1662,9 +1662,9 @@
       <e:attribute name="on-duplicates" required="no" default="error(xs:QName(err:XTDE3365))">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="ordering" default="random">
+      <e:attribute name="ordering" default="undefined">
          <e:attribute-value-template>
-            <e:constant value="random"/>
+            <e:constant value="undefined"/>
             <e:constant value="sorted"/>
             <e:constant value="insertion"/>
          </e:attribute-value-template>

--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -1127,6 +1127,9 @@ map.element =
       global.atts,
       sequence-constructor.model
    }
+# TODO: add @on-duplicates
+# TODO: add @ordering
+
 map-entry.element =
    element map-entry {
       extension.atts,

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -1143,7 +1143,9 @@ of problems processing the schema using various tools
       <xs:complexContent mixed="true">
         <xs:extension base="xsl:sequence-constructor">
           <xs:attribute name="on-duplicates" type="xsl:expression"/>
+          <xs:attribute name="ordering" type="xsl:avt"/>
           <xs:attribute name="_on-duplicates" type="xs:string"/>
+          <xs:attribute name="_ordering" type="xs:string"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35464,6 +35464,11 @@ the same group, and the-->
          
          <div2 id="map-instructions">
             <head>Map Instructions</head>
+            
+            <changes>
+               <change issue="564" PR="1609" date="2024-11-25">Ordered maps are introduced.</change>
+             </changes>
+            
             <p>Two instructions are added to XSLT to facilitate the construction of maps.</p>
 
             <?element xsl:map?>
@@ -35478,18 +35483,38 @@ the same group, and the-->
 
             <p><phrase diff="chg" at="2022-01-01">In the absense of duplicate keys,</phrase> the result of the instruction  
                is then given by the XPath 3.1 expression:</p>
-            <eg role="non-xml" xml:space="preserve">map:merge($maps)</eg>
+            <eg role="non-xml" xml:space="preserve">map:merge($maps, { 'ordering': $ordering })</eg>
+            
+            <p>where <code>$ordering</code> is the <termref def="dt-effective-value"/> of the <code>ordering</code>
+            attribute, defaulting to <code>"undefined"</code>.</p>
 
             <note>
                <p>Informally: <phrase diff="chg" at="2022-01-01">in the absence of duplicate keys</phrase> the resulting map contains
                   the union of the map entries from the supplied sequence of maps.</p>
             </note>
             
-            <p>If the <code>ordering</code> attribute is present then its <termref def="dt-effective-value"/> is used
-            as the value of the <code>ordering</code> option in the call to <code>map:merge</code>.</p>
             
             <note>
-               <p>The effect of the three different map ordering options is explained in <xspecref spec="DM40" ref="map-items"/>.</p>
+               <p>The effect of the three different map ordering options is explained 
+                  in <xspecref spec="DM40" ref="map-items"/>. In summary:</p>
+               <ulist>
+                  <item><p>The value <code>undefined</code> means that the order of entries
+                  in the map is <termref def="dt-implementation-dependent"/>; it may, for example,
+                  be the result of a randomized hashing algorithm.</p></item>
+                  <item><p>The value <code>sorted</code> means that the map maintains entries
+                  sorted in key order. If this option is chosen then it is required that the
+                  keys be mutually comparable: an error will result if there is a key whose
+                  data type does not define ordering (for example, <code>xs:QName</code>), or if
+                  there are two keys whose data types are not mutually comparable (for example,
+                  <code>xs:integer</code> and <code>xs:string</code>). Strings are sorted
+                  using the Unicode Codepoint Collation.</p></item>
+                  <item><p>The value <code>insertion</code> means that the map will retain entries
+                  in the order of the initial sequence that results from evaluation of the
+                  contained sequence constructor.</p></item>
+               </ulist>
+               <p>The selected ordering applies not only to the map that is returned from this
+               <elcode>xsl:map</elcode> instruction, but also to any maps that are subsequently derived
+               from this by adding or removing entries.</p>
             </note>
             
             <p>The handling of duplicate keys is described in <specref ref="duplicate-keys"/> below.</p>
@@ -35498,7 +35523,8 @@ the same group, and the-->
 
 
             <p>There is no requirement that the supplied input maps should have the same or
-               compatible types. The type of a map (for example <code>map(xs:integer,
+               compatible types, except for sorted maps where the keys must be comparable. 
+               The type of a map (for example <code>map(xs:integer,
                   xs:string)</code>) is descriptive of the entries it currently contains, but is not
                a constraint on how the map may be combined with other maps.</p>
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35483,10 +35483,10 @@ the same group, and the-->
 
             <p><phrase diff="chg" at="2022-01-01">In the absense of duplicate keys,</phrase> the result of the instruction  
                is then given by the XPath 3.1 expression:</p>
-            <eg role="non-xml" xml:space="preserve">map:merge($maps, { 'ordering': $ordering })</eg>
+            <eg role="non-xml" xml:space="preserve">map:merge($maps, { 'retain-order': $ordered })</eg>
             
-            <p>where <code>$ordering</code> is the <termref def="dt-effective-value"/> of the <code>ordering</code>
-            attribute, defaulting to <code>"undefined"</code>.</p>
+            <p>where <code>$ordered</code> is the <termref def="dt-effective-value"/> of the <code>ordered</code>
+            attribute, defaulting to <code>false</code>.</p>
 
             <note>
                <p>Informally: <phrase diff="chg" at="2022-01-01">in the absence of duplicate keys</phrase> the resulting map contains
@@ -35495,26 +35495,21 @@ the same group, and the-->
             
             
             <note>
-               <p>The effect of the three different map ordering options is explained 
+               <p>The effect of the <code>ordered</code> options is explained 
                   in <xspecref spec="DM40" ref="map-items"/>. In summary:</p>
                <ulist>
-                  <item><p>The value <code>undefined</code> means that the order of entries
+                  <item><p>The default value <code>no</code> means that the order of entries
                   in the map is <termref def="dt-implementation-dependent"/>; it may, for example,
                   be the result of a randomized hashing algorithm.</p></item>
-                  <item><p>The value <code>sorted</code> means that the map maintains entries
-                  sorted in key order. If this option is chosen then it is required that the
-                  keys be mutually comparable: an error will result if there is a key whose
-                  data type does not define ordering (for example, <code>xs:QName</code>), or if
-                  there are two keys whose data types are not mutually comparable (for example,
-                  <code>xs:integer</code> and <code>xs:string</code>). Strings are sorted
-                  using the Unicode Codepoint Collation.</p></item>
-                  <item><p>The value <code>insertion</code> means that the map will retain entries
-                  in the order of the initial sequence that results from evaluation of the
-                  contained sequence constructor.</p></item>
+                  
+                  <item><p>The value <code>yes</code> means that the order of entries
+                  in the returned map will reflect
+                  the order of items in the sequence that results from evaluation of the
+                  contained sequence constructor; furthermore, the map will have the
+                  property <code>ordered=true</code>, which means that new entries
+                  added using <xfunction>map:put</xfunction> will be added at the end.</p></item>
                </ulist>
-               <p>The selected ordering applies not only to the map that is returned from this
-               <elcode>xsl:map</elcode> instruction, but also to any maps that are subsequently derived
-               from this by adding or removing entries.</p>
+               
             </note>
             
             <p>The handling of duplicate keys is described in <specref ref="duplicate-keys"/> below.</p>
@@ -35523,7 +35518,7 @@ the same group, and the-->
 
 
             <p>There is no requirement that the supplied input maps should have the same or
-               compatible types, except for sorted maps where the keys must be comparable. 
+               compatible types.
                The type of a map (for example <code>map(xs:integer,
                   xs:string)</code>) is descriptive of the entries it currently contains, but is not
                a constraint on how the map may be combined with other maps.</p>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -35485,6 +35485,13 @@ the same group, and the-->
                   the union of the map entries from the supplied sequence of maps.</p>
             </note>
             
+            <p>If the <code>ordering</code> attribute is present then its <termref def="dt-effective-value"/> is used
+            as the value of the <code>ordering</code> option in the call to <code>map:merge</code>.</p>
+            
+            <note>
+               <p>The effect of the three different map ordering options is explained in <xspecref spec="DM40" ref="map-items"/>.</p>
+            </note>
+            
             <p>The handling of duplicate keys is described in <specref ref="duplicate-keys"/> below.</p>
 
   

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3455,7 +3455,7 @@ The key/value pairs in the serialized output retain the
   <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of entries in the map.</p>
   
   <note><p>The order is <termref def="impdep">implementation-dependent</termref> in
-  the default case where the <xtermref spec="DM40" ref="dt-ordering">ordering</xtermref>
+  the default case where the <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
   property of the map is <code>undefined</code>.</p></note>
 <!--<imp-dep-feature>When map items are serialized using the JSON
 output method, the order in which key/value pairs appear in the
@@ -3861,7 +3861,7 @@ for serializing an atomic item. The values are serialized in the same way as the
 </p>
 
 <note><p>The order of entries is <termref def="impdep">implementation-dependent</termref> in
-  the default case where the <xtermref spec="DM40" ref="dt-ordering">ordering</xtermref>
+  the default case where the <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
   property of the map is <code>undefined</code>.</p></note>
 </item>
 

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3456,7 +3456,7 @@ The key/value pairs in the serialized output retain the
   
   <note><p>The order is <termref def="impdep">implementation-dependent</termref> in
   the default case where the <xtermref spec="DM40" ref="dt-ordering">ordering</xtermref>
-  property of the map is <code>random</code>.</p></note>
+  property of the map is <code>undefined</code>.</p></note>
 <!--<imp-dep-feature>When map items are serialized using the JSON
 output method, the order in which key/value pairs appear in the
 serialized output is 
@@ -3862,7 +3862,7 @@ for serializing an atomic item. The values are serialized in the same way as the
 
 <note><p>The order of entries is <termref def="impdep">implementation-dependent</termref> in
   the default case where the <xtermref spec="DM40" ref="dt-ordering">ordering</xtermref>
-  property of the map is <code>random</code>.</p></note>
+  property of the map is <code>undefined</code>.</p></note>
 </item>
 
 <item><p>A <termref def="dt-function-item">function item</termref> is

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3451,13 +3451,16 @@ the <termref def="dt-string-value">string value</termref> of the key
 the serialized JSON value of the entry,
 separated by delimiters according to the JSON object 
 syntax, i.e. <code>{key:value, key:value, ...}</code>.
-The order in which each key/value pair appears 
-in the serialized output is 
-<termref def="impdep">implementation-dependent</termref>.</p>
-<imp-dep-feature>When map items are serialized using the JSON
+The key/value pairs in the serialized output retain the 
+  <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of entries in the map.</p>
+  
+  <note><p>The order is <termref def="impdep">implementation-dependent</termref> in
+  the default case where the <xtermref spec="DM40" ref="dt-ordering">ordering</xtermref>
+  property of the map is <code>random</code>.</p></note>
+<!--<imp-dep-feature>When map items are serialized using the JSON
 output method, the order in which key/value pairs appear in the
 serialized output is 
-<termref def="impdep">implementation-dependent</termref>.</imp-dep-feature>
+<termref def="impdep">implementation-dependent</termref>.</imp-dep-feature>-->
 <p>If any two keys of the map item have the same 
 <termref def="dt-string-value">string value</termref>,
 serialization error <errorref code="0022" class="RE"/> is raised,
@@ -3851,9 +3854,16 @@ to output parentheses around a singleton if this avoids buffering data in memory
 A <termref def="dt-map-item">map item</termref> is serialized using the syntax of a 
 <xspecref spec="XP40" ref="doc-xpath40-MapConstructor"/> without the optional <code>map</code>
 keyword, that is in the format <code>{key:value, key:value, ...}</code>.
-The order of entries is implementation-dependent. The key is serialized by applying the rules 
+The key/value pairs in the serialized output retain the 
+  <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of entries in the map.
+   The key is serialized by applying the rules 
 for serializing an atomic item. The values are serialized in the same way as the members of an array (see above).
-</p></item>
+</p>
+
+<note><p>The order of entries is <termref def="impdep">implementation-dependent</termref> in
+  the default case where the <xtermref spec="DM40" ref="dt-ordering">ordering</xtermref>
+  property of the map is <code>random</code>.</p></note>
+</item>
 
 <item><p>A <termref def="dt-function-item">function item</termref> is
 serialized to the representation <code>name#A</code> where 

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3455,8 +3455,8 @@ The key/value pairs in the serialized output retain the
   <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of entries in the map.</p>
   
   <note><p>The order is <termref def="impdep">implementation-dependent</termref> in
-  the default case where the <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
-  property of the map is <code>undefined</code>.</p></note>
+  the default case where the <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref>
+  property of the map is <code>false</code>.</p></note>
 <!--<imp-dep-feature>When map items are serialized using the JSON
 output method, the order in which key/value pairs appear in the
 serialized output is 
@@ -3861,8 +3861,8 @@ for serializing an atomic item. The values are serialized in the same way as the
 </p>
 
 <note><p>The order of entries is <termref def="impdep">implementation-dependent</termref> in
-  the default case where the <xtermref spec="DM40" ref="dt-map-ordering">ordering</xtermref>
-  property of the map is <code>undefined</code>.</p></note>
+  the default case where the <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref>
+  property of the map is <code>false</code>.</p></note>
 </item>
 
 <item><p>A <termref def="dt-function-item">function item</termref> is


### PR DESCRIPTION
Fix #564

Introduces ordered maps: specifically, sorted maps which return entries in order sorted by key, and fifo maps which return entries in the order of insertion.

Although this has been on the TODO-list for a long time and has many useful applications, raising a PR at this stage is particularly motivated by comments on the elements-to-maps() function pointing out that having a predictable order of properties in serialized JSON can be very useful, and that many existing XML-to-JSON converters achieve this. This gives the opportunity, for example, to parse JSON into a representation that retains input order, delete and/or add some properties, and then serializate the JSON with the order retained.