### PR TITLE
Fix bug in build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -763,12 +763,28 @@ task xslt_resources(
   }
 }
 
+task xslt_xml(
+  dependsOn: ["xslt_merge_catalog", "saxon_config"],
+  description: "Create the XML version of the specification"
+) {
+  inputs.file "${projectDir}/style/identity.xsl"
+  inputs.file xslt_merge_catalog.outputs.getFiles().getSingleFile()
+  outputs.file "${buildDir}/www/xslt-40/xslt-40.xml"
+
+  doLast {
+    transform("${xslt_merge_catalog.outputs.getFiles().getSingleFile().toString()}",
+              "${projectDir}/style/identity.xsl",
+              "${xslt_xml.outputs.getFiles().getSingleFile()}")
+  }
+}
+
 task xslt_html(
-  dependsOn: ["xslt_merge_catalog", "xslt_resources", "setup_crossref_indexes", "saxon_config"],
+  dependsOn: ["xslt_merge_catalog", "xslt_resources", "setup_crossref_indexes", "saxon_config", "xslt_xml"],
   description: "Create the HTML version of the specification"
 ) {
   outputs.file("${buildDir}/www/xslt-40/Overview.html")
   inputs.dir("${projectDir}/specifications/xslt-40/style")
+  inputs.file xslt_xml.outputs.getFiles().getSingleFile()
 
   doLast {
     transform("${xslt_merge_catalog.outputs.getFiles().getSingleFile().toString()}",
@@ -821,21 +837,6 @@ task xslt_html_diff(
   doLast {
     fixupHtml("${buildDir}/xslt-40/highlighted-diff.xml",
               "${buildDir}/www/xslt-40/Overview-diff.html")
-  }
-}
-
-task xslt_xml(
-  dependsOn: ["xslt_merge_catalog", "saxon_config"],
-  description: "Create the XML version of the specification"
-) {
-  inputs.file "${projectDir}/style/identity.xsl"
-  inputs.file xslt_merge_catalog.outputs.getFiles().getSingleFile()
-  outputs.file "${buildDir}/www/xslt-40/xslt-40.xml"
-
-  doLast {
-    transform("${xslt_merge_catalog.outputs.getFiles().getSingleFile().toString()}",
-              "${projectDir}/style/identity.xsl",
-              "${xslt_xml.outputs.getFiles().getSingleFile()}")
   }
 }
 


### PR DESCRIPTION
Changing `xslt.xml` didn't actually cause the HTML for the XSLT specification to be rebuilt. 👎 
