### PR TITLE
Abbreviate suffixes on cross-spec links

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -284,7 +284,7 @@ for transition to Proposed Recommendation. </p>'>
                 cross-document links in this document. Each such link consists of a pointer to a
                 specific section followed a superscript specifying the linked document. The
                 superscripts have the following meanings: XQ <bibref ref="xquery-40"/>, XT <bibref ref="xslt-40"/>,
-            XP <bibref ref="xpath-40"/>, and DM <bibref ref="xpath-datamodel-31"/>.</p>
+            XP <bibref ref="xpath-40"/>, and DM <bibref ref="xpath-datamodel-40"/>.</p>
          
          <div2 id="operators" diff="add" at="2022-12-20">
             <head>Operators</head>
@@ -12662,7 +12662,7 @@ currently, Version 9.0.0.
                <!--<bibl  id="xquery-30"
                      key="XQuery 3.0: An XML Query Language"/>-->
                <bibl  id="xquery-40"
-                     key="XQuery 4.1: An XML Query Language">
+                     key="XQuery 4.0: An XML Query Language">
                  <emph>CITATION: T.B.D.</emph>
                </bibl>
                <!--<bibl  id="xmlschema-1"

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -141,8 +141,8 @@
          <p>
             <emph>This document contains hyperlinks to specific sections or definitions within other
                documents in this family of specifications. These links are indicated visually by a
-               superscript identifying the target specification: for example XP40 for XPath 4.0,
-               DM40 for the XDM data model version 4.0, FO40 for Functions and Operators version
+               superscript identifying the target specification: for example XP for XPath 4.0,
+               DM for the XDM data model version 4.0, FO for Functions and Operators version
                4.0.</emph>
          </p>
          

--- a/specifications/xslt-40/style/xslt.xsl
+++ b/specifications/xslt-40/style/xslt.xsl
@@ -773,12 +773,12 @@ constructor. These elements are:</p>
   <xsl:variable name="link" select="translate(if (contains($fname, '#')) then substring-before($fname, '#') else $fname, ':', '-')"/>
   <xsl:variable name="vn" select="if (@spec eq 'FO31') then '31' else if (@spec eq '30') then '30' else '40'"/>
   <xsl:variable name="baseuri"
-                select="if ($vn = '40')
-                        then 'https://www.w3.org/TR/xpath-functions'
-                        else 'https://qt4cg.org/specifications/xpath-functions'"/>
+                select="if ($vn = '40')                       
+                        then 'https://qt4cg.org/specifications/xpath-functions'
+                        else 'https://www.w3.org/TR/xpath-functions'"/>
   <a href="{$baseuri}-{$vn}/#func-{$link}">
     <code><xsl:value-of select="."/></code>
-  </a><sup><small><xsl:value-of select="(@spec, 'FO40')[1]"/></small></sup>
+  </a><sup><small><xsl:value-of select="(@spec, 'FO')[1]"/></small></sup>
 </xsl:template>
   
   <xsl:template match="termref">

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -743,7 +743,7 @@
     <xsl:variable name="div" select="$doc//*[@id=$ref]"/>
     <xsl:variable name="nt" select="($doc//*[@def=$ref])[1]"/>
     <xsl:variable name="uri" select="replace($doc/document-summary/@uri, '^http:', 'https:')"/>
-
+    <xsl:variable name="shortSpec" select="replace(@spec, '40$', '')"/>
     <xsl:choose>
       <xsl:when test="$div">
         <xsl:variable name="linktext">
@@ -770,7 +770,7 @@
         </xsl:choose>
         <sup>
           <small>
-            <xsl:value-of select="@spec"/>
+            <xsl:value-of select="$shortSpec"/>
           </small>
         </sup>
       </xsl:when>
@@ -787,7 +787,7 @@
         </xsl:choose>
         <sup>
           <small>
-            <xsl:value-of select="@spec"/>
+            <xsl:value-of select="$shortSpec"/>
           </small>
         </sup>
       </xsl:when>
@@ -804,7 +804,7 @@
         </xsl:choose>
         <sup>
           <small>
-            <xsl:value-of select="@spec"/>
+            <xsl:value-of select="$shortSpec"/>
           </small>
         </sup>
       </xsl:when>
@@ -855,7 +855,7 @@
     -->
     <xsl:variable name="nt" select="($doc//prod[@id=$ref], $doc//prod[.=$ref], $doc//nt[@def=$ref])[1]"/>
     <xsl:variable name="uri" select="replace($doc/document-summary/@uri, '^http:', 'https:')"/>
-
+    <xsl:variable name="shortSpec" select="replace(@spec, '40$', '')"/>
     <xsl:choose>
       <xsl:when test="contains(@spec, 'XP') and not($nt)">
         <!-- XP and XQ are a special case -->
@@ -879,7 +879,7 @@
         </xsl:choose>
         <sup>
           <small>
-            <xsl:value-of select="@spec"/>
+            <xsl:value-of select="$shortSpec"/>
           </small>
         </sup>
       </xsl:when>
@@ -906,7 +906,7 @@
         </xsl:choose>
         <sup>
           <small>
-            <xsl:value-of select="@spec"/>
+            <xsl:value-of select="$shortSpec"/>
           </small>
         </sup>
       </xsl:when>
@@ -929,7 +929,7 @@
         </xsl:choose>
         <sup>
           <small>
-            <xsl:value-of select="@spec"/>
+            <xsl:value-of select="$shortSpec"/>
           </small>
         </sup>
       </xsl:otherwise>
@@ -1002,6 +1002,7 @@
         <xsl:variable name="doc" select="document(concat('../build/etc/', @spec, '.xml'))"/>
         <xsl:variable name="termdef" select="$doc//termdef[@id=$ref]"/>
         <xsl:variable name="uri" select="replace($doc/document-summary/@uri, '^http:', 'https:')"/>
+        <xsl:variable name="shortSpec" select="replace(@spec, '40$', '')"/>
 
         <xsl:choose>
           <xsl:when test="not($termdef)">
@@ -1035,7 +1036,7 @@
             </xsl:choose>
             <sup>
               <small>
-                <xsl:value-of select="@spec"/>
+                <xsl:value-of select="$shortSpec"/>
               </small>
             </sup>
           </xsl:when>
@@ -1052,7 +1053,7 @@
             </xsl:choose>
             <sup>
               <small>
-                <xsl:value-of select="@spec"/>
+                <xsl:value-of select="$shortSpec"/>
               </small>
             </sup>
           </xsl:otherwise>


### PR DESCRIPTION
Stylesheet change for cross-spec links (xspecref, xnt, xtermref) to drop the redundant "40" version suffix - for example the suffix becomes DM rather than DM40, since the vast majority of links will point to the 4.0 version of the document.