### PR TITLE
1713 Revise code for generating production rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -568,7 +568,7 @@ task xslt_grammar(
     transform("${projectDir}/specifications/xslt-40/src/xslt.xml",
               "${projectDir}/specifications/xslt-40/style/convert-grammar.xsl",
               "${buildDir}/xslt-40/src/xslt-40-assembled.xml",
-              ["spec": "xslt-40",
+              ["spec": "xslt40",
                "grammar-file": buildDir.toURI().resolve("xslt-40/temp-xslt40-grammar.xml"),
                "tokens-file": buildDir.toURI().resolve("xslt-40/tokens.xml")])
   }

--- a/schema/xmlspec.dtd
+++ b/schema/xmlspec.dtd
@@ -1376,7 +1376,7 @@
 <!ENTITY % prod.attlist "INCLUDE">
 <![%prod.attlist;[
 <!ATTLIST prod
-        %common-idreq.att;
+        %common.att;
 	num	CDATA	#IMPLIED>
 ]]>
 

--- a/schema/xmlspec.dtd
+++ b/schema/xmlspec.dtd
@@ -1324,7 +1324,7 @@
 <!--    scrap: Collection of EBNF language productions. -->
 <!ENTITY % scrap.element "INCLUDE">
 <![%scrap.element;[
-<!ELEMENT scrap (head, (prodgroup | prod | bnf | prodrecap)+)>
+<!ELEMENT scrap (head?, (prodgroup | prod | bnf | prodrecap)+)>
 ]]>
 <!--    lang attribute:
         The scrap can link to a description of the language used,

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -349,8 +349,11 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:zeroOrMore>
     <g:zeroOrMore name="FunctionsAndVarsList" lookahead="2">
       <g:choice name="FunctionOrVar">
-        <g:ref name="ContextValueDecl" lookahead="2" if="xquery40"/>
-        <g:ref name="AnnotatedDecl" lookahead="2" if="xquery40"/>
+        <g:ref name="ContextValueDecl" lookahead="2"/>
+        <g:ref name="VarDecl"/>
+        <g:ref name="FunctionDecl"/>
+        <g:ref name="ItemTypeDecl"/>
+        <g:ref name="NamedRecordTypeDecl"/>
         <g:ref name="OptionDecl" lookahead="2"/>
       </g:choice>
       <g:ref name="Separator"/>
@@ -584,8 +587,8 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:string>ft-option</g:string>
     <g:ref name="FTMatchOptions"/>
   </g:production>
-
-  <g:production name="AnnotatedDecl" if="xquery40">
+  
+  <!--<g:production name="AnnotatedDecl" if="xquery40">
     <g:string>declare</g:string>
     <g:zeroOrMore>
       <g:choice>
@@ -599,7 +602,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="ItemTypeDecl"/>
       <g:ref name="NamedRecordTypeDecl"/>
     </g:choice>
-  </g:production>
+  </g:production>-->
 
   <g:production name="CompatibilityAnnotation" if="update10 update30">
     <g:string>updating</g:string>
@@ -640,6 +643,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="VarDecl" if="xquery40">
+    <g:string>declare</g:string>
+    <g:zeroOrMore>
+      <g:choice>
+        <g:ref name="CompatibilityAnnotation" if="update10 update30"/>
+        <g:ref name="Annotation"/>
+      </g:choice>
+    </g:zeroOrMore>
     <g:string>variable</g:string>
     <g:ref name="VarNameAndType"/>
     <g:choice name="VarDeclAssignmentOrExtern">
@@ -699,9 +709,13 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     </g:choice>
   </g:production>
 
-  <g:production name="FunctionDecl" if=" xquery40" xgc-id="reserved-function-names">
+  <g:production name="FunctionDecl" if=" xquery40" xgc-id="reserved-function-names">   
+    <g:string>declare</g:string>
     <g:optional name="optionalUpdateQualifierForFunctionDecl" if="update10 update30" not-if="xquery40">
       <g:string process-value="yes">updating</g:string>
+    </g:optional>
+    <g:optional>
+      <g:ref name="Annotation"/>
     </g:optional>
     <g:string>function</g:string>
     <g:ref name="_Function_QName_or_EQName" unfold="yes"/>   
@@ -763,6 +777,10 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="ItemTypeDecl" if="xquery40">
+    <g:string>declare</g:string>
+    <g:optional>
+      <g:ref name="Annotation"/>
+    </g:optional>
     <g:string>type</g:string>
     <g:ref name="EQName"/>
     <g:string>as</g:string>
@@ -770,6 +788,11 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   <g:production name="NamedRecordTypeDecl" if="xquery40">
+    <g:string>declare</g:string>
+    <g:optional>
+      <g:ref name="Annotation"/>
+    </g:optional>
+    <g:string>type</g:string>
     <g:string>record</g:string>
     <g:ref name="EQName"/>
     <g:string>(</g:string>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -2107,8 +2107,9 @@ ErrorVal ::= "$" VarName
   </g:production>
 
   <g:production name="FunctionCall" comment-id="parens" xgc-id="reserved-function-names">
-    <g:ref name="_Function_QName_or_EQName" unfold="yes"/>
-    <g:ref name="ArgumentList" if="xpath40 xquery40  xslt40-patterns"/>
+    <!--<g:ref name="_Function_QName_or_EQName" unfold="yes"/>-->
+    <g:ref name="EQName"/>
+    <g:ref name="ArgumentList"/>
   </g:production>
 
   <g:production name="Argument" if="xpath40 xquery40  xslt40-patterns">
@@ -2421,7 +2422,8 @@ ErrorVal ::= "$" VarName
   </g:production>
 
   <g:production name="NamedFunctionRef" if="xpath40 xquery40  xslt40-patterns" xgc-id="reserved-function-names">
-    <g:ref name="_Function_QName_or_EQName" unfold="yes"/>
+    <!--<g:ref name="_Function_QName_or_EQName" unfold="yes"/>-->
+    <g:ref name="EQName"/>
     <g:string>#</g:string>
     <g:ref name="IntegerLiteral"/>
   </g:production>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -45,9 +45,6 @@ apply.
 
   <!-- ====================== Grammar Productions ==================== -->
 
-
-  
-  <!-- [ start XSLT 4.0 Patterns -->
   
   <!-- The QueryList production is  not in the official grammar,
        and is not shown in the bnf.  It is here only for the purpose
@@ -63,6 +60,7 @@ apply.
     </g:zeroOrMore>
   </g:production>
   
+   <!-- [ start XSLT 4.0 Patterns -->
 
   <g:production name="Pattern40" if="xslt40-patterns">
     <g:choice name="Pattern40Choices">
@@ -1241,11 +1239,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:string process-value="yes">some</g:string>
       <g:string process-value="yes">every</g:string>
     </g:choice>
-    <g:ref name="QuantifierBinding"/>
-    <g:zeroOrMore name="QuantifiedVarDeclListTail">
-      <g:string>,</g:string>
+    <g:oneOrMore name="QuantifiedVarDeclListTail" separator=",">
       <g:ref name="QuantifierBinding"/>
-    </g:zeroOrMore>
+    </g:oneOrMore>
     <g:string>satisfies</g:string>
     <g:ref name="ExprSingle"/>
   </g:production>
@@ -1425,7 +1421,7 @@ ErrorVal ::= "$" VarName
     <g:ref name="EnclosedExpr" if="xquery40"/>
   </g:production>
 
-  <g:production name="NameTestUnion" if="xpath40 xquery40">
+  <g:production name="NameTestUnion" if="xpath40 xquery40 xslt40-patterns">
     <g:oneOrMore separator="|">
       <g:ref name="NameTest"/>
     </g:oneOrMore>
@@ -1890,13 +1886,8 @@ ErrorVal ::= "$" VarName
       <g:ref name="URIQualifiedStar" needs-exposition-parens="yes" if="xpath40 xquery40  xslt40-patterns"/>
     </g:choice>
   </g:production>
-
-  <!--<g:production name="FilterExprP" if=" xslt40-patterns">
-    <g:ref name="PrimaryExpr"/>
-    <g:ref name="PredicateList"/>
-  </g:production>-->
   
-  <g:production name="FilterExpr" if="xpath40 xquery40">
+  <g:production name="FilterExpr" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="PostfixExpr"/>
     <g:ref name="Predicate"/>
   </g:production>
@@ -1972,19 +1963,19 @@ ErrorVal ::= "$" VarName
     <g:string>]</g:string>
   </g:production>
   
-  <g:production name="LookupExpr" if="xpath40 xquery40">
+  <g:production name="LookupExpr" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="PostfixExpr"/>
     <g:ref name="Lookup"/>
   </g:production>
   
-  <g:production name="FilterExprAM" if="xpath40 xquery40">
+  <g:production name="FilterExprAM" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="PostfixExpr"/>
     <g:string>?[</g:string>
     <g:ref name="Expr"/>
     <g:string>]</g:string>
   </g:production>
 
-  <g:production name="Lookup" if="xpath40 xquery40">
+  <g:production name="Lookup" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:string>?</g:string>
       <g:string>??</g:string>
@@ -1996,7 +1987,7 @@ ErrorVal ::= "$" VarName
     <g:ref name="KeySpecifier"/>
   </g:production>
   
-  <g:production name="Modifier">
+  <g:production name="Modifier" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:string>pairs</g:string>
       <g:string>keys</g:string>
@@ -2005,19 +1996,19 @@ ErrorVal ::= "$" VarName
     </g:choice>
   </g:production>
   
-  <g:production name="KeySpecifier" if="xpath40 xquery40">
+  <g:production name="KeySpecifier" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="NCName"/>
       <g:ref name="IntegerLiteral"/>
-      <g:ref name="StringLiteral" if="xpath40 xquery40"/>
-      <g:ref name="VarRef" if="xpath40 xquery40"/>
+      <g:ref name="StringLiteral"/>
+      <g:ref name="VarRef"/>
       <g:ref name="ParenthesizedExpr"/>
       <g:ref name="LookupWildcard"/>
       <!--<g:ref name="TypeQualifier"/>-->
     </g:choice>
   </g:production>
   
-  <g:production name="LookupWildcard">
+  <g:production name="LookupWildcard" if="xpath40 xquery40 xslt40-patterns">
     <g:string process-value="yes">*</g:string>
   </g:production>
   
@@ -2026,11 +2017,11 @@ ErrorVal ::= "$" VarName
     <g:ref name="SequenceType"/>
   </g:production>-->
 
-  <g:production name="ArrowStaticFunction">
+  <g:production name="ArrowStaticFunction" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="EQName"/>
   </g:production>
   
-  <g:production name="ArrowDynamicFunction">
+  <g:production name="ArrowDynamicFunction" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="VarRef"/>
       <g:ref name="InlineFunctionExpr"/>
@@ -2048,16 +2039,16 @@ ErrorVal ::= "$" VarName
       <g:ref name="VarRef"/>
       <g:ref name="ParenthesizedExpr"/>
       <g:ref name="ContextValueRef" if="xpath40 xquery40  xslt40-patterns"/>
-      <g:ref name="FunctionCall" lookahead="2"/>
+      <g:ref name="FunctionCall" lookahead="2" if="xpath40 xquery40  xslt40-patterns"/>
       <g:ref name="OrderedExpr" if=" xquery40" lookahead="2"/>
       <g:ref name="UnorderedExpr" if=" xquery40" lookahead="2"/>
       <g:ref name="NodeConstructor" if="xquery40" lookahead="2"/>
       <g:ref name="FunctionItemExpr" if="xpath40 xquery40  xslt40-patterns"/>
-      <g:ref name="MapConstructor" if="xpath40 xquery40"/>
-      <g:ref name="ArrayConstructor" if="xpath40 xquery40"/>
-      <g:ref name="StringTemplate" if="xpath40 xquery40"/>
+      <g:ref name="MapConstructor" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="ArrayConstructor" if="xpath40 xquery40 xslt40-patterns"/>
+      <g:ref name="StringTemplate" if="xpath40 xquery40 xslt40-patterns"/>
       <g:ref name="StringConstructor" if="xquery40"/>
-      <g:ref name="UnaryLookup" if="xpath40 xquery40"/>
+      <g:ref name="UnaryLookup" if="xpath40 xquery40 xslt40-patterns"/>
     </g:choice>
   </g:production>
 
@@ -2452,7 +2443,7 @@ ErrorVal ::= "$" VarName
 
   <!-- ] end Function Items -->
   
-  <g:production name="MapConstructor" if="xpath40 xquery40">
+  <g:production name="MapConstructor" if="xpath40 xquery40 xslt40-patterns">
     <g:optional>
       <g:string>map</g:string>
     </g:optional>
@@ -2460,38 +2451,31 @@ ErrorVal ::= "$" VarName
     <g:zeroOrMore separator=",">
       <g:ref name="MapConstructorEntry"/>
     </g:zeroOrMore>
-    <!--<g:optional>
-      <g:ref name="MapConstructorEntry"/>
-      <g:zeroOrMore>
-        <g:string>,</g:string>
-        <g:ref name="MapConstructorEntry"/>
-      </g:zeroOrMore>
-    </g:optional>-->
     <g:ref name="Rbrace"/>
   </g:production>
 
-  <g:production name="MapConstructorEntry" if="xpath40 xquery40">
+  <g:production name="MapConstructorEntry" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="MapKeyExpr"/>
     <g:string>:</g:string>
     <g:ref name="MapValueExpr"/>
   </g:production>
 
-  <g:production name="MapKeyExpr" if="xpath40 xquery40">
+  <g:production name="MapKeyExpr" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="ExprSingle"/>
   </g:production>
 
-  <g:production name="MapValueExpr" if="xpath40 xquery40">
+  <g:production name="MapValueExpr" if="xpath40 xquery40 xslt40-patterns">
     <g:ref name="ExprSingle"/>
   </g:production>
 
-  <g:production name="ArrayConstructor" if="xpath40 xquery40">
+  <g:production name="ArrayConstructor" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="SquareArrayConstructor"/>
       <g:ref name="CurlyArrayConstructor"/>
     </g:choice>
   </g:production>
 
-  <g:production name="SquareArrayConstructor" if="xpath40 xquery40">
+  <g:production name="SquareArrayConstructor" if="xpath40 xquery40 xslt40-patterns">
     <g:string>[</g:string>
     <g:zeroOrMore separator=",">
       <g:ref name="ExprSingle"/>
@@ -2499,12 +2483,12 @@ ErrorVal ::= "$" VarName
     <g:string>]</g:string>
   </g:production>
 
-  <g:production name="CurlyArrayConstructor" if="xpath40 xquery40">
+  <g:production name="CurlyArrayConstructor" if="xpath40 xquery40 xslt40-patterns">
     <g:string>array</g:string>
     <g:ref name="EnclosedExpr"/>
   </g:production>
   
-  <g:production name="StringTemplate" if="xpath40 xquery40" whitespace-spec="explicit">
+  <g:production name="StringTemplate" if="xpath40 xquery40 xslt40-patterns" whitespace-spec="explicit">
     <g:string>`</g:string>
     <g:zeroOrMore>
       <g:choice>
@@ -2515,7 +2499,7 @@ ErrorVal ::= "$" VarName
     <g:string>`</g:string>
   </g:production>
   
-  <g:production name="StringTemplateFixedPart" if="xpath40 xquery40" whitespace-spec="explicit">
+  <g:production name="StringTemplateFixedPart" if="xpath40 xquery40 xslt40-patterns" whitespace-spec="explicit">
     <g:zeroOrMore>
       <g:choice>
         <g:ref name="Char" subtract-reg-expr="('{' | '}' | '`')"/>
@@ -2526,7 +2510,7 @@ ErrorVal ::= "$" VarName
     </g:zeroOrMore>
   </g:production>
   
-  <g:production name="StringTemplateVariablePart" if="xpath40 xquery40" whitespace-spec="explicit">
+  <g:production name="StringTemplateVariablePart" if="xpath40 xquery40 xslt40-patterns" whitespace-spec="explicit">
     <g:ref name="EnclosedExpr"/>
   </g:production>
 
@@ -2558,7 +2542,7 @@ ErrorVal ::= "$" VarName
     <g:ref name="StringInterpolationEnd"/>
   </g:production>
 
-  <g:production name="UnaryLookup" if="xpath40 xquery40">
+  <g:production name="UnaryLookup" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:string>?</g:string>
       <g:string>??</g:string>
@@ -2694,7 +2678,7 @@ ErrorVal ::= "$" VarName
     <g:string>attribute</g:string>
     <g:string>(</g:string>
     <g:optional name="OptionalAttributeTestBody">
-      <g:ref name="NameTestUnion" if="xpath40 xquery40"/>
+      <g:ref name="NameTestUnion"/>
       <g:optional name="AttributeTestBodyOptionalParam">
         <g:string>,</g:string>
         <g:ref name="TypeName"/>
@@ -2714,7 +2698,7 @@ ErrorVal ::= "$" VarName
     <g:string>element</g:string>
     <g:string>(</g:string>
     <g:optional name="OptionalElementTestBody">
-      <g:ref name="NameTestUnion" if="xpath40 xquery40"/>
+      <g:ref name="NameTestUnion"/>
       <g:optional name="ElementTestBodyOptionalParam">
         <g:string>,</g:string>
         <g:ref name="TypeName"/>
@@ -2864,28 +2848,10 @@ ErrorVal ::= "$" VarName
     </g:choice>
   </g:production>
   
-  <!--<g:production name="SelfReference" if="xpath40 xquery40 xslt40-patterns">
-    <g:string>..</g:string>
-    <g:optional>
-      <g:ref name="OccurrenceIndicator"/>
-    </g:optional>
-  </g:production>-->
-  
   <g:production name="ExtensibleFlag" if="xpath40 xquery40 xslt40-patterns">
     <g:string>,</g:string>
     <g:string>*</g:string>
   </g:production>
-  
-  <!--<g:production name="LocalUnionType" if="xpath40 xquery40 xslt40-patterns">
-    <g:string>union</g:string>
-    <g:string>(</g:string>
-    <g:ref name="ItemType"/>
-    <g:zeroOrMore>
-      <g:string>,</g:string>
-      <g:ref name="ItemType"/>
-    </g:zeroOrMore>
-    <g:string>)</g:string>
-  </g:production>-->
   
   <g:production name="EnumerationType" if="xpath40 xquery40 xslt40-patterns">
     <g:string>enum</g:string>
@@ -2893,11 +2859,6 @@ ErrorVal ::= "$" VarName
     <g:oneOrMore separator=",">
       <g:ref name="StringLiteral"/>
     </g:oneOrMore>
-<!--    <g:ref name="StringLiteral"/>
-    <g:zeroOrMore>
-      <g:string>,</g:string>
-      <g:ref name="StringLiteral"/>
-    </g:zeroOrMore>-->
     <g:string>)</g:string>
   </g:production>
 
@@ -2921,13 +2882,6 @@ ErrorVal ::= "$" VarName
     <g:ref name="SequenceType"/>
     <g:string>)</g:string>
   </g:production>
-  
-  <!--<g:production name="NamedItemType" if="xpath40 xquery40 xslt40-patterns">
-    <g:string>item-type</g:string>
-    <g:string>(</g:string>
-    <g:ref name="EQName"/>
-    <g:string>)</g:string>
-  </g:production>-->
 
   <g:production name="ChoiceItemType" if="xpath40 xquery40  xslt40-patterns">
     <g:string>(</g:string>
@@ -3612,7 +3566,7 @@ ErrorVal ::= "$" VarName
   </g:production>
 
   <g:production name="_Function_QName_or_EQName" if="_Function_QName_or_EQName">
-    <g:ref name="FunctionEQName" if="xpath40 xquery40  xslt40-patterns"/>
+    <g:ref name="FunctionEQName" if="xpath40 xquery40 xslt40-patterns"/>
   </g:production>
 
   <g:production name="EQName" node-type="void" if="xpath40 xquery40  xslt40-patterns">
@@ -3622,7 +3576,7 @@ ErrorVal ::= "$" VarName
     </g:choice>
   </g:production>
 
-  <g:production name="FunctionEQName" exposition-name="EQName" show="no" node-type="void" whitespace-spec="explicit" if="xpath40 xquery40  xslt40-patterns">
+  <g:production name="FunctionEQName" exposition-name="EQName" show="no" node-type="void" whitespace-spec="explicit" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>
       <g:ref name="FunctionQName"/>
       <g:ref name="URIQualifiedName"/>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -12585,12 +12585,13 @@ example, combining the values <code>1</code>, <code>(2, 3)</code>, and <code>( )
 in the sequence <code>(1, 2, 3)</code>.</p>
          <div3 id="construct_seq">
             <head>Sequence Concatenation</head>
-            <scrap>
-               <prodrecap ref="Expr"/>
-            </scrap>
+ 
             <p>
                <termdef term="comma operator" id="dt-comma-operator"
-                     >One way to construct a sequence is by using the <term>comma operator</term>, which evaluates each of its operands and concatenates the resulting sequences, in order, into a single result sequence.</termdef> Empty parentheses can be used to denote an empty sequence.</p>
+                     >One way to construct a sequence is by using the <term>comma operator</term>, 
+                  which evaluates each of its operands and concatenates the resulting sequences, in order, 
+                  into a single result sequence.</termdef> See <nt def="Expr"/>. 
+               Empty parentheses can be used to denote an empty sequence.</p>
             <p>A sequence may contain duplicate
 <termref def="dt-item"
                >items</termref>, but a sequence is never an item in another sequence. When a

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -95,8 +95,7 @@ of <bibref
             <p>For example the following production rule indicates that an <code>Expr</code>
             consists of one or more occurrences of <code>ExprSingle</code>, separated by commas:</p>
             
-            <scrap>
-               <head/>
+            <scrap role="example">
                <prodrecap ref="Expr"/>
             </scrap>
             
@@ -237,13 +236,12 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
             def="EQName">EQName</nt>.</p>
 
       <scrap>
-         <head/>
-         <prodrecap id="EQName" ref="EQName"/>
-         <prodrecap id="QName" ref="QNameToken"/>
+         <prodrecap ref="EQName"/>
+         <!--<prodrecap id="QName" ref="QNameToken"/>
          <prodrecap ref="URILiteral" id="URILiteral" role="xquery"/>
          <prodrecap id="URIQualifiedName" ref="URIQualifiedName"/>
          <prodrecap id="BracedURILiteral" ref="BracedURILiteral"/>
-         <prodrecap ref="NCNameTok"/>
+         <prodrecap ref="NCNameTok"/>-->
       </scrap>
 
 
@@ -3666,10 +3664,7 @@ defined in <xspecref
             in an &language; expression, the <nt
             def="SequenceType">SequenceType</nt> syntax is used.</p>
          <scrap>
-            <head/>
-            <prodrecap id="SequenceType" ref="SequenceType"/>
-            <prodrecap id="ItemType" ref="ItemType"/>
-            <prodrecap id="OccurrenceIndicator" ref="OccurrenceIndicator"/>
+            <prodrecap ref="SequenceType"/>
          </scrap>
          
       
@@ -4013,43 +4008,7 @@ types</term> (such as <code>xs:integer</code>) and function types
             
             
             <scrap>
-               <head/>
                <prodrecap ref="ItemType"/>
-               <prodrecap id="AnyItemTest" ref="AnyItemTest"/>
-               <prodrecap id="TypeName" ref="TypeName"/>
-               
-               
-               <prodrecap id="KindTest" ref="KindTest"/>
-               
-               <prodrecap id="DocumentTest" ref="DocumentTest"/>
-               
-               <prodrecap ref="ElementTest"/>
-               <prodrecap ref="SchemaElementTest"/>
-               <prodrecap ref="AttributeTest"/>
-               
-               <prodrecap ref="SchemaAttributeTest"/>
-               
-               <prodrecap id="ElementName" ref="ElementName"/>
-
-               
-               <prodrecap id="AttributeName" ref="AttributeName"/>
-               
-               <prodrecap id="PITest" ref="PITest"/>
-               <prodrecap id="CommentTest" ref="CommentTest"/>
-               <prodrecap id="NamespaceNodeTest" ref="NamespaceNodeTest"/>
-               
-               <prodrecap id="TextTest" ref="TextTest" />
-               <prodrecap id="AnyKindTest" ref="AnyKindTest"/>
-               <prodrecap ref="FunctionType"/>
-               <prodrecap ref="AnyFunctionType"/>
-               <prodrecap ref="TypedFunctionType"/>
-               <prodrecap ref="TypedFunctionParam"/>
-               <prodrecap id="ChoiceItemType" ref="ChoiceItemType"/>
-               <prodrecap ref="MapType"/>
-               <prodrecap ref="RecordType"/>
-               <prodrecap ref="ArrayType"/>
-               <!--<prodrecap ref="LocalUnionType"/>-->
-               <prodrecap ref="EnumerationType"/>
             </scrap>
 
                
@@ -4346,9 +4305,8 @@ types</term> (such as <code>xs:integer</code>) and function types
 
                <p><termdef id="dt-enumeration-type" term="enumeration type">An <term>EnumerationType</term>
                   accepts a fixed set of string values.</termdef></p>
-               <scrap headstyle="show">
-                  <head/>
-                  <prodrecap id="EnumerationType" ref="EnumerationType"/>   
+               <scrap>
+                  <prodrecap ref="EnumerationType"/>   
                </scrap>
                
                <p>An <termref def="dt-enumeration-type"/> has a value space consisting of a set of <code>xs:string</code>
@@ -4629,13 +4587,8 @@ declare variable $orange-fruit as my:fruit := "orange";
                   </change>
                </changes>
 
-               <scrap diff="chg" at="A">
-                  <head/>
-                  <prodrecap id="ElementTest" ref="ElementTest"/>
-                  <prodrecap id="NameTestUnion" ref="NameTestUnion"/>
-                  <prodrecap ref="NameTest"/>
-                  <prodrecap ref="Wildcard"/>
-                  <prodrecap ref="TypeName"/>
+               <scrap>
+                  <prodrecap ref="ElementTest"/>
                </scrap>
 
 
@@ -4825,9 +4778,7 @@ matches any nilled or non-nilled element node whose type annotation is
                <head>Schema Element Types</head>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="SchemaElementTest" ref="SchemaElementTest"/>
-                  <prodrecap ref="ElementName"/>
+                  <prodrecap ref="SchemaElementTest"/>
                </scrap>
 
                <p>
@@ -4964,13 +4915,8 @@ in the following two situations:
                   </change>
                </changes>
 
-               <scrap diff="chg" at="A">
-                  <head/>
+               <scrap>
                   <prodrecap id="AttributeTest" ref="AttributeTest"/>
-                  <prodrecap ref="NameTestUnion"/>
-                  <prodrecap ref="NameTest"/>
-                  <prodrecap ref="Wildcard"/>
-                  <prodrecap ref="TypeName"/>
                </scrap>
 
 
@@ -5119,9 +5065,7 @@ name.</p>
                <head>Schema Attribute Types</head>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="SchemaAttributeTest" ref="SchemaAttributeTest"/>
-                  <prodrecap ref="AttributeName"/>
+                  <prodrecap ref="SchemaAttributeTest"/>
                </scrap>
 
                <p>
@@ -5216,12 +5160,7 @@ name.</p>
 
                
                <scrap>
-                  <head/>
-                  <prodrecap id="FunctionType" ref="FunctionType"/>
-                  <prodrecap role="xquery" ref="Annotation"/>
-                  <prodrecap id="AnyFunctionType" ref="AnyFunctionType"/>
-                  <prodrecap id="TypedFunctionType" ref="TypedFunctionType"/>
-                  <prodrecap id="TypedFunctionParam" ref="TypedFunctionParam"/>
+                  <prodrecap ref="FunctionType"/>
                </scrap>
 
 
@@ -5391,11 +5330,9 @@ name.</p>
                either matches any map, or that matches maps whose keys and values
                are constrained to specific types.</p>
                
-               <scrap headstyle="show">
+               <scrap>
                   <head/>
-                  <prodrecap id="MapType" ref="MapType"/>
-                  <prodrecap id="AnyMapType" ref="AnyMapType"/>
-                  <prodrecap id="TypedMapType" ref="TypedMapType"/>
+                  <prodrecap ref="MapType"/>
                </scrap>
 
 
@@ -5575,15 +5512,8 @@ name.</p>
 		             execution.</p>
 
 
-               <scrap headstyle="show">
-                  <head/>
-                  <prodrecap id="RecordType" ref="RecordType"/>
-                  <prodrecap id="AnyRecordType" ref="AnyRecordType"/>
-                  <prodrecap id="TypedRecordType" ref="TypedRecordType"/>
-                  <prodrecap id="FieldDeclaration" ref="FieldDeclaration"/>
-                  <prodrecap id="FieldName" ref="FieldName"/>
-                  <!--<prodrecap id="SelfReference" ref="SelfReference"/>  -->  
-                  <prodrecap id="ExtensibleFlag" ref="ExtensibleFlag"/>    
+               <scrap>
+                  <prodrecap ref="RecordType"/>
                </scrap>
 
               
@@ -5816,10 +5746,7 @@ declare record Particle (
                are constrained to a specific type.</p>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="ArrayType" ref="ArrayType"/>
-                  <prodrecap id="AnyArrayType" ref="AnyArrayType"/>
-                  <prodrecap id="TypedArrayType" ref="TypedArrayType"/>
+                  <prodrecap ref="ArrayType"/>
                </scrap>
 
 
@@ -8389,11 +8316,14 @@ return $f(12.3)]]></eg>
                >Query Body</termref>  containing an expression whose value is the result of the query. An expression is represented in the XQuery grammar by the symbol <nt
                def="Expr">Expr</nt>.</phrase>
       </p>
+      <scrap role="xpath">
+         <prodrecap ref="XPath"/>
+      </scrap>
+      <scrap role="xquery">
+         <prodrecap ref="Expr"/>
+      </scrap>
       <scrap>
-         <head/>
-         <prodrecap ref="XPath" id="XPath" role="xpath"/>
-         <prodrecap ref="Expr" id="Expr"/>
-         <prodrecap id="ExprSingle" ref="ExprSingle"/>
+         <prodrecap ref="ExprSingle"/>
       </scrap>
       <p>The &language; operator that has lowest precedence is the <termref def="dt-comma-operator"
             >comma operator</termref>, which is used to combine two operands to form a sequence. 
@@ -8428,79 +8358,12 @@ return $f(12.3)]]></eg>
 and <nt def="OrExpr"
          >OrExpr</nt>. Each of these expressions is described in a separate section of this document.</p>
       
-      <!--<div2 id="with-expressions" diff="del" at="Issue1075">
-         <head>Setting Namespace Context</head>
-         <scrap headstyle="suppress">
-            <head/>
-            <prodrecap id="WithExpr" ref="WithExpr"/>
-            <prodrecap id="NamespaceDeclaration" ref="NamespaceDeclaration"/>
-            <prodrecap role="xquery" ref="URILiteral"/>
-            <prodrecap ref="EnclosedExpr"/>
-         </scrap>
-         
-         <p>The namespace context for an expression can be set using a construct of the form:</p>
-         
-         <eg><![CDATA[with xmlns="http://example.com/,
-     xmlns:a="http://example.com/a" {
-       /doc/a:element/b
-}]]></eg>
-         
-         <p>The static context for the enclosed expression will be the same as the static context for the
-         <nt def="WithExpr">WithExpr</nt> itself, except for modifications defined below.</p>
-         
-         <p>The <code>QName</code> used in a <nt def="NamespaceDeclaration">NamespaceDeclaration</nt>
-         must be either <code>xmlns</code> or <code>xmlns:prefix</code> where <code>prefix</code> is some
-         <code>NCName</code>.</p>
-         
-         <p>If more than one <nt def="NamespaceDeclaration">NamespaceDeclaration</nt> specifies
-         the same <code>QName</code>, all but the last of the duplicates are ignored.</p>
-         
-         <p>If the QName is <code>"xmlns"</code> then:</p>
-         <ulist>
-            <item>
-               <p>If the <code role="xquery">URILiteral</code><code role="xpath">StringLiteral</code> is a zero-length string:</p>
-               <ulist>
-                  <item><p>The 
-                     <termref def="dt-default-namespace-elements-and-types"/> is set to <emph>absent</emph>, meaning
-                  that unprefixed element names are treated as being in no namespace.</p>
-                  <p>TODO: reconcile this with the "fixed" setting in the XQuery prolog.</p></item>
-                  <item><p>Any binding for the zero-length prefix in the 
-                     <termref def="dt-static-namespaces"/> is removed.</p></item>
-               </ulist>
-            </item>
-            <item>
-               <p>If the <code role="xquery">URILiteral</code><code role="xpath">StringLiteral</code> is not zero-length:</p>
-               <ulist>
-                  <item><p>The 
-                     <termref def="dt-default-namespace-elements-and-types"/> is set to the supplied namespace URI, meaning
-                     that unprefixed element names are treated as being in that namespace.</p>
-                     <p>TODO: reconcile this with the "fixed" setting in the XQuery prolog.</p></item>
-                  <item><p>A binding that maps the zero-length prefix to the specified namespace URI is
-                     added to the <termref def="dt-static-namespaces"/>.</p></item>
-               </ulist>
-            </item>
-         </ulist>
-         
-         <p>If the QName is in the form <code>xmlns:prefix</code> then the <code role="xquery">URILiteral</code><code role="xpath">StringLiteral</code>
-            must not be zero-length; the effect is that a binding that maps the given <code>prefix</code> to 
-            the specified namespace URI is added to the <termref def="dt-static-namespaces"/>.</p>
-         
-         <p>For example, the expression:</p>
-         
-         <eg>with xmlns="http://www.acme.com/" {a/b[c=3]}</eg>
-         
-         <p>is equivalent to the expression:</p>
-         
-         <eg>Q{http://www.acme.com/}a/Q{http://www.acme.com/}b[Q{http://www.acme.com/}c=3]</eg>
-         
-      </div2>-->
+     
       
       <div2 id="comments">
          <head>Comments</head>
-         <scrap headstyle="suppress">
-            <head/>
-            <prodrecap id="Comment" ref="Comment"/>
-            <prodrecap id="CommentContents" ref="CommentContents"/>
+         <scrap>
+            <prodrecap ref="Comment"/>
          </scrap>
          <p>Comments may be used to provide information relevant to programmers who read <phrase
             role="xquery">a query, either in the <termref def="dt-prolog"
@@ -8535,10 +8398,7 @@ and <nt def="OrExpr"
                ref="id-string-constructors"/>.</phrase>
 </p>
          <scrap>
-            <head/>
-            <prodrecap id="PrimaryExpr" ref="PrimaryExpr"/>
-            <prodrecap id="FunctionItemExpr" ref="FunctionItemExpr"/>
-            <!--<prodrecap id="TildeExpr" ref="TildeExpr"/>-->
+            <prodrecap ref="PrimaryExpr"/>
          </scrap>
  
          <!--<p>The usage of the <nt def="TildeExpr"/> is described in <specref ref="id-arrow-operator"/>.</p>
@@ -8547,8 +8407,7 @@ and <nt def="OrExpr"
             <head>Literals</head>
             
             <scrap>
-               <head/>
-               <prodrecap id="Literal" ref="Literal"/>
+               <prodrecap ref="Literal"/>
             </scrap>
             <p>
                <termdef id="dt-literal" term="literal"
@@ -8568,19 +8427,7 @@ and <nt def="OrExpr"
                </changes>
                
                <scrap>
-                  <head/>
-                  <prodrecap id="NumericLiteral" ref="NumericLiteral"/>
-                  <prodrecap id="IntegerLiteral" ref="IntegerLiteral"/>
-                  <prodrecap id="HexIntegerLiteral" ref="HexIntegerLiteral"/>
-                  <prodrecap id="BinaryIntegerLiteral" ref="BinaryIntegerLiteral"/>
-                  <prodrecap id="DecimalLiteral" ref="DecimalLiteral"/>
-                  <prodrecap id="DoubleLiteral" ref="DoubleLiteral"/>
-                  <prodrecap id="Digits" ref="Digits"/>
-                  <prodrecap id="DecDigit" ref="DecDigit"/>
-                  <prodrecap id="HexDigits" ref="HexDigits"/>
-                  <prodrecap id="HexDigit" ref="HexDigit"/>
-                  <prodrecap id="BinaryDigits" ref="BinaryDigits"/>
-                  <prodrecap id="BinaryDigit" ref="BinaryDigit"/>
+                  <prodrecap ref="NumericLiteral"/>
                </scrap>
             
             
@@ -8695,14 +8542,7 @@ and <nt def="OrExpr"
                <head>String Literals</head>
                
                <scrap>
-                  <head/>
                   <prodrecap id="StringLiteral" ref="StringLiteral"/>
-                  <prodrecap id="AposStringLiteral" ref="AposStringLiteral"/>
-                  <prodrecap id="QuotStringLiteral" ref="QuotStringLiteral"/>
-                  <prodrecap id="PredefinedEntityRef" role="xquery" ref="PredefinedEntityRef"/>
-                  <prodrecap id="CharRef"  role="xquery" ref="CharRef"/>
-                  <prodrecap id="EscapeQuot" ref="EscapeQuot"/>
-                  <prodrecap id="EscapeApos" ref="EscapeApos"/>
                </scrap>
  
 
@@ -8925,9 +8765,7 @@ string in its lexical space.</p>
          <div3 id="id-variables">
             <head>Variable References</head>
             <scrap>
-               <head/>
-               <prodrecap id="VarRef" ref="VarRef"/>
-               <prodrecap ref="EQName"/>
+               <prodrecap ref="VarRef"/>
             </scrap>
             <p>
                <termdef id="dt-variable-reference" term="variable reference"
@@ -8964,8 +8802,7 @@ At evaluation time, the value of a variable reference is the value to which the 
          <div3 id="id-context-value-references">
             <head>Context Value References</head>
             <scrap>
-               <head/>
-               <prodrecap id="ContextValueRef" ref="ContextValueRef"/>
+               <prodrecap ref="ContextValueRef"/>
             </scrap>
 
             <p>A <term>context value reference</term> evaluates to
@@ -8985,8 +8822,7 @@ At evaluation time, the value of a variable reference is the value to which the 
          <div3 id="id-paren-expressions">
             <head>Parenthesized Expressions</head>
             <scrap>
-               <head/>
-               <prodrecap id="ParenthesizedExpr" ref="ParenthesizedExpr"/>
+               <prodrecap ref="ParenthesizedExpr"/>
 
 
             </scrap>
@@ -9011,8 +8847,7 @@ At evaluation time, the value of a variable reference is the value to which the 
             <head>Enclosed Expressions</head>
             <p>
                <scrap>
-                  <head/>
-                  <prodrecap id="EnclosedExpr" ref="EnclosedExpr"/>
+                  <prodrecap ref="EnclosedExpr"/>
                </scrap>
                <termdef term="enclosed expression" id="dt-enclosed-expression"
                   >An <term>enclosed expression</term> is an instance of the <nt def="EnclosedExpr"
@@ -9038,10 +8873,7 @@ At evaluation time, the value of a variable reference is the value to which the 
          
          <scrap>
             <head/>
-            <prodrecap id="PostfixExpr" ref="PostfixExpr"/>
-            <prodrecap ref="FilterExpr"/>
-            <prodrecap ref="DynamicFunctionCall"/>
-            <prodrecap ref="LookupExpr"/>
+            <prodrecap ref="PostfixExpr"/>
          </scrap>
          
          <p>A postfix expression takes one of the following forms:</p>
@@ -9104,9 +8936,7 @@ At evaluation time, the value of a variable reference is the value to which the 
             </changes>
             
             <scrap>
-               <head/>
-               <prodrecap id="FilterExpr" ref="FilterExpr"/>
-               <prodrecap id="Predicate" ref="Predicate"/>
+               <prodrecap ref="FilterExpr"/>
             </scrap>
             
             <p>A filter expression consists of a base expression followed by
@@ -9353,15 +9183,9 @@ At evaluation time, the value of a variable reference is the value to which the 
             </changes>
             
             <scrap>
-               <head/>
-               <prodrecap id="FunctionCall" ref="FunctionCall"/>
-               <prodrecap id="ArgumentList" ref="ArgumentList"/>
-               <prodrecap ref="PositionalArguments"/>               
-               <prodrecap id="Argument" ref="Argument"/>
-               <prodrecap id="ArgumentPlaceholder" ref="ArgumentPlaceholder"/>
-               <prodrecap ref="KeywordArguments"/>
-               <prodrecap id="KeywordArgument" ref="KeywordArgument"/>
+               <prodrecap ref="FunctionCall"/>
             </scrap>
+            
             <p><termdef term="static function call" id="dt-static-function-call">A <term>static function call</term> 
                consists of an EQName followed by a parenthesized list of zero or more arguments.</termdef></p>
             <p diff="add" at="A">The argument list consists of zero or more positional arguments,
@@ -9755,12 +9579,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                <head>Dynamic Function Calls</head>
                
                <scrap>
-                  <head/>
-                  <prodrecap id="DynamicFunctionCall" ref="DynamicFunctionCall"/>
-                  <prodrecap id="PositionalArgumentList" ref="PositionalArgumentList"/>              
-                  <prodrecap id="PositionalArguments" ref="PositionalArguments"/>  
-                  <prodrecap ref="Argument"/>
-                  <prodrecap ref="ArgumentPlaceholder"/>
+                  <prodrecap ref="DynamicFunctionCall"/>
                </scrap>
                
                <p>
@@ -10402,9 +10221,7 @@ return $a("A")]]></eg>
             <head>Named Function References</head>
 
             <scrap>
-               <head/>
-               <prodrecap id="NamedFunctionRef" ref="NamedFunctionRef"/>
-               <prodrecap ref="EQName"/>
+               <prodrecap ref="NamedFunctionRef"/>
             </scrap>
 
             <p>
@@ -10598,15 +10415,7 @@ return $a("A")]]></eg>
             </changes>
 
             <scrap>
-               <head/>
-               <prodrecap id="InlineFunctionExpr" ref="InlineFunctionExpr"/>
-               <prodrecap ref="Annotation" role="xquery"/>
-               <prodrecap ref="AnnotationValue" role="xquery"/>
-               <prodrecap ref="FunctionSignature" id="FunctionSignature"/>
-               <prodrecap id="ParamList" ref="ParamList"/>
-               <prodrecap ref="VarNameAndType"/>
-               <prodrecap id="TypeDeclaration" ref="TypeDeclaration"/>
-               <prodrecap ref="FunctionBody" role="xpath"/>
+               <prodrecap ref="InlineFunctionExpr"/>
             </scrap>
 
 
@@ -10962,9 +10771,7 @@ return $incrementors[2](4)]]></eg>
          <head>Path Expressions</head>
 
          <scrap>
-            <head/>
-            <prodrecap id="PathExpr" ref="PathExpr"/>
-            <prodrecap ref="RelativePathExpr"/>
+            <prodrecap ref="PathExpr"/>
          </scrap>
          <p>
             <termdef id="dt-path-expression" term="path expression"
@@ -11109,8 +10916,7 @@ return $incrementors[2](4)]]></eg>
             <head>Relative Path Expressions</head>
 
             <scrap>
-               <head/>
-               <prodrecap id="RelativePathExpr" ref="RelativePathExpr"/>
+               <prodrecap ref="RelativePathExpr"/>
             </scrap>
 
             <p>
@@ -11244,11 +11050,7 @@ return if (every $r in $R satisfies $r instance of node())
             <head>Steps</head>
             <scrap>
                <head/>
-               <prodrecap id="StepExpr" ref="StepExpr"/>
-               <prodrecap ref="AxisStep"/>
-               <prodrecap id="ForwardStep" ref="ForwardStep"/>
-               <prodrecap id="ReverseStep" ref="ReverseStep"/>
-               <prodrecap ref="Predicate"/>
+               <prodrecap ref="StepExpr"/>
             </scrap>
             <p>
                <termdef term="step" id="dt-step">A <term>step</term> is a part of a <termref
@@ -11324,10 +11126,10 @@ return if (every $r in $R satisfies $r instance of node())
                      <code>following-or-self</code>, and <code>following-sibling-or-self</code>.
                   </change>
                </changes>
+               
                <scrap>
-                  <head/>
-                  <prodrecap id="ForwardAxis" ref="ForwardAxis"/>
-                  <prodrecap id="ReverseAxis" ref="ReverseAxis"/>
+                  <prodrecap ref="ForwardAxis"/>
+                  <prodrecap ref="ReverseAxis"/>
                </scrap>
 
 
@@ -11695,15 +11497,9 @@ return if (every $r in $R satisfies $r instance of node())
       A node test determines which nodes contained by an axis are selected by a <termref
                         def="dt-step">step</termref>.</termdef>
                </p>
+               
                <scrap>
-                  <head/>
                   <prodrecap id="NodeTest" ref="NodeTest"/>
-                  <prodrecap id="UnionNodeTest" ref="UnionNodeTest"/>
-                  <prodrecap id="SimpleNodeTest" ref="SimpleNodeTest"/>
-                  <prodrecap id="NameTest" ref="NameTest"/>
-                  <prodrecap id="Wildcard" ref="Wildcard"/>
-                  <prodrecap ref="EQName"/>
-                  <prodrecap ref="KindTest"/>
                </scrap>
                
                <p diff="add" at="2022-12-13">A <nt def="UnionNodeTest">UnionNodeTest</nt> matches a node <var>N</var>
@@ -12048,9 +11844,7 @@ return if (every $r in $R satisfies $r instance of node())
             <head>Predicates within Steps</head>
 
             <scrap>
-               <head/>
-               <prodrecap id="AxisStep" ref="AxisStep"/>
-               <prodrecap ref="Predicate"/>
+               <prodrecap ref="AxisStep"/>
             </scrap>
             <p id="dt-predicate"
                   >A predicate within a <nt def="AxisStep"/> has similar syntax and semantics
@@ -12476,7 +12270,6 @@ last <code>chapter</code> or <code>appendix</code> child of the context node.</p
          <div3 id="abbrev">
             <head>Abbreviated Syntax</head>
             <scrap>
-               <head/>
                <prodrecap id="AbbrevForwardStep" ref="AbbrevForwardStep"/>
                <prodrecap id="AbbrevReverseStep" ref="AbbrevReverseStep"/>
             </scrap>
@@ -12793,7 +12586,6 @@ in the sequence <code>(1, 2, 3)</code>.</p>
          <div3 id="construct_seq">
             <head>Sequence Concatenation</head>
             <scrap>
-               <head/>
                <prodrecap ref="Expr"/>
             </scrap>
             <p>
@@ -12855,9 +12647,7 @@ the value <code>10.50</code>, the result of this expression is the sequence <cod
          <div3 id="id-range-expressions" diff="chg" at="A">
             <head>Range Expressions</head>
             <scrap>
-               <head/>
-               <!--<prodrecap id="ByExpr" ref="ByExpr"/>-->
-               <prodrecap id="RangeExpr" ref="RangeExpr"/>
+               <prodrecap ref="RangeExpr"/>
             </scrap>
             <p>A <term>RangeExpression</term> can be used to construct a sequence of 
 integers. Each of the operands is
@@ -12962,9 +12752,7 @@ every integer between the two operands, in increasing order. </p>
          <div3 id="combining_seq">
             <head>Combining Node Sequences</head>
             <scrap>
-               <head/>
-               <prodrecap id="UnionExpr" ref="UnionExpr"/>
-               <prodrecap id="IntersectExceptExpr" ref="IntersectExceptExpr"/>
+               <prodrecap ref="UnionExpr"/>
             </scrap>
             <p>&language; provides the following operators for combining sequences of
 nodes:</p>
@@ -13088,11 +12876,7 @@ the results are the same.
 multiplication, division, and modulus, in their usual binary and unary
 forms.</p>
          <scrap>
-            <head/>
-            <prodrecap id="AdditiveExpr" ref="AdditiveExpr"/>
-            <prodrecap id="MultiplicativeExpr" ref="MultiplicativeExpr"/>
-            <prodrecap id="UnaryExpr" ref="UnaryExpr"/>
-            <prodrecap id="ValueExpr" ref="ValueExpr"/>
+            <prodrecap ref="AdditiveExpr"/>
          </scrap>
          <p>A subtraction operator must be preceded by whitespace if
 it could otherwise be interpreted as part of the previous token. For
@@ -13266,8 +13050,7 @@ course to the use of parentheses. Therefore, the following two examples have dif
          <div3 id="id-string-concat-expr">
             <head>String Concatenation Expressions</head>
             <scrap>
-               <head/>
-               <prodrecap ref="StringConcatExpr" id="StringConcatExpr"/>
+               <prodrecap ref="StringConcatExpr"/>
             </scrap>
             <p>String concatenation expressions allow the string representations of values to be
                concatenated. In &language;, <code>$a || $b</code> is equivalent to
@@ -13287,11 +13070,7 @@ course to the use of parentheses. Therefore, the following two examples have dif
             </changes>
             
             <scrap>
-               <head/>
-               <prodrecap ref="StringTemplate" id="StringTemplate"/>
-               <prodrecap ref="StringTemplateFixedPart" id="StringTemplateFixedPart"/>
-               <prodrecap ref="StringTemplateVariablePart" id="StringTemplateVariablePart"/>
-               <prodrecap ref="EnclosedExpr"/>
+               <prodrecap ref="StringTemplate"/>
             </scrap>
             <p>String templates provide an alternative way of constructing strings. For example,
             the expression <code>`Pi is { round(math:pi(), 4) }`</code> returns the string <code>"Pi is 3.1416"</code>.</p>
@@ -13448,11 +13227,7 @@ return `The months with 31 days are: { $longMonths }.`]]></eg>
                delimiters in &language;.</p>
             
             <scrap>
-               <head/>
-               <prodrecap id="StringConstructor" ref="StringConstructor"/>
-               <prodrecap id="StringConstructorContent" ref="StringConstructorContent"/>
-               <prodrecap ref="StringConstructorChars" id="StringConstructorChars"/>
-               <prodrecap id="StringInterpolation" ref="StringInterpolation"/>
+               <prodrecap ref="StringConstructor"/>
             </scrap>
             
             <note diff="add" at="2023-01-29">
@@ -13597,12 +13372,7 @@ declare function local:prize-message($a) as xs:string {
 three kinds of comparison expressions, called value comparisons, general
 comparisons, and node comparisons.</p>
          <scrap>
-            <head/>
-            <prodrecap ref="ComparisonExpr" id="ComparisonExpr"/>
-            <prodrecap ref="ValueComp" id="ValueComp"/>
-            <prodrecap id="GeneralComp" ref="GeneralComp"/>
-            <prodrecap id="NodeComp" ref="NodeComp"/>
-
+            <prodrecap ref="ComparisonExpr"/>
          </scrap>
 
          <note role="xpath">
@@ -14078,9 +13848,7 @@ side occurs before the node identified by the right side in document order:</p>
 an <term>or-expression</term>. If a logical expression does not raise an error, its value is always one
 of the boolean values <code>true</code> or <code>false</code>.</p>
          <scrap>
-            <head/>
-            <prodrecap ref="OrExpr" id="OrExpr"/>
-            <prodrecap ref="AndExpr" id="AndExpr"/>
+            <prodrecap ref="OrExpr"/>
          </scrap>
          <p>The first step in evaluating a logical expression is to find the  <termref def="dt-ebv"
                >effective boolean value</termref> of each of its operands (see <specref ref="id-ebv"
@@ -14290,25 +14058,7 @@ encountered in finding the effective boolean value of its operand,
          <p>XQuery provides node constructors that can create XML nodes within a query.</p>
 
          <scrap>
-            <head/>
-            <prodrecap id="NodeConstructor" ref="NodeConstructor"/>
-            <prodrecap id="DirectConstructor" ref="DirectConstructor"/>
-            <prodrecap id="DirElemConstructor" ref="DirElemConstructor"/>
-            <prodrecap id="DirElemContent" ref="DirElemContent"/>
-            <prodrecap id="ElementContentChar" ref="ElementContentChar"/>
-            <prodrecap id="CommonContent" ref="CommonContent"/>
-            <prodrecap id="CDataSection" ref="CDataSection"/>
-            <prodrecap id="CDataSectionContents" ref="CDataSectionContents"/>
-            <prodrecap id="DirAttributeList" ref="DirAttributeList"/>
-            <prodrecap id="DirAttributeValue" ref="DirAttributeValue"/>
-
-            <prodrecap ref="QuotAttrValueContent" id="QuotAttrValueContent"/>
-            <prodrecap ref="AposAttrValueContent" id="AposAttrValueContent"/>
-            <prodrecap id="QuotAttrContentChar" ref="QuotAttrContentChar"/>
-            <prodrecap id="AposAttrContentChar" ref="AposAttrContentChar"/>
-            <prodrecap ref="EscapeQuot"/>
-            <prodrecap ref="EscapeApos"/>
-            <prodrecap ref="EnclosedExpr"/>
+            <prodrecap ref="NodeConstructor"/>
          </scrap>
 
          <p>Constructors are provided for element, attribute, document, text, comment, and processing instruction nodes. Two kinds of constructors are provided: <term>direct constructors</term>, which use an XML-like notation that can incorporate enclosed expressions, and <term>computed constructors</term>, which use a notation based on enclosed expressions. </p>
@@ -15279,14 +15029,7 @@ end of the content, or by a <nt
             <p>XQuery allows an expression to generate a processing instruction node or a comment node. This can be accomplished by using a <term>direct processing instruction constructor</term> or a <term>direct comment constructor</term>. In each case, the syntax of the constructor expression is
 based on the syntax of a similar construct in XML.</p>
             <scrap>
-               <head/>
-
-               <prodrecap id="DirPIConstructor" ref="DirPIConstructor"/>
-               <prodrecap id="DirPIContents" ref="DirPIContents"/>
-               <prodrecap id="DirCommentConstructor" ref="DirCommentConstructor"/>
-               <prodrecap id="DirCommentContents" ref="DirCommentContents"/>
-               <!--prodrecap id="PITarget" ref="PITarget" not included here
-because it invalidates the document.-->
+               <prodrecap ref="DirPIConstructor"/>
             </scrap>
             <p>A direct processing instruction constructor creates a processing instruction node whose <code>target</code> property is <nt
                   def="PITarget" id="PITarget"
@@ -15323,8 +15066,7 @@ because it invalidates the document.-->
             <head>Computed Constructors</head>
 
             <scrap>
-               <head/>
-               <prodrecap id="ComputedConstructor" ref="ComputedConstructor"/>
+               <prodrecap ref="ComputedConstructor"/>
             </scrap>
 
             <p>An alternative way to create nodes is by using a <term id="term-elem-ctor"
@@ -15394,12 +15136,7 @@ same result as the first example in <specref
                </changes>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="CompElemConstructor" ref="CompElemConstructor"/>
-                  <prodrecap id="CompNodeName" ref="CompNodeName"/>
-                  <prodrecap id="UnreservedName" ref="UnreservedName"/>
-                  <prodrecap id="EnclosedContentExpr" ref="EnclosedContentExpr"/>
-                  <prodrecap ref="EnclosedExpr"/>
+                  <prodrecap ref="CompElemConstructor"/>
                </scrap>
 
                <p>
@@ -15708,11 +15445,7 @@ element {
                   </change>
                </changes>
                <scrap>
-                  <head/>
-                  <prodrecap id="CompAttrConstructor" ref="CompAttrConstructor"/>
-                  <prodrecap ref="CompNodeName"/>
-                  <prodrecap ref="UnreservedName"/>
-                  <prodrecap ref="EnclosedExpr"/>
+                  <prodrecap ref="CompAttrConstructor"/>
                </scrap>
 
                <p>A computed attribute constructor creates a new attribute node,
@@ -16031,9 +15764,7 @@ attribute {
                <head>Document Node Constructors</head>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="CompDocConstructor" ref="CompDocConstructor"/>
-                  <prodrecap ref="EnclosedExpr"/>
+                  <prodrecap ref="CompDocConstructor"/>
                </scrap>
 
                <p>All document node constructors are computed constructors. The result of a document node constructor is a new document node, with its own node identity.</p>
@@ -16120,9 +15851,7 @@ attribute {
                <head>Text Node Constructors</head>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="CompTextConstructor" ref="CompTextConstructor"/>
-                  <prodrecap ref="EnclosedExpr"/>
+                  <prodrecap ref="CompTextConstructor"/>
                </scrap>
 
                <p>All text node constructors are computed constructors. The result of a text node constructor is a new text node, with its own node identity.</p>
@@ -16166,11 +15895,7 @@ attribute {
                </changes>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="CompPIConstructor" ref="CompPIConstructor"/>
-                  <prodrecap ref="CompNodeNCName"/>
-                  <prodrecap ref="UnreservedNCName"/>
-                  <prodrecap ref="EnclosedExpr"/>
+                  <prodrecap ref="CompPIConstructor"/>
                </scrap>
 
                <p>A computed processing instruction constructor (<nt def="CompPIConstructor"
@@ -16282,8 +16007,7 @@ return processing-instruction { $target } { "beep" }]]></eg>
 
                <scrap>
                   <head/>
-                  <prodrecap id="CompCommentConstructor" ref="CompCommentConstructor"/>
-                  <prodrecap ref="EnclosedExpr"/>
+                  <prodrecap ref="CompCommentConstructor"/>
                </scrap>
 
                <p>A computed comment constructor (<nt def="CompCommentConstructor"
@@ -16339,11 +16063,7 @@ return comment { concat($homebase, ", we have a problem.") }]]></eg>
                </changes>
                
                <scrap>
-                  <head/>
-                  <prodrecap id="CompNamespaceConstructor" ref="CompNamespaceConstructor"/>
-                  <prodrecap ref="CompNodeNCName"/>
-                  <prodrecap ref="UnreservedNCName"/>
-                  <prodrecap ref="EnclosedExpr"/>
+                  <prodrecap ref="CompNamespaceConstructor"/>
                </scrap>
 
 
@@ -16731,43 +16451,7 @@ element because it is defined by a <termref
          expressions, that can be used to bind variables to values. These are described in the
          following sections.</p>
          <scrap role="xquery">
-            <head/>
-            <prodrecap id="FLWORExpr" ref="FLWORExpr11" role="xquery"/>
-            <prodrecap id="InitialClause" ref="InitialClause" role="xquery"/>
-            <prodrecap id="IntermediateClause" ref="IntermediateClause" role="xquery"/>
-            <prodrecap id="ForClause" ref="ForClause"/>
-            <prodrecap id="ForBinding" ref="ForBinding"/>
-            <prodrecap id="ForItemBinding" ref="ForItemBinding"/>
-            <prodrecap id="ForMemberBinding" ref="ForMemberBinding"/>
-            <prodrecap id="ForEntryBinding" ref="ForEntryBinding"/>
-            <prodrecap id="ForEntryKeyBinding" ref="ForEntryKeyBinding"/>
-            <prodrecap id="ForEntryValueBinding" ref="ForEntryValueBinding"/>
-            <prodrecap id="LetClause" ref="LetClause"/>
-            <prodrecap id="LetBinding" ref="LetBinding"/>
-            <prodrecap id="VarNameAndType" ref="VarNameAndType"/>
-            <prodrecap ref="TypeDeclaration"/>
-            <prodrecap id="AllowingEmpty" ref="AllowingEmpty" role="xquery"/>
-            <prodrecap id="PositionalVar" ref="PositionalVar"/>
-            <prodrecap id="WindowClause" ref="WindowClause" role="xquery"/>
-            <prodrecap id="TumblingWindowClause" ref="TumblingWindowClause" role="xquery"/>
-            <prodrecap id="SlidingWindowClause" ref="SlidingWindowClause" role="xquery"/>
-            <prodrecap id="WindowStartCondition" ref="WindowStartCondition" role="xquery"/>
-            <prodrecap id="WindowEndCondition" ref="WindowEndCondition" role="xquery"/>
-            <prodrecap id="WindowVars" ref="WindowVars" role="xquery"/>
-            <prodrecap ref="CurrentVar" role="xquery"/>
-            <prodrecap ref="PreviousVar" role="xquery"/>
-            <prodrecap ref="NextVar" role="xquery"/>
-            <prodrecap ref="CountClause" role="xquery"/>
-            <prodrecap ref="WhereClause" role="xquery"/>
-            <prodrecap ref="WhileClause" role="xquery"/>
-            <prodrecap id="GroupByClause" ref="GroupByClause" role="xquery"/>
-            <prodrecap id="GroupingSpec" ref="GroupingSpec" role="xquery"/>
-            <!--<prodrecap id="GroupingVariable" ref="GroupingVariable" role="xquery"/>-->
-            <prodrecap ref="OrderByClause" role="xquery"/>
-            <prodrecap ref="OrderSpec" id="OrderSpec" role="xquery"/>
-            <prodrecap ref="OrderModifier" id="OrderModifier" role="xquery"/>
-            <prodrecap ref="ReturnClause" id="ReturnClause" role="xquery"/>
-            <prodrecap id="ForLetReturn" ref="ForLetReturn" role="xpath"/>
+            <prodrecap ref="FLWORExpr11"/>
          </scrap>
          <p role="xquery">The semantics of FLWOR expressions are based on a concept called a <term>tuple stream</term>. <termdef
                id="id-tuple-stream-foobar" term="tuple stream"
@@ -16887,18 +16571,9 @@ let $z := g($x, $y)]]></eg>
             </changes>
             
             <scrap>
-               <head/>
                <prodrecap ref="ForClause"/>
-               <prodrecap ref="ForBinding"/>
-               <prodrecap ref="ForItemBinding"/>
-               <prodrecap ref="ForMemberBinding"/>
-               <prodrecap ref="ForEntryBinding"/>
-               <prodrecap ref="ForEntryKeyBinding"/>
-               <prodrecap ref="ForEntryValueBinding"/>
-               <prodrecap ref="TypeDeclaration"/>
-               <prodrecap ref="AllowingEmpty"/>
-               <prodrecap ref="PositionalVar"/>
             </scrap>
+            
             <p>A <code>for</code> clause is used for iteration. Each variable in a <code>for</code> clause iterates over a 
                sequence, an array, or a map.</p>
             
@@ -17228,10 +16903,7 @@ for member $y in $expr2]]></eg>
                </change>
             </changes>
             <scrap>
-               <head/>
                <prodrecap ref="LetClause"/>
-               <prodrecap ref="LetBinding"/>
-               <prodrecap ref="TypeDeclaration"/>
             </scrap>
             <p>The purpose of a <code>let</code> clause is to bind values to one or more variables. Each variable is bound to the result of evaluating an expression.</p>
             <p>If a <code>let</code> clause contains multiple variables, it is semantically equivalent to multiple <code>let</code> clauses, each containing a single variable. For example, the clause</p>
@@ -17264,19 +16936,7 @@ let $e := doc("emps.xml")/emps/emp[deptno eq $d]]]></eg>
             </changes>
             
             <scrap>
-               <head/>
                <prodrecap ref="WindowClause"/>
-               <prodrecap ref="TumblingWindowClause"/>
-               <prodrecap ref="SlidingWindowClause"/>
-               <prodrecap ref="VarNameAndType"/>
-               <prodrecap ref="WindowStartCondition"/>
-               <prodrecap ref="WindowEndCondition"/>
-               <prodrecap ref="WindowVars"/>
-               <prodrecap id="CurrentVar" ref="CurrentVar"/>
-               <prodrecap ref="PositionalVar"/>
-               <prodrecap id="PreviousVar" ref="PreviousVar"/>
-               <prodrecap id="NextVar" ref="NextVar"/>
-               <prodrecap id="VarName" ref="VarName"/>
             </scrap>
 
             <p>Like a <code>for</code> clause, a <code>window</code> clause
@@ -17829,8 +17489,7 @@ group by $symbol]]></eg>
          <div3 id="id-where" role="xquery">
             <head>Where Clause</head>
             <scrap>
-               <head/>
-               <prodrecap id="WhereClause" ref="WhereClause"/>
+               <prodrecap ref="WhereClause"/>
             </scrap>
             <p>A <code>where</code> clause serves as a filter for the tuples in its input tuple stream. The expression in the <code>where</code> clause, called the <term>where-expression</term>, is evaluated once for
                each of these tuples. If the <termref
@@ -17883,8 +17542,7 @@ return $x</phrase>
             </changes>
             
             <scrap>
-               <head/>
-               <prodrecap id="WhileClause" ref="WhileClause"/>
+               <prodrecap ref="WhileClause"/>
             </scrap>
             
             <p>A <code>while</code> clause serves as a filter for the tuples 
@@ -17960,8 +17618,7 @@ return $x]]></eg>
          <div3 id="id-count" role="xquery">
             <head>Count Clause</head>
             <scrap>
-               <head/>
-               <prodrecap id="CountClause" ref="CountClause"/>
+               <prodrecap ref="CountClause"/>
             </scrap>
 
             <p>The purpose of a <code>count</code> clause is to enhance the tuple
@@ -18033,10 +17690,7 @@ return &lt;product rank="{ $rank }"&gt;{ $p/name, $p/sales }&lt;/product&gt;</eg
          <div3 id="id-group-by" role="xquery">
             <head>Group By Clause</head>
             <scrap>
-               <head/>
                <prodrecap ref="GroupByClause"/>
-               <prodrecap ref="GroupingSpec"/>
-               <prodrecap ref="VarNameAndType"/>
             </scrap>
 
 
@@ -18422,12 +18076,9 @@ return $product/@code</eg>
          <div3 id="id-order-by-clause" role="xquery">
             <head>Order By Clause</head>
             <scrap>
-               <head/>
-               <prodrecap id="OrderByClause" ref="OrderByClause"/>
-               <prodrecap ref="OrderSpec"/>
-               <prodrecap ref="OrderModifier"/>
-
+               <prodrecap ref="OrderByClause"/>
             </scrap>
+            
             <p>The purpose of an <code>order by</code> clause is to impose a value-based ordering on the tuples in the tuple stream. The output tuple stream of the <code>order by</code> clause contains the same tuples as its input tuple stream, but the tuples may be in a different order.</p>
             <p>An <code>order by</code> clause contains one or more ordering specifications, called <nt
                   def="OrderSpec"
@@ -18744,11 +18395,9 @@ return $b</eg>
          <div3 id="id-return-clause" role="xquery">
             <head>Return Clause</head>
             <scrap>
-               <head/>
-
-
                <prodrecap ref="ReturnClause"/>
             </scrap>
+            
             <p>The <code>return</code> clause is the final clause of a FLWOR expression. The <code>return</code> clause is evaluated once for each tuple in its input tuple stream,  using the variable bindings in the respective tuples, in the order in which these tuples appear in the input tuple stream. The results of these evaluations are concatenated, as if by the <termref
                   def="dt-comma-operator"
                >comma operator</termref>, to form the result of the FLWOR expression.</p>
@@ -18831,16 +18480,7 @@ return ($i, $j)]]></eg>
             members of an array, or the entries in a map.</p>
 
          <scrap>
-            <head/>
             <prodrecap ref="ForExpr"/>
-            <prodrecap ref="ForClause"/>
-            <prodrecap ref="ForBinding"/>
-            <prodrecap ref="ForItemBinding"/>
-            <prodrecap ref="ForMemberBinding"/>
-            <prodrecap ref="ForEntryBinding"/>
-            <prodrecap ref="ForLetReturn"/>
-            <prodrecap ref="TypeDeclaration"/>
-            <prodrecap ref="PositionalVar"/>
          </scrap>
 
          <p>A <code>for</code> expression is evaluated as follows:</p>
@@ -19089,12 +18729,7 @@ return $line/value]]></eg>
          <p>XPath allows a variable to be declared and bound to a value using a <term>let expression</term>.</p>
 
          <scrap>
-            <head/>
             <prodrecap ref="LetExpr"/>
-            <prodrecap ref="LetClause"/>
-            <prodrecap ref="LetBinding"/>
-            <prodrecap ref="ForLetReturn"/>
-            <prodrecap ref="TypeDeclaration"/>
          </scrap>
 
          <p>A let expression is evaluated as follows:</p>
@@ -19231,11 +18866,7 @@ processing with JSON processing.</p>
                <p>A map can be created using a <nt def="MapConstructor">MapConstructor</nt>.</p>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="MapConstructor" ref="MapConstructor"/>
-                  <prodrecap id="MapConstructorEntry" ref="MapConstructorEntry"/>
-                  <prodrecap id="MapKeyExpr" ref="MapKeyExpr"/>
-                  <prodrecap id="MapValueExpr" ref="MapValueExpr"/>
+                  <prodrecap ref="MapConstructor"/>
                </scrap>
                
                <note>
@@ -19512,10 +19143,7 @@ processing with JSON processing.</p>
 
                <p>An array is created using an <nt def="ArrayConstructor">ArrayConstructor</nt>.</p>
                <scrap>
-                  <head/>
-                  <prodrecap id="ArrayConstructor" ref="ArrayConstructor"/>
-                  <prodrecap id="SquareArrayConstructor" ref="SquareArrayConstructor"/>
-                  <prodrecap id="CurlyArrayConstructor" ref="CurlyArrayConstructor"/>
+                  <prodrecap ref="ArrayConstructor"/>
                </scrap>
 
                <p>
@@ -19704,14 +19332,7 @@ processing with JSON processing.</p>
                <head>Postfix Lookup Expressions</head>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="LookupExpr" ref="LookupExpr"/>
-                  <prodrecap id="Lookup" ref="Lookup"/>
-                  <prodrecap id="Modifier" ref="Modifier"/>
-                  <prodrecap id="KeySpecifier" ref="KeySpecifier"/>
-                  <prodrecap id="LookupWildcard" ref="LookupWildcard"/>
-                  <!--<prodrecap id="TypeQualifier" ref="TypeQualifier"/>-->
-                  
+                  <prodrecap ref="LookupExpr"/>
                </scrap>
                
                <p>A <code>Lookup</code> has two parts: the <code>KeySpecifier</code>
@@ -20000,12 +19621,7 @@ processing with JSON processing.</p>
                <head>Unary Lookup</head>
                
                <scrap>
-                  <head/>
-                  <prodrecap id="UnaryLookup" ref="UnaryLookup"/>
-                  <prodrecap ref="Modifier"/>
-                  <prodrecap ref="KeySpecifier"/>
-                  <prodrecap ref="LookupWildcard"/>
-                  <!--<prodrecap ref="TypeQualifier"/>-->
+                  <prodrecap ref="UnaryLookup"/>
                </scrap>
                
                
@@ -20500,8 +20116,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
             </changes>
 
                <scrap>
-                  <head/>
-                  <prodrecap id="FilterExprAM" ref="FilterExprAM"/>
+                  <prodrecap ref="FilterExprAM"/>
                </scrap>
             
             <p>Maps and arrays can be filtered using the construct <code><var>INPUT</var>?[<var>FILTER</var>]</code>.
@@ -20664,10 +20279,7 @@ return $map?[?key ge 2]</eg>
             </change>
          </changes>
          <scrap>
-            <head/>
-            <prodrecap id="OrderedExpr" ref="OrderedExpr"/>
-            <prodrecap id="UnorderedExpr" ref="UnorderedExpr"/>
-            <prodrecap ref="EnclosedExpr"/>
+            <prodrecap ref="OrderedExpr"/>
          </scrap>
 
          
@@ -20701,15 +20313,8 @@ return $map?[?key ge 2]</eg>
          </changes>
          
          <p diff="chg" at="2022-12-07">&language; allows conditional expressions to be written in several different ways.</p>
-         <scrap diff="chg" at="2023-01-10">
-            <head/>
-            <prodrecap id="IfExpr" ref="IfExpr"/>
-            <prodrecap id="UnbracedActions" ref="UnbracedActions"/>
-            <prodrecap id="BracedAction" ref="BracedAction"/>
-            <!--<prodrecap id="ThenAction" ref="ThenAction"/>
-            <prodrecap id="ElseIfAction" ref="ElseIfAction"/>
-            <prodrecap id="ElseAction" ref="ElseAction"/>-->
-            <prodrecap ref="EnclosedExpr"/>
+         <scrap>
+            <prodrecap ref="IfExpr"/>
          </scrap>
          
          <p>The braced expression <code>if (<var>C</var>) then {<var>T</var>}</code> is equivalent to the
@@ -20813,8 +20418,7 @@ else
          </changes>
          
          <scrap>
-            <head/>
-            <prodrecap id="OtherwiseExpr" ref="OtherwiseExpr"/>
+            <prodrecap ref="OtherwiseExpr"/>
          </scrap>
 
          <p>The <code>otherwise</code> expression returns the value of its first operand, unless this is an empty
@@ -20855,13 +20459,7 @@ else
             </change>
          </changes>
          <scrap>
-            <head/>
-            <prodrecap id="SwitchExpr" ref="SwitchExpr"/>
-            <prodrecap id="SwitchComparand" ref="SwitchComparand"/>
-            <prodrecap id="SwitchCases" ref="SwitchCases"/>
-            <prodrecap id="BracedSwitchCases" ref="BracedSwitchCases"/>
-            <prodrecap id="SwitchCaseClause" ref="SwitchCaseClause"/>
-            <prodrecap id="SwitchCaseOperand" ref="SwitchCaseOperand"/>
+            <prodrecap ref="SwitchExpr"/>
          </scrap>
          <p>
 The <term>switch expression</term> chooses one of several expressions to evaluate based on the
@@ -20974,12 +20572,11 @@ switch () {
          </changes>
          <p>Quantified expressions support existential and universal quantification. The
 value of a quantified expression is always <code>true</code> or <code>false</code>.</p>
+         
          <scrap>
-            <head/>
-            <prodrecap id="QuantifiedExpr" ref="QuantifiedExpr"/>
-            <prodrecap id="QuantifierBinding" ref="QuantifierBinding"/>
-            <prodrecap ref="TypeDeclaration"/>
+            <prodrecap ref="QuantifiedExpr"/>
          </scrap>
+         
          <p>A <term>quantified expression</term> begins with
 a <term>quantifier</term>, which is the keyword <code>some</code> or <code>every</code>, 
 followed by one or more in-clauses that are used to bind variables,
@@ -21169,14 +20766,7 @@ raised by the XQuery implementation and errors explicitly raised in a
 query using the <code>fn:error()</code> function.</p>
 
          <scrap>
-            <head/>
-            <prodrecap id="TryCatchExpr" ref="TryCatchExpr"/>
-            <prodrecap id="TryClause" ref="TryClause"/>
-            <!--<prodrecap id="EnclosedTryTargetExpr" ref="EnclosedTryTargetExpr"/>-->
-            <prodrecap id="CatchClause" ref="CatchClause"/>
-            <prodrecap ref="NameTestUnion"/>
-            <prodrecap ref="NameTest"/>
-            <prodrecap ref="EnclosedExpr"/>
+            <prodrecap ref="TryCatchExpr"/>
          </scrap>
 
 
@@ -21457,8 +21047,7 @@ type.
          <div3 id="id-instance-of">
             <head>Instance Of</head>
             <scrap>
-               <head/>
-               <prodrecap id="InstanceofExpr" ref="InstanceofExpr"/>
+               <prodrecap ref="InstanceofExpr"/>
             </scrap>
             <p>The boolean
 operator <code>instance of</code>
@@ -21545,12 +21134,7 @@ matching</termref>; otherwise it returns <code>false</code>. For example:</p>
             </changes>
             
             <scrap>
-               <head/>
-               <prodrecap id="TypeswitchExpr" ref="TypeswitchExpr"/>
-               <prodrecap id="TypeswitchCases" ref="TypeswitchCases"/>
-               <prodrecap id="BracedTypeswitchCases" ref="BracedTypeswitchCases"/>
-               <prodrecap id="CaseClause" ref="CaseClause"/>
-               <prodrecap id="SequenceTypeUnion" ref="SequenceTypeUnion"/>
+               <prodrecap ref="TypeswitchExpr"/>
             </scrap>
             <p role="xquery"
                   >The <term>typeswitch</term> expression chooses one of
@@ -21666,11 +21250,7 @@ be used to process an expression in a way that depends on its <termref
          <div3 id="id-cast">
             <head>Cast</head>
             <scrap>
-               <head/>
-               <prodrecap id="CastExpr" ref="CastExpr"/>
-               <prodrecap id="CastTarget" ref="CastTarget"/>
-               <prodrecap ref="ChoiceItemType"/>
-               <prodrecap ref="EnumerationType"/>
+               <prodrecap ref="CastExpr"/>
             </scrap>
             <p>Sometimes
 it is necessary to convert a value to a specific datatype. For this
@@ -21808,14 +21388,11 @@ The result of a cast expression is one of the following:
          </div3>
          <div3 id="id-castable">
             <head>Castable</head>
+            
             <scrap>
-               <head/>
-
-               <prodrecap id="CastableExpr" ref="CastableExpr"/>
-               <prodrecap ref="CastTarget"/>
-               <prodrecap ref="ChoiceItemType"/>
-               <prodrecap ref="EnumerationType"/>
+               <prodrecap ref="CastableExpr"/>
             </scrap>
+            
             <p>&language;
 provides an expression that tests whether a given value
 is castable into a given target type. 
@@ -21973,10 +21550,11 @@ usa:zipcode?)</code>.</p>
 
          <div3 id="id-treat">
             <head>Treat</head>
+            
             <scrap>
-               <head/>
-               <prodrecap id="TreatExpr" ref="TreatExpr"/>
+               <prodrecap ref="TreatExpr"/>
             </scrap>
+            
             <p>&language; provides an
 expression called <code>treat</code> that can be used to modify the
 <termref
@@ -22182,8 +21760,7 @@ return string-join($chopped, '; ')
 
 
          <scrap>
-            <head/>
-            <prodrecap id="SimpleMapExpr" ref="SimpleMapExpr"/>
+            <prodrecap ref="SimpleMapExpr"/>
          </scrap>
 
          <p>
@@ -22303,17 +21880,7 @@ return string-join($chopped, '; ')
          left-hand expression as the first argument to the function.</p>
 
          <scrap>
-            <head/>
-            <prodrecap id="ArrowExpr" ref="ArrowExpr"/>
-            <prodrecap id="SequenceArrowTarget" ref="SequenceArrowTarget"/>
-            <prodrecap id="MappingArrowTarget" ref="MappingArrowTarget"/>
-            <prodrecap id="LookupArrowTarget" ref="LookupArrowTarget"/>
-            <prodrecap id="ArrowTarget" ref="ArrowTarget"/>
-            <prodrecap id="ArrowStaticFunction" ref="ArrowStaticFunction"/>
-            <prodrecap id="ArrowDynamicFunction" ref="ArrowDynamicFunction"/>
-            <prodrecap ref="InlineFunctionExpr"/>
-            <prodrecap ref="ArgumentList"/>
-            <prodrecap ref="PositionalArgumentList"/>
+            <prodrecap ref="ArrowExpr"/>
          </scrap>
          
          <p>The arrow syntax is particularly helpful when applying multiple
@@ -22544,10 +22111,7 @@ return $rectangle =?> area()</eg>
          </changes>
 
          <scrap>
-            <head/>
-            <prodrecap id="ValidateExpr" ref="ValidateExpr"/>
-            <prodrecap id="ValidationMode" ref="ValidationMode"/>
-            <prodrecap ref="EnclosedExpr"/>
+            <prodrecap ref="ValidateExpr"/>
          </scrap>
 
          <p>A <code>validate</code> expression can be used to validate a
@@ -22866,10 +22430,7 @@ so that fallback behavior can be defined for implementations that do not
 recognize a particular extension.</p>
 
          <scrap>
-            <head/>
-            <prodrecap id="ExtensionExpr" ref="ExtensionExpr"/>
-            <prodrecap id="Pragma" ref="Pragma"/>
-            <prodrecap id="PragmaContents" ref="PragmaContents"/>
+            <prodrecap ref="ExtensionExpr"/>
          </scrap>
 
          <p>An extension expression consists of one or more <term>pragmas</term>, followed by an optional expression (the <term>associated expression</term>). <termdef

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -16725,16 +16725,13 @@ element because it is defined by a <termref
             <code>for</code>, <code>let</code>, <code>where</code>, <code>order by</code>, 
             and <code>return</code>, which introduce some of the clauses used in FLWOR expressions 
             (but this is not a complete list of such clauses.)</p>
-         <p role="xquery">The complete syntax of a FLWOR expression is shown here, and relevant parts 
-            of the syntax are repeated in subsequent sections of this document.</p>
+         <p role="xquery">The overall syntax of a FLWOR expression is shown here, and relevant parts 
+            of the syntax are expanded in subsequent sections.</p>
          <p role="xpath">XPath provides two closely-related expressions, called For and Let
-         expressions, that can be used to bind variables to values. The complete syntax is shown
-         here, and relevant parts 
-            of the syntax are repeated in subsequent sections of this document.</p>
-         <scrap>
+         expressions, that can be used to bind variables to values. These are described in the
+         following sections.</p>
+         <scrap role="xquery">
             <head/>
-            <prodrecap id="ForExpr" ref="ForExpr" role="xpath"/>
-            <prodrecap id="ForExpr" ref="LetExpr" role="xpath"/>
             <prodrecap id="FLWORExpr" ref="FLWORExpr11" role="xquery"/>
             <prodrecap id="InitialClause" ref="InitialClause" role="xquery"/>
             <prodrecap id="IntermediateClause" ref="IntermediateClause" role="xquery"/>

--- a/specifications/xquery-40/src/introduction.xml
+++ b/specifications/xquery-40/src/introduction.xml
@@ -130,10 +130,8 @@
 	<p>In the grammar productions in this document, named symbols are underlined and literal text is
 		enclosed in double quotes. For example, the following productions describe the syntax of a
 		static function call:</p>
-	<scrap>
-		<head/>
+	<scrap role="example">
 		<prodrecap ref="FunctionCall"/>
-		<prodrecap ref="ArgumentList"/>
 	</scrap>
 	<p>The productions should be read as follows: A function call consists of an <nt
 			def="EQName">EQName</nt> followed by an <nt def="ArgumentList">ArgumentList</nt>. The

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1066,7 +1066,7 @@ return $node/xx:bing]]>
     <head>Annotations</head>
 
     <scrap>
-      <prodrecap ref="AnnotatedDecl"/>
+      <prodrecap ref="Annotation"/>
     </scrap>
 
     <p>XQuery uses annotations to declare properties associated with functions (inline or declared
@@ -1155,12 +1155,12 @@ return $node/xx:bing]]>
     </changes>
 
     <scrap>
-      <prodrecap ref="AnnotatedDecl"/>
+      <prodrecap ref="VarDecl"/>
     </scrap>
 
 
 
-    <p><termdef id="dt-variable-declartion" term="variable declaration">A <term>variable declaration</term> 
+    <p><termdef id="dt-variable-declaration" term="variable declaration">A <term>variable declaration</term> 
       in the XQuery prolog defines the name and <termref def="dt-static-type">static
         type</termref> of a variable, and optionally a value for the variable. It adds to the 
         <termref def="dt-in-scope-variables">in-scope
@@ -1550,7 +1550,7 @@ declare context value as document-node()* := collection($uri); </eg>
  
 
     <scrap>
-      <prodrecap ref="AnnotatedDecl"/>
+      <prodrecap ref="FunctionDecl"/>
     </scrap>
 
     <p> A function declaration specifies whether the implementation of the function 
@@ -1887,7 +1887,7 @@ local:depth(doc("partlist.xml"))
     the <termref def="dt-item-type-designator"/> in full.</p>
     
     <scrap>
-      <prodrecap ref="AnnotatedDecl"/>
+      <prodrecap ref="ItemTypeDecl"/>
     </scrap>
     
     <p>An item type declaration adds a <termref def="dt-named-item-type"/> to the <termref def="dt-in-scope-named-item-types"/>
@@ -1986,7 +1986,7 @@ local:depth(doc("partlist.xml"))
     <p>The syntax is as follows:</p>
     
     <scrap>
-      <prodrecap ref="AnnotatedDecl"/>
+      <prodrecap ref="NamedRecordTypeDecl"/>
     </scrap>
     
     <p>A named record declaration serves as both a <termref def="dt-named-item-type"/> and as a 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2,16 +2,7 @@
 <div1 role="xquery" id="id-query-prolog">
   <head role="xquery">Modules and Prologs</head>
   <scrap>
-    <head/>
-    <prodrecap id="Module" ref="Module"/>
-
-    <prodrecap id="MainModule" ref="MainModule"/>
-    <prodrecap id="LibraryModule" ref="LibraryModule"/>
-    <prodrecap id="Prolog" ref="Prolog"/>
-    <prodrecap id="Setter" ref="Setter"/>
-    <prodrecap id="Import" ref="Import"/>
-    <prodrecap id="Separator" ref="Separator"/>
-    <prodrecap id="QueryBody" ref="QueryBody"/>
+    <prodrecap ref="Module"/>
   </scrap>
   <p>A query can be assembled from one or more fragments called <term>modules</term>. <termdef
       term="module" id="dt-module">A <term>module</term> is a fragment of XQuery code that conforms
@@ -62,8 +53,7 @@
     <head>Version Declaration</head>
 
     <scrap>
-      <head/>
-      <prodrecap id="VersionDecl" ref="VersionDecl"/>
+      <prodrecap ref="VersionDecl"/>
     </scrap>
 
     <p>
@@ -168,8 +158,7 @@
   <div2 id="id-module-declaration">
     <head>Module Declaration</head>
     <scrap>
-      <head></head>
-      <prodrecap id="ModuleDecl" ref="ModuleDecl"/>
+      <prodrecap ref="ModuleDecl"/>
     </scrap>
     <p>
       <termdef id="dt-module-declaration" term="module declaration">A <term>module
@@ -205,8 +194,7 @@
   <div2 id="id-boundary-space-decls">
     <head>Boundary-space Declaration</head>
     <scrap>
-      <head></head>
-      <prodrecap id="BoundarySpaceDecl" ref="BoundarySpaceDecl"/>
+      <prodrecap ref="BoundarySpaceDecl"/>
     </scrap>
     <p>
       <termdef id="dt-boundary-space-decl" term="boundary-space declaration">A <term>boundary-space
@@ -227,9 +215,7 @@
   <div2 id="id-default-collation-declaration">
     <head>Default Collation Declaration</head>
     <scrap>
-      <head></head>
-
-      <prodrecap id="DefaultCollationDecl" ref="DefaultCollationDecl"/>
+      <prodrecap ref="DefaultCollationDecl"/>
     </scrap>
     <p>
       <termdef term="default collation declaration" id="dt-default-collation-decl">A <term>default
@@ -258,8 +244,7 @@
   <div2 id="id-base-uri-decl">
     <head>Base URI Declaration</head>
     <scrap>
-      <head></head>
-      <prodrecap id="BaseURIDecl" ref="BaseURIDecl"/>
+      <prodrecap ref="BaseURIDecl"/>
     </scrap>
 
     <p>
@@ -307,9 +292,7 @@
   <div2 id="id-construction-declaration">
     <head>Construction Declaration</head>
     <scrap>
-      <head></head>
-
-      <prodrecap id="ConstructionDecl" ref="ConstructionDecl"/>
+      <prodrecap ref="ConstructionDecl"/>
     </scrap>
     <p>
       <termdef term="construction declaration" id="dt-construction-decl">A <term>construction
@@ -338,9 +321,7 @@
        </change>
     </changes>
     <scrap>
-      <head></head>
-
-      <prodrecap id="OrderingModeDecl" ref="OrderingModeDecl"/>
+      <prodrecap ref="OrderingModeDecl"/>
     </scrap>
     <p>
       The ordering mode declaration is retained from earlier XQuery versions,
@@ -356,9 +337,7 @@
   <div2 id="id-empty-order-decl">
     <head>Empty Order Declaration</head>
     <scrap>
-      <head></head>
-
-      <prodrecap id="EmptyOrderDecl" ref="EmptyOrderDecl"/>
+      <prodrecap ref="EmptyOrderDecl"/>
     </scrap>
     <p>
       <termdef term="empty order declaration" id="dt-empty-order-decl">An <term>empty order
@@ -380,10 +359,7 @@
   <div2 id="id-copy-namespaces-decl">
     <head>Copy-Namespaces Declaration</head>
     <scrap>
-      <head></head>
-      <prodrecap id="CopyNamespacesDecl" ref="CopyNamespacesDecl"/>
-      <prodrecap id="PreserveMode" ref="PreserveMode"/>
-      <prodrecap id="InheritMode" ref="InheritMode"/>
+      <prodrecap ref="CopyNamespacesDecl"/>
     </scrap>
 
     <p>
@@ -417,9 +393,7 @@ declaration">A
       </change>
     </changes>
     <scrap>
-      <head></head>
-      <prodrecap id="DecimalFormatDecl" ref="DecimalFormatDecl"/>
-      <prodrecap id="DFPropertyName" ref="DFPropertyName"/>
+      <prodrecap ref="DecimalFormatDecl"/>
     </scrap>
     
     <p>
@@ -509,10 +483,7 @@ return (
     </changes>
     
     <scrap>
-      <head></head>
-
-      <prodrecap id="SchemaImport" ref="SchemaImport"/>
-      <prodrecap id="SchemaPrefix" ref="SchemaPrefix"/>
+      <prodrecap ref="SchemaImport"/>
     </scrap>
 
 
@@ -691,9 +662,7 @@ return (
   <div2 id="id-module-import">
     <head>Module Import</head>
     <scrap>
-      <head></head>
-
-      <prodrecap id="ModuleImport" ref="ModuleImport"/>
+      <prodrecap ref="ModuleImport"/>
     </scrap>
     <p>
       <termdef term="module import" id="dt-module-import">A <term>module import</term> imports the
@@ -905,10 +874,7 @@ $triangle</eg>
       </change>
     </changes>
     <scrap>
-      <head></head>
-      <prodrecap id="NamespaceDecl" ref="NamespaceDecl"/>
-
-
+      <prodrecap ref="NamespaceDecl"/>
     </scrap>
 
     <p>
@@ -999,9 +965,7 @@ return $node/xx:bing]]>
       </change>
     </changes>
     <scrap>
-      <head></head>
-      <prodrecap id="DefaultNamespaceDecl" ref="DefaultNamespaceDecl"/>
-
+      <prodrecap ref="DefaultNamespaceDecl"/>
     </scrap>
     <p>
       <term>Default namespace declarations</term> can be used in a <termref def="dt-prolog"
@@ -1102,11 +1066,7 @@ return $node/xx:bing]]>
     <head>Annotations</head>
 
     <scrap>
-      <head></head>
-      <prodrecap id="AnnotatedDecl" ref="AnnotatedDecl"/>
-      <prodrecap ref="InlineFunctionExpr"/>
-      <prodrecap id="Annotation" ref="Annotation"/>
-      <prodrecap id="AnnotationValue" ref="AnnotationValue"/>
+      <prodrecap ref="AnnotatedDecl"/>
     </scrap>
 
     <p>XQuery uses annotations to declare properties associated with functions (inline or declared
@@ -1195,15 +1155,7 @@ return $node/xx:bing]]>
     </changes>
 
     <scrap>
-      <head></head>
       <prodrecap ref="AnnotatedDecl"/>
-      <prodrecap ref="Annotation"/>
-      <prodrecap id="VarDecl" ref="VarDecl"/>
-      <prodrecap ref="VarNameAndType"/>
-      <prodrecap ref="VarName"/>
-      <prodrecap ref="TypeDeclaration"/>
-      <prodrecap id="VarValue" ref="VarValue"/>
-      <prodrecap id="VarDefaultValue" ref="VarDefaultValue"/>
     </scrap>
 
 
@@ -1438,8 +1390,7 @@ declare function local:f() { $b }; </eg>
     </changes>
 
     <scrap>
-      <head></head>
-      <prodrecap id="ContextValueDecl" ref="ContextValueDecl"/>
+      <prodrecap ref="ContextValueDecl"/>
     </scrap>
 
     <!-- ================================================================== -->
@@ -1598,17 +1549,8 @@ declare context value as document-node()* := collection($uri); </eg>
  
  
 
-    <scrap diff="chg" at="variadicity">
-      <head></head>
+    <scrap>
       <prodrecap ref="AnnotatedDecl"/>
-      <prodrecap ref="Annotation"/>
-      <prodrecap id="FunctionDecl" ref="FunctionDecl"/>
-      <prodrecap id="ParamListWithDefaults" ref="ParamListWithDefaults"/>
-      <prodrecap id="ParamWithDefault" ref="ParamWithDefault"/>
-      <prodrecap ref="Param"/>
-      <prodrecap id="FunctionBody" ref="FunctionBody"/>
-      <prodrecap ref="TypeDeclaration"/>
-      <prodrecap ref="EnclosedExpr"/>
     </scrap>
 
     <p> A function declaration specifies whether the implementation of the function 
@@ -1945,10 +1887,7 @@ local:depth(doc("partlist.xml"))
     the <termref def="dt-item-type-designator"/> in full.</p>
     
     <scrap>
-      <head></head>
       <prodrecap ref="AnnotatedDecl"/>
-      <prodrecap ref="Annotation"/>
-      <prodrecap id="ItemTypeDecl" ref="ItemTypeDecl"/>
     </scrap>
     
     <p>An item type declaration adds a <termref def="dt-named-item-type"/> to the <termref def="dt-in-scope-named-item-types"/>
@@ -2047,13 +1986,7 @@ local:depth(doc("partlist.xml"))
     <p>The syntax is as follows:</p>
     
     <scrap>
-      <head></head>
       <prodrecap ref="AnnotatedDecl"/>
-      <prodrecap ref="Annotation"/>
-      <prodrecap id="NamedRecordTypeDecl" ref="NamedRecordTypeDecl"/>
-      <prodrecap id="ExtendedFieldDeclaration" ref="ExtendedFieldDeclaration"/>
-      <prodrecap ref="FieldDeclaration"/>
-      <prodrecap ref="FieldName"/>
     </scrap>
     
     <p>A named record declaration serves as both a <termref def="dt-named-item-type"/> and as a 
@@ -2308,11 +2241,9 @@ return $box =?> area()</eg>
         implementation. Each option consists of an identifying EQName and a StringLiteral.</termdef>
     </p>
     <scrap>
-      <head></head>
-      <prodrecap id="OptionDecl" ref="OptionDecl"/>
-
-
+      <prodrecap ref="OptionDecl"/>
     </scrap>
+    
     <p>Typically, a particular option will be recognized by some implementations and not by others.
       The syntax is designed so that option declarations can be successfully parsed by all
       implementations.</p>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!DOCTYPE spec SYSTEM "../schema/xsltspec.dtd">
-<!-- 
-   Draft A. xsl:if, xsl:when/xsl:otherwise, xsl:switch
---><spec xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" w3c-doctype="rec" status="int-review"><!--role="editors-copy"--> 
+<spec xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+      w3c-doctype="rec" status="int-review"><!--role="editors-copy"--> 
  
    <header>
       <title>XSL Transformations (XSLT)</title>
@@ -9720,23 +9719,7 @@ and <code>version="1.0"</code> otherwise.</p>
                            variables</xtermref> are defined by the <termref def="dt-variable-binding-element">variable binding elements</termref>
                         that are in scope for the containing element (see <specref ref="variables-and-parameters"/>).</p>
                   </item>
-                  <!--<item>
-                     <p>The <xtermref spec="XP40" ref="dt-context-value-static-type">context value
-                           static type</xtermref> may be determined by an XSLT processor that
-                        performs static type inferencing, using rules that are outside the scope of
-                        this specification; if no static type inferencing is done, then the context
-                        value static type for every XPath expression is <code>item()</code>.</p>
-                        
-                        <note diff="add" at="2023-10-30"><p>Although XPath 4.0 allows the context value to be an arbitrary sequence,
-                        at the interface between XSLT 4.0 and XPath 4.0 it is always either a single item,
-                        or absent. The only exception to this is when an XPath 4.0 expression is evaluated
-                        using <elcode>xsl:evaluate</elcode>, in which case the <xtermref spec="XP40" ref="dt-context-value"/>
-                        may be supplied as an arbitrary sequence.</p></note>
-                        
-                        <note><p>Note that some limited static type inferencing is
-                           required in the case of a processor that performs streamability analysis:
-                           see <specref ref="determining-static-type"/>.</p></note>
-                  </item>-->
+                  
                   <item>
                      <p>The <xtermref spec="XP40" ref="dt-statically-known-function-definitions">statically known
                            function definitions</xtermref> are:</p>
@@ -10716,20 +10699,16 @@ and <code>version="1.0"</code> otherwise.</p>
                      <p>Where an attribute is defined to contain a <termref def="dt-pattern">pattern</termref>, it is a <termref def="dt-static-error">static
                            error</termref> if the pattern does not match the production <nt def="Pattern40">Pattern40</nt>.</p>
                   </error></p>
-               <p>The grammar for patterns uses the notation defined in <xspecref spec="XP40" ref="EBNFNotation">Notation</xspecref>. </p>
+               <p>The complete grammar for patterns is listed in <specref ref="pattern-syntax-summary"/>. 
+                  It uses the notation defined in <xspecref spec="XP40" ref="EBNFNotation">Notation</xspecref>. </p>
                <p>The lexical rules for patterns are the same as the lexical rules
                   for XPath expressions, as defined in <xspecref spec="XP40" ref="lexical-structure">Lexical structure</xspecref>. Comments are permitted between tokens, using the
                   syntax <code>(: ... :)</code>. All other provisions of the XPath grammar apply
                   where relevant, for example the rules for whitespace handling and
                   extra-grammatical constraints.</p>
                
-               <scrap headstyle="show" id="Patterns-scrap" diff="add" at="2022-01-01">
-                  <head></head>
-                  
-                  <prodrecap ref="Pattern40" id="Pattern40"/>
-                  <prodrecap ref="PredicatePattern" id="PredicatePattern"/>
-                  <prodrecap ref="TypePattern" id="TypePattern"/>
-                  <prodrecap ref="NodePattern" id="NodePattern"/>
+               <scrap headstyle="show" id="Patterns-scrap" >
+                  <prodrecap ref="Pattern40"/>
                </scrap>
                
                <p diff="add" at="2022-01-01">Patterns fall into three groups:</p>
@@ -10754,9 +10733,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   <head>Predicate Patterns</head>
                   
                   <scrap headstyle="show" id="PredicatePatterns-scrap">
-                     <head></head>
                      <prodrecap ref="PredicatePattern"/>
-                     <prodrecap ref="Predicate" id="Predicate"/>
                   </scrap>
                   
                   <p>A <nt def="PredicatePattern">PredicatePattern</nt>
@@ -10806,21 +10783,7 @@ and <code>version="1.0"</code> otherwise.</p>
                   </changes>
                   
                   <scrap headstyle="show" id="TypePatterns-scrap">
-                     <head></head>
                      <prodrecap ref="TypePattern"/>
-                     <prodrecap ref="WrappedItemTest" id="WrappedItemTest"/>
-                     <prodrecap ref="ChoiceItemType" id="ChoiceItemType"/>
-                     <prodrecap ref="AnyItemTest" id="AnyItemTest"/>
-                     <prodrecap ref="FunctionType" id="FunctionType"/>
-                     <prodrecap ref="MapType" id="MapType"/>
-                     <prodrecap ref="ArrayType" id="ArrayType"/>
-                     <prodrecap ref="RecordType" id="RecordType"/>
-                     <prodrecap ref="FieldDeclaration" id="FieldDeclaration"/>
-                     <prodrecap ref="FieldName" id="FieldName"/>
-                     <prodrecap ref="ExtensibleFlag" id="ExtensibleFlag"/>
-                     <prodrecap ref="EnumerationType" id="EnumerationType"/>
-                     <prodrecap ref="TypeName" id="TypeName"/>
-                     <prodrecap ref="Predicate"/>
                   </scrap>
                   
       
@@ -10888,26 +10851,7 @@ and <code>version="1.0"</code> otherwise.</p>
                
 
                <scrap id="NodePatterns-scrap">
-                  <head></head>
-
                   <prodrecap ref="NodePattern"/>
-                  <prodrecap ref="UnionExprP" id="UnionExprP"/>
-                  <prodrecap ref="IntersectExceptExprP" id="IntersectExceptExprP"/>
-                  <prodrecap ref="PathExprP" id="PathExprP"/>
-                  <prodrecap ref="RootedPath" id="RootedPath"/>
-                  <prodrecap ref="FunctionCallP" id="FunctionCallP"/>
-                  <prodrecap ref="OuterFunctionName" id="OuterFunctionName"/>
-                  <prodrecap ref="ArgumentListP" id="ArgumentListP"/>
-                  <prodrecap ref="ArgumentP" id="ArgumentP"/>
-                  <prodrecap ref="RelativePathExprP" id="RelativePathExprP"/>
-                  <prodrecap ref="StepExprP" id="StepExprP"/>
-                  <prodrecap ref="PostfixExprP" id="PostfixExprP"/>
-                  <prodrecap ref="ParenthesizedExprP" id="ParenthesizedExprP"/>
-                  <prodrecap ref="AxisStepP" id="AxisStepP"/>
-                  <prodrecap ref="ForwardStepP" id="ForwardStepP"/>
-                  <prodrecap ref="ForwardAxisP" id="ForwardAxisP"/>
-
-
                </scrap>
                
                <p>Node Patterns are used to match XDM nodes.</p>
@@ -19299,13 +19243,8 @@ and <code>version="1.0"</code> otherwise.</p>
                
                <p diff="add" at="2023-05-19">The <xtermref spec="XP40" ref="dt-static-context"/> for the 
                   initializing expression of an optional parameter of an <elcode>xsl:function</elcode> declaration
-                  is the same as the static context for a <termref def="dt-static-expression"/>, 
-                  with the following exceptions:</p>
-               
-               <ulist diff="add" at="2023-05-19">
-                
-                  <item><p>The <xtermref spec="XP40" ref="dt-context-value-static-type"/> is <code>item()*</code>.</p></item>
-               </ulist>
+                  is the same as the static context for a <termref def="dt-static-expression"/>.</p>
+
                
                <p diff="add" at="2023-05-19">The <xtermref  spec="XP40" ref="dt-dynamic-context"/> for the initializing 
                   expression of an optional parameter 
@@ -25689,7 +25628,7 @@ the same group, and the-->
 
                <note>
                   <p>An alternative solution to this requirement is to use map constructors: see
-                        <specref ref="map-constructors"/>.</p>
+                        <xspecref spec="XP40" ref="id-map-constructors"/>.</p>
                </note>
             </example>
 
@@ -33467,7 +33406,7 @@ the same group, and the-->
                   <head>Streamability of Map Constructors</head>
 
                   <p>The <termref def="dt-posture"/> and <termref def="dt-sweep"/> of a map
-                     constructor (see <specref ref="map-constructors"/>) are the same as the
+                     constructor (see <xspecref spec="XP40" ref="id-map-constructors"/>) are the same as the
                         <termref def="dt-posture"/> and <termref def="dt-sweep"/> of the equivalent
                         <elcode>xsl:map</elcode> instruction. The equivalent
                         <elcode>xsl:map</elcode> instruction is formed by creating a sequence of
@@ -35895,79 +35834,7 @@ the same group, and the-->
             </div3>
          </div2>
 
-         <div2 id="map-constructors" diff="del" at="2022-01-01">
-            <head>Map Constructors</head>
-            <p>A Map Constructor is a new kind of expression added to the syntax of XPath.</p>
-            <note>
-               <p>Map Constructors are defined in XPath 3.1. They are available in XSLT 3.0 whether
-                  or not XPath 3.1 is supported. The specification given here is intended to be
-                  identical to the specification in XPath 3.1.</p>
-            </note>
-            <p>The syntax of <xnt spec="XP40" ref="doc-xpath40-PrimaryExpr">PrimaryExpr</xnt> is
-               extended to permit <code>MapConstructor</code> as an additional alternative.</p>
-
-            <scrap headstyle="show" id="MapConstructor-scrap">
-               <head>MapConstructor</head>
-               <prodgroup>
-                  <prod num="52" id="NT-PrimaryExpr">
-                     <lhs>PrimaryExpr</lhs>
-                     <rhs>Literal | VarRef | ParenthesizedExpr | ContextItemExpr | FunctionCall |
-                        FunctionItemExpr<br/> | MapConstructor</rhs>
-                  </prod>
-
-                  <prod num="202" id="NT-MapConstructor">
-                     <lhs>MapConstructor</lhs>
-                     <rhs>"map" "{" (MapConstructorEntry ("," MapConstructorEntry )*)? "}" </rhs>
-                  </prod>
-                  <prod num="203" id="NT-MapConstructorEntry">
-                     <lhs>MapConstructorEntry</lhs>
-                     <rhs>MapKeyExpr ":" MapValueExpr </rhs>
-                  </prod>
-                  <prod num="204" id="NT-MapKeyExpr">
-                     <lhs>MapKeyExpr</lhs>
-                     <rhs><xnt ref="doc-xpath40-ExprSingle" spec="XP40">ExprSingle</xnt></rhs>
-                  </prod>
-                  <prod num="205" id="NT-MapValueExpr">
-                     <lhs>MapValueExpr</lhs>
-                     <rhs><xnt ref="doc-xpath40-ExprSingle" spec="XP40">ExprSingle</xnt></rhs>
-                  </prod>
-               </prodgroup>
-            </scrap>
-
-
-
-            <note>
-               <p>In some circumstances, it is necessary to include whitespace
-                  before or after the colon to ensure that this grammar is correctly parsed; this
-                  arises for example when the <code>KeyExpr</code> ends with a name and the
-                     <code>ValueExpr</code> starts with a name. </p>
-            </note>
-
-            <p>The value of the expression is a map whose entries correspond to the key-value pairs
-               obtained by evaluating the successive <code>KeyExpr</code> and <code>ValueExpr</code>
-               expressions.</p>
-            <p>Each <code>KeyExpr</code> expression is evaluated and atomized; a type error <xerrorref spec="XP40" class="TY" code="0004"/> occurs if the result is not a single atomic item. If the key is of
-               type <code>xs:untypedAtomic</code> it is converted to <code>xs:string</code>. The
-               associated value is the result of evaluating the corresponding
-                  <code>ValueExpr</code>. If two or more entries have the <term>same key</term> then 
-               a dynamic error occurs <errorref spec="XT" class="DE" code="3365"/>.</p>
-            <p>For example, the following expression constructs a map with seven entries:</p>
-            <eg role="non-xml" xml:space="preserve">
-{
-  "Su" : "Sunday",
-  "Mo" : "Monday",
-  "Tu" : "Tuesday",
-  "We" : "Wednesday",
-  "Th" : "Thursday",
-  "Fr" : "Friday",
-  "Sa" : "Saturday"
-}</eg>
-            <note>
-               <p>Unlike the <function>map:merge</function> function, the number of entries in a map
-                  that is constructed using a map expression is known statically.</p>
-            </note>
-
-         </div2>
+         
          
          <div2 id="maps-streaming">
             <head>Maps and Streaming</head>
@@ -39540,6 +39407,42 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                elsewhere.</p>
          </note>
          <?error-summary?>
+      </inform-div1>
+      <inform-div1 id="pattern-syntax-summary">
+         <head>Pattern Syntax Summary</head>
+         
+         <p>This appendix gives the grammar for XSLT patterns. The top-level rule for
+         patterns is <nt ref="Pattern40"/>.</p>
+         
+         <p>This is an extension of the grammar for XPath expressions.
+            The extended BNF notation is explained at <xspecref spec="XP40" ref="EBNFNotation"/>.</p>
+         
+         <p>Productions that are identical to their counterparts in XPath 4.0 are suffixed
+         <code>XP</code> and link to the corresponding production in the XPath 4.0 specification.
+         Productions whose names end with <code>P</code> are restrictions of the corresponding
+         XPath production: for example, <code>ArgumentListP</code> is a restricted form of the
+         XPath production <code>ArgumentList</code>.</p>
+         
+         <div2 id="ebnf-for-patterns">
+         <scrap id="BNF-Grammar" role="non-terminal-structure-expand">
+            <prodgroup>
+              <prodrecap id="BNF-Grammar-prods" ref="BNF-Grammar-prods"/>
+            </prodgroup>
+         </scrap>
+         </div2>
+         <div2 id="terminal-symbols">
+            <head>Terminal Symbols</head>
+            <scrap headstyle="show">
+              <head/>
+              <prodrecap id="DefinedLexemes" ref="DefinedLexemes"/>
+            </scrap>
+            <p>The following symbols represent portions of terminal symbols; they are not
+              themselves terminal symbols referenced in the grammar.</p>
+            <scrap headstyle="show">
+              <head/>
+              <prodrecap id="LocalTerminalSymbols" ref="LocalTerminalSymbols"/>
+            </scrap>
+          </div2>
       </inform-div1>
       <inform-div1 id="implementation-defined-features">
          <head>Checklist of Implementation-Defined Features</head>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -39412,7 +39412,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
          <head>Pattern Syntax Summary</head>
          
          <p>This appendix gives the grammar for XSLT patterns. The top-level rule for
-         patterns is <nt ref="Pattern40"/>.</p>
+         patterns is <nt def="Pattern40"/>.</p>
          
          <p>This is an extension of the grammar for XPath expressions.
             The extended BNF notation is explained at <xspecref spec="XP40" ref="EBNFNotation"/>.</p>

--- a/specifications/xslt-40/style/convert-grammar.xsl
+++ b/specifications/xslt-40/style/convert-grammar.xsl
@@ -52,27 +52,5 @@
     <xsl:next-match/>
   </xsl:template>
   
-<!--  <xsl:template match="nt[@def]">
-    <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
-    <xsl:variable name="grammar" select="document($fn,.)"/>
-    <xsl:variable name="orig">
-      <xsl:call-template name="get-gnotation"/>
-    </xsl:variable>
-    
-    <nt>
-      <xsl:attribute name="def">
-        <xsl:variable name="def" select="@def"/>
-        <!-\- Override "hack" in base template so we always link to doc- -\->
-        <xsl:text>doc-</xsl:text>
-        <xsl:if test="true()">
-          <xsl:value-of select="$grammar/g:grammar/g:language/@id"/>
-          <xsl:text>-</xsl:text>
-        </xsl:if>
-        <xsl:value-of select="@def"/>
-      </xsl:attribute>
-      <xsl:apply-templates/>
-    </nt>
-  </xsl:template>-->
-  
 </xsl:stylesheet>
 

--- a/specifications/xslt-40/style/xslt.xsl
+++ b/specifications/xslt-40/style/xslt.xsl
@@ -82,7 +82,8 @@
 
           <xsl:choose>
             <xsl:when test="$pcount gt 0">
-              <xsl:message select="'Cannot reach occurrence #' || $pcount+1 || ' of ' || $name"/>
+              <!-- MHK: dropped the message, we just link to the first occurrence and this is harmless -->
+              <!--<xsl:message select="'In function finder, cannot reach occurrence #' || $pcount+1 || ' of xsl:' || $name"/>--> 
             </xsl:when>
             <xsl:otherwise>
               <option><xsl:sequence select="'xsl:' || @name || '&#8291;'"/></option>

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -3836,11 +3836,11 @@ described in <specref ref="text-output"/>.</p></item>
 
 <item><p>
 An <termref def="dt-array-item">array item</termref> is serialized using the syntax 
-of a <xspecref spec="XP40" ref="doc-xpath40-SquareArrayConstructor"/>, 
-that is as <code>[member,member, ... ]</code>. The members, which in general are sequences, 
-are serialized in the form <code>(item,item, ...)</code> where the items are serialized by 
+of a <xnt spec="XP40" ref="SquareArrayConstructor"/>, 
+that is as <code>[member, member, ... ]</code>. The members, which in general are sequences, 
+are serialized in the form <code>(item, item, ...)</code> where the items are serialized by 
 applying these rules recursively. The items are separated by commas 
-(not by the item-separator character). The enclosing parentheses are optional if the sequence 
+(not by the <code>item-separator</code> character). The enclosing parentheses are optional if the sequence 
 has length one. </p>
 <note><p>The serializer should avoid outputting the parentheses if it is able 
 to determine the length of the sequence before serializing the first item; but it is allowed 

--- a/style/assemble-spec.xsl
+++ b/style/assemble-spec.xsl
@@ -148,7 +148,17 @@
       </xsl:call-template>
     </xsl:for-each>
   </xsl:template>
+  
+  <!-- MHK 2025-01-19: ignore a prodrecap that isn't the first in a scrap -->
+  
+  <xsl:variable name="principal-productions" select="//prodrecap[not(preceding-sibling::prodrecap)]"/>
+  <xsl:template match="prodrecap[preceding-sibling::prodrecap]"/>
 
+  <!-- Handle a prodrecap that is the first in a scrap -->
+  <!-- MHK 2025-01-19: ignore any subsequent prodrecap elements; instead, decide which productions
+       to include in this scrap algorithmically. The logic is basically to include all productions
+       in the subtree of this one that are not themselves principal productions, where a principal
+       production is one that is the first production in its own scrap. -->
   <xsl:template match="prodrecap">
 
     <xsl:variable name="debugging" select="false()"/>
@@ -382,16 +392,20 @@
       <xsl:attribute name="def">
         <xsl:variable name="def" select="@def"/>
         <xsl:choose>
-          <!-- Bit of a hack here.  The problem is no doc def exists for some productions.  -->
-          <!-- In any case, perhaps -->
-          <!--   there should other criteria to decide if we link to the exposition or not! -->
+          <xsl:when test="$def = $principal-productions/@id">doc-</xsl:when>
+          <xsl:otherwise>prod-</xsl:otherwise>
+        </xsl:choose>
+        <!--<xsl:choose>
+          <!-\- Bit of a hack here.  The problem is no doc def exists for some productions.  -\->
+          <!-\- In any case, perhaps -\->
+          <!-\-   there should other criteria to decide if we link to the exposition or not! -\->
           <xsl:when test="$grammar/g:grammar//g:token[@name=$def and @is-xml='yes']">
             <xsl:text>prod-</xsl:text>
           </xsl:when>
           <xsl:otherwise>
             <xsl:text>doc-</xsl:text>
           </xsl:otherwise>
-        </xsl:choose>
+        </xsl:choose>-->
         <xsl:if test="true()">
           <xsl:value-of select="$grammar/g:grammar/g:language/@id"/>
           <xsl:text>-</xsl:text>

--- a/style/assemble-spec.xsl
+++ b/style/assemble-spec.xsl
@@ -25,7 +25,7 @@
 
   <!-- xsl:variable name="grammar" select="document($grammar-file)"/ -->
   <xsl:variable name="sourceTree" select="/"/>
-  <xsl:variable name="prodrecaps" select="//prodrecap"/>
+  <xsl:variable name="prodrecaps" select="//prodrecap[not(parent::*/@role='example')]"/>
 
   <!-- Generate a comment that identifies as much as we can about the XSLT processor being used -->
   <xsl:template match="/" priority="100">
@@ -149,16 +149,14 @@
     </xsl:for-each>
   </xsl:template>
   
-  <!-- MHK 2025-01-19: ignore a prodrecap that isn't the first in a scrap -->
   
-  <xsl:variable name="principal-productions" select="//prodrecap[not(preceding-sibling::prodrecap)]"/>
-  <xsl:template match="prodrecap[preceding-sibling::prodrecap]"/>
-
-  <!-- Handle a prodrecap that is the first in a scrap -->
-  <!-- MHK 2025-01-19: ignore any subsequent prodrecap elements; instead, decide which productions
+  <xsl:variable name="principal-productions" select="$prodrecaps"/>
+  
+  <!-- Handle a prodrecap -->
+  <!-- MHK 2025-01-19: We now decide which productions
        to include in this scrap algorithmically. The logic is basically to include all productions
        in the subtree of this one that are not themselves principal productions, where a principal
-       production is one that is the first production in its own scrap. -->
+       production is one that appears in its own scrap. -->
   <xsl:template match="prodrecap">
 
     <xsl:variable name="debugging" select="false()"/>
@@ -172,7 +170,7 @@
       </xsl:comment>
     </xsl:if>
 
-    <xsl:variable name="name" select="@ref"/>
+    <xsl:variable name="name" select="@ref" as="attribute(ref)"/>
 
     <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
     <xsl:variable name="grammar" select="document($fn,.)"/>

--- a/style/assemble-spec.xsl
+++ b/style/assemble-spec.xsl
@@ -91,46 +91,22 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template name="get-gnotation">
-    <!-- Assumes predrecap context -->
-    <xsl:variable name="k" select="@orig"/>
-    <xsl:choose>
-      <xsl:when test="$k">
-        <xsl:variable name="gfn" select="document($grammar-map-file-name,.)//*[string(@name)=string($k)]"/>
-        <xsl:value-of select="$gfn/@notation"/>
-        <!-- xsl:message>
-          <xsl:text>grammar file: </xsl:text><xsl:value-of select="$gfn"/>
-          <xsl:text>, k: '</xsl:text><xsl:value-of select="$k"/><xsl:text>'</xsl:text>
-        </xsl:message -->
-      </xsl:when>
-      <xsl:otherwise>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
 
 
   <xsl:template match="prodrecap[@id='DefinedLexemes' or @role='DefinedLexemes']">
     <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
     <xsl:variable name="grammar" select="document($fn,.)"/>
-    <xsl:variable name="orig">
-      <xsl:call-template name="get-gnotation"/>
-    </xsl:variable>
     <xsl:for-each select="$grammar/g:grammar">
-      <xsl:call-template name="add-terminals">
-        <!--<xsl:with-param name="orig" select="$orig"/>-->
-      </xsl:call-template>
+      <xsl:call-template name="add-terminals"/>
     </xsl:for-each>
   </xsl:template>
 
   <xsl:template match="prodrecap[@id='LocalTerminalSymbols' or @role='LocalTerminalSymbols']">
     <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
     <xsl:variable name="grammar" select="document($fn,.)"/>
-    <!--<xsl:variable name="orig">
-      <xsl:call-template name="get-gnotation"/>
-    </xsl:variable>-->
+
     <xsl:for-each select="$grammar/g:grammar">
       <xsl:call-template name="add-terminals">
-        <!--<xsl:with-param name="orig" select="$orig"/>-->
         <xsl:with-param name="do-local-terminals" select="true()"/>
       </xsl:call-template>
     </xsl:for-each>
@@ -139,20 +115,16 @@
   <xsl:template match="prodrecap[@id='BNF-Grammar-prods' or @role='BNF-Grammar-prods']">
     <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
     <xsl:variable name="grammar" select="document($fn,.)"/>
-    <!--<xsl:variable name="orig">
-      <xsl:call-template name="get-gnotation"/>
-    </xsl:variable>-->
 
     <xsl:for-each select="$grammar/g:grammar">
       <xsl:call-template name="add-non-terminals">
-        <!--<xsl:with-param name="orig" select="$orig"/>-->
       </xsl:call-template>
     </xsl:for-each>
   </xsl:template>
   
   
   
-  <!-- Handle a prodrecap -->
+  <!-- Handle a general prodrecap -->
   <!-- MHK 2025-01-19: We now decide which productions
        to include in each scrap algorithmically. The logic is basically to include all productions
        in the subtree of this one that are not themselves principal productions, where a principal
@@ -196,59 +168,14 @@
 
     <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
     <xsl:variable name="grammar" select="document($fn,.)"/>
-    <xsl:variable name="orig">
-      <xsl:call-template name="get-gnotation"/>
-    </xsl:variable>
-
-    <xsl:if test="$debugging">
-      <xsl:comment>
-        DEBUG: template match="prodrecap" ...
-        $fn      = '<xsl:value-of select="$fn"/>'
-        $grammar = [the document at $fn]
-        $orig    = '<xsl:value-of select="$orig"/>'
-      </xsl:comment>
-    </xsl:if>
-
-    <xsl:variable name="result_id_noid_part">
-      <xsl:if test="not(@id)">
-        <!-- pull some nasty trick to handle multiply defined productions. -->
-        <!-- Don wants this... -->
-        <!-- Don't change the 'noid_' text... "lhs-text" template depends on it. -->
-        <xsl:value-of select="concat('noid_', generate-id(.), '.')"/>
-      </xsl:if>
-    </xsl:variable>
-
-    <!--
-        Note that in this template, we're only concerned with
-        whether or not @id is present; we ignore any value it has.
-    -->
-
-    <xsl:if test="$debugging">
-      <xsl:comment>
-        DEBUG: template match="prodrecap" ...
-        Calling template "show-prod"
-        with parameters:
-          name         = <xsl:value-of select="$name"/>
-          orig         = <xsl:value-of select="$orig"/>
-          result_id_noid_part   = <xsl:value-of select="$result_id_noid_part"/>
-      </xsl:comment>
-    </xsl:if>
 
     <xsl:for-each select="$grammar"> 
       <!-- switch context to the grammar document -->
       <xsl:call-template name="show-prod">
         <xsl:with-param name="name" select="$name"/>
-        <!--<xsl:with-param name="orig" select="$orig"/>-->
-        <xsl:with-param name="result_id_noid_part" select="$result_id_noid_part"/>
         <xsl:with-param name="id-prefix" select="$id-prefix" tunnel="yes"/>
       </xsl:call-template>
     </xsl:for-each>
-
-    <xsl:if test="$debugging">
-      <xsl:comment>
-        DEBUG: template match="prodrecap" exiting
-      </xsl:comment>
-    </xsl:if>
 
   </xsl:template>
 
@@ -400,9 +327,6 @@
   <xsl:template match="nt[@def]">
     <xsl:variable name="fn"><xsl:call-template name="get-gfn"/></xsl:variable>
     <xsl:variable name="grammar" select="document($fn,.)"/>
-    <xsl:variable name="orig">
-      <xsl:call-template name="get-gnotation"/>
-    </xsl:variable>
 
     <nt>
       <xsl:attribute name="def">
@@ -411,19 +335,8 @@
           <xsl:when test="$def = $prodrecaps/@ref">doc-</xsl:when>
           <xsl:otherwise>prod-</xsl:otherwise>
         </xsl:choose>
-        <!--<xsl:choose>
-          <!-\- Bit of a hack here.  The problem is no doc def exists for some productions.  -\->
-          <!-\- In any case, perhaps -\->
-          <!-\-   there should other criteria to decide if we link to the exposition or not! -\->
-          <xsl:when test="$grammar/g:grammar//g:token[@name=$def and @is-xml='yes']">
-            <xsl:text>prod-</xsl:text>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>doc-</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>-->
+
         <xsl:if test="true()">
-          <!--<xsl:value-of select="$grammar/g:grammar/g:language/@id"/>-->
           <xsl:value-of select="$spec"/>
           <xsl:text>-</xsl:text>
         </xsl:if>

--- a/style/grammar2spec.xsl
+++ b/style/grammar2spec.xsl
@@ -567,8 +567,8 @@
   <xsl:template name="show-prod">
     <xsl:param name="name"/>
     <xsl:param name="id-prefix" as="xs:string" tunnel="yes" select="''"/>
-    <xsl:param name="result_id_noid_part"/>
-
+    <!--<xsl:param name="result_id_noid_part"/>
+-->
     <xsl:variable name="production" select="key('defns_by_name', $name)
                             [not(@alias-for and not(@inline='false'))]"/>
 
@@ -602,7 +602,7 @@
       <xsl:call-template name="make-prod">
         <xsl:with-param name="id-generator" 
                         select="function($name) {$id-prefix || 'doc-' || $spec || '-' || $name}"/>
-        <xsl:with-param name="result_id_noid_part" select="$result_id_noid_part"/>
+        <!--<xsl:with-param name="result_id_noid_part" select="$result_id_noid_part"/>-->
         <xsl:with-param name="result_id_docprod_part" select="'doc-'"/>
       </xsl:call-template>
     </xsl:for-each>
@@ -613,7 +613,7 @@
       <xsl:call-template name="make-prod">
         <xsl:with-param name="id-generator" 
                         select="function($name) {$id-prefix || 'doc-' || $spec || '-' || $scrap-root-name || '-' || $name}"/>
-        <xsl:with-param name="result_id_noid_part" select="$result_id_noid_part"/>
+        <!--<xsl:with-param name="result_id_noid_part" select="$result_id_noid_part"/>-->
         <xsl:with-param name="result_id_docprod_part" select="'NONE'"/>
       </xsl:call-template>
     </xsl:for-each>
@@ -673,15 +673,23 @@
       </xsl:if>
   </xsl:template>
   
- 
+  <xsl:template match="g:ref[@unfold='yes']" mode="gather-sub-productions" as="element(*)?">
+      <xsl:param name="subtree-root" as="element(*)" tunnel="yes"/>
+      <xsl:param name="depth" as="xs:integer"/>
+      <xsl:variable name="this" select="."/>
+      <xsl:apply-templates select="key('defns_by_name', $this/@name)">
+         <xsl:with-param name="depth" select="$depth"/>
+      </xsl:apply-templates>
+  </xsl:template>
+  
+  <!-- Make a production rule -->
 
   <xsl:template name="make-prod">
     <!-- A function to generate an ID for the production rule, given the production name -->
     <xsl:param name="id-generator" as="function(xs:string) as xs:string"/>
-    <!-- A function to generate a link for the LHS -->
-    <xsl:param name="lhs-link-generator" as="(function(xs:string) as xs:string)?" select="()"/>
+    <!-- A prefix to be used to make the ID unique, for example 'example-' -->
     <xsl:param name="id-prefix" as="xs:string" tunnel="yes" select="''"/>
-    <xsl:param name="result_id_noid_part" select="''"/>
+    <!--<xsl:param name="result_id_noid_part" select="''"/>-->
     <xsl:param name="result_id_docprod_part"/> <!-- 'doc-' or 'prod-' or "NONE"-->
 
     <xsl:variable name="base_language_id" select="$spec (: (/g:grammar/g:language/@id)[1] :)"/>

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -1230,17 +1230,30 @@
           </xsl:attribute>
         </xsl:if>-->
 
+        <xsl:variable name="id-parts" select="tokenize(../@id, '-')"/>
         <xsl:choose>
-          <!-- Make a link to the production table ... -->
-          <xsl:when test="starts-with(../@id,'doc-')
-                          and id(concat('prod-',substring-after(../@id,'doc-')))">
+          <!-- For a principal production in the document body, make a link to the appendix ... -->
+          <xsl:when test="$id-parts[1] = 'doc'
+                          and id('prod-' || substring-after(../@id,'doc-'))">
             <code>
-              <a href="#{concat('prod-',substring-after(../@id,'doc-'))}">
+              <a href="#prod-{substring-after(../@id, 'doc-')}">
                 <xsl:apply-templates/>
               </a>
             </code>
           </xsl:when>
-          <!-- Make a link to the lhs in the doc ... -->
+          <!-- For a subsidiary production in the document body, make a link to the appendix ... -->
+          <xsl:when test="$id-parts[1] = 'doc'
+                          and $id-parts[3] = ../../prod[1]/lhs[1]
+                          and id('prod-' || $id-parts[2] || '-' || string(.))">
+            <!-- for example: doc-xpath40-SequenceType-ItemType links to prod-xpath40-ItemType -->
+            <code>
+              <a href="#prod-{$id-parts[2]}-{.}">
+                <xsl:apply-templates/>
+              </a>
+            </code>
+          </xsl:when>
+          <!-- For a production in the appendix corresponding to a principal production in the
+            document body, make a link to the inline version ... -->
           <xsl:when test="starts-with(../@id,'prod-')
                           and id(concat('doc-',substring-after(../@id,'prod-')))">
             <code>

--- a/style/xmlspec-override.xsl
+++ b/style/xmlspec-override.xsl
@@ -14,12 +14,6 @@
     ... which see for decls of 'show-markup', 'show.diff.markup', etc.
   -->
 
-  <!--
-  <xsl:import href="issues.xsl"/>
-  <xsl:include href="issues-spec.xsl"/>
-  <xsl:param name="issues-file" select="'issues.xml'"/>
-  -->
-
   <xsl:output method="xml" encoding="utf-8"/>
 
   <xsl:param name="additional.css.2"/>
@@ -41,27 +35,6 @@
     <xsl:comment><xsl:value-of select="$XSLTprocessor"/></xsl:comment>
     <xsl:apply-templates/>
   </xsl:template> 
-
-  <!--========= Issues related templates ========== -->
-  <!--
-  <xsl:template match="p[@id='issues-list']">
-    <xsl:apply-templates select="document($issues-file)"/>
-  </xsl:template>
-  -->
-
-  <!-- mode: number -->
-  <!-- xsl:template mode="number-simple" match="prod">
-    <xsl:text>[</xsl:text>
-    <xsl:choose>
-      <xsl:when test="lhs/@number-id">
-        <xsl:value-of select="lhs/@number-id"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:text>XX</xsl:text>
-      </xsl:otherwise>
-    </xsl:choose>
-    <xsl:text>]</xsl:text>
-  </xsl:template -->
 
   <!-- ===================================================================== -->
   <!-- Templates that deal with EBNF -->
@@ -210,15 +183,17 @@
             <xsl:value-of select="."/>
           </xsl:otherwise>
         </xsl:choose>
-
-        <!--
+        
+        <!-- Following code deleted by MHK 2025-01-21. For rationale see QT4 issue 1719. -->
+<!--
+        <!-\-
           Our inability to create a link for $ref-id may be a sign of
           something wrong, so we'll print a message saying so, unless
           its one of the cases where it's expected...
-        -->
+        -\->
         <xsl:variable name="doc_designation" select="ancestor::spec/header/w3c-designation"/>
 
-        <!--
+        <!-\-
           Exception #1:
           In specs for language extensions (update, scripting, full text),
           the appendix provides EBNF for the whole language (base + extension),
@@ -226,7 +201,7 @@
           Thus, in the appendix, the LHS symbol in a base language production,
           which wants to point to the corresponding production in the doc body,
           doesn't have one to point to.
-        -->
+        -\->
         <xsl:variable name="exception_for_extension_to_base" select="
             (
               contains($doc_designation, 'xquery-update-10')
@@ -267,20 +242,20 @@
             )
           "/>
 
-        <!--
+        <!-\-
           Also, the Update 1.0 doc has Core productions in the body,
           but they're not collected in an appendix. So we expect
           inability to link from the former to the latter.
-        -->
+        -\->
         <xsl:variable name="exception_for_update10_core" select="
             contains($doc_designation, 'xquery-update-10')
             and
             starts-with($ref-id, 'prod-core-')
           "/>
 
-        <xsl:if test="not($exception_for_extension_to_base) and not($exception_for_update10_core)">
+        <!-\-<xsl:if test="not($exception_for_extension_to_base) and not($exception_for_update10_core)">
           <xsl:message>Warning: link-text-with-check was unable to make a link for $ref-id="<xsl:value-of select="$ref-id"/>"</xsl:message>
-        </xsl:if>
+        </xsl:if>-\->-->
 
       </xsl:otherwise>
     </xsl:choose>

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -1195,6 +1195,24 @@
       </xsl:choose>
     </a>
   </xsl:template>
+  
+  <!-- Matching of production names within the RHS of a production rule in the document body -->
+  <xsl:template match="scrap/prod/rhs//nt">
+    <xsl:variable name="localDefn" select="ancestor::scrap/prod[lhs = current()]"/>
+    <xsl:choose>
+      <!-- If the relevant rule appears within the same scrap -->
+      <xsl:when test="exists($localDefn)">
+        <a href="#{$localDefn/@id}"><xsl:value-of select="."/></a>
+      </xsl:when>
+      <!-- If the relevant rule is the head rule of another scrap -->
+      <xsl:when test="exists(//prod[@id=replace(current()!@def, '^prod-', 'doc-')])">
+        <a href="#{replace(@def, '^prod-', 'doc-')}"><xsl:value-of select="."/></a>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:next-match/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
 
   <!-- ====================================================================== -->

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -4,7 +4,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:my="http://www.w3.org/qtspecs/build/functions"
   exclude-result-prefixes="my xs"
-  version="2.0"
+  version="3.0"
 >
   
   <!-- Modified version of xsl-query.xsl produced November 2016 to produce HTML5 -->
@@ -947,20 +947,10 @@
         </a>
       </xsl:when>
       <xsl:when test="not($nt)">
-        <xsl:message>
-          <xsl:text>Error: cannot resolve xnt </xsl:text>
-          <xsl:value-of select="@ref"/>
-          <xsl:text> in </xsl:text>
-          <xsl:value-of select="@spec"/>
-          <xsl:text> at id=</xsl:text>
-          <xsl:value-of select="(ancestor::*/@id)[last()]"/>
-        </xsl:message>
+        <xsl:message expand-text='1'>Error: cannot resolve xnt {@ref} in {@spec
+          } at id={(ancestor::*/@id)[last()]}</xsl:message>  
         <span class="markup-error">
-          <xsl:text>[NT </xsl:text>
-          <xsl:value-of select="@ref"/>
-          <xsl:text> IN </xsl:text>
-          <xsl:value-of select="@spec"/>
-          <xsl:text>]</xsl:text>
+          <xsl:text expand-text='1'>[NT {@ref} IN {@spec}]</xsl:text>
           <xsl:apply-templates/>
         </span>
       </xsl:when>
@@ -1169,14 +1159,9 @@
                           else key('ids', $doc-def)"/>
 
     <xsl:if test="not($target)">
-      <xsl:message>
-        <xsl:text>Error: cannot resolve nt: </xsl:text>
-        <xsl:value-of select="@def"/>
-      </xsl:message>
+      <xsl:message expand-text="1">Error: cannot resolve nt: {@def} at {(ancestor::*/@id)[last()]}</xsl:message>
       <span class="markup-error">
-        <xsl:text>[ERROR: no </xsl:text>
-        <xsl:value-of select="@def"/>
-        <xsl:text>]</xsl:text>
+        <xsl:text expand-text="1">[ERROR: no nt {@def}]</xsl:text>
       </span>
     </xsl:if>
     <a>
@@ -1197,6 +1182,8 @@
   </xsl:template>
   
   <!-- Matching of production names within the RHS of a production rule in the document body -->
+  <!-- Added by MHK 21 Jan 2025 -->
+  
   <xsl:template match="scrap/prod/rhs//nt">
     <xsl:variable name="localDefn" select="ancestor::scrap/prod[lhs = current()]"/>
     <xsl:choose>


### PR DESCRIPTION
The main change here is to change the way "scraps" are expanded: these are the local collections of production rules that appear inline within the spec. These are now driven by a single `prodrecap` element naming the rule to be expanded, and the logic is now automated for deciding (a) which subsidiary production rules to include in the scrap, and (b) which occurrence of a production rule to use as the target for a hyperlinked reference to that rule, depending on where the reference appears.

Along with this there has been a fair bit of deletion of legacy code and general modernisation (e.g using XSLT 2.0 and 3.0 constructs where appropriate).