### PR TITLE
1606 Drop named item types, refine named record types, esp in XSLT

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -596,7 +596,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:choice>
       <g:ref name="VarDecl"/>
       <g:ref name="FunctionDecl"/>
-      <g:ref name="ItemTypeDecl"/>
+      <!--<g:ref name="ItemTypeDecl"/>-->
       <g:ref name="NamedRecordTypeDecl"/>
     </g:choice>
   </g:production>
@@ -762,12 +762,12 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="Rbrace"/>
   </g:production>
   
-  <g:production name="ItemTypeDecl" if="xquery40">
+  <!--<g:production name="ItemTypeDecl" if="xquery40">
     <g:string>type</g:string>
     <g:ref name="EQName"/>
     <g:string>as</g:string>
     <g:ref name="ItemType"/>
-  </g:production>
+  </g:production>-->
   
   <g:production name="NamedRecordTypeDecl" if="xquery40">
     <g:string>record</g:string>

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -420,8 +420,8 @@
          <p>It is a <termref def="dt-static-error">static error</termref> if an <termref
                def="dt-expanded-qname"/> used as an <nt def="ItemType"/>
                in a <nt def="SequenceType"/> is not defined
-            in the <termref def="dt-static-context"/> either as a <termref def="dt-named-item-type"/>
-            in the <termref def="dt-in-scope-named-item-types"/>,
+            in the <termref def="dt-static-context"/> either as a <termref def="dt-named-record-type"/>
+            in the <termref def="dt-in-scope-named-record-types"/>,
             or as a <termref def="dt-generalized-atomic-type"/>
             in the <termref def="dt-is-types"/>.</p>
       </error>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -765,30 +765,32 @@ inferred by static type inference as discussed in  <specref
 
                
                
-               <item diff="add" at="A">
+               <item>
                   <p>
 
-                     <termdef id="dt-in-scope-named-item-types" term="in-scope named item types">
-                        <term>In-scope named item types.</term> This is a mapping from 
+                     <termdef id="dt-in-scope-named-record-types" term="in-scope named record types">
+                        <term>In-scope named record types.</term> This is a mapping from 
                         <termref def="dt-expanded-qname">expanded QName</termref> to 
-                        <termref def="dt-named-item-type">named item types</termref>.</termdef></p>
-                   <p><termdef id="dt-named-item-type" term="named item type">A <term>named item type</term>
-                      is an <code>ItemType</code> identified by an <termref def="dt-expanded-qname"/>.</termdef>
+                        record types.</termdef></p>
+                   <p><termdef id="dt-named-record-type" term="named record type">A <term>named record type</term>
+                      is a <code>RecordType</code> identified by an <termref def="dt-expanded-qname"/>.</termdef>
                   </p>
-                  <p>Named item types serve two purposes:</p>
+                  <p>Named record types serve two purposes:</p>
                   <ulist>
-                     <item><p>They allow frequently used item types, especially complex item types such as
-                        record types, to be given simple names, to avoid repeating the definition 
+                     <item><p>They allow frequently used record types 
+                        to be given simple names, to avoid repeating the definition 
                         every time it is used.</p></item>
                      <item><p>They allow the definition of recursive types, which are useful for
                      describing recursive data structures such as lists and trees. For details see
                      <specref ref="id-recursive-record-tests"/>. </p></item>
                   </ulist>
                   <note>
-                     <p role="xquery">In XQuery, named item types can be declared in the Query Prolog.</p>
-                     <p role="xpath">Named item types can be defined in a <termref def="dt-host-language">host language</termref> 
+                     <p role="xquery">In XQuery, named record types can be declared in the Query Prolog.</p>
+                     <p role="xpath">Named record types can be defined in a <termref def="dt-host-language">host language</termref> 
                         such as XQuery 4.0 and in XSLT 4.0, but not in XPath 4.0 itself. They are available in XPath
                         only if the host language provides the ability to define them.</p>
+                     <p>Certain named record types defined in <bibref ref="xpath-functions-40"/>
+                     are always present in the static context.</p>
                   </note>
                </item>
 
@@ -4032,9 +4034,9 @@ the schema type named <code>us:address</code>.</p>
                <termref def="dt-in-scope-namespaces"/> in the <termref def="dt-static-context"/>. If the
                name is an unprefixed <code>NCName</code>, then it is expanded according to the
                   <termref def="dt-default-namespace-elements-and-types"/>.</p></item>
-               <item><p>If the name matches a <termref def="dt-named-item-type"/> in the <termref def="dt-static-context"/>,
-                  then it is taken as a reference to the corresponding item type. The rules that
-               apply are the rules for the expanded item type definition.</p></item>
+               <item><p>If the name matches a <termref def="dt-named-record-type"/> in the <termref def="dt-static-context"/>,
+                  then it is taken as a reference to the corresponding record type. The rules that
+               apply are the rules for the expanded record type definition.</p></item>
                <item><p>Otherwise, it must match the name of a type in the <termref def="dt-is-types">in-scope schema types</termref>
                   in the <termref def="dt-static-context"/>: specifically, an <termref def="dt-atomic-type"/>
                   or a <termref def="dt-pure-union-type"/>.
@@ -4126,8 +4128,8 @@ the schema type named <code>us:address</code>.</p>
                      <item><p>Using the QName of a type in the <termref def="dt-issd"/> that is an 
                         <termref def="dt-atomic-type"/>
                      or a <termref def="dt-pure-union-type"/>.</p></item>
-                     <item><p>Using a QName that identifies a <termref def="dt-named-item-type"/> that resolves
-                        to a <termref def="dt-generalized-atomic-type"/>.</p></item>
+                     <!--<item><p>Using a QName that identifies a <termref def="dt-named-item-type"/> that resolves
+                        to a <termref def="dt-generalized-atomic-type"/>.</p></item>-->
                      <item><p>Using a <nt def="ChoiceItemType">ChoiceItemType</nt> where every alternative
                         is itself a <termref def="dt-generalized-atomic-type"/>.</p></item>
                      <!--<item><p>Using a <nt def="LocalUnionType">LocalUnionType</nt> as described below.</p></item>-->
@@ -4433,7 +4435,7 @@ declare variable $orange-fruit as my:fruit := "orange";
                QName must identify a type in the <termref def="dt-issd"/>. This can be any <termref def="dt-schema-type"/>: either a simple type,
                or (except in the case of attributes) a complex type. If it is a simple type then it can be an atomic, union, or
                list type. It can be a built-in type (such as <code>xs:integer</code>) or a user-defined type. It must however
-               be the name of a type defined in a schema; it cannot be a <termref def="dt-named-item-type"/>.</p>
+               be the name of a type defined in a schema; it cannot be a <termref def="dt-named-record-type"/>.</p>
             
                <div4 id="id-simple-node-tests">
                   <head>Simple Node Tests</head>
@@ -5128,7 +5130,7 @@ name.</p>
             of <specref ref="id-itemtype-subtype"/>.</p>
             
             <div4 id="id-function-test">
-               <head>Function Type</head>
+               <head>Function Types</head>
                <changes>
                   <change issue="1192" PR="1197" date="2024-05-21">The keyword <code>fn</code> is allowed as a synonym for <code>function</code>
                   in function types, to align with changes to inline function declarations.</change>
@@ -5279,7 +5281,7 @@ name.</p>
             </div4>
 
             <div4 id="id-map-test">
-               <head>Map Type</head>
+               <head>Map Types</head>
                <scrap headstyle="show">
                   <head/>
                   <prodrecap id="MapType" ref="MapType"/>
@@ -5456,7 +5458,7 @@ name.</p>
             
             
             <div4 id="id-record-test" diff="add" at="A">
-               <head>Record Type</head>
+               <head>Record Types</head>
                
                <changes>
                   <change>
@@ -5470,17 +5472,28 @@ name.</p>
                      The syntax <code>record()</code> is allowed; the only thing it matches is an empty map.
                   </change>
                </changes>
+               
+               <p><termdef id="dt-record-type" term="record type">A <term>record type</term> is an
+               <termref def="dt-item-type"/> that places constraints on the entries that may appear in a
+               <termref def="dt-map"/>. Specifically, it may constrain the key values that can appear
+               in a map, and the types of the values associated with those keys.</termdef></p>
+               
+               <p>A <termref def="dt-record-type"/> may be defined using the following syntax:</p>
+               
                <scrap headstyle="show">
                   <head/>
                   <prodrecap id="RecordType" ref="RecordType"/>
                   <prodrecap id="AnyRecordType" ref="AnyRecordType"/>
                   <prodrecap id="TypedRecordType" ref="TypedRecordType"/>
                   <prodrecap id="FieldDeclaration" ref="FieldDeclaration"/>
-                  <prodrecap id="FieldName" ref="FieldName"/>
-                  <!--<prodrecap id="SelfReference" ref="SelfReference"/>  -->  
+                  <prodrecap id="FieldName" ref="FieldName"/> 
                   <prodrecap id="ExtensibleFlag" ref="ExtensibleFlag"/>    
                </scrap>
 
+               <note><p>The <nt def="RecordType">RecordType</nt> syntax shown here is not the only way
+               of designating a <termref def="dt-record-type"/>. For example, XSLT and XQuery provide additional
+               ways of designating record types; and some record types are supplied as built-in type definitions
+               in <bibref ref="xpath-functions-40"/>.</p></note>
               
                <p>A <nt def="RecordType">RecordType</nt> matches maps that meet specific criteria.</p>
 
@@ -5506,7 +5519,7 @@ name.</p>
                   <code>map(*)</code>: that is, it allows any map.</p></item>
                </ulist>
                
-               <p>A record type can constrain only those entries whose keys are strings, but when the record
+               <p>A <termref def="dt-record-type"/> can constrain only those entries whose keys are strings, but when the record
 		             type is marked as extensible, then other entries may be present in the map with either string or non-string keys.
 		             Entries whose key is a string can be expressed using an (unquoted) NCName if the key conforms to
 		             NCName syntax, or using a (quoted) string literal otherwise.</p>
@@ -5537,7 +5550,8 @@ name.</p>
                      documentary value.</p>
                </note>
                
-               <p>The names of the fields in a record type must be distinct <errorref class="ST" code="0021"/>.</p>
+               <p>The names of the fields in a <termref def="dt-record-type"/> 
+                  must be distinct <errorref class="ST" code="0021"/>.</p>
                
               
                
@@ -5551,7 +5565,7 @@ name.</p>
 		             execution.</p>
 
                <p>If a variable <code>$rec</code> is known to conform to a particular
-		             record type, then when a lookup expression <code>$rec?field</code> is used, (a) the processor
+		             <termref def="dt-record-type"/>, then when a lookup expression <code>$rec?field</code> is used, (a) the processor
 		             can report a type error if <code>$rec</code> cannot contain an entry with name <code>field</code>
                    (see <specref ref="id-implausible-lookup-expressions"/>),
 		             and (b) the processor can make static type inferences about the type of value returned by 
@@ -5563,8 +5577,10 @@ name.</p>
 		                this is a useful technique where the information to be supplied across the interface is highly
 		                variable. However, the type signature for such functions typically declares the argument type
 		                as <code>map(*)</code>, which gives very little information (and places very few constraints)
-		                on the values that are actually passed across. Using record types offers the possibility of
-		                improving this: for example, the options argument of <function>fn:parse-json</function>, previously
+
+		                on the values that are actually passed across. Using 
+                     <termref def="dt-record-type">record types</termref> offers the possibility of
+		                improving this: for example, the options argument of <code>fn:parse-json</code>, previously
 		                given as <code>map(*)</code>, can now be expressed as <code>record(liberal? as xs:boolean, 
 		                   duplicates? as xs:string, escape? as xs:boolean, fallback as fn(xs:string) as xs:string, *)</code>.
 		                In principle the <code>xs:string</code> type used to describe the <code>duplicates</code>
@@ -5572,7 +5588,7 @@ name.</p>
 		                of <code>xs:string</code> that enumerates the permitted values (<code>"reject"</code>,
 		                   <code>"use-first"</code>, <code>"use-last"</code>). 
 		                </p>
-                  <p>The use of a record type in the signature of such a function causes the 
+                  <p>The use of a <termref def="dt-record-type"/> in the signature of such a function causes the 
 		                   <termref def="dt-coercion-rules">coercion rules</termref>
 		                to be invoked. So, for example, if the function expects an entry in the map to be an <code>xs:double</code>
 		                value, it becomes possible to supply a map in which the corresponding entry has type <code>xs:integer</code>.</p>
@@ -5582,7 +5598,8 @@ name.</p>
                </note>
 
                <note>
-                  <p>One of the motivations for introducing record types is to enable better pattern matching
+                  <p>One of the motivations for introducing <termref def="dt-record-type">record types</termref> 
+                     is to enable better pattern matching
 		             in XSLT when processing JSON input. With XML input, patterns are often based
 		             around XML element names. JSON has no direct equivalent of XML’s element names; matching a JSON object
 		             such as <code>{longitude: 130.2, latitude: 53.4}</code> relies instead on recognizing the property
@@ -5591,7 +5608,7 @@ name.</p>
 		                <code>match="record(longitude, latitude)"</code></p>
                </note>
 
-               <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
+               <p>Rules defining whether one <termref def="dt-record-type"/> is a <termref def="dt-subtype"/> of another
                   are given in <specref ref="id-item-subtype-records"/>.</p>
 
             </div4>
@@ -5599,7 +5616,7 @@ name.</p>
             <div4 id="id-recursive-record-tests" diff="add" at="issue295">
                <head>Recursive Record Types</head>
                
-               <p>A named record type <var>N</var> is said to be recursive if its 
+               <p>A named <termref def="dt-record-type"/> <var>N</var> is said to be recursive if its 
                   definition includes a direct or indirect reference to <var>N</var>. 
                </p>
                
@@ -5618,13 +5635,14 @@ name.</p>
                
                
                
-               <p>Instances of recursive record types can be constructed and interrogated in the normal way.
+               <p>Instances of recursive <termref def="dt-record-type">record types</termref> 
+                  can be constructed and interrogated in the normal way.
                For example a list of length 3 can be constructed as:</p>
                <p><eg>{ "value": 1, "next": { "value": 2, "next": { "value": 3 } } }</eg></p>
                <p>and the third value in the map can be retrieved as <code>$list?next?next?value</code>.
                In practice, recursive data structures are usually manipulated using recursive functions.</p>
                
-               <p>It is possible to define a recursive record type that cannot be instantiated, because it
+               <p>It is possible to define a recursive <termref def="dt-record-type"/> that cannot be instantiated, because it
                has no finite instances: for example (in XQuery) <code>declare record X (next as X);</code>.
                Such a record declaration is <termref def="dt-implausible"/>, so the processor may
                treat it as an error <errorref class="ST" code="0023"/>, but it is not obliged to do so.</p>
@@ -5633,7 +5651,7 @@ name.</p>
                specification of the function <function>fn:random-number-generator</function>.</p></note>
                
                <p>Recursive type definitions need to be handled specially by the subtyping rules; 
-                  a naïve approach of simply replacing each reference to a named item type 
+                  a naïve approach of simply replacing each reference to a named record type 
                with its definition would make the assessment of the subtype relationship non-terminating.
                For details see <specref ref="id-itemtype-subtype"/>.</p>
                
@@ -6128,17 +6146,14 @@ declare record Particle (
                <p diff="chg" at="Issue451">The rules in this section apply to 
                   <termref def="dt-item-type">item types</termref>, not to 
                   <termref def="dt-item-type-designator">item type designators</termref>.
-                  For example, if the name <code>STR</code> has been defined in the
-                  static context as a <termref def="dt-named-item-type"/> referring to the type <code>xs:string</code>,
-                  then anything said here about the type <code>xs:string</code> applies equally
-                  whether it is designated as <code>xs:string</code> or as <code>STR</code>,
-                  or indeed as the parenthesized forms <code>(xs:string)</code> or
-                 <code>(STR)</code>.</p>
+                  For example, the parenthesized name <code>(xs:string)</code> designates the
+                  same type as <code>xs:string</code>, and anything said here about one form
+                  applies equally to the other.</p>
 
 
                
-               <p diff="chg" at="issue295">References to <termref def="dt-named-item-type">named item types</termref> 
-                  are handled as described in <specref ref="id-itemtype-subtype-aliases"/>.</p>            
+               <!--<p diff="chg" at="issue295">References to <termref def="dt-named-item-type">named item types</termref> 
+                  are handled as described in <specref ref="id-itemtype-subtype-aliases"/>.</p>            -->
                
                <p>The relationship <code>A ⊆ B</code> is true
                if and only if at least one of the conditions listed in the following subsections applies:</p>
@@ -6760,7 +6775,7 @@ declare record Particle (
                      <item diff="add" at="A">
                         <p>All of the following are true:</p>
                         <olist>
-                           <item><p><var>A</var> is a record type.</p></item>
+                           <item><p><var>A</var> is a <termref def="dt-record-type"/>.</p></item>
                            <item><p><var>B</var> is <code>map(*)</code> or <code>record(*)</code>.</p></item>
                         </olist>
                         <example>
@@ -6774,7 +6789,7 @@ declare record Particle (
                      <item diff="add" at="A">
                         <p>All of the following are true:</p>
                         <olist>
-                           <item><p><var>A</var> is a non-extensible record type</p></item>
+                           <item><p><var>A</var> is a non-extensible <termref def="dt-record-type"/></p></item>
                            <item><p><var>B</var> is <code>map(<var>K</var>, <var>V</var>)</code></p></item>
                            <item><p><var>K</var> is either <code>xs:string</code> or <code>xs:anyAtomicType</code></p></item>
                            <item><p>For every field <var>F</var> in <var>A</var>,
@@ -6793,8 +6808,8 @@ declare record Particle (
                      <item diff="add" at="A">
                         <p>All of the following are true:</p>
                         <olist>
-                           <item><p><var>A</var> is a non-extensible record type.</p></item>
-                           <item><p><var>B</var> is a non-extensible record type.</p></item>
+                           <item><p><var>A</var> is a non-extensible <termref def="dt-record-type"/>.</p></item>
+                           <item><p><var>B</var> is a non-extensible <termref def="dt-record-type"/>.</p></item>
                            <item><p>Every field in <var>A</var> is also declared in <var>B</var>.</p></item>
                            <item><p>Every mandatory field in <var>B</var> is also declared  as mandatory in <var>A</var>.</p></item>
                            <item><p>For every field that is declared in both <var>A</var> and <var>B</var>,
@@ -6814,8 +6829,8 @@ declare record Particle (
                         <item diff="add" at="A">
                            <p>All of the following are true:</p>
                            <olist>
-                              <item><p><var>A</var> is an extensible record type</p></item>
-                              <item><p><var>B</var> is an extensible record type</p></item>
+                              <item><p><var>A</var> is an extensible <termref def="dt-record-type"/>.</p></item>
+                              <item><p><var>B</var> is an extensible <termref def="dt-record-type"/>.</p></item>
                               <item><p>Every mandatory field in <var>B</var> is also declared  as mandatory in <var>A</var>.</p></item>
                               <item><p>For every field that is declared in both <var>A</var> and <var>B</var>,
                                  where the declared type in <var>A</var> is <var>T</var> 
@@ -6839,8 +6854,8 @@ declare record Particle (
                      <item diff="add" at="A">
                         <p>All of the following are true:</p>
                         <olist>
-                           <item><p><var>A</var> is a non-extensible record type.</p></item>
-                           <item><p><var>B</var> is an extensible record type.</p></item>
+                           <item><p><var>A</var> is a non-extensible <termref def="dt-record-type"/>.</p></item>
+                           <item><p><var>B</var> is an extensible <termref def="dt-record-type"/>.</p></item>
                            <item><p>Every mandatory field in <var>B</var> is also declared as mandatory in <var>A</var>.</p></item>
                            <!--<item><p>Every field that is declared in <var>B</var> with a type other than <code>item()*</code>
                               is also declared in <var>A</var>.</p></item>-->
@@ -6862,18 +6877,16 @@ declare record Particle (
                   </olist>
                </div4>
                <div4 id="id-itemtype-subtype-aliases" diff="add" at="issue295">
-                  <head>Named Item Types</head>
-                  <p>This section describes how references to <termref def="dt-named-item-type">named item types</termref>
+                  <head>Named Record Types</head>
+                  <p>This section describes how references to <termref def="dt-named-record-type">named record types</termref>
                   are handled when evaluating the subtype relationship.</p>
-                  <p>Named item types can be classified as recursive or non-recursive. 
-                     A recursive type is one that references itself, directly or indirectly. Only named record
-                  types are allowed to be recursive.</p>
-                  <p>In the case of references to non-recursive named item types, the reference
-                  is fully expanded as the first step in evaluating the subtype relationship. For example
-                  this means that if <var>U</var> is a named item type with the expansion 
-                     <code>(xs:integer | xs:double)</code>,
-                     then <code>xs:integer ⊆ U</code> is true, because 
-                     <code>xs:integer ⊆ (xs:integer | xs:double)</code> is true.</p>
+                  <p>Named record types can be classified as recursive or non-recursive. 
+                     A recursive type is one that references itself, directly or indirectly.</p>
+                  <p>In the case of references to non-recursive named record types, the reference
+                  can be fully expanded as the first step in evaluating the subtype relationship. For example
+                  this means that if <var>U</var> is a named record type with the expansion 
+                     <code>record(first as xs:string, *)</code>,
+                     then <code>record(first as xs:string, last as xs:string) ⊆ U</code> is true.</p>
                   <p>Recursive record types are considered to be, in the terminology of the computer science
                   literature, <term>iso-recursive</term> (rather than <term>equi-recursive</term>). 
                      This means that a recursive type name is not
@@ -6889,13 +6902,13 @@ declare record Particle (
                         <var>A</var> ⊆ <var>B</var> is true if and only if 
                         <var>A</var> and <var>B</var>
                         are references to the same named record type.</p></item>
-                     <item><p>If <var>A</var> is a reference to a recursive named item type, then
+                     <item><p>If <var>A</var> is a reference to a recursive record type, then
                         <var>A</var> ⊆ <var>B</var> is true if either:</p>
                         <ulist>
                            <item><p><var>A</var> and <var>B</var>
                               are references to the same named record type.</p></item>
                            <item><p><code>record(*) ⊆ B</code>.</p>
-                           <note><p>This is because only record types are allowed to be recursive.</p></note></item>
+                           </item>
                         </ulist>
                      </item>
                   </ulist>
@@ -21639,9 +21652,9 @@ atomized value of the input expression is called the <term>input type</term>.
 The target type must be a <termref def="dt-generalized-atomic-type"/>. In practice
                this means it may be any of:</p>
             <ulist>
-               <item diff="add" at="issue688"><p>The name of an <termref def="dt-named-item-type">named item type</termref>
+               <!--<item diff="add" at="issue688"><p>The name of an <termref def="dt-named-item-type">named item type</termref>
                defined in the <termref def="dt-static-context"/>, which in turn must refer to an item
-               type in one of the following categories.</p></item>
+               type in one of the following categories.</p></item>-->
                <item><p>The name of a type defined in the  <termref def="dt-is-types">in-scope schema types</termref>, 
                   which must be a simple type (of variety atomic, list or union) <errorref class="ST" code="0052"/> .
                   In addition, the target type cannot be <code>xs:NOTATION</code>, <code>xs:anySimpleType</code>,
@@ -21821,11 +21834,8 @@ else $x cast as xs:string]]></eg>
                and can be found in <xspecref spec="FO40" ref="constructor-functions"/>.</p>
             
             
-               <p>There is also a constructor function for every <termref def="dt-named-item-type"/> 
-               in the <termref def="dt-static-context"/>
-            that expands either to a <termref def="dt-generalized-atomic-type"/> 
-            <phrase diff="add" at="issue617">or to
-            a <nt def="RecordType">RecordType</nt></phrase>.</p> 
+               <p>There is also a constructor function for every <termref def="dt-named-record-type"/> 
+               in the <termref def="dt-static-context"/>.</p> 
             
                <p>All such constructor functions are classified as
                <termref def="dt-system-function">system functions</termref>.</p>
@@ -21896,14 +21906,14 @@ expression <code
 usa:zipcode?)</code>.</p>
                   <eg role="parse-test"><![CDATA[usa:zipcode("12345")]]></eg>
                </item>
-               <item>
+               <!--<item>
                   <p>If <code>my:chrono</code> is a named item type that expands to
                      <code>(xs:date | xs:time | xs:dateTime)</code>, then the result
                      of <code>my:chrono("12:00:00Z")</code> is the <code>xs:time</code>
                      value <code>12:00:00Z</code>.</p>
-               </item>
+               </item>-->
                <item diff="add" at="issue617">
-                  <p>If <code>my:location</code> is a named item type that expands
+                  <p>If <code>my:location</code> is a named record type that expands
                   to <code>record(latitude as xs:double, longitude as xs:double)</code>,
                   then the result of <code>my:location(50.52, -3.02)</code> is
                   the map <code>{ 'latitude': 50.52e0, 'longitude': -3.02e0 }</code>.</p>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2127,7 +2127,7 @@ local:depth(doc("partlist.xml"))
       
         <note><p>A reference to a named record type
         cannot (in general) be directly replaced by the corresponding record definition during parsing. This is 
-        because forwards references and self-references are allowed; replacing the name by the 
+        because forward references and self-references are allowed; replacing the name by the 
         definition is a process that might not terminate.</p></note>
       
         <p>A recursive record type will only be instantiable if every field whose value may contain instances of the record type

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -698,11 +698,11 @@ return (
     <p>
       <termdef term="module import" id="dt-module-import">A <term>module import</term> imports the
         public variable declarations, public function declarations<phrase diff="add" at="A">, 
-          and public item type declarations</phrase> from one or more <termref
+          and public record type declarations</phrase> from one or more <termref
           def="dt-library-module">library modules</termref> into the <termref
           def="dt-statically-known-function-definitions"/>, <termref
           def="dt-in-scope-variables">in-scope variables</termref><phrase diff="add" at="A">,
-          or <termref def="dt-in-scope-named-item-types"/></phrase> of the importing <termref
+          or <termref def="dt-in-scope-named-record-types"/></phrase> of the importing <termref
           def="dt-module">module</termref>.</termdef> Each module import names a <termref
         def="dt-target-namespace">target namespace</termref> and imports an <termref
         def="dt-implementation-defined">implementation-defined</termref> set of modules that share
@@ -711,23 +711,31 @@ return (
         namespaces</termref>, and it may provide optional hints for locating the modules to be
       imported.</p>
 
-    <p>If a module <var>A</var> imports module <var>B</var>, the static context of module
+    <p>If a module <var>A</var> imports module <var>B</var>, then:</p>
+      
+      <ulist>
+        <item><p>The static context of module
       <var>A</var> will contain the <termref
         def="dt-statically-known-function-definitions"/>, <termref
-          def="dt-in-scope-variables">in-scope variables</termref><phrase diff="add" at="A">,
-            or <termref def="dt-in-scope-named-item-types"/></phrase> of
-      module <var>B</var>, and the dynamic context of module <var>A</var> will contain the
-        public <termref def="dt-variable-values">variable values</termref> and <termref
-        def="dt-dynamically-known-function-definitions"/> of module <var>B</var>. It will
-      not contain:</p>
-    
-    <ulist>
-      <item><p>Private functions, variables, and item types declared in <var>B</var>.</p></item>
+          def="dt-in-scope-variables">in-scope variables</termref>,
+            and <termref def="dt-in-scope-named-record-types"/> of
+      module <var>B</var> (including constructor functions associated with
+      <termref def="dt-in-scope-named-record-types"/>)</p></item>
+        <item><p>The static context of <var>A</var> will not contain:</p>
+        <ulist>
+      <item><p>Private functions, variables, and record types declared in <var>B</var>.</p></item>
       <item><p>Functions, variables, and item types not
       declared directly in <var>B</var>, but imported from some other library module.</p></item>
       <item><p>Other components such as <termref def="dt-issd">in-scope schema definitions</termref> or <termref
         def="dt-static-namespaces">statically known namespaces</termref> declared in <var>B</var>.</p></item>
     </ulist>
+        
+        </item>
+      <item><p>The dynamic context of module <var>A</var> will contain the
+        public <termref def="dt-variable-values">variable values</termref> and <termref
+        def="dt-dynamically-known-function-definitions"/> of module <var>B</var>.</p></item>
+      </ulist>
+    
 
     <p>The following example illustrates a module import:</p>
 
@@ -774,8 +782,15 @@ return (
       module <var>A</var> does not have access to the functions and
       variables declared in module <var>C</var>. </p>
     
- 
-
+    <p>A module may import public variable and function declarations that are defined using named record types
+    which are not themselves imported, either because the type definitions are private, or because they are defined
+    in a module that is not itself imported. In such a case the importing module may reference the variable
+    or function in question, but it cannot reference the named record type used in the declaration of the
+    variable or function.</p>
+    
+    <p>Similarly, a module may import public variable and function declarations that are defined using
+    schema types that are not themselves imported.</p>
+    
     <example>
       <head>Schema Information and Module Import</head>
 
@@ -848,8 +863,8 @@ $triangle</eg>
       <p>If one module contains an <code>import module</code> declaration with the target namespace
           <code>M</code>, then all public variables and public functions in the contexts of modules
         whose target namespace is <code>M</code> must be accessible in the importing module,
-        regardless whether the participation of the imported module was directly due to this "import
-        module" declaration.</p>
+        regardless whether the participation of the imported module was directly due to this <code>import
+        module</code> declaration.</p>
 
     </div3>
 
@@ -857,7 +872,7 @@ $triangle</eg>
     <div3 id="id-module-handling-location-uris">
       <head>Location URIs</head>
 
-      <p>The term “location URIs” refers to the URIs in the <code>at</code> clause of an
+      <p>The term <term>location URIs</term> refers to the URIs in the <code>at</code> clause of an
         <code>import module</code> declaration.</p>
 
       <p>Products should (by default or at user option) take account of all the location URIs in an
@@ -1937,7 +1952,7 @@ local:depth(doc("partlist.xml"))
     </div3>
   </div2>
   
-  <div2 id="id-item-type-declaration" diff="add" at="A">
+  <!--<div2 id="id-item-type-declaration" diff="add" at="A">
     <head>Item Type Declarations</head>
     
     <p>An item type declaration defines a name for an <termref def="dt-item-type"/>. Defining a name for an item type
@@ -2028,13 +2043,16 @@ local:depth(doc("partlist.xml"))
     in public function and variable declarations are themselves public.</p></note>
     
     
-  </div2>
+  </div2>-->
   
   <div2 id="id-named-record-types">
     <head>Named Record Types</head>
-    <p>Although item type declarations, as described in <specref ref="id-item-type-declaration"/>, can be
-    used to give names to record types as well as any other item type, named record types as described
-    in this section provide a more concise syntax, plus additional functionality. In particular:</p>
+    <p>A record type declaration defines a name representing a <termref def="dt-record-type"/>. 
+      Defining a name for a record type
+    allows it to be referenced by name rather than repeating
+    the <termref def="dt-item-type-designator"/> in full.</p>
+    
+    <p>Named record types also introduce additional capability beyond anonymous record types:</p>
     
     <ulist>
       <item><p>Named record types can be recursive.</p></item>
@@ -2056,12 +2074,11 @@ local:depth(doc("partlist.xml"))
       <prodrecap ref="FieldName"/>
     </scrap>
     
-    <p>A named record declaration serves as both a <termref def="dt-named-item-type"/> and as a 
-      <termref def="dt-function-definition"/>, and
-      it therefore inherits rules from both these roles. In particular:</p>
+    <p>The name appearing in a record declaration serves as both an item type and as a 
+      function name, and it therefore inherits rules from both these roles. In particular:</p>
             
     <olist>
-       <item><p>Its name must not be the same as the name of any other named item type, or any
+       <item><p>Its name must not be the same as the name of any other <termref def="dt-named-record-type"/>, or any
          generalized atomic type, that is present in the same static context <errorref class="ST" code="0048"/>.</p></item>
        <item><p>If the declaration appears within a <termref def="dt-library-module"/> then its name
        must be in the <termref def="dt-target-namespace"/> of the library module <errorref class="ST" code="0048"/>.
@@ -2088,13 +2105,14 @@ local:depth(doc("partlist.xml"))
       <head>Named Records as Item Types</head>
     
       
-      <p>As a named item type declaration, the construct:</p>
+      <p>Given the record type declaration:</p>
         
         <eg>declare record cx:complex(r as xs:double, i as xs:double := 0);</eg>
       
-        <p>is equivalent to:</p>
+        <p>it becomes possible to use the name <code>cx:complex</code> effectively as a synonym for the
+          item type:</p>
         
-        <eg>declare type cx:complex as record(r as xs:double, i as xs:double);</eg>
+        <eg>record(r as xs:double, i as xs:double)</eg>
         
         <p>Any initializing expressions for fields are ignored for this purpose.</p>
       
@@ -2103,14 +2121,14 @@ local:depth(doc("partlist.xml"))
         of the type, and it does not affect the result of retrieval operations such as the lookup operator.</p></note>
       
         
-        <p>There is however one significant difference: the name of a named record declaration is available throughout the static
+        <p>The name of a named record declaration is available throughout the static
           context of the module in which it is declared, including within the record declaration itself. This means that
           named record declarations can be self-recursive or mutually recursive.</p>
       
-        <note><p>Unlike a named item type declared using <code>declare type</code>, a reference to a named record type
-        cannot (in general) be directly replaced by the corresponding record definition during parsing. This is not only
-        because forwards references are allowed; it is also because a recursive record type cannot be expressed using
-        the usual <nt def="RecordType"/> syntax.</p></note>
+        <note><p>A reference to a named record type
+        cannot (in general) be directly replaced by the corresponding record definition during parsing. This is 
+        because forwards references and self-references are allowed; replacing the name by the 
+        definition is a process that might not terminate.</p></note>
       
         <p>A recursive record type will only be instantiable if every field whose value may contain instances of the record type
         (directly or indirectly) is optional or emptiable. Specifically, it must either be an optional field, or its type

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -94,7 +94,7 @@
          <e:constant value="attribute-set"/>
          <e:constant value="variable"/>
          <e:constant value="mode"/>
-         <e:constant value="item-type"/>
+         <e:constant value="record-type"/>
          <e:constant value="*"/>
       </e:attribute>
       <e:attribute name="names" required="yes">
@@ -120,7 +120,7 @@
          <e:constant value="attribute-set"/>
          <e:constant value="variable"/>
          <e:constant value="mode"/>
-         <e:constant value="item-type"/>
+         <e:constant value="record-type"/>
          <e:constant value="*"/>
       </e:attribute>
       <e:attribute name="names" required="yes">
@@ -835,24 +835,42 @@
       </e:allowed-parents>
    </e:element-syntax>
    
-   <e:element-syntax name="item-type">
+   <e:element-syntax name="record-type">
       <e:in-category name="declaration"/>
       <e:attribute name="name" required="yes">
          <e:data-type name="eqname"/>
-      </e:attribute>
-      <e:attribute name="as">
-         <e:data-type name="item-type"/>
       </e:attribute>
       <e:attribute name="visibility">
          <e:constant value="private"/>
          <e:constant value="final"/>
       </e:attribute>
-      <e:empty/>
+      <e:attribute name="extensible">
+         <e:data-type name="boolean"/>
+      </e:attribute>
+      <e:sequence>
+         <e:element name="field" repeat="zero-or-more"/>
+      </e:sequence>
       <e:allowed-parents>
          <e:parent name="package"/>
          <e:parent name="stylesheet"/>
          <e:parent name="transform"/>
       </e:allowed-parents>
+   </e:element-syntax>
+   
+   <e:element-syntax name="field">
+      <e:attribute name="name" required="yes">
+         <e:data-type name="NCName"/>
+      </e:attribute>
+      <e:attribute name="as" required="no" default="item()*">
+         <e:data-type name="sequence-type"/>
+      </e:attribute>
+      <e:attribute name="required" required="no" default="yes">
+         <e:data-type name="boolean"/>
+      </e:attribute>
+      <e:attribute name="default" required="no" default="()">
+         <e:data-type name="expression"/>
+      </e:attribute>
+      <e:empty/>
    </e:element-syntax>
 
    <e:element-syntax name="function">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -134,7 +134,7 @@
             published on 8 June 2017. Changes are presented in <specref ref="whats-new-in-xslt4"/>. </p>
          <p>XSLT 4.0 is designed to be used in conjunction with XPath 4.0, which is defined in
                <bibref ref="xpath-40"/>. XSLT shares the same data model as XPath 4.0, which is
-            defined in <bibref ref="xpath-datamodel-30"/>, and it uses the library of functions and
+            defined in <bibref ref="xpath-datamodel-40"/>, and it uses the library of functions and
             operators defined in <bibref ref="xpath-functions-40"/>. XPath 4.0 and the underlying
             function library introduce a number of enhancements, for example the availability of
             union and record types. </p>
@@ -178,7 +178,7 @@
                HTML, XHTML, or SVG. However, XSLT is used for a wide range of transformation tasks,
                not exclusively for formatting and presentation applications.</p>
             <p>A transformation expressed in XSLT describes rules for transforming input data into output data. The inputs and outputs
-                  will all be instances of the XDM data model, described in <bibref ref="xpath-datamodel-30"/>. In the simplest and most common case, the input is
+                  will all be instances of the XDM data model, described in <bibref ref="xpath-datamodel-40"/>. In the simplest and most common case, the input is
                   an XML document referred to as the source document or <termref def="dt-source-tree">source tree</termref>, and the output is an XML document
                   referred to as the <termref def="dt-result-tree">result tree</termref>. It is also possible to process multiple source
                   documents, to generate multiple result documents, and to handle formats other than
@@ -275,7 +275,7 @@
                   performs the functions of an <termref def="dt-processor">XSLT processor</termref>
                   is referred to as an <term>implementation</term>.</termdef></p>
             <p>
-               <termdef id="dt-tree" term="tree">The term <term>tree</term> is used (as in <bibref ref="xpath-datamodel-30"/>) to refer to the aggregate consisting of a
+               <termdef id="dt-tree" term="tree">The term <term>tree</term> is used (as in <bibref ref="xpath-datamodel-40"/>) to refer to the aggregate consisting of a
                   parentless node together with all its descendant nodes, plus all their attributes
                   and namespaces.</termdef>
             </p>
@@ -294,14 +294,14 @@
             <olist>
                <item>
                   <p><termdef id="dt-principal-result" term="principal result">A <term>principal
-                           result</term>: this can be any sequence of items (as defined in <bibref ref="xpath-datamodel-30"/>).</termdef> The principal result is the value
+                           result</term>: this can be any sequence of items (as defined in <bibref ref="xpath-datamodel-40"/>).</termdef> The principal result is the value
                      returned by the function or template in the stylesheet that is nominated as the
                      entry point, as described in <specref ref="initiating"/>.</p>
                </item>
                <item>
                   <p><termdef id="dt-secondary-result" term="secondary result">Zero or more
                            <term>secondary results</term>: each secondary result can be any sequence
-                        of items (as defined in <bibref ref="xpath-datamodel-30"/>).</termdef> A
+                        of items (as defined in <bibref ref="xpath-datamodel-40"/>).</termdef> A
                      secondary result is the value returned by evaluating the body of an
                         <elcode>xsl:result-document</elcode> instruction.</p>
                </item>
@@ -396,7 +396,8 @@
                that allow the user to influence the behavior.</p>
             <p>A paragraph labeled as a <term>Note</term> or described as an <term>example</term> is
                non-normative.</p>
-            <p>Many terms used in this document are defined in the XPath specification <bibref ref="xpath-30"/> or the XDM specification <bibref ref="xpath-datamodel-30"/>.
+            <p>Many terms used in this document are defined in the XPath specification <bibref ref="xpath-40"/> 
+               or the XDM specification <bibref ref="xpath-datamodel-40"/>.
                Particular attention is drawn to the following:</p>
             <ulist>
                <item>
@@ -405,7 +406,7 @@
                         is defined in <!--<bibref ref="xpath-30"/>--><xspecref spec="XP40" ref="id-atomization"/>. It is a process that takes as input a sequence of
                            items, and returns a sequence of
                         atomic items, in which the nodes are replaced by their typed values as
-                        defined in <bibref ref="xpath-datamodel-30"/>. 
+                        defined in <bibref ref="xpath-datamodel-40"/>. 
                         <phrase diff="del" at="2022-01-01">If the XPath 3.1 feature is implemented,
                         then</phrase> Arrays (see <specref ref="arrays"/>) are atomized by atomizing their
                         members, recursively.</termdef> For some items (for example, elements with element-only
@@ -3659,7 +3660,9 @@
                <p>The components which can be declared in one package and
                   referenced in another are: <termref def="dt-stylesheet-function">functions</termref>, <termref def="dt-named-template">named
                      templates</termref>, <termref def="dt-attribute-set">attribute sets</termref>,
-                     <termref def="dt-mode">modes</termref>,  and <termref def="dt-global-variable">global variables</termref> and <termref def="dt-stylesheet-parameter">parameters</termref>.</p>
+                     <termref def="dt-mode">modes</termref>, <termref def="dt-global-variable">global variables</termref> 
+                  and <termref def="dt-stylesheet-parameter">parameters</termref>, 
+                  and <termref def="dt-named-record-type">named record types</termref></p>
 
                <p>In addition, <termref def="dt-key">keys</termref> and <termref def="dt-accumulator">accumulators</termref>
                   are classified as named components because they can contain references to
@@ -3721,7 +3724,9 @@
                <ulist>
                   <item>
                      <p>A component defined in one package can be overridden by a component in
-                        another package, provided the signatures are type-compatible.</p>
+                        another package, provided the signatures are type-compatible.
+                       This does not apply to <termref def="dt-named-record-type">named record types</termref>,
+                       which cannot be overridden.</p>
                   </item>
                   <item>
                      <p>The author of a package can declare whether the components in the package
@@ -3747,7 +3752,13 @@
 
                <p><termdef id="dt-component" term="component">The term <term>component</term> is
                      used to refer to any of the following: a <termref def="dt-stylesheet-function">stylesheet function</termref>, a <termref def="dt-named-template">named
-                        template</termref>, a <termref def="dt-mode">mode</termref>, an <termref def="dt-accumulator-function">accumulator</termref>, an <termref def="dt-attribute-set">attribute set</termref>, a <termref def="dt-key">key</termref>, <termref def="dt-global-variable">global variable</termref>, or a <termref def="dt-mode">mode</termref>.</termdef></p>
+                        template</termref>, a <termref def="dt-mode">mode</termref>, 
+                     an <termref def="dt-accumulator-function">accumulator</termref>, 
+                  an <termref def="dt-attribute-set">attribute set</termref>, 
+                  a <termref def="dt-key">key</termref>, 
+                  a <termref def="dt-global-variable">global variable</termref>,
+                  a <termref def="dt-named-record-type"/>,
+                  or a <termref def="dt-mode">mode</termref>.</termdef></p>
 
                <p><termdef id="dt-symbolic-identifier" term="symbolic identifier">The <term>symbolic
                         identifier</term> of a <termref def="dt-component">component</termref> is a
@@ -4075,7 +4086,7 @@
 
                   <p>The visibility of a 
                      named template, function, variable, attribute set, mode,
-                     <phrase diff="add" at="2024-01-12">or named item type</phrase>
+                     <phrase diff="add" at="2024-01-12">or named record type</phrase>
                      declared within a package is the first of the following that applies, subject to consistency
                      constraints which are defined below:</p>
 
@@ -4196,6 +4207,14 @@
                            only when the component declaration has an explicit
                               <code>visibility</code> attribute, and the component is also listed
                            explicitly by name in an <elcode>xsl:expose</elcode> declaration.)</p>
+                     </error>
+                  </p>
+                  
+                  <p>
+                     <error spec="XT" type="static" class="SE" code="3015">
+                        <p>It is a <termref def="dt-static-error">static error</termref> if the
+                           explicit exposed visibility of a <termref def="dt-named-record-type"/>
+                           component is anything other than <code>private</code> or <code>final</code>.</p>
                      </error>
                   </p>
 
@@ -4376,6 +4395,15 @@
                         <p>It is a <termref def="dt-static-error">static error</termref> if the 
                            <code>component</code> attribute of <elcode>xsl:accept</elcode> specifies <code>*</code>
                            (meaning all component kinds) and the <code>names</code> attribute is not a wildcard.</p>
+                     </error>
+                  </p>
+                  
+                  <p>
+                     <error spec="XT" type="static" class="SE" code="3032">
+                        <p>It is a <termref def="dt-static-error">static error</termref> if an 
+                           <elcode>xsl:accept</elcode> declaration attempts to set the 
+                           <code>visibility</code> of a <termref def="dt-named-record-type"/>
+                           to anything other than <code>final</code>, <code>private</code>, or <code>hidden</code>.</p>
                      </error>
                   </p>
 
@@ -4836,10 +4864,10 @@
                         </item>
                         
                         <item>
-                           <p>Except where recursive types are involved, a named item type
-                           (declared in an <elcode>xsl:item-type</elcode> declaration) is considered
+                           <p>Except where recursive types are involved, a named record type
+                           (declared in an <elcode>xsl:record-type</elcode> declaration) is considered
                            identical to its expansion. With recursive types, the same type names must
-                           be used. By implication, the named type must itself be declared or exposed
+                           be used. By implication, the named record type must itself be declared or exposed
                            with <code>visibility="final"</code>.</p>
                         </item>
                      </olist>
@@ -5809,7 +5837,12 @@
             <div3 id="packages-csv-library-example">
                <head>Worked Example of a Library Package</head>
 
-
+               <note>
+                  <p>XSLT 4.0 provides built-in functions for parsing CSV files (for example
+                  the functions <xfunction>parse-csv</xfunction> and <xfunction>csv-to-xml</xfunction>
+                  that should not be confused with the functionality defined by this example. The
+                  example pre-dates the XSLT 4.0 capabilities.</p>
+               </note>
 
 
 
@@ -6528,9 +6561,6 @@ and <code>version="1.0"</code> otherwise.</p>
                   <elcode>xsl:include</elcode>
                </sitem>
                <sitem>
-                  <elcode>xsl:item-type</elcode>
-               </sitem>
-               <sitem>
                   <elcode>xsl:key</elcode>
                </sitem>
                <sitem>                 
@@ -6547,6 +6577,9 @@ and <code>version="1.0"</code> otherwise.</p>
                </sitem>
                <sitem>
                   <elcode>xsl:preserve-space</elcode>
+               </sitem>
+               <sitem>
+                  <elcode>xsl:record-type</elcode>
                </sitem>
                <sitem>
                   <elcode>xsl:strip-space</elcode>
@@ -10546,12 +10579,15 @@ and <code>version="1.0"</code> otherwise.</p>
                                  contains entries with keys <code>"first"</code> and <code>"last"</code>. </p>
                            </item>
                            <item>
-                              <p><code>type(complex)</code> matches any value that is an instance of the item type declared in an <elcode>xsl:item-type</elcode>
-                                 declaration with name <code>"complex"</code></p>
+                              <p><code>type(my:complex)</code> matches any value that is an instance of the <xtermref spec="XP40" ref="dt-record-type"/> 
+                                 declared in an <elcode>xsl:record-type</elcode>
+                                 declaration with name <code>my:complex</code></p>
                            </item>
                            <item>
-                              <p><code>type(complex)[?i eq 0]</code> matches any value that is an instance of the item type declared in an <elcode>xsl:item-type</elcode>
-                                 declaration with name <code>"complex"</code> and that is a map with an entry having key <code>i</code> and value zero.</p>
+                              <p><code>type(my:complex)[?i eq 0]</code> matches any value that is an instance of the 
+                                 <xtermref spec="XP40" ref="dt-record-type"/> declared in an <elcode>xsl:record-type</elcode>
+                                 declaration with name <code>my:complex</code> and that is a map 
+                                 with an entry having key <code>i</code> and value zero.</p>
                            </item>
                         </olist>
                      </item>
@@ -11118,26 +11154,30 @@ and <code>version="1.0"</code> otherwise.</p>
             </div3>
             
          </div2>
-         <div2 id="named-item-types" diff="add" at="2022-01-01">
-            <head>Defining Named Item Types</head>
+         <div2 id="named-record-types" diff="add" at="2024-11-27">
+            <head>Defining Named Record Types</head>
             
             <changes>
-               <change date="2022-01-01">
-                  Named item types can be declared using the new <elcode>xsl:item-type</elcode>
-                  element. This is designed to avoid repeating lengthy type definitions (for example
-                  function types and record types) every time they are used. [This feature was
-                  present in the editor's draft presented to the WG when it started work.]
+               <change issue="1606" date="2024-11-27">
+                  Named record types can be declared using the new <elcode>xsl:record-type</elcode>
+                  element. This is designed to avoid repeating lengthy type definitions; it also
+                  allows recursive record types to be defined.
                </change>
             </changes>
             
-            <?element xsl:item-type?>
+            <?element xsl:record-type?>
+            <?element xsl:field?>
             
-            <p>An <elcode>xsl:item-type</elcode> declaration associates a name with an item type, and allows the type
-            to be referenced by name throughout the stylesheet package.</p>
+            <p>An <elcode>xsl:record-type</elcode> declaration associates a name with a 
+               <xtermref spec="XP40" ref="dt-record-type"/>, and allows the 
+               record type to be referenced by name throughout the stylesheet package.</p>
             <example id="e-item-type-complex">
-               <p>The following example declares a named item type for complex numbers, and uses it in a variable
+               <p>The following example declares a named record type for complex numbers, and uses it in a variable
                   declaration and a function declaration.</p>
-               <eg><![CDATA[<xsl:item-type name="cx:complex" as="record(r as xs:double, i as xs:double)"/>
+               <eg><![CDATA[<xsl:record-type name="cx:complex">
+  <xsl:field nmae="r" as="xs:double" required="yes"/>
+  <xsl:field nmae="i" as="xs:double" required="no"/>
+</xsl:record>
 
 <xsl:variable name="i" as="cx:complex" select="cx:complex(0, 1)"/>
 
@@ -11147,48 +11187,75 @@ and <code>version="1.0"</code> otherwise.</p>
   <xsl:sequence select="cx:complex($x?r + $y?r, $x?i + $y?i)"/>
 </xsl:function>
                   ]]></eg>
-               <p>Note how the item type declaration has implicitly declared a constructor function
-                  <code>cx:complex</code> that can be used to create instances of the item type;
+               <p>Note how the record type declaration has implicitly declared a constructor function
+                  <code>cx:complex</code> that can be used to create instances of the record type;
                   details of this mechanism are at <xspecref spec="XP40" ref="id-constructor-functions"/>.</p>
             </example>
-            <p>Using named item types makes the stylesheet more readable, and improves potential for change: a change
+            
+            <p><termref def="dt-named-record-type" term="named record type">An <elcode>xsl:record-type</elcode> 
+               declaration defines a <term>named record type</term> that may be referenced within any
+            <code>SequenceType</code> or <code>ItemType</code> within the containing stylesheet package,
+            for example in the <code>as</code> attributes of the declarations of functions, templates,
+            and global variables.</termref>.</p>
+            
+            <p><error spec="XT" type="static" class="SE" code="4050"><p>It is a <termref def="dt-static-error"/> 
+               if the names of the fields in an <elcode>xsl:record-type</elcode>
+               declaration are not distinct.</p></error></p>
+            
+            <p>In addition, the <elcode>xsl:record-type</elcode> declaration defines a constructor function 
+               of the same name that is added to the static context. This imposes additional requirements:</p>
+            
+            <ulist>
+               <item><p>The name of the record type must be in a namespace.</p></item>
+               <item><p>The name of each field of the record type must be an <code>xs:NCName</code>.</p></item>
+            </ulist>
+            
+            <p>Using named record types makes the stylesheet more readable, and improves potential for change: a change
             to the way complex numbers are implemented in this example is less likely to affect users of the function
-            library. However, named item types do not provide true encapsulation or information hiding; users of the 
+            library. However, named record types do not provide true encapsulation or information hiding; users of the 
             function library can still treat complex numbers as raw maps if they wish.</p>
-            <p>The <elcode>xsl:item-type</elcode> declaration adds an entry to the 
-               <xtermref spec="XP40" ref="dt-in-scope-named-item-types"/>
+            
+            <p>The <elcode>xsl:record-type</elcode> declaration adds an entry to the 
+               <xtermref spec="XP40" ref="dt-in-scope-named-record-types"/>
             component of the static context for XPath expressions, and also becomes available for use wherever
             XSLT allows an <code>ItemType</code> to appear.</p>
-            <p>The scope of a named item type is the <termref def="dt-package"/> in which it is declared. If it
+            
+            <p>The scope of a named record type is the <termref def="dt-package"/> in which it is declared. If it
             is declared with <code>visibility="final"</code> then it also becomes available for use in using
-            packages. Named item types cannot be overridden in a using package, so the only permitted values for
+            packages. Named record types cannot be overridden in a using package, so the only permitted values for
             <code>visibility</code> are <code>private</code> and <code>final</code>.</p>
-            <p>The name of the item type is the expanded name formed by resolving the <code>name</code> attribute.
+            
+            <p>The name of the record type is the expanded name formed by resolving the <code>name</code> attribute.
             A lexical QName with no prefix is treated as a no-namespace name.</p>
-            <p>If two <elcode>xsl:item-type</elcode> declarations in a <termref def="dt-package"/> have the same
+            
+            <p>If two <elcode>xsl:record-type</elcode> declarations in a <termref def="dt-package"/> have the same
             name, then the one with higher <termref def="dt-import-precedence"/> is used. </p>
             <p><error spec="XT" type="static" class="SE" code="4030">
                <p>It is a <termref def="dt-static-error">static error</termref> if a package contains two 
-                  <elcode>xsl:item-type</elcode>
+                  <elcode>xsl:record-type</elcode>
                   declarations having the same <termref def="dt-import-precedence">import
                      precedence</termref>, unless there is another definition of the same
-                  item type with higher import precedence.</p>
+                  record type with higher import precedence.</p>
             </error></p>
-            <p diff="add" at="issue295">An item type declaration may refer directly or indirectly to itself if
-               it satisfies the conditions defined in <xspecref spec="XP40" ref="id-recursive-record-tests"/>.
+            
+            <p diff="add" at="issue295">A record type declaration may refer directly or indirectly to itself.
             This allows types to be declared that match recursive data structures such as linked lists
             and trees.</p>
-            <p><error spec="XT" type="static" class="SE" code="4035">
+            
+            <p>A named record type with visibility <code>private</code> may be used in the definition of
+            a component (such as a variable, a function, a template, or another named record type) that is itself
+            <code>public</code>. Another package may reference such a component even though it cannot reference
+            the types used in its definition.</p>
+            
+            <!--<p><error spec="XT" type="static" class="SE" code="4035">
                <p>It is a <termref def="dt-static-error">static error</termref> for an item type named
                   <var>N</var> to contain in its <code>as</code> attribute a reference to <var>N</var>,
                   or to an item type that references <var>N</var> directly or indirectly, unless it satisfies
                   the conditions defined in <xspecref spec="XP40" ref="id-recursive-record-tests"/>.</p>
-            </error></p>
-            <p>TODO: add named item types to xsl:accept and xsl:expose. Clarify that when a function or variable
-            is exported to a different package, its declared type/signature uses the expanded form of any named
-            item type; there is no requirement for the using package to know the named item types. But it becomes
-            easier to use the exposed variables and functions if the names of the types are exposed too.</p>
+            </error></p>-->
+            
          </div2>
+         
          <div2 id="defining-decimal-format">
             <head>Defining a Decimal Format</head>
             
@@ -12690,11 +12757,15 @@ and <code>version="1.0"</code> otherwise.</p>
 ]</eg>
                <p>The following template rules are used. The setting <code>expand-text="yes"</code> is assumed:</p>
                <eg><![CDATA[
-<xsl:item-type name="book" as="record(Title, Authors, Category, *)"/>                  
+<xsl:record-type name="eg:book" extensible="yes">
+  <xsl:field name="Title"/>
+  <xsl:field name="Authors"/>
+  <xsl:field name="Category"/>
+</xsl:record>
 <xsl:template name="xsl:initial-template">
   <xsl:apply-templates select="parse-json('input.json')"/>
 </xsl:template>  
-<xsl:template match="array(book)">
+<xsl:template match="array(eg:book)">
   <h1>Christmas Book Selection</h1>
   <table>
     <thead>
@@ -12710,7 +12781,7 @@ and <code>version="1.0"</code> otherwise.</p>
     </tbody>
   </table>
 </xsl:template>
-<xsl:template match="type(book)">
+<xsl:template match="type(eg:book)">
   <tr>
     <td>{?Title}</td>
     <td>{?Authors?* => string-join(", ")}</td>
@@ -17730,7 +17801,7 @@ and <code>version="1.0"</code> otherwise.</p>
                      <td rowspan="1" colspan="1"><termref def="dt-absent">Absent</termref></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">In-scope named item types</td>
+                     <td rowspan="1" colspan="1">In-scope named record types</td>
                      <td rowspan="1" colspan="1">None</td>
                   </tr>
                   <tr>


### PR DESCRIPTION
Fix #1606
Fix #1506
Fix #1485

This PR drops the general concept of declaring named item types in XQuery and XSLT, and focuses on declaring named record types. The rules for named record types are tidied up editorially in XQuery (for example there is a clearer distinction between the syntax production `RecordType` and the concept of a record type, which can be declared either using that syntax, or otherwise). In XSLT the `<xsl:item-type>` declaration is dropped and an `<xsl:record-type>` declaration is introduced.