### PR TITLE
Two minor corrections of `minus-sign` spec

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -1219,7 +1219,7 @@ constructor, as described in <specref
                         <item>
                            <p>
                               <termdef id="id-static-decimal-format-minus-sign" term="minus-sign">
-                                 <term>minus-sign</term> is the single character used to mark negative numbers; the
+                                 <term>minus-sign</term> is the string used to mark negative numbers; the
                                  default value is <char>U+002D</char>.</termdef>
                            </p>
                         </item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11368,7 +11368,7 @@ and <code>version="1.0"</code> otherwise.</p>
                </item>
                <item>
                   <p>
-                     <code>minus-sign</code> specifies the string used to represent a negative
+                     <code>minus-sign</code> specifies the string used to mark a negative
                      number; the default value is <char>U+002D</char>.</p>
                </item>
             </ulist>


### PR DESCRIPTION
Per #1250, `minus-sign` is now a string rather than a single character.

This change:

 - corrects that in one place where it was still said to be a character
 - changes the formulation from "represent" to "mark" a negative number.

Sorry for opening a branch in this repo. I did this accidentally, omitting the fork that I originally wanted to create.