### PR TITLE
1650 Tidy up fn:type-of

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -544,89 +544,6 @@
       </fos:examples>
    </fos:function>
    
-   <fos:function name="node-kind" prefix="fn">
-      <fos:signatures>
-         <fos:proto name="node-kind" return-type="enum('document', 'element', 'attribute', 'text', 'comment', 'processing-instruction', 'namespace')?">
-            <fos:arg name="node" type="node()?" default="." usage="inspection"/>
-         </fos:proto>
-      </fos:signatures>
-      <fos:properties arity="0">
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-dependent</fos:property>
-         <fos:property>focus-dependent</fos:property>
-      </fos:properties>
-      <fos:properties arity="1">
-         <fos:property>deterministic</fos:property>
-         <fos:property>context-independent</fos:property>
-         <fos:property>focus-independent</fos:property>
-      </fos:properties>
-      <fos:summary>
-         <p>Returns the kind of node, for example <code>"element"</code> or <code>"attribute"</code>.</p>
-      </fos:summary>
-      <fos:rules>
-         <p>If the argument is omitted, it defaults to the context value (<code>.</code>).</p>
-         <p>If <code>$node</code> is the empty sequence, the empty sequence is returned.</p>
-         <p>Otherwise, the function returns the kind of the supplied node.</p>
-      </fos:rules>
-      <fos:equivalent style="xpath-expression" covers-error-cases="false">
-$node ! (
-  if (self::document-node()) then "document"
-  else if (self::element()) then "element"
-  else if (self::attribute()) then "attribute"
-  else if (self::text()) then "text"
-  else if (self::comment()) then "comment"
-  else if (self::processing-instruction()) then "processing-instruction"
-  else "namespace"
-)
-      </fos:equivalent>
-      <fos:errors>
-         <p>The following errors may be raised when <code>$node</code> is omitted:</p>
-         <ulist>
-            <item>
-               <p>If the context value is <xtermref ref="dt-absent" spec="DM40"
-                     >absent</xtermref>,
-                  type error <xerrorref spec="XP"
-                     class="DY" code="0002" type="type"/>.</p>
-            </item>
-            <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
-                     code="0004" type="type"/>.</p>
-            </item>
-         </ulist>
-
-      </fos:errors>
- 
-      <fos:examples>
-         <fos:variable name="e" id="v-node-kind-e"><![CDATA[<doc>
-  <p id="alpha" xml:id="beta">One</p>
-  <p id="gamma" xmlns="http://example.com/ns">Two</p>
-  <ex:p id="delta" xmlns:ex="http://example.com/ns">Three</ex:p>
-  <?pi 3.14159?>
-</doc>]]>
-         </fos:variable>
-         <fos:example>
-            <fos:test use="v-node-kind-e" spec="XQuery">
-               <fos:expression>node-kind($e//*[@id = 'alpha'])</fos:expression>
-               <fos:result>"element"</fos:result>
-            </fos:test>
-            <fos:test use="v-node-kind-e" spec="XQuery">
-               <fos:expression>node-kind($e//@id[. = 'gamma'])</fos:expression>
-               <fos:result>"attribute"</fos:result>
-            </fos:test>
-            <fos:test use="v-node-kind-e" spec="XQuery">
-               <fos:expression>node-kind($e//node()[.='3.14159'])</fos:expression>
-               <fos:result>"processing-instruction"</fos:result>
-            </fos:test>
-            <fos:test use="v-node-kind-e" spec="XQuery">
-               <fos:expression>node-kind($e//no-such-node)</fos:expression>
-               <fos:result>()</fos:result>
-            </fos:test>
-         </fos:example>
-      </fos:examples>
-      <fos:changes>
-         <fos:change issue="148" PR="1523" date="2024-10-22"><p>New in 4.0</p></fos:change>
-      </fos:changes>
-   </fos:function>
    
    <fos:function name="type-of" prefix="fn">
       <fos:signatures>
@@ -757,7 +674,7 @@ $node ! (
                <fos:result>"empty-sequence()"</fos:result>
             </fos:test>
             <fos:test use="v-type-of-e" spec="XQuery">
-               <fos:expression>type-of($e//doc/child::node())</fos:expression>
+               <fos:expression>type-of($e/child::node())</fos:expression>
                <fos:result>"(element()|processing-instruction())+"</fos:result>
             </fos:test>
             <fos:test>
@@ -771,6 +688,18 @@ $node ! (
             <fos:test>
                <fos:expression>type-of((1, 1.2, 2))</fos:expression>
                <fos:result>"(xs:integer|xs:decimal)+"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>type-of([1, 2, 3])</fos:expression>
+               <fos:result>"array(*)"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>type-of({ 'a':1 })</fos:expression>
+               <fos:result>"map(*)"</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>type-of(type-of#1)</fos:expression>
+               <fos:result>"function(*)"</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -817,12 +817,7 @@ for transition to Proposed Recommendation. </p>'>
                for this error are defined in the specification of each function.</p>
                <note><p>It is the responsibility of each function implementation to invoke this conversion; it
                does not happen automatically as a consequence of the function-calling rules.</p></note></item>
-               <item><p>In cases where an option is list-valued, by convention the function should accept
-               either a sequence or an array: but this rule applies only if the specification
-               of the option explicitly accepts either. Accepting a sequence is convenient if the
-               value is generated programmatically using an XPath expression; while accepting an array 
-               allows the options to be held in an external file in JSON format, to be read using
-               a call on the <code>fn:json-doc</code> function.</p></item>
+               
                <item><p>In cases where the value of an option is itself a map, the specification
                of the particular function must indicate whether or not these rules apply recursively 
                to the contents of that map.</p></item>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -817,7 +817,12 @@ for transition to Proposed Recommendation. </p>'>
                for this error are defined in the specification of each function.</p>
                <note><p>It is the responsibility of each function implementation to invoke this conversion; it
                does not happen automatically as a consequence of the function-calling rules.</p></note></item>
-               
+               <item><p>In cases where an option is list-valued, by convention the function should accept
+               either a sequence or an array: but this rule applies only if the specification
+               of the option explicitly accepts either. Accepting a sequence is convenient if the
+               value is generated programmatically using an XPath expression; while accepting an array 
+               allows the options to be held in an external file in JSON format, to be read using
+               a call on the <code>fn:json-doc</code> function.</p></item>
                <item><p>In cases where the value of an option is itself a map, the specification
                of the particular function must indicate whether or not these rules apply recursively 
                to the contents of that map.</p></item>


### PR DESCRIPTION
Drop fn:node-kind from the function catalog so it disappears from the function finder

Correct one example of fn:type-of and add some more examples.

Fix #1650