### PR TITLE
1705 Say that max precision is implementation-defined

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -2065,6 +2065,10 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
                      <code>$value</code>.</p>
             </item>
          </olist>
+         
+         <p>There may be <termref def="implementation-defined"/> limits on the precision
+         available. If the requested <code>$precision</code> is outside this range, it should
+         be adjusted to the nearest value supported by the implementation.</p>
 
       </fos:rules>
       <fos:notes>
@@ -2202,6 +2206,10 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
          <fos:change issue="1187 1274" PR="1260 1275" date="2024-06-11">
             <p>A third argument has been added, providing control over the rounding mode.</p>
          </fos:change>
+         <fos:change issue="1705" date="2025-01-01">
+            <p>It is explicitly stated that the limits for <code>$precision</code>
+            are implementation-defined.</p>
+         </fos:change>
       </fos:changes>
    </fos:function>
    <fos:function name="round-half-to-even" prefix="fn">
@@ -2254,6 +2262,10 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
                   returned according to the sign of the original argument.</p>
             </item>
          </olist>
+         
+         <p>There may be <termref def="implementation-defined"/> limits on the precision
+         available. If the requested <code>$precision</code> is outside this range, it should
+         be adjusted to the nearest value supported by the implementation.</p>
 
       </fos:rules>
       <fos:notes>
@@ -2314,6 +2326,12 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="1705" date="2025-01-01">
+            <p>It is explicitly stated that the limits for <code>$precision</code>
+            are implementation-defined.</p>
+         </fos:change>
+      </fos:changes>
    </fos:function>
    
    
@@ -2356,9 +2374,9 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
             </item>
          </olist>
          
-         <p>If <code>$precision</code> exceeds the maximum precision for <code>xs:decimal</code>
-         values supported by the implementation, then the maximum available precision is
-         used in its place.</p>
+         <p>There may be <termref def="implementation-defined"/> limits on the precision
+         available. If the requested <code>$precision</code> is outside this range, it should
+         be adjusted to the nearest value supported by the implementation.</p>
          
       </fos:rules>
       <fos:errors>


### PR DESCRIPTION
Applies to fn:round, fn:round-half-to-even, fn:divide-decimals

Fix #1705