### PR TITLE
1725 Define more detailed rules for duplicates in maps

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23027,7 +23027,7 @@ xs:QName('xs:double')</eg></fos:result>
                   <termref
                      def="dt-same-key"
                      >same key</termref>, then the way this is handled is
-                  controlled by the second (<code>$options</code>) argument.</p>
+                  controlled by the <code>$options</code> argument.</p>
             </item>
          </olist>
 
@@ -23046,6 +23046,22 @@ xs:QName('xs:double')</eg></fos:result>
                   >option parameter conventions</termref> apply.
             </p>
             </item>
+            <item><p>In the event that two or more entries in the input maps have the 
+               <termref def="dt-same-key"/>:</p>
+               <olist>
+                  <item><p>A single entry is created by combining the values of the duplicates,
+                  in a way determined by the supplied <code>$options</code>.</p></item>
+                  <item><p>The key of the combined entry is one of the duplicate keys: 
+                     which one is chosen is <termref def="implementation-defined"/>.
+                  (Two keys that are deemed duplicates may differ: for example they may have
+                  different type annotations, or they may be <code>xs:dateTime</code>
+                   values with different timezones.)</p></item>
+                  <item><p>The position of the combined entry in the <xtermref spec="DM40" ref="dt-entry-order"/>
+                  of the result map corresponds to the position of the first appearance of
+                  the corresponding key value in the input.</p></item>
+               </olist>
+            
+            </item>
             <item>
                <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
 
@@ -23055,74 +23071,57 @@ xs:QName('xs:double')</eg></fos:result>
                         taken if two maps in the input sequence <code>$maps</code> contain entries with key values
                         <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
                         <termref
-                           def="dt-same-key">same key</termref>.
+                           def="dt-same-key">same key</termref>. This option and the <code>combine</code>
+                        option are mutually exclusive.
                      </fos:meaning>
                      <fos:type>xs:string</fos:type>
                      <fos:default>use-first</fos:default>
                      <fos:values>
-                        <fos:value value="reject"
-                              >
-                           An error is raised <errorref class="JS"
-                              code="0003"
-                           /> if duplicate keys are encountered.
+                        <fos:value value="reject">
+                           Equivalent to specifying <code>"combine": fn(){error(xs:QName("err:FOJS0003"), ...)</code>
+                           (the remaining arguments to <function>fn:error</function> being
+                           <termref def="implementation-defined"/>).
                         </fos:value>
                         <fos:value value="use-first"
-                              >
-                           If duplicate keys are present, all but the first of a set of duplicates are ignored, 
-                           where the ordering is based on the order of maps in the <code>$maps</code> argument.
+                              >Equivalent to specifying <code>"combine": fn($a, $b){ $a }</code>.
                         </fos:value>
                         <fos:value value="use-last"
-                              >
-                           If duplicate keys are present, all but the last of a set of duplicates are ignored, 
-                           where the ordering is based on the order of maps in the <code>$maps</code> argument.
+                              >Equivalent to specifying <code>"combine": fn($a, $b){ $b }</code>.
                         </fos:value>
                         <fos:value value="use-any"
-                              >
-                           If duplicate keys are present, all but one of a set of duplicates are ignored, 
-                           and it is <termref
-                              def="implementation-dependent"
-                           >implementation-dependent</termref>
-                           which one is retained. 
+                              >Equivalent to specifying <code>"combine": fn($a, $b){ one-of($a, $b) }</code>
+                           where <code>one-of</code> chooses either <code>$a</code> or <code>$b</code> in
+                           an <termref def="implementation-defined"/> way.
                         </fos:value>
                         <fos:value value="combine"
-                              >
-                           If duplicate keys are present, the result map includes an entry for the key whose 
-                           associated value is the 
-                           <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> 
-                           of all the values associated with the key, 
-                           retaining order based on the order of maps in the <code>$maps</code> argument.
-                           The key value in the result map that corresponds to such a set of duplicates must
-                           be the <termref
-                              def="dt-same-key"
-                              >same key</termref> as each of the duplicates, but it is
-                           otherwise unconstrained: for example if the duplicate keys are <code>xs:byte(1)</code>
-                           and <code>xs:short(1)</code>, the key in the result could legitimately be <code>xs:long(1)</code>.
+                              >Equivalent to specifying <code>"combine": fn($a, $b){ $a, $b }</code>.
                         </fos:value>
                      </fos:values>
                   </fos:option>
-                  <!--<fos:option key="retain-order">
-                     <fos:meaning>Determines the 
-                        <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of the
-                        entries in the returned map, as well as the value of the map’s 
-                        <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref> property.
-                     </fos:meaning>
-                     <fos:type>xs:boolean</fos:type>
-                     <fos:default>false</fos:default>
-                     <fos:values>
-                        <fos:value value="false">
-                           The <code>ordered</code> property of the returned map is <code>false</code>, and its
-                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                           is <termref def="implementation-dependent"/>.
-                        </fos:value>
-                        <fos:value value="insertion">
-                           The <code>ordering</code> property of the returned map is <code>true</code>, and its
-                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                           reflects the order of the maps supplied in <code>$maps</code>,
-                           and within each input map, the <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                           of the entries in that map.
-                        </fos:value>
-                     </fos:values>
-                  </fos:option>-->
+ 
+                  <fos:option key="combine">
+                        <fos:meaning>Supplies a function for handling duplicate keys: specifically, the action to be
+                           taken if two maps in the input sequence <code>$maps</code> contain entries with key values
+                           <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
+                           <termref
+                              def="dt-same-key">same key</termref>. This option and the <code>duplicates</code>
+                           option are mutually exclusive.
+                        </fos:meaning>
+                        <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
+                        <fos:default>fn($a, $b){ $a }</fos:default>
+                        <fos:values>
+                           <fos:value value="User-supplied function">
+                              A function with signature <code>fn(item()*, item()*) as item()*</code>.
+                              The function is called for any entry in an input map that has the 
+                              <termref def="dt-same-key"/> as a previous entry. The first argument
+                              is the existing value associated with the key; the second argument
+                              is the value associated with the key in the duplicate input entry,
+                              and the result is the new value to be associated with the key.
+                           </fos:value>
+                        </fos:values>
+                              
+                     </fos:option>
+
                </fos:options>
 
                
@@ -23133,26 +23132,24 @@ xs:QName('xs:double')</eg></fos:result>
       </fos:rules>
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
 let $FOJS0003 := QName("http://www.w3.org/2005/xqt-errors", "FOJS0003")
-let $duplicates-handler := {
-  "use-first": fn($a, $b) { $a },
-  "use-last":  fn($a, $b) { $b },
-  "combine":   fn($a, $b) { $a, $b },
-  "reject":    fn($a, $b) { fn:error($FOJS0003) },
-  "use-any":   fn($a, $b) { fn:random-number-generator()?permute(($a, $b))[1] }
-}
-let $combine := fn($A as map(*), $B as map(*), $deduplicator as fn(*)) {
-  fold-left(map:keys($B), $A, fn($z, $k) { 
-    if (map:contains($z, $k))
-    then map:put($z, $k, $deduplicator($z($k), $B($k)))
-    else map:put($z, $k, $B($k))
-  })
-}
-return fold-left($maps, {},
-  $combine(?, ?, $duplicates-handler($options?duplicates otherwise "use-first"))
-)        
+let $combiner := $options?combine
+  otherwise {
+      "use-first": fn($a, $b) { $a },
+      "use-last":  fn($a, $b) { $b },
+      "combine":   fn($a, $b) { $a, $b },
+      "reject":    fn($a, $b) { fn:error($FOJS0003) },
+      "use-any":   fn($a, $b) { fn:random-number-generator()?permute(($a, $b))[1] }
+    } ($options?duplicates)
+  otherwise        fn($a, $b) { $a }
+  
+return map:of-pairs($maps =!> map:pairs(), { "combine": $combiner });  
       </fos:equivalent>
      
       <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="RG" code="0013"
+               /> if both the <code>combine</code> and <code>duplicates</code>
+            options are present.</p>
+         
          <p>An error is raised <errorref spec="FO" class="JS" code="0003"
                /> if the value of 
           <code>$options</code> indicates that duplicates are to be rejected, and a duplicate key is encountered.</p>
@@ -23165,17 +23162,18 @@ return fold-left($maps, {},
 
       <fos:notes>
          <note>
-            <p>By way of explanation, <code>$combine</code> is a function that combines
-            two maps by iterating over the keys of the second map, adding each key and its corresponding
-            value to the first map as it proceeds. The second call of <function>fn:fold-left</function>
-            in the <code>return</code> clause then iterates over the maps supplied in the call
-            to <function>map:merge</function>, accumulating a single map that absorbs successive maps
-            in the input sequence by calling <code>$combine</code>.</p>
-
-
-            <p>This algorithm processes the supplied maps in a defined order, but processes the keys within
-         each map in implementation-dependent order.</p>
-
+            <p>By way of explanation, the function first reduces the sequence of input maps
+               to a sequence of key-value pairs, retaining order of both the maps and of the
+               entries within each map. It then combines key-value pairs having the
+               <termref def="dt-same-key"/> by applying the <code>$combine</code> function
+               successively to pairs of duplicates. The position in the <xtermref spec="DM40" ref="dt-entry-order"/>
+               of the result map of an entry formed by combining duplicates corresponds to the
+               position of the first occurrence of the key in the input sequence. This is true
+               even whien the option <code>use-last</code> is used: the value of the resulting
+               entry corresponds to the last entry with a given key, but the position of the entry
+               in the result map corresponds to the position of the first entry with that key.
+            </p>
+            
             <p>The use of <function>fn:random-number-generator</function> represents one possible conformant
          implementation for <code>"duplicates": "use-any"</code>, but it is not the only conformant
          implementation and is not intended to be a realistic implementation. The purpose of this
@@ -23270,6 +23268,14 @@ return fold-left($maps, {},
 
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="1725">
+            <p>For consistency with the new functions <function>map:build</function>
+            and <function>map:of-pairs</function>, the handling of duplicates
+            may now be controlled by the <code>combine</code> option as an alternative
+            to the existing <code>duplicates</code> option.</p>
+         </fos:change>
+      </fos:changes>
    </fos:function>
 
    <fos:function name="of-pairs" prefix="map">
@@ -23299,9 +23305,11 @@ return fold-left($maps, {},
             <code>$input</code>
             argument.</p>
          
-         <p>The <code>$options</code> argument can be used to control the ordering of the result, 
-            and the way in which duplicate keys are handled.
+         <p>The <code>$options</code> argument can be used to control 
+            the way in which duplicate keys are handled.
             The <termref def="option-parameter-conventions">option parameter conventions</termref> apply.
+            The handling of duplicates is defined to be the same as in an equivalent call of
+            the <function>map:build</function> function: see the formal equivalent below.
          </p>
  
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
@@ -23315,28 +23323,17 @@ return fold-left($maps, {},
                </fos:meaning>
                <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
                <fos:default>fn:op(',')</fos:default>
-            </fos:option>
-            <!--<fos:option key="retain-order">
-               <fos:meaning>Determines the 
-                  <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> of the
-                  entries in the returned map, as well as value of the map’s
-                  <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref> property.
-               </fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false</fos:default>
                <fos:values>
-                  <fos:value value="false">
-                     The <code>ordered</code> property of the returned map is <code>false</code>, and its
-                     <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                     is <termref def="implementation-dependent"/>.
-                  </fos:value>
-                  <fos:value value="true">
-                     The <code>ordered</code> property of the returned map is <code>true</code>, and its
-                     <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                     retains the order of the items supplied in <code>$input</code>.
-                  </fos:value>
-               </fos:values>
-            </fos:option>-->
+                  <fos:value value="User-supplied function">
+                        The function is called for any entry in an input map that has the 
+                        <termref def="dt-same-key"/> as a previous entry. The first argument
+                        is the existing value associated with the key; the second argument
+                        is the value associated with the key in the duplicate input entry,
+                        and the result is the new value to be associated with the key.
+                     </fos:value>
+                  </fos:values>
+            </fos:option>
+            
          </fos:options>
 
 
@@ -24636,50 +24633,48 @@ else map:put($map, $key, $action(()))
                new key-value pair to the map, with that key and that value. </p></item>
             <item><p>If the key is already present, the processor calls the <code>combine</code>
                function in the <code>$options</code> argument to combine the existing value for the key with the new value,
-               and replaces the entry with this combined value.</p></item>
+               and replaces the entry with this combined value.</p>
+               <p>The key of the combined entry is taken from one of the duplicate entries:
+                  it is <termref def="implementation-defined"/> which one is used. (It is
+                  possible for two keys to be considered duplicates even if they differ:
+                  for example, they may have different type annotations, or they may
+                  be <code>xs:dateTime</code> values with different timezones.)
+               </p>
+               <p>The position of the combined entry in the <xtermref spec="DM40" ref="dt-entry-order"/>
+               of the result map is based on the position of the first entry having that key
+               in the input sequence (that is, the order of keys in the result is the order
+               of first appearance in the input.</p>
+            </item>
          </ulist>
          
-         <p>The <code>$options</code> argument can be used to control the way in which duplicate keys are handled.
-               The <termref
-                     def="option-parameter-conventions"
-                  >option parameter conventions</termref> apply.
-            </p>
+         <p>The <code>$options</code> argument can be used to control the 
+            and the way in which duplicate keys are handled.
+            The <termref def="option-parameter-conventions">option parameter conventions</termref> apply.
+         </p>
  
-               <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
+         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
 
-               <fos:options>
-                  <fos:option key="combine">
-                     <fos:meaning>A function that is used to combine two different values that are supplied
-                        for the same key. The default is to combine the two values using
-                        <xtermref spec="XP40" ref="dt-sequence-concatenation"/>.
-                     </fos:meaning>
-                     <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
-                     <fos:default>fn:op(',')</fos:default>
-                  </fos:option>
-                  <!--<fos:option key="retain-order">
-                     <fos:meaning>Determines the 
-                        <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>, of the
-                        entries in the returned map, and the value of the returned map’s 
-                        <xtermref spec="DM40" ref="dt-map-ordered">ordered</xtermref> property.
-                     </fos:meaning>
-                     <fos:type>xs:boolean</fos:type>
-                     <fos:default>false</fos:default>
-                     <fos:values>
-                        <fos:value value="false">
-                           The <code>ordered</code> property of the returned map is <code>false</code>, and its
-                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> is 
-                           <termref def="implementation-dependent"/>.
-                        </fos:value>
-             
-                        <fos:value value="true">
-                           The <code>ordered</code> property of the returned map is <code>true</code>, and its
-                           <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-                           reflects the order of the items supplied in <code>$input</code>,
-                           and within each of those items, the order of the keys returned by the <code>$keys</code> function.
-                        </fos:value>
-                     </fos:values>
-                  </fos:option>-->
-               </fos:options>
+         <fos:options>
+            <fos:option key="combine">
+               <fos:meaning>A function that is used to combine two different values that are supplied
+                  for the same key. The default is to combine the two values using
+                  <xtermref spec="XP40" ref="dt-sequence-concatenation"/>, retaining their order
+                  in the input sequence.
+               </fos:meaning>
+               <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
+               <fos:default>fn:op(',')</fos:default>
+               <fos:values>
+                  <fos:value value="User-supplied function">
+                        The function is called for any entry in an input map that has the 
+                        <termref def="dt-same-key"/> as a previous entry. The first argument
+                        is the existing value associated with the key; the second argument
+                        is the value associated with the key in the duplicate input entry,
+                        and the result is the new value to be associated with the key.
+                     </fos:value>
+                  </fos:values>
+            </fos:option>
+            
+         </fos:options>
 
          
          

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -13299,11 +13299,10 @@ ISBN 0 521 77752 6.</bibl>
                   to the chosen radix.</p>
             </error>
             <error class="RG" code="0013"
-               label="Unknown option."
+               label="Inconsistent options."
                type="dynamic">
-               <p>Raised if the option in an <termref def="options">option map</termref> is not
-                  described in the specification, if it is not supported by the implementation and
-                  if its name is in no namespace.</p>
+               <p>Raised if an inconsistent set of options is supplied
+                  in an <termref def="options">option map</termref>.</p>
             </error>
             
             <error class="RX" code="0001" label="Invalid regular expression flags." type="static">


### PR DESCRIPTION
Clarifies the rules for how duplicates are handled by map:merge, map:build, map:of-pairs, and xsl:map.

Introduces a callback option for map:merge that is compatible with map:build and map:of-pairs, to increase commonality between all four functions/instructions.

Fix #1725