### PR TITLE
1485 Add xsl:record-type declaration

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -5681,8 +5681,10 @@ name.</p>
                
                <p>The equivalent in XSLT is:</p>
                
-               <eg><![CDATA[<xsl:item-type name="my:list" 
-               as="record(value as item()*, next? as my:list)"/>]]></eg>
+               <eg><![CDATA[<xsl:record-type name="my:list">
+   <xsl:field name="value" as="item()*"/>
+   <xsl:field name="next" as="my:list" required="no"/>
+</xsl:record-type>]]></eg>
                
                
                

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -95,6 +95,7 @@
          <e:constant value="variable"/>
          <e:constant value="mode"/>
          <e:constant value="item-type"/>
+         <e:constant value="record-type"/>
          <e:constant value="*"/>
       </e:attribute>
       <e:attribute name="names" required="yes">
@@ -121,6 +122,7 @@
          <e:constant value="variable"/>
          <e:constant value="mode"/>
          <e:constant value="item-type"/>
+         <e:constant value="record-type"/>
          <e:constant value="*"/>
       </e:attribute>
       <e:attribute name="names" required="yes">
@@ -840,18 +842,59 @@
       <e:attribute name="name" required="yes">
          <e:data-type name="eqname"/>
       </e:attribute>
-      <e:attribute name="as">
+      <e:attribute name="as" default="'item()*'">
          <e:data-type name="item-type"/>
       </e:attribute>
-      <e:attribute name="visibility">
+      <e:attribute name="visibility" default="'private'">
          <e:constant value="private"/>
-         <e:constant value="final"/>
+         <e:constant value="public"/>
       </e:attribute>
       <e:empty/>
       <e:allowed-parents>
          <e:parent name="package"/>
          <e:parent name="stylesheet"/>
          <e:parent name="transform"/>
+      </e:allowed-parents>
+   </e:element-syntax>
+   
+   <e:element-syntax name="record-type">
+      <e:in-category name="declaration"/>
+      <e:attribute name="name" required="yes">
+         <e:data-type name="eqname"/>
+      </e:attribute>
+      <e:attribute name="extensible" default="'no'">
+         <e:data-type name="boolean"/>
+      </e:attribute>
+      <e:attribute name="visibility" default="'private'">
+         <e:constant value="private"/>
+         <e:constant value="public"/>
+      </e:attribute>
+      <e:sequence>
+         <e:element repeat="zero-or-more" name="field"/>
+      </e:sequence>
+      <e:allowed-parents>
+         <e:parent name="package"/>
+         <e:parent name="stylesheet"/>
+         <e:parent name="transform"/>
+      </e:allowed-parents>
+   </e:element-syntax>
+   
+   <e:element-syntax name="field">
+      <e:attribute name="name" required="yes">
+         <e:data-type name="NCName"/>
+      </e:attribute>
+      <e:attribute name="as" default="'item()*'">
+         <e:data-type name="sequence-type"/>
+      </e:attribute>
+      <e:attribute name="required" default="'yes'">
+         <e:data-type name="boolean"/>
+      </e:attribute>
+      <e:attribute name="default">
+         <e:data-type name="expression"/>
+      </e:attribute>
+      <e:empty/>
+      <e:allowed-parents>
+         <e:parent name="record-type"/>
       </e:allowed-parents>
    </e:element-syntax>
 
@@ -895,9 +938,6 @@
          <e:constant value="maybe"/>
       </e:attribute>
       <e:attribute name="cache" required="no" default="'no'">
-         <e:data-type name="boolean"/>
-      </e:attribute>
-      <e:attribute name="variadic" required="no" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>
       <e:sequence>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -972,7 +972,6 @@ of problems processing the schema using various tools
           <xs:attribute name="override-extension-function" type="xsl:yes-or-no"/>
           <xs:attribute name="new-each-time" type="xsl:yes-or-no-or-maybe"/>
           <xs:attribute name="cache" type="xsl:yes-or-no"/>
-          <xs:attribute name="variadic" type="xsl:yes-or-no"/>
           <xs:attribute name="_name" type="xs:string"/>
           <xs:attribute name="_override" type="xs:string"/>
           <xs:attribute name="_as" type="xs:string"/>
@@ -981,7 +980,6 @@ of problems processing the schema using various tools
           <xs:attribute name="_override-extension-function" type="xs:string"/>
           <xs:attribute name="_new-each-time" type="xs:string"/>
           <xs:attribute name="_cache" type="xs:string"/>
-          <xs:attribute name="_variadic" type="xs:string"/>
           <xs:assert test="exists(@name | @_name)"/>
           <xs:assert test="every $e in xsl:param satisfies empty($e/(@visibility | @_visibility))">
             <xs:annotation>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -6559,6 +6559,9 @@ and <code>version="1.0"</code> otherwise.</p>
                   <elcode>xsl:preserve-space</elcode>
                </sitem>
                <sitem>
+                  <elcode>xsl:record-type</elcode>
+               </sitem>
+               <sitem>
                   <elcode>xsl:strip-space</elcode>
                </sitem>
                <sitem>
@@ -10557,11 +10560,13 @@ and <code>version="1.0"</code> otherwise.</p>
                                  contains entries with keys <code>"first"</code> and <code>"last"</code>. </p>
                            </item>
                            <item>
-                              <p><code>type(complex)</code> matches any value that is an instance of the item type declared in an <elcode>xsl:item-type</elcode>
+                              <p><code>type(complex)</code> matches any value that is an instance of the item type 
+                                 declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
                                  declaration with name <code>"complex"</code></p>
                            </item>
                            <item>
-                              <p><code>type(complex)[?i eq 0]</code> matches any value that is an instance of the item type declared in an <elcode>xsl:item-type</elcode>
+                              <p><code>type(complex)[?i eq 0]</code> matches any value that is an instance of the 
+                                 item type declared in an <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
                                  declaration with name <code>"complex"</code> and that is a map with an entry having key <code>i</code> and value zero.</p>
                            </item>
                         </olist>
@@ -11224,7 +11229,8 @@ and <code>version="1.0"</code> otherwise.</p>
                of the name by its definition. In consequence, named item types cannot be recursive, since
                this would make the textual expansion non-terminating.</p>
                <p>The name of the item type is the expanded name formed by resolving the <code>name</code> attribute.
-               A lexical QName with no prefix is treated as a no-namespace name.</p>
+               A lexical QName with no prefix is treated as being in the 
+               <xtermref spec="XP40" ref="dt-default-namespace-elements-and-types"/>.</p>
                <p>If two <elcode>xsl:item-type</elcode> declarations in a <termref def="dt-package"/> have the same
                name, then the one with higher <termref def="dt-import-precedence"/> is used. </p>
                <p><error spec="XT" type="static" class="SE" code="4030">
@@ -11234,7 +11240,7 @@ and <code>version="1.0"</code> otherwise.</p>
                         precedence</termref>, unless there is another definition with the same
                      name and higher import precedence. It is also a static error if the name
                   of the item type uses a <termref def="dt-reserved-namespace"/>, or if it has the same
-                  name as a type in the <xtermref spec="XP40">in-scope schema types</xtermref> of
+                  name as a type in the <xtermref spec="XP40" ref="dt-is-types">in-scope schema types</xtermref> of
                   the static context.</p>
                </error></p>
                
@@ -11309,18 +11315,18 @@ and <code>version="1.0"</code> otherwise.</p>
                   <item><p>An <elcode>xsl:record-type</elcode> declaration also
                   implicitly defines a constructor function, of the same name,
                   and adds this to the set of 
-                  <xtermref spec="XP40" def="dt-statically-known-function-definitions"/>
+                  <xtermref spec="XP40" ref="dt-statically-known-function-definitions"/>
                   in the static context.</p></item>
                </ulist>
                
                <p>Because of its dual role, the name of an <elcode>xsl:record-type</elcode>
                declaration must be valid both as an item type name and as a function name.
                This means the name must be distinct from other type names and function names
-               in the static context.</p>
+               in the static context. It also means that the name must be in a namespace.</p>
                
                <p>Considered as an item type, the <elcode>xsl:record-type</elcode>
                declaration is equivalent to an <elcode>xsl:item-type</elcode> declaration
-               formed by the template rule, evaluated in the context of 
+               formed by the following template rule, evaluated in the context of 
                a namespace alias <code>&lt;xsl:namespace-alias stylesheet-prefix="t"
                result-prefix="xsl"/></code>:</p>
                
@@ -11425,7 +11431,9 @@ and <code>version="1.0"</code> otherwise.</p>
             </xsl:choose>  
          </xsl:for-each>
         
-         <!-- if the record type is extensible, add entries from the options parameter -->
+         <!-- if the record type is extensible, 
+              add entries from the options parameter -->
+              
          <xsl:if test="exists($options-param)">
             <t:sequence select="${$options-param}"/>
          </xsl:if>   
@@ -11436,7 +11444,7 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <p>For example, the declaration:</p>
                
-               <eg><![CDATA[<xsl:record-type name="cx:complex" extensible="yes">
+               <eg><![CDATA[<xsl:record-type name="cx:complex">
     <xsl:field name="r" as="xs:double"/>
     <xsl:field name="i" as="xs:double" required="no" default="0"/>
 </xsl:record-type>]]></eg>
@@ -11457,7 +11465,7 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <eg><![CDATA[<xsl:record-type name="cx:complex" visibility="public">
     <xsl:field name="r" as="xs:double"/>
-    <xsl:field name="i" as="xs:double" required="no" default="0"/>
+    <xsl:field name="i" as="xs:double" required="no"/>
 </xsl:record-type>]]></eg>
                
                <p>produces the equivalent function declaration:</p>
@@ -11487,7 +11495,7 @@ and <code>version="1.0"</code> otherwise.</p>
     <xsl:param name="r" as="xs:double"/>
     <xsl:param name="i" as="xs:double"/>
     <xsl:param name="options" as="map(*)" required="no" default="{}"/>
-    <xsl:map on-duplicates="fn($first, $second){{$first}}">
+    <xsl:map on-duplicates="fn($first, $second){$first}">
        <xsl:map-entry key="'r'" select="$r"/>
        <xsl:map-entry key="'i'" select="$i"/>
        <xsl:sequence select="$options"/>   
@@ -11505,13 +11513,14 @@ and <code>version="1.0"</code> otherwise.</p>
                overridden by another <elcode>xsl:function</elcode> declaration with
                higher import precedence. If the visibility is <code>public</code>
                then it can also be overridden using <elcode>xsl:override</elcode>
-               in another <termref def="dt-stylesheet-package"/>.</p>
+               in another <termref def="dt-package"/>.</p>
              
                <p>The scope of a named record type is the <termref def="dt-package"/> in which it is declared. If it
                is declared with <code>visibility="public"</code> then it also becomes available for use in using
                packages. </p>
                <p>The name of the record type is the expanded name formed by resolving the <code>name</code> attribute.
-               A lexical QName with no prefix is treated as a no-namespace name.</p>
+               Because function names are always in a namespace, the name must be prefixed.</p>
+               
                <p>If two <elcode>xsl:record-type</elcode> declarations in a <termref def="dt-package"/> have the same
                name, then the one with higher <termref def="dt-import-precedence"/> is used. </p>
                <p><error spec="XT" type="static" class="SE" code="4030">
@@ -11539,7 +11548,43 @@ and <code>version="1.0"</code> otherwise.</p>
                   record type is private, however, means that it is impossible to
                   override a variable or function that references the record type.</p>
                
-             
+               <example>
+                  <head>Defining a Binary Tree</head>
+                  <p>This example illustrates the definition of a recursive record type.
+                  The record type represents a node of a binary tree containing a payload value
+                  in each node, together with optional references to left and right subtrees.
+                  As well as the data fields, the record type defines a <code>depth</code> function 
+                  that returns the maximum depth of the tree, by making recursive calls on its
+                  subtrees.</p>
+                  
+                  <eg><![CDATA[<xsl:record-type name="my:binary-tree">
+   <xsl:field name="left" as="my:binary-tree?"/>
+   <xsl:field name="payload" as="item()*"/>
+   <xsl:field name="right" as="my:binary-tree?"/>
+   <xsl:field name="depth" as="fn(my:binary-tree) as xs:integer"
+      default="fn() {1 + max((?left =?> depth(), ?right =?> depth())) otherwise 0)}"/>
+</xsl:record-type>]]></eg>
+                  
+                  <p>The <code>=?></code> operator is described in
+                  <xspecref spec="XP40" ref="lookup-arrow-expression"/>. Its effect
+                  is to make a dynamic call on a function item that is present as
+                  an entry in a map, passing that map implicitly as the first argument.
+                  It thus mimics method invocation in object-oriented languages, though
+                  there is no inheritance or encapsulation.</p>
+                  
+                  <p>The following code builds a simple tree and calculates its depth:</p>
+                  
+                  <eg><![CDATA[
+let $tree := my:binary-tree(
+               my:binary-tree((), 17, ()),
+               18,
+               my:binary-tree((), 19, 
+                 my:binary-tree((), 20, ())))
+return $tree =?> depth()]]></eg>
+               
+               
+                  <p>Returning the result 3.</p>
+               </example>
             </div3>
          </div2>
          <div2 id="defining-decimal-format">
@@ -13042,11 +13087,16 @@ and <code>version="1.0"</code> otherwise.</p>
   }
 ]</eg>
                <p>The following template rules are used. The setting <code>expand-text="yes"</code> is assumed:</p>
-               <eg><![CDATA[
-<xsl:item-type name="book" as="record(Title, Authors, Category, *)"/>                  
+               <eg><![CDATA[<xsl:record-type name="book" extensible="yes">
+  <xsl:field name="Title"/>
+  <xsl:field name="Authors"/>
+  <xsl:field name="Category"/>
+</xsl:record-type>
+
 <xsl:template name="xsl:initial-template">
   <xsl:apply-templates select="parse-json('input.json')"/>
 </xsl:template>  
+
 <xsl:template match="array(book)">
   <h1>Christmas Book Selection</h1>
   <table>
@@ -13063,6 +13113,7 @@ and <code>version="1.0"</code> otherwise.</p>
     </tbody>
   </table>
 </xsl:template>
+
 <xsl:template match="type(book)">
   <tr>
     <td>{?Title}</td>
@@ -13070,7 +13121,7 @@ and <code>version="1.0"</code> otherwise.</p>
     <td>{?Category}</td>
     <td>${?Price}</td>
   </tr>
-</xsl:template>  
+</xsl:template>
 ]]></eg>
             </example>
             <note>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -4033,10 +4033,9 @@
 
                   <p>The <elcode>xsl:function</elcode>, <elcode>xsl:template</elcode>,
                         <elcode>xsl:attribute-set</elcode>, <elcode>xsl:variable</elcode>, 
-                      and
-                        <elcode>xsl:mode</elcode>
+                        <elcode>xsl:mode</elcode>, <elcode>xsl:item-type</elcode>, and <elcode>xsl:record-type</elcode>
                      <termref def="dt-declaration">declarations</termref> each have an optional
-                        <code>visibility</code> attribute. The value is one of <code>private</code>,
+                        <code>visibility</code> attribute. The permitted value is some subset of <code>private</code>,
                         <code>public</code>, <code>abstract</code>, or <code>final</code> (never
                         <code>hidden</code>). In the case of
                            an <elcode>xsl:param</elcode> element there is no explicit 
@@ -4075,7 +4074,7 @@
 
                   <p>The visibility of a 
                      named template, function, variable, attribute set, mode,
-                     <phrase diff="add" at="2024-01-12">or named item type</phrase>
+                     named item type, or named record type
                      declared within a package is the first of the following that applies, subject to consistency
                      constraints which are defined below:</p>
 
@@ -4836,18 +4835,29 @@
                         </item>
                         
                         <item>
-                           <p>Except where recursive types are involved, a named item type
+                           <p>A named item type
                            (declared in an <elcode>xsl:item-type</elcode> declaration) is considered
-                           identical to its expansion. With recursive types, the same type names must
-                           be used. By implication, the named type must itself be declared or exposed
-                           with <code>visibility="final"</code>.</p>
+                           identical to its expansion.</p>
+                        </item>
+                        
+                        <item>
+                           <p>Two named record types are compared by name, not by content. This is
+                              because named record types may potentially be recursive, so the name
+                              cannot always be expanded to an expressible record type designator.
+                              By implication, the named record type must itself be declared or exposed
+                              with <code>visibility="public"</code>.</p>
                         </item>
                      </olist>
                   </note>
 
 
-                  <p>Modes are not overridable, so the <elcode>xsl:mode</elcode> declaration cannot
-                     appear as a child of <elcode>xsl:override</elcode>.</p>
+                  <p>Modes, named item types, and named record type are not overridable, 
+                     so <elcode>xsl:mode</elcode>, <elcode>xsl:item-type</elcode>, and
+                     <elcode>xsl:record-type</elcode> declarations cannot
+                     appear as children of <elcode>xsl:override</elcode>. However,
+                     the constructor function implicitly created from an 
+                     <elcode>xsl:record-type</elcode> declaration may be overridden
+                     in an <elcode>xsl:function</elcode> declaration.</p>
                </div4>
                <div4 id="refer-to-overridden">
                   <head>Referring to Overridden Components</head>
@@ -11119,76 +11129,418 @@ and <code>version="1.0"</code> otherwise.</p>
             </div3>
             
          </div2>
-         <div2 id="named-item-types" diff="add" at="2022-01-01">
-            <head>Defining Named Item Types</head>
+         <div2 id="named-types">
+            <head>Named Types</head>
             
-            <changes>
-               <change date="2022-01-01">
-                  Named item types can be declared using the new <elcode>xsl:item-type</elcode>
-                  element. This is designed to avoid repeating lengthy type definitions (for example
-                  function types and record types) every time they are used. [This feature was
-                  present in the editor's draft presented to the WG when it started work.]
-               </change>
-            </changes>
+            <p>XSLT 4.0 introduces two new and closely-related constructs allowing item
+            types to be given names, and to be referred to by name anywhere that item types
+            are used, for example in function declarations and variable declarations.</p>
             
-            <?element xsl:item-type?>
+            <p>The <elcode>xsl:item-type</elcode> declaration allows any item type to be given
+            a name. It is particularly useful to avoid repetitive use of the same choice types,
+            enumeration types, or function types, and means that if the definition changes, the change only
+            needs to be made in one place.</p>
             
-            <p>An <elcode>xsl:item-type</elcode> declaration associates a name with an item type, and allows the type
-            to be referenced by name throughout the stylesheet package.</p>
-            <example id="e-item-type-complex">
-               <p>The following example declares a named item type for complex numbers, and uses it in a variable
-                  declaration and a function declaration.</p>
-               <eg><![CDATA[<xsl:item-type name="cx:complex" as="record(r as xs:double, i as xs:double)"/>
+            <p>The <elcode>xsl:record-type</elcode> declaration takes this a step further.
+            Like <elcode>xsl:item-type</elcode>, it allows a name to be given to any
+            record type. In addition, though, it offers two further capabilities:</p>
+            
+            <ulist>
+               <item><p>Named record types can be recursive, allowing definitions of
+               recursive data structures such as lists and trees.</p></item>
+               <item><p>Declaring a named record type automatically establishes
+               a constructor function for records of that type; the constructor
+               function has the same name as the record type itself.</p></item>
+            </ulist>
+            
+            <div3 id="named-item-types">
+               <head>Named Item Types</head>
+            
+            
+               <changes>
+                  <change date="2022-01-01">
+                     Named item types can be declared using the new <elcode>xsl:item-type</elcode>
+                     element. This is designed to avoid repeating lengthy type definitions (for example
+                     function types) every time they are used. [This feature was
+                     present in the editor's draft presented to the WG when it started work.]
+                  </change>
+               </changes>
+            
+               <?element xsl:item-type?>
+               
+               <p>An <elcode>xsl:item-type</elcode> declaration associates a name with an item type, and allows the type
+               to be referenced by name throughout the stylesheet package.</p>
+               <example id="e-item-type-colors">
+                  <p>The following example declares a named item type for colors, and uses it in three variable
+                     declarations and a function declaration.</p>
+                  <eg><![CDATA[<xsl:item-type name="my:color" as="enum('red', 'green', 'blue')"/>
+   
+<xsl:variable name="RED" as="my:color" select="'red'"/>
+<xsl:variable name="GREEN" as="my:color" select="'green'"/>
+<xsl:variable name="BLUE" as="my:color" select="'blue'"/>
 
+<xsl:function name="my:html-color" as="xs:string">
+  <xsl:param name="color" as="my:color"/>
+  <xsl:switch select="$color">
+    <xsl:when test="$RED">#FF0000</xsl:when>
+    <xsl:when test="$GREEN">#008000</xsl:when>
+    <xsl:when test="$BLUE">#0000FF</xsl:when>
+  </xsl:switch>
+</xsl:function>
+                     ]]></eg>
+                  
+               </example>
+               
+               <example id="e-item-type-colors">
+                  <p>The following example declares a named choice type for the two binary
+                     types <code>xs:hexBinary</code> and <code>xs:base64Binary</code>
+                     and uses it in a function declaration that compares two such values
+                     for equality.</p>
+                  <eg><![CDATA[<xsl:item-type name="my:binary" as="(xs:hexBinary | xs:base64Binary)"/>
+
+<xsl:function name="my:binary-equal" as="xs:boolean">
+  <xsl:param name="x" as="my:binary"/>
+  <xsl:param name="y" as="my:binary"/>
+  <xsl:sequence select="$x eq $y"/>
+</xsl:function>
+                     ]]></eg>
+                  
+               </example>
+               
+               <p>Using named item types makes the stylesheet more readable, and improves potential for change: a change
+               to the set of colors allowed by the type <code>my:color</code> is less likely to affect users of a function
+               library. However, named item types do not provide true encapsulation or information hiding; users of the 
+               function library can still treat enumeration values as simple strings if they wish.</p>
+               <p>The <elcode>xsl:item-type</elcode> declaration adds an entry to the 
+                  <xtermref spec="XP40" ref="dt-in-scope-named-item-types"/>
+               component of the static context for XPath expressions, and also becomes available for use wherever
+               XSLT allows an <code>ItemType</code> to appear.</p>
+               <p>The scope of a named item type is the <termref def="dt-package"/> in which it is declared. If it
+               is declared with <code>visibility="public"</code> then it also becomes available for use in using
+               packages. (Since there is no mechanism for the using package to override the definition,
+               <code>public</code> effectively means <code>final</code>.)</p>
+               <p>A named item type is essentially an abbreviation for the item type designator appearing in the
+               <code>as</code> attribute, and the semantics can be defined in terms of textual replacement
+               of the name by its definition. In consequence, named item types cannot be recursive, since
+               this would make the textual expansion non-terminating.</p>
+               <p>The name of the item type is the expanded name formed by resolving the <code>name</code> attribute.
+               A lexical QName with no prefix is treated as a no-namespace name.</p>
+               <p>If two <elcode>xsl:item-type</elcode> declarations in a <termref def="dt-package"/> have the same
+               name, then the one with higher <termref def="dt-import-precedence"/> is used. </p>
+               <p><error spec="XT" type="static" class="SE" code="4030">
+                  <p>It is a <termref def="dt-static-error">static error</termref> if a package contains two 
+                     <elcode>xsl:item-type</elcode> or <elcode>xsl:record-type</elcode>
+                     declarations having the same name and the same <termref def="dt-import-precedence">import
+                        precedence</termref>, unless there is another definition with the same
+                     name and higher import precedence. It is also a static error if the name
+                  of the item type uses a <termref def="dt-reserved-namespace"/>, or if it has the same
+                  name as a type in the <xtermref spec="XP40">in-scope schema types</xtermref> of
+                  the static context.</p>
+               </error></p>
+               
+               <p><error spec="XT" type="static" class="SE" code="4035">
+                  <p>It is a <termref def="dt-static-error">static error</termref> for an item type named
+                     <var>N</var> to contain in its <code>as</code> attribute a reference to <var>N</var>,
+                     or to an item type that references <var>N</var> directly or indirectly.</p>
+               </error></p>
+               <p>It is permissible to use a private named item type in the declaration of a public
+               variable, function, or template. A package that uses (or overrides) such a component
+               will not be able to use the type name, but it can use the underlying type definition,
+               or provide its own declaration of the relevant item type, using the same name or
+               a different name.</p>
+               </div3>
+            <div3 id="named-record-types">
+               <head>Named Record Types</head>
+               <changes>
+                  <change issue="1485" date="2025-01-16">
+                     Named record types are introduced.
+                  </change>
+               </changes>
+               
+               <?element xsl:record-type?>
+               <?element xsl:field?>
+               
+               <p>An <elcode>xsl:record-type</elcode> declaration associates a name 
+                  with a record type, and allows the record type
+                  to be referenced by name throughout the stylesheet package.</p>
+               
+               <example id="e-item-type-complex">
+                  <p>The following example declares a named record type for complex numbers, 
+                     and uses it in a variable
+                     declaration and a function declaration.</p>
+                  <eg><![CDATA[<xsl:record-type name="cx:complex">
+    <xsl:field name="r" as="xs:double"/>
+    <xsl:field name="i" as="xs:double"/>
+</xsl:record-type>
+   
 <xsl:variable name="i" as="cx:complex" select="cx:complex(0, 1)"/>
-
+   
 <xsl:function name="cx:add" as="cx:complex">
   <xsl:param name="x" as="cx:complex"/>
   <xsl:param name="y" as="cx:complex"/>
   <xsl:sequence select="cx:complex($x?r + $y?r, $x?i + $y?i)"/>
 </xsl:function>
-                  ]]></eg>
-               <p>Note how the item type declaration has implicitly declared a constructor function
-                  <code>cx:complex</code> that can be used to create instances of the item type;
-                  details of this mechanism are at <xspecref spec="XP40" ref="id-constructor-functions"/>.</p>
-            </example>
-            <p>Using named item types makes the stylesheet more readable, and improves potential for change: a change
-            to the way complex numbers are implemented in this example is less likely to affect users of the function
-            library. However, named item types do not provide true encapsulation or information hiding; users of the 
-            function library can still treat complex numbers as raw maps if they wish.</p>
-            <p>The <elcode>xsl:item-type</elcode> declaration adds an entry to the 
-               <xtermref spec="XP40" ref="dt-in-scope-named-item-types"/>
-            component of the static context for XPath expressions, and also becomes available for use wherever
-            XSLT allows an <code>ItemType</code> to appear.</p>
-            <p>The scope of a named item type is the <termref def="dt-package"/> in which it is declared. If it
-            is declared with <code>visibility="final"</code> then it also becomes available for use in using
-            packages. Named item types cannot be overridden in a using package, so the only permitted values for
-            <code>visibility</code> are <code>private</code> and <code>final</code>.</p>
-            <p>The name of the item type is the expanded name formed by resolving the <code>name</code> attribute.
-            A lexical QName with no prefix is treated as a no-namespace name.</p>
-            <p>If two <elcode>xsl:item-type</elcode> declarations in a <termref def="dt-package"/> have the same
-            name, then the one with higher <termref def="dt-import-precedence"/> is used. </p>
-            <p><error spec="XT" type="static" class="SE" code="4030">
-               <p>It is a <termref def="dt-static-error">static error</termref> if a package contains two 
-                  <elcode>xsl:item-type</elcode>
-                  declarations having the same <termref def="dt-import-precedence">import
-                     precedence</termref>, unless there is another definition of the same
-                  item type with higher import precedence.</p>
-            </error></p>
-            <p diff="add" at="issue295">An item type declaration may refer directly or indirectly to itself if
-               it satisfies the conditions defined in <xspecref spec="XP40" ref="id-recursive-record-tests"/>.
-            This allows types to be declared that match recursive data structures such as linked lists
-            and trees.</p>
-            <p><error spec="XT" type="static" class="SE" code="4035">
-               <p>It is a <termref def="dt-static-error">static error</termref> for an item type named
-                  <var>N</var> to contain in its <code>as</code> attribute a reference to <var>N</var>,
-                  or to an item type that references <var>N</var> directly or indirectly, unless it satisfies
-                  the conditions defined in <xspecref spec="XP40" ref="id-recursive-record-tests"/>.</p>
-            </error></p>
-            <p>TODO: add named item types to xsl:accept and xsl:expose. Clarify that when a function or variable
-            is exported to a different package, its declared type/signature uses the expanded form of any named
-            item type; there is no requirement for the using package to know the named item types. But it becomes
-            easier to use the exposed variables and functions if the names of the types are exposed too.</p>
+]]></eg>
+                  <p>Note how the record type declaration has implicitly declared a constructor function
+                     <code>cx:complex</code> that can be used to create instances of the item type.</p>
+               </example>
+               
+               <p><error spec="XT" class="SE" code="4050">
+                  <p>It is a <termref def="dt-static-error"/> 
+                     if the names of the fields in an <elcode>xsl:record-type</elcode>
+                     declaration are not distinct.</p>
+               </error></p>
+               
+               <p><error spec="XT" class="SE" code="4051">
+                  <p>It is a <termref def="dt-static-error"/> 
+                     if an <elcode>xsl:field</elcode> element has a <code>default</code>
+                     attribute unless it specifies <code>required="no"</code>.</p>
+               </error></p>
+               
+              <p>An <elcode>xsl:record-type</elcode> declaration has two effects:</p>
+               
+               <ulist>
+                  <item><p>In the same way as <elcode>xsl:item-type</elcode>, it defines
+                  a named item type in the static context, allowing the record type to
+                  be referenced by name anywhere an <code>ItemType</code> can appear,
+                  for example in the declarations of functions and variables. Unlike
+                  types declared in <elcode>xsl:item-type</elcode>, however,
+                  named record types can be recursive.</p></item>
+                  <item><p>An <elcode>xsl:record-type</elcode> declaration also
+                  implicitly defines a constructor function, of the same name,
+                  and adds this to the set of 
+                  <xtermref spec="XP40" def="dt-statically-known-function-definitions"/>
+                  in the static context.</p></item>
+               </ulist>
+               
+               <p>Because of its dual role, the name of an <elcode>xsl:record-type</elcode>
+               declaration must be valid both as an item type name and as a function name.
+               This means the name must be distinct from other type names and function names
+               in the static context.</p>
+               
+               <p>Considered as an item type, the <elcode>xsl:record-type</elcode>
+               declaration is equivalent to an <elcode>xsl:item-type</elcode> declaration
+               formed by the template rule, evaluated in the context of 
+               a namespace alias <code>&lt;xsl:namespace-alias stylesheet-prefix="t"
+               result-prefix="xsl"/></code>:</p>
+               
+               <eg><![CDATA[<xsl:template match="xsl:record-type" expand-text="yes">
+   <t:item-type name="{@name}"
+                visibility="{@visibility otherwise 'private'}">
+     <xsl:attribute name="as">
+        <xsl:text>record(</xsl:text>
+        <xsl:for-each select="xsl:field" separator=", ">
+           <xsl:variable name="optional"
+                         as="xs:boolean"
+                         select="normalize-space(@required) = ('no','false','0')"/>
+           {@name}{'?'[$optional]} as {@as otherwise 'item()*'}
+        </xsl:for-each>
+        <xsl:if test="normalize-space(@extensible) = ('yes','true','1')">
+           <xsl:text>, *</xsl:text>
+        </xsl:if>
+        <xsl:text>)</xsl:text>
+      </xsl:attribute>  
+   </t:item-type>
+</xsl:template>   
+]]></eg>
+               <p>This generated <elcode>xsl:item-type</elcode> declaration must
+               meet all the constraints placed on user-written 
+               <elcode>xsl:item-type</elcode> declarations, including the rule
+               requiring names to be unique, but not including the rule
+               disallowing recursive references.</p>
+               
+               <p>For example, the declaration:</p>
+               
+               <eg><![CDATA[<xsl:record-type name="cx:complex" extensible="yes">
+    <xsl:field name="r" as="xs:double"/>
+    <xsl:field name="i" as="xs:double" required="no" default="0"/>
+</xsl:record-type>]]></eg>
+               
+               <p>produces the equivalent item type declaration:</p>
+               
+               <eg><![CDATA[<xsl:item-type name="cx:complex"
+       as="record(r as xs:double, i? as xs:double, *)"/>]]></eg>
+               
+               <p>Considered as a function declaration, an <elcode>xsl:record-type</elcode>
+               declaration is equivalent to an <elcode>xsl:function</elcode> declaration
+               formed by the following template rule, evaluated in the context of 
+               a namespace alias <code>&lt;xsl:namespace-alias stylesheet-prefix="t"
+               result-prefix="xsl"/></code>:</p>
+               
+               <eg><![CDATA[<xsl:template match="xsl:record-type">
+    <t:function name="{@name}"
+                as="{@name}"
+                visibility="{(@visibility otherwise 'private')}">
+                
+      <!-- if the record type is extensible, choose a name for the options parameter -->
+      <xsl:variable name="options-param" as="xs:string?">
+         <xsl:if test="normalize-space(@extensible) = ('yes', 'true', 'a')"
+                 then="('options', (1 to count(xsl:field)) ! `options{.}`)
+                         [not(. = current()/xsl:field/@name)][1]"/>
+      </xsl:variable>                   
+      
+      <!-- declare the parameters -->
+      <xsl:for-each select="xsl:field">
+         <t:param name="{@name}"
+                  required="{@required otherwise 'yes'}">
+            <xsl:attribute name="as">
+               <xsl:variable name="as" 
+                             select="normalize-space(@as otherwise 'item()*')"/>
+               <xsl:variable name="optional" 
+                             select="normalize-space(@required) = ('no', 'false', '0')"/>
+               <xsl:choose>
+                  <xsl:when test="not($optional)" select="$as"/>
+                  <!-- for optional fields, amend the required type to allow () -->
+                  <xsl:when test="matches($as, '[?*]$')" select="$as"/>
+                  <xsl:when test="matches($as, '\+$')" select="replace($as, '\+$', '*')"/>
+                  <xsl:otherwise select="$as || '?'"/>
+               </xsl:choose>
+            </xsl:attribute>
+            <xsl:if test="@default">
+               <xsl:attribute name="select" select="@default"/>
+            </xsl:if>   
+         </t:param>
+      </xsl:for-each>
+      
+      <!-- for an extensible record type, declare the options parameter -->
+      <xsl:if test="exists($options-param)">
+         <t:param name="{$options-param}" as="map(*)" required="no" select="{}"/>
+      </xsl:if>           
+      
+      <!-- function body: construct a map -->
+      <t:map on-duplicates="fn($first, $second){{$first}}">
+         <xsl:for-each select="xsl:field">
+            <xsl:variable name="optional" 
+                          select="normalize-space(@required) = ('no', 'false', '0')"/>
+            <xsl:choose>
+              <xsl:when test="$optional and not(@default)">
+                 <!-- omit map entries for optional fields if no value is supplied -->
+                 <t:if test="exists(${@name})">
+                    <t:map-entry key="'{@name}'" select="${@name}"/>
+                 </t:if>
+              </xsl:when>
+              <xsl:otherwise>
+                <t:map-entry key="'{@name}'" select="${@name}"/>
+              </xsl:otherwise>  
+            </xsl:choose>  
+         </xsl:for-each>
+        
+         <!-- if the record type is extensible, add entries from the options parameter -->
+         <xsl:if test="exists($options-param)">
+            <t:sequence select="${$options-param}"/>
+         </xsl:if>   
+
+      </t:map>
+    </t:function>          
+</xsl:template>]]></eg>
+               
+               <p>For example, the declaration:</p>
+               
+               <eg><![CDATA[<xsl:record-type name="cx:complex" extensible="yes">
+    <xsl:field name="r" as="xs:double"/>
+    <xsl:field name="i" as="xs:double" required="no" default="0"/>
+</xsl:record-type>]]></eg>
+               
+               <p>produces the equivalent function declaration:</p>
+               
+               <eg><![CDATA[<xsl:function name="cx:complex" as="cx:complex" visibility="private">
+    <xsl:param name="r" as="xs:double"/>
+    <xsl:param name="i" as="xs:double" required="no" select="0"/>
+    <xsl:map>
+       <xsl:map-entry key="'r'" select="$r"/>
+       <xsl:map-entry key="'i'" select="$i"/>
+    </xsl:map>
+</xsl:function>]]></eg>
+               
+               <p>No entry is generated in the constructed map for a field that
+               is declared as optional with no default. So the declaration:</p>
+               
+               <eg><![CDATA[<xsl:record-type name="cx:complex" visibility="public">
+    <xsl:field name="r" as="xs:double"/>
+    <xsl:field name="i" as="xs:double" required="no" default="0"/>
+</xsl:record-type>]]></eg>
+               
+               <p>produces the equivalent function declaration:</p>
+               
+               <eg><![CDATA[<xsl:function name="cx:complex" as="cx:complex" visibility="public">
+    <xsl:param name="r" as="xs:double"/>
+    <xsl:param name="i" as="xs:double?" required="no"/>
+    <xsl:map>
+       <xsl:map-entry key="'r'" select="$r"/>
+       <xsl:if test="exists($i)">
+          <xsl:map-entry key="'i'" select="$i"/>
+       </xsl:if>   
+    </xsl:map>
+</xsl:function>]]></eg>
+               
+               <p>If the record type is extensible, the generated function
+                  includes an optional <code>options</code> parameter So the declaration:</p>
+               
+               <eg><![CDATA[<xsl:record-type name="cx:complex" extensible="yes">
+    <xsl:field name="r" as="xs:double"/>
+    <xsl:field name="i" as="xs:double"/>
+</xsl:record-type>]]></eg>
+               
+               <p>produces the equivalent function declaration:</p>
+               
+               <eg><![CDATA[<xsl:function name="cx:complex" as="cx:complex" visibility="private">
+    <xsl:param name="r" as="xs:double"/>
+    <xsl:param name="i" as="xs:double"/>
+    <xsl:param name="options" as="map(*)" required="no" default="{}"/>
+    <xsl:map on-duplicates="fn($first, $second){{$first}}">
+       <xsl:map-entry key="'r'" select="$r"/>
+       <xsl:map-entry key="'i'" select="$i"/>
+       <xsl:sequence select="$options"/>   
+    </xsl:map>
+</xsl:function>]]></eg>
+               
+               <p>This generated <elcode>xsl:function</elcode> declaration must
+               meet all the constraints placed on user-written 
+               <elcode>xsl:function</elcode> declarations, including the rule
+               requiring the combination of name and arity to be unique.</p>
+               
+               <p>The generated <elcode>xsl:function</elcode> declaration has the
+               import precedence associated with the stylesheet module in which the
+               <elcode>xsl:record-type</elcode> declaration appears, and it may be
+               overridden by another <elcode>xsl:function</elcode> declaration with
+               higher import precedence. If the visibility is <code>public</code>
+               then it can also be overridden using <elcode>xsl:override</elcode>
+               in another <termref def="dt-stylesheet-package"/>.</p>
+             
+               <p>The scope of a named record type is the <termref def="dt-package"/> in which it is declared. If it
+               is declared with <code>visibility="public"</code> then it also becomes available for use in using
+               packages. </p>
+               <p>The name of the record type is the expanded name formed by resolving the <code>name</code> attribute.
+               A lexical QName with no prefix is treated as a no-namespace name.</p>
+               <p>If two <elcode>xsl:record-type</elcode> declarations in a <termref def="dt-package"/> have the same
+               name, then the one with higher <termref def="dt-import-precedence"/> is used. </p>
+               <p><error spec="XT" type="static" class="SE" code="4030">
+                  <p>It is a <termref def="dt-static-error">static error</termref> if a package contains two 
+                     <elcode>xsl:record-type</elcode>
+                     declarations having the same <termref def="dt-import-precedence">import
+                        precedence</termref>, unless there is another definition of the same
+                     record type with higher import precedence.</p>
+               </error></p>
+               <p>A record type declaration may refer directly or indirectly to itself if
+                  it satisfies the conditions defined in <xspecref spec="XP40" ref="id-recursive-record-tests"/>.
+               This allows types to be declared that match recursive data structures such as linked lists
+               and trees.</p>
+               <p><error spec="XT" type="static" class="SE" code="4035">
+                  <p>It is a <termref def="dt-static-error">static error</termref> for an item type named
+                     <var>N</var> to contain in its <code>as</code> attribute a reference to <var>N</var>,
+                     or to an item type that references <var>N</var> directly or indirectly, unless it satisfies
+                     the conditions defined in <xspecref spec="XP40" ref="id-recursive-record-tests"/>.</p>
+               </error></p>
+               
+               <p>A named record type with visibility <code>private</code> may be used in the definition of a 
+                  component (such as a variable, a function, a template, or another named record 
+                  type) that is itself public. Another package may reference such a component 
+                  even though it cannot reference the types used in its definition. The fact that the
+                  record type is private, however, means that it is impossible to
+                  override a variable or function that references the record type.</p>
+               
+             
+            </div3>
          </div2>
          <div2 id="defining-decimal-format">
             <head>Defining a Decimal Format</head>


### PR DESCRIPTION
Adds named record types to XSLT, with much the same spec as for XQuery, but some extra tweaks for handling visibility and overriding.

Fix #1485