### PR TITLE
Add dedication to MSM (action QT4CG-088-01)

### DIFF
--- a/etc/status-general.xml
+++ b/etc/status-general.xml
@@ -71,4 +71,10 @@
 <!-- ************************************************************************** -->
       &patent-policy-paragraph;
 
+<note role="dedication" id="dedication">
+<p>The publications of this community group 
+<loc href="../xquery-40/xpath-40.html#dedication">are dedicated</loc> to our co-chair,
+Michael Sperberg-McQueen (1954–2024).</p>
+</note>
+
     </status>

--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -233,6 +233,12 @@ for transition to Proposed Recommendation. </p>'>
                 in their <term>History</term> notes. Comments are invited, in the form of GitHub
                 issues at <loc href="https://github.com/qt4cg/qtspecs"
                     >https://github.com/qt4cg/qtspecs</loc>.</p>
+
+<note role="dedication" id="dedication">
+<p>The publications of this community group 
+<loc href="../xquery-40/xpath-40.html#dedication">are dedicated</loc> to our co-chair,
+Michael Sperberg-McQueen (1954–2024).</p>
+</note>
         </status>
 
         <langusage>

--- a/specifications/EXPath/file/src/file-functions.xml
+++ b/specifications/EXPath/file/src/file-functions.xml
@@ -236,6 +236,12 @@ for transition to Proposed Recommendation. </p>'>
                 in their <term>History</term> notes. Comments are invited, in the form of GitHub
                 issues at <loc href="https://github.com/qt4cg/qtspecs"
                     >https://github.com/qt4cg/qtspecs</loc>.</p>
+
+<note role="dedication" id="dedication">
+<p>The publications of this community group 
+<loc href="../xquery-40/xpath-40.html#dedication">are dedicated</loc> to our co-chair,
+Michael Sperberg-McQueen (1954–2024).</p>
+</note>
         </status>
 
         <langusage>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -216,6 +216,12 @@ for transition to Proposed Recommendation. </p>'>
              the W3C XSLT 4.0 Extensions Community Group. Individual functions specified in the document may be at
              different stages of review, reflected in their <term>History</term> notes. Comments are invited,
              in the form of GitHub issues at <loc href="https://github.com/qt4cg/qtspecs">https://github.com/qt4cg/qtspecs</loc>.</p>
+
+<note role="dedication" id="dedication">
+<p>The publications of this community group 
+<loc href="../xquery-40/xpath-40.html#dedication">are dedicated</loc> to our co-chair,
+Michael Sperberg-McQueen (1954–2024).</p>
+</note>
        </status>
 
         <langusage>

--- a/specifications/xquery-40/src/xquery-header.xml
+++ b/specifications/xquery-40/src/xquery-header.xml
@@ -104,7 +104,20 @@
   <status>
     <p>This is a draft prepared by the QT4CG (officially registered in W3C as the
       XSLT Extensions Community Group). Comments are invited.</p>
-  </status>
+
+<note role="dedication" id="dedication">
+<p role="xpath">The publications of this community group are dedicated to our co-chair,
+Michael Sperberg-McQueen (1954–2024).</p>
+<p role="xpath">Michael was central to the development of XML and many related technologies.
+He brought a polymathic breadth of knowledge and experience to everything he
+did. This, combined with his indefatigable curiosity and appetite for learning,
+made him an invaluable contributor to our project, along with many others. We
+have lost a brilliant thinker, a patient teacher, and a loyal friend.</p>
+<p role="xquery">The publications of this community group 
+<loc href="xpath-40.html#dedication">are dedicated</loc> to our co-chair,
+Michael Sperberg-McQueen (1954–2024).</p>
+</note>
+</status>
 
 <abstract id="id-abstract"><p role="xpath" diff="chg">
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -126,6 +126,11 @@
                Claim(s)</loc> must disclose the information in accordance with <loc href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6
                of the W3C Patent Policy</loc>.</p>-->
 
+<note role="dedication" id="dedication">
+<p>The publications of this community group 
+<loc href="../xquery-40/xpath-40.html#dedication">are dedicated</loc> to our co-chair,
+Michael Sperberg-McQueen (1954–2024).</p>
+</note>
       </status>
       <abstract>
          <p>This specification defines the syntax and semantics of XSLT 4.0, a language designed

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -1329,6 +1329,15 @@
     <xsl:apply-templates/>
   </xsl:template>
 
+  <!-- dedication -->
+  <xsl:template match="note[contains-token(@role, 'dedication')]">
+    <div class="dedication">
+      <xsl:sequence select="@id"/>
+      <h3>Dedication</h3>
+      <xsl:apply-templates/>
+    </div>
+  </xsl:template>
+
   <!-- note: a note about the spec -->
   <xsl:template match="note">
     <div class="note">


### PR DESCRIPTION
I've had this action on my plate for a while. Having written a dedication, there's a follow-up question of where to put it. Having it in only one specification isn't wrong, but it seems slightly odd given that MSM contributed to them all. In the end, I decided to put a full dedication in the XPath specification and link to it from the others. 

My rationale for the XPath spec is that it's probaly one that everyone reads. Another possibility was the Data Model as it's "foundational" but I think it's less read than XPath. 

The published PR won't be write because there are tooling changes required. I've attached a couple of screen shots, one of the full dedication in XPath:

------
![Screenshot 2025-01-14 at 14-00-08 XML Path Language (XPath) 4 0 WG Review Draft](https://github.com/user-attachments/assets/d83aa982-b783-44c8-8fb7-25787200bf13)
------

And another of the link from the other specs (from XSLT, I think, but they're all the same).

------
![Screenshot 2025-01-14 at 13-59-08 XSL Transformations (XSLT) Version 4 0](https://github.com/user-attachments/assets/634de4b0-59cb-4898-8c16-ddff4ddd3876)
------