### PR TITLE
1407 TOC structure for types

### DIFF
--- a/specifications/xpath-functions-40/style/xpath-functions.xsl
+++ b/specifications/xpath-functions-40/style/xpath-functions.xsl
@@ -26,7 +26,7 @@
 
 <xsl:param name="additional.css" select="'xpath-functions-40.css'"/>
 
-<xsl:param name="toc.level" select="3"/>
+<xsl:param name="toc.level" select="5"/>
 
 <xsl:key name="id" match="*" use="@id"/>
 
@@ -719,35 +719,7 @@
     </div>
   </xsl:template>
 
-<!-- ============================================================ -->
-  
-  <!-- Deleted MHK 2016-11-10 - can't see any need for this -->
 
-  <!--<xsl:template match="table">
-    <table summary="A table [this is bad style]">
-      <xsl:for-each select="@*">
-        <!-\- Wait: some of these aren't HTML attributes after all... -\->
-        <xsl:if test="local-name(.) != 'diff'
-                      and local-name(.) != 'role'">
-          <xsl:copy>
-            <xsl:apply-templates/>
-          </xsl:copy>
-        </xsl:if>
-      </xsl:for-each>
-      <xsl:apply-templates/>
-
-      <xsl:if test=".//footnote">
-        <tbody>
-          <tr>
-            <td>
-              <xsl:apply-templates select=".//footnote" mode="table.notes"/>
-            </td>
-          </tr>
-        </tbody>
-      </xsl:if>
-    </table>
-  </xsl:template>
--->
 <!-- ============ CREATE THE QUICK REFERENCE APPENDIX ===================== -->
 
 <xsl:template match="/">

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -1133,6 +1133,12 @@ It is a static error if the name of a feature in
             <nt def="EQName">EQName</nt>.</p>
       </error>
       
+      <error spec="XP" code="0152" class="ST" type="static">
+         <p>It is a <termref def="dt-static-error">static error</termref> 
+            if a key type named in a <nt def="TypedMapType"/> is not a
+            <termref def="dt-generalized-atomic-type"/>.</p>
+      </error>
+      
 
    </error-list>
 </div1>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4468,7 +4468,7 @@ declare variable $orange-fruit as my:fruit := "orange";
                be the name of a type defined in a schema; it cannot be a <termref def="dt-named-item-type"/>.</p>
             
                <div4 id="id-simple-node-tests">
-                  <head>Simple Node Tests</head>
+                  <head>Simple Node Types</head>
                <ulist>
 
                   <item>
@@ -4591,7 +4591,7 @@ declare variable $orange-fruit as my:fruit := "orange";
                   
                
             <div4 id="id-element-test">
-               <head>Element Test</head>
+               <head>Element Types</head>
                
                <changes>
                   <change issue="107" PR="286" date="2023-01-17">
@@ -4799,11 +4799,11 @@ matches any nilled or non-nilled element node whose type annotation is
                they match exactly the same set of element nodes, and (b) each is a subtype
                of the other, so in practice they are indistinguishable.</p></note>
 
-            </div4>
+            
                
 
-            <div4 id="id-schema-element-test">
-               <head>Schema Element Test</head>
+            <div5 id="id-schema-element-test">
+               <head>Schema Element Types</head>
 
                <scrap>
                   <head/>
@@ -4928,10 +4928,10 @@ in the following two situations:
                </ulist>
       
 
+            </div5>
             </div4>
-
             <div4 id="id-attribute-test">
-               <head>Attribute Test</head>
+               <head>Attribute Types</head>
                
                <changes>
                   <change issue="107" PR="286" date="2023-01-17">
@@ -5094,10 +5094,10 @@ name.</p>
                the choice item type <code>(attribute(p)|attribute(q))</code>. However, (a)
                they match exactly the same set of attribute nodes, and (b) each is a subtype
                of the other, so in practice they are indistinguishable.</p></note>
-            </div4>
+            
 
-            <div4 id="id-schema-attribute-test">
-               <head>Schema Attribute Test</head>
+            <div5 id="id-schema-attribute-test">
+               <head>Schema Attribute Types</head>
 
                <scrap>
                   <head/>
@@ -5161,6 +5161,7 @@ name.</p>
                   Unlike the situation with a <nt def="SchemaElementTest">SchemaElementTest</nt>,
                   few problems arise if the attribute was validated using a different
                   schema. This is because attributes do not have substitution groups.</p>
+            </div5>
             </div4>
          </div3>
          <div3 id="id-function-map-array-tests">
@@ -5173,7 +5174,7 @@ name.</p>
             of <specref ref="id-itemtype-subtype"/>.</p>
             
             <div4 id="id-function-test">
-               <head>Function Type</head>
+               <head>Function Types</head>
                <changes>
                   <change issue="1192" PR="1197" date="2024-05-21">The keyword <code>fn</code> is allowed as a synonym for <code>function</code>
                   in function types, to align with changes to inline function declarations.</change>
@@ -5639,9 +5640,9 @@ name.</p>
                <p>Rules defining whether one record type is a <termref def="dt-subtype"/> of another
                   are given in <specref ref="id-item-subtype-records"/>.</p>
 
-            </div4>
             
-            <div4 id="id-recursive-record-tests" diff="add" at="issue295">
+            
+            <div5 id="id-recursive-record-tests" diff="add" at="issue295">
                <head>Recursive Record Types</head>
                
                <p>A named record type <var>N</var> is said to be recursive if its 
@@ -5757,8 +5758,8 @@ declare record Particle (
                </example>
    
                
+            </div5>
             </div4>
-
             <div4 id="id-array-test">
                <head>Array Types</head>
 
@@ -6189,7 +6190,7 @@ declare record Particle (
                if and only if at least one of the conditions listed in the following subsections applies:</p>
 
                <div4 id="id-item-subtype-general">
-                  <head>General Rules</head>
+                  <head>General Subtyping Rules</head>
                   <p>Given <termref def="dt-item-type">item types</termref> <var>A</var> and <var>B</var>, 
                      <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
  
@@ -6218,7 +6219,7 @@ declare record Particle (
                </div4>
                
                <div4 id="id-item-subtype-choice">
-                  <head>Choice Item Types</head>
+                  <head>Subtyping of Choice Item Types</head>
                   <p>The following rules determine whether <code><var>A</var> ⊆ <var>B</var></code> is true in the
                   case where either <var>A</var> or <var>B</var> or both is a <termref def="dt-choice-item-type"/>.</p>
                   
@@ -6245,7 +6246,7 @@ declare record Particle (
                   </note>
                </div4>
                <div4 id="id-item-subtype-atomic">
-                  <head>Atomic and Union Types</head>
+                  <head>Subtyping of Atomic and Union Types</head>
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
   
                      <olist>
@@ -6300,7 +6301,12 @@ declare record Particle (
                      </olist>
                </div4>
                <div4 id="id-item-subtype-nodes">
-                  <head>Node Types: General Rules</head>
+                  <head>Subtyping of Node Types</head>
+                  <p>The following subsections describe the subtype relationships
+                  among node types.</p>
+                  <div5 id="id-item-subtype-nodes-general">
+                     <head>Subtyping Nodes: General Rules</head>
+                  
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                   
                      <olist>
@@ -6343,9 +6349,9 @@ declare record Particle (
                            </example>
                         </item>
                      </olist>
-               </div4>
-               <div4 id="id-item-subtype-elements">
-                  <head>Node Types: Element Tests</head>
+               </div5>
+               <div5 id="id-item-subtype-elements">
+                  <head>Subtyping Nodes: Elements</head>
                   
                   <p diff="chg" at="Issue23"><termdef id="dt-wildcard-matches" term="wildcard-matches">In these rules, if <var>MU</var> and <var>NU</var> 
                      are <nt def="NameTestUnion">NameTestUnions</nt>, 
@@ -6471,9 +6477,9 @@ declare record Particle (
 
                         </item>
                   </olist>
-               </div4>
-               <div4 id="id-item-subtype-attributes">
-                  <head>Node Types: Attribute Tests</head>
+               </div5>
+               <div5 id="id-item-subtype-attributes">
+                  <head>Subtyping Nodes: Attributes</head>
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                     <olist>
                         <item>
@@ -6558,9 +6564,10 @@ declare record Particle (
                            </example>
                         </item>
                      </olist>
+               </div5>
                </div4>
                <div4 id="id-item-subtype-functions">
-                  <head>Functions</head>
+                  <head>Subtyping Functions</head>
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                   
 
@@ -6617,7 +6624,7 @@ declare record Particle (
                      </olist>
                </div4>
                <div4 id="id-item-subtype-maps">
-                  <head>Maps</head>
+                  <head>Subtyping Maps</head>
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                   
                      <olist>
@@ -6700,7 +6707,7 @@ declare record Particle (
                      </olist>
                </div4>
                <div4 id="id-item-subtype-arrays">
-                  <head>Arrays</head>
+                  <head>Subtyping Arrays</head>
                   <p>Given item types <var>A</var> and <var>B</var>, <code><var>A</var> ⊆ <var>B</var></code> is true if any of the following apply:</p>
                   
                      <olist>   
@@ -6768,7 +6775,7 @@ declare record Particle (
                      </olist>
                </div4>
                <div4 id="id-item-subtype-records">
-                  <head>Record Types</head>
+                  <head>Subtyping Records</head>
                   <p>Given item types <var>A</var> and <var>B</var>, <var>A</var> <code>⊆</code> <var>B</var> is true if any of the following apply:</p>
                   <olist>
                      <item diff="add" at="issue52">
@@ -6879,7 +6886,7 @@ declare record Particle (
                   </olist>
                </div4>
                <div4 id="id-itemtype-subtype-aliases" diff="add" at="issue295">
-                  <head>Named Item Types</head>
+                  <head>Subtyping of Named Item Types</head>
                   <p>This section describes how references to <termref def="dt-named-item-type">named item types</termref>
                   are handled when evaluating the subtype relationship.</p>
                   <p>Named item types can be classified as recursive or non-recursive. 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3635,48 +3635,9 @@ defined in <xspecref
             <termref def="dt-value">values</termref> that can be bound to variables, used in 
             expressions, or passed to functions. It then describes how these
             relate to <termref def="dt-schema-type">schema types</termref>,
-            that is, the simple and complex types defined in an XSD schema.</p>       
-
-      <div2 id="id-sequencetype-syntax">
-         <head>Sequence Types</head>
-
-         <p>
-            <termdef id="dt-sequence-type" term="sequence type"
-                  >A <term>sequence type</term> is a type that can be expressed using the <nt
-                  def="SequenceType">SequenceType</nt>
-                  syntax. Sequence types are used whenever it is necessary to refer to a type in an &language; expression. 
-                  The term <term>sequence type</term> suggests that this syntax is used to describe the type of an &language; value, 
-               which is always a sequence.</termdef>
-         </p>
-      <p diff="add" at="B">
-         <termdef id="dt-item-type" term="item type"
-            >An <term>item type</term> is a type that can be expressed using the <nt
-               def="ItemType">ItemType</nt> syntax, which forms part of the <nt def="SequenceType">SequenceType</nt>
-            syntax. Item types match individual <termref def="dt-item">items</termref>.</termdef>
-         
-         In most cases, the set of items matched by an item type consists either
-         exclusively of <termref def="dt-atomic-item">atomic items</termref>,
-         exclusively of <termref def="dt-node">nodes</termref>, 
-         or exclusively of <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>.
-         Exceptions include the generic types <code>item()</code>, which matches all items, <code>xs:error</code>,
-         which matches no items, and <termref def="dt-choice-item-type">choice item types</termref>,
-         which can match any combination of types.
-      </p>
-         
-         
-         
-         
-         <p>Whenever it is necessary to refer to a type in an &language; expression, the <nt
-            def="SequenceType">SequenceType</nt> syntax is used.</p>
-         <scrap>
-            <head/>
-            <prodrecap id="SequenceType" ref="SequenceType"/>
-            <prodrecap id="ItemType" ref="ItemType"/>
-            <prodrecap id="OccurrenceIndicator" ref="OccurrenceIndicator"/>
-         </scrap>
-         
+            that is, the simple and complex types defined in an XSD schema.</p>
       
-      <p diff="add" at="Issue451">In many situations the terms <term>item type</term> and 
+      <note><p>In many situations the terms <term>item type</term> and 
          <term>sequence type</term> are used interchangeably to refer either to the type itself,
          or to the syntactic construct that designates the type: so in the expression
          <code>$x instance of xs:string*</code>, the construct <code>xs:string*</code>
@@ -3686,29 +3647,47 @@ defined in <xspecref
          <termref def="dt-item-type"/> and <termref def="dt-sequence-type"/> to
          refer to the actual types, while using the production names <nt def="ItemType">ItemType</nt>
          and <nt def="SequenceType">SequenceType</nt> to refer to the syntactic
-         designators of these types.</p>
+         designators of these types.</p></note>
+
+      <div2 id="id-sequencetype-syntax">
+         <head>Sequence Types</head>
+
+         <p>
+            <termdef id="dt-sequence-type" term="sequence type"
+                  >A <term>sequence type</term> is a type that can be expressed using the <nt
+                  def="SequenceType">SequenceType</nt>
+                  syntax. Sequence types are used whenever it is necessary to refer to a type in an &language; expression. 
+                  Since all values are sequences, every value matches one or more <term>sequence types</term>.</termdef>
+         </p>
+      
+         
+         
+         <p>Whenever it is necessary to refer to a <term>sequence type</term> 
+            in an &language; expression, the <nt
+            def="SequenceType">SequenceType</nt> syntax is used.</p>
+         <scrap>
+            <head/>
+            <prodrecap id="SequenceType" ref="SequenceType"/>
+            <prodrecap id="ItemType" ref="ItemType"/>
+            <prodrecap id="OccurrenceIndicator" ref="OccurrenceIndicator"/>
+         </scrap>
+         
+      
+      
       
       <p><termdef id="dt-sequence-type-designator" term="sequence type designator">A
       <term>sequence type designator</term> is a syntactic construct conforming to the grammar rule
          <nt def="SequenceType">SequenceType</nt>. A sequence type designator is said
       to <term>designate</term> a <termref def="dt-sequence-type"/>.</termdef></p>
       
-      <p><termdef id="dt-item-type-designator" term="item type designator">An
-         <term>item type designator</term> is a syntactic construct conforming to the grammar rule
-         <nt def="ItemType">ItemType</nt>. An item type designator is said
-         to <term>designate</term> an <termref def="dt-item-type"/>.</termdef></p>
-      
-      <note><p>Two <termref def="dt-item-type-designator">item type designators</termref> may designate the
-      same item type. For example, <code>element()</code> and <code>element(*)</code> are equivalent,
-      as are <code>attribute(A)</code> and <code>attribute(A, xs:anySimpleType)</code>.</p></note>
-         
+       
 
 
             <p>With the exception of the special type
 <code>empty-sequence()</code>, a <termref
                   def="dt-sequence-type"
                   >sequence type</termref> consists of an
-<term>item type</term> that constrains the type of each item in the
+<termref def="dt-item-type"/> that constrains the type of each item in the
 sequence, and a <term>cardinality</term> that constrains the number of
 items in the sequence. Apart from the item type <code>item()</code>,
 which permits any kind of item, item types divide into <term>node
@@ -3716,30 +3695,12 @@ types</term> (such as <code>element()</code>), <term>generalized atomic
 types</term> (such as <code>xs:integer</code>) and function types
 (such as <code>function() as item()*</code>).</p>
 
-            <p>
-               <termref def="dt-qname">Lexical QNames</termref> appearing in a <termref
-                  def="dt-sequence-type"
-                  >sequence type</termref> have their
-		  prefixes expanded to namespace URIs by means of the
-		  <termref
-                  def="dt-static-namespaces"
-                  >statically known namespaces</termref> and (where applicable) the
-		    <termref def="dt-default-namespace-elements-and-types"/>.
-      Equality of QNames is defined by the <code>eq</code> operator.</p>
-
-
-            <p>Item types representing element
-and attribute nodes may specify the required <termref
-                  def="dt-type-annotation"
-                  >type annotations</termref> of those nodes in
-the form of a <termref
-                  def="dt-schema-type"
-                  >schema
-type</termref>. Thus the item type <code>element(*, us:address)</code>
-denotes any element node whose type annotation is (or is derived from)
-the schema type named <code>us:address</code>.</p>
-
-            <p>The occurrence indicators <code>+</code>, <code>*</code>, and <code>?</code> bind to the last <nt def="ItemType"
+            
+            <p>The cardinality of a <termref def="dt-sequence-type"/> is represented
+               in the <termref def="dt-sequence-type-designator"/> syntax by
+               an <nt def="OccurrenceIndicator"/>. 
+               The occurrence indicators <code>+</code>, <code>*</code>, and <code>?</code> 
+               bind to the last <nt def="ItemType"
                   >ItemType</nt> in the <nt def="SequenceType"
                   >SequenceType</nt>, as described in the <loc href="#parse-note-occurrence-indicators"
                   >occurrence-indicators</loc> constraint.</p>
@@ -4004,6 +3965,52 @@ the schema type named <code>us:address</code>.</p>
          <div2 id="id-matching-item">
                <head>Item Types</head>
             
+            <p diff="add" at="B">
+         <termdef id="dt-item-type" term="item type"
+            >An <term>item type</term> is a type that can be expressed using the <nt
+               def="ItemType">ItemType</nt> syntax, which forms part of the <nt def="SequenceType">SequenceType</nt>
+            syntax. Item types match individual <termref def="dt-item">items</termref>.</termdef></p>
+            
+            <note><p>While this definition is adequate for the purpose of defining the syntax
+            of &language;, it ignores the fact that there are also item types that cannot be
+            expressed using &language; syntax: specifically, item types that reference
+            an anonymous simple type or complex type defined in a schema. Such types 
+            can appear as type annotations on nodes following schema validation.</p></note>
+         
+         <p>In most cases, the set of items matched by an item type consists either
+         exclusively of <termref def="dt-atomic-item">atomic items</termref>,
+         exclusively of <termref def="dt-node">nodes</termref>, 
+         or exclusively of <xtermref spec="DM40" ref="dt-function-item">function items</xtermref>.
+         Exceptions include the generic types <code>item()</code>, which matches all items, <code>xs:error</code>,
+         which matches no items, and <termref def="dt-choice-item-type">choice item types</termref>,
+         which can match any combination of types.
+      </p>
+            
+      <p><termdef id="dt-item-type-designator" term="item type designator">An
+         <term>item type designator</term> is a syntactic construct conforming to the grammar rule
+         <nt def="ItemType">ItemType</nt>. An item type designator is said
+         to <term>designate</term> an <termref def="dt-item-type"/>.</termdef></p>
+      
+      <note><p>Two <termref def="dt-item-type-designator">item type designators</termref> may designate the
+      same item type. For example, <code>element()</code> and <code>element(*)</code> are equivalent,
+      as are <code>attribute(A)</code> and <code>attribute(A, xs:anySimpleType)</code>.</p></note>
+        
+      <p>
+               <termref def="dt-qname">Lexical QNames</termref> appearing in an <termref
+                  def="dt-item-type-designator"/> <phrase role="xquery">(other than within
+                  a <termref def="dt-function-assertion"/>)</phrase> have their
+		  prefixes expanded to namespace URIs by means of the
+		  <termref
+                  def="dt-static-namespaces"
+                  >statically known namespaces</termref> and (where applicable) the
+		    <termref def="dt-default-namespace-elements-and-types"/>.
+      Equality of QNames is defined by the <code>eq</code> operator.</p>
+
+
+            
+   
+         
+            
             
             <scrap>
                <head/>
@@ -4128,7 +4135,8 @@ the schema type named <code>us:address</code>.</p>
                   
                   <p>
                      <termdef id="dt-generalized-atomic-type" term="generalized atomic type"
-                        >A <term>generalized atomic type</term> is an item type whose instances are all
+                        >A <term>generalized atomic type</term> is an 
+                        <termref def="dt-item-type"/> whose instances are all
                         atomic items. Generalized atomic types include (a) 
                         <termref def="dt-atomic-type">atomic types</termref>, either built-in
                         (for example <code>xs:integer</code>) or imported from a schema, 
@@ -4450,22 +4458,32 @@ declare variable $orange-fruit as my:fruit := "orange";
                   </change>
                </changes>
                
-               <p diff="add" at="A">Some of the constructs described in this section include a <nt def="TypeName">TypeName</nt>. This appears 
+               <p>Node types are <termref def="dt-item-type">item types</termref> whose 
+                  instances are all <termref def="dt-node">nodes</termref>.</p>
+               
+               <p>The syntax for node types is also used for <termref def="dt-node-test">node tests</termref>
+               within path expressions. This explains why the production rules have names such as
+               <code>NodeTest</code> rather than <code>NodeType</code>.</p>
+               
+               <p>Some of the constructs described in this section include a <nt def="TypeName">TypeName</nt>. This appears 
                   as <var>T</var> in:</p>
                
-               <ulist diff="add" at="A">
+               <ulist>
                   <item><p><code>element(N, T)</code></p></item>
                   <item><p><code>attribute(N, T)</code></p></item>
                   <item><p><code>document-node(element(N, T))</code></p></item>
                </ulist>
                
-               <p diff="add" at="A">In these constructs, the type name <var>T</var> is expanded using the <termref def="dt-in-scope-namespaces"/>
+               <p>Like other lexical QNames, the type name <var>T</var> is expanded using the <termref def="dt-in-scope-namespaces"/>
                   in the <termref def="dt-static-context"/>, using the <termref def="dt-default-namespace-elements-and-types"/> 
                   if it is unprefixed. The resulting
                QName must identify a type in the <termref def="dt-issd"/>. This can be any <termref def="dt-schema-type"/>: either a simple type,
                or (except in the case of attributes) a complex type. If it is a simple type then it can be an atomic, union, or
                list type. It can be a built-in type (such as <code>xs:integer</code>) or a user-defined type. It must however
                be the name of a type defined in a schema; it cannot be a <termref def="dt-named-item-type"/>.</p>
+            
+              
+            
             
                <div4 id="id-simple-node-tests">
                   <head>Simple Node Types</head>
@@ -4779,7 +4797,7 @@ matches any nilled or non-nilled element node whose type annotation is
                
                <p diff="add" at="Issue451">
                   Where a <nt def="TypeName">TypeName</nt> is included in an 
-                  <nt def="ElementTest">ElementTest</nt> <var>T</var>, and element node will only
+                  <nt def="ElementTest">ElementTest</nt> <var>T</var>, an element node will only
                   match the test if it has been validated against a schema that 
                   defines type <var>T</var>; furthermore, <var>T</var> must be
                   present in the <termref def="dt-issd"/> of the static context of the
@@ -5184,80 +5202,102 @@ name.</p>
                      <term>MapTest</term>, and <term>RecordTest</term>, with no
                   change in meaning.</change>
                </changes>
+               
+               <p>A <nt def="FunctionType">FunctionType</nt> matches selected <termref 
+                     def="dt-function-item">function items</termref>,
+                  potentially checking their <xtermref spec="DM40"
+                     ref="dt-signature">signature</xtermref>
+                  (which includes the types of the arguments and results).</p>
 
+               
                <scrap>
                   <head/>
                   <prodrecap id="FunctionType" ref="FunctionType"/>
+                  <prodrecap role="xquery" ref="Annotation"/>
                   <prodrecap id="AnyFunctionType" ref="AnyFunctionType"/>
                   <prodrecap id="TypedFunctionType" ref="TypedFunctionType"/>
                </scrap>
 
 
-               <p>A <nt def="FunctionType">FunctionType</nt> matches selected <termref 
-                     def="dt-function-item">function items</termref>,
-                  potentially checking their <xtermref spec="DM40"
-                     ref="dt-signature">signature</xtermref>
-                  (which includes the types of the arguments and results<phrase role="xquery">, and also their annotations, 
-                     as described in <specref ref="id-annotations"/>)</phrase>).</p>
-
+    <p>The keywords <code>function</code> and <code>fn</code> are synonyms.</p>
+               
+               <p role="xquery">If the <nt def="FunctionType"/> contains an 
+               <nt def="Annotation"/>, then this is interpreted as a
+               <termref def="dt-function-assertion"/>, as described below.</p>
+               
     <p>An <nt def="AnyFunctionType">AnyFunctionType</nt>
-    matches any item that is a function.</p>
+    matches any <termref def="dt-function-item"/>, including a map or an array. For example,
+    the following expressions all return true:</p>
+               
+               <ulist>
+                  <item><p><code>fn:name#1 instance of function(*)</code></p></item>
+                  <item><p><code>fn{@id} instance of function(*)</code></p></item>
+                  <item><p><code>fn:random-number-generator() instance of function(*)</code></p></item>
+                  <item><p><code>[1, 2, 3] instance of fn(*)</code></p></item>
+                  <item><p><code>{} instance of fn(*)</code></p></item>
+               </ulist>
 
-    <p>A <nt def="TypedFunctionType">TypedFunctionType</nt> matches an
-    item if it is a <termref  def="dt-function-item"/> and the function’s type signature (as defined in
+    <p>A <nt def="TypedFunctionType">TypedFunctionType</nt> matches
+    a <termref  def="dt-function-item"/> if the function’s type signature (as defined in
     <xspecref spec="DM40" ref="function-items"/>) is a <termref def="dt-subtype"
                      >subtype</termref> of the <nt def="TypedFunctionType"
                   >TypedFunctionType</nt>.</p>
                
-               <note><p>The keywords <code>function</code> and <code>fn</code> are synonymous.</p></note>
-
                
-               <p diff="add" at="issue730">In addition, a <nt def="TypedFunctionType">TypedFunctionType</nt>
+               
+               <p>In consequence, a <nt def="TypedFunctionType">TypedFunctionType</nt>
                may match certain maps and arrays, as described in <specref ref="id-map-test"/> and
                <specref ref="id-array-test"/></p>
 
               
 
                <p>
-    Here are some examples of <nt def="FunctionType">FunctionType</nt>s:
+    Here are some examples of expressions that 
+    use a <nt def="TypedFunctionType">TypedFunctionType</nt>:
   </p>
-               <olist>
+               <ulist>
                   <item>
                      <p>
-                        <code>function(*)</code> matches any function, including maps and arrays.</p>
-                     <note><p>This can also be written <code>fn(*)</code>.</p></note>
-                  </item>
-                  <item role="xquery">
-                     <p>
-                        <code>%my:assertion function(*)</code> matches any <termref 
-                           def="dt-function-item"
-                           >function</termref> if the implementation-defined function assertion <code>%my:assertion</code> is satisfied.
-    </p>
-                  </item>
-                  <item>
-                     <p>
-                        <code>function(xs:int, xs:int) as xs:int</code> matches any <termref 
-                           def="dt-function-item"
-                           >function item</termref> with the function signature <code>function(xs:int, xs:int) as xs:int</code>.
+                        <code>fn:count#1 instance of function(item()*) as xs:integer</code> returns true,
+                        because the signature of the function item <code>fn:count#1</code>
+                        is <code>function(item()*) as xs:integer</code>.
                      </p>
-                     <note><p>This can also be written <code>fn(xs:int, xs:int) as xs:int</code>.</p></note>
+                  </item>
+                  <item>
+                     <p>
+                        <code>fn:count#1 instance of function(xs:string*) as item()</code> returns true,
+                        because the signature of the function item <code>fn:count#1</code>
+                        is a subtype of <code>function(xs:string*) as item()</code>.
+                     </p>
                   </item>
                   <item role="xquery">
                      <p>
-                        <code>%my:assertion function(xs:int, xs:int) as xs:int</code> matches any <termref
+                        <code>$F instance of %my:assertion function(*)</code> is true if
+                        <code>$F</code> is a <termref 
+                           def="dt-function-item"
+                           >function</termref> that satisfies the implementation-defined 
+                        function assertion <code>%my:assertion</code>.
+    </p>
+                  </item>
+                  <item role="xquery">
+                     <p>
+                        <code>$F instance of %my:assertion function(xs:int, xs:int) as xs:int</code> 
+                        is true if <code>$F</code> is a <termref
                            def="dt-function-item"/> with the function signature <code>function(xs:int, xs:int) as xs:int</code> 
-                        if the implementation-defined function assertion <code>%my:assertion</code> is satisfied.
+                        that satisfies the implementation-defined function assertion <code>%my:assertion</code>.
     </p>
                   </item>
                   <item>
                      <p>
-                        <code>function(xs:anyAtomicType) as item()*</code> matches any map, or any function with the required signature.</p>
+                        <code>function(xs:anyAtomicType) as item()*</code> matches any map, 
+                        or any other function item with the required signature.</p>
                   </item>
                   <item>
                      <p>
-                        <code>function(xs:integer) as item()*</code> matches any array, or any function with the required signature.</p>
+                        <code>function(xs:integer) as item()*</code> matches any array, 
+                        or any other function item with the required signature.</p>
                   </item>
-               </olist>
+               </ulist>
 
                <p id="id-function-assertion" role="xquery">
                   <termdef id="dt-function-assertion" term="function assertion"
@@ -5271,7 +5311,8 @@ name.</p>
     specifications in the XQuery family may also use function
     assertions in the future.</p>
                
-               <p role="xquery">An unprefixed QName is taken to refer to the namespace
+               <p role="xquery">An unprefixed QName used 
+                  within a <termref def="dt-function-assertion"/> is taken to refer to the namespace
                   <code>http://www.w3.org/2012/xquery</code>. Since this is a 
                   <termref def="dt-reserved-namespaces">reserved namespace</termref>,
                   and no assertions are currently defined in this namespace, this means that
@@ -5319,13 +5360,15 @@ name.</p>
 
   
   </p>
-               
-               
-
             </div4>
 
             <div4 id="id-map-test">
                <head>Map Types</head>
+               
+               <p>A <nt def="MapType">MapType</nt> designates an item type that
+               either matches any map, or that matches maps whose keys and values
+               are constrained to specific types.</p>
+               
                <scrap headstyle="show">
                   <head/>
                   <prodrecap id="MapType" ref="MapType"/>
@@ -5335,8 +5378,10 @@ name.</p>
 
 
 
+               <p>An <nt def="AnyMapType"/>
+                  <code>map(*)</code> matches any map.</p> 
+               
                <p>The <nt def="MapType">MapType</nt>
-                  <code>map(*)</code> matches any map. The <nt def="MapType">MapType</nt>
                   <code>map(K, V)</code> matches any map where every key
                   is an instance of <code>K</code> and every value is an
                   instance of <code>V</code>.</p>
@@ -5345,13 +5390,12 @@ name.</p>
                
                <p diff="add" at="A">Although the grammar for <code>TypedMapType</code>
                allows the key to be described using the full <code>ItemType</code> syntax, the item type used must be
-               a <termref def="dt-generalized-atomic-type"/>. [TODO: error code].</p>
+               a <termref def="dt-generalized-atomic-type"/> <errorref class="ST" code="0152"/>.</p>
 
-               <p>Examples:</p>
-
-               <p>Given a map <code>$M</code> whose keys are integers and whose
+               
+               <p>For example, given a map <code>$M</code> whose keys are integers and whose
   results are strings, such as <code>{ 0: "no", 1: "yes" }</code>,
-  consider the results of the following expressions:
+  the following following expressions deliver the result shown:
   </p>
 
                <ulist>
@@ -5372,12 +5416,12 @@ name.</p>
                   </item>
                   <item>
                      <p>
-                        <code>not($M instance of map(xs:int, xs:string))</code>  returns <code>true()</code>
+                        <code>$M instance of map(xs:int, xs:string)</code>  returns <code>false()</code>
                      </p>
                   </item>
                   <item>
                      <p>
-                        <code>not($M instance of map(xs:integer, xs:token))</code>  returns <code>true()</code>
+                        <code>$M instance of map(xs:integer, xs:token))</code>  returns <code>false()</code>
                      </p>
                   </item>
                </ulist>
@@ -5425,32 +5469,9 @@ name.</p>
                </note>
 
 
-               <p diff="del" at="issue730">Because of the rules for subtyping of function 
-                  types according to their signature, it follows that the item type
-                  <code>function(A) as item()*</code>, where A is an <termref def="dt-atomic-type"/>, 
-                  also matches any map, regardless of the type of the keys actually
-                  found in the map. For example, a map whose keys are all strings can be 
-                  supplied where the required type is <code>function(xs:integer) as item()*</code>; 
-                  a call on the map that treats it as a function with an integer argument 
-                  will always succeed, and will always return an empty sequence.</p>
+              
 
 
-
-               <p diff="del" at="issue730">The function signature of a map matching type
-  <code>map(K, V)</code>, treated as a function, is
-  <code>function(xs:anyAtomicType) as V?</code>.  It is thus always a
-  subtype of <code>function(xs:anyAtomicType) as item()*</code> regardless of the
-  actual types of the keys and values in the map.  The rules for
-                  <termref
-                     def="dt-function-coercion"
-                     >function coercion</termref> mean that any map can be supplied as a value in a
-  context where the required type has a more specific return type,
-  such as <code>function(xs:anyAtomicType) as xs:integer</code>, even when the map
-  does not match in the sense required to satisfy the <code>instance of</code>
-  operator. In such cases, a type error will occur only if an actual
-  call on the map (treated as a function) returns a value that is not
-  an instance of the required return type.
-</p>
 
                <p>Examples:</p>
 
@@ -5516,6 +5537,22 @@ name.</p>
                      The syntax <code>record()</code> is allowed; the only thing it matches is an empty map.
                   </change>
                </changes>
+               
+               <p>A <nt def="RecordType">RecordType</nt> matches maps that meet specific criteria.</p>
+
+               <p>For example, the <code>RecordType</code>
+                  <code>record(r as xs:double, i as xs:double)</code>
+		             matches a map if the map has exactly two entries: an entry with key <code>"r"</code>
+		                whose value is a singleton <code>xs:double</code> value, and an entry with key <code>"i"</code>
+		                whose value is also a singleton <code>xs:double</code> value.</p>
+               
+               <p>Record types describe a subset of the value space of maps. They do not define any new kinds of
+		             values, or any additional operations. They are useful in many cases to describe more accurately the
+		             type of a variable, function parameter, or function result, giving benefits both in the readability
+		             of the code, and in the ability of the processor to detect and diagnose type errors and to optimize
+		             execution.</p>
+
+
                <scrap headstyle="show">
                   <head/>
                   <prodrecap id="RecordType" ref="RecordType"/>
@@ -5528,14 +5565,7 @@ name.</p>
                </scrap>
 
               
-               <p>A <nt def="RecordType">RecordType</nt> matches maps that meet specific criteria.</p>
-
-               <p>For example, the <code>RecordType</code>
-                  <code>record(r as xs:double, i as xs:double)</code>
-		             matches a map if the map has exactly two entries: an entry with key <code>"r"</code>
-		                whose value is a singleton <code>xs:double</code> value, and an entry with key <code>"i"</code>
-		                whose value is also a singleton <code>xs:double</code> value.</p>
-
+               
 
                <p>If the list of fields ends with <code>",*"</code> then the record type is said to be
 		                <term>extensible</term>. For example, the <code>RecordType</code>
@@ -5549,7 +5579,7 @@ name.</p>
                   is not extensible. The only thing it matches is an empty map.</p></item>
                   <item><p>The syntax <code>record(*)</code> defines an extensible record type that has no explicit
                   field declarations. It is equivalent to the item type
-                  <code>map(*)</code>: that is, it allows any map.</p></item>
+                  <code>map(*)</code>: that is, it matches any map.</p></item>
                </ulist>
                
                <p>A record type can constrain only those entries whose keys are strings, but when the record
@@ -5590,11 +5620,7 @@ name.</p>
 
                
 
-               <p>Record types describe a subset of the value space of maps. They do not define any new kinds of
-		             values, or any additional operations. They are useful in many cases to describe more accurately the
-		             type of a variable, function parameter, or function result, giving benefits both in the readability
-		             of the code, and in the ability of the processor to detect and diagnose type errors and to optimize
-		             execution.</p>
+               
 
                <p>If a variable <code>$rec</code> is known to conform to a particular
 		             record type, then when a lookup expression <code>$rec?field</code> is used, (a) the processor
@@ -5762,6 +5788,10 @@ declare record Particle (
             </div4>
             <div4 id="id-array-test">
                <head>Array Types</head>
+               
+               <p>An <nt def="ArrayType">ArrayType</nt> designates an item type that
+               either matches all arrays, or that matches arrays whose members
+               are constrained to a specific type.</p>
 
                <scrap>
                   <head/>
@@ -5771,9 +5801,9 @@ declare record Particle (
                </scrap>
 
 
-               <p>The <nt def="AnyArrayType">AnyArrayType</nt>
-                  <code>array(*)</code> matches any
-  array. The <nt def="TypedArrayType"
+               <p>An <nt def="AnyArrayType"/>
+                  <code>array(*)</code> matches any array.</p> 
+               <p>The <nt def="TypedArrayType"
                      >TypedArrayType</nt>
                   <code>array(X)</code> matches any array
   in which every array member matches the <nt
@@ -5811,6 +5841,11 @@ declare record Particle (
                   <item>
                      <p>
                         <code>[ (1, 2), (3, 4) ] instance of array(xs:integer+)</code> returns <code>true()</code>
+                     </p>
+                  </item>
+                  <item>
+                     <p>
+                        <code>[ [1, 2], [3, 4] ] instance of array(array(xs:integer+))</code> returns <code>true()</code>
                      </p>
                   </item>
                </ulist>
@@ -5887,12 +5922,13 @@ declare record Particle (
             </div4>
          </div3>
             <div3 id="id-xs-error">
-               <head>xs:error</head>
-               <p>The type <code>xs:error</code> has an empty value space; it never appears as a dynamic type or as the content type of a dynamic element or attribute type. 
+               <head>The type <code>xs:error</code></head>
+               <p>The item type <code>xs:error</code> has an empty value space; 
+                  it never appears as a dynamic type or as the content type of a dynamic element or attribute type. 
                   
                   
-                  It was defined in XML Schema in the interests of making the type system complete and closed, and it is also available in &language;
-                  for similar reasons.</p>
+                  It was defined in XML Schema in the interests of making the type system complete and closed, 
+                  and it is also available in &language; for similar reasons.</p>
                
                <note>
                   <p>Even though it cannot occur in an instance, <code>xs:error</code> is a valid type name in a sequence type. The

--- a/specifications/xslt-40/style/diff.xsl
+++ b/specifications/xslt-40/style/diff.xsl
@@ -81,40 +81,6 @@
 
 <xsl:param name="called.by.diffspec" as="xs:integer" select="1"/>
 
-<!-- ==================================================================== -->
-
-  <!--<!-\- spec: the specification itself -\->
-  <xsl:template match="spec">
-    <html>
-      <xsl:call-template name="make-lang-attribute"/>
-      <xsl:call-template name="make-head"/>
-      
-      <body>
-        
-        
-        <xsl:apply-templates/>
-        <xsl:if test="//footnote[not(ancestor::table)]">
-          <hr/>
-          <div class="endnotes">
-            <xsl:text>&#10;</xsl:text>
-            <h3>
-              <xsl:call-template name="anchor">
-                <xsl:with-param name="conditional" select="0"/>
-                <xsl:with-param name="default.id" select="'endnotes'"/>
-              </xsl:call-template>
-              <xsl:text>End Notes</xsl:text>
-            </h3>
-            <dl>
-              <xsl:apply-templates select="//footnote[not(ancestor::table)]"
-                                   mode="notes"/>
-            </dl>
-          </div>
-        </xsl:if>
-      </body>
-    </html>
-  </xsl:template>
-  -->
-  
 
 <!-- ==================================================================== -->
 

--- a/specifications/xslt-40/style/xslt-diff.xsl
+++ b/specifications/xslt-40/style/xslt-diff.xsl
@@ -50,12 +50,7 @@
     xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax">
     <xsl:text>element-syntax-chg</xsl:text>
   </xsl:template>
-  
-  <!--<xsl:template match="*[@mark='yes']" priority="100">
-    <mark>
-      <xsl:next-match/>
-    </mark>
-    </xsl:template>-->
+ 
   
   <!-- following template can be activated to insert paragraph numbers after every para -->
   <xsl:template match="p[$show.diff.markup=1]" use-when="false()">   

--- a/specifications/xslt-40/style/xslt.xsl
+++ b/specifications/xslt-40/style/xslt.xsl
@@ -526,27 +526,7 @@ constructor. These elements are:</p>
     </pre>
   </xsl:template>
 
-<!--<xsl:template match="processing-instruction('glossary')">
-    <dl>
-    <xsl:for-each select="//termdef[not(ancestor-or-self::*[@diff][1][@diff='del'])]">
-      <xsl:sort select="lower-case(@term)"/>
-      <dt>
-        <a href="#{@id}"><xsl:value-of select="@term"/></a>
-      </dt>
-      <dd>
-        <p>
-          <xsl:apply-templates/>
-        </p>
-        <xsl:if test="@open='true'">
-          <xsl:variable name="close" select="../following-sibling::p[@role='closetermdef'][1]"/>
-          <xsl:apply-templates select="../following-sibling::*[$close >> .]"/>
-        </xsl:if>
-      </dd>
-    </xsl:for-each>
-    </dl>
-</xsl:template>-->
-  
-  
+
   <xsl:template match="processing-instruction('xslt-defined-functions')">
       <xsl:variable name="content">
       <glist>
@@ -824,32 +804,7 @@ constructor. These elements are:</p>
 			</a>
 	</xsl:template>
 
-<!--
-  <xsl:template match="altlocs">
-    <p>
-      <xsl:text>This document is also available </xsl:text>
-      <xsl:text>in these non-normative formats: </xsl:text>
-      <xsl:for-each select="loc">
-        <xsl:if test="position() &gt; 1">
-          <xsl:if test="last() &gt; 2">
-            <xsl:text>, </xsl:text>
-          </xsl:if>
-          <xsl:if test="last() = 2">
-            <xsl:text> </xsl:text>
-          </xsl:if>
-        </xsl:if>
-        <xsl:if test="position() = last() and position() &gt; 1">and&#160;</xsl:if>
-        <!- - next line changed by MHK - ->
-        <xsl:apply-templates select="."/>
-      </xsl:for-each>
-      <xsl:text>.</xsl:text>
-    </p>
-  </xsl:template>
-	
-	<xsl:template match="altlocs/loc">
-	        <a href="{$latest}{@href}"><xsl:value-of select="."/></a>
-	</xsl:template>
--->
+
   
   <!-- Links to Bugzilla entries in the form <loc href="bugNNNNN"/> -->
     

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -904,6 +904,13 @@
       <xsl:text> (Non-Normative)</xsl:text>
     </h2>
   </xsl:template>
+  
+  <xsl:template match="div1/head/text() | div2/head/text() | div3/head/text() | div4/head/text() | inform-div1/head/text()">
+    <!-- insert a link to self, to make the ID value visible for the benefit of anyone wanting to create a link -->
+    <a href="#{../../@id}" style="text-decoration: none">
+      <xsl:next-match/>
+    </a>
+  </xsl:template>
 
   <xsl:template match="issue/head">
     <p class="prefix">


### PR DESCRIPTION
Addresses part of #1407:

* Improves the section headings and levels for the Types and Subtyping sections
* Level-4 headings (and level-5 if there were any) are no longer omitted from the F&O TOC.

There are other suggestions in #1407 regarding the spec prose that are not (yet) implemented.

Changing the CSS to adjust presentation of level-4 and level-5 headings in the TOC is way above my level of CSS competence, there's some very elaborate logic in this area, and anyone who wants to tackle it is welcome.