### PR TITLE
1628 Clarify rules for XQuery version declaration

### DIFF
--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -74,48 +74,66 @@
       encoding.</termdef></p>
 
       
-      <p><termdef id="dt-version-number" term="XQuery version number">An <term>XQuery version number</term> consists of two integers 
-        separated by a dot. The first integer is referred to as the <term>major version number</term>; the second as the 
-        <term>minor version number</term>.</termdef> <phrase diff="add" at="2023-10-19">An <term>integer</term> 
-          here means a sequence of decimal digits with no sign or other punctuation.</phrase></p>
-    
       
-  
-      <p>Any XQuery processor that implements any version of XQuery with a given major number must accept any query with 
-      the same major version number. The processor may reject
-      queries labeled with a different major version number. The processor may reject queries with the 
-      same major version number and a greater minor version number than the processor recognizes.</p>
+      <p><termdef id="dt-version-number" term="XQuery version number">An <term>XQuery version number</term> 
+        consists of two integers, referred to as the 
+        <term>major version number</term> and the  <term>minor version number</term>.</termdef></p>
     
-      <note diff="add" at="2023-10-19"><p>The version numbers <code>4.01</code> and <code>4.1</code> are equivalent: 
-        both have a major number of 4 and a minor number of 1. Version <code>4.10</code> by the same reasoning
-        has a higher minor number than version <code>4.2</code>.</p></note>
-
+      <p>The version number is written as a <code>StringLiteral</code> following the <code>version</code>
+      keyword, and in a conformant &language; query it <rfc2119>must</rfc2119> match the regular expression 
+      <code>[1-9][0-9]*\.[0-9]</code>: for example <code>"4.0"</code>. The major version is the integer 
+        preceding the dot (which must be written without any leading zero); the minor version is the
+      integer after the dot (which must be a single digit).</p>
+    
+      <note>
+        <p>XQuery 1.0 and 3.0 allowed the version number to be any string; XQuery 3.1 constrained it
+        to consist of two integers separated by a dot. This left it unclear, for example,
+        whether "3.01" was the same version number as "3.1", or whether "3.10" represented a higher version
+        than "3.2". In 4.0 the rules have therefore been made stricter, to avoid any ambiguity.</p>
+      </note>
+    
+      <p>If the version declaration is not
+      present or the version is not included in the declaration, an
+      XQuery 4.0 processor assumes a version of "4.0", unless configured otherwise using
+      some external mechanism.</p>
+    
+      <p>The version number "4.0" indicates the intent that the module
+      be processed by an <termref def="dt-xquery-40-processor">XQuery
+        4.0 processor</termref>.</p>
+    
+      <p>An &language; processor must accept a module in which the version number is given as
+      "1.0", "3.0", or "3.1". It is then <termref def="dt-implementation-defined"/> whether
+      the module is processed using the syntax and semantics of the &language; specification, or the rules
+      of the relevant earlier version. For example, if a query module specifies version <code>"3.0"</code>
+      but contains a call to the <code>parse-html</code> function, the processor at its option can
+      either raise an error, or process the function call according to the &language; specification.</p>
+    
+      <p>The &language; specification does not attempt to define the semantics of a query in which
+      different modules use different version numbers. One approach is to process all modules as if
+      they specified version "4.0". Another approach (which may be appropriate if modules
+      are separately compiled) is to process each module using its own version number; but it is then
+      <termref def="dt-implementation-defined"/> what happens if (say) a 3.1 module imports a 
+      4.0 library module that declares a function with a signature that 3.1 does not recognize.</p>
+    
+      <p>A conformant &language; processor <rfc2119>may</rfc2119> raise an error if the version number is anything
+      other than "1.0", "3.0", "3.1", or "4.0". If the processor does not raise an error, the effect of such
+      a query is <termref def="dt-implementation-defined"/>.</p>
+    
+      <note>
+        <p>The effect of this rule is to permit the use of non-standard version numbers to
+        label non-standard extensions of the XQuery language. It also leaves flexibility as
+        to how an &language; processor should handle future version numbers such as "4.1",
+        or version numbers such as "1" or "3.00" that were permitted by earlier XQuery
+        specifications.</p>
+      </note>
+  
       <p>If a query is rejected because of a version mismatch with the processor, a static error  
       <errorref code="0031" class="ST"/> must be raised.</p>
       
-      <note><p>The processor is allowed to provide an option to require that minor versions also match,
-        or that the minor number of the version in the query is not larger than the largest minor version 
-        understood by the processor in this major release of XQuery, or to allow more permissive version 
-        matching, perhaps with warnings, but the behavior is then outside the scope of this specification.</p></note>
-
-    <p>The version number “4.0” indicates the intent that the module
-      be processed by an <termref def="dt-xquery-40-processor">XQuery
-        4.0 processor</termref>.</p>
-        
-     <p>Similarly, the version number “1.0” indicates the intent that the module
-      be processed by an <termref def="dt-xquery-10-processor">XQuery
-      1.0 processor</termref>, “3.0” an <termref
-      def="dt-xquery-30-processor" >XQuery 3.0 processor</termref>, 
-      and “3.1” an <termref def="dt-xquery-31-processor">XQuery
-      3.1 processor</termref>.</p>
+      
     
-    <p>If the version declaration is not
-      present or the version is not included in the declaration, an
-      XQuery 4.0 processor assumes a version of “4.0”.</p>
     
-    <note diff="add" at="2023-10-19"><p>This does not preclude the use of an external API or other configuration
-    mechanism that instructs a piece of software to behave as an XQuery 4.0 processor.</p></note>
-
+    
       
 
 


### PR DESCRIPTION
Fix #1628

Hopefully the new rules are clearer. They were motivated by a couple of test cases using weird version numbers such as "4.00".