### PR TITLE
1652 Use function markup

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -33,8 +33,8 @@
    <fos:record-type id="uri-structure-record" extensible="true">
       <fos:field name="uri" type="xs:string?" required="false">
          <fos:meaning>
-            <p>The original URI. This element is returned by <code>fn:parse-uri</code>,
-            but ignored by <code>fn:build-uri</code>.</p>
+            <p>The original URI. This element is returned by <function>fn:parse-uri</function>,
+            but ignored by <function>fn:build-uri</function>.</p>
          </fos:meaning>
       </fos:field>
       <fos:field name="scheme" type="xs:string?" required="false">
@@ -154,7 +154,7 @@
          <fos:meaning>
             <p>For a simple type, a function item that can be used to construct instances of this type. In the case of a named
              type that is present in the dynamic context, the result is the same function as returned by 
-               <code>fn:function-lookup</code> applied to the type name (with arity one). For details see <specref ref="constructor-functions-for-xsd-types"/>
+               <function>fn:function-lookup</function> applied to the type name (with arity one). For details see <specref ref="constructor-functions-for-xsd-types"/>
                and <specref ref="constructor-functions-for-user-defined-types"/>. 
                Constructor function items are also available for
                anonymous types, and for types that might not be present in the dynamic context. 
@@ -205,7 +205,7 @@
             <code>xs:integer</code> value, and its associated value is a function
             item obtained as if by evaluating a named function reference
             <code>Q#N</code>, using the static and dynamic context of the call on
-            <code>fn:load-xquery-module</code>. The function item can be invoked
+            <function>fn:load-xquery-module</function>. The function item can be invoked
             using the rules for dynamic function invocation.</p>
          </fos:meaning>         
       </fos:field>
@@ -287,7 +287,7 @@
       <fos:field name="rows" type="array(xs:string)*" required="true">
          <fos:meaning><p>This entry is a sequence of arrays of strings, holding the parsed
                   rows of the CSV data. The format is the same as the result of the
-                  <code>fn:csv-to-arrays</code> function, except that the first row
+                  <function>fn:csv-to-arrays</function> function, except that the first row
                   is omitted in the case where the <code>header</code>
                   option is <code>true</code>. If there are no data rows in the CSV, the
                   value will be an empty sequence.</p></fos:meaning>
@@ -382,7 +382,7 @@
             <code>xs:integer</code> value, and its associated value is a function
             item obtained as if by evaluating a named function reference
             <code>Q#N</code>, using the static and dynamic context of the call on
-            <code>fn:load-xquery-module</code>. The function item can be invoked
+            <function>fn:load-xquery-module</function>. The function item can be invoked
             using the rules for dynamic function invocation.</p>
          </fos:meaning>         
       </fos:field>
@@ -654,7 +654,7 @@ $node ! (
                <olist>
                   <item><p>For each item in <code>$value</code>, construct a string representing its item type
                   as described below.</p></item>
-                  <item><p>Eliminate duplicate strings from this list by applying the <code>fn:distinct-values</code>
+                  <item><p>Eliminate duplicate strings from this list by applying the <function>fn:distinct-values</function>
                   function, forming a sequence of strings <var>$ss</var>.</p></item>
                   <item><p>If <var>$ss</var> contains only one string, use that string.</p></item>
                   <item><p>Otherwise, return the result of the expression <code>`({fn:string-join(<var>$ss</var>, "|")})`</code>.</p></item>
@@ -960,7 +960,7 @@ $node ! (
          <p>If the argument is omitted, it defaults to the context value (<code>.</code>).<phrase diff="del" at="2022-11-29"> The
             behavior of the function if the argument is omitted is exactly the same as if the
             context value had been passed as the argument.</phrase></p>
-         <p> The result of <code>fn:data</code> is the sequence of atomic items produced by
+         <p> The result of <function>fn:data</function> is the sequence of atomic items produced by
             applying the following rules to each item in <code>$input</code>:</p>
          <ulist>
             <item>
@@ -975,7 +975,7 @@ $node ! (
                   />).</p>
             </item>
             <item>
-               <p>If the item is an array, the result of applying <code>fn:data</code> to
+               <p>If the item is an array, the result of applying <function>fn:data</function> to
                   each member of the array, in order, is appended to the result sequence.</p>
             </item>
          </ulist>
@@ -993,8 +993,8 @@ $node ! (
                <xtermref ref="dt-absent" spec="DM40">absent</xtermref>.</p>
       </fos:errors>
       <fos:notes>
-         <p>The process of applying the <code>fn:data</code> function to a sequence is referred to
-            as <code>atomization</code>. In many cases an explicit call on <code>fn:data</code> is
+         <p>The process of applying the <function>fn:data</function> function to a sequence is referred to
+            as <term>atomization</term>. In many cases an explicit call on <function>fn:data</function> is
             not required, because atomization is invoked implicitly when a node or sequence of nodes
             is supplied in a context where an atomic item or sequence of atomic items is
             required.</p>
@@ -1080,7 +1080,7 @@ $node ! (
             the parent element.</p></note>
 
 
-         <p>See also <code>fn:static-base-uri</code>.</p>
+         <p>See also <function>fn:static-base-uri</function>.</p>
       </fos:rules>
       <fos:errors>
          <p>The following errors may be raised when <code>$node</code> is omitted:</p>
@@ -1158,23 +1158,23 @@ $node ! (
             resource having the same <code>document-uri</code> property. In addition, the specification
             explicitly allows implementations, at user request, to relax the requirements for determinism 
             of resource access functions, which makes it possible for multiple calls of functions such as
-            <code>fn:doc</code>, <code>fn:json-doc</code>, or <code>fn:collection</code> to return
+            <function>fn:doc</function>, <function>fn:json-doc</function>, or <function>fn:collection</function> to return
             different results for the same supplied URI.</p>
         
          <p>Although the uniqueness of the <code>document-uri</code> property is no longer
             an absolute constraint, it is still desirable that implementations should where possible
             respect the principle that URIs are usable as identifiers for resources.</p>
          
-         <p diff="chg" at="issue898">In the case of a document node <code>$D</code> returned by the <code>fn:doc</code>
+         <p diff="chg" at="issue898">In the case of a document node <code>$D</code> returned by the <function>fn:doc</function>
             function, it will generally be the case that <code>fn:document-uri($D)</code> returns a URI <code>$U</code>
             such that a call on <code>fn:doc($U)</code> in the same dynamic context will return the same document
             node <code>$D</code>. The URI <code>$U</code> will not necessarily be the same URI that was originally
-            passed to the <code>fn:doc</code> function, since several URIs may identify the same resource.</p>
+            passed to the <function>fn:doc</function> function, since several URIs may identify the same resource.</p>
          
 
-         <p diff="chg" at="issue898">It is <rfc2119>recommended</rfc2119> that implementations of <code>fn:collection</code>
+         <p diff="chg" at="issue898">It is <rfc2119>recommended</rfc2119> that implementations of <function>fn:collection</function>
             should ensure that any documents included in the returned collection, if they have a non-empty
-            <code>fn:document-uri</code> property, should be such that a call on <code>fn:doc</code> supplying this URI
+            <function>fn:document-uri</function> property, should be such that a call on <function>fn:doc</function> supplying this URI
             returns the same document node.</p>
          
          
@@ -1200,13 +1200,13 @@ $node ! (
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Calling the <code>fn:error</code> function raises an application-defined error.</p>
+         <p>Calling the <function>fn:error</function> function raises an application-defined error.</p>
       </fos:summary>
       <fos:rules>
          <p>This function never returns a value. Instead it always raises an error. The effect of
             the error is identical to the effect of dynamic errors raised implicitly, for example
             when an incorrect argument is supplied to a function.</p>
-         <p>The parameters to the <code>fn:error</code> function supply information that is
+         <p>The parameters to the <function>fn:error</function> function supply information that is
             associated with the error condition and that is made available to a caller that asks for
             information about the error. The error may be caught either by the host language (using
             a try/catch construct in XSLT or XQuery, for example), or by the calling application or
@@ -1338,7 +1338,7 @@ $node ! (
       </fos:rules>
       <fos:notes>
          <p>If the trace information is unrelated to a specific value,
-            <code>fn:message</code> can be used instead.</p>
+            <function>fn:message</function> can be used instead.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -1387,11 +1387,11 @@ $node ! (
          <p>Outputs trace information and discards the result.</p>
       </fos:summary>
       <fos:rules>
-         <p>Similar to <code>fn:trace</code>, the values of <code>$input</code>,
+         <p>Similar to <function>fn:trace</function>, the values of <code>$input</code>,
             typically serialized and converted to an <code>xs:string</code>, and <code>$label</code>
             (if supplied and non-empty) <rfc2119>may</rfc2119> be output to an
             <termref def="implementation-defined"/> destination.</p>
-         <p>In contrast to <code>fn:trace</code>, the function returns an empty sequence.</p>
+         <p>In contrast to <function>fn:trace</function>, the function returns an empty sequence.</p>
          <p>Any serialization of the implementation’s log output <rfc2119>must not</rfc2119> raise an error.
             This can e.g. be achieved by using a serialization method that can handle arbitrary
             input, such as the <xspecref spec="SER31" ref="adaptive-output"/>.</p>
@@ -2310,7 +2310,7 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
                value <code>150.014999389...</code>, which is closer to
                <code>150.01</code> than to <code>150.02</code>.</p>
          <p>From 4.0, the effect of this function can also be achieved by
-         calling <code>fn:round</code> with the third argument set to <code>"half-to-even"</code>.</p>
+         calling <function>fn:round</function> with the third argument set to <code>"half-to-even"</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -3144,7 +3144,7 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
          </p>
 
 
-         <p>The evaluation of the <code>fn:format-number</code> function takes place in two
+         <p>The evaluation of the <function>fn:format-number</function> function takes place in two
             phases, an analysis phase described in <specref
                ref="analyzing-picture-string"
                /> and a
@@ -3190,11 +3190,11 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
          <p>In previous versions of XSLT and XQuery, decimal formats were typically defined in the
          static context using custom declarations (<code>&lt;xsl:decimal-format></code> in XSLT,
          <code>declare decimal-format</code> in XQuery) and then selected by name in a call on
-         <code>fn:format-number</code>. This mechanism remains available, but in 4.0, 
+         <function>fn:format-number</function>. This mechanism remains available, but in 4.0, 
             it may be more convenient to dispense with these
             declarations, and instead to define a decimal format as a map bound to a global
             variable, which can be referenced in the <code>$options</code> argument of the 
-            <code>fn:format-number</code> call.</p>
+            <function>fn:format-number</function> call.</p>
 
       </fos:notes>
       <fos:examples>
@@ -3362,11 +3362,11 @@ return if (starts-with($preprocessed, "-")) then -$abs else +$abs
             the function delivers the same result as casting <code>$value</code> 
             (after removal of whitespace and underscores) to <code>xs:integer</code>.</p>
          <p>If underscores or whitespace in the input need to be rejected, then
-         the string should first be validated, perhaps using <code>fn:matches</code>.</p>
+         the string should first be validated, perhaps using <function>fn:matches</function>.</p>
          <p>If other characters may legitimately appear in the input, for example
          a leading <code>0x</code>, then this must first be removed by pre-processing the input.</p>
          <p>If the input uses a different family of digits, then the value should first
-         be converted to the required digits using <code>fn:translate</code>.</p>
+         be converted to the required digits using <function>fn:translate</function>.</p>
          <p>A string in the lexical space of <code>xs:hexBinary</code> will always
          be an acceptable input, provided it is not too long. So, for example, the expression
          <code>"1DE=" => xs:base64Binary() => xs:hexBinary() => xs:string() => parse-integer(16)</code>
@@ -4961,8 +4961,8 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
             is <code>true</code>, because those expressions convert the <code>xs:decimal</code> value
             <code>0.1</code> to the <code>xs:double</code> value <code>0.1e0</code>
             before the comparison.</p>
-         <p>Although operations such as sorting and the <code>fn:min</code> and <code>fn:max</code>
-            functions invoke <code>fn:compare</code> to perform numeric comparison, these functions
+         <p>Although operations such as sorting and the <function>fn:min</function> and <function>fn:max</function>
+            functions invoke <function>fn:compare</function> to perform numeric comparison, these functions
             in some cases treat <code>NaN</code> differently.</p>
       </fos:notes>
       <fos:examples>
@@ -5164,7 +5164,7 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
                <item><p><code>concat(("a", "b"), (), ("c", "d"))</code> returns <code>"abcd"</code>.</p></item>
             </ulist>
             
-            <p>A static call on the <code>concat</code> function must use positional arguments,
+            <p>A static call on the <function>fn:concat</function> function must use positional arguments,
                it cannot use keywords.</p>
             
             <p>Each of the parameters has the required type
@@ -5172,18 +5172,18 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
             a sequence of atomic items by applying atomization. These sequences are then combined (by 
             <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref>) 
                into a single sequence, and each item in the combined sequence
-            is converted to a string using the <code>fn:string</code> function. The strings are then concatenated
+            is converted to a string using the <function>fn:string</function> function. The strings are then concatenated
             with no separator.</p>
          
          
          
          <p>If XPath 1.0 compatibility mode is set to true in the static context of a
-            static function call to <code>fn:concat</code>, then each supplied argument 
+            static function call to <function>fn:concat</function>, then each supplied argument 
             <code>$v</code> is first reduced to a single
             string, the result of the expression <code>xs:string($v[1])</code>. This is special-case
-            processing for the <code>fn:concat</code> function, it is not something
+            processing for the <function>fn:concat</function> function, it is not something
             that follows from the general rules for calling variadic functions. This reflects the fact that
-            <code>fn:concat</code> had custom behavior in XPath 1.0. This rule applies only to
+            <function>fn:concat</function> had custom behavior in XPath 1.0. This rule applies only to
             static function calls.</p>
          
          <p>A named function reference can be used to create a function item with any arity: for example
@@ -5198,9 +5198,9 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
       <fos:notes>
          <p>As mentioned in <specref ref="string-types"
                /> Unicode normalization is not automatically
-            applied to the result of <code>fn:concat</code>. If a normalized result is required,
-               <code>fn:normalize-unicode</code> can be applied to the <code>xs:string</code>
-            returned by <code>fn:concat</code>. The following XQuery:</p>
+            applied to the result of <function>fn:concat</function>. If a normalized result is required,
+               <function>fn:normalize-unicode</function> can be applied to the <code>xs:string</code>
+            returned by <function>fn:concat</function>. The following XQuery:</p>
          <eg xml:space="preserve">
 let $v1 := "I plan to go to Mu"
 let $v2 := "?nchen in September"
@@ -5220,9 +5220,9 @@ return normalize-unicode(concat($v1, $v2))</eg>
             or the numeric character reference <code>&amp;#x0308;</code>, will return:</p>
          <p><code>"I plan to go to München in September"</code></p>
          <p>This returned result is normalized in NFC.</p>
-         <p>Alternatives to the <code>fn:concat</code> function include the concatenation operator
+         <p>Alternatives to the <function>fn:concat</function> function include the concatenation operator
          <code>||</code> (for example <code>$x || '-' || $y</code>), the use of string templates 
-         (for example <code>`{$x}-{$y}`)</code>, and the <code>fn:string-join</code> function.</p>
+         (for example <code>`{$x}-{$y}`)</code>, and the <function>fn:string-join</function> function.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -5632,7 +5632,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
                ref="xml"/>.</p>
 
          <p>If no argument is supplied, then <code>$value</code> defaults to the string value
-            (calculated using <code>fn:string</code>) of the context value (<code>.</code>). </p>
+            (calculated using <function>fn:string</function>) of the context value (<code>.</code>). </p>
       </fos:rules>
       <fos:errors>
 
@@ -5785,7 +5785,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
             details of the stability policy regarding changes to the normalization rules in future
             versions of Unicode. If the input string contains codepoints that are unassigned in the
             relevant version of Unicode, or for which no normalization rules are defined, the
-               <code>fn:normalize-unicode</code> function leaves such codepoints unchanged. If the
+               <function>fn:normalize-unicode</function> function leaves such codepoints unchanged. If the
             implementation supports the requested normalization form then it <rfc2119>must</rfc2119>
             be able to handle every input string without raising an error.</p>
       </fos:rules>
@@ -5829,7 +5829,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       </fos:rules>
       <fos:notes>
          <p>Case mappings may change the length of a string. In general, the
-               <code>fn:upper-case</code> and <code>fn:lower-case</code> functions are not inverses
+               <function>fn:upper-case</function> and <function>fn:lower-case</function> functions are not inverses
             of each other: <code>fn:lower-case(fn:upper-case($s))</code> is not guaranteed to
             return <code>$s</code>, nor is <code>fn:upper-case(fn:lower-case($s))</code>. The
             character <char>U+0131</char> (used in Turkish) 
@@ -5890,7 +5890,7 @@ return normalize-unicode(concat($v1, $v2))</eg>
       </fos:rules>
       <fos:notes>
          <p>Case mappings may change the length of a string. In general, the
-               <code>fn:upper-case</code> and <code>fn:lower-case</code> functions are not inverses
+               <function>fn:upper-case</function> and <function>fn:lower-case</function> functions are not inverses
             of each other: <code>fn:lower-case(fn:upper-case($s))</code> is not guaranteed to
             return <code>$s</code>, nor is <code>fn:upper-case(fn:lower-case($s))</code>. The
             character <char>U+0131</char> (used in Turkish)<!--Latin small letter dotless i (ı, U+0131, used in Turkish)--> 
@@ -7175,7 +7175,7 @@ Tak, tak, tak! - da kommen sie.
                <p>Note that the rules for function coercion mean that the function actually
                   supplied for the <code>$action</code> parameter may be an arity-1 function: the
                   second argument does not need to be declared if it is not used.</p>
-               <p>The replacement string is obtained by invoking <code>fn:string</code>
+               <p>The replacement string is obtained by invoking <function>fn:string</function>
                   for the result of the function call.</p>
             </item>
             <item><p>Otherwise, if the <code>$replacement</code> argument is present and is not
@@ -7441,7 +7441,7 @@ Tak, tak, tak! - da kommen sie.
          form strips leading and trailing whitespace, whereas the two-argument form delivers an extra
          zero-length token if leading or trailing whitespace is present.</p>
          <p>The function returns no information about the separators that were found
-         in the string. If this information is required, the <code>fn:analyze-string</code> function
+         in the string. If this information is required, the <function>fn:analyze-string</function> function
          can be used instead.</p>
          <p>The separator used by the one-argument form of the function is any sequence
             of tab (<char>U+0009</char>), newline (<char>U+000A</char>), carriage return
@@ -7536,9 +7536,9 @@ Tak, tak, tak! - da kommen sie.
                >implementation-dependent</termref>. The children of this element are a
             sequence of <code>fn:match</code> and <code>fn:non-match</code> elements. This sequence
             is formed by breaking the <code>$value</code> string into a sequence of strings,
-            returning any substring that matches <code>$pattern</code> as the content of a
-               <code>match</code> element, and any intervening substring as the content of a
-               <code>non-match</code> element.</p>
+            returning any substring that matches <code>$pattern</code> as the content of an
+               <code>fn:match</code> element, and any intervening substring as the content of an
+               <code>fn:non-match</code> element.</p>
          <p>More specifically, the function starts at the beginning of the input string and attempts
             to find the first substring that matches the regular expression. If there are several
             matches, the first match is defined to be the one whose starting position comes first in
@@ -7610,7 +7610,7 @@ Tak, tak, tak! - da kommen sie.
             The concept of “schema awareness”, however, is a matter for host languages to define and is outside
             the scope of the function library specification.</p>
          <p>The declarations and definitions in the schema are not automatically available in
-            the static context of the <code>fn:analyze-string</code> call (or of any other
+            the static context of the <function>fn:analyze-string</function> call (or of any other
             expression). The contents of the static context are host-language defined, and in some
             host languages are implementation-defined.</p>
          <p>The schema defines the outermost element, <code>analyze-string-result</code>, in such
@@ -7989,34 +7989,34 @@ some $t in $value ! tokenize(.) satisfies
                spec="XP31" ref="id-ebv"/>.</p>
          <ulist>
             <item>
-               <p>If <code>$input</code> is the empty sequence, <code>fn:boolean</code> returns
+               <p>If <code>$input</code> is the empty sequence, <function>fn:boolean</function> returns
                      <code>false</code>.</p>
             </item>
             <item>
                <p>If <code>$input</code> is a sequence whose first item is a node,
-                     <code>fn:boolean</code> returns <code>true</code>.</p>
+                     <function>fn:boolean</function> returns <code>true</code>.</p>
             </item>
             <item>
                <p>If <code>$input</code> is a singleton value of type <code>xs:boolean</code> or a
-                  derived from <code>xs:boolean</code>, <code>fn:boolean</code> returns
+                  derived from <code>xs:boolean</code>, <function>fn:boolean</function> returns
                      <code>$input</code>.</p>
             </item>
             <item>
                <p>If <code>$input</code> is a singleton value of type <code>xs:untypedAtomic</code>, 
                   <code>xs:string</code>, <code>xs:anyURI</code>, or a type derived from <code>xs:string</code>
-                  or <code>xs:anyURI</code>, <code>fn:boolean</code> returns <code>false</code> if the operand value has
+                  or <code>xs:anyURI</code>, <function>fn:boolean</function> returns <code>false</code> if the operand value has
                   zero length; otherwise it returns <code>true</code>.</p>
             </item>
             <item>
                <p>If <code>$input</code> is a singleton value of any numeric type or a type derived
-                  from a numeric type, <code>fn:boolean</code> returns <code>false</code> if the
+                  from a numeric type, <function>fn:boolean</function> returns <code>false</code> if the
                   operand value is <code>NaN</code> or is numerically equal to zero; otherwise it
                   returns <code>true</code>.</p>
             </item>
          </ulist>
       </fos:rules>
       <fos:errors>
-         <p>In all cases other than those listed above, <code>fn:boolean</code> raises a type error <errorref
+         <p>In all cases other than those listed above, <function>fn:boolean</function> raises a type error <errorref
                class="RG" code="0006"/>.</p>
       </fos:errors>
       <fos:notes>
@@ -8812,7 +8812,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       </fos:summary>
       <fos:rules>
          <p>The result is the <code>xs:yearMonthDuration</code> whose length in months is equal to
-            the result of applying the <code>fn:round</code> function to the value obtained by
+            the result of applying the <function>fn:round</function> function to the value obtained by
             multiplying the length in months of <code>$arg1</code> by the value of
                <code>$arg2</code>.</p>
          <p>If <code>$arg2</code> is positive or negative zero, the result is a zero-length
@@ -8858,7 +8858,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
       </fos:summary>
       <fos:rules>
          <p>The result is the <code>xs:yearMonthDuration</code> whose length in months is equal to
-            the result of applying the <code>fn:round</code> function to the value obtained by
+            the result of applying the <function>fn:round</function> function to the value obtained by
             dividing the length in months of <code>$arg1</code> by the value of
             <code>$arg2</code>.</p>
          <p>If <code>$arg2</code> is positive or negative infinity, the result is a zero-length
@@ -12266,7 +12266,7 @@ represented by the <code>$value</code> argument took place or will take place.
             format described here is very widely used.</p>
 
          <p>An <bibref ref="rfc1123"
-               /> date can be generated approximately using <code>fn:format-dateTime</code> with a picture
+               /> date can be generated approximately using <function>fn:format-dateTime</function> with a picture
             string of <code>"[FNn3], [D01] [MNn3] [Y04] [H01]:[m01]:[s01] [Z0000]"</code>.</p>
       </fos:notes>
       <fos:examples>
@@ -12574,8 +12574,8 @@ else QName("", $value)</eg>
          <p>The namespace URI parts are considered equal if they are both <xtermref ref="dt-absent"
                spec="DM40"
                >absent</xtermref>, or if they are both present and equal under the rules
-            of the <code>fn:codepoint-equal</code> function.</p>
-         <p>The local parts are also compared under the rules of the <code>fn:codepoint-equal</code>
+            of the <function>fn:codepoint-equal</function> function.</p>
+         <p>The local parts are also compared under the rules of the <function>fn:codepoint-equal</function>
             function.</p>
       </fos:rules>
       <fos:notes>
@@ -12713,7 +12713,7 @@ else QName("", $value)</eg>
       </fos:examples>
       <fos:changes>
          <fos:change><p>Reformulated in 4.0 in terms of the new
-            <code>fn:in-scope-namespaces</code> function; the semantics are unchanged.</p></fos:change>
+            <function>fn:in-scope-namespaces</function> function; the semantics are unchanged.</p></fos:change>
       </fos:changes>
    </fos:function>
    <fos:function name="in-scope-namespaces" prefix="fn" diff="add" at="A">
@@ -12793,7 +12793,7 @@ else QName("", $value)</eg>
       </fos:notes>
       <fos:changes>
          <fos:change><p>Reformulated in 4.0 in terms of the new
-            <code>fn:in-scope-namespaces</code> function; the semantics are unchanged.</p></fos:change>
+            <function>fn:in-scope-namespaces</function> function; the semantics are unchanged.</p></fos:change>
       </fos:changes>
    </fos:function>
    <fos:function name="binary-equal" prefix="op">
@@ -12885,8 +12885,8 @@ else QName("", $value)</eg>
          <p>The namespace URI parts are considered equal if they are both <xtermref ref="dt-absent"
                spec="DM40"
                >absent</xtermref>, or if they are both present and equal under the rules
-            of the <code>fn:codepoint-equal</code> function.</p>
-         <p>The local parts are also compared under the rules of the <code>fn:codepoint-equal</code>
+            of the <function>fn:codepoint-equal</function> function.</p>
+         <p>The local parts are also compared under the rules of the <function>fn:codepoint-equal</function>
             function.</p>
       </fos:rules>
       <fos:notes>
@@ -13226,7 +13226,7 @@ else QName("", $value)</eg>
                def="implementation-defined"
             >implementation-defined</termref> whether XSD 1.1 is
             supported.</p>
-         <p>Generally <code>fn:number</code> returns <code>NaN</code> rather than raising a dynamic
+         <p>Generally <function>fn:number</function> returns <code>NaN</code> rather than raising a dynamic
             error if the argument cannot be converted to <code>xs:double</code>. However, a type
             error is raised in the usual way if the supplied argument cannot be atomized or if the
             result of atomization does not match the required argument type.</p>
@@ -13711,7 +13711,7 @@ let $newi := $o/tool</eg>
 </xsl:if>  
 ]]></eg>
          <p>This is because it makes two downward selections to read the child <code>row</code>
-            elements. The use of <code>fn:has-children</code> in the <code>xsl:if</code> conditional
+            elements. The use of <function>fn:has-children</function> in the <code>xsl:if</code> conditional
             is intended to circumvent this restriction.</p>
          <p>Although the function was introduced to support streaming use cases, it has general
             utility as a convenience function.</p>
@@ -14338,7 +14338,7 @@ return exists($break)
       </fos:summary>
       <fos:rules>
          <p>The items of <code>$values</code> are compared against each other, according to the
-            rules of <code>fn:distinct-values</code> and with <code>$coll</code> as the collation
+            rules of <function>fn:distinct-values</function> and with <code>$coll</code> as the collation
             selected according to the rules in <specref ref="choosing-a-collation"/>.</p>
          <p>From each resulting set of values that are considered equal, one value will be
             returned if the set contains more than one value.</p>
@@ -14813,7 +14813,7 @@ filter($input, fn($item, $pos) { $pos gt 1 })
          which means that a type error occurs if it is called with a negative value.</p>
          <p>If the input sequence contains nodes, these are not copied: instead, the result sequence contains
          multiple references to the same node. So, for example, <code>fn:count(fn:replicate(/, 6)|())</code>
-         returns <code>1</code>, because the <code>fn:replicate</code> call creates duplicates, and the
+         returns <code>1</code>, because the <function>fn:replicate</function> call creates duplicates, and the
             union operation eliminates them.</p>
       </fos:notes>
       <fos:examples>
@@ -15141,9 +15141,9 @@ return slice($input, $start, $end)
       <fos:notes>
          <p>The result includes both the item that matches the <code>$from</code> condition
          and the item that matches the <code>$to</code> condition. To select a subsequence that
-         starts after the <code>$from</code> item, apply the <code>fn:tail</code> function 
+         starts after the <code>$from</code> item, apply the <function>fn:tail</function> function 
          to the result. To select a subsequence that ends before the <code>$to</code> item,
-         apply the <code>fn:trunk</code> function to the result.</p>
+         apply the <function>fn:trunk</function> function to the result.</p>
          
          <p>The predicate functions supplied to the <code>$from</code> and <code>$to</code>
          parameters can include an integer position argument as well as the item itself.
@@ -15273,7 +15273,7 @@ return slice($input, $start, $end)
          <code>fn:items-at($input, 3)</code> returns the same result as <code>$input[3]</code>.</p>
          <p>Compared with a simple positional filter expression, the function is useful because:</p>
          <olist>
-            <item><p>It can select items at multiple positions, and unlike <code>fn:subsequence</code>,
+            <item><p>It can select items at multiple positions, and unlike <function>fn:subsequence</function>,
             these do not need to be contiguous.</p></item>
             <item><p>The <code>$at</code> expression can depend on the focus.</p></item>
             <item><p>The order of the returned items can differ from their order in the <code>$input</code> sequence.</p></item>
@@ -15899,7 +15899,7 @@ return contains-subsequence(
          <p>The function can be used to discard unneeded output of expressions
             (functions, third-party libraries, etc.).</p>
          <p>It can also be used to discard results during development.</p>
-         <p>The function is utilized by built-in functions such as <code>map:get</code>
+         <p>The function is utilized by built-in functions such as <function>map:get</function>
             to return an empty sequence for arbitrary input.</p>
          <p>It is <termref def="implementation-dependent">implementation-dependent</termref>
             whether the supplied argument is evaluated or ignored. An implementation may decide to
@@ -16157,7 +16157,7 @@ else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0005'))
                <fos:option key="normalization-form">
                   <fos:meaning>If present, indicates that text and attributes are converted to the specified
                      Unicode normalization form prior to comparison. The value is as for the corresponding
-                     argument of <code>fn:normalize-unicode</code>.
+                     argument of <function>fn:normalize-unicode</function>.
                   </fos:meaning>
                   <fos:type>xs:string?</fos:type>
                   <fos:default>()</fos:default>
@@ -16215,7 +16215,7 @@ else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0005'))
                      consisting entirely of whitespace.
                      The value <code>normalize</code> ignores whitespace text nodes in the same way as
                      the <code>strip</code> option, and additionally compares text and attribute nodes after 
-                     normalizing whitespace in accordance with the rules of the <code>fn:normalize-space</code> 
+                     normalizing whitespace in accordance with the rules of the <function>fn:normalize-space</function> 
                      function. The detailed rules, given below, also take into account type annotations and 
                      <code>xml:space</code> attributes.
                   </phrase>
@@ -16228,7 +16228,7 @@ else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0005'))
          <note><p>As a general rule for boolean options (but not invariably), the value <code>true</code> indicates 
             that the comparison is more strict. </p></note>
 
-         <p>In the following rules, where a recursive call on <code>fn:deep-equal</code> is made, this is assumed
+         <p>In the following rules, where a recursive call on <function>fn:deep-equal</function> is made, this is assumed
          to use the same values of <code>$options</code> as the original call.</p>
          
          <p>The rules reference a function <code>equal-strings</code> which compares two <code>xs:string</code>
@@ -16236,9 +16236,9 @@ else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0005'))
          
          <olist>
             <item><p>If the <code>whitespace</code> option is set to <code>normalize</code>, then each string is processed
-               by calling the <code>fn:normalize-space</code> function.</p></item>
+               by calling the <function>fn:normalize-space</function> function.</p></item>
             <item><p>If the <code>normalization-form</code> option is present, each string is then normalized
-            by calling the <code>fn:normalize-unicode</code> function, supplying the specified normalization
+            by calling the <function>fn:normalize-unicode</function> function, supplying the specified normalization
             form.</p></item>           
             <item><p>The two strings are then compared for equality under the requested collation.</p></item>
          </olist>
@@ -16350,7 +16350,7 @@ declare function equal-strings(
                               collation is not used when comparing keys), and </p>
                         </item>
                         <item>
-                           <p>has the same associated value (compared using the <code>fn:deep-equal</code>
+                           <p>has the same associated value (compared using the <function>fn:deep-equal</function>
                               function, recursively).</p>
                         </item>
                      </olist>
@@ -16588,7 +16588,7 @@ declare function equal-strings(
                               </item>
                            </olist>
                            <note><p>Namespace nodes are not considered directly unless they appear in the top-level sequences
-                           passed explicitly to the <code>fn:deep-equal</code> function.</p></note>
+                           passed explicitly to the <function>fn:deep-equal</function> function.</p></note>
                         </item>
                         <item>
                            <p>Both nodes are comment nodes, and the <code>equal-strings</code> function 
@@ -16662,7 +16662,7 @@ declare function equal-strings(
          two numeric values, it might return <code>true</code> if they are equal to six decimal places.</p>
          
          <p>It is good practice for the <code>items-equal</code> callback function to be reflexive,
-         symmetric, and transitive; if it is not, then the <code>fn:deep-equal</code> function itself
+         symmetric, and transitive; if it is not, then the <function>fn:deep-equal</function> function itself
          will lack these qualities. <emph>Reflexive</emph> means that every item (including <code>NaN</code>)
          should be equal to itself; <emph>symmetric</emph> means that <code>items-equal(A, B)</code>
          should return the same result as <code>items-equal(B, A)</code>, and <emph>transitive</emph>
@@ -17118,7 +17118,7 @@ declare function equal-strings(
             compare equal under the selected collation, or if two different <code>xs:dateTime</code>
             values compare equal despite being in different timezones.</p>
          <p>If the converted sequence contains exactly one value then that value is returned.</p>
-         <p>The default type when the <code>fn:max</code> function is applied to
+         <p>The default type when the <function>fn:max</function> function is applied to
             <code>xs:untypedAtomic</code> values is <code>xs:double</code>. This differs from the
             default type for operators such as <code>lt</code>, and for sorting in XQuery and XSLT,
             which is <code>xs:string</code>.</p>
@@ -17189,7 +17189,7 @@ declare function equal-strings(
       </fos:examples>
       <fos:changes>
          <fos:change issue="866" PR="881" date="2023-12-06">
-            <p>The way that <code>fn:min</code> and <code>fn:max</code> compare numeric values of different types
+            <p>The way that <function>fn:min</function> and <function>fn:max</function> compare numeric values of different types
               has changed. The most noticeable effect is that when these functions are applied to a sequence of
                  <code>xs:integer</code> or <code>xs:decimal</code> values, the result is an <code>xs:integer</code> or 
                  <code>xs:decimal</code>, rather than the result of converting this to an <code>xs:double</code></p>
@@ -17279,7 +17279,7 @@ declare function equal-strings(
             compare equal under the selected collation, or if two different <code>xs:dateTime</code>
             values compare equal despite being in different timezones.</p>
          <p>If the converted sequence contains exactly one value then that value is returned.</p>
-         <p>The default type when the <code>fn:min</code> function is applied to
+         <p>The default type when the <function>fn:min</function> function is applied to
                <code>xs:untypedAtomic</code> values is <code>xs:double</code>. This differs from the
             default type for operators such as <code>lt</code>, and for sorting in XQuery and XSLT,
             which is <code>xs:string</code>.</p>
@@ -17351,7 +17351,7 @@ declare function equal-strings(
       </fos:examples>
       <fos:changes>
          <fos:change issue="866" PR="881" date="2023-12-06">
-            <p>The way that <code>fn:min</code> and <code>fn:max</code> compare numeric values of different types
+            <p>The way that <function>fn:min</function> and <function>fn:max</function> compare numeric values of different types
               has changed. The most noticeable effect is that when these functions are applied to a sequence of
                  <code>xs:integer</code> or <code>xs:decimal</code> values, the result is an <code>xs:integer</code> or 
                  <code>xs:decimal</code>, rather than the result of converting this to an <code>xs:double</code></p>
@@ -17645,7 +17645,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <code>is-id</code> property. For legacy reasons, this function returns the element
             that has the <code>is-id</code> property, whereas it would be more appropriate to return
             its parent, that being the element that is uniquely identified by the ID. A new function
-               <code>fn:element-with-id</code> has been introduced with the desired
+               <function>fn:element-with-id</function> has been introduced with the desired
             behavior.</p>
 
          <p> If the data model is constructed from an Infoset, an attribute will have the
@@ -17700,7 +17700,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <fos:postamble>Assuming the <code>empnr</code> element is given the type
                      <code>xs:ID</code> as a result of schema validation, the element will have the
                      <code>is-id</code> property and is therefore selected. Note the difference from
-                  the behavior of <code>fn:element-with-id</code>.</fos:postamble>
+                  the behavior of <function>fn:element-with-id</function>.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -17729,10 +17729,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:rules>
 
          <note>
-            <p>The effect of this function is identical to <code>fn:id</code> in respect of
+            <p>The effect of this function is identical to <function>fn:id</function> in respect of
                elements that have an attribute with the <code>is-id</code> property. However, it
                behaves differently in respect of element nodes with the <code>is-id</code> property.
-               Whereas the <code>fn:id</code> function, for legacy reasons, returns the element that has the
+               Whereas the <function>fn:id</function> function, for legacy reasons, returns the element that has the
                   <code>is-id</code> property, this function returns the element identified by the ID,
                which is the parent of the element having the <code>is-id</code> property.</p>
          </note>
@@ -17817,8 +17817,8 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 
       </fos:errors>
       <fos:notes>
-         <p>This function is equivalent to the <code>fn:id</code> function except when dealing with
-            ID-valued element nodes. Whereas the <code>fn:id</code> function selects the element
+         <p>This function is equivalent to the <function>fn:id</function> function except when dealing with
+            ID-valued element nodes. Whereas the <function>fn:id</function> function selects the element
             containing the identifier, this function selects its parent.</p>
          <p>If the data model is constructed from an Infoset, an attribute will have the
                <code>is-id</code> property if the corresponding attribute in the Infoset had an
@@ -17875,7 +17875,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                <fos:postamble>Assuming the <code>empnr</code> element is given the type
                      <code>xs:ID</code> as a result of schema validation, the element will have the
                      <code>is-id</code> property and is therefore its parent is selected. Note the
-                  difference from the behavior of <code>fn:id</code>.</fos:postamble>
+                  difference from the behavior of <function>fn:id</function>.</fos:postamble>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -18028,9 +18028,9 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 )/ancestor::employee/last
 => string()</eg></fos:expression>
                <fos:result>"Brown"</fos:result>
-               <fos:postamble>Assuming that <code>manager</code> has the is-idref property, the call on <code>fn:idref</code> selects
+               <fos:postamble>Assuming that <code>manager</code> has the is-idref property, the call on <function>fn:idref</function> selects
                   the <code>manager</code> element. If, instead, the <code>manager</code> had a <code>ref</code>
-               attribute with the is-idref property, the call on <code>fn:idref</code> would select the attribute node.</fos:postamble>
+               attribute with the is-idref property, the call on <function>fn:idref</function> would select the attribute node.</fos:postamble>
             </fos:test>
          </fos:example>
          <fos:example>
@@ -18040,7 +18040,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
 )/ancestor::employee/last
 => string()</eg></fos:expression>
                <fos:result>"Singh"</fos:result>
-               <fos:postamble>Assuming that <code>employee/deputy</code> has the is-idref property, the call on <code>fn:idref</code> selects
+               <fos:postamble>Assuming that <code>employee/deputy</code> has the is-idref property, the call on <function>fn:idref</function> selects
                   the <code>deputy</code> element.</fos:postamble>
             </fos:test>
          </fos:example>
@@ -18078,7 +18078,8 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             expression (if it does not raise an error) will always return <code>true</code>:</p>
          <eg xml:space="preserve">doc("foo.xml") is doc("foo.xml")</eg>
          <note diff="add" at="issue898"><p>This equivalence applies only because the two calls on
-            the <code>doc</code> function have the same dynamic context. If two calls on <code>doc</code>
+            the <function>fn:doc</function> function have the same dynamic context. 
+            If two calls on <function>fn:doc</function>
            have different dynamic contexts, then the mapping from URIs to document
          nodes in the two contexts may differ, which means that different document nodes may be returned
          for the same URI.
@@ -18096,8 +18097,8 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <note>
             <p>If <code>$source</code> is read from a source document, it is generally appropriate to
                resolve it relative to the base URI property of the relevant node in the source
-               document. This can be achieved by calling the <code>fn:resolve-uri</code> function,
-               and passing the resulting absolute URI as an argument to the <code>fn:doc</code>
+               document. This can be achieved by calling the <function>fn:resolve-uri</function> function,
+               and passing the resulting absolute URI as an argument to the <function>fn:doc</function>
                function.</p>
          </note>
          <p>If two calls to this function supply different absolute URI References as arguments, the
@@ -18190,7 +18191,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:errors>
       <fos:changes>
          <fos:change issue="898" PR="905" date="2024-01-09">
-            <p>The rule that multiple calls on <code>fn:doc</code>
+            <p>The rule that multiple calls on <function>fn:doc</function>
             supplying the same absolute URI must return the same document node has been clarified;
             in particular the rule does not apply if the dynamic context for the two calls requires
             different processing of the documents (such as schema validation or whitespace stripping).</p>
@@ -18224,7 +18225,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             within the same <termref
                def="execution-scope"
                /> must return a document node. However,
-            if nondeterministic processing has been selected for the <code>fn:doc</code> function,
+            if nondeterministic processing has been selected for the <function>fn:doc</function> function,
             this guarantee is lost.</p>
       </fos:rules>
    </fos:function>
@@ -18292,7 +18293,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             a valid <code>xs:anyURI</code>.</p>
       </fos:errors>
       <fos:notes>
-         <p>In earlier versions of this specification, the primary use for the <code>fn:collection</code> function
+         <p>In earlier versions of this specification, the primary use for the <function>fn:collection</function> function
          was to retrieve a collection of XML documents, perhaps held as lexical XML in operating
          system filestore, or perhaps held in an XML database. In this release the concept has
          been generalised to allow other resources to be retrieved: for example JSON documents might
@@ -18366,7 +18367,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       </fos:errors>
       <fos:notes>
          <p>In some implementations, there might be a close relationship between <term>collections</term> (as retrieved
-         by the <code>fn:collection</code> function), and <term>URI collections</term> (as retrieved by this function).
+         by the <function>fn:collection</function> function), and <term>URI collections</term> (as retrieved by this function).
          For example, a collection might return XML documents, and the corresponding URI collection might return
          the URIs of those documents. However, this specification does not impose such a close relationship. For example, there
          may be collection URIs accepted by one of the two functions and not by the other; a collection might contain
@@ -18374,22 +18375,22 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          resource.</p>
 
          <!-- Marked for deletion; assumes a collection() that returns only document nodes. -->
-         <p diff="del" at="2023-12-26">Thus, some implementations might ensure that calling <code>fn:uri-collection</code> and then
-            applying <code>fn:doc</code> to each of the returned URIs delivers the same result as
-            calling <code>fn:collection</code> with the same argument; however, this is not
+         <p diff="del" at="2023-12-26">Thus, some implementations might ensure that calling <function>fn:uri-collection</function> and then
+            applying <function>fn:doc</function> to each of the returned URIs delivers the same result as
+            calling <function>fn:collection</function> with the same argument; however, this is not
             guaranteed.</p>
 
-         <p>In the case where <code>fn:uri-collection</code> returns the URIs of resources that
-            could also be retrieved directly using <code>fn:collection</code>, there are several reasons why it 
+         <p>In the case where <function>fn:uri-collection</function> returns the URIs of resources that
+            could also be retrieved directly using <function>fn:collection</function>, there are several reasons why it 
             might be appropriate to use this function in preference
-            to the <code>fn:collection</code> function. For example:</p>
+            to the <function>fn:collection</function> function. For example:</p>
 
          <ulist>
             <item>
                <p>It allows different URIs for different kinds of resource to be dereferenced in
                   different ways: for
                   example, the returned URIs might be referenced using the
-                     <code>fn:unparsed-text</code> function rather than the <code>fn:doc</code>
+                     <function>fn:unparsed-text</function> function rather than the <function>fn:doc</function>
                   function.</p>
             </item>
             <item>
@@ -18398,7 +18399,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </item>
             <item>
                <p>It allows recovery from failures to read, parse, or validate individual documents,
-                  by calling the <code>fn:doc</code> (or other dereferencing) function within the scope of try/catch.</p>
+                  by calling the <function>fn:doc</function> (or other dereferencing) function within the scope of try/catch.</p>
             </item>
             <item>
                <p>It allows selection of which documents to read based on their URI, for example
@@ -18419,7 +18420,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          </ulist>
 
          <p>For some of these use cases, this assumes that the cost of calling
-               <code>fn:collection</code> might be significant (for example, it might involving
+               <function>fn:collection</function> might be significant (for example, it might involving
             retrieving all the documents in the collection over the network and parsing them). This
             will not necessarily be true of all implementations.</p>
 
@@ -18443,7 +18444,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>The <code>fn:unparsed-text</code> function reads an external resource (for example, a
+         <p>The <function>fn:unparsed-text</function> function reads an external resource (for example, a
             file) and returns a string representation of the resource.</p>
       </fos:summary>
       <fos:rules>
@@ -18554,10 +18555,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:notes>
          <p>If it is appropriate to use a base URI other than the dynamic base URI (for example,
             when resolving a relative URI reference read from a source document) then it is
-            advisable to resolve the relative URI reference using the <code>fn:resolve-uri</code>
-            function before passing it to the <code>fn:unparsed-text</code> function.</p>
+            advisable to resolve the relative URI reference using the <function>fn:resolve-uri</function>
+            function before passing it to the <function>fn:unparsed-text</function> function.</p>
          <p>There is no essential relationship between the sets of URIs accepted by the two
-            functions <code>fn:unparsed-text</code> and <code>fn:doc</code> (a URI accepted by one
+            functions <function>fn:unparsed-text</function> and <function>fn:doc</function> (a URI accepted by one
             may or may not be accepted by the other), and if a URI is accepted by both there is no
             essential relationship between the results (different resource representations are
             permitted by the architecture of the web).</p>
@@ -18659,7 +18660,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>The <code>fn:unparsed-text-lines</code> function reads an external resource (for
+         <p>The <function>fn:unparsed-text-lines</function> function reads an external resource (for
             example, a file) and returns its contents as a sequence of strings, one for each line of
             text in the string representation of the resource.</p>
       </fos:summary>
@@ -18676,7 +18677,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          
          <fos:options>
             <fos:option key="encoding">
-               <fos:meaning>Defines the encoding of the resource, following the rules of <code>fn:unparsed-text</code>.
+               <fos:meaning>Defines the encoding of the resource, following the rules of <function>fn:unparsed-text</function>.
                </fos:meaning>
                <fos:type>xs:string?</fos:type>
                <fos:default>()</fos:default>
@@ -18702,12 +18703,12 @@ return $lines[not(position() = last() and . = '')]
             line ending were not present.</p>
       </fos:rules>
       <fos:errors>
-         <p>Error conditions are the same as for the <code>fn:unparsed-text</code> function.</p>
+         <p>Error conditions are the same as for the <function>fn:unparsed-text</function> function.</p>
 
       </fos:errors>
 
       <fos:notes>
-         <p>See the notes for <code>fn:unparsed-text</code>.</p>
+         <p>See the notes for <function>fn:unparsed-text</function>.</p>
       </fos:notes>
       <fos:changes>
          <fos:change issue="1116 1278" PR="1117 1279" date="2024-05-21">
@@ -18729,51 +18730,51 @@ return $lines[not(position() = last() and . = '')]
       </fos:properties>
       <fos:summary>
          <p>Allows an application to determine
-            whether a call on <code>fn:unparsed-text</code> with particular arguments 
+            whether a call on <function>fn:unparsed-text</function> with particular arguments 
             would succeed.</p>
       </fos:summary>
       <fos:rules>
-         <p>The <code>fn:unparsed-text-available</code> function determines whether a call
-            on the <code>fn:unparsed-text</code> function with identical arguments would
+         <p>The <function>fn:unparsed-text-available</function> function determines whether a call
+            on the <function>fn:unparsed-text</function> function with identical arguments would
             return a string.</p>
          <p>If the first argument is an empty sequence, the function returns <code>false</code>. </p>
          <p>In other cases, the function returns <code>true</code> if a call on
-               <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>
+               <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
             with the same arguments would succeed, and
-            <code>false</code> if a call on <code>fn:unparsed-text</code> 
-            or <code>fn:unparsed-text-lines</code> with the same arguments would
+            <code>false</code> if a call on <function>fn:unparsed-text</function> 
+            or <function>fn:unparsed-text-lines</function> with the same arguments would
             fail with a non-recoverable dynamic error.</p>
          
-         <p>The functions <code>fn:unparsed-text</code> and
-               <code>fn:unparsed-text-available</code> have the same requirement for
+         <p>The functions <function>fn:unparsed-text</function> and
+               <function>fn:unparsed-text-available</function> have the same requirement for
                <termref
                def="dt-deterministic"
                >determinism</termref> as the functions
-               <code>fn:doc</code> and <code>fn:doc-available</code>. This means that unless the
+               <function>fn:doc</function> and <function>fn:doc-available</function>. This means that unless the
             user has explicitly stated a requirement for a reduced level of determinism, either of
             these functions if called twice with the same arguments during the course of a
             transformation <rfc2119>must</rfc2119> return the same results each time; moreover, the
-            results of a call on <code>fn:unparsed-text-available</code>
+            results of a call on <function>fn:unparsed-text-available</function>
             <rfc2119>must</rfc2119> be consistent with the results of a subsequent call on
                <code>unparsed-text</code> with the same arguments.</p>
       </fos:rules>
       <fos:notes>
          <p>This function was introduced before XQuery and XSLT allowed errors to be caught;
             with current versions of these host languages, catching an error from
-            <code>fn:unparsed-text</code> may provide a better alternative.</p>
-         <p>The specification requires that the <code>fn:unparsed-text-available</code> function should
+            <function>fn:unparsed-text</function> may provide a better alternative.</p>
+         <p>The specification requires that the <function>fn:unparsed-text-available</function> function should
             actually attempt to read the resource identified by the URI, and check that it is
             correctly encoded and contains no characters that are invalid in XML. Implementations
             may avoid the cost of repeating these checks for example by caching the validated
             contents of the resource, to anticipate a subsequent call on the
-               <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>
+               <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
             function. Alternatively, implementations may be able to rewrite an expression such as
                <code>if (unparsed-text-available(A)) then unparsed-text(A) else ...</code> to
             generate a single call internally.</p>
-         <p>Since the function <code>fn:unparsed-text-lines</code> succeeds or fails under
-            exactly the same circumstances as <code>fn:unparsed-text</code>, the
-               <code>fn:unparsed-text-available</code> function may equally be used to test
-            whether a call on <code>fn:unparsed-text-lines</code> would succeed.</p>
+         <p>Since the function <function>fn:unparsed-text-lines</function> succeeds or fails under
+            exactly the same circumstances as <function>fn:unparsed-text</function>, the
+               <function>fn:unparsed-text-available</function> function may equally be used to test
+            whether a call on <function>fn:unparsed-text-lines</function> would succeed.</p>
          <p></p>
 
       </fos:notes>
@@ -18846,7 +18847,7 @@ return $lines[not(position() = last() and . = '')]
             access to environment variables. For example, the name of the account under which the
             query is running may be useful information to a would-be intruder. An implementation may
             therefore choose to restrict access to the environment, or may provide a facility to
-            make <code>fn:environment-variable</code> always return the empty sequence.</p>
+            make <function>fn:environment-variable</function> always return the empty sequence.</p>
 
       </fos:notes>
    </fos:function>
@@ -18861,7 +18862,7 @@ return $lines[not(position() = last() and . = '')]
       </fos:properties>
       <fos:summary>
          <p>Returns a list of environment variable names that are suitable for passing to
-               <code>fn:environment-variable</code>, as a (possibly empty) sequence of strings.</p>
+               <function>fn:environment-variable</function>, as a (possibly empty) sequence of strings.</p>
       </fos:summary>
       <fos:rules>
          <p>The function returns a sequence of strings, being the names of the environment variables
@@ -18874,11 +18875,11 @@ return $lines[not(position() = last() and . = '')]
       <fos:notes>
          <p>The function returns a list of strings, containing no duplicates.</p>
          <p>It is intended that the strings in this list should be suitable for passing to
-               <code>fn:environment-variable</code>.</p>
+               <function>fn:environment-variable</function>.</p>
 
          <p>See also the note on security under the definition of the
-               <code>fn:environment-variable</code> function. If access to environment variables has
-            been disabled, <code>fn:available-environment-variables</code> always returns the empty
+               <function>fn:environment-variable</function> function. If access to environment variables has
+            been disabled, <function>fn:available-environment-variables</function> always returns the empty
             sequence.</p>
       </fos:notes>
    </fos:function>
@@ -19000,7 +19001,7 @@ return $lines[not(position() = last() and . = '')]
          
          <p>The result of the function is a <i>parcel</i>. A parcel is a single item,
          but its exact form is implementation-dependent. The only guaranteed operations
-         that apply to parcels are the <code>fn:unparcel</code> and <code>array:of-members</code>
+         that apply to parcels are the <function>fn:unparcel</function> and <function>array:of-members</function>
          functions.</p>
          
          
@@ -19008,10 +19009,10 @@ return $lines[not(position() = last() and . = '')]
       
       <fos:notes>
          <p>The main use case for this function is for temporary values used while constructing
-         or deconstructing arrays using the <code>array:of-members</code> and <code>array:members</code>
+         or deconstructing arrays using the <function>array:of-members</function> and <function>array:members</function>
          functions, and higher-level constructs that may be defined in terms of these primitives
-         in XSLT or XQuery. The <code>array:of-members</code> function constructs an array from a sequence
-         of parcels, and the <code>array:members</code> function does the reverse.</p>
+         in XSLT or XQuery. The <function>array:of-members</function> function constructs an array from a sequence
+         of parcels, and the <function>array:members</function> function does the reverse.</p>
          <p>Applications may also choose to use parcels to represent nested sequences directly,
          without converting these to arrays. However, there are few operations available on parcels
          unless they are first converted to something else.</p>
@@ -19159,7 +19160,7 @@ return $lines[not(position() = last() and . = '')]
          <p>A common use case for this function is to handle input documents that contain nested
             XML documents embedded within CDATA sections. Since the content of the CDATA section are
             exposed as text, the receiving query or stylesheet may pass this text to the
-               <code>fn:parse-xml</code> function to create a tree representation of the nested
+               <function>fn:parse-xml</function> function to create a tree representation of the nested
             document.</p>
          <p>Similarly, nested XML within comments is sometimes encountered, and lexical XML is
             sometimes returned by extension functions, for example, functions that access web
@@ -19167,8 +19168,8 @@ return $lines[not(position() = last() and . = '')]
          <p>A use case arises in XSLT where there is a need to preprocess an input document before
             parsing. For example, an application might wish to edit the document to remove its
             DOCTYPE declaration. This can be done by reading the raw text using the
-               <code>fn:unparsed-text</code> function, editing the resulting string, and then
-            passing it to the <code>fn:parse-xml</code> function.</p>
+               <function>fn:unparsed-text</function> function, editing the resulting string, and then
+            passing it to the <function>fn:parse-xml</function> function.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -19276,11 +19277,11 @@ return $lines[not(position() = last() and . = '')]
             incorporates this well-formed parsed entity would not be namespace-well-formed.</p>
       </fos:errors>
       <fos:notes>
-         <p>See also the notes for the <code>fn:parse-xml</code> function.</p>
-         <p>The main differences between <code>fn:parse-xml</code> and
-               <code>fn:parse-xml-fragment</code> are that for <code>fn:parse-xml</code>, the
+         <p>See also the notes for the <function>fn:parse-xml</function> function.</p>
+         <p>The main differences between <function>fn:parse-xml</function> and
+               <function>fn:parse-xml-fragment</function> are that for <function>fn:parse-xml</function>, the
             children of the resulting document node must contain exactly one element node and no
-            text nodes, wheras for <code>fn:parse-xml-fragment</code>, the resulting document node
+            text nodes, wheras for <function>fn:parse-xml-fragment</function>, the resulting document node
             can have any number (including zero) of element and text nodes among its children. An
             additional difference is that the <emph>text declaration</emph> at the start of an
             external entity has slightly different syntax from the <emph>XML declaration</emph> at
@@ -19315,8 +19316,8 @@ return $lines[not(position() = last() and . = '')]
                   class="DC" code="0006"
                   /> because the <code>standalone</code> keyword is not permitted in the text
                declaration that appears at the start of an external general parsed entity. (Thus, it
-               is not the case that any input accepted by the <code>fn:parse-xml</code> function
-               will also be accepted by <code>fn:parse-xml-fragment</code>.)</p>
+               is not the case that any input accepted by the <function>fn:parse-xml</function> function
+               will also be accepted by <function>fn:parse-xml-fragment</function>.)</p>
          </fos:example>
       </fos:examples>
       <fos:changes>
@@ -19759,13 +19760,13 @@ return $lines[not(position() = last() and . = '')]
                /> is raised. (For example, this occurs if the map supplied to
          <code>use-character-maps</code> includes a key that is a string whose length is not one (1)).</p>
          <p>If any serialization error occurs, including the detection of an invalid value for a
-            serialization parameter as described above, this results in the <code>fn:serialize</code> call failing with
+            serialization parameter as described above, this results in the <function>fn:serialize</function> call failing with
             a dynamic error.</p>
       </fos:errors>
       <fos:notes>
          <p>One use case for this function arises when there is a need to construct an XML document
             containing nested XML documents within a CDATA section (or on occasions within a
-            comment). See <code>fn:parse-xml</code> for further details.</p>
+            comment). See <function>fn:parse-xml</function> for further details.</p>
          <p>Another use case arises when there is a need to call an extension function that expects
             a lexical XML document as input.</p>
          <p>Another use case for this function is serializing instances of the data model into a human
@@ -20173,7 +20174,7 @@ serialize(
                spec="XP31" ref="id-xp-evaluation-context-components"
                />.) This is an
                <code>xs:dateTime</code> that is current at some time during the evaluation of a
-            query or transformation in which <code>fn:current-dateTime</code> is executed.</p>
+            query or transformation in which <function>fn:current-dateTime</function> is executed.</p>
          <p>This function is <termref def="dt-deterministic"
                />. The precise instant during the query
             or transformation represented by the value of <code>fn:current-dateTime()</code> is
@@ -20212,10 +20213,10 @@ serialize(
       <fos:rules>
          <p>Returns <code>xs:date(fn:current-dateTime())</code>. This is an <code>xs:date</code>
             (with timezone) that is current at some time during the evaluation of a query or
-            transformation in which <code>fn:current-date</code> is executed.</p>
+            transformation in which <function>fn:current-date</function> is executed.</p>
          <p>This function is <termref def="dt-deterministic"
                />. The precise instant during the query
-            or transformation represented by the value of <code>fn:current-date</code> is <termref
+            or transformation represented by the value of <function>fn:current-date</function> is <termref
                def="implementation-dependent">implementation-dependent</termref>.</p>
       </fos:rules>
       <fos:notes>
@@ -20245,7 +20246,7 @@ serialize(
       <fos:rules>
          <p>Returns <code>xs:time(fn:current-dateTime())</code>. This is an <code>xs:time</code>
             (with timezone) that is current at some time during the evaluation of a query or
-            transformation in which <code>fn:current-time</code> is executed.</p>
+            transformation in which <function>fn:current-time</function> is executed.</p>
          <p>This function is <termref def="dt-deterministic"
                />. The precise instant during the query
             or transformation represented by the value of <code>fn:current-time()</code> is <termref
@@ -20330,8 +20331,8 @@ serialize(
                spec="XP31" ref="eval_context"/>.</p>
       </fos:rules>
       <fos:notes>
-         <p>The default language property can never be absent. The functions <code>fn:format-integer</code>,
-         <code>fn:format-date</code>, <code>fn:format-time</code>, and <code>fn:format-dateTime</code>
+         <p>The default language property can never be absent. The functions <function>fn:format-integer</function>,
+         <function>fn:format-date</function>, <function>fn:format-time</function>, and <function>fn:format-dateTime</function>
          are defined to use the default language if no explicit language is supplied. The default language
          may play a role in selection of a default collation, but this is not a requirement.</p>
       </fos:notes>
@@ -20363,9 +20364,9 @@ serialize(
             and run-time resources respectively. This is appropriate when the implementation allows
             the output of static analysis (a “compiled” query or stylesheet) to be deployed for execution
             to a different location from the one where static analysis took place. In this situation, the
-               <code>fn:static-base-uri</code> function should return a URI suitable for locating
+               <function>fn:static-base-uri</function> function should return a URI suitable for locating
             resources needed during dynamic evaluation.</p>
-         <p>If a call on the <code>fn:static-base-uri</code> function appears within the expression used
+         <p>If a call on the <function>fn:static-base-uri</function> function appears within the expression used
          to define the value of an optional parameter to a user-defined function, then the value supplied
          to the function (if the argument is omitted) will be the executable base URI from the dynamic
          context of the function caller. This allows such a function to resolve relative URIs supplied
@@ -20390,10 +20391,10 @@ serialize(
          <p>Returns <phrase diff="chg" at="2023-05-26">a function item</phrase> having a given name and arity, if there is one.</p>
       </fos:summary>
       <fos:rules>
-         <p diff="chg" at="2023-05-26">A call to <code>fn:function-lookup</code> starts by looking for a 
+         <p diff="chg" at="2023-05-26">A call to <function>fn:function-lookup</function> starts by looking for a 
             <xtermref spec="XP40" ref="dt-function-definition">function definition</xtermref>
              in the named functions component of the dynamic context
-            (specifically, the dynamic context of the call to <code>fn:function-lookup</code>),
+            (specifically, the dynamic context of the call to <function>fn:function-lookup</function>),
             using the expanded QName supplied as <code>$name</code> and the arity supplied as
             <code>$arity</code>. There can be at most one such function definition.</p>
          
@@ -20404,10 +20405,10 @@ serialize(
          definition using the same rules as for evaluation of a named function reference 
          (see <xspecref spec="XP40" ref="id-named-function-ref"/>). The captured context of
          the returned function item (if it is context dependent) is the static and dynamic context of 
-         the call on <code>fn:function-lookup</code>.</p>
+         the call on <function>fn:function-lookup</function>.</p>
 
  
-         <p>If the arguments to <code>fn:function-lookup</code> identify a function that is present
+         <p>If the arguments to <function>fn:function-lookup</function> identify a function that is present
             in the static context of the function call, the function will always return the same
             function that a static reference to this function would bind to. If there is no such
             function in the static context, then the results depend on what is present in the
@@ -20441,31 +20442,31 @@ serialize(
             contain a particular function, and to call a function in that module only if it is
             available in the version that was imported. A static call would cause a static error if
             the function is not available, whereas getting the function using
-               <code>fn:function-lookup</code> allows the caller to take fallback action in this
+               <function>fn:function-lookup</function> allows the caller to take fallback action in this
             situation. </p>
-         <p>If the function that is retrieved by <code>fn:function-lookup</code> is <termref
+         <p>If the function that is retrieved by <function>fn:function-lookup</function> is <termref
                def="dt-context-dependent"
                >context-dependent</termref>, that is, if it has
             dependencies on the static or dynamic context of its caller, the context that applies is
-            the static and/or dynamic context of the call to the <code>fn:function-lookup</code>
+            the static and/or dynamic context of the call to the <function>fn:function-lookup</function>
             function itself. The context thus effectively forms part of the closure of the returned
             function. This mainly applies when the target of
-               <code>fn:function-lookup</code> is a built-in function, because user-defined
+               <function>fn:function-lookup</function> is a built-in function, because user-defined
             functions typically have no dependency on the static or dynamic context of the function call
             (an exception arises when the expressions used to define default values for parameters
             are context-dependent). The rule
-            applies recursively, since <code>fn:function-lookup</code> is itself a context-dependent
+            applies recursively, since <function>fn:function-lookup</function> is itself a context-dependent
             built-in function. </p>
-         <p>However, the static and dynamic context of the call to <code>fn:function-lookup</code>
+         <p>However, the static and dynamic context of the call to <function>fn:function-lookup</function>
             may play a role even when the selected function definition is not itself context dependent,
             if the expressions used to establish default parameter values are context dependent.</p>
-         <p>User-defined XSLT or XQuery functions should be accessible to <code>fn:function-lookup</code>
-         only if they are statically visible at the location where the call to <code>fn:function-lookup</code>
+         <p>User-defined XSLT or XQuery functions should be accessible to <function>fn:function-lookup</function>
+         only if they are statically visible at the location where the call to <function>fn:function-lookup</function>
          appears. This means that private functions, if they are not statically visible in the containing
-         module, should not be accessible using <code>fn:function-lookup</code>.</p>
+         module, should not be accessible using <function>fn:function-lookup</function>.</p>
          <p diff="add" at="2023-05-26">The function identity is determined in the same way as for
          a named function reference. Specifically, if there is no context dependency, two calls
-         on <code>fn:function-lookup</code> with the same name and arity must return the same function.</p>
+         on <function>fn:function-lookup</function> with the same name and arity must return the same function.</p>
          <p>These specifications do not define any circumstances in which the dynamic context will
             contain functions that are not present in the static context, but neither do they rule
             this out. For example an API <rfc2119>may</rfc2119> provide the ability to add functions
@@ -20473,7 +20474,7 @@ serialize(
          
          <p>The mere fact that a function exists and has a name does not of itself mean that the
          function is present in the dynamic context. For example, functions obtained through
-         use of the <code>fn:load-xquery-module</code> function are not added to the dynamic context.</p>
+         use of the <function>fn:load-xquery-module</function> function are not added to the dynamic context.</p>
          
          
       </fos:notes>
@@ -20557,7 +20558,7 @@ returns the result of
          <p>Returns the arity of the function identified by a function item.</p>
       </fos:summary>
       <fos:rules>
-         <p>The <code>fn:function-arity</code> function returns the arity (number of arguments) of
+         <p>The <function>fn:function-arity</function> function returns the arity (number of arguments) of
             the function identified by <code>$function</code>.</p>
       </fos:rules>
       <fos:examples>
@@ -20598,7 +20599,7 @@ return function-arity($initial)</eg></fos:expression>
          <p>Returns the annotations of the function item.</p>
       </fos:summary>
       <fos:rules>
-         <p>The <code>fn:function-annotations</code> function returns the annotations of
+         <p>The <function>fn:function-annotations</function> function returns the annotations of
             <code>$function</code> as a sequence of (key, value) pairs.
             Note that several annotations on a function can share the same name. The order
             of the annotations is retained.</p>
@@ -20615,9 +20616,9 @@ return function-arity($initial)</eg></fos:expression>
       </fos:rules>
       <fos:notes>
          <p>The type of the result is the same as the type of the first argument
-            to the <code>map:of-pairs</code> function. This means that in the common case where the annotation names are all unique, 
+            to the <function>map:of-pairs</function> function. This means that in the common case where the annotation names are all unique, 
             the result of the function can readily be converted into a map by calling 
-            <code>map:of-pairs</code>.</p>
+            <function>map:of-pairs</function>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -20769,7 +20770,7 @@ fold-left($input, (), fn($result, $next, $pos) {
          <p>If <code>$predicate</code> is an arity-1 function,
             the function call <code>fn:filter($input, $predicate)</code> has a very similar effect to the
             expression <code>$input[$predicate(.)]</code>. There are some differences, however. In the case of
-               <code>fn:filter</code>, the function <code>$F</code> is required to return an optional boolean;
+               <function>fn:filter</function>, the function <code>$F</code> is required to return an optional boolean;
             there is no special treatment for numeric predicate values, and no conversion to an
             effective boolean value. Also, with a filter expression <code>$input[$predicate(.)]</code>,
             the focus within the predicate is different from that outside; this means that the use of a
@@ -21079,10 +21080,10 @@ declare function fold-right (
             the case of multiplication, or a zero-length string in the case of string concatenation)
             that causes the function to return the value of the other argument unchanged.</p>
          <p>In cases where the function performs an associative operation on its two arguments (such
-            as addition or multiplication), <code>fn:fold-right</code> produces the same result as
-               <code>fn:fold-left</code>.</p>
+            as addition or multiplication), <function>fn:fold-right</function> produces the same result as
+               <function>fn:fold-left</function>.</p>
          <p>The value of the third argument of <code>$action</code> corresponds to the position
-            of the item in the input sequence. Thus, in contrast to <code>fn:fold-left</code>,
+            of the item in the input sequence. Thus, in contrast to <function>fn:fold-left</function>,
             it is initally set to the number of items in the input sequence.</p>
       </fos:notes>
       <fos:examples>
@@ -21207,7 +21208,7 @@ return fn($input as item()*, $functions as fn(*)*) as item()* {
       <fos:errors>
          <p>An error <errorref class="AP" code="0001" type="type"/> is raised if the arity of any
             function <code>$f</code> in <code>$functions</code> is different from the number of
-            members in the array that is passed to <code>fn:apply</code>.</p>
+            members in the array that is passed to <function>fn:apply</function>.</p>
          <p>An error <errorref class="RG" code="0006" type="type"/> is raised if any item supplied as
               a function argument cannot be coerced to the required type.</p>
       </fos:errors>
@@ -21223,7 +21224,7 @@ return fn($input as item()*, $functions as fn(*)*) as item()* {
                   arity of one. Any function may have any arity. </p>
             </item>
             <item>
-               <p>Using <code>fn:chain</code> may result in more readable XPath expressions than
+               <p>Using <function>fn:chain</function> may result in more readable XPath expressions than
                   chaining expressions using arrow operators.</p>
             </item>
          </olist>
@@ -21516,7 +21517,7 @@ declare function while-do(
             side-effects. As long as a given condition is met, an new value is computed and tested
             again. Depending on the use case, the value can be a simple atomic item or an arbitrarily
             complex data structure.</p>
-         <p>The function <code>fn:do-until</code> can be used to perform the action before the
+         <p>The function <function>fn:do-until</function> can be used to perform the action before the
             first predicate test.</p>
          <p>Note that, just as when writing recursive functions, it is easy to construct infinite
             loops.</p>
@@ -21671,7 +21672,7 @@ declare function do-until(
             side-effects. A new value is computed and tested until a given condition fails. Depending
             on the use case, the value can be a simple atomic item or an arbitrarily complex data
             structure.</p>
-         <p>The function <code>fn:while-do</code> can be used to perform the action after the
+         <p>The function <function>fn:while-do</function> can be used to perform the action after the
             first predicate test.</p>
          <p>Note that, just as when writing recursive functions, it is easy to construct infinite
             loops.</p>
@@ -22032,7 +22033,7 @@ return sort($in, $SWEDISH)</eg>
             using the supplied <code>$comparators</code>. The result is a sorted sequence.</p>
          <p>Each comparator function takes two items and returns an <code>xs:integer</code> that
             defines the relationship between these items, in accordance with the
-            <code>fn:compare</code> function:</p>
+            <function>fn:compare</function> function:</p>
          <ulist>
             <item><p>The comparators are evaluated one after the other, either completely or
                until the result is an integer other than <code>0</code>.</p></item>
@@ -22140,7 +22141,7 @@ return sort-with($persons/person, (
          empty sequence, the function returns an empty sequence.
          </p>
          <p>The value of <code>$step</code> is a function that takes a single node as input, and returns a set of nodes as its result.</p> 
-         <p>The result of the <code>fn:transitive-closure</code> function is the set of nodes that are reachable from
+         <p>The result of the <function>fn:transitive-closure</function> function is the set of nodes that are reachable from
             <code>$node</code> by applying the <code>$step</code> function one or more times.</p>
          
          <p>Although <code>$step</code> may return any sequence of nodes, the result is treated as a set: the order of nodes
@@ -22570,7 +22571,7 @@ xs:QName('xs:double')</eg></fos:result>
          <p>Determines whether two atomic items are equal, under the rules used for comparing keys in a map.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>fn:atomic-equal</code> is used to compare two atomic items for equality. This function
+         <p>The function <function>fn:atomic-equal</function> is used to compare two atomic items for equality. This function
          has the following properties (which do not all apply to the <code>eq</code> operator):</p>
          <ulist>
             <item><p>Any two atomic items can be compared, regardless of their type.</p></item>
@@ -22727,8 +22728,8 @@ xs:QName('xs:double')</eg></fos:result>
          <p>The function is used to assess whether two atomic
             items are considered to be duplicates when used as keys in a map. A map cannot
             contain two separate entries whose keys are <term>the same</term> as defined by this function. 
-            The function is also used when matching keys in functions such as <code>map:get</code>
-            and <code>map:remove</code>.</p>
+            The function is also used when matching keys in functions such as <function>map:get</function>
+            and <function>map:remove</function>.</p>
          
          <p>The rules for comparing keys in a map are chosen to ensure that the comparison is:</p>
          <ulist>
@@ -22746,11 +22747,11 @@ xs:QName('xs:double')</eg></fos:result>
          <p>Two atomic items may be distinguishable even though they are equal under this comparison. For example: they may have
          different type annotations; dates and times may have different timezones; <code>xs:QName</code> values may have different
          prefixes.</p>
-         <p>Unlike the <code>eq</code> operator and the <code>fn:deep-equal</code> function, <code>xs:hexBinary</code> and
+         <p>Unlike the <code>eq</code> operator and the <function>fn:deep-equal</function> function, <code>xs:hexBinary</code> and
          <code>xs:base64Binary</code> values are considered distinct. This decision was made in order to preserve backwards
          compatibility: if the values were treated as interchangeable, it would become impossible to construct certain maps that
          could be validly constructed using earlier versions of the specification, and it would be difficult to make maps fully
-         interoperable between processors supporting different language versions, for example when calling <code>fn:transform</code>.</p>
+         interoperable between processors supporting different language versions, for example when calling <function>fn:transform</function>.</p>
          <p>As always, any algorithm that delivers the right result is acceptable. For example, when testing whether an <code>xs:double</code>
          value <var>D</var> is the same key as an <code>xs:decimal</code> value that has <var>N</var> significant digits, it is not
          necessary to know all the digits in the decimal expansion of <var>D</var> to establish the result: computing the first <var>N+1</var> 
@@ -22820,7 +22821,7 @@ xs:QName('xs:double')</eg></fos:result>
          <p>Returns a map that combines the entries from a number of existing maps.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:merge</code>
+         <p>The function <function>map:merge</function>
             <phrase>returns a map</phrase> that
             is formed by combining the contents of the maps supplied in the <code>$maps</code>
             argument.</p>
@@ -22955,16 +22956,16 @@ return fold-left($maps, {},
          <note>
             <p>By way of explanation, <code>$combine</code> is a function that combines
             two maps by iterating over the keys of the second map, adding each key and its corresponding
-            value to the first map as it proceeds. The second call of <code>fn:fold-left</code>
+            value to the first map as it proceeds. The second call of <function>fn:fold-left</function>
             in the <code>return</code> clause then iterates over the maps supplied in the call
-            to <code>map:merge</code>, accumulating a single map that absorbs successive maps
+            to <function>map:merge</function>, accumulating a single map that absorbs successive maps
             in the input sequence by calling <code>$combine</code>.</p>
 
 
             <p>This algorithm processes the supplied maps in a defined order, but processes the keys within
          each map in implementation-dependent order.</p>
 
-            <p>The use of <code>fn:random-number-generator</code> represents one possible conformant
+            <p>The use of <function>fn:random-number-generator</function> represents one possible conformant
          implementation for <code>"duplicates": "use-any"</code>, but it is not the only conformant
          implementation and is not intended to be a realistic implementation. The purpose of this
          option is to allow the implementation to use whatever strategy is most efficient; for example,
@@ -23074,7 +23075,7 @@ return fold-left($maps, {},
       </fos:summary>
       <fos:rules>
          
-         <p>The function <code>map:of-pairs</code>
+         <p>The function <function>map:of-pairs</function>
             <phrase>returns a map</phrase> that
             is formed by combining <termref def="dt-key-value-pair-map">key-value pair maps</termref> supplied in the 
             <code>$input</code>
@@ -23092,7 +23093,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
       <fos:errors>
          <p>The function can be made to fail with a dynamic error in the event that
          duplicate keys are present in the input sequence by supplying a <code>$combine</code>
-         function that invokes the <code>fn:error</code> function.</p>
+         function that invokes the <function>fn:error</function> function.</p>
       </fos:errors>
 
       <fos:notes>
@@ -23122,8 +23123,8 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
   5: &quot;Freitag&quot;, 
   6: &quot;Samstag&quot;
 }</eg></fos:result>
-               <fos:postamble>The function <code>map:of-pairs</code> is the inverse of
-                  <code>map:pairs</code>.</fos:postamble>
+               <fos:postamble>The function <function>map:of-pairs</function> is the inverse of
+                  <function>map:pairs</function>.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression><eg><![CDATA[map:of-pairs((
@@ -23202,7 +23203,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
          <p>Returns a sequence containing all the keys present in a map.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, the function <code>map:keys</code> takes any
+         <p>Informally, the function <function>map:keys</function> takes any
             <termref def="dt-map">map</termref> as its <code>$map</code> argument and returns
             the keys that are present in the map as a sequence of atomic items, in <termref
                def="implementation-dependent">implementation-dependent</termref> order.</p>
@@ -23247,7 +23248,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
          <p>Returns a sequence containing selected keys present in a map.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, the function <code>map:keys</code> takes any
+         <p>Informally, the function <function>map:keys</function> takes any
             <termref def="dt-map">map</termref> as its <code>$map</code> argument. The
             <code>$predicate</code> function takes the key and the value of the corresponding
             map entry as an argument, and the result is a sequence containing the keys of those
@@ -23338,7 +23339,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>Returns a sequence containing all the values present in a map, in unpredictable order.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:values</code> takes any <termref def="dt-map"
+         <p>The function <function>map:values</function> takes any <termref def="dt-map"
             >map</termref>
             as its <code>$map</code> argument and returns the values that are present in the map as
             a sequence, in <termref
@@ -23394,7 +23395,7 @@ return map:keys-where($birthdays, fn($name, $date) {
             as a <termref def="dt-singleton-map"/>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:entries</code> takes any <termref def="dt-map"
+         <p>The function <function>map:entries</function> takes any <termref def="dt-map"
             >map</termref>
             as its <code>$map</code> argument and returns the key-value pairs that are present in the map as
             a sequence of <termref def="dt-singleton-map">singleton maps</termref>, in <termref
@@ -23443,7 +23444,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          as a <termref def="dt-key-value-pair-map"/>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:pairs</code> takes any <termref def="dt-map"
+         <p>The function <function>map:pairs</function> takes any <termref def="dt-map"
             >map</termref>
             as its <code>$map</code> argument and returns the keys that are present in the map as
             a sequence of <termref def="dt-key-value-pair-map">key-value pair maps</termref>, in <termref
@@ -23501,7 +23502,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>Tests whether a supplied map contains an entry for a given key.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:contains</code> returns <code>true</code> if the <termref def="dt-map"
+         <p>The function <function>map:contains</function> returns <code>true</code> if the <termref def="dt-map"
                >map</termref> supplied as <code>$map</code> contains an entry with the <termref
                   def="dt-same-key">same key</termref> as <code>$key</code>; otherwise it returns <code>false</code>.</p>
       </fos:rules>
@@ -23591,7 +23592,7 @@ return map:keys-where($birthdays, fn($name, $date) {
          <p>Returns the value associated with a supplied key in a given map.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:get</code> attempts to find an entry within the <termref
+         <p>The function <function>map:get</function> attempts to find an entry within the <termref
                def="dt-map"
                >map</termref> supplied as <code>$map</code> that has 
             the <termref
@@ -23615,10 +23616,10 @@ return (
 )
       </fos:equivalent>
       <fos:notes>
-         <p>A return value of <code>()</code> from <code>map:get</code> could indicate that
+         <p>A return value of <code>()</code> from <function>map:get</function> could indicate that
             the key is present in the map with an associated value of <code>()</code>, or it could
             indicate that the key is not present in the map. The two cases can be distinguished by
-            calling <code>map:contains</code><phrase diff="add" at="2022-12-16">, or by using
+            calling <function>map:contains</function><phrase diff="add" at="2022-12-16">, or by using
             a <code>$fallback</code> function to return a value known never to appear in the map</phrase>.</p>
          
          <p diff="add" at="2022-12-16">The <code>$fallback</code> function can be used in a number of ways:</p>
@@ -23626,7 +23627,7 @@ return (
          <ulist diff="add" at="2022-12-16">
             <item><p>It might return a conventional value such as <code>NaN</code> to indicate that no matching
             key was found.</p></item>
-            <item><p>It might raise a dynamic error, by means of a call on <code>fn:error</code>.</p></item>
+            <item><p>It might raise a dynamic error, by means of a call on <function>fn:error</function>.</p></item>
             <item><p>It might compute a result algorithmically. For example, if the map holds a table of
             abbreviations, such as <code>{ 'CA': 'Canada', 'UK': 'United Kingdom', 'US': 'United States' }</code>,
             then specifying <code>fallback := fn:identity#1</code> has the effect that the key value is returned
@@ -23692,7 +23693,7 @@ return (
             and returns the corresponding values.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:find</code> searches the sequence supplied as <code>$input</code>
+         <p>The function <function>map:find</function> searches the sequence supplied as <code>$input</code>
          looking for map entries whose key is the <termref
                def="dt-same-key"
             >same key</termref>
@@ -23813,7 +23814,7 @@ declare function map:find($input as item()*,
          any existing entry for the same key.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:put</code> returns <phrase>a <termref def="dt-map"
+         <p>The function <function>map:put</function> returns <phrase>a <termref def="dt-map"
                >map</termref> that</phrase> contains all entries from the supplied <code>$map</code>,
             with the exception of any entry whose key is the <termref
                def="dt-same-key"
@@ -23890,7 +23891,7 @@ declare function map:find($input as item()*,
             represents a single key-value pair.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:entry</code> returns a <termref def="dt-map"
+         <p>The function <function>map:entry</function> returns a <termref def="dt-map"
                >map</termref> which  contains a single
             entry. The key of the entry in the new map is
                <code>$key</code>, and its associated value is <code>$value</code>.</p>
@@ -23902,8 +23903,8 @@ declare function map:find($input as item()*,
       </fos:equivalent>
       <fos:notes>
          
-         <p>The function <code>map:entry</code> is intended primarily for use in conjunction with
-            the function <code>map:merge</code>. For example, a map containing seven entries may be
+         <p>The function <function>map:entry</function> is intended primarily for use in conjunction with
+            the function <function>map:merge</function>. For example, a map containing seven entries may be
             constructed like this:</p>
 
          <eg><![CDATA[
@@ -23916,7 +23917,7 @@ map:merge((
   map:entry("Fr", "Friday"),
   map:entry("Sa", "Saturday")
 ))]]></eg>
-         <p>The <code>map:merge</code> function can be used to construct
+         <p>The <function>map:merge</function> function can be used to construct
             a map with a variable number of entries, for example:</p>
          <eg><![CDATA[
 map:merge(//book ! map:entry(isbn, .))]]></eg>
@@ -23948,7 +23949,7 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
             represents a single key-value pair.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:pair</code> returns a <termref def="dt-map"
+         <p>The function <function>map:pair</function> returns a <termref def="dt-map"
             >map</termref> which contains two entries, one (with the key <code>"key"</code>)
             containing <code>$key</code> and the other (with the key <code>"value"</code>)
             containing <code>$value</code>.</p>
@@ -23961,8 +23962,8 @@ map:merge(//book ! map:entry(isbn, .))]]></eg>
       <fos:notes>
          <p>The function call <code>map:pair(K, V)</code> produces the same result as the
          expression <code>{ "key": K, "value": V }</code>.</p>
-         <p>The function <code>map:pair</code> is intended primarily for use in conjunction with
-            the function <code>map:of-pairs</code>. A map may be constructed like this:</p>
+         <p>The function <function>map:pair</function> is intended primarily for use in conjunction with
+            the function <function>map:of-pairs</function>. A map may be constructed like this:</p>
 
          <eg><![CDATA[
 map:of-pairs((
@@ -23974,7 +23975,7 @@ map:of-pairs((
   map:pair("Fr", "Friday"),
   map:pair("Sa", "Saturday")
 ))]]></eg>
-         <p>The <code>map:of-pairs</code> function can be used to construct
+         <p>The <function>map:of-pairs</function> function can be used to construct
             a map with a variable number of entries, for example:</p>
          <eg><![CDATA[map:of-pairs(//book ! map:pair(./isbn, .))]]></eg>
       </fos:notes>
@@ -24007,7 +24008,7 @@ map:of-pairs((
          <p>Returns a map containing all the entries from a supplied map, except <phrase>those having a specified key</phrase>.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:remove</code> returns a <termref def="dt-map"
+         <p>The function <function>map:remove</function> returns a <termref def="dt-map"
                >map</termref> containing all the entries in <code>$map</code> except for any entry whose key is 
             the <termref
                def="dt-same-key">same key</termref> as <phrase>an item in</phrase>
@@ -24066,7 +24067,7 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
             <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> of the results.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:for-each</code> takes any <termref def="dt-map"
+         <p>The function <function>map:for-each</function> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map, in <termref
                def="implementation-dependent"
@@ -24092,7 +24093,7 @@ map:filter($map, fn($k, $v) { not(some($keys, atomic-equal($k, ?))) })
   fn($k, $v) { $k }
 )</eg></fos:expression>
                <fos:result allow-permutation="true">(1, 2)</fos:result>
-               <fos:postamble>This function call is equivalent to calling <code>map:keys</code>. The
+               <fos:postamble>This function call is equivalent to calling <function>map:keys</function>. The
                   result is in implementation-dependent order.</fos:postamble>
             </fos:test>
             <fos:test>
@@ -24152,7 +24153,7 @@ return <box>{
          <p>Selects entries from a map, returning a new map.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:filter</code> takes any <termref def="dt-map"
+         <p>The function <function>map:filter</function> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map; the result is a new map containing those entries for which
             the function returns <code>true</code>. A return value of <code>()</code> from the
@@ -24277,7 +24278,7 @@ else map:put($map, $key, $action(()))
          have the same keys as the input, but (potentially) different associated values.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:substitute</code> takes any <termref def="dt-map"
+         <p>The function <function>map:substitute</function> takes any <termref def="dt-map"
                >map</termref> as its <code>$map</code> argument and applies the supplied function
             to each entry in the map; the result is a map that associates the original set of key
             values with the results of these function calls.</p>
@@ -24363,7 +24364,7 @@ fold-left($input, {}, fn($map, $item, $pos) {
          <p>The default action for combining entries with duplicate keys is to perform a 
             <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> 
             of the corresponding values,
-            equivalent to the <code>duplicates: combine</code> option on <code>map:merge</code>. Other potentially useful
+            equivalent to the <code>duplicates: combine</code> option on <function>map:merge</function>. Other potentially useful
             functions for combining duplicates include:</p>
          <ulist>
             <item><p><code>fn($a, $b) { $a }</code> Use the first value and discard the remainder</p></item>
@@ -24392,7 +24393,7 @@ fold-left($input, {}, fn($map, $item, $pos) {
 )</eg></fos:expression>
                <fos:result>{ 1: "one", 2: "two", 3: "three", 4: "four", 5: "five" }</fos:result>
                <fos:postamble>Returns a map with five entries. The function to compute the key is an identity function, the
-                  function to compute the value invokes <code>fn:format-integer</code>.</fos:postamble>
+                  function to compute the value invokes <function>fn:format-integer</function>.</fos:postamble>
             </fos:test>
             <fos:test>
                <fos:expression><eg>map:build(
@@ -24485,7 +24486,7 @@ return map:build($titles/title, fn($title) { $title/ix })
          </fos:example>
          <fos:example>
             <p>The following expression creates a map allowing efficient access to every element in a document by means
-               of its <code>fn:generate-id</code> value:</p>
+               of its <function>fn:generate-id</function> value:</p>
             <eg>map:build(//*, generate-id#1)</eg>
          </fos:example>
       </fos:examples>
@@ -24509,7 +24510,7 @@ return map:build($titles/title, fn($title) { $title/ix })
          <p>Returns the number of entries in the supplied map.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <code>map:size</code> takes any <termref def="dt-map"
+         <p>The function <function>map:size</function> takes any <termref def="dt-map"
                >map</termref>
             as its <code>$map</code> argument and returns the number of entries that are present
             in the map.</p>
@@ -24563,7 +24564,7 @@ return map:build($titles/title, fn($title) { $title/ix })
             </p>
          
          <p>The function does not check whether the implementation actually recognizes
-         the resulting collation URI: that can be achieved using the <code>fn:collation-available</code>
+         the resulting collation URI: that can be achieved using the <function>fn:collation-available</function>
          function.</p>
          
          
@@ -24728,13 +24729,13 @@ return map:build($titles/title, fn($title) { $title/ix })
          <ulist>
             <item><p><code>equality</code> indicates that the intended purpose of the collation
             URI is to compare strings for equality, for example in functions such as 
-            <code>fn:index-of</code> or <code>fn:deep-equal</code>.</p></item>
+            <function>fn:index-of</function> or <function>fn:deep-equal</function>.</p></item>
             <item><p><code>sort</code> indicates that the intended purpose of the collation
             URI is to sort or compare different strings in a collating sequence, for example
-            in functions such as <code>fn:sort</code> or <code>fn:max</code>.</p></item>
+            in functions such as <function>fn:sort</function> or <function>fn:max</function>.</p></item>
             <item><p><code>substring</code> indicates that the intended purpose of the collation
             URI is to establish whether one string is a substring of another, for example
-            in functions such as <code>fn:contains</code> or <code>fn:starts-with</code>.</p></item>
+            in functions such as <function>fn:contains</function> or <function>fn:starts-with</function>.</p></item>
          </ulist>
          
          <p>The function returns true if and only if the implementation recognizes the candidate
@@ -24839,8 +24840,8 @@ return map:build($titles/title, fn($title) { $title/ix })
             codepoint equality is inappropriate for comparing keys, then a common technique is to
             normalize the key so that equality matching becomes feasible. There are many ways
             keys can be normalized, for example by use of functions such as
-               <code>fn:upper-case</code>, <code>fn:lower-case</code>,
-               <code>fn:normalize-space</code>, or <code>fn:normalize-unicode</code>, but this
+               <function>fn:upper-case</function>, <function>fn:lower-case</function>,
+               <function>fn:normalize-space</function>, or <function>fn:normalize-unicode</function>, but this
             function provides a way of normalizing them according to the rules of a specified
             collation. For example, if the collation ignores accents, then the function will
             generate the same collation key for two input strings that differ only in their use of
@@ -25088,9 +25089,9 @@ return $M(collation-key("a", $C))</eg></fos:expression>
                      <p>By default, the escape sequence is replaced with the Unicode
                      <code>REPLACEMENT CHARACTER</code>. The function is <emph>not</emph>
                      called for an escape sequence that is invalid against the grammar (for example <code>\x0A</code>). 
-                     The string, which results from invoking <code>fn:string</code> on the result
+                     The string, which results from invoking <function>fn:string</function> on the result
                      of the function, is inserted into the result in place of the invalid character. The
-                     function also has the option of raising a dynamic error by calling <code>fn:error</code>.</p>
+                     function also has the option of raising a dynamic error by calling <function>fn:error</function>.</p>
                   </fos:value>
                </fos:values>
             </fos:option>
@@ -25188,7 +25189,7 @@ return $M(collation-key("a", $C))</eg></fos:expression>
       </fos:errors>
       <fos:notes>
          <p>To read a JSON file, this function can be used in conjunction with the
-               <code>fn:unparsed-text</code> function.</p>
+               <function>fn:unparsed-text</function> function.</p>
          <p>Many JSON implementations allow commas to be used after the last item in an object or
             array, although the specification does not permit it. The option
                <code>spec="liberal"</code> is provided to allow such deviations from the
@@ -25482,7 +25483,7 @@ return json-to-xml($json, $options)]]></eg>
                   <p>The output uses exponential notation if and only if the input uses exponential notation.</p>
                   <p>The rules have changed since version 3.1 of this specification. In previous versions, the supplied
                      number was cast to an <code>xs:double</code>, and then serialized using the rules of the 
-                     <code>fn:string</code> function. This resulted in JSON numbers using exponential notation
+                     <function>fn:string</function> function. This resulted in JSON numbers using exponential notation
                      for values outside the range 1e-6 to 1e6, and led to a loss of precision for 64-bit integer
                      values.                 
                   </p>
@@ -25609,7 +25610,7 @@ return json-to-xml($json, $options)]]></eg>
             </item>
          </olist>
          <p>The rule allowing the top-level element to have a <code>key</code> attribute (which is ignored)
-         allows any element in the output of the <code>fn:json-to-xml</code> function
+         allows any element in the output of the <function>fn:json-to-xml</function> function
          to be processed: for example, it is possible to take a JSON document, convert it to XML, select
          a subtree based on the value of a <code>key</code> attribute, and then convert this subtree
          back to JSON, perhaps after a transformation. The rule means that an element with the appropriate name will be 
@@ -25701,8 +25702,8 @@ return json-to-xml($json, $options)]]></eg>
                <fos:type>xs:string</fos:type>
                <fos:default>"default"</fos:default>
                <fos:values>
-                  <fos:value value="lexical">Names are output in the form produced by the <code>fn:name</code> function.</fos:value>
-                  <fos:value value="local">Names are output in the form produced by the <code>fn:local-name</code> function.</fos:value>
+                  <fos:value value="lexical">Names are output in the form produced by the <function>fn:name</function> function.</fos:value>
+                  <fos:value value="local">Names are output in the form produced by the <function>fn:local-name</function> function.</fos:value>
                   <fos:value value="eqname">Names in a namespace are output in the form <code>"Q{uri}local"</code>.
                   Names in no namespace are output using the local name alone.</fos:value>
                   <fos:value value="default">An element name is output as a local name alone if either (a) it is
@@ -25844,8 +25845,8 @@ return json-to-xml($json, $options)]]></eg>
          
          <p>The <code>$value</code> argument is CSV data, as defined in <bibref ref="rfc4180"/>, in the form of 
             an <code>xs:string</code> value. The function first parses this string using
-            <code>fn:csv-to-arrays</code>, and then further processes the result. The initial
-            parsing is exactly as defined for <code>fn:csv-to-arrays</code>, and can be controlled
+            <function>fn:csv-to-arrays</function>, and then further processes the result. The initial
+            parsing is exactly as defined for <function>fn:csv-to-arrays</function>, and can be controlled
             using the same options. Additional options are available to control the way in which
             header information and column names are handled.</p>
          
@@ -26508,7 +26509,7 @@ return csv-to-arrays(
       </fos:summary>
       <fos:rules>
          <p>The arguments have the same meaning, and are subject to the same constraints, as
-         the arguments of <code>fn:parse-csv</code>.</p>
+         the arguments of <function>fn:parse-csv</function>.</p>
          
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
          
@@ -26562,7 +26563,7 @@ return document {
  
       </fos:rules>
       <fos:errors>
-         <p>See <code>fn:parse-csv</code>.</p>
+         <p>See <function>fn:parse-csv</function>.</p>
       </fos:errors>
       <fos:examples>
          <fos:variable name="crlf" id="escaped-crlf-3"><![CDATA[char('\r') || char('\n')]]></fos:variable>
@@ -27000,9 +27001,9 @@ return document {
                      <p>By default, the escape sequence is replaced with the Unicode
                      <code>REPLACEMENT CHARACTER</code>. The function is <emph>not</emph>
                      called for an escape sequence that is invalid against the grammar (for example <code>\x0A</code>).
-                     The string, which results from invoking <code>fn:string</code> on the result
+                     The string, which results from invoking <function>fn:string</function> on the result
                      of the function, is inserted into the result in place of the invalid character. The
-                     function also has the option of raising a dynamic error by calling <code>fn:error</code>.</p>
+                     function also has the option of raising a dynamic error by calling <function>fn:error</function>.</p>
                   </fos:value>
                </fos:values>
             </fos:option>
@@ -27278,12 +27279,12 @@ return document {
 
       </fos:rules>
       <fos:errors>
-         <p>The function may raise any error defined for the <code>fn:unparsed-text</code> or <code>fn:parse-json</code>
+         <p>The function may raise any error defined for the <function>fn:unparsed-text</function> or <function>fn:parse-json</function>
          functions.</p>
       </fos:errors>
       <fos:notes>
          <p>If the input cannot be decoded (that is, converted into a sequence of Unicode codepoints, which may or may not represent characters),
-            then a dynamic error occurs as with the <code>fn:unparsed-text</code> function.</p>
+            then a dynamic error occurs as with the <function>fn:unparsed-text</function> function.</p>
          <p>If the input can be decoded,
             then the possibility still arises that the resulting sequence of codepoints includes codepoints that do not represent characters that are valid in the
             version of XML that the processor supports. Such codepoints are translated into JSON escape sequences (for example, <code>\uFFFF</code>),
@@ -27291,7 +27292,7 @@ return document {
             defaults to a function that returns the Unicode <code>REPLACEMENT CHARACTER</code> (<code>xFFFD</code>).</p>
       </fos:notes>
       <fos:changes>
-         <fos:change><p>Additional options are available, as defined by <code>fn:parse-json</code>.</p></fos:change>
+         <fos:change><p>Additional options are available, as defined by <function>fn:parse-json</function>.</p></fos:change>
       </fos:changes>
       
    </fos:function>
@@ -27415,7 +27416,7 @@ return document {
                                  </ulist>
                               
                                  <p>The property value is the result of atomizing the attribute node and applying the
-                                 <code>fn:json</code> function to the result. (For untyped attributes, the result
+                                 <function>fn:json</function> function to the result. (For untyped attributes, the result
                                  will always be a single string.)</p>
                               
                            
@@ -27429,7 +27430,7 @@ return document {
                               <item>
                                  <p>If the element has a type annotation that is a simple type, or if its content
                                  comprises a single text node, then a property <code>#value</code> set to the result
-                                 of atomizing the element node and applying the <code>fn:json</code> function
+                                 of atomizing the element node and applying the <function>fn:json</function> function
                                  to the result.</p>
                               </item>
                               <item>
@@ -27446,7 +27447,7 @@ return document {
                               </item>
                               <item><p>Otherwise, a property <code>#content</code> whose value is an array, with
                               one member for each child node (including whitespace-only text nodes), obtained
-                              by applying the <code>fn:json</code> function to that child node.</p></item>
+                              by applying the <function>fn:json</function> function to that child node.</p></item>
                            </ulist>
                         </item>
                      </ulist>
@@ -27476,7 +27477,7 @@ return document {
                      (if non-empty) set to the prefix of the attribute’s name, <code>#namespace</code>
                      (if non-empty) set to the namespace URI, and <code>#value</code> set to
                         the result of atomizing the attribute value and applying the
-                        <code>fn:json</code> function to the result.</p>
+                        <function>fn:json</function> function to the result.</p>
                   </item>
                   <item><p><emph>Namespace nodes</emph></p></item>
                   <item><p>Namespace nodes that are reached via an element node result in no output.</p></item>
@@ -27492,7 +27493,7 @@ return document {
                and applying escaping rules. If the property name thus generated is the same as a previously output
                property name, then it is made unique by appending <code>"(N)"</code> where <var>N</var> is the smallest
                positive integer that makes the resulting value unique.</p>
-               <p>The property value is derived by applying the <code>fn:json</code> function to the value in the map entry.</p>
+               <p>The property value is derived by applying the <function>fn:json</function> function to the value in the map entry.</p>
                
                <note><p>Conflicts between property names can arise because the XDM model allows keys of different types,
                   for example the <code>xs:date</code> value <code>2020-12-31</code> and the string value 
@@ -27506,7 +27507,7 @@ return document {
             <item>
                <p><emph>Arrays</emph></p>
                <p>An XDM array is output as a JSON array. Each member of the XDM array generates one entry in the
-                  JSON array, in order, obtained by applying the <code>fn:json</code> function to the XDM array member.</p>              
+                  JSON array, in order, obtained by applying the <function>fn:json</function> function to the XDM array member.</p>              
             </item>
             <item>
                <p><emph>Functions</emph></p>
@@ -27628,7 +27629,7 @@ return document {
            count(array:members($array))
       </fos:equivalent>
       <fos:notes>
-         <p>Note that because an array is an item, the <code>fn:count</code> function
+         <p>Note that because an array is an item, the <function>fn:count</function> function
             when applied to an array always returns <code>1</code>.</p>
       </fos:notes>
       <fos:examples>
@@ -27727,7 +27728,7 @@ return document {
          If <code>$position</code> is less than one or greater than <code>array:size($array)</code>,
          then the <code>$fallback</code> function is called, supplying the value of <code>$position</code>
          as the argument value; and the result of this call is returned.</p>
-         <p diff="chg" at="2022-12-16">The default <code>$fallback</code> function raises a dynamic error. The call on <code>fn:error</code>
+         <p diff="chg" at="2022-12-16">The default <code>$fallback</code> function raises a dynamic error. The call on <function>fn:error</function>
          shown as the default is for illustrative purposes only; apart from the error code (<code>err:FOAY0001</code>)
             the details of the error (such as the error message) are <termref def="implementation-dependent">implementation-dependent</termref>.</p>
         
@@ -28136,7 +28137,7 @@ $array
          
          <p>Informally, all members of <code>$array</code> are compared with <code>$target</code>.
             An array member is compared to the target value using the rules of the
-            <code>fn:deep-equal</code> function, with the specified (or defaulted) collation.
+            <function>fn:deep-equal</function> function, with the specified (or defaulted) collation.
             The index position of the member is included in the result sequence if the
             comparison returns true.
          </p>
@@ -28291,7 +28292,7 @@ array:fold-left($array, (), fn($indices, $member, $pos) {
          <p>Returns an array containing selected members of a supplied input array based on their position.</p>
       </fos:summary>
       <fos:rules>
-         <p>Informally, the array is converted to a sequence, the function <code>fn:slice</code>
+         <p>Informally, the array is converted to a sequence, the function <function>fn:slice</function>
          is applied to this sequence, and the resulting sequence is converted back to an array.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression"><![CDATA[
@@ -28913,7 +28914,7 @@ return array:filter(
             array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is defined formally below, in terms of the equivalent <code>fn:fold-left</code>
+         <p>The function is defined formally below, in terms of the equivalent <function>fn:fold-left</function>
             function for sequences.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression"><![CDATA[
@@ -29001,7 +29002,7 @@ return array:fold-left($input, (),
             array.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is defined formally below, in terms of the equivalent <code>fn:fold-right</code>
+         <p>The function is defined formally below, in terms of the equivalent <function>fn:fold-right</function>
             function for sequences.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression"><![CDATA[
@@ -29017,7 +29018,7 @@ fold-right(
          <p>If the supplied array contains two members <code>$m</code> and <code>$n</code>, the function returns 
             <code>$action($m, $action($n, $zero))</code>; and similarly for an input array with more than two members.</p>
          <p>The value of the third argument of <code>$action</code> corresponds to the position
-            of the member in the input array. Thus, in contrast to <code>array:fold-left</code>,
+            of the member in the input array. Thus, in contrast to <function>array:fold-left</function>,
             it is initally set to the number of members in the input array.</p>
       </fos:notes>
       <fos:examples>
@@ -29246,7 +29247,7 @@ array:build(
             dm:iterate-array($array, map:entry('value', ?))
       </fos:equivalent>     
       <fos:notes>
-         <p>This function is the inverse of <code>array:of-members</code>.</p>   
+         <p>This function is the inverse of <function>array:of-members</function>.</p>   
       </fos:notes>
  
       <fos:examples>
@@ -29304,7 +29305,7 @@ array:for-each($array, fn($member) { [] => array:append($member) })
       <fos:notes>
          <p>The function call <code>array:split($array)</code> produces the same result as the
             expression <code>for member $m in $array return [ $m ]</code>.</p>
-         <p>This function is the inverse of <code>array:join</code>.</p>   
+         <p>This function is the inverse of <function>array:join</function>.</p>   
       </fos:notes>
  
       <fos:examples>
@@ -29380,7 +29381,7 @@ fold-left($input, [], fn($array, $record) {
       </fos:equivalent>
 
       <fos:notes>
-         <p>This function is the inverse of <code>array:members</code>.</p>       
+         <p>This function is the inverse of <function>array:members</function>.</p>       
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -29472,7 +29473,7 @@ fold-left($input, [], fn($array, $record) {
             (for example, in the case where a non-string sort key is followed by another sort key 
             that requires a collation) the empty string can be supplied.</p>
          
-         <p>The result of the function is defined by reference to the <code>fn:sort</code> function.</p>
+         <p>The result of the function is defined by reference to the <function>fn:sort</function> function.</p>
       </fos:rules>
             <fos:equivalent style="xpath-expression"><![CDATA[
 $array
@@ -29633,7 +29634,7 @@ declare function array:flatten(
          for-each(array:members($array), map:get(?, 'value'))
       </fos:equivalent>
       <fos:notes>
-         <p>Unlike <code>array:flatten</code>, the function does not apply recursively
+         <p>Unlike <function>array:flatten</function>, the function does not apply recursively
          to nested arrays.</p>
          <p>If <code>$A</code> is a single array item, then <code>array:values($A)</code>
          returns the same result as <code>$A?*</code>.</p>
@@ -29769,7 +29770,7 @@ declare function array:flatten(
                def="execution-scope">execution scope</termref> as the calling module.</p>
 
          <p>The library module that is loaded may import other modules using an <code>import module</code> declaration. The result of
-            <code>fn:load-xquery-module</code> does not include global variables or functions declared in such a transitively imported module.
+            <function>fn:load-xquery-module</function> does not include global variables or functions declared in such a transitively imported module.
             However, the <code>options</code> map supplied in the function call <rfc2119>may</rfc2119> 
             (and if no default is defined, <rfc2119>must</rfc2119>)
             supply values for external variables declared in transitively loaded library modules.</p>
@@ -29835,7 +29836,7 @@ declare function array:flatten(
             its arity range will be from 3 to 4, so the result will include two function items corresponding to <code>F#3</code>
             and <code>F#4</code>. In the lower-arity function item, <code>F#3</code>, the fourth parameter will take its
             default value. If the expression that initializes the default value is context sensitive, the static and dynamic
-            context for its evaluation are the static and dynamic contexts of the <code>fn:load-xquery-module</code>
+            context for its evaluation are the static and dynamic contexts of the <function>fn:load-xquery-module</function>
             function call itself.
          </p>
          
@@ -30185,7 +30186,7 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                <fos:applies-to>1.0, 2.0, 3.0</fos:applies-to>
                <fos:meaning>The URI of the principal result document; also used as the base URI for
             resolving relative URIs of secondary result documents. If the value is a relative 
-            reference, it is resolved against the static base URI of the <code>fn:transform</code> 
+            reference, it is resolved against the static base URI of the <function>fn:transform</function> 
             function call. </fos:meaning>
 
                <fos:type>xs:string</fos:type>
@@ -30222,7 +30223,7 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                   <fos:value value="serialized"
                         >The result is delivered as
                         a string, representing the results of serialization. Note that (as with the
-                            <code>fn:serialize</code> function) the final encoding stage of
+                            <function>fn:serialize</function> function) the final encoding stage of
                         serialization (which turns a sequence of characters into a sequence of
                         octets) is either skipped, or reversed by decoding the octet stream back
                         into a character stream.</fos:value>
@@ -30252,7 +30253,7 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
             </fos:option>
             <fos:option key="enable-trace">
                <fos:applies-to>2.0, 3.0</fos:applies-to>
-               <fos:meaning>Indicates whether any <code>fn:trace</code> functions in the stylesheet are to
+               <fos:meaning>Indicates whether any <function>fn:trace</function> functions in the stylesheet are to
             generate diagnostic messages. The destination and formatting of any such messages is
             implementation-defined.</fos:meaning>
                <fos:type>xs:boolean</fos:type>
@@ -30340,10 +30341,10 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                   the transformation (both the principal result and secondary results), in whatever
                   form it would otherwise be delivered (document, serialized, or raw). The first 
                   argument of the function is the key used to identify the result in the map return
-                  by the <code>fn:transform</code> function (for example, this will be the supplied 
+                  by the <function>fn:transform</function> function (for example, this will be the supplied 
                   base output URI in the case of the principal result, or the string “output” if no
                   base output URI was supplied). The second argument is the 
-                  actual value. The value that is returned in the result of the <code>fn:transform</code> 
+                  actual value. The value that is returned in the result of the <function>fn:transform</function> 
                   function is the result of applying this post-processing.
                   
                   <note>
@@ -30361,10 +30362,10 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                            def="implementation-defined">implementation-defined</termref>.</p>
                            <p>If the primary purpose of the post-processing function is achieved by 
                         means of such side-effects, and if the actual results are not needed by 
-                        the caller of the <code>fn:transform</code> function, then it does not matter what 
+                        the caller of the <function>fn:transform</function> function, then it does not matter what 
                         the post-processing function actually returns (it could be an empty 
                         sequence, for example).</p>
-                           <p>Calls to <code>fn:transform</code> can potentially have side-effects 
+                           <p>Calls to <function>fn:transform</function> can potentially have side-effects 
                         even in the absence of the post-processing option, because the XSLT 
                         specification allows a stylesheet to invoke extension functions 
                         that have side-effects. The semantics in this case are <termref
@@ -30405,7 +30406,7 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                <fos:applies-to>1.0, 2.0, 3.0</fos:applies-to>
                <fos:meaning>Serialization parameters for the principal result document. The supplied map
             follows the same rules that apply to a map supplied as the second argument of
-                <code>fn:serialize</code>. <ulist>
+                <function>fn:serialize</function>. <ulist>
                      <item><p>When a parameter is supplied, the corresponding value overrides or augments
                         the value specified in the unnamed <code>xsl:output</code> declaration (or
                         its default), following the same rules as when one <code>xsl:output</code>
@@ -30452,14 +30453,14 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                      def="implementation-defined"
                      >implementation-defined</termref> whether this
             parameter has any effect. If the value is a relative reference, it is resolved against
-            the static base URI of the <code>fn:transform</code> function call.</fos:meaning>
+            the static base URI of the <function>fn:transform</function> function call.</fos:meaning>
                <fos:type>xs:string</fos:type>
                <fos:default-description>n/a</fos:default-description>
             </fos:option>
             <fos:option key="stylesheet-location">
                <fos:applies-to>1.0, 2.0, 3.0</fos:applies-to>
                <fos:meaning>URI that can be used to locate the principal stylesheet module. If relative, it
-            is resolved against the static base URI of the <code>fn:transform</code> function call.
+            is resolved against the static base URI of the <function>fn:transform</function> function call.
             The value also acts as the default for stylesheet-base-uri.</fos:meaning>
                <fos:type>xs:string</fos:type>
                <fos:default-description>n/a</fos:default-description>
@@ -30560,8 +30561,8 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
                def="implementation-dependent"
                >implementation-dependent</termref> whether running the function twice against the same
          inputs produces identical results. The results of two invocations may differ in the identity of any returned nodes; they may also
-         differ in other respects, for example because the value of <code>fn:current-dateTime</code> is different for the two invocations,
-         or because the contents of external documents accessed using <code>fn:doc</code> or <code>xsl:source-document</code> change between
+         differ in other respects, for example because the value of <function>fn:current-dateTime</function> is different for the two invocations,
+         or because the contents of external documents accessed using <function>fn:doc</function> or <code>xsl:source-document</code> change between
          one invocation and the next.</p>
 
 
@@ -30589,7 +30590,7 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
          <p>If a static or dynamic error is reported by the XSLT processor, this function fails with a dynamic error, retaining the XSLT error code.</p>
          <p>A dynamic error is raised <errorref class="XT" code="0003" type="dynamic"
                /> if the XSLT transformation invoked by a call on
-            <code>fn:transform</code> fails with a static or dynamic error, and no more specific error code is available. </p>
+            <function>fn:transform</function> fails with a static or dynamic error, and no more specific error code is available. </p>
          <note>
             <p>XSLT 1.0 does not define any error codes, so this is the likely outcome with an XSLT 1.0 processor. XSLT 2.0 and 3.0 do
          define error codes, but some APIs do not expose them. If multiple errors are signaled by the transformation (which is most likely
@@ -30604,7 +30605,7 @@ return $variables(QName("http://example.com/dyn", "value"))</eg></fos:expression
          <p>A dynamic error is raised <errorref class="XT" code="0006" type="dynamic"
             /> if the transformation produces output containing
             characters available only in XML 1.1, and the calling processor cannot handle such characters.</p>
-         <p>Recursive use of the <code>fn:transform</code> function may lead to catastrophic failures such as
+         <p>Recursive use of the <function>fn:transform</function> function may lead to catastrophic failures such as
          non-termination or stack overflow. No error code is assigned to such conditions, since they cannot necessarily
          be detected by the processor.</p>
 
@@ -30664,9 +30665,9 @@ return $result?output//body
 
    
 
-         <p>Calling the <code>fn:random-number-generator</code> function with no arguments is equivalent to calling the single-argument
+         <p>Calling the <function>fn:random-number-generator</function> function with no arguments is equivalent to calling the single-argument
          form of the function with an implementation-dependent seed.</p>
-         <p>Calling the <code>fn:random-number-generator</code> function with an empty sequence as <code>$seed</code> 
+         <p>Calling the <function>fn:random-number-generator</function> function with an empty sequence as <code>$seed</code> 
             is equivalent to calling the single-argument form of the function with an implementation-dependent seed.</p>
          <p>If a <code>$seed</code> is supplied, it may be an atomic item of any type.</p>
          <p>Both forms of the function are <termref def="dt-deterministic"
@@ -30682,7 +30683,7 @@ return $result?output//body
          <p>The function returned in the <code>permute</code> entry <rfc2119>should</rfc2119> be such that all permutations 
             of the supplied sequence are equally likely to be chosen.</p>
 
-         <p>The map returned by the <code>fn:random-number-generator</code> function <rfc2119>may</rfc2119> contain additional entries beyond
+         <p>The map returned by the <function>fn:random-number-generator</function> function <rfc2119>may</rfc2119> contain additional entries beyond
             those specified here, but it <rfc2119>must</rfc2119> match the  
             <phrase
                diff="chg" at="A"
@@ -30731,7 +30732,7 @@ declare %private function local:random-sequence(
 };
 local:random-sequence(200)
             </eg>
-            <p>An equivalent result can be achieved with <code>fn:fold-left</code>:</p>
+            <p>An equivalent result can be achieved with <function>fn:fold-left</function>:</p>
             <eg>
 tail(fold-left(
   (1 to 200),
@@ -31153,8 +31154,8 @@ fn($item) {
          
          <p>That is, the supplied function for computing key values is wrapped in a function that
          converts any <code>xs:untypedAtomic</code> values in its result to <code>xs:double</code>. This makes
-         the function consistent with the behavior of <code>fn:min</code> and <code>fn:max</code>,
-         but inconsistent with <code>fn:sort</code>, which treats untyped values as strings.</p>
+         the function consistent with the behavior of <function>fn:min</function> and <function>fn:max</function>,
+         but inconsistent with <function>fn:sort</function>, which treats untyped values as strings.</p>
          
          <p>The result of the function is obtained as follows:</p>
          <ulist>
@@ -31507,8 +31508,8 @@ return $item
          
          <p>That is, the supplied function for computing key values is wrapped in a function that
             converts any <code>xs:untypedAtomic</code> values in its result to <code>xs:double</code>. This makes
-            the function consistent with the behavior of <code>fn:min</code> and <code>fn:max</code>,
-            but inconsistent with <code>fn:sort</code>, which treats untyped values as strings.</p>
+            the function consistent with the behavior of <function>fn:min</function> and <function>fn:max</function>,
+            but inconsistent with <function>fn:sort</function>, which treats untyped values as strings.</p>
          
          <p>The result of the function is obtained as follows:</p>
          <ulist>
@@ -31728,7 +31729,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
          <p>The result of the function <code>fn:all-equal($values, $collation)</code> is <code>true</code> if and only if the result
             of <code>fn:count(fn:distinct-values($values, $collation)) le 1</code> is <code>true</code> (that is, if the sequence
             is empty, or if all the items in the sequence are equal under the rules of the 
-            <code>fn:distinct-values</code> function).</p>
+            <function>fn:distinct-values</function> function).</p>
       </fos:rules>
       
 
@@ -31811,7 +31812,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
             of <code>fn:count(fn:distinct-values($values, $collation)) eq fn:count($values)</code> is <code>true</code> 
             (that is, if the sequence
             is empty, or if all the items in the sequence are distinct under the rules of the 
-            <code>fn:distinct-values</code> function).</p>
+            <function>fn:distinct-values</function> function).</p>
       </fos:rules>
       
 
@@ -32196,7 +32197,7 @@ fold-left($input, false(), fn($result, $item, $pos) {
          trailing <code>/</code> as special cases.</p></note>
 
          <p>Applying <emph>uri decoding</emph> is equivalent to
-         calling <code>fn:decode-from-uri</code> on the string.</p>
+         calling <function>fn:decode-from-uri</function> on the string.</p>
 
          <p>The <emph>query-parameters</emph> value is constructed as follows.
          Start with an empty map. Tokenize the <emph>query</emph> on
@@ -32237,14 +32238,14 @@ fold-left($input, false(), fn($result, $item, $pos) {
       </fos:errors>
 
       <fos:notes>
-         <p>Like <code>fn:resolve-uri</code>, this function handles the additional characters
+         <p>Like <function>fn:resolve-uri</function>, this function handles the additional characters
          allowed in <bibref ref="rfc3987"/> IRIs in the same way that other unreserved
          characters are handled.</p>
-         <p>Unlike <code>fn:resolve-uri</code>, this function is not attempting to resolve
+         <p>Unlike <function>fn:resolve-uri</function>, this function is not attempting to resolve
          one URI against another and consequently, the errors that can arise under those
-         circumstances do not apply here. The <code>fn:parse-uri</code> function will
+         circumstances do not apply here. The <function>fn:parse-uri</function> function will
          accept strings that would raise errors if resolution was attempted;
-         see <code>fn:build-uri</code>.</p>
+         see <function>fn:build-uri</function>.</p>
       </fos:notes>
       
 <fos:examples role="wide">
@@ -32616,7 +32617,7 @@ specifically aware of the <code>jar:</code> scheme.</p>
 <fos:example>
 <p>This example demonstrates that parsing the URI treats non-URI characters in
 lexical IRIs as “unreserved characters”. The rationale for this is given in the
-description of <code>fn:resolve-uri</code>.</p>
+description of <function>fn:resolve-uri</function>.</p>
 <fos:test>
 <fos:expression><eg>parse-uri("http://www.example.org/Dürst")</eg></fos:expression>
 <fos:result><eg>{
@@ -32793,7 +32794,7 @@ path with an explicit <code>file:</code> scheme.</p>
         is made to determine if a password or standard port are present,
         the <code>authority</code> value is simply added to the string.)</p>
 
-        <p>The <code>fn:parse-uri</code> function removes
+        <p>The <function>fn:parse-uri</function> function removes
         percent-escaping when it constructs the
         <code>path-segments</code>, <code>query-parameters</code>, and
         <code>fragment</code> properties. That’s often the most
@@ -33281,7 +33282,7 @@ month = '0', d | '1', ['0'|'1'|'2'] .
          exclude the “00” forms for month and day, but this is only intended to be
          an illustrative example.</p></note>
 
-         <p>The <code>fn:invisible-xml</code> function takes a grammar and
+         <p>The <function>fn:invisible-xml</function> function takes a grammar and
          returns a function that can be used to parse input strings. In practice,
          constructing a parser from a grammar may be an expensive operation.
          Returning a parsing function makes it easy to efficiently reuse
@@ -33310,7 +33311,7 @@ month = '0', d | '1', ['0'|'1'|'2'] .
          for the Invisible XML specification grammar. This <rfc2119>should</rfc2119> be the same
          grammar that the implementation uses to parse iXML grammars. If <code>$grammar</code> is not
          empty, it <rfc2119>must</rfc2119> be a valid Invisible XML grammar.
-         If it is not, <code>fn:invisible-xml</code> raises
+         If it is not, <function>fn:invisible-xml</function> raises
          <code>err:FOIX0001</code>.</p>
          
          <p>The parsing function that is returned behaves as follows:</p>
@@ -33421,7 +33422,7 @@ return $result
             </item>
             <item><p>The <code>id</code> property described in the previous paragraphs is allocated
             only to the top-level map or array (the one supplied as an explicit argument to the
-               <code>fn:pin</code> function). The function is <emph>not</emph>
+               <function>fn:pin</function> function). The function is <emph>not</emph>
                   <termref def="dt-deterministic">deterministic</termref>: that is, if the function is called
                   twice with the same arguments, it is <termref def="implementation-dependent"
                      >implementation-dependent</termref> whether the same <code>id</code> property is allocated on both
@@ -33555,8 +33556,8 @@ return pin($data)??languages[. = 'German'] ! label(.)?path()[1]</eg></fos:expres
             to the data model described in <xspecref spec="DM40" ref="id-LabeledItems"/>.</p>
          <p>The data model allows any item to be labeled, and allows the label to be any map
             with string-valued keys. Currently the only operation that creates labeled values is
-         the <code>fn:pin</code> function. For examples illustrating the use of <code>fn:label</code>,
-         see <code>fn:pin</code>.</p>
+         the <function>fn:pin</function> function. For examples illustrating the use of <function>fn:label</function>,
+         see <function>fn:pin</function>.</p>
          
       </fos:notes>
       

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -403,7 +403,7 @@ for transition to Proposed Recommendation. </p>'>
                bound to the correct URI. The host language may also define a default namespace for
                function calls, in which case function names in that namespace need not be prefixed
                at all. In many cases the default namespace will be 
-               <code>http://www.w3.org/2005/xpath-functions</code>, allowing a call on the <code>fn:name</code>
+               <code>http://www.w3.org/2005/xpath-functions</code>, allowing a call on the <function>fn:name</function>
                function (for example) to be written as <code>name()</code> rather than <code>fn:name()</code>; 
                in this document, however, all example function calls are explicitly prefixed.</p>
             
@@ -488,7 +488,7 @@ for transition to Proposed Recommendation. </p>'>
                   </example>
                   
                   <p diff="add" at="2022-12-20">Sometimes there is a need to use an operator as a function.
-                  To meet this requirement, the function <code>fn:op</code> takes any simple binary operator as its argument,
+                  To meet this requirement, the function <function>fn:op</function> takes any simple binary operator as its argument,
                   and returns a corresponding function. So for example <code>fn:for-each-pair($seq1, $seq2, op("+"))</code>
                   performs a pairwise addition of the values in two input sequences.</p>
                   
@@ -508,7 +508,7 @@ for transition to Proposed Recommendation. </p>'>
             <p>A function is uniquely defined by its name and arity (number of arguments); it is therefore
             not possible to have two different functions that have the same name and arity, but different
             types in their signature. That is, function overloading in this sense of the term is not permitted.
-            Consequently, functions such as <code>fn:string</code> which accept arguments of many different
+            Consequently, functions such as <function>fn:string</function> which accept arguments of many different
             types have a signature that defines a very general argument type, in this case <code>item()?</code>
             which accepts any single item; supplying an inappropriate item (such as a function item) causes
             a dynamic error.</p>
@@ -543,7 +543,7 @@ for transition to Proposed Recommendation. </p>'>
                   used only where there is a strong precedent in other programming languages (as with <code>math:sin</code> and 
                   <code>math:cos</code> for sine and cosine). If a
                   function name contains a <bibref ref="xmlschema-2"/> datatype name, it may have
-                  intercapitalized spelling and is used in the function name as such. An example is <code>fn:timezone-from-dateTime</code>.</p>
+                  intercapitalized spelling and is used in the function name as such. An example is <function>fn:timezone-from-dateTime</function>.</p>
             </div3>
             <div3 id="id-function-signatures-summary">
                <head>Function summary</head>
@@ -651,7 +651,7 @@ for transition to Proposed Recommendation. </p>'>
                formal specifications that invoke fn:atomic-equal.</edtext></ednote>
                
                <p>There is no attempt to write formal equivalents for functions that have complex logic
-               (such as <code>fn:format-number</code>) or dependencies (such as <code>fn:doc</code>); the aim
+               (such as <function>fn:format-number</function>) or dependencies (such as <function>fn:doc</function>); the aim
                of the formal equivalents is to define as rigorously as possible a platform of basic
                functionality that can be used as a solid foundation for more complex features.</p>
                
@@ -674,7 +674,7 @@ for transition to Proposed Recommendation. </p>'>
                <p>Many of the examples are given in structured form, showing example expressions and their expected results.
                These published examples are derived from executable test cases, so they follow a standard format. In general,
                the actual result of the expression is expected to be deep-equal to the presented result, under the
-               rules of the <code>fn:deep-equal</code> function with default options. In some cases the result is qualified
+               rules of the <function>fn:deep-equal</function> function with default options. In some cases the result is qualified
                to indicate that the order of items in the result is implementation-dependent, or that numeric results
                are approximate.</p>
                
@@ -727,7 +727,7 @@ for transition to Proposed Recommendation. </p>'>
             </example>
             <p>Note that this function signature is different from a signature in which the
                     parameter is omitted. See, for example, the two signatures
-                    for <code>fn:string</code>. In the first signature, the parameter is omitted
+                    for <function>fn:string</function>. In the first signature, the parameter is omitted
                     and the argument defaults to the context value, referred to as <code>.</code>.
                     In the second signature, the argument must be present but may be the empty
                     sequence, written as <code>()</code>.
@@ -764,7 +764,7 @@ for transition to Proposed Recommendation. </p>'>
             <p>As a matter of convention, a number of functions defined in this document take
             a parameter whose value is a map, defining options controlling the detail of how
             the function is evaluated. Maps are a new datatype introduced in XPath 3.1.</p>
-            <p>For example, the function <code>fn:xml-to-json</code> has an options parameter
+            <p>For example, the function <function>fn:xml-to-json</function> has an options parameter
             allowing specification of whether the output is to be indented. A call might be written:</p>
             <eg><![CDATA[xml-to-json($input, { 'indent': true() })]]></eg>
             <p><termdef id="option-parameter-conventions" term="option parameter conventions">Functions
@@ -787,8 +787,8 @@ for transition to Proposed Recommendation. </p>'>
                   For example, instances of <code>xs:untypedAtomic</code>
                   or <code>xs:anyURI</code> are equally acceptable.</p>
                   <note><p>This means that the implementation of the function can check for the
-               presence and value of particular options using the functions <code>map:contains</code>
-               and/or <code>map:get</code>.</p></note></item>
+               presence and value of particular options using the functions <function>map:contains</function>
+               and/or <function>map:get</function>.</p></note></item>
                <item><p>Implementations <rfc2119>may</rfc2119> attach an 
                   <termref def="implementation-defined">implementation-defined</termref> meaning to
                   options in the map that are not described in this specification. These options
@@ -822,7 +822,7 @@ for transition to Proposed Recommendation. </p>'>
                of the option explicitly accepts either. Accepting a sequence is convenient if the
                value is generated programmatically using an XPath expression; while accepting an array 
                allows the options to be held in an external file in JSON format, to be read using
-               a call on the <code>fn:json-doc</code> function.</p></item>
+               a call on the <function>fn:json-doc</function> function.</p></item>
                <item><p>In cases where the value of an option is itself a map, the specification
                of the particular function must indicate whether or not these rules apply recursively 
                to the contents of that map.</p></item>
@@ -999,8 +999,8 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   returned <code>xs:string</code> values are normalized in the sense of <bibref ref="charmod"/>.</p>
                <note>
                   <p>In functions that involve character counting such
-                     as <code>fn:substring</code>, <code>fn:string-length</code> and
-                     <code>fn:translate</code>, what is counted is the number of XML <termref def="character">characters</termref>
+                     as <function>fn:substring</function>, <function>fn:string-length</function> and
+                     <function>fn:translate</function>, what is counted is the number of XML <termref def="character">characters</termref>
                      in the string (or equivalently, the number of Unicode codepoints). Some
                      implementations may represent a codepoint above <char>U+FFFF</char> using two 16-bit
                      values known as a surrogate pair. A surrogate pair counts as one character, not two.</p>
@@ -1095,7 +1095,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p><termdef id="execution-scope" term="execution scope">An <term>execution scope</term> is a sequence of
                   calls to the function library during which certain aspects of the state are required to remain invariant.
-                  For example, two calls to <code>fn:current-dateTime</code> within the same execution scope will return the same result.
+                  For example, two calls to <function>fn:current-dateTime</function> within the same execution scope will return the same result.
                   The execution scope is defined by the host language that invokes the function library.</termdef>
                   In XSLT, for example, any two function calls executed during
                   the same transformation are in the same execution scope (except that static expressions, such as those used in
@@ -1137,8 +1137,8 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                evaluation context <phrase diff="add" at="2023-03-12">of the caller</phrase>
                   as well as on the actual supplied arguments (if any). A function definition may
                be context-dependent for some arities in its arity range, and context-independent
-               for others: for example <code>fn:name#0</code> is context-dependent
-                  while <code>fn:name#1</code> is context-independent.</termdef></p>
+               for others: for example <function>fn:name#0</function> is context-dependent
+                  while <function>fn:name#1</function> is context-independent.</termdef></p>
                
                <p><termdef id="dt-context-independent" term="context-independent">A 
                   <phrase diff="chg" at="2023-03-12"><xtermref spec="XP40" ref="dt-function-definition">function definition</xtermref></phrase> 
@@ -1149,13 +1149,13 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <ulist diff="add" at="2023-03-12">
                   <item><p>Functions that explicitly deliver the value of a component of the static or dynamic context,
-                  for example <code>fn:static-base-uri</code>, <code>fn:default-collation</code>,
-                  <code>fn:position</code>, or <code>fn:last</code>.</p></item>
+                  for example <function>fn:static-base-uri</function>, <function>fn:default-collation</function>,
+                  <function>fn:position</function>, or <function>fn:last</function>.</p></item>
                   <item><p>Functions with an optional parameter whose default value is taken from the static
-                     or dynamic context of the caller, usually either the context value (for example, <code>fn:node-name</code>)
-                     or the default collation (for example, <code>fn:index-of</code>).</p></item>
+                     or dynamic context of the caller, usually either the context value (for example, <function>fn:node-name</function>)
+                     or the default collation (for example, <function>fn:index-of</function>).</p></item>
                   <item><p>Functions that use the static context of the caller to expand or disambiguate
-                  the values of supplied arguments: for example <code>fn:doc</code> expands its first
+                  the values of supplied arguments: for example <function>fn:doc</function> expands its first
                   argument using the static base URI of the caller, and <code>xs:QName</code> expands its first argument
                   using the in-scope namespaces of the caller.</p></item>
                </ulist>
@@ -1200,12 +1200,12 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <p>A <phrase diff="chg" at="2023-03-12">function definition</phrase> that is context-dependent 
                   can be used as <phrase diff="add" at="2023-03-12">the target of</phrase> a named
-               function reference, can be partially applied, and can be found using <code>fn:function-lookup</code>. 
+               function reference, can be partially applied, and can be found using <function>fn:function-lookup</function>. 
                The principle in such cases is that the static context used for the function evaluation
                is taken from the static context of the named function reference, partial function application, or the call
-               on <code>fn:function-lookup</code>; and the dynamic context for the function evaluation is taken from the dynamic
+               on <function>fn:function-lookup</function>; and the dynamic context for the function evaluation is taken from the dynamic
                context of the evaluation of the named function reference, partial function application, or the call
-               of <code>fn:function-lookup</code>. <phrase diff="add" at="2023-03-12">These constructs all deliver a 
+               of <function>fn:function-lookup</function>. <phrase diff="add" at="2023-03-12">These constructs all deliver a 
                   <xtermref spec="DM40" ref="dt-function-item">function item</xtermref>
                   having a <term>captured context</term> based on the static and dynamic
                   context of the construct that created the function item. This captured context forms 
@@ -1220,22 +1220,22 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <olist diff="del" at="2023-03-12">
                
-               <item><p>The functions <code>fn:current-date</code>, <code>fn:current-dateTime</code>, <code>fn:current-time</code>, 
-                  <code>fn:default-language</code>, <code>fn:implicit-timezone</code>,
-               <code>fn:adjust-date-to-timezone</code>, <code>fn:adjust-dateTime-to-timezone</code>, and
-               <code>fn:adjust-time-to-timezone</code> depend on properties of the dynamic context that are
+               <item><p>The functions <function>fn:current-date</function>, <function>fn:current-dateTime</function>, <function>fn:current-time</function>, 
+                  <function>fn:default-language</function>, <function>fn:implicit-timezone</function>,
+               <function>fn:adjust-date-to-timezone</function>, <function>fn:adjust-dateTime-to-timezone</function>, and
+               <function>fn:adjust-time-to-timezone</function> depend on properties of the dynamic context that are
                fixed within the <termref def="execution-scope">execution scope</termref>. The same applies to a
                number of functions in the <code>op:</code> namespace that manipulate dates and times and
                that make use of the implicit timezone. These functions will return the same
                result if called repeatedly during a single <termref def="execution-scope">execution scope</termref>.</p></item>
                
-                  <item><p>A number of functions including <code>fn:base-uri#0</code>, <code>fn:data#0</code>, 
-                     <code>fn:document-uri#0</code>, <code>fn:element-with-id#1</code>, <code>fn:id#1</code>, 
-                     <code>fn:idref#1</code>, <code>fn:lang#1</code>, <code>fn:last#0</code>, <code>fn:local-name#0</code>,
-                     <code>fn:name#0</code>, <code>fn:namespace-uri#0</code>, <code>fn:normalize-space#0</code>, 
-                     <code>fn:number#0</code>, <code>fn:path#0</code>, <code>fn:position#0</code>, 
-                     <code>fn:root#0</code>, <code>fn:string#0</code>, and
-               <code>fn:string-length#0</code> depend on the <xtermref ref="dt-focus" spec="XP31">focus</xtermref>. 
+                  <item><p>A number of functions including <function>fn:base-uri#0</function>, <function>fn:data#0</function>, 
+                     <function>fn:document-uri#0</function>, <function>fn:element-with-id#1</function>, <function>fn:id#1</function>, 
+                     <function>fn:idref#1</function>, <function>fn:lang#1</function>, <function>fn:last#0</function>, <function>fn:local-name#0</function>,
+                     <function>fn:name#0</function>, <function>fn:namespace-uri#0</function>, <function>fn:normalize-space#0</function>, 
+                     <function>fn:number#0</function>, <function>fn:path#0</function>, <function>fn:position#0</function>, 
+                     <function>fn:root#0</function>, <function>fn:string#0</function>, and
+               <function>fn:string-length#0</function> depend on the <xtermref ref="dt-focus" spec="XP31">focus</xtermref>. 
                      These functions will in general return
                different results on different calls if the focus is different.</p>
                   <p>A function is <term>focus-dependent</term>
@@ -1247,7 +1247,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                         
  
                
-                  <item><p>The function <code>fn:default-collation</code> and many 
+                  <item><p>The function <function>fn:default-collation</function> and many 
                      string-handling operators and functions depend
                on the default collation and the in-scope collations, which are both properties
                of the static context. If a particular call of one of these functions is
@@ -1257,7 +1257,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                appearing in different places in the source code) may produce different results
                even if the explicit arguments are the same.</p></item>
                
-                  <item><p>Functions such as <code>fn:static-base-uri</code>, <code>fn:doc</code>, and <code>fn:collection</code> depend on
+                  <item><p>Functions such as <function>fn:static-base-uri</function>, <function>fn:doc</function>, and <function>fn:collection</function> depend on
                other aspects of the static context. As with functions that depend on
                collations, a single call will produce the same results on each call if the
                explicit arguments are the same, but two calls appearing in different places in
@@ -1265,11 +1265,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                </olist>
                
-               <p>The <code>fn:function-lookup</code> function is a special case because it is
+               <p>The <function>fn:function-lookup</function> function is a special case because it is
                potentially dependent on everything in the static and dynamic context. This is because the static and dynamic
-               context of the call to <code>fn:function-lookup</code> 
+               context of the call to <function>fn:function-lookup</function> 
                   <phrase diff="chg" at="2023-03-12">form the captured context of the
-               function item</phrase> that <code>fn:function-lookup</code> returns.</p>
+               function item</phrase> that <function>fn:function-lookup</function> returns.</p>
                
                <p diff="del" at="2023-03-12"><termdef id="dt-implicit-arguments" term="implicit argument">For a
                   <termref def="dt-context-dependent">context-dependent</termref> function, 
@@ -1291,24 +1291,24 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                
                <ulist>
                <item><p><termdef id="dt-nondeterministic-wrt-ordering" term="nondeterministic with respect to ordering">Some 
-                  functions (such as <code>fn:distinct-values</code>, <code>fn:unordered</code>, <code>map:keys</code>,
-                  and <code>map:for-each</code>) produce results in an
+                  functions (such as <function>fn:distinct-values</function>, <function>fn:unordered</function>, <function>map:keys</function>,
+                  and <function>map:for-each</function>) produce results in an
                   <termref def="implementation-defined">implementation-defined</termref> or 
                   <termref def="implementation-dependent">implementation-dependent</termref> order. 
                   In such cases two calls with the same arguments are not guaranteed to produce the results in the same order. These functions are
                said to be <term>nondeterministic with respect to ordering</term>.</termdef></p></item>
                
-               <item><p>Some functions (such as <code>fn:analyze-string</code>,
-                  <code>fn:parse-xml</code>, <code>fn:parse-xml-fragment</code>, 
-                  <code>fn:parse-html</code>, and <code>fn:json-to-xml</code>) 
+               <item><p>Some functions (such as <function>fn:analyze-string</function>,
+                  <function>fn:parse-xml</function>, <function>fn:parse-xml-fragment</function>, 
+                  <function>fn:parse-html</function>, and <function>fn:json-to-xml</function>) 
                   construct a tree of nodes to
                represent their results. There is no guarantee that repeated calls with the same
                arguments will return the same identical node (in the sense of the <code>is</code>
                operator). However, if non-identical nodes are returned, their content will be the
-               same in the sense of the <code>fn:deep-equal</code> function. Such a function is said 
+               same in the sense of the <function>fn:deep-equal</function> function. Such a function is said 
                to be <term>nondeterministic with respect to node identity</term>.</p></item>
                
-               <item><p>Some functions (such as <code>fn:doc</code> and <code>fn:collection</code>) create new nodes by reading external
+               <item><p>Some functions (such as <function>fn:doc</function> and <function>fn:collection</function>) create new nodes by reading external
                documents. Such functions are guaranteed to be <termref def="dt-deterministic">deterministic</termref> with the exception that
                an implementation is allowed to make them nondeterministic as a user option.</p></item>
                
@@ -1321,7 +1321,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                repeated calls with the same explicit and implicit arguments <rfc2119>must</rfc2119> return
                identical results.</p>
                
-               <p><termdef id="dt-variadic" term="variadic">The function <code>fn:concat</code>
+               <p><termdef id="dt-variadic" term="variadic">The function <function>fn:concat</function>
                   is defined to be variadic: it accepts any number of arguments. No other function
                   has this property.</termdef></p>
             </div3>           
@@ -1337,7 +1337,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
             <p>Each of these functions has an arity-zero signature which is equivalent to the arity-one
             form, with the context value supplied as the implicit first argument. In addition, each of the
             arity-one functions accepts an empty sequence as the argument, in which case it generally delivers
-            an empty sequence as the result: the exception is <code>fn:string</code>, which delivers
+            an empty sequence as the result: the exception is <function>fn:string</function>, which delivers
             a zero-length string.</p>
             <table role="data">
                <col width="25%" span="1"/>
@@ -1354,7 +1354,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                </thead>
                <tbody><tr>
                      <td>
-                               <code>fn:node-name</code>
+                               <function>fn:node-name</function>
                            </td>
                      <td>
                                <code>node-name</code>
@@ -1365,7 +1365,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   </tr>
                   <tr>
                      <td>
-                               <code>fn:nilled</code>
+                               <function>fn:nilled</function>
                            </td>
                      <td>
                                <code>nilled</code>
@@ -1376,7 +1376,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   </tr>
                   <tr>
                      <td>
-                               <code>fn:string</code>
+                               <function>fn:string</function>
                            </td>
                      <td>
                                <code>string-value</code>
@@ -1388,7 +1388,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   </tr>
                   <tr>
                      <td>
-                               <code>fn:data</code>
+                               <function>fn:data</function>
                            </td>
                      <td>
                                <code>typed-value</code>
@@ -1398,7 +1398,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   </tr>
                   <tr>
                      <td>
-                               <code>fn:base-uri</code>
+                               <function>fn:base-uri</function>
                            </td>
                      <td>
                                <code>base-uri</code>
@@ -1409,7 +1409,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   </tr>
                   <tr>
                      <td>
-                               <code>fn:document-uri</code>
+                               <function>fn:document-uri</function>
                            </td>
                      <td>
                                <code>document-uri</code>
@@ -1496,7 +1496,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
 	
 	         <p>In this document, as well as in <bibref ref="xquery-40"/> and <bibref ref="xpath-40"/>,
 	            the phrase <quote>an error is raised</quote>
-	                is used. Raising an error is equivalent to calling the <code>fn:error</code>
+	                is used. Raising an error is equivalent to calling the <function>fn:error</function>
 	                function defined in this section with the provided error code. Except where otherwise
 	                specified, errors defined in this specification are dynamic errors. Some errors,
 	                however, are classified as type errors. Type errors are typically used where the presence
@@ -1508,9 +1508,9 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
 	                in this document is identified by an <code>xs:QName</code> that is in the
 	                <code>http://www.w3.org/2005/xqt-errors</code> namespace, represented in this document by the <code>err</code> prefix. It is this
 	                <code>xs:QName</code> that is actually passed as an argument to the
-	                <code>fn:error</code> function. Calling this function raises an error.  For a
+	                <function>fn:error</function> function. Calling this function raises an error.  For a
 	                more detailed treatment of error handing, see <xspecref spec="XP31" ref="id-handling-dynamic"/>.</p>
-	         <p>The <code>fn:error</code> function is a general function that may be called as above
+	         <p>The <function>fn:error</function> function is a general function that may be called as above
 	                but may also be called from <bibref ref="xquery-40"/> or <bibref ref="xpath-40"/>
 	                applications with, for example, an <code>xs:QName</code> argument. </p>
 	         <div3 id="func-error">
@@ -1902,9 +1902,9 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
                boolean value.</p>
             <note><p diff="add" at="2023-12-05">For a description of the different ways of comparing numeric
                values using the operators <code>=</code> and <code>eq</code> and the functions
-               <code>fn:deep-equal</code> and <code>fn:atomic-equal</code>, 
+               <function>fn:deep-equal</function> and <function>fn:atomic-equal</function>, 
                see <xspecref spec="XP40" ref="id-atomic-comparisons"/>.</p></note>
-            <note><p diff="add" at="2023-12-18">See also the function <code>fn:compare</code>.</p></note>
+            <note><p diff="add" at="2023-12-18">See also the function <function>fn:compare</function>.</p></note>
             <?local-function-index?>
             <div3 id="func-numeric-equal">
                <head><?function op:numeric-equal?></head>
@@ -1926,7 +1926,7 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
                             argument is <code>NaN</code>, <code>NaN</code> is returned.</p>
                </item>
                <item>
-                  <p>With the exception of <code>fn:abs</code>, functions with arguments of 
+                  <p>With the exception of <function>fn:abs</function>, functions with arguments of 
                      type <code>xs:float</code> and <code>xs:double</code> that are positive or
                             negative infinity return positive or negative infinity.</p>
                </item>
@@ -1934,9 +1934,9 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
             <?local-function-index?>
             
             <note>
-               <p>The <code>fn:round</code> function has been extended with a third argument
-               in version 4.0 of this specification; this means that the <code>fn:ceiling</code>,
-               <code>fn:floor</code>, and <code>fn:round-half-to-even</code> functions are now
+               <p>The <function>fn:round</function> function has been extended with a third argument
+               in version 4.0 of this specification; this means that the <function>fn:ceiling</function>,
+               <function>fn:floor</function>, and <function>fn:round-half-to-even</function> functions are now
                technically redundant. They are retained, however, both for backwards compatibility
                and for convenience.</p>             
             </note>
@@ -1967,7 +1967,7 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
             <code>xs:float</code>, <code>xs:decimal</code>, or <code>xs:double</code>
             using the constructor functions described in <specref ref="constructor-functions"/>
             or using <code>cast</code> expressions as described in <specref ref="casting"/>.</p>
-            <p>In addition the <code>fn:number</code> function is available to convert strings
+            <p>In addition the <function>fn:number</function> function is available to convert strings
             to values of type <code>xs:double</code>. It differs from the <code>xs:double</code>
             constructor function in that any value outside the lexical space of the <code>xs:double</code>
             datatype is converted to the <code>xs:double</code> value <code>NaN</code>.</p>
@@ -2002,7 +2002,7 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
 		   
 		   <note>
 		      <p>This function can be used to format any numeric quantity, including an integer. For integers, however,
-		         the <code>fn:format-integer</code> function offers additional possibilities. Note also that the picture
+		         the <function>fn:format-integer</function> function offers additional possibilities. Note also that the picture
 		         strings used by the two functions are not 100% compatible, though they share some options in common.</p>
 		   </note>
 	
@@ -2302,12 +2302,12 @@ be preceded by the <xtermref spec="XP31" ref="id-static-decimal-format-minus-sig
             <div3 id="formatting-the-number">
                <head>Formatting the number</head>
                <p>This section describes the second phase of processing of the
-<code>fn:format-number</code> function. This phase takes as input a number to be formatted
+<function>fn:format-number</function> function. This phase takes as input a number to be formatted
 (referred to as the <emph>input number</emph>), and the variables set up by
 analyzing the decimal format in the static context and the
 <termref def="dt-picture-string">picture string</termref>, as described above.
  The result of this phase is a string, which forms the return value of 
-the <code>fn:format-number</code> function.</p>
+the <function>fn:format-number</function> function.</p>
                <p>The algorithm for this second stage of processing is as follows:</p>
                <olist>
                   <item>
@@ -2376,7 +2376,7 @@ For example, 1.0 is preferred to
 rounded so that it uses no more than <code>maximum-fractional-part-size</code> digits in
 its fractional part. The <var>rounded number</var> is defined to be the result of
 converting the <var>mantissa</var> to an <code>xs:decimal</code> value, as described above,
-and then calling the function <code>fn:round-half-to-even</code> with this converted number
+and then calling the function <function>fn:round-half-to-even</function> with this converted number
 as the first argument and the <code>maximum-fractional-part-size</code> as the second
 argument, again with no limits on the <code>totalDigits</code> or <code>fractionDigits</code> in the
 result.</p>
@@ -2634,7 +2634,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
 					One possible candidate is that the resource is a locale description
 					expressed using the Locale Data Markup Language: see <bibref ref="UNICODE-TR35"/>.
 					</p>
-               <p>Functions such as <code>fn:compare</code> and <code>fn:max</code> that
+               <p>Functions such as <function>fn:compare</function> and <function>fn:max</function> that
                         compare <code>xs:string</code> values use a single collation URI to identify
                         all aspects of the collation rules. This means that any parameters such as
                         the strength of the collation must be specified as part of the collation
@@ -2676,7 +2676,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                supplied strings.</p> 
                
                <p>The collation is defined as follows. Each of the two strings is
-               converted to a sequence of integers using the <code>fn:string-to-codepoints</code>
+               converted to a sequence of integers using the <function>fn:string-to-codepoints</function>
                function. These two sequences <code>$A</code> and <code>$B</code> are then compared as follows: </p>
                
                <olist>
@@ -2783,7 +2783,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                   or that are applicable only to substring matching.</p></note>
                
                <p>UCA collation URIs can be conveniently generated using the
-                  <code>fn:collation</code> function.</p>
+                  <function>fn:collation</function> function.</p>
             </div3>
             <div3 id="html-ascii-case-insensitive-collation" diff="chg" at="issue668">
                <head>The HTML ASCII Case-Insensitive Collation</head>
@@ -2819,7 +2819,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                <note><p>HTML5 defines the semantics of equality matching using this collation; <phrase diff="add" at="issue668">this
                   specification additionally defines ordering rules. </phrase>
                   The collation supports collation units and can therefore
-               be used with functions such as <code>fn:contains</code>; each Unicode codepoint is a single collation unit.</p>
+               be used with functions such as <function>fn:contains</function>; each Unicode codepoint is a single collation unit.</p>
                
                   <p>The corresponding HTML5 definition is: A string <var>A</var> is an ASCII case-insensitive match 
                      for a string <var>B</var>, if the ASCII lowercase of <var>A</var> is the ASCII lowercase of <var>B</var>.</p></note>
@@ -2835,7 +2835,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                   <item>
                      <p>If the function specifies an explicit collation, CollationA (e.g., if
                                 the optional collation argument is specified in a call of the
-                                <code>fn:compare</code> function), then:</p>
+                                <function>fn:compare</function> function), then:</p>
                      <ulist>
                         <item>
                            <p>If CollationA is supported by the implementation, then
@@ -2902,8 +2902,8 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                         <code>xs:string</code>, they are guaranteed to return values that are instances of
                         <code>xs:string</code>, but the value might or might not be an instance of the
                         particular subtype of <code>xs:string</code> to which they were applied. </p>
-               <p>The strings returned by <code>fn:concat</code> and <code>fn:string-join</code> are not guaranteed to be normalized.  
-			   But see note in <code>fn:concat</code>.
+               <p>The strings returned by <function>fn:concat</function> and <function>fn:string-join</function> are not guaranteed to be normalized.  
+			   But see note in <function>fn:concat</function>.
                 </p>
             </notes>
             <div3 id="func-char" diff="add" at="2022-11-19">
@@ -2959,8 +2959,8 @@ string conversion of the number as obtained above, and the appropriate <var>suff
             <p>When a collation is specified, the rules are more complex.</p>
             <p>All collations support the capability of deciding whether two <termref def="string">strings</termref> are
                     considered equal, and if not, which of the strings should be regarded as
-                    preceding the other. For functions such as <code>fn:compare</code>, this is
-                    all that is required. For other functions, such as <code>fn:contains</code>,
+                    preceding the other. For functions such as <function>fn:compare</function>, this is
+                    all that is required. For other functions, such as <function>fn:contains</function>,
                     the collation needs to support an additional property: it must be able to
                     decompose the string into a sequence of collation units, each unit consisting of
                     one or more characters, such that two strings can be compared by pairwise
@@ -3172,7 +3172,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                      this rule is unchanged from 1.0, but is renumbered [67])</p>
                      <note>
                         <p>Reluctant quantifiers have no effect on the results of the
-                                        boolean <code>fn:matches</code> function, since this
+                                        boolean <function>fn:matches</function> function, since this
                                         function is only interested in discovering whether a match
                                         exists, and not where it exists.</p>
                      </note>
@@ -3184,7 +3184,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                         recognized. The regular expression syntax defined by <bibref ref="xmlschema-2"/> 
 						      allows a regular expression to contain parenthesized sub-expressions, but attaches no special
                         significance to them. Some operations associated with regular expressions (for example,
-                           back-references, and the <code>fn:replace</code> function) allow access to the parts of the
+                           back-references, and the <function>fn:replace</function> function) allow access to the parts of the
                            input string that matched a sub-expression (called captured substrings).<!-- bug 17160 --></p>
                      
                      <p><termdef id="dt-capturing-subexpression" term="capturing sub-expression">A 
@@ -3240,7 +3240,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                      <p>In the absence of back-references (see below), 
                         the presence of the optional <code>?:</code> has no effect on the set of strings
                      that match the regular expression, but causes the left parenthesis not to be counted
-                     by operations (such as <code>fn:replace</code> and back-references) that number the capturing sub-expressions 
+                     by operations (such as <function>fn:replace</function> and back-references) that number the capturing sub-expressions 
                         within a regular expression.</p>
                   </div4>
                <div4 id="back-references">
@@ -3464,7 +3464,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                      by preceding it with a backslash.</p>
                          <p>Furthermore, when this flag is present, the characters <code>$</code> and
                          <code>\</code> have no special significance when used in the replacement string
-                         supplied to the <code>fn:replace</code> function.</p>
+                         supplied to the <function>fn:replace</function> function.</p>
                         <p>This flag can be used in conjunction with the <code>i</code> flag. If it is used
                            together with the <code>m</code>, <code>s</code>, <code>x</code>, 
                            <phrase diff="add" at="issue999">or <code>c</code></phrase> flag, that flag
@@ -3556,7 +3556,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
            convenient access to commonly used information.</p>
 
            <p>The path, if there is one, is tokenized on “/” characters and
-           each segment is unescaped (as per the <code>fn:decode-from-uri</code> function). Consider the URI
+           each segment is unescaped (as per the <function>fn:decode-from-uri</function> function). Consider the URI
            <code>http://example.com/path/to/a%2fb</code>.
            The path portion has to be returned as <code>/path/to/a%2fb</code> because
            decoding the <code>%2f</code> would change the nature of the path.
@@ -3666,7 +3666,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 			   is precisely equivalent to the duration <code>PT90S</code> (ninety seconds); these are
 			   different representations of the same value, and the result of any operation will be
 			   the same regardless which representation is used. For example, the function
-			   <code>fn:seconds-from-duration</code> returns 30 in both cases.</p>
+			   <function>fn:seconds-from-duration</function> returns 30 in both cases.</p>
 	     
 	      <!--<p>Conditions such as underflow and overflow may occur with arithmetic on
 	         durations: see <specref ref="duration-limits"/> </p>-->
@@ -3789,7 +3789,7 @@ For <code>xs:duration</code> and its subtypes, including the two subtypes <code>
         </div2>
 	     <div2 id="duration-construction">
 	        <head>Constructing durations</head>	        
-	        <p>This section decribes the <code>fn:seconds</code> function, which constructs
+	        <p>This section decribes the <function>fn:seconds</function> function, which constructs
 	        an <code>xs:dayTimeDuration</code> value representing a decimal number of seconds.</p>
 	        <?local-function-index?>
 	        <div3 id="func-seconds">
@@ -4270,8 +4270,8 @@ the <code>year</code>, <code>month</code> and <code>day</code> components are re
 
 		<div3 id="rules-for-datetime-formatting">
 		<head>The date/time formatting functions</head>
-            <p>The <code>fn:format-dateTime</code>, <code>fn:format-date</code>, 
-and <code>fn:format-time</code> 
+            <p>The <function>fn:format-dateTime</function>, <function>fn:format-date</function>, 
+and <function>fn:format-time</function> 
 functions format <code>$value</code> as a string using 
 the picture string specified by the <code>$picture</code> argument,
 the calendar specified by the <code>$calendar</code> argument,
@@ -4281,8 +4281,8 @@ The result of the function is the formatted string representation of the supplie
   <code>xs:dateTime</code>, <code>xs:date</code>, or <code>xs:time</code> value.</p>
             <p>
                <termdef id="dt-date-formatting-function" term="date formatting function">The three 
-                  functions <code>fn:format-dateTime</code>, <code>fn:format-date</code>, 
-                  and <code>fn:format-time</code> are referred to collectively as the
+                  functions <function>fn:format-dateTime</function>, <function>fn:format-date</function>, 
+                  and <function>fn:format-time</function> are referred to collectively as the
                    <term>date formatting functions</term>.</termdef>
             </p>
             <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
@@ -4435,7 +4435,7 @@ variation thereof for the chosen language, and the remainder of the value is for
                <p>A dynamic error is reported <errorref class="FD" code="1350"/>
  if a component specifier within the picture 
  refers to components that are not available in the given type of <code>$value</code>,
- for example if the picture supplied to the <code>fn:format-time</code> refers
+ for example if the picture supplied to the <function>fn:format-time</function> refers
  to the year, month, or day component.</p>
                <p>It is not an error to include a timezone component when the supplied
  value has no timezone. In these circumstances the timezone component will be ignored.</p>
@@ -4445,7 +4445,7 @@ either:</p>
                <ulist>
                   <item>
                      <p>any format token permitted as a primary format token in the second argument 
-of the <code>fn:format-integer</code> function, indicating
+of the <function>fn:format-integer</function> function, indicating
 that the value of the component is to be output numerically using the specified number format (for example,
 <code>1</code>, <code>01</code>, <code>i</code>, <code>I</code>, <code>w</code>, <code>W</code>,
 or <code>Ww</code>) or </p>
@@ -4482,7 +4482,7 @@ a second presentation modifier as follows:</p>
                         <td>either <code>a</code> or <code>t</code></td>
                         <td>indicates alphabetic or traditional numbering respectively,
                            the default being <termref def="implementation-defined"/>. 
-                           This has the same meaning as in the second argument of <code>fn:format-integer</code>.</td>
+                           This has the same meaning as in the second argument of <function>fn:format-integer</function>.</td>
                      </tr>
                      <tr>
                         <td>either <code>c</code> or <code>o</code></td>
@@ -4491,7 +4491,7 @@ a second presentation modifier as follows:</p>
                            <code>seventh</code>, or <code>7º</code>
                            for an ordinal number.
 						This has the same meaning as
-in the second argument of <code>fn:format-integer</code>. 
+in the second argument of <function>fn:format-integer</function>. 
 The actual representation of the ordinal form of a number
 may depend not only on the language, but also on the grammatical context (for example,
 in some languages it must agree in gender).</td>
@@ -4501,7 +4501,7 @@ in some languages it must agree in gender).</td>
 			   
                <note>
                   <p>Although the formatting rules are expressed in terms of the rules
-for format tokens in <code>fn:format-integer</code>, the formats actually used may be specialized
+for format tokens in <function>fn:format-integer</function>, the formats actually used may be specialized
 to the numbering of date components where appropriate. For example, in Italian, it is conventional to
 use an ordinal number (<code>primo</code>) for the first day of the month, and cardinal numbers
 (<code>due, tre, quattro ...</code>) for the remaining days. A processor may therefore use
@@ -4668,7 +4668,7 @@ modifier is also present, then the width modifier takes precedence.</p>
 		                  seconds value is <code>25.8235</code>, the reversed fractional seconds value is <code>5328</code>.
 		               </p></item>
 		               <item><p>The reversed fractional seconds value is formatted using the reversed decimal digit pattern according to the 
-		                  rules of the <code>fn:format-integer</code> function. Given the examples above, the result is <code>5'328</code>
+		                  rules of the <function>fn:format-integer</function> function. Given the examples above, the result is <code>5'328</code>
 		               </p></item>
 		               <item><p>The resulting string is reversed. In our example, the result is <code>823'5</code>.</p></item>
 		               <item><p>If the result contains more digits than the number of mandatory-digit-signs and optional-digit-signs in the 
@@ -4681,7 +4681,7 @@ modifier is also present, then the width modifier takes precedence.</p>
 		         </olist>
 		      <note>
 		         <p>The reason for presenting the algorithm in this way is that it enables maximum reuse of the rules defined for
-		            <code>fn:format-integer</code>. Since the fractional seconds value is not properly an integer, the rules do not
+		            <function>fn:format-integer</function>. Since the fractional seconds value is not properly an integer, the rules do not
 		            work if used directly: for example, the positions of grouping separators need to be counted from the left rather
 		            than from the right. Implementations, as always, are free to use a different algorithm that yields the same result.</p>
 		      </note>
@@ -5624,11 +5624,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <head>Functions that test the cardinality of sequences</head>
             <p>The following functions test the cardinality of their sequence arguments.</p>
             <?local-function-index?>
-            <p>The functions <code>fn:zero-or-one</code>, <code>fn:one-or-more</code>, and
-                    <code>fn:exactly-one</code> defined in this section, check that the cardinality
+            <p>The functions <function>fn:zero-or-one</function>, <function>fn:one-or-more</function>, and
+                    <function>fn:exactly-one</function> defined in this section, check that the cardinality
                     of a sequence is in the expected range. They are particularly useful with regard
                     to static typing. For example, the function call <code>fn:remove($seq, fn:index-of($seq2, 'abc'))</code>
-                    requires the result of the call on <code>fn:index-of</code> to be a singleton integer, 
+                    requires the result of the call on <function>fn:index-of</function> to be a singleton integer, 
                     but the static type system cannot infer this; writing the expression as 
                     <code>fn:remove($seq, fn:exactly-one(fn:index-of($seq2, 'abc')))</code> 
                     will provide a suitable static type at query analysis time, and ensures that the length of the sequence is
@@ -5669,7 +5669,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <div2 id="aggregate-functions">
             <head>Aggregate functions</head>
             <p>Aggregate functions take a sequence as argument and return a single value
-                    computed from values in the sequence. Except for <code>fn:count</code>, the
+                    computed from values in the sequence. Except for <function>fn:count</function>, the
                     sequence must consist of values of a single type or one if its subtypes, or they
                     must be numeric. <code>xs:untypedAtomic</code> values are permitted in the
                     input sequence and handled by special conversion rules. The type of the items in
@@ -5762,7 +5762,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <div2 id="xml-functions">
             <head>Functions on XML Data</head>
             <p>These functions convert between the lexical representation of XML and the tree representation.</p>
-            <p>(The <code>fn:serialize</code> function also handles HTML and JSON output, but is included in this section
+            <p>(The <function>fn:serialize</function> function also handles HTML and JSON output, but is included in this section
             for editorial convenience.)</p>
             <?local-function-index?>
             <div3 id="func-parse-xml">
@@ -5788,7 +5788,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="html-xdm-mapping">
                <head>XDM Mapping from HTML DOM Nodes</head>
                
-               <p>The <code>fn:parse-html</code> function conceptually works in two phases:</p>
+               <p>The <function>fn:parse-html</function> function conceptually works in two phases:</p>
                
                <olist>
                   <item><p>The lexical HTML (supplied as a string) is parsed into an HTML DOM
@@ -6608,7 +6608,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="html-parser-options">
                <head>HTML parser options</head>
                <p>This section describes the record structure used to pass options to the
-               <code>fn:parse-html</code> function.</p>
+               <function>fn:parse-html</function> function.</p>
 
 
 
@@ -6638,7 +6638,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
             
             <?local-function-index?>
-            <p>Note also that the function <code>fn:serialize</code> has an option to act as the inverse function to <code>fn:parse-json</code>.</p>
+            <p>Note also that the function <function>fn:serialize</function> has an option to act as the inverse function to <function>fn:parse-json</function>.</p>
             
   
                
@@ -6647,18 +6647,18 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   
                   
                   <p>This section defines a mapping from JSON data to XDM maps and arrays. Two functions are available
-                     to support this mapping: <code>fn:parse-json</code> and <code>fn:serialize</code> (with options
+                     to support this mapping: <function>fn:parse-json</function> and <function>fn:serialize</function> (with options
                      selecting JSON as the output method).
-                     The <code>fn:parse-json</code> function will accept any JSON text as input, and converts it
-                     to XDM data values. The <code>fn:serialize</code> function (with JSON as the output method) will accept any XDM
-                     value produced using <code>fn:parse-json</code> and convert it back to the original JSON text
+                     The <function>fn:parse-json</function> function will accept any JSON text as input, and converts it
+                     to XDM data values. The <function>fn:serialize</function> function (with JSON as the output method) will accept any XDM
+                     value produced using <function>fn:parse-json</function> and convert it back to the original JSON text
                      (subject to insignificant variations such as reordering the properties in a JSON object). </p>
                   
                   <note><p>The conversion is lossless if recommended JSON good practice is followed. Information may however be lost if
                      (a) JSON numbers are not exactly representable as double-precision floating point, or (b) duplicate key
                      values appear within a JSON object.</p></note>
                   
-                  <p>The representation of JSON data produced by the <code>fn:parse-json</code> function
+                  <p>The representation of JSON data produced by the <function>fn:parse-json</function> function
                      has been chosen with ease of manipulation as a design aim. For example, a simple JSON object
                      such as <code>{ "Sun": 1, "Mon": 2, "Tue": 3, ... }</code> produces a simple map, so if the result
                      of parsing is held in <code>$weekdays</code>, the number for a given weekday can be extracted
@@ -6676,8 +6676,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                   
                   
                   <p>This section defines a mapping from JSON data to XML (specifically, to XDM element and attribute nodes). A
-                     function <code>fn:json-to-xml</code> is provided to take a JSON string as input and convert it
-                     to the XML representation, and a second function <code>fn:xml-to-json</code> performs the reverse operation.</p>
+                     function <function>fn:json-to-xml</function> is provided to take a JSON string as input and convert it
+                     to the XML representation, and a second function <function>fn:xml-to-json</function> performs the reverse operation.</p>
                   
                   <p>The XML representation is designed to be capable of representing any valid JSON text including
                      one that uses characters which are not valid in XML. The transformation is normally lossless: that is,
@@ -6816,15 +6816,15 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      <item><p>The JSON value <code>null</code> is represented by an element named <code>null</code>, with empty content.</p></item>
                      <item><p>The JSON values <code>true</code> and <code>false</code> are represented by an element named <code>boolean</code>,
                         with content conforming to the type <code>xs:boolean</code>. When the element is created by the
-                        <code>fn:json-to-xml</code> function, the string value of the element will be <code>true</code> or <code>false</code>.
-                        The <code>fn:xml-to-json</code> function also recognizes other strings that validate as <code>xs:boolean</code>,
+                        <function>fn:json-to-xml</function> function, the string value of the element will be <code>true</code> or <code>false</code>.
+                        The <function>fn:xml-to-json</function> function also recognizes other strings that validate as <code>xs:boolean</code>,
                         for example <code>1</code> and <code>0</code>. Leading and trailing whitespace is accepted.
                      </p></item>
                      <item><p>A JSON number is represented by an element named <code>number</code>,
                         with content conforming to the type <code>xs:double</code>, with the additional restriction that the value
                         must not be positive or negative infinity, nor <code>NaN</code>. The
-                        <code>fn:json-to-xml</code> function creates an element whose string value is lexically the same as the JSON representation
-                        of the number. The <code>fn:xml-to-json</code> function generates a JSON representation that is the result of casting the
+                        <function>fn:json-to-xml</function> function creates an element whose string value is lexically the same as the JSON representation
+                        of the number. The <function>fn:xml-to-json</function> function generates a JSON representation that is the result of casting the
                         (typed or untyped) value of the node to <code>xs:double</code> and then casting the result to <code>xs:string</code>.
                         Leading and trailing whitespace is accepted.
                         Since JSON does not impose limits on the range or precision
@@ -6844,8 +6844,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                         of child elements each of which represents one of the name/value pairs in the object. The representation of the
                         name/value pair <var>N:V</var> is obtained by taking the element that represents the value <var>V</var> (by applying these
                         rules recursively) and adding an attribute with name <code>key</code> (in no namespace), whose
-                        value is <var>N</var> as an instance of <code>xs:string</code>. The functions <code>fn:json-to-xml</code> and
-                        <code>fn:xml-to-json</code> both retain the order of entries, subject to rules about how duplicate keys are handled. The
+                        value is <var>N</var> as an instance of <code>xs:string</code>. The functions <function>fn:json-to-xml</function> and
+                        <function>fn:xml-to-json</function> both retain the order of entries, subject to rules about how duplicate keys are handled. The
                         key may be represented in escaped or unescaped form.</p></item>
                      
                   </olist>
@@ -6876,8 +6876,8 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                      of schema validation.</p>
                   
                   <p>The namespace prefix associated with the namespace <code>http://www.w3.org/2005/xpath-functions</code> (if any) is immaterial.
-                     The effect of the <code>fn:xml-to-json</code> function does not depend on the choice of prefix, and the prefix (if any) generated by the
-                     <code>fn:json-to-xml</code> function is <termref def="implementation-dependent">implementation-dependent</termref>.</p>
+                     The effect of the <function>fn:xml-to-json</function> function does not depend on the choice of prefix, and the prefix (if any) generated by the
+                     <function>fn:json-to-xml</function> function is <termref def="implementation-dependent">implementation-dependent</termref>.</p>
                </div3>
             
             
@@ -6955,7 +6955,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             
             <?local-function-index?>
             
-            <p>The most basic function for parsing CSV is <code>fn:csv-to-arrays</code>
+            <p>The most basic function for parsing CSV is <function>fn:csv-to-arrays</function>
             which recognizes the delimiters for rows and fields and returns a sequence
             of arrays each corresponding to one row. The fields within each array are
             represented as instances of <code>xs:string</code>.</p>
@@ -7042,11 +7042,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
             <div3 id="basic-csv-to-xdm-mapping">
                <head>Basic parsing of CSV to arrays</head>
 
-               <p>The result of <code>fn:csv-to-arrays</code> is a sequence of rows, where
+               <p>The result of <function>fn:csv-to-arrays</function> is a sequence of rows, where
                   each row is represented as an array of <code>xs:string</code> values.</p>
 
                <p>The first row of the CSV is returned in the same way as all the other rows.
-                  <code>fn:csv-to-arrays</code> does not distinguish between a header row and data
+                  <function>fn:csv-to-arrays</function> does not distinguish between a header row and data
                   rows, and returns all of them.</p>
 
 <example>
@@ -7059,7 +7059,7 @@ Field 1A,Field 1B,Field 1C
 Field 2A,Field 2B,Field 2C'
                </eg>
 
-               <p>the <code>fn:csv-to-arrays</code> function produces</p>
+               <p>the <function>fn:csv-to-arrays</function> function produces</p>
 
                <eg>
 (
@@ -7097,7 +7097,7 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                   However, the reality is that CSVs can, and sometimes do, contain a variable number
                   of fields in a row. As a result, this function does
                   not truncate or pad the number of fields in each row for any reason.
-                  The <code>fn:csv-to-xml</code> and <code>fn:parse-csv</code> functions provide
+                  The <function>fn:csv-to-xml</function> and <function>fn:parse-csv</function> functions provide
                   facilities to enforce uniformity and an expected number of
                   columns.</p>
                </example>
@@ -7111,8 +7111,8 @@ Field 2A,Field 2B,Field 2C,Field 2D'
                <head>Enhanced parsing of CSV data to maps and arrays</head>
 
 
-               <p>While <code>fn:csv-to-arrays</code> simply delivers the CSV content
-                  as a sequence of arrays, the <code>fn:parse-csv</code> function goes a step
+               <p>While <function>fn:csv-to-arrays</function> simply delivers the CSV content
+                  as a sequence of arrays, the <function>fn:parse-csv</function> function goes a step
                   further and enables access to the data using column names. The column
                   names may be taken either from the first row of the CSV data, or from
                   data supplied by the caller in the <code>options</code> parameter.</p>
@@ -7130,7 +7130,7 @@ Field 2A,Field 2B,Field 2C,Field 2D'
             <div3 id="csv-represent-as-xml">
                <head>Representing CSV data as XML</head>
 
-               <p>The <code>fn:csv-to-xml</code> function returns an XDM node tree representing the CSV data.
+               <p>The <function>fn:csv-to-xml</function> function returns an XDM node tree representing the CSV data.
                   Following is a CSV text and the XML serialization of the corresponding node tree.</p>
 
                <eg>Name,Date,Amount
@@ -7207,7 +7207,7 @@ Bob,2023-07-14,2.34
                <eg>let $crlf := fn:char(0x0D)||fn:char(0x0A)</eg>
 
                <example id="csv-to-html-table">
-                  <head>Converting a CSV into an HTML-style table using <code>fn:parse-csv</code></head>
+                  <head>Converting a CSV into an HTML-style table using <function>fn:parse-csv</function></head>
 
                   <p>Direct conversion is a matter of iterating across the records and fields to
                      generate <code>&lt;tr&gt;</code> and <code>&lt;td&gt;</code> elements.</p>
@@ -7266,9 +7266,9 @@ return <table>
                   ]]></eg>
                </example>
                <example id="csv-to-html-table-csv-to-xml">
-                  <head>Converting a CSV into an HTML-style table using <code>fn:csv-to-xml</code></head>
+                  <head>Converting a CSV into an HTML-style table using <function>fn:csv-to-xml</function></head>
 
-                  <p>The <code>fn:csv-to-xml</code> function makes these kinds of
+                  <p>The <function>fn:csv-to-xml</function> function makes these kinds of
                      conversion-to-XML-table tasks simpler by providing a simple XML represenation of the data. Here, in XQuery:</p>
 
                   <eg><![CDATA[
@@ -7347,7 +7347,7 @@ return <table>
             <p>Invisible XML defines a BNF-like language for specifying grammars, together with 
             a mapping from sentences in that grammar to an XML representation. By defining an
             Invisible XML grammar, a great variety of non-XML data formats can be manipulated
-            as if they were XML. The function <code>fn:invisible-xml</code> takes a grammar
+            as if they were XML. The function <function>fn:invisible-xml</function> takes a grammar
             as input, and returns a function which can be used for parsing data instances
             and converting them to XML node trees.</p>
             <div3 id="func-invisible-xml">
@@ -7401,7 +7401,7 @@ return <table>
                <phrase diff="del" at="2023-01-29">Some host languages may exclude higher-order functions from the set of functions
             that they support, or may include such functions in an optional conformance feature.</phrase></p>
             
-            <note><p>Some functions such as <code>fn:parse-json</code> allow the option of supplying a callback function
+            <note><p>Some functions such as <function>fn:parse-json</function> allow the option of supplying a callback function
             for example to define exception behavior. Where this is not essential to the use of the function,
             the function has not been classified as higher-order for this purpose; in applications where function items
             cannot be created, these particular options will not be available.</p></note>
@@ -7541,15 +7541,15 @@ return <table>
             of the same type (for example, they can include a mixture of integers and strings).</p>
          
          <p>Maps are immutable, and have no identity separate from their content. 
-            For example, the <code>map:remove</code> function returns a map that differs
+            For example, the <function>map:remove</function> function returns a map that differs
             from the supplied map by the omission (typically) of one entry, but the supplied map is not changed by the operation.
-            Two calls on <code>map:remove</code> with the same arguments return maps that are
+            Two calls on <function>map:remove</function> with the same arguments return maps that are
             indistinguishable from each other; there is no way of asking whether these are “the same map”.</p>
          
          <p>A map can also be viewed as a function from keys to associated values. To achieve this, a map is also a 
             function item. The function corresponding to the map has the signature 
             <code>function($key as xs:anyAtomicValue) as item()*</code>. Calling the function has the same effect as calling
-            the <code>get</code> function: the expression
+            the <function>map:get</function> function: the expression
             <code>$map($key)</code> returns the same result as <code>get($map, $key)</code>. For example, if <code>$books-by-isbn</code>
             is a map whose keys are ISBNs and whose assocated values are <code>book</code> elements, then the expression
             <code>$books-by-isbn("0470192747")</code> returns the <code>book</code> element with the given ISBN.
@@ -7652,8 +7652,8 @@ return <table>
             an empty map, in preference to a call on <code>dm:empty-map()</code>.</p>
             
             <p>The formal equivalents are not intended to provide a realistic way of implementating the
-            functions (in particular, any real implementation might be expected to implement <code>map:get</code>
-            and <code>map:put</code> much more efficiently). They do, however, provide a framework that allows
+            functions (in particular, any real implementation might be expected to implement <function>map:get</function>
+            and <function>map:put</function> much more efficiently). They do, however, provide a framework that allows
             the correctness of a practical implementation to be verified.</p>
             
             <ednote><edtext>TODO: as yet there is no formal equivalent for <code>map:find()</code>.</edtext></ednote>
@@ -7672,7 +7672,7 @@ return <table>
             
             
             
-            <p>There is no operation to atomize a map or convert it to a string. The function <code>fn:serialize</code> can in some cases
+            <p>There is no operation to atomize a map or convert it to a string. The function <function>fn:serialize</function> can in some cases
             be used to produce a JSON representation of a map.</p>
             
             
@@ -7749,12 +7749,12 @@ return <table>
             <head>Converting Elements to Maps</head>
             <changes>
                <change issue="528">
-                  A new function <code>fn:elements-to-maps</code> is provided for converting XDM trees
-                  to maps suitable for serialization as JSON. Unlike the <code>fn:xml-to-json</code> function
+                  A new function <function>fn:elements-to-maps</function> is provided for converting XDM trees
+                  to maps suitable for serialization as JSON. Unlike the <function>fn:xml-to-json</function> function
                   retained from 3.1, this can handle arbitrary XML as input.
                </change>
             </changes>
-            <p>The <code>fn:elements-to-maps</code> function converts XML element nodes to maps, in a form
+            <p>The <function>fn:elements-to-maps</function> function converts XML element nodes to maps, in a form
                suitable for serialization as JSON. This section describes the mappings used by this function.</p>
             
             <p>This mapping is designed with three objectives:</p>
@@ -7860,7 +7860,7 @@ return <table>
                
                <ulist>
                   <item><p>The layout to be used for a specific element name can be explicitly selected in the options
-                  to the <code>fn:elements-to-maps</code> function.</p></item>
+                  to the <function>fn:elements-to-maps</function> function.</p></item>
                   <item><p>In the absence of an explicit selection, if the data has been schema-validated, the layout is 
                      inferred from the content model for the element type as defined in the schema.</p></item>
                   <item>
@@ -7888,7 +7888,7 @@ return <table>
                
                <ulist>
                   <item><p><term>Layout name</term>: the name to be used to select this layout in
-                  the <code>$options</code> parameter of the <code>fn:elements-to-maps</code> function.</p></item>
+                  the <code>$options</code> parameter of the <function>fn:elements-to-maps</function> function.</p></item>
                   <item><p><term>Usage</term>: the situations for which this layout is designed.</p></item>
                   <item><p><term>Example input</term>: an example of a typical element for which this layout is appropriate,
                      shown as serialized XML.</p></item>
@@ -7897,7 +7897,7 @@ return <table>
                   for the top-level elements supplied in the <code>$elements</code> argument; when used to convert
                      a descendant element, the corresponding key-value pair may appear as part of a larger map, depending
                      on the layout chosen for its parent element..</p>
-                  <note><p>The <code>fn:elements-to-maps</code> function produces maps as its result, but it is convenient
+                  <note><p>The <function>fn:elements-to-maps</function> function produces maps as its result, but it is convenient
                   to illustrate the form of the map by showing the effect of serializing the map as JSON.</p></note></item>
                   
                   <item><p><term>Mapping rules</term>: The rules for mapping the XML element to an XDM map
@@ -8333,7 +8333,7 @@ return <table>
                                  <code>list</code> layout.</p> 
                               
                               <p>If there are no children and the element is untyped (which can occur when 
-                                 this layout is chosen explicitly via the options to <code>fn:elements-to-maps</code>)
+                                 this layout is chosen explicitly via the options to <function>fn:elements-to-maps</function>)
                                  then the content property is omitted (since the child element name is unknown).
                                  But if the element is typed, then the content property is included and set to
                                  an empty array.</p>
@@ -8663,7 +8663,7 @@ return <table>
                         </tr>-->
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>The element node is serialized as if by the <code>fn:serialize</code>
+                           <td><p>The element node is serialized as if by the <function>fn:serialize</function>
                               function, and the resulting content is output as an atomic item of type 
                               <code>xs:string</code>.</p>
                               <p>The serialization parameter <code>method</code> is set to
@@ -8698,10 +8698,10 @@ return <table>
                
                <olist>
                   <item><p>If an explicit layout is given for the element name of <code>$E</code> in the
-                  options argument of the <code>fn:elements-to-maps</code> function call, then that layout is used.</p></item>
+                  options argument of the <function>fn:elements-to-maps</function> function call, then that layout is used.</p></item>
                   
                   <item><p>Let <code>$elements</code> be the value of the first argument to the
-                  <code>fn:elements-to-maps</code> function call.</p></item>
+                  <function>fn:elements-to-maps</function> function call.</p></item>
                   
                   <item><p>A layout is said to be disabled if its name is listed in the <code>disable-layouts</code>
                   option.</p></item>
@@ -8926,7 +8926,7 @@ return <table>
                   <item><p>The option <code>local</code> discards all namespace information: all elements and attributes
                   are output using the local name alone.</p></item>
                   <item><p>The option <code>lexical</code> outputs element and attribute names in the form 
-                     obtained by calling the function <code>fn:name</code>. If the name has a prefix,
+                     obtained by calling the function <function>fn:name</function>. If the name has a prefix,
                   the prefix is retained in the output. However, the output contains no information that enables the
                   prefix to be associated with a namespace URI, so this format is suitable only when prefixes 
                   in the input documents are used predictably.</p></item>
@@ -8988,7 +8988,7 @@ return <table>
                   
                </olist>
                
-               <note><p>Atomic items in the result of the <code>fn:elements-to-maps</code> function
+               <note><p>Atomic items in the result of the <function>fn:elements-to-maps</function> function
                   may be of any atomic type. The type information is lost if the result is 
                   subsequently serialized as JSON.</p></note>
             </div3>
@@ -8997,7 +8997,7 @@ return <table>
                <head>Lost XDM Information</head>
                
                <p>This section is non-normative. Its purpose is to explain what information available
-               in the XDM nodes supplied as input to the <code>fn:elements-to-maps</code> function
+               in the XDM nodes supplied as input to the <function>fn:elements-to-maps</function> function
                is missing from the output.</p>
                
                <ulist>
@@ -9219,12 +9219,12 @@ return <table>
             <p><emph>This section is non-normative.</emph></p>
 
             <p>Because a map is a function item, functions that apply to functions also apply
-               to maps. A map is an anonymous function, so <code>fn:function-name</code> returns the empty
-               sequence; <code>fn:function-arity</code> always returns <code>1</code>.</p>
+               to maps. A map is an anonymous function, so <function>fn:function-name</function> returns the empty
+               sequence; <function>fn:function-arity</function> always returns <code>1</code>.</p>
             
-            <p>Maps may be compared using the <code>fn:deep-equal</code> function.</p>
+            <p>Maps may be compared using the <function>fn:deep-equal</function> function.</p>
             
-            <p>There is no function or operator to atomize a map or convert it to a string (other than <code>fn:serialize</code>,
+            <p>There is no function or operator to atomize a map or convert it to a string (other than <function>fn:serialize</function>,
                which can be used to serialize some maps as JSON texts).</p>
             
             <p>XPath 4.0 defines a number of syntactic constructs that operate on maps. These all have equivalents
@@ -9284,7 +9284,7 @@ return <table>
             an empty array, in preference to a call on <code>dm:empty-array()</code>.</p>
             
             <p>The formal equivalents are not intended to provide a realistic way of implementating the
-            functions (in particular, any real implementation might be expected to implement <code>array:get</code>
+            functions (in particular, any real implementation might be expected to implement <function>array:get</function>
             much more efficiently). They do, however, provide a framework that allows
             the correctness of a practical implementation to be verified.</p>
             
@@ -9300,9 +9300,9 @@ return <table>
                is assumed to be bound to the namespace URI <code>http://www.w3.org/2005/xpath-functions/array</code>.</p>   
             
             <p>As with all other values, arrays are treated as immutable. 
-               For example, the <code>array:reverse</code> function returns an array that differs from the supplied
+               For example, the <function>array:reverse</function> function returns an array that differs from the supplied
                array in the order of its members, but the supplied array is not changed by the operation. Two calls
-               on <code>array:reverse</code> with the same argument will return arrays that are indistinguishable from
+               on <function>array:reverse</function> with the same argument will return arrays that are indistinguishable from
                each other; there is no way of asking whether these are “the same array”. Like sequences, arrays have no identity. </p>
             
             
@@ -9310,9 +9310,9 @@ return <table>
             <p diff="chg" at="2023-02-20">All functionality on arrays is defined in terms of two primitives:</p>
             
             <ulist diff="chg" at="2023-02-20">
-               <item><p>The function <code>array:members</code> decomposes an array to a sequence of 
+               <item><p>The function <function>array:members</function> decomposes an array to a sequence of 
                   <term>value records</term>.</p></item>
-               <item><p>The function <code>array:of-members</code> composes an array from a sequence of 
+               <item><p>The function <function>array:of-members</function> composes an array from a sequence of 
                <term>value records</term>.</p></item>
             </ulist>
             
@@ -9420,7 +9420,7 @@ return <table>
             <head>Other Operations on Arrays</head>
             <p><emph>This section is non-normative.</emph></p>
             
-            <p>Arrays may be compared using the <code>fn:deep-equal</code> function.</p>
+            <p>Arrays may be compared using the <function>fn:deep-equal</function> function.</p>
             
             <p>The XPath language provides explicit syntax for certain operations on arrays.
                These constructs can all be specified in terms of function primitives:</p>
@@ -9933,8 +9933,8 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
    <p>When a constructor function for a namespace-sensitive type is used as a literal function item
       or in a partial function application (for example, <code>xs:QName#1</code> or <code>xs:QName(?)</code>) the namespace
       bindings that are relevant are those from the static context of the literal function item or partial function application.
-      When a constructor function for a namespace-sensitive type is obtained by means of the <code>fn:function-lookup</code>
-      function, the relevant namespace bindings are those from the static context of the call on <code>fn:function-lookup</code>.</p>           
+      When a constructor function for a namespace-sensitive type is obtained by means of the <function>fn:function-lookup</function>
+      function, the relevant namespace bindings are those from the static context of the call on <function>fn:function-lookup</function>.</p>           
               
    <note><p>When the supplied argument to the <code>xs:QName</code> constructor
    function is a node, the node is atomized in the usual way, and if the result is <code>xs:untypedAtomic</code> it is then
@@ -10028,7 +10028,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                     types of <code>xs:numeric</code>, and its lexical space subsumes the lexical space of the other numeric
                     types. Thus, unlike XPath numeric literals, the result does not depend on the lexical form of the supplied
                     value. The reason for this design choice is to retain compatibility with the function conversion rules:
-                    functions such as <code>fn:abs</code> and <code>fn:round</code> are declared to expect an instance
+                    functions such as <function>fn:abs</function> and <function>fn:round</function> are declared to expect an instance
                     of <code>xs:numeric</code> as their first or only argument, and compatibility with the function conversion
                     rules defined in earlier versions of these specifications demands that when an untyped atomic item
                     (or untyped node) is supplied as the argument, it is converted to an <code>xs:double</code> value
@@ -11520,7 +11520,7 @@ There is no constructor function for <code>xs:NOTATION</code>. Constructors are 
                <head>Casting to date and time types</head>
                <p>In several situations, casting to date and time types requires the extraction
                         of a component from <var>SV</var> or from the result of
-                        <code>fn:current-dateTime</code> and converting it to an
+                        <function>fn:current-dateTime</function> and converting it to an
                         <code>xs:string</code>. These conversions must follow certain rules. For
                         example, converting an <code>xs:integer</code> year value requires
                         converting to an <code>xs:string</code> with four or more characters, preceded
@@ -12458,7 +12458,7 @@ If <var>SV</var> is an instance of <code>xs:string</code> or <code>xs:untypedAto
             
             <p>If the list type has a <code>pattern</code> facet, the pattern must match
             the supplied value after collapsing whitespace (an operation equivalent to the
-            use of the <code>fn:normalize-space</code> function).</p>
+            use of the <function>fn:normalize-space</function> function).</p>
             
             <p>For example, the expression <code>cast "A B C D" as xs:NMTOKENS</code>
             produces a sequence of four <code>xs:NMTOKEN</code> values, 
@@ -12788,10 +12788,10 @@ ISBN 0 521 77752 6.</bibl>
          <p>The error text provided with these errors is non-normative.</p>
          <error-list>
             <error class="ER" code="0000" label="Unidentified error." type="dynamic">
-               <p>Error code used by <code>fn:error</code> when no other error code is provided.</p>
+               <p>Error code used by <function>fn:error</function> when no other error code is provided.</p>
             </error>
             <error class="AP" code="0001" label="Wrong number of arguments." type="dynamic">
-               <p>Raised when <code>fn:apply</code> is called and the arity of the supplied function is not
+               <p>Raised when <function>fn:apply</function> is called and the arity of the supplied function is not
                   the same as the number of members in the supplied array.</p>
             </error>
             <error class="AR" code="0001" label="Division by zero." type="dynamic">
@@ -12805,7 +12805,7 @@ ISBN 0 521 77752 6.</bibl>
                <p>This error is raised when an integer used to select a member of an array is outside the range of values for that array.</p>
             </error>
             <error class="AY" code="0002" label="Negative array length." type="dynamic">
-               <p>This error is raised when the <code>$length</code> argument to <code>array:subarray</code> is negative.</p>
+               <p>This error is raised when the <code>$length</code> argument to <function>array:subarray</function> is negative.</p>
             </error>
             <error class="CA" code="0001" label="Input value too large for decimal."
                    type="dynamic">
@@ -12813,7 +12813,7 @@ ISBN 0 521 77752 6.</bibl>
                implementation-defined limits for the datatype.</p>
             </error>
             <error class="CA" code="0002" label="Invalid lexical value." type="dynamic">
-               <p>Raised by <code>fn:resolve-QName</code> and <code>fn:QName</code> when a supplied value does not have the lexical
+               <p>Raised by <function>fn:resolve-QName</function> and <function>fn:QName</function> when a supplied value does not have the lexical
                form of a QName or URI respectively; and when casting to decimal, if the supplied value is <code>NaN</code> or Infinity.</p>
             </error>
             <error class="CA" code="0003" label="Input value too large for integer."
@@ -12832,24 +12832,24 @@ ISBN 0 521 77752 6.</bibl>
                than the implementation can represent (the implementation also has the option of rounding).</p>
             </error>
             <error class="CH" code="0001" label="Codepoint not valid." type="dynamic">
-               <p diff="chg" at="2023-06-12">Raised by <code>fn:codepoints-to-string</code> if the input contains an integer that is not the codepoint
+               <p diff="chg" at="2023-06-12">Raised by <function>fn:codepoints-to-string</function> if the input contains an integer that is not the codepoint
                of a <termref def="dt-permitted-character">permitted character</termref>.</p>
             </error>
             <error class="CH" code="0002" label="Unsupported collation." type="dynamic">
                <p>Raised by any function that uses a collation if the requested collation is not recognized.</p>
             </error>
             <error class="CH" code="0003" label="Unsupported normalization form." type="static">
-               <p>Raised by <code>fn:normalize-unicode</code> if the requested normalization form is not
+               <p>Raised by <function>fn:normalize-unicode</function> if the requested normalization form is not
                supported by the implementation.</p>
             </error>
             <error class="CH" code="0004" label="Collation does not support collation units."
                    type="dynamic">
-               <p>Raised by functions such as <code>fn:contains</code> if the requested collation does
+               <p>Raised by functions such as <function>fn:contains</function> if the requested collation does
                not operate on a character-by-character basis.</p>
             </error>
             <error class="CH" code="0005" label="Unrecognized or invalid character name."
                type="dynamic">
-               <p diff="chg" at="2023-06-12">Raised by <code>fn:char</code> if the supplied character name is not recognized, or
+               <p diff="chg" at="2023-06-12">Raised by <function>fn:char</function> if the supplied character name is not recognized, or
                if it represents a codepoint that is not
                a <termref def="dt-permitted-character">permitted character</termref>.</p>
             </error>
@@ -12876,7 +12876,7 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <!--<error class="CV" code="0005" label="Non-positive integer provided as column index."
                type="dynamic">
-               <p>Raised by <code>fn:parse-csv</code>, <code>fn:csv-to-xml</code>, and the function
+               <p>Raised by <function>fn:parse-csv</function>, <function>fn:csv-to-xml</function>, and the function
                   from the <code>field</code> entry of <code>csv-columns-record</code>, if an
                   argument referring to a column index is zero or negative. (The options
                   <code>number-of-columns</code>, <code>filter-columns</code>, or in a map passed
@@ -12885,86 +12885,86 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="CV" code="0006" label="Both options number-of-columns and filter-columns set"
                type="dynamic">
-               <p>Raised by <code>fn:parse-csv</code> and <code>fn:csv-to-xml</code>, if both the
+               <p>Raised by <function>fn:parse-csv</function> and <function>fn:csv-to-xml</function>, if both the
                   <code>number-of-columns</code> and <code>filter-columns</code> options are set:
                   they are mutually exclusive.</p>
             </error>-->
             <error class="DC" code="0001" label="No context document." type="dynamic">
-               <p>Raised by <code>fn:id</code>, <code>fn:idref</code>, and <code>fn:element-with-id</code>
+               <p>Raised by <function>fn:id</function>, <function>fn:idref</function>, and <function>fn:element-with-id</function>
                   if the node that identifies the tree to be searched is a node in a tree whose root is not
                   a document node.</p>
             </error>
             <error class="DC" code="0002" label="Error retrieving resource." type="dynamic">
-               <p>Raised by <code>fn:doc</code>, <code>fn:collection</code>, and <code>fn:uri-collection</code>
+               <p>Raised by <function>fn:doc</function>, <function>fn:collection</function>, and <function>fn:uri-collection</function>
                to indicate that either the supplied URI cannot be dereferenced to obtain a resource, or the resource
                that is returned is not parseable as XML.</p>
             </error>
             <error class="DC" code="0003" label="Function not defined as deterministic." type="dynamic">
-               <p>Raised by <code>fn:doc</code>, <code>fn:collection</code>, and <code>fn:uri-collection</code> 
+               <p>Raised by <function>fn:doc</function>, <function>fn:collection</function>, and <function>fn:uri-collection</function> 
                   to indicate that it is not possible to
                return a result that is guaranteed deterministic.</p>
             </error>
             <error class="DC" code="0004" label="Invalid collection URI."
                    type="dynamic">
-               <p>Raised by <code>fn:collection</code> and <code>fn:uri-collection</code> 
+               <p>Raised by <function>fn:collection</function> and <function>fn:uri-collection</function> 
                   if the argument is not a valid <code>xs:anyURI</code>.</p>
             </error>
             <error class="DC" code="0005" label="Invalid URI reference."
                    type="dynamic">
-               <p>Raised (optionally) by <code>fn:doc</code> if the argument 
+               <p>Raised (optionally) by <function>fn:doc</function> if the argument 
                   is not a valid <code>xs:anyURI</code>.</p>
             </error>
             <error class="DC" code="0006" label="String passed to fn:parse-xml is not a well-formed XML document."
                type="dynamic">
-               <p>Raised by <code>fn:parse-xml</code> if the supplied string is not a well-formed and namespace-well-formed XML document;
+               <p>Raised by <function>fn:parse-xml</function> if the supplied string is not a well-formed and namespace-well-formed XML document;
                or if DTD validation is requested and the document is not valid against its DTD.</p>
             </error>
             <error class="DC" code="0007" label="String passed to fn:parse-xml is not a DTD-valid XML document."
                type="dynamic">
-               <p>Raised by <code>fn:parse-xml</code> if DTD validation is requested and the supplied string 
+               <p>Raised by <function>fn:parse-xml</function> if DTD validation is requested and the supplied string 
                   has no DTD or is not valid against the DTD.</p>
             </error>
             <error class="DC" code="0008" label="Invalid value for the xsd-validation option of fn:parse-xml."
                type="dynamic">
-               <p>Raised when the <code>xsd-validation</code> option to <code>fn:parse-xml</code> is supplied,
+               <p>Raised when the <code>xsd-validation</code> option to <function>fn:parse-xml</function> is supplied,
                   and the value is not one of the permitted values; for example if the option <code>type Q{U}NNN</code>
                   is used, and <code>Q{U}NNN</code> does not identify a type in the static context.</p>
             </error>
             <error class="DC" code="0009" label="Processor is not schema-aware."
                type="dynamic">
-               <p>Raised when the <code>xsd-validation</code> option to <code>fn:parse-xml</code> is set to
+               <p>Raised when the <code>xsd-validation</code> option to <function>fn:parse-xml</function> is set to
                   a value other than <code>skip</code>, if the processor is not schema-aware.</p>
             </error>
             
             <error class="DC" code="0010" label="The processor does not support serialization."
                type="dynamic">
-               <p>Raised when <code>fn:serialize</code> is called and the processor does not support serialization,
+               <p>Raised when <function>fn:serialize</function> is called and the processor does not support serialization,
                in cases where the host language makes serialization an optional feature.</p>
             </error>
             <error class="DC" code="0011" label="String passed to fn:parse-html is not a well-formed HTML document."
                    type="dynamic">
-               <p>Raised by <code>fn:parse-html</code> if the supplied string is not a well-formed HTML document.</p>
+               <p>Raised by <function>fn:parse-html</function> if the supplied string is not a well-formed HTML document.</p>
             </error>
             <error class="DC" code="0012" label="Unsupported HTML parser option."
                    type="dynamic">
-               <p>Raised by <code>fn:parse-html</code> if a key passed to <code>$options</code>, or its value,
+               <p>Raised by <function>fn:parse-html</function> if a key passed to <code>$options</code>, or its value,
                   is not supported by the implementation.</p>
             </error>
             <error class="DC" code="0013" label="No validating XML parser available."
                type="dynamic">
-               <p>Raised when the <code>dtd-validation</code> option to <code>fn:parse-xml</code> is set,
+               <p>Raised when the <code>dtd-validation</code> option to <function>fn:parse-xml</function> is set,
                   if no validating XML parser is available. Note: it is <rfc2119>recommended</rfc2119>
                that all processors should support the <code>dtd-validation</code> option, but there
                may be environments (such as web browsers) where this is not practically feasible.</p>
             </error>
             <error class="DC" code="0014" label="String passed to fn:parse-xml is not a schema-valid XML document."
                type="dynamic">
-               <p>Raised by <code>fn:parse-xml</code> if XSD validation is requested and the XML document
+               <p>Raised by <function>fn:parse-xml</function> if XSD validation is requested and the XML document
                   represented by the supplied string is not valid against the relevant XSD schema.</p>
             </error>
 			<error class="DF" code="1280" label="Invalid decimal format name."
                    type="dynamic">
-               <p>This error is raised if the decimal format name supplied to <code>fn:format-number</code> is not a valid QName,
+               <p>This error is raised if the decimal format name supplied to <function>fn:format-number</function> is not a valid QName,
 			   or if the prefix in the QName is undeclared, or if there is no decimal format in the static context with
 			   a matching name.</p>
             </error>
@@ -12972,15 +12972,15 @@ ISBN 0 521 77752 6.</bibl>
 			<error class="DF" code="1290" label="Invalid decimal format property."
                    type="dynamic">
                <p>This error is raised if a decimal format value supplied to
-               <code>fn:format-number</code> is not valid for the associated property,
+               <function>fn:format-number</function> is not valid for the associated property,
                or if the properties of the decimal format resulting from a supplied map
                do not have distinct values.</p>
             </error>
             
 			<error class="DF" code="1310" label="Invalid decimal format picture string."
                    type="dynamic">
-               <p>This error is raised if the picture string supplied to <code>fn:format-number</code> or 
-                  <code>fn:format-integer</code> has invalid syntax.</p>
+               <p>This error is raised if the picture string supplied to <function>fn:format-number</function> or 
+                  <function>fn:format-integer</function> has invalid syntax.</p>
             </error>
             <error class="DT" code="0001" label="Overflow/underflow in date/time operation."
                    type="dynamic">
@@ -13000,50 +13000,50 @@ ISBN 0 521 77752 6.</bibl>
             </error>
 			<error class="FD" code="1340" label="Invalid date/time formatting parameters."
                    type="dynamic">
-               <p>This error is raised if the picture string or calendar supplied to <code>fn:format-date</code>, <code>fn:format-time</code>, 
-			   or <code>fn:format-dateTime</code> has invalid syntax.</p>
+               <p>This error is raised if the picture string or calendar supplied to <function>fn:format-date</function>, <function>fn:format-time</function>, 
+			   or <function>fn:format-dateTime</function> has invalid syntax.</p>
             </error>
 			<error class="FD" code="1350" label="Invalid date/time formatting component."
                    type="dynamic">
-               <p>This error is raised if the picture string supplied to <code>fn:format-date</code> 
-			   selects a component that is not present in a date, or if the picture string supplied to <code>fn:format-time</code> 
+               <p>This error is raised if the picture string supplied to <function>fn:format-date</function> 
+			   selects a component that is not present in a date, or if the picture string supplied to <function>fn:format-time</function> 
 			   selects a component that is not present in a time.</p>
             </error>
 
             <error class="HA" code="0001" label="Invalid algorithm." type="dynamic">
-               <p>Raised by <code>fn:hash</code> if the effective value of the supplied
+               <p>Raised by <function>fn:hash</function> if the effective value of the supplied
                algorithm is not one of the values supported by the implementation.</p>
             </error>
             
             <error class="JS" code="0001" label="JSON syntax error." type="dynamic">
-               <p>Raised by functions such as <code>fn:json-doc</code>, <code>fn:parse-json</code> 
-                  or <code>fn:json-to-xml</code> 
+               <p>Raised by functions such as <function>fn:json-doc</function>, <function>fn:parse-json</function> 
+                  or <function>fn:json-to-xml</function> 
                   if the string supplied as input does not conform to the JSON grammar (optionally with implementation-defined extensions).</p>
             </error>
             
             <error class="JS" code="0003" label="JSON duplicate keys." type="dynamic">
-               <p>Raised by functions such as <code>map:merge</code>, <code>fn:json-doc</code>, 
-                  <code>fn:parse-json</code> or <code>fn:json-to-xml</code> 
+               <p>Raised by functions such as <function>map:merge</function>, <function>fn:json-doc</function>, 
+                  <function>fn:parse-json</function> or <function>fn:json-to-xml</function> 
                   if the input contains duplicate keys, when the chosen policy is to reject duplicates.</p>
             </error>
             
             <error class="JS" code="0004" label="JSON: not schema-aware." type="dynamic">
-               <p>Raised by <code>fn:json-to-xml</code> if validation 
+               <p>Raised by <function>fn:json-to-xml</function> if validation 
                   is requested when the processor does not support schema validation or typed nodes.</p>
             </error>
             
             <error class="JS" code="0005" label="Invalid options." type="dynamic">
-               <p>Raised by functions such as <code>map:merge</code>, <code>fn:parse-json</code>,
-                  and <code>fn:xml-to-json</code> if the <code>$options</code> map contains an invalid entry.</p>
+               <p>Raised by functions such as <function>map:merge</function>, <function>fn:parse-json</function>,
+                  and <function>fn:xml-to-json</function> if the <code>$options</code> map contains an invalid entry.</p>
             </error>
             
             <error class="JS" code="0006" label="Invalid XML representation of JSON." type="dynamic">
-               <p>Raised by <code>fn:xml-to-json</code> if the XML input does not
+               <p>Raised by <function>fn:xml-to-json</function> if the XML input does not
                   conform to the rules for the XML representation of JSON.</p>
             </error>
             
             <error class="JS" code="0007" label="Bad JSON escape sequence." type="dynamic">
-               <p>Raised by <code>fn:xml-to-json</code> if the XML input uses the attribute
+               <p>Raised by <function>fn:xml-to-json</function> if the XML input uses the attribute
                   <code>escaped="true"</code> or <code>escaped-key="true"</code>, and the corresponding string
                   or key contains an invalid JSON escape sequence.</p>
             </error>
@@ -13051,37 +13051,37 @@ ISBN 0 521 77752 6.</bibl>
             
             
             <error class="NS" code="0004" label="No namespace found for prefix." type="dynamic">
-               <p>Raised by <code>fn:resolve-QName</code> and analogous functions if a supplied QName has a 
+               <p>Raised by <function>fn:resolve-QName</function> and analogous functions if a supplied QName has a 
                   prefix that has no binding to a namespace.</p>
             </error>
             <error class="NS" code="0005" label="Base-uri not defined in the static context."
                    type="dynamic">
-               <p>Raised by <code>fn:resolve-uri</code> if no base URI is available for resolving a relative URI.</p>
+               <p>Raised by <function>fn:resolve-uri</function> if no base URI is available for resolving a relative URI.</p>
             </error>
             
             <error class="QM" code="0001" label="Module URI is a zero-length string."
                type="dynamic">
-               <p>Raised by <code>fn:load-xquery-module</code> if the supplied module URI is zero-length.</p>
+               <p>Raised by <function>fn:load-xquery-module</function> if the supplied module URI is zero-length.</p>
             </error>
             <error class="QM" code="0002" label="Module URI not found."
                type="dynamic">
-               <p>Raised by <code>fn:load-xquery-module</code> if no module can be found with the supplied module URI.</p>
+               <p>Raised by <function>fn:load-xquery-module</function> if no module can be found with the supplied module URI.</p>
             </error>
             <error class="QM" code="0003" label="Static error in dynamically loaded XQuery module."
                type="dynamic">
-               <p>Raised by <code>fn:load-xquery-module</code> if a static error 
+               <p>Raised by <function>fn:load-xquery-module</function> if a static error 
                   (including a statically detected type error) is encountered when processing the library module.</p>
             </error>
             
             <error class="QM" code="0005" label="Parameter for dynamically loaded XQuery module has incorrect type."
                type="dynamic">
-               <p>Raised by <code>fn:load-xquery-module</code> if a value is supplied for the initial context 
+               <p>Raised by <function>fn:load-xquery-module</function> if a value is supplied for the initial context 
                   item or for an external variable, and the value does not conform to the required
                   type declared in the dynamically loaded module.</p>
             </error>
             <error class="QM" code="0006" label="No suitable XQuery processor available."
                type="dynamic">
-               <p>Raised by <code>fn:load-xquery-module</code> if no XQuery processor is available supporting the requested
+               <p>Raised by <function>fn:load-xquery-module</function> if no XQuery processor is available supporting the requested
                   XQuery version (or if none is available at all).</p>
             </error>
             
@@ -13093,53 +13093,53 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="RG" code="0002" label="Invalid argument to fn:resolve-uri."
                    type="dynamic">
-               <p>Raised when either argument to <code>fn:resolve-uri</code> is not a valid URI/IRI.</p>
+               <p>Raised when either argument to <function>fn:resolve-uri</function> is not a valid URI/IRI.</p>
             </error>
             <error class="RG" code="0003"
                    label="fn:zero-or-one called with a sequence containing more than one item."
                    type="dynamic">
-               <p>Raised by <code>fn:zero-or-one</code> if the supplied value contains more than one item.</p> 
+               <p>Raised by <function>fn:zero-or-one</function> if the supplied value contains more than one item.</p> 
             </error>
             <error class="RG" code="0004"
                    label="fn:one-or-more called with a sequence containing no items."
                    type="dynamic"> 
-               <p>Raised by <code>fn:one-or-more</code> if the supplied value is an empty sequence.</p>
+               <p>Raised by <function>fn:one-or-more</function> if the supplied value is an empty sequence.</p>
             </error>
             <error class="RG" code="0005"
                    label="fn:exactly-one called with a sequence containing zero or more than one item."
                    type="dynamic">
-               <p>Raised by <code>fn:exactly-one</code> if the supplied value is not a singleton sequence.</p>
+               <p>Raised by <function>fn:exactly-one</function> if the supplied value is not a singleton sequence.</p>
             </error>
             <error class="RG" code="0006" label="Invalid argument type." type="static">
-               <p>Raised by functions such as <code>fn:max</code>, <code>fn:min</code>, <code>fn:avg</code>, <code>fn:sum</code>
+               <p>Raised by functions such as <function>fn:max</function>, <function>fn:min</function>, <function>fn:avg</function>, <function>fn:sum</function>
                if the supplied sequence contains values inappropriate to this function.</p> 
             </error>
             <error class="RG" code="0008"
                    label="The two arguments to fn:dateTime have inconsistent timezones."
                    type="dynamic">
-               <p>Raised by <code>fn:dateTime</code> if the two arguments both have timezones and the timezones are different.</p>
+               <p>Raised by <function>fn:dateTime</function> if the two arguments both have timezones and the timezones are different.</p>
             </error>
             <error class="RG" code="0009"
                    label="Error in resolving a relative URI against a base URI in fn:resolve-uri."
                    type="dynamic">
-               <p>A catch-all error for <code>fn:resolve-uri</code>, recognizing that the implementation can choose between a variety
+               <p>A catch-all error for <function>fn:resolve-uri</function>, recognizing that the implementation can choose between a variety
                of algorithms and that some of these may fail for a variety of reasons.</p>
             </error>
             <error class="RG" code="0010"
                label="Invalid date/time."
                type="dynamic">
-               <p>Raised when the input to <code>fn:parse-ietf-date</code> does not match the prescribed
+               <p>Raised when the input to <function>fn:parse-ietf-date</function> does not match the prescribed
                   grammar, or when it represents an invalid date/time such as 31 February.</p>
             </error>
             <error class="RG" code="0011"
                label="Invalid radix."
                type="dynamic">
-               <p>Raised when the radix supplied to <code>fn:parse-integer</code> is not in the range 2 to 36.</p>
+               <p>Raised when the radix supplied to <function>fn:parse-integer</function> is not in the range 2 to 36.</p>
             </error>
             <error class="RG" code="0012"
                label="Invalid digits."
                type="dynamic">
-               <p>Raised when the digits in the string supplied to <code>fn:parse-integer</code> are not in the range appropriate
+               <p>Raised when the digits in the string supplied to <function>fn:parse-integer</function> are not in the range appropriate
                   to the chosen radix.</p>
             </error>
             <error class="RG" code="0013"
@@ -13151,49 +13151,49 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             
             <error class="RX" code="0001" label="Invalid regular expression flags." type="static">
-               <p>Raised by regular expression functions such as <code>fn:matches</code> and <code>fn:replace</code> if the
+               <p>Raised by regular expression functions such as <function>fn:matches</function> and <function>fn:replace</function> if the
                regular expression flags contain a character other than <code>i</code>, <code>m</code>, <code>q</code>, <code>s</code>, or <code>x</code>.</p>
             </error>
             <!--End of text replaced by erratum E25-->
             <error class="RX" code="0002" label="Invalid regular expression." type="dynamic">
-               <p>Raised by regular expression functions such as <code>fn:matches</code> and <code>fn:replace</code> if the
+               <p>Raised by regular expression functions such as <function>fn:matches</function> and <function>fn:replace</function> if the
                   regular expression is syntactically invalid.</p>
             </error>
             <error class="RX" code="0003" label="Regular expression matches zero-length string."
                    type="dynamic">
-               <p>For functions such as <code>fn:replace</code> and <code>fn:tokenize</code>, raises an error if
+               <p>For functions such as <function>fn:replace</function> and <function>fn:tokenize</function>, raises an error if
                the supplied regular expression is capable of matching a zero length string.</p>
             </error>
             <error class="RX" code="0004" label="Invalid replacement string." type="dynamic">
-               <p>Raised by <code>fn:replace</code> to report errors in the replacement string.</p>
+               <p>Raised by <function>fn:replace</function> to report errors in the replacement string.</p>
             </error>
             <error class="RX" code="0005" label="Incompatible arguments for fn:replace." type="dynamic">
-               <p>Raised by <code>fn:replace</code> if both the <code>$replacement</code> 
+               <p>Raised by <function>fn:replace</function> if both the <code>$replacement</code> 
                   and <code>$action</code> arguments are supplied.</p>
             </error>
             <error class="TY" code="0012" label="Argument to fn:data contains a node that does not have a typed value."
                    type="dynamic">
-               <p>Raised by <code>fn:data</code>, or by implicit atomization, if applied to a node with no typed value,
+               <p>Raised by <function>fn:data</function>, or by implicit atomization, if applied to a node with no typed value,
                the main example being an element validated against a complex type that defines it to have element-only content.</p>
             </error>
             <error class="TY" code="0013" label="The argument to fn:data contains a function item."
                type="dynamic">
-               <p>Raised by <code>fn:data</code>, or by implicit atomization, if the sequence to be atomized contains
+               <p>Raised by <function>fn:data</function>, or by implicit atomization, if the sequence to be atomized contains
                 a function item other than an array.</p>
             </error>
             <error class="TY" code="0014" label="The argument to fn:string is a function item."
                type="dynamic">
-               <p>Raised by <code>fn:string</code>, or by implicit string conversion, if the input sequence contains
+               <p>Raised by <function>fn:string</function>, or by implicit string conversion, if the input sequence contains
                   a function item.</p>
             </error>
             <!--<error class="TY" code="0015" label="An argument to fn:deep-equal contains a function item."
                type="dynamic">
-               <p>Raised by <code>fn:deep-equal</code> if either input sequence contains a
+               <p>Raised by <function>fn:deep-equal</function> if either input sequence contains a
                   function item.</p> 
             </error>-->
             <error class="UT" code="1170" label="Invalid URI reference."
                type="dynamic">
-               <p>Raised by <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>
+               <p>Raised by <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
                   if the <code>$source</code> argument contains a fragment identifier,
                   or if it cannot be resolved to an absolute URI (for example, because the
                   base-URI property in the static context is absent), or if it cannot be used to
@@ -13201,7 +13201,7 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="UT" code="1190" label="Cannot decode external resource."
                type="dynamic">
-               <p diff="chg" at="2023-06-12">Raised by <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>
+               <p diff="chg" at="2023-06-12">Raised by <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
                   if the <code>$encoding</code> argument is not a valid encoding name,
                   if the processor does not support the specified encoding, if the string
                   representation of the retrieved resource contains octets that cannot be decoded
@@ -13211,7 +13211,7 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="UT" code="1200" label="Cannot infer encoding of external resource."
                type="dynamic">
-               <p>Raised by <code>fn:unparsed-text</code> or <code>fn:unparsed-text-lines</code>
+               <p>Raised by <function>fn:unparsed-text</function> or <function>fn:unparsed-text-lines</function>
                   if the <code>$encoding</code> argument is absent and the processor
                   cannot infer the encoding using external information and the
                   encoding is not UTF-8.</p>
@@ -13228,26 +13228,26 @@ ISBN 0 521 77752 6.</bibl>
             </error>
             <error class="XT" code="0002" label="Invalid parameters to XSLT transformation"
                type="dynamic">
-               <p>A dynamic error is raised if the parameters supplied to <code>fn:transform</code> are invalid, for example
+               <p>A dynamic error is raised if the parameters supplied to <function>fn:transform</function> are invalid, for example
                   if two mutually exclusive parameters are supplied. If a suitable XSLT error code is available (for example in the
                case where the requested <code>initial-template</code> does not exist in the stylesheet), that error code should
                be used in preference.</p>
             </error>
             <error class="XT" code="0003" label="XSLT transformation failed"
                type="dynamic">
-               <p>A dynamic error is raised if an XSLT transformation invoked using <code>fn:transform</code> fails with a
+               <p>A dynamic error is raised if an XSLT transformation invoked using <function>fn:transform</function> fails with a
                   static or dynamic error. The XSLT error code is used if available; this error code provides a fallback when no XSLT
                   error code is returned, for example because the processor is an XSLT 1.0 processor.</p>
             </error>
             <error class="XT" code="0004" label="XSLT transformation has been disabled"
                type="dynamic">
-               <p>A dynamic error is raised if the <code>fn:transform</code> function is invoked when XSLT transformation (or a specific
+               <p>A dynamic error is raised if the <function>fn:transform</function> function is invoked when XSLT transformation (or a specific
                   transformation option) has been disabled for security or other reasons.</p>
             </error>
             
             <error class="XT" code="0006" label="XSLT output contains non-accepted characters"
                type="dynamic">
-               <p>A dynamic error is raised if the result of the <code>fn:transform</code> function contains characters available
+               <p>A dynamic error is raised if the result of the <function>fn:transform</function> function contains characters available
                   only in XML 1.1 and the calling processor cannot handle such characters.</p>
             </error>
             
@@ -13264,8 +13264,8 @@ ISBN 0 521 77752 6.</bibl>
                the <code>fn</code> namespace.
             </change>
          </changes>
-         <p>Two functions in this specification, <code>fn:analyze-string</code> and
-         <code>fn:json-to-xml</code>, produce results in the form of an XDM node tree that must conform
+         <p>Two functions in this specification, <function>fn:analyze-string</function> and
+         <function>fn:json-to-xml</function>, produce results in the form of an XDM node tree that must conform
          to a specified schema, defined in this appendix. 
          In both cases the elements in the result are in the namespace 
          <code>http://www.w3.org/2005/xpath-functions</code>, which is therefore the target namespace
@@ -13289,21 +13289,21 @@ ISBN 0 521 77752 6.</bibl>
          <?doc xpath-functions.xsd?>
          
          <div2 id="schema-for-analyze-string">
-            <head>Schema for the result of <code>fn:analyze-string</code></head>
-            <p>This schema describes the output of the function <code>fn:analyze-string</code>.</p>
+            <head>Schema for the result of <function>fn:analyze-string</function></head>
+            <p>This schema describes the output of the function <function>fn:analyze-string</function>.</p>
             <p>The schema is reproduced below, and can also be found in <loc href="analyze-string.xsd">analyze-string.xsd</loc>:</p>
             <?doc analyze-string.xsd?>
          </div2>
          <div2 id="schema-for-json">
-            <head>Schema for the result of <code>fn:json-to-xml</code></head>
-            <p>This schema describes the output of the function <code>fn:json-to-xml</code>, and the input to the
-            function <code>fn:xml-to-json</code>. </p>
+            <head>Schema for the result of <function>fn:json-to-xml</function></head>
+            <p>This schema describes the output of the function <function>fn:json-to-xml</function>, and the input to the
+            function <function>fn:xml-to-json</function>. </p>
             <p>The schema is reproduced below, and can also be found in <loc href="schema-for-json.xsd">schema-for-json.xsd</loc>:</p>
             <?doc schema-for-json.xsd?>
          </div2>
          <div2 id="schema-for-csv">
-            <head>Schema for the result of <code>fn:csv-to-xml</code></head>
-            <p>This schema describes the output of the function <code>fn:csv-to-xml</code>.</p>
+            <head>Schema for the result of <function>fn:csv-to-xml</function></head>
+            <p>This schema describes the output of the function <function>fn:csv-to-xml</function>.</p>
             <p>The schema is reproduced below, and can also be found in <loc href="schema-for-csv.xsd">schema-for-csv.xsd</loc>:</p>
             <?doc schema-for-csv.xsd?>
          </div2>
@@ -13518,8 +13518,8 @@ ISBN 0 521 77752 6.</bibl>
 	           <item><p>The keyword for the argument has changed from <code>arg</code> to <code>value</code>.</p></item>
 	           <item><p>The argument is now optional, and defaults to the context value (which is atomized if necessary).
 	           This change aligns constructor functions such as <code>xs:string</code>, <code>xs:boolean</code>,
-	              and <code>xs:numeric</code> with <code>fn:string</code>, <code>fn:boolean</code>,
-	              and <code>fn:number</code>.</p></item>
+	              and <code>xs:numeric</code> with <function>fn:string</function>, <function>fn:boolean</function>,
+	              and <function>fn:number</function>.</p></item>
 	        </olist>
 	     </div2>
 	     <div2 id="miscellaneous-changes">
@@ -13580,8 +13580,8 @@ ISBN 0 521 77752 6.</bibl>
         
         <olist>
            <item>
-              <p>In <code>fn:deep-equal</code>, and in other functions such as <code>fn:distinct-values</code>
-              that refer to <code>fn:deep-equal</code>, the rules for comparing values of different numeric types 
+              <p>In <function>fn:deep-equal</function>, and in other functions such as <function>fn:distinct-values</function>
+              that refer to <function>fn:deep-equal</function>, the rules for comparing values of different numeric types 
                  (for example, <code>xs:double</code> and <code>xs:decimal</code>) have changed. 
                  In previous versions of the specification, <code>xs:decimal</code> values were converted
               to <code>xs:double</code>, leading to a possible loss of precision. This could make 
@@ -13604,30 +13604,30 @@ ISBN 0 521 77752 6.</bibl>
            </item>
            <item diff="add" at="2024-06-18">
               <p>In previous versions, unrecognized options supplied to the <code>$options</code>
-              parameter of functions such as <code>fn:parse-json</code> were silently ignored. In
+              parameter of functions such as <function>fn:parse-json</function> were silently ignored. In
               4.0, they are rejected as a type error, unless they are QNames with a non-absent namespace,
               or are extensions recognized by the implementation.</p>
            </item>
            <item diff="add" at="2022-12-18">
-              <p>In version 4.0, omitting the <code>$value</code> of <code>fn:error</code> has the same
+              <p>In version 4.0, omitting the <code>$value</code> of <function>fn:error</function> has the same
                  effect as setting it to an empty sequence. In 3.1, the effects could be different (the effect of omitting
                  the argument was implementation-defined).</p>
            </item>
            <item diff="add" at="2023-03-13">
-              <p>In version 3.1, the <code>fn:deep-equal</code> function did not merge adjacent text nodes after stripping
+              <p>In version 3.1, the <function>fn:deep-equal</function> function did not merge adjacent text nodes after stripping
                  comments and processing instructions, so the elements <code><![CDATA[<a>abc<!--note1-->def</code>]]></code>
                  and <code><![CDATA[<a>abcde<!--note2-->f</code>]]></code> were considered non-equal. In version 4.0, 
                  the text nodes are now merged prior to comparison, so these two elements compare equal.</p>
            </item>
            <item diff="add" at="2024-10-01">
-              <p>The format of numeric values in the output of <code>fn:xml-to-json</code> may be different. 
+              <p>The format of numeric values in the output of <function>fn:xml-to-json</function> may be different. 
                  In version 3.1, the supplied value was parsed as an <code>xs:double</code> and then serialized
                  using the casting rules, resulting in an input value of 10000000 being output as <code>1e7</code>.
                  In version 4.0, the value is output <emph>as is</emph>, except for any changes (such as stripping
                  of leading zeroes or a leading plus sign) that might be needed to ensure the result is valid JSON.</p>
            </item>
            <item diff="add" at="2023-03-06">
-              <p>In version 4.0, the function signature of <code>fn:namespace-uri-for-prefix</code> constrains the
+              <p>In version 4.0, the function signature of <function>fn:namespace-uri-for-prefix</function> constrains the
                  first argument to be either an <code>xs:NCName</code> or a zero-length string (the new coercion rules
                  mean that any string in the form of an <code>xs:NCName</code> is acceptable). If a string is supplied
                  that does not meet these requirements, a type error will be raised. In version 3.1, this was not an error:
@@ -13647,13 +13647,13 @@ ISBN 0 521 77752 6.</bibl>
               have been changed to use an argument type of <code>xs:string?</code>.</p>
            </item>
            <item diff="add" at="issue866">
-              <p>The way that <code>fn:min</code> and <code>fn:max</code> compare numeric values of different types
+              <p>The way that <function>fn:min</function> and <function>fn:max</function> compare numeric values of different types
               has changed. The most noticeable effect is that when these functions are applied to a sequence of
                  <code>xs:integer</code> or <code>xs:decimal</code> values, the result is an <code>xs:integer</code> or 
                  <code>xs:decimal</code>, rather than the result of converting this to an <code>xs:double</code>.</p>
            </item>
            <item diff="add" at="issue780">
-              <p>The type of the third argument of <code>fn:format-number</code> has 
+              <p>The type of the third argument of <function>fn:format-number</function> has 
                  changed from <code>xs:string</code> to <code>(xs:string | xs:QName)</code>.
                  Because the expected type of this parameter is no longer <code>xs:string</code>, the
                  special coercion rules for <code>xs:string</code> parameters no longer apply.

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -891,13 +891,13 @@ constructor, as described in <specref
         during static analysis.
       </phrase></p>
       <p><phrase diff="del" at="2023-05-19">The Static Base URI is available during dynamic evaluation by use of the 
-      <code>fn:static-base-uri</code> function, and is used implicitly during dynamic 
-      evaluation by functions such as <code>fn:doc</code>. </phrase>Relative URI references are 
+      <function>fn:static-base-uri</function> function, and is used implicitly during dynamic 
+      evaluation by functions such as <function>fn:doc</function>. </phrase>Relative URI references are 
       resolved as described in <specref
                         ref="id-resolve-relative-uri"/>.</p>
                   
                   <p diff="add" at="2023-05-19">At execution time,
-                  relative URIs supplied to functions such as <code>fn:doc</code>
+                  relative URIs supplied to functions such as <function>fn:doc</function>
                   are resolved against the <termref def="dt-executable-base-uri"/>,
                   which may or may not be the same as the Static Base URI.</p>
 
@@ -914,7 +914,7 @@ constructor, as described in <specref
       object code is distributed to a different location for execution. It 
       would then be inappropriate to use the same location when resolving 
       <code>import module</code> declarations as when retrieving source 
-      documents using the <code>fn:doc</code> function. If an implementation uses different 
+      documents using the <function>fn:doc</function> function. If an implementation uses different 
       values for the Static Base URI during static analysis and during dynamic 
       evaluation, then it is implementation-defined which of the two values is 
       used for particular operations that rely on the Static Base URI; for 
@@ -929,7 +929,7 @@ constructor, as described in <specref
                         <term>Statically known decimal
 		      formats.</term> This is a mapping from QNames to decimal formats, with one default format that has no visible name,
 		      referred to as the unnamed decimal format. Each
-		      format is available for use when formatting numbers using the <code>fn:format-number</code> function.</termdef>
+		      format is available for use when formatting numbers using the <function>fn:format-number</function> function.</termdef>
                   </p>
                   
                   <p>Decimal formats are described in <specref ref="id-decimal-formats"/>.</p>
@@ -979,8 +979,8 @@ constructor, as described in <specref
                      
                      <p>For an overview of variadic functions, see <specref ref="id-variadic-functions-overview"/>.</p>
                      
-                     <note><p>Examples of system functions defined to be variadic are <code>fn:concat</code>
-                     and <code>fn:codepoints-to-string</code>. User-written functions in XQuery may
+                     <note><p>Examples of system functions defined to be variadic are <function>fn:concat</function>
+                     and <function>fn:codepoints-to-string</function>. User-written functions in XQuery may
                      be declared as variadic by using the <code>%variadic</code> annotation; the equivalent
                      in XSLT is to use the attribute <code>xsl:function/@variadic = "yes"</code>.</p></note>
                      
@@ -1055,11 +1055,11 @@ constructor, as described in <specref
                         if its result depends on the static or dynamic context of its caller.
                         A function definition may
                         be context-dependent for some arities in its arity range, and context-independent
-                        for others: for example <code>fn:name#0</code> is context-dependent
-                        while <code>fn:name#1</code> is context-independent.</termdef></p>
+                        for others: for example <function>fn:name#0</function> is context-dependent
+                        while <function>fn:name#1</function> is context-independent.</termdef></p>
                      
-                     <note diff="add" at="2023-03-11"><p>Some system functions, such as <code>fn:position</code>, <code>fn:last</code>,
-                        and <code>fn:static-base-uri</code>, exist for the sole purpose of providing information
+                     <note diff="add" at="2023-03-11"><p>Some system functions, such as <function>fn:position</function>, <function>fn:last</function>,
+                        and <function>fn:static-base-uri</function>, exist for the sole purpose of providing information
                         about the static or dynamic context of their caller.</p></note>
                      <note><p diff="add" at="2023-03-11"><termref def="dt-application-function">Application functions</termref> 
                         are context dependent only to the extent that they define optional parameters with default
@@ -1112,7 +1112,7 @@ constructor, as described in <specref
                         </change>
                      </changes>
                      <p>Each decimal format defines a set of properties, which control the interpretation of characters
-                        in the picture string supplied to the <code>fn:format-number</code>
+                        in the picture string supplied to the <function>fn:format-number</function>
                         function, and also specify characters to be used in the result
                         of formatting the number.</p>
                      
@@ -1204,7 +1204,7 @@ constructor, as described in <specref
                      </p>
                      
                      <p>The following properties specify 
-                        characters to be used in the picture string supplied to the <code>fn:format-number</code>
+                        characters to be used in the picture string supplied to the <function>fn:format-number</function>
                         function, but not in the formatted number. In each case the value must be a single character.
                      </p>
                      
@@ -1272,7 +1272,7 @@ constructor, as described in <specref
                </change>
                <change issue="1161" PR="1265" date="2024-06-11">
                   The rules regarding the <code>document-uri</code> property of nodes returned by the
-                  <code>fn:collection</code> function have been relaxed.
+                  <function>fn:collection</function> function have been relaxed.
                </change>
             </changes>
             <p>
@@ -1496,7 +1496,7 @@ the number of items in the sequence obtained by evaluating <var
                         other function definitions that are not known statically.
       </termdef></p>
      
-                  <p>The function definitions in the dynamic context are used primarily by the <code>fn:function-lookup</code>
+                  <p>The function definitions in the dynamic context are used primarily by the <function>fn:function-lookup</function>
                   function.</p>
                   <p>If two function definitions in the <termref def="dt-dynamically-known-function-definitions"/> have the same
                      name, then their <termref def="dt-arity-range">arity ranges</termref> must not overlap.</p>
@@ -1504,7 +1504,7 @@ the number of items in the sequence obtained by evaluating <var
                   available statically is primarily to allow for cases where the run-time execution
                   environment is significantly different from the compile-time environment. This could happen, for example,
                   if a stylesheet or query is compiled within a web server and then executed in the web browser.
-                  The <code>fn:function-lookup</code> function allows dynamic discovery of resources that were not
+                  The <function>fn:function-lookup</function> function allows dynamic discovery of resources that were not
                   available statically.</p></note>
                   
   <!--                supplies a function for each signature in 
@@ -1548,7 +1548,7 @@ the number of items in the sequence obtained by evaluating <var
                            >implementation-dependent</termref> point in time during the processing of <phrase
                            role="xquery">a query</phrase>
                         <phrase role="xpath"
-                           >an expression</phrase>, and includes an explicit timezone. It can be retrieved by the  <code>fn:current-dateTime</code> function. 
+                           >an expression</phrase>, and includes an explicit timezone. It can be retrieved by the  <function>fn:current-dateTime</function> function. 
                         If called multiple times during the execution of <phrase
                            role="xquery">a query</phrase>
                         <phrase role="xpath"
@@ -1577,11 +1577,11 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                      <term>Executable Base URI.</term> This is an absolute URI used
                      to resolve relative URIs during the evaluation of expressions;
                      it is used, for example, to resolve a relative URI supplied
-                     to the <code>fn:doc</code> or <code>fn:unparsed-text</code>
+                     to the <function>fn:doc</function> or <function>fn:unparsed-text</function>
                      functions.
                   </termdef></p>
                   <p>URIs are resolved as described in <specref ref="id-resolve-relative-uri"/>.</p>
-                  <p>The function <code>fn:static-base-uri</code>, despite its name, returns the
+                  <p>The function <function>fn:static-base-uri</function>, despite its name, returns the
                      value of the <termref def="dt-executable-base-uri"/>.</p>
                   <p>In many straightforward processing scenarios, the <termref def="dt-executable-base-uri"/>
                   in the dynamic context will be the same as the <termref def="dt-static-base-uri"/> for the
@@ -1594,7 +1594,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                      on the development machine, by reference to the <termref def="dt-static-base-uri"/>,
                      while resources needed during execution (such as reference data files) will be located
                      on the production machine, accessed via the <termref def="dt-executable-base-uri"/>.</p></item>
-                     <item><p>When the <code>fn:static-base-uri</code> function is called within
+                     <item><p>When the <function>fn:static-base-uri</function> function is called within
                      the initializing expression of an optional parameter in a function declaration,
                      it returns the executable base URI of the relevant function call. This allows a user-written
                      function to accept two parameters: a required parameter containing a relative URI, and an
@@ -1619,7 +1619,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                   
                   <note diff="add" at="2023-05-19"><p>Although the default collation is defined (in 4.0) as a property of the
                      dynamic context, its value will in nearly all cases be known statically. The reason it is defined in the
-                     dynamic context is to allow a call on the <code>fn:default-collation</code> function to be used when defining
+                     dynamic context is to allow a call on the <function>fn:default-collation</function> function to be used when defining
                      the default value of an optional parameter to a user-defined function. In this situation,
                      the actual value supplied for the parameter is taken from the dynamic context of the relevant function call.</p></note>
                   
@@ -1630,7 +1630,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                      <termdef id="dt-default-language" term="default language">
                         <term>Default language.</term>
   This is the natural language used when creating human-readable output
-  (for example, by the functions <code>fn:format-date</code> and <code>fn:format-integer</code>)
+  (for example, by the functions <function>fn:format-date</function> and <function>fn:format-integer</function>)
   if no other language is requested. 
   The value is a language code as defined by the type <code>xs:language</code>.</termdef>
                   </p>
@@ -1641,7 +1641,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                      <termdef id="dt-default-calendar" term="default calendar">
                         <term>Default calendar.</term>
     This is the calendar used when formatting dates in human-readable output
-    (for example, by the functions <code>fn:format-date</code> and <code>fn:format-dateTime</code>)
+    (for example, by the functions <function>fn:format-date</function> and <function>fn:format-dateTime</function>)
     if no other calendar is requested. 
     The value is a string.</termdef>
                   </p>
@@ -1652,8 +1652,8 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                      <termdef id="dt-default-place" term="default place">
                         <term>Default place.</term>
     This is a geographical location used to identify the place where events happened (or will happen) when
-    processing dates and times using functions such as <code>fn:format-date</code>, <code>fn:format-dateTime</code>,
-     and <code>fn:civil-timezone</code>,
+    processing dates and times using functions such as <function>fn:format-date</function>, <function>fn:format-dateTime</function>,
+     and <function>fn:civil-timezone</function>,
     if no other place is specified. It is used when translating timezone offsets to civil timezone names,
     and when using calendars where the translation from ISO dates/times to a local representation is dependent
     on geographical location. Possible representations of this information are an ISO country code or an
@@ -1672,7 +1672,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
     represents the absolute URI of a resource. The document node is the root of a tree that represents that resource 
     using the <termref
                            def="dt-datamodel"
-                           >data model</termref>. The document node is returned by the <code>fn:doc</code> 
+                           >data model</termref>. The document node is returned by the <function>fn:doc</function> 
     function when applied to that URI.</termdef> The set of available documents may be empty.</p>
                   <!--<p>If there are one or more 
     URIs in <termref def="dt-available-docs"
@@ -1696,7 +1696,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                         <term>Available text resources</term>. 
   This is a mapping of strings to text resources. Each string
   represents the absolute URI of a resource. The resource is returned
-  by the <code>fn:unparsed-text</code> function when applied to that
+  by the <function>fn:unparsed-text</function> function when applied to that
   URI.</termdef> The set of available text resources may be empty.</p>
                </item>
 
@@ -1709,7 +1709,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                          strings to sequences of items. Each string
                          represents the absolute URI of a
                          resource. The sequence of items represents
-                         the result of the <code>fn:collection</code>
+                         the result of the <function>fn:collection</function>
                          function when that URI is supplied as the
                          argument. </termdef> The set of available
                             collections may be empty.</p>
@@ -1724,7 +1724,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                   <note>
                      <p>That is to say, the <code>document-uri</code> property of nodes returned
                         by the <function>fn:collection</function> function should be such that
-                        calling <code>fn:doc</code> with that URI returns the relevant node.</p>
+                        calling <function>fn:doc</function> with that URI returns the relevant node.</p>
                      <p>It is not always possible to ensure this, especially in cases where 
                         dereferencing of document or collection URIs is configurable using
                         configuration files or user-supplied resolver code.</p>
@@ -1736,7 +1736,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                   <p>
                      <termdef id="dt-default-collection" term="default collection">
                         <term>Default  collection.</term>
-    This is the sequence of items  that would result from calling the <code>fn:collection</code> function
+    This is the sequence of items  that would result from calling the <function>fn:collection</function> function
     with no arguments.</termdef> The value of <term>default   collection</term> may be initialized by the
     implementation.</p>
                </item>
@@ -1750,7 +1750,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
     represents the absolute URI of a
     resource which can be interpreted as an aggregation of a number of individual resources each of which
     has its own URI. The sequence of URIs represents
-    the result of the <code>fn:uri-collection</code>
+    the result of the <function>fn:uri-collection</function>
     function when that URI is supplied as the
     argument. </termdef> There is no implication that the URIs in this sequence
     can be successfully dereferenced, or that the resources they refer to have any particular media type.</p>
@@ -1758,9 +1758,9 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                      <p>An implementation <rfc2119>may</rfc2119> maintain some consistent relationship between the available
     collections and the available URI collections, for example by ensuring that the result of
   <code>fn:uri-collection(X)!fn:doc(.)</code> is the same as the result of <code>fn:collection(X)</code>.
-    However, this is not required. The <code>fn:uri-collection</code> function is more 
-    general than <code>fn:collection</code> in that <phrase diff="del" at="A">it allows access to resources other 
-    than XML documents; at the same time,</phrase> <code>fn:collection</code> allows access to 
+    However, this is not required. The <function>fn:uri-collection</function> function is more 
+    general than <function>fn:collection</function> in that <phrase diff="del" at="A">it allows access to resources other 
+    than XML documents; at the same time,</phrase> <function>fn:collection</function> allows access to 
     nodes that might lack individual URIs, for example nodes corresponding 
     to XML fragments stored in the rows of a relational database.</p>
                   </note>
@@ -1770,7 +1770,7 @@ comparison or arithmetic operation. The implicit timezone is an  <termref
                   <p>
                      <termdef id="dt-default-uri-collection" term="default URI collection">
                         <term>Default URI collection.</term>
-    This is the sequence of URIs that would result from calling the <code>fn:uri-collection</code> function
+    This is the sequence of URIs that would result from calling the <function>fn:uri-collection</function> function
     with no arguments.</termdef> The value of <term>default URI collection</term> may be initialized by the
     implementation.</p>
                </item>
@@ -2174,7 +2174,7 @@ data (step DQ4), and on the <termref
          <div3 id="id-input-sources">
             <head>Input Sources</head>
             
-            <p>&language; has a set of functions that provide access to XML documents (<code>fn:doc</code>, <code>fn:doc-available</code>), collections (<code>fn:collection</code>, <code>fn:uri-collection</code>), text files (<code>fn:unparsed-text</code>, <code>fn:unparsed-text-lines</code>, <code>fn:unparsed-text-available</code>), and environment variables (<code>fn:environment-variable</code>, <code>fn:available-environment-variables</code>).  These functions are defined in <xspecref
+            <p>&language; has a set of functions that provide access to XML documents (<function>fn:doc</function>, <function>fn:doc-available</function>), collections (<function>fn:collection</function>, <function>fn:uri-collection</function>), text files (<function>fn:unparsed-text</function>, <function>fn:unparsed-text-lines</function>, <function>fn:unparsed-text-available</function>), and environment variables (<function>fn:environment-variable</function>, <function>fn:available-environment-variables</function>).  These functions are defined in <xspecref
                spec="FO40" ref="fns-on-docs"/>.</p>
             
             
@@ -2225,7 +2225,7 @@ as described in <bibref
             See <specref ref="id-output-declarations"/>.</p>
             
             <p role="xquery">Serialization can also be invoked from within a query
-               by calling the <code>fn:serialize</code> function.</p>
+               by calling the <function>fn:serialize</function> function.</p>
 
             <note>
                <p>This definition of serialization is the definition
@@ -2237,7 +2237,7 @@ the scope of the &language; specification.</p>
             </note>
 
             <p role="xpath">Serialization is outside the scope of the XPath specification, except
-               to the extent that there is a function <code>fn:serialize</code> that enables
+               to the extent that there is a function <function>fn:serialize</function> that enables
                serialization to be invoked.</p>
 
             
@@ -2656,7 +2656,7 @@ is equal to zero. Errors raised by system functions and operators are defined in
                   ref="xpath-functions-40"/> or the host language.</p>
 
             <p>A dynamic error can also be raised explicitly by calling the
-<code>fn:error</code> function, which always raises a dynamic error and never
+<function>fn:error</function> function, which always raises a dynamic error and never
 returns a value.  This function is defined in <xspecref
                   spec="FO40" ref="func-error"
                   />. For example, the following
@@ -2962,11 +2962,11 @@ would raise an error because it has an <code>id</code> child whose value is not 
             
             <ulist>
             
-               <item><p><code>round(tokenize($input))</code>. The result of <code>fn:tokenize</code>
+               <item><p><code>round(tokenize($input))</code>. The result of <function>fn:tokenize</function>
                is a sequence of strings (<code>xs:string*</code>), while the required type for the
-               first argument of <code>fn:round</code> is optional numeric (<code>xs:numeric?</code>).
-               The expression can succeed only in the exceptional case where the result of <code>fn:tokenize</code>
-               is an empty sequence, in which case the result of <code>fn:round</code> will also be
+               first argument of <function>fn:round</function> is optional numeric (<code>xs:numeric?</code>).
+               The expression can succeed only in the exceptional case where the result of <function>fn:tokenize</function>
+               is an empty sequence, in which case the result of <function>fn:round</function> will also be
                an empty sequence; it is therefore highly likely that the expression was written in error.</p></item>
                   
                <item><p><code>parse-csv($input)?column-names</code>. The signature of the <code>parse-csv</code>
@@ -3265,7 +3265,7 @@ tree T2.</p>
                            denotes a complex type with element-only content, then the typed value
                            of the node is <xtermref
                               spec="DM40" ref="dt-absent"
-                           />. The <code>fn:data</code> function raises a
+                           />. The <function>fn:data</function> function raises a
                            <termref
                               def="dt-type-error">type error</termref>
                            <xerrorref spec="FO40" class="TY" code="0012"
@@ -3277,7 +3277,7 @@ tree T2.</p>
                            <code>temperature</code> and <code>precipitation</code>. The typed
                            value of E6 is <xtermref
                               spec="DM40" ref="dt-absent"
-                           />, and the <code>fn:data</code> function
+                           />, and the <function>fn:data</function> function
                            applied to E6 raises an error.
                         </p>
                      </item>
@@ -3301,12 +3301,12 @@ either a sequence of atomic items or a <termref
                <xerrorref spec="FO40" class="TY" code="0012"/>.  <termdef id="dt-atomization"
                   term="atomization">
                   <term>Atomization</term> of a sequence
-is defined as the result of invoking the <code>fn:data</code> function, as defined in <xspecref
+is defined as the result of invoking the <function>fn:data</function> function, as defined in <xspecref
                      spec="FO40" ref="func-data"/>.</termdef>
             </p>
             <p> The semantics of
-<code>fn:data</code> are repeated here for convenience. The result of
-<code>fn:data</code> is the sequence of atomic items produced by
+<function>fn:data</function> are repeated here for convenience. The result of
+<function>fn:data</function> is the sequence of atomic items produced by
 applying the following rules to each item in the input
 sequence:</p>
             <ulist>
@@ -3391,44 +3391,44 @@ value. <termdef id="dt-ebv"
                   term="effective boolean value"
                      >The
 <term>effective boolean value</term> of a value is defined as the result
-of applying the <code>fn:boolean</code> function to the value, as
+of applying the <function>fn:boolean</function> function to the value, as
 defined in <xspecref
                      spec="FO40" ref="func-boolean"/>.</termdef>
             </p>
 
-            <p>The dynamic semantics of <code>fn:boolean</code> are repeated here for convenience:</p>
+            <p>The dynamic semantics of <function>fn:boolean</function> are repeated here for convenience:</p>
 
             <olist>
 
                <item>
-                  <p>If its operand is an empty sequence, <code>fn:boolean</code> returns <code>false</code>.</p>
+                  <p>If its operand is an empty sequence, <function>fn:boolean</function> returns <code>false</code>.</p>
                </item>
 
                <item>
-                  <p>If its operand is a sequence whose first item is a node, <code>fn:boolean</code> returns <code>true</code>.</p>
-               </item>
-
-               <item>
-                  <p>If its operand is a <termref def="dt-singleton"
-                        >singleton</termref> value of type <code>xs:boolean</code> or derived from <code>xs:boolean</code>, <code>fn:boolean</code> returns the value of its operand unchanged.</p>
+                  <p>If its operand is a sequence whose first item is a node, <function>fn:boolean</function> returns <code>true</code>.</p>
                </item>
 
                <item>
                   <p>If its operand is a <termref def="dt-singleton"
-                        >singleton</termref> value of type <code>xs:string</code>, <code>xs:anyURI</code>, <code>xs:untypedAtomic</code>, or a type derived from one of these, <code>fn:boolean</code> returns <code>false</code> if the operand value has zero length; otherwise it returns <code>true</code>.</p>
+                        >singleton</termref> value of type <code>xs:boolean</code> or derived from <code>xs:boolean</code>, <function>fn:boolean</function> returns the value of its operand unchanged.</p>
+               </item>
+
+               <item>
+                  <p>If its operand is a <termref def="dt-singleton"
+                        >singleton</termref> value of type <code>xs:string</code>, <code>xs:anyURI</code>, <code>xs:untypedAtomic</code>, or a type derived from one of these, <function>fn:boolean</function> returns <code>false</code> if the operand value has zero length; otherwise it returns <code>true</code>.</p>
                </item>
 
                <item>
                   <p>If its operand is a <termref def="dt-singleton"
                         >singleton</termref> value of any <termref def="dt-numeric"
-                        >numeric</termref> type or derived from a numeric type, <code>fn:boolean</code> returns <code>false</code> if the operand value is <code>NaN</code> or is numerically equal to zero; otherwise it returns <code>true</code>.</p>
+                        >numeric</termref> type or derived from a numeric type, <function>fn:boolean</function> returns <code>false</code> if the operand value is <code>NaN</code> or is numerically equal to zero; otherwise it returns <code>true</code>.</p>
                </item>
 
                <item>
-                  <p>In all other cases, <code>fn:boolean</code> raises a type error <xerrorref
+                  <p>In all other cases, <function>fn:boolean</function> raises a type error <xerrorref
                         spec="FO40" class="RG" code="0006"/>.</p>
                   <note>
-                     <p>For instance, <code>fn:boolean</code> raises a type error if the operand is a function, a map, or an array.</p>
+                     <p>For instance, <function>fn:boolean</function> raises a type error if the operand is a function, a map, or an array.</p>
                   </note>
                </item>
             </olist>
@@ -3442,7 +3442,7 @@ defined in <xspecref
                </item>
 
                <item>
-                  <p>The <code>fn:not</code> function</p>
+                  <p>The <function>fn:not</function> function</p>
                </item>
 
                <item role="xquery">
@@ -3531,7 +3531,7 @@ defined in <xspecref
             </note>
 
             <p>Whitespace is normalized using the whitespace normalization rules
-      of <code>fn:normalize-space</code>. If the result of whitespace
+      of <function>fn:normalize-space</function>. If the result of whitespace
       normalization contains only whitespace, the corresponding URI
       consists of the empty string.  <phrase
                   role="xquery"
@@ -4032,7 +4032,7 @@ the schema type named <code>us:address</code>.</p>
                         <code>item()</code> matches
                         any single <termref def="dt-item">item</termref>.</p>
                      <p>For example, <code>item()</code> matches the atomic
-                        item <code>1</code>, the element <code>&lt;a/&gt;</code>, or the function <code>fn:concat#3</code>.</p>
+                        item <code>1</code>, the element <code>&lt;a/&gt;</code>, or the function <function>fn:concat#3</function>.</p>
                </item>
                <item>
                   
@@ -5540,7 +5540,7 @@ name.</p>
 		                variable. However, the type signature for such functions typically declares the argument type
 		                as <code>map(*)</code>, which gives very little information (and places very few constraints)
 		                on the values that are actually passed across. Using record types offers the possibility of
-		                improving this: for example, the options argument of <code>fn:parse-json</code>, previously
+		                improving this: for example, the options argument of <function>fn:parse-json</function>, previously
 		                given as <code>map(*)</code>, can now be expressed as <code>record(liberal? as xs:boolean, 
 		                   duplicates? as xs:string, escape? as xs:boolean, fallback as fn(xs:string) as xs:string, *)</code>.
 		                In principle the <code>xs:string</code> type used to describe the <code>duplicates</code>
@@ -5606,7 +5606,7 @@ name.</p>
                treat it as an error <errorref class="ST" code="0023"/>, but it is not obliged to do so.</p>
                
                <note><p>For an example of a practical use of recursive record types, see the
-               specification of the function <code>fn:random-number-generator</code>.</p></note>
+               specification of the function <function>fn:random-number-generator</function>.</p></note>
                
                <p>Recursive type definitions need to be handled specially by the subtyping rules; 
                   a naïve approach of simply replacing each reference to a named item type 
@@ -7045,7 +7045,7 @@ declare record Particle (
                      in certain XSLT constructs. They are not invoked in other contexts such as dynamic function calls,
                      for converting the result of an inline function to its required type,
                      for partial function application, or for implicit function calls such as
-                     occur when evaluating functions such as <code>fn:for-each</code> and <code>fn:filter</code>.</p>
+                     occur when evaluating functions such as <function>fn:for-each</function> and <function>fn:filter</function>.</p>
                </note>
                
                
@@ -7242,7 +7242,7 @@ declare record Particle (
                                     
                                     <p>This change allows the arguments of existing functions to be defined with a
                                        
-                                       more precise type. For example, the <code>$position</code> argument of <code>array:get</code>
+                                       more precise type. For example, the <code>$position</code> argument of <function>array:get</function>
                                        
                                        could be defined as <code>xs:positiveInteger</code> 
                                        rather than <code>xs:integer</code>.</p>
@@ -7404,9 +7404,9 @@ declare record Particle (
                <p>Examples of implausible coercions include the following:</p>
                
                <ulist>
-                  <item><p><code>round(timezone-from-time($now))</code>. The result of <code>fn:timezone-from-time</code>
+                  <item><p><code>round(timezone-from-time($now))</code>. The result of <function>fn:timezone-from-time</function>
                   is of type <code>xs:dayTimeDuration?</code>, which is substantively disjoint with the required type
-                  of <code>fn:round</code>, namely <code>xs:numeric?</code>.</p></item>
+                  of <function>fn:round</function>, namely <code>xs:numeric?</code>.</p></item>
                   <item><p><code>function($x as xs:integer) as array(xs:string) { array { 1 to $x } }</code>. The type
                   of the function body is <code>array(xs:integer)</code>, which is substantively disjoint with the
                   required type <code>array(xs:string)</code>: the function can succeed only in the exceptional case
@@ -7462,12 +7462,12 @@ declare record Particle (
                      then <var>F</var> is wrapped in a new function that declares and ignores the
                   additional argument; the following steps are then applied to this new function.</p>
                      <p>For example, if <var>T</var> is <code>function(node(), xs:boolean) as xs:string</code>,
-                  and the supplied function is <code>fn:name#1</code>, then the supplied function is effectively
+                  and the supplied function is <function>fn:name#1</function>, then the supplied function is effectively
                   replaced by <code>function($n as node(), $b as xs:boolean) as xs:string { fn:name($n) }</code></p>
                      <note>
                         <p>This mechanism makes it easier to design versatile and extensible higher-order functions. 
                      For example, in previous versions of this specification, the second argument of
-                     the <code>fn:filter</code> function expected an argument of type 
+                     the <function>fn:filter</function> function expected an argument of type 
                      <code>function(item()) as xs:boolean</code>. This has now been extended to
                      <code>function(item(), xs:integer) as xs:boolean</code>, but existing code continues
                      to work, because callback functions that are not interested in the value of the second
@@ -7798,7 +7798,7 @@ return $f(12.3)]]></eg>
                <example id="eg-coercion-to-string">
                   <head>Coercion to <code>xs:string</code></head>
                   <p>Consider the case where the required type (of a variable, or a function argument)
-                  is <code>xs:string</code>. For example, the second argument of <code>fn:matches</code>,
+                  is <code>xs:string</code>. For example, the second argument of <function>fn:matches</function>,
                   which expects a regular expression. The table below illustrates the values that might be supplied, and
                   the coercions that are applied.</p>
                   
@@ -7843,7 +7843,7 @@ return $f(12.3)]]></eg>
                            <td valign="top"><p>Supplying a number where a string is expected raises a type error.</p>
                               <p role="xpath">However, if XPath 1.0
                               compatibility mode is enabled, the number is converted to a string as if
-                           by the <code>fn:string</code> function.</p></td>
+                           by the <function>fn:string</function> function.</p></td>
                         </tr>
                         <tr role="xpath">
                            <td valign="top"><code>//author/@id</code></td>
@@ -7876,7 +7876,7 @@ return $f(12.3)]]></eg>
                               array to be atomized, and the value after atomization is a single string.</p>
                               <p>Supplying an array holding multiple strings would fail.</p>
                               <p role="xpath">In XPath 1.0 compatibility mode, supplying an array will fail, 
-                                 regardless of the array contents, because the <code>fn:string</code> function does not 
+                                 regardless of the array contents, because the <function>fn:string</function> function does not 
                                  accept arrays.</p>
                            </td>
                         </tr>
@@ -7887,7 +7887,7 @@ return $f(12.3)]]></eg>
                <example id="eg-coercion-to-decimal">
                   <head>Coercion to <code>xs:decimal?</code></head>
                   <p>Consider the case where the required type (of a variable, or a function argument)
-                     is <code>xs:decimal?</code>. For example, the first argument of <code>fn:seconds</code>,
+                     is <code>xs:decimal?</code>. For example, the first argument of <function>fn:seconds</function>,
                      which expects a decimal number of seconds. The table below illustrates the values that might be supplied, and
                      the coercions that are applied.</p>
                   
@@ -8012,7 +8012,7 @@ return $f(12.3)]]></eg>
                </example>
                <example id="eg-coercion-to-union">
                   <head>Coercion to a union type</head>
-                  <p>Consider the first parameter of the function <code>fn:char</code>, whose declared
+                  <p>Consider the first parameter of the function <function>fn:char</function>, whose declared
                   type is <code>(xs:string | xs:positiveInteger)</code>. The rules are the same
                   as if it were a union typed declared in an imported schema.</p>
                   
@@ -8033,7 +8033,7 @@ return $f(12.3)]]></eg>
                            <td valign="top"><code>"#"</code></td>
                            <td valign="top"><p>The supplied value is of type <code>xs:string</code>, which is one of the allowed
                               types. As far as the coercion rules are concerned, the call therefore succeeds. Under the
-                              semantic rules for the <code>fn:char</code> function, however, this value is not accepted;
+                              semantic rules for the <function>fn:char</function> function, however, this value is not accepted;
                               a dynamic error (as distinct from a type error) is therefore raised.</p></td>
                         </tr>
                         <tr>
@@ -8047,7 +8047,7 @@ return $f(12.3)]]></eg>
                            <td valign="top"><p>The supplied element node is atomized. Assuming that the node has not been schema-validated,
                               the result is an instance of <code>xs:untypedAtomic</code>. The member types of the choice
                               are tested in order. Conversion to <code>xs:string</code> with the value "0x25" succeeds, so 
-                              the <code>fn:char</code> function is called supplying this string; but the function rejects this
+                              the <function>fn:char</function> function is called supplying this string; but the function rejects this
                               string as semantically invalid. The same would happen if the value were, say, <![CDATA[<a>37</a>]]>.
                               Supplying such a value requires an explicit cast, for example <code>fn:char( xs:positiveInteger( ./a ))</code>.</p>
                            </td>
@@ -9180,7 +9180,7 @@ At evaluation time, the value of a variable reference is the value to which the 
          <p diff="chg" at="B">The functions defined by a statically known <termref def="dt-function-definition"/> can be invoked using a
             <termref def="dt-static-function-call"/>. <termref def="dt-function-item">Function items</termref> corresponding
             to these definitions can also be obtained, as dynamic values, by evaluating a <termref def="dt-named-function-ref"/>. 
-            <termref def="dt-function-item">Function items</termref> can also be obtained using the <code>fn:function-lookup</code>
+            <termref def="dt-function-item">Function items</termref> can also be obtained using the <function>fn:function-lookup</function>
             function: in this case the function name and arity do not need to be known statically, and the function definition
             need not be present in the <termref def="dt-static-context"/>, so long as it is in the <termref def="dt-dynamic-context"/>.</p>
          
@@ -9224,13 +9224,13 @@ At evaluation time, the value of a variable reference is the value to which the 
                   static context whose name matches <var>f</var> where <code>MinP ≤ N and MaxP ≥ N</code>.
                The result of evaluating a function reference is a <termref def="dt-function-item"/> which can be called
                using a dynamic function call. Function items are never variadic and their arguments
-               are always supplied positionally. For example, the function reference <code>fn:concat#3</code>
+               are always supplied positionally. For example, the function reference <function>fn:concat#3</function>
                returns a function item with arity 3, which is always called by supplying three positional
-               arguments, and whose effect is the same as a static call on <code>fn:concat</code> with
+               arguments, and whose effect is the same as a static call on <function>fn:concat</function> with
                three positional arguments. <!--The arity must not exceed the number of arguments that
                can be supplied positionally. Therefore, in the case of a function reference to a map-variadic functions
-               such as <code>fn:serialize#2</code>, a dynamic call must supply the map-valued argument
-               (the serialization parameters) in the form of a map; the function reference <code>fn:serialize#3</code>
+               such as <function>fn:serialize#2</function>, a dynamic call must supply the map-valued argument
+               (the serialization parameters) in the form of a map; the function reference <function>fn:serialize#3</function>
                is an error, because <var>MaxP</var> = 2.--></p>
                
                <p>The detailed rules for evaluating static function calls and function references are defined
@@ -9619,8 +9619,8 @@ At evaluation time, the value of a variable reference is the value to which the 
             <ulist>
                <item><p>A <term>named function reference</term> (see <specref ref="id-named-function-ref"/>)
                constructs a function item by reference to <termref def="dt-function-definition">function definitions</termref>
-                  in the static context. For example, <code>fn:node-name#1</code>
-               returns a function item whose effect is to call the static <code>fn:node-name</code> function
+                  in the static context. For example, <function>fn:node-name#1</function>
+               returns a function item whose effect is to call the static <function>fn:node-name</function> function
                with one argument.</p></item>
                <item><p>An <term>inline function</term> (see <specref ref="id-inline-func"/><!-- and <specref ref="id-lambda-expressions"/>-->)
                   constructs a function item whose <phrase diff="chg" at="2023-03-11">body</phrase> is defined locally. For example, the
@@ -9633,12 +9633,12 @@ At evaluation time, the value of a variable reference is the value to which the 
                   <code>".txt"</code>.</p></item>
                <item><p>Maps and arrays are also function items. See <specref ref="id-map-constructors"/>
                and <specref ref="id-array-constructors"/>.</p></item>
-               <item diff="add" at="B"><p>The <code>fn:function-lookup</code> function can be called to discover functions
+               <item diff="add" at="B"><p>The <function>fn:function-lookup</function> function can be called to discover functions
                that are present in the <termref def="dt-dynamic-context"/>.</p></item>
-               <item diff="add" at="B"><p>The <code>fn:load-xquery-module</code> function can be called to load functions
+               <item diff="add" at="B"><p>The <function>fn:load-xquery-module</function> function can be called to load functions
                   dynamically from an external XQuery library module.</p></item>
-               <item diff="add" at="B"><p>Some system functions such as <code>fn:random-number-generator</code> 
-                  and <code>fn:op</code> return a <termref def="dt-function-item"/> as their result.</p></item>
+               <item diff="add" at="B"><p>Some system functions such as <function>fn:random-number-generator</function> 
+                  and <function>fn:op</function> return a <termref def="dt-function-item"/> as their result.</p></item>
             </ulist>
             
             <p>These constructs are described in detail in the following sections, or in
@@ -10018,7 +10018,7 @@ return $vat(doc('wares.xml')/shop/article)
                         <p>A partial function application need not have any explicitly supplied parameters.
                         For example, the partial function application <code>fn:string(?)</code>
                         is allowed; it has exactly the same effect as the named function reference
-                        <code>fn:string#1</code>. </p></note>
+                        <function>fn:string#1</function>. </p></note>
                   </item>
                   <item>
                      <p>Explicitly supplied parameters and defaulted parameters are evaluated and 
@@ -10044,7 +10044,7 @@ return $vat(doc('wares.xml')/shop/article)
                      
                      <p diff="add" at="2024-02-02">In the particular case where all the supplied arguments
                      are placeholders, the error behavior <rfc2119>should</rfc2119> be the same as
-                     for an equivalent <termref def="dt-named-function-ref"/>: for example, <code>fn:id#1</code>
+                     for an equivalent <termref def="dt-named-function-ref"/>: for example, <function>fn:id#1</function>
                      fails if there is no context node, and <code>fn:id(?)</code> <rfc2119>should</rfc2119>
                      fail likewise.</p>
                      
@@ -10087,7 +10087,7 @@ return $vat(doc('wares.xml')/shop/article)
                            </p>
                            <note><p>A partial function application can be used to change the order
                            of parameters, for example <code>fn:contains(substring := ?, value := ?)</code>
-                           returns a function item that is equivalent to <code>fn:contains#2</code>,
+                           returns a function item that is equivalent to <function>fn:contains#2</function>,
                            but with the order of arguments reversed.</p></note>
                         </item>
                         
@@ -10128,7 +10128,7 @@ return $vat(doc('wares.xml')/shop/article)
                         <eg role="parse-test"><![CDATA[let $sum-of-squares := fold-right(?, 0, function($a, $b) { $a*$a + $b })
 return $sum-of-squares(1 to 3)]]></eg>
                         <p>
-                           <code>$sum-of-squares</code> is an anonymous function. It has one parameter, named <code>$seq</code>, which is taken from the corresponding parameter in <code>fn:fold-right</code> (the other two parameters are fixed). The implementation is the implementation of <code>fn:fold-right</code>, which is a context-independent system function. The nonlocal bindings contain the fixed bindings for the second and third parameters of <code>fn:fold-right</code>.</p>
+                           <code>$sum-of-squares</code> is an anonymous function. It has one parameter, named <code>$seq</code>, which is taken from the corresponding parameter in <function>fn:fold-right</function> (the other two parameters are fixed). The implementation is the implementation of <function>fn:fold-right</function>, which is a context-independent system function. The nonlocal bindings contain the fixed bindings for the second and third parameters of <function>fn:fold-right</function>.</p>
                      </example>
               
                   </item>
@@ -10336,7 +10336,7 @@ return $a("A")]]></eg>
                <p>Consider:</p>
                <eg role="parse-test"><![CDATA[let $f := <foo/>/fn:name#0 return <bar/>/$f()]]></eg>
                <p>The function <code>fn:name()</code>, with no arguments, returns the name of the context node. The function
-               item delivered by evaluating the expression <code>fn:name#0</code> returns the name of the element that was the
+               item delivered by evaluating the expression <function>fn:name#0</function> returns the name of the element that was the
                context node at the point where the function reference was evaluated (that is, the <code>&lt;foo&gt;</code> element).
                This expression therefore returns <code>"foo"</code>, not <code>"bar"</code>.</p>
             </example>
@@ -10344,9 +10344,9 @@ return $a("A")]]></eg>
 
                <p diff="add" at="2023-12-12">An error is raised if the identified function depends on components of the static or dynamic
                   context that are not present, or that have unsuitable values. For example <errorref 
-                     class="DY" code="0002" type="type"/> is raised for the expression <code>fn:name#0</code>
+                     class="DY" code="0002" type="type"/> is raised for the expression <function>fn:name#0</function>
                   if the context item is absent, and <xerrorref spec="FO" class="DC" code="0001" type="dynamic"
-                  /> is raised for the call <code>fn:id#1</code> if the context item is not a node
+                  /> is raised for the call <function>fn:id#1</function> if the context item is not a node
                   in a tree that is rooted at a document node. The error that is raised is the same as the error that would
                   be raised by the corresponding function if called with the same static and dynamic context.</p>
            
@@ -10383,12 +10383,12 @@ return $a("A")]]></eg>
                              <p>This rule applies even across different 
                                 <xtermref spec="FO40" ref="execution-scope">execution scopes</xtermref>:
                              for example if a parameter to a call to <function>fn:transform</function> is set to the
-                             result of the expression <code>fn:abs#1</code>, then the function item passed as the parameter
-                                value will be identical to that obtained by evaluating the expression <code>fn:abs#1</code>
+                             result of the expression <function>fn:abs#1</function>, then the function item passed as the parameter
+                                value will be identical to that obtained by evaluating the expression <function>fn:abs#1</function>
                              within the target XSLT stylesheet.</p>
                            <p>This rule also applies when the target function definition is 
                            <xtermref spec="FO40" ref="dt-nondeterministic">nondeterministic</xtermref>. 
-                           For example all evaluations of the named function reference <code>map:keys#2</code>
+                           For example all evaluations of the named function reference <function>map:keys#2</function>
                            return identical function items, even though two evaluations of <function>map:keys</function>
                            with the same arguments may produce different results.</p>
                         </item>
@@ -10414,7 +10414,7 @@ return $a("A")]]></eg>
                      the required type of each excess parameter in the result is the same
                      as the required type of the last declared parameter of <var>FD</var>.</p>
                      <note><p>The required type of each
-                     parameter of <code>fn:concat#3</code> is thus <code>xs:anyAtomicType*</code>,
+                     parameter of <function>fn:concat#3</function> is thus <code>xs:anyAtomicType*</code>,
                      which means that a call such as <code>concat#3(("a","b"), ("c","d"), ())</code>
                      is allowed.</p></note>-->
                   </item>
@@ -10432,11 +10432,11 @@ return $a("A")]]></eg>
                </ulist>
             </p>
             
-            <note diff="add" at="variadicity"><p>Consider the system function <code>fn:format-date</code>,
-            which has an arity range of 2 to 5. The named function reference <code>fn:format-date#3</code>
+            <note diff="add" at="variadicity"><p>Consider the system function <function>fn:format-date</function>,
+            which has an arity range of 2 to 5. The named function reference <function>fn:format-date#3</function>
             returns a function item whose three parameters correspond to the first three parameters
-            of <code>fn:format-date</code>; the remaining two arguments will take their default values.
-               To obtain an arity-3 function that binds to arguments 1, 2, and 5 of <code>fn:format-date</code>,
+            of <function>fn:format-date</function>; the remaining two arguments will take their default values.
+               To obtain an arity-3 function that binds to arguments 1, 2, and 5 of <function>fn:format-date</function>,
             use the partial function application <code>format-date(?, ?, place := ?)</code>.</p></note>
 
             
@@ -10452,12 +10452,12 @@ return $a("A")]]></eg>
                <item>
                   <p>
                      <code role="parse-test"
-                     >fn:abs#1</code> references the <code>fn:abs</code> function which takes a single argument.</p>
+                     >fn:abs#1</code> references the <function>fn:abs</function> function which takes a single argument.</p>
                </item>
                <item>
                   <p>
                      <code role="parse-test"
-                     >fn:concat#5</code> references the <code>fn:concat</code> function which takes 5 arguments.</p>
+                     >fn:concat#5</code> references the <function>fn:concat</function> function which takes 5 arguments.</p>
                </item>
                <item>
                   <p>
@@ -10696,7 +10696,7 @@ return $incrementors[2](4)]]></eg>
                   <item><p><code>function { head(.) + foot(.) }</code> - a function that expects a sequence of numbers
                      as its argument, and returns the sum of the first and last items in the sequence.</p></item>
                </ulist>
-               <p>Focus functions are often useful as arguments to simple higher-order functions such as <code>fn:sort</code>.
+               <p>Focus functions are often useful as arguments to simple higher-order functions such as <function>fn:sort</function>.
                For example, to sort employees by salary, write <code>sort(//employee, (), fn { +@salary })</code>.
                (The unary plus has the effect of converting the attribute’s value to a number, for numeric sorting).</p>
                <p>Focus functions can also be useful on the right-hand side of the <termref def="dt-sequence-arrow-operator"/>
@@ -10768,7 +10768,7 @@ return $incrementors[2](4)]]></eg>
             
             <ulist>
                <item><p>Some <termref def="dt-system-function">system functions</termref>
-               such as <code>fn:concat</code> and <code>fn:codepoints-to-string</code>
+               such as <function>fn:concat</function> and <function>fn:codepoints-to-string</function>
                are defined to be variadic.</p></item>
                <item><p>User-written functions defined in XQuery can be defined as variadic by
                use of the annotation <code>%variadic</code> on the function declaration.</p></item>
@@ -10790,7 +10790,7 @@ return $incrementors[2](4)]]></eg>
             <p>In static function calls the effect of defining a function as variadic is that
             the value for the (single or final) parameter can be spread across multiple arguments
             rather than being supplied as a single argument. For example a sequence
-            of strings can be supplied to the <code>fn:concat</code> function either as
+            of strings can be supplied to the <function>fn:concat</function> function either as
             a single argument: <code>concat(("a", "b", "c"))</code> or as a series of separate
             arguments: <code>concat("a", "b", "c")</code>. It is also possible to mix
             the two approaches: the call <code>concat("a", (), ("b", "c"))</code> has
@@ -10812,7 +10812,7 @@ return $incrementors[2](4)]]></eg>
             variadic: a function item always has a fixed arity and must be called with the
             correct number of arguments.</p>
             
-            <p>So, for example, <code>fn:concat#3</code> creates a function item with
+            <p>So, for example, <function>fn:concat#3</function> creates a function item with
             arity 3, which must always be called with three arguments. The required type
             for each of these arguments is the same as the required type declared on the
             final parameter in the function definition, which in this case is
@@ -10824,7 +10824,7 @@ return $incrementors[2](4)]]></eg>
             parameter being <code>xs:anyAtomicType*</code>. This function is equivalent
                to the anonymous function <code>fn($x) { fn:concat("[", $x, "]") }</code>.
             The semantics of partial function application are equivalent to first evaluating
-            a named function reference with appropriate arity (in this case <code>fn:concat#3</code>)
+            a named function reference with appropriate arity (in this case <function>fn:concat#3</function>)
             and then performing a dynamic partial application of the resulting function item.</p>
             
             <example id="example-variadic-function">
@@ -12831,7 +12831,7 @@ every integer between the two operands, in increasing order. </p>
                <eg role="parse-test">10 to 10</eg>
                <p>The result of this example is a sequence of length zero.</p>
                <eg role="parse-test">15 to 10</eg>
-               <p>This example uses the <code>fn:reverse</code> function to construct a sequence of six integers in decreasing order. 
+               <p>This example uses the <function>fn:reverse</function> function to construct a sequence of six integers in decreasing order. 
                   It evaluates to the sequence 15, 14, 13, 12, 11, 10.</p>
                <eg role="parse-test">reverse(10 to 15)</eg>
             </example>
@@ -12846,7 +12846,7 @@ every integer between the two operands, in increasing order. </p>
                is <code>-200 to -100 by 2</code>.</p>
             </note>-->
             
-            <note><p>To construct a sequence of integers based on steps other than 1, use the <code>fn:slice</code>
+            <note><p>To construct a sequence of integers based on steps other than 1, use the <function>fn:slice</function>
                function, as defined in <xspecref spec="FO31" ref="general-seq-funcs"/>.</p></note>
 
          </div3>
@@ -13042,7 +13042,7 @@ Similarly, the operands of a <code>MultiplicativeExpr</code> are grouped from le
             <item>
                <p>If the atomized operand is now an instance of type <code>xs:boolean</code>, <code>xs:string</code>,
 <code>xs:decimal</code> (including <code>xs:integer</code>), <code>xs:float</code>, or <code>xs:untypedAtomic</code>, then it
-is converted to the type <code>xs:double</code> by applying the <code>fn:number</code> function. (Note that <code>fn:number</code> returns the value <code>NaN</code> if its operand cannot be converted to a number.)</p>
+is converted to the type <code>xs:double</code> by applying the <function>fn:number</function> function. (Note that <function>fn:number</function> returns the value <code>NaN</code> if its operand cannot be converted to a number.)</p>
             </item>
          </olist>
          <p>
@@ -13298,7 +13298,7 @@ return `The months with 31 days are: { $longMonths }.`]]></eg>
                   way of writing a string literal: <code>"Goethe"</code>, <code>'Goethe'</code>, and <code>`Goethe`</code>
                are interchangeable. This means that back-ticks can sometimes be a useful way of delimiting a string
                that contains both single and double quotes: <code>`He said: "I didn't."`</code>.</p>
-               <p>It is sometimes useful to use string templates in conjunction with the <code>fn:char</code> function
+               <p>It is sometimes useful to use string templates in conjunction with the <function>fn:char</function> function
                   to build strings containing special characters, for example <code>`Chapter{ fn:char("nbsp") }{ $chapNr }`</code>.</p>
             </note>
             
@@ -13709,7 +13709,7 @@ always <code>true</code> or <code>false</code>.</p>
                <item>
                   <p>If the comparison operator is <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code>, or <code>&gt;=</code>, then each item in both of the
 operand sequences is converted to the type  <code>xs:double</code> by applying the
-<code>fn:number</code> function. (Note that <code>fn:number</code> returns the value <code>NaN</code> if its operand cannot be converted to a number.)</p>
+<function>fn:number</function> function. (Note that <function>fn:number</function> returns the value <code>NaN</code> if its operand cannot be converted to a number.)</p>
                </item>
 
                <item>
@@ -13728,7 +13728,7 @@ applying the following rules. If a <code>cast</code> operation called for by the
                         <p>If at least one of the two atomic items is an instance of a <termref
                               def="dt-numeric"
                               >numeric</termref> type, then both atomic items are converted to the type <code>xs:double</code> by
-applying the <code>fn:number</code> function.</p>
+applying the <function>fn:number</function> function.</p>
                      </item>
 
                      <item>
@@ -14162,19 +14162,19 @@ following expression must raise a <termref def="dt-dynamic-error"
          </ulist>
 
          <p>In addition to and- and or-expressions, &language; provides a
-function named <code>fn:not</code> that takes a general sequence as
-parameter and returns a boolean value.  The <code>fn:not</code> function
+function named <function>fn:not</function> that takes a general sequence as
+parameter and returns a boolean value.  The <function>fn:not</function> function
 is defined in <bibref
                ref="xpath-functions-40"
                />. The
-<code>fn:not</code> function reduces its parameter to an <termref
+<function>fn:not</function> function reduces its parameter to an <termref
                def="dt-ebv"
                >effective boolean value</termref>. It then returns
 <code>true</code> if the effective boolean value of its parameter is
 <code>false</code>, and <code>false</code> if the effective boolean
 value of its parameter is <code>true</code>. If an error is
 encountered in finding the effective boolean value of its operand,
-<code>fn:not</code> raises the same error.</p>
+<function>fn:not</function> raises the same error.</p>
 
 
       </div2>
@@ -16448,7 +16448,7 @@ serialized (see <specref
                   ref="id-serialization"
                   />), and may also
 affect the behavior of certain functions that operate on nodes, such
-as <code>fn:name</code>. Note the difference between <termref
+as <function>fn:name</function>. Note the difference between <termref
                   def="dt-in-scope-namespaces"
                   >in-scope namespaces</termref>, which is a
 dynamic property of an element node, and <termref
@@ -18299,13 +18299,13 @@ return (
             <note>
                <p>If a collation name is specified, it must be supplied as a literal string; it cannot
                   be computed dynamically. A workaround in such cases is to use
-                   the <code>fn:collation-key</code> function. For example:</p>
+                   the <function>fn:collation-key</function> function. For example:</p>
                
                <eg role="parse-test">for $p in $products
 group by collation-key($p/description, $collation)
 return $product/@code</eg>
                
-               <p>Note however that the <code>fn:collation-key</code> function might not work
+               <p>Note however that the <function>fn:collation-key</function> function might not work
                   for all collations.</p>
             </note>
             
@@ -18606,9 +18606,9 @@ return $e/name]]></eg>
             </ulist>
             <note>
                <p>If a collation name is specified, it must be supplied as a literal string; it cannot
-                  be computed dynamically. Two possible workarounds are to use the <code>fn:sort</code> function
-               or the <code>fn:collation-key</code> function.</p>
-               <p>Using <code>fn:sort</code> the expression</p>
+                  be computed dynamically. Two possible workarounds are to use the <function>fn:sort</function> function
+               or the <function>fn:collation-key</function> function.</p>
+               <p>Using <function>fn:sort</function> the expression</p>
                <eg role="parse-test">for $b in $books/book[price &lt; 100]
 order by $b/title
 return $b</eg>
@@ -18630,7 +18630,7 @@ sort(
 order by collation-key($b/title, $collation)
 return $b</eg>
                
-               <p>Note however that the <code>fn:collation-key</code> function might not work
+               <p>Note however that the <function>fn:collation-key</function> function might not work
                for all collations.</p>
                
             </note>
@@ -18909,7 +18909,7 @@ are listed after the name of the author.
 
 The ordering of <code>author</code> elements in the result is <termref
                def="dt-implementation-dependent"
-               >implementation-dependent</termref> due to the semantics of the <code>fn:distinct-values</code> function.</p>
+               >implementation-dependent</termref> due to the semantics of the <function>fn:distinct-values</function> function.</p>
          <eg><![CDATA[<author>Stevens</author>
 <title>TCP/IP Illustrated</title>
 <title>Advanced Programming in the Unix environment</title>
@@ -20136,7 +20136,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                      expression <code>$A?$x</code>, if <code>$A</code> is an array and <code>$x</code>
                      (after atomization) is <code>xs:untypedAtomic</code> then the value of <code>$x</code>
                      is converted to an integer (by virtue of the coercion rules applying to a call
-                     on <code>array:get</code>). With a deep lookup expression <code>$A??$x</code>, by
+                     on <function>array:get</function>). With a deep lookup expression <code>$A??$x</code>, by
                      contrast, the semantics are defined in terms of a map lookup, in which 
                      <code>xs:untypedAtomic</code> items are always treated as strings.
                   </p>
@@ -20173,7 +20173,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                
                <example id="ex-deep-lookup">
                   <head>Examples of Deep Lookup Expressions</head>
-                  <p>Consider the tree <code>$tree</code> of maps and arrays that results from applying the <code>fn:parse-json</code>
+                  <p>Consider the tree <code>$tree</code> of maps and arrays that results from applying the <function>fn:parse-json</function>
                   function to the following input:</p>
                   <eg><![CDATA[
 {
@@ -20473,7 +20473,7 @@ return $map?[?key ge 2]</eg>
             with an expression such as <code>??name</code>, there is no way of navigating from 
                the items in the result to any related items. 
                Pinned maps and arrays provide a solution to this problem; if a map or array
-            is pinned (by calling the <code>fn:pin</code> function), then values found by navigating
+            is pinned (by calling the <function>fn:pin</function> function), then values found by navigating
             within the map or array are <term>labeled</term>, which provides supplementary information
             about their location within the containing tree structure.</p>
             
@@ -20484,7 +20484,7 @@ return $map?[?key ge 2]</eg>
             <p>More specifically, if a map <code>$M</code> or an array <code>$A</code> is pinned,
             then any value returned by <code>map:get($M, $key)</code> or <code>array:get($A, $index)</code>
             will be a sequence of labeled items. The label can be obtained by calling the function
-            <code>fn:label</code>, and the result will be a map having the following properties:</p>
+            <function>fn:label</function>, and the result will be a map having the following properties:</p>
             
             <ulist>
                <item><p><code>pinned</code>: set to <code>true</code>. This means that any
@@ -20495,7 +20495,7 @@ return $map?[?key ge 2]</eg>
                <item><p><code>key</code>: the key (<code>$key</code>) or index (<code>$index</code>)
                that was used to select the item.</p></item>
                <item><p><code>position</code>: in the general case the value returned by
-               <code>map:get</code> or <code>array:get</code> is a sequence, and each item in the
+               <function>map:get</function> or <function>array:get</function> is a sequence, and each item in the
                   sequence is labeled with its 1-based position in that sequence.</p></item>
                <item><p><code>ancestors</code>: a zero-arity function that delivers the item's parent (its
                containing map or array), that item's parent, and so on, recursively, up to
@@ -20507,7 +20507,7 @@ return $map?[?key ge 2]</eg>
                key or index of the item comes last).</p></item>
             </ulist>
             
-            <p>The formal model for the <code>fn:pin</code> is that it returns a deep copy of the 
+            <p>The formal model for the <function>fn:pin</function> is that it returns a deep copy of the 
                supplied map or array in which all items in the recursive content have been labeled.
             This is a useful model because it avoids the need to specify the effect of each individual
             function and operator on the structure. For example, the rule has the consequence that the result of
@@ -20515,13 +20515,13 @@ return $map?[?key ge 2]</eg>
             <code>[ 1, 2, 4 ]</code>. In a practical implementation, however, it is likely that labels
             will be attached to items lazily, at the time they are retrieved. Such an implementation will need
             to recognize pinned maps and arrays and treat them specially when operations such as
-            <code>array:get</code>, <code>array:remove</code>, <code>array:for-each</code>,
-            <code>array:subarray</code>, and their map counterparts, are evaluated.</p>
+            <function>array:get</function>, <function>array:remove</function>, <function>array:for-each</function>,
+            <function>array:subarray</function>, and their map counterparts, are evaluated.</p>
             
            
             <p>Because maps and arrays selected from a pinned map or array are themselves pinned,
             deep lookup operations (whether conducted using the deep lookup operator <code>??</code>,
-            or the <code>map:find</code> function, or by user-written recursive code) will deliver
+            or the <function>map:find</function> function, or by user-written recursive code) will deliver
             a labeled value whose <code>parent</code> or <code>ancestor</code> properties can 
                be used to navigate back up through the tree.</p>
             
@@ -20540,7 +20540,7 @@ return $map?[?key ge 2]</eg>
             and <code>??</code> flatten their result to a single sequence, so any empty values
             are effectively discarded from the result. For this reason, pinned arrays and maps
             work best when all values in arrays and maps are singleton items. An option is therefore provided
-            on the <code>fn:parse-json</code> and <code>fn:json-doc</code> functions to change
+            on the <function>fn:parse-json</function> and <function>fn:json-doc</function> functions to change
             the representation of JSON <code>null</code> values (whose default is an empty
             sequence, <code>()</code>) to a user-supplied value.</p></note>
             
@@ -20574,13 +20574,13 @@ return $map?[?key ge 2]</eg>
          of evaluating the expression <code>E</code>.</p>
          
          <note><p>In addition to <code>ordered</code> and <code>unordered</code> expressions, 
-            XQuery provides a function named <code>fn:unordered</code> that operates on any sequence 
+            XQuery provides a function named <function>fn:unordered</function> that operates on any sequence 
             of items and returns the same sequence in an <termref
 
                def="dt-implementation-defined"
-               >implementation-defined</termref> order. A call to the <code>fn:unordered</code> 
+               >implementation-defined</termref> order. A call to the <function>fn:unordered</function> 
             function may be thought of as giving permission for the argument expression to be 
-            materialized in whatever order the system finds most efficient. The <code>fn:unordered</code> 
+            materialized in whatever order the system finds most efficient. The <function>fn:unordered</function> 
             function relaxes ordering only for the sequence that is its immediate operand, whereas the <code>unordered</code> 
             expression in earlier XQuery versions sets the ordering mode for its operand expression and 
             all nested expressions.</p></note>
@@ -20834,7 +20834,7 @@ raised <errorref class="TY" code="0004"/>. In the absence of a switch comparand,
                <p diff="chg" at="2023-02-20">Otherwise, the singleton <term>switch value</term> is compared individually
                with each item in the <term>case value</term> in turn, and a match
                occurs if and only if these two atomic items compare equal under the rules of
-               the <code>fn:deep-equal</code> function with default options, using the default 
+               the <function>fn:deep-equal</function> function with default options, using the default 
                collation in the static context.</p>
             </item>
          </olist>
@@ -20890,11 +20890,11 @@ switch {
   default return "not comparable"
 }]]></eg>
          
-         <note diff="add" at="issue671"><p>The comparisons are performed using the <code>fn:deep-equal</code>
+         <note diff="add" at="issue671"><p>The comparisons are performed using the <function>fn:deep-equal</function>
          function, after atomization. This means that a case expression such as <code>@married</code>
             tests <code>fn:data(@married)</code> rather than <code>fn:boolean(@married)</code>. 
          If the effective boolean value of the expression is wanted,
-         this can be achieved with an explicit call of <code>fn:boolean</code>.</p></note>
+         this can be achieved with an explicit call of <function>fn:boolean</function>.</p></note>
       </div2>
 
       <div2 id="id-quantified-expressions">
@@ -21010,7 +21010,7 @@ one <code>employee</code> element satisfies the given comparison expression:</p>
                <note diff="add" at="A"><p>Like many quantified expressions, this can be simplified. This example can be written
                   <code>every $emp in /emps/employee satisfies $emp/salary[@current = 'true']</code>, or even
                   more concisely as <code>empty(/emps/employee[not(salary/@current = 'true')]</code>.</p>
-               <p>Another alternative in &language; is to use the higher-order functions <code>fn:some</code> and <code>fn:every</code>.
+               <p>Another alternative in &language; is to use the higher-order functions <function>fn:some</function> and <function>fn:every</function>.
                This example can be written <code diff="chg" at="2023-04-25">fn:every(/emps/employee, fn { salary/@current = 'true' })</code></p>
                </note>
             </item>
@@ -21632,7 +21632,7 @@ sequence is permitted.</p>
             
 
             <p>Casting a node to <code>xs:QName</code> can cause surprises because it uses the static context of the cast expression to provide the namespace bindings for this operation. 
-Instead of casting to <code>xs:QName</code>, it is generally preferable to use the <code>fn:QName</code> function, which allows the namespace context to be taken from the document containing the QName.</p>
+Instead of casting to <code>xs:QName</code>, it is generally preferable to use the <function>fn:QName</function> function, which allows the namespace context to be taken from the document containing the QName.</p>
 
 
             <p>The semantics of the <code>cast</code> expression

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -238,8 +238,8 @@
         overriding any implementation-defined default.</termdef> The default collation is the
       collation that is used by functions and operators that require a collation if no other
       collation is specified. For example, the <code>gt</code> operator on strings is defined by a
-      call to the <code>fn:compare</code> function, which takes an optional collation parameter.
-      Since the <code>gt</code> operator does not specify a collation, the <code>fn:compare</code>
+      call to the <function>fn:compare</function> function, which takes an optional collation parameter.
+      Since the <code>gt</code> operator does not specify a collation, the <function>fn:compare</function>
       function implements <code>gt</code> by using the default collation.</p>
     <p>If neither the implementation nor the Prolog specifies a default collation, the Unicode
       codepoint collation (<code>http://www.w3.org/2005/xpath-functions/collation/codepoint</code>)
@@ -269,7 +269,7 @@
         resolving relative URI references.</termdef> For example, the <termref
         def="dt-static-base-uri">Static Base URI</termref> property is used when resolving relative
       references for <termref def="dt-module-import">module import</termref> and for the
-        <code>fn:doc</code> function.</p>
+        <function>fn:doc</function> function.</p>
 
     <note>
       <p>As discussed in the definition of <termref def="dt-static-base-uri">Static Base
@@ -1140,7 +1140,7 @@ return $node/xx:bing]]>
           <code>eg:sequential</code>. 
         If the namespace URI of an annotation is not recognized by the 
         implementation, then the annotation has no effect, other than being available for inspection
-        using the <code>fn:function-annotations</code> function.</p> 
+        using the <function>fn:function-annotations</function> function.</p> 
      <p>Implementations may also provide 
       a way for users to define their own annotations.
         Implementations must not define annotations, or allow users to define annotations, in 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10842,7 +10842,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <changes>
                      <change issue="1375 1522" PR="1378" date="2024-10-15">
                         A function call at the outermost level can now be named using any valid <code>EQName</code>
-                        (for example <code>fn:doc</code>) provided it binds to one of the permitted functions
+                        (for example <xfunction>fn:doc</xfunction>) provided it binds to one of the permitted functions
                         <xfunction>fn:doc</xfunction>, <xfunction>fn:id</xfunction>, <xfunction>fn:element-with-id</xfunction>, 
                         <function>fn:key</function>, or <xfunction>fn:root</xfunction>. 
                         If two functions are called, for example <code>doc('a.xml')/id('abc')</code>,
@@ -33441,7 +33441,7 @@ the same group, and the-->
                      <termref def="dt-absorption"/>, I = <termref def="dt-inspection"/>, T =
                      <termref def="dt-transmission"/>, N = <termref def="dt-navigation"/>). So, for
                   example, the entry <code>fn:remove(T, A)</code> means that for the function
-                     <code>fn:remove#2</code>, the <termref def="dt-operand-usage"/> of the first
+                     <xfunction>fn:remove#2</xfunction>, the <termref def="dt-operand-usage"/> of the first
                   argument is <termref def="dt-transmission"/>, and the <termref def="dt-operand-usage"/> of the second argument is <termref def="dt-absorption"/>. By reference to the general rules in <specref ref="general-streamability-rules"/>, this demonstrates that if the <termref def="dt-context-posture"/> is <termref def="dt-striding"/>, the posture and sweep of the expression
                      <code>sum(remove(*,1))</code> will be <code>grounded</code> and
                      <code>consuming</code> respectively. </p>


### PR DESCRIPTION
Replace `<code>` with `<function>` tags where appropriate.

Fix #1652