### PR TITLE
Remove DTD/stylesheet distractions at the top of the schema

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -1,15 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--* <!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200105//EN"
-       "http://www.w3.org/2001/XMLSchema.dtd" [
-<!ENTITY % schemaAttrs "
-  xmlns:xs   CDATA #IMPLIED
-  xmlns:xsl  CDATA #IMPLIED
-  xmlns:xsd  CDATA #IMPLIED"
->
-<!ENTITY % p "xs:">
-<!ENTITY % s ":xs">
-]> *-->
-<!--<?xml-stylesheet href="http://www.w3.org/2008/09/xsd.xsl" type=" t e x t / x s l"?>-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
            xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning"


### PR DESCRIPTION
We decided to close #374 without further action. This PR just cleans up the relevant schema file by removing the DTD and stylesheet related comment(s).