### PR TITLE
Fix CSS for production tables

### DIFF
--- a/specifications/css/qtspecs.css
+++ b/specifications/css/qtspecs.css
@@ -150,8 +150,7 @@ td.castOther     { background-color: yellow;
                    vertical-align: middle;
                  }
                  
-td.prodComment   { background-color: #f5f5f5;
-                   font-style: italic;
+td.prodComment   { font-style: italic;
                    color: black;
                    text-align: right;
                  }
@@ -167,6 +166,12 @@ background: repeating-linear-gradient(
   #ffdddd 20px,
   #ffdddd 80px
 );
+}
+
+table.scrap {
+    layout: fixed;
+    border-spacing: 0;
+    border-collapse: collapse;
 }
 
 table.scrap td {


### PR DESCRIPTION
This PR removes some extraneous space between the rows and columns in the production tables (cellspacing) and turns off the odd grey background on comments. (I don't think the grey backbround was helping any, but if you disagree...)