### PR TITLE
1682 Type promotion and operator mapping

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -3062,8 +3062,8 @@ compare($N * $arg2, 0) eq compare($arg1, 0).</eg>
          <p>The <code>$value</code> argument may be of any numeric data type
             (<code>xs:double</code>, <code>xs:float</code>, <code>xs:decimal</code>, or their
             subtypes including <code>xs:integer</code>). Note that if an <code>xs:decimal</code> is
-            supplied, it is not automatically promoted to an <code>xs:double</code>, as such
-            promotion can involve a loss of precision.</p>
+            supplied, it is not automatically converted to an <code>xs:double</code>, as such
+            conversion can involve a loss of precision.</p>
          <p>If the supplied value of the <code>$value</code> argument is an empty sequence, the
             function behaves as if the supplied value were the <code>xs:double</code> value
                <code>NaN</code>.</p>
@@ -3928,8 +3928,8 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
                ref="ieee754-2019"
             /> specification of the <code>pown</code> function applied to a
             64-bit binary floating point value and an integer.</p>
-         <p>Otherwise <code>$y</code> is converted to an <code>xs:double</code> by numeric
-            promotion, and the result is <code>$x</code> raised to the power of
+         <p>Otherwise <code>$y</code> is cast to an <code>xs:double</code>, 
+            and the result is <code>$x</code> raised to the power of
                <code>$y</code> as defined in the <bibref
                ref="ieee754-2019"
             /> specification of the
@@ -8373,7 +8373,7 @@ xs:dayTimeDuration($arg2) div xs:dayTimeDuration('PT1S')
          <p>The result of <code>seconds($n)</code> is approximately equal to the result of
          the expression <code>xs:dayTimeDuration('PT1S') * $n</code>. The equivalence is only
          approximate, because <code>seconds($n)</code> uses the exact <code>xs:decimal</code>
-         value supplied, whereas multiplying a duration by a number first promotes the number
+         value supplied, whereas multiplying a duration by a number first converts the number
          to an <code>xs:double</code> value, which may lose precision.</p>
       </fos:notes>
       <fos:examples>
@@ -14428,29 +14428,9 @@ return exists($break)
          </ulist>
          
 
-         <p diff="del" at="A"
-               >If the input sequence contains values of different numeric types that differ from each
-            other by small amounts, then the eq operator is not transitive, because of rounding
-            effects occurring during type promotion. In the situation where the input contains three
-            values <code>A</code>, <code>B</code>, and <code>C</code> such that <code>A eq B</code>,
-               <code>B eq C</code>, but <code>A ne C</code>, then the number of items in the result
-            of the function (as well as the choice of which items are returned) is <termref
-               def="implementation-dependent"
-            >implementation-dependent</termref>, subject only to the constraints that (a) no two
-            items in the result sequence compare equal to each other, and (b) every input item that
-            does not appear in the result sequence compares equal to some item that does appear in
-            the result sequence.</p>
+         
 
-         <p diff="del" at="A">For example, this arises when computing:</p>
-
-         <eg diff="del" at="A"><![CDATA[    distinct-values(
-            (xs:float('1.0'),
-            xs:decimal('1.0000000000100000000001',
-            xs:double('1.00000000001'))]]></eg>
-
-         <p diff="del" at="A"
-               >because the values of type <code>xs:float</code> and <code>xs:double</code> both compare
-            equal to the value of type <code>xs:decimal</code> but not equal to each other. </p>
+         
       </fos:rules>
       <fos:notes>
          <p>If <code>$values</code> is the empty sequence, the function returns the empty sequence.</p>
@@ -17152,26 +17132,21 @@ declare function equal-strings(
       </fos:summary>
       <fos:rules>
          <p>If <code>$values</code> is the empty sequence, the empty sequence is returned.</p>
-         <p>If <code>$values</code> contains values of type <code>xs:untypedAtomic</code> they are cast
-            to <code>xs:double</code>. </p>
-         <p>Duration values must either all be <code>xs:yearMonthDuration</code> values or must all
-            be <code>xs:dayTimeDuration</code> values. For numeric values, the numeric promotion
-            rules defined in <specref
-               ref="op.numeric"
-               /> are used to promote all values to a single
-            common type. After these operations, <code>$values</code> must satisfy the following condition:</p>
-         <p>There must be a type <var>T</var> such that:</p>
+         <p>Any item in <code>$values</code> that is an instance of <code>xs:untypedAtomic</code> 
+            is cast to <code>xs:double</code>. </p>
+         <p>After this conversion, one of the following conditions must be true:</p>
          <olist>
-            <item><p>every item in <code>$values</code> is an instance of <var>T</var>.</p></item>
-            <item><p><var>T</var> is one of <code>xs:double</code>, <code>xs:float</code>,
-                  <code>xs:decimal</code>, <code>xs:yearMonthDuration</code>, or
-                  <code>xs:dayTimeDuration</code>.</p></item>
+            <item><p>Every item in <code>$values</code> is an instance of <code>xs:yearMonthDuration</code>.</p></item>
+            <item><p>Every item in <code>$values</code> is an instance of <code>xs:dayTimeDuration</code>.</p></item>
+            <item><p>Every item in <code>$values</code> is an instance of <code>xs:numeric</code>.</p></item>
          </olist>
-
+         
 
          <p>The function returns the average of the values as <code>sum($values) div
             count($values)</code>; but the implementation may use an otherwise equivalent algorithm
-            that avoids arithmetic overflow.</p>
+            that avoids arithmetic overflow. Note that the <function>fn:sum</function> function
+            allows the input sequence to be reordered, which may affect the result in edge cases
+            when the sequence contains a mixture of different numeric types.</p>
 
       </fos:rules>
       <fos:errors>
@@ -17219,6 +17194,16 @@ declare function equal-strings(
                   code="0006"/>. </p>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="1682" date="2025-01-27">
+            <p>In 3.1, given a mixed input sequence such as (1, 3, 4.2e0), the specification 
+            was unclear whether it was permitted to add the first two integer items using
+            integer arithmetic, rather than converting all items to doubles before
+            performing any arithmetic. The 4.0 specification is clear that this is
+            permitted; but since the items can be reordered before being added, this
+            is not required.</p>
+         </fos:change>
+      </fos:changes>
    </fos:function>
    
    <fos:function name="max" prefix="fn">
@@ -17558,34 +17543,36 @@ declare function equal-strings(
          <p>Returns a value obtained by adding together the values in <code>$values</code>.</p>
       </fos:summary>
       <fos:rules>
-         <p>Any values of type <code>xs:untypedAtomic</code> in <code>$values</code> are cast to
+         <p>The result of the function when a single argument 
+            is supplied is the result of the expression: <code>fn:sum($arg, 0)</code>.</p>
+         <p>Any value of type <code>xs:untypedAtomic</code> in <code>$values</code> is cast to
                <code>xs:double</code>. The items in the resulting sequence may be reordered in an
             arbitrary order. The resulting sequence is referred to below as the converted
             sequence.</p>
-         <p diff="chg" at="2023-01-17">If the converted sequence is empty, then the function returns
+         <p>If the converted sequence is empty, then the function returns
             the value of the argument <code>$zero</code>, which defaults to 
             the <code>xs:integer</code> value <code>0</code>.</p>
-         <p>If the converted sequence contains the value <code>NaN</code>, <code>NaN</code> is
-            returned.</p>
-         <p>All items in <code>$values</code> must be numeric or derived from a single base type. In
-            addition, the type must support addition. Duration values must either all be
-               <code>xs:yearMonthDuration</code> values or must all be
-               <code>xs:dayTimeDuration</code> values. For numeric values, the numeric promotion
-            rules defined in <specref
-               ref="op.numeric"
-               /> are used to promote all values to a single
-            common type. The sum of a sequence of integers will therefore be an integer, while the
-            sum of a numeric sequence that includes at least one <code>xs:double</code> will be an
-               <code>xs:double</code>. </p>
-         <p>The result of the function is the value of the
+         <p>In other cases the items in the converted sequence are added pairwise according
+         the rules of the <code>+</code> operator.</p>
+
+         <p>Specifically, the result of the function is the value of the
             expression:</p>
          <eg xml:space="preserve">
 if (empty($c)) then $zero
 else if (count($c) eq 1) then $c
 else head($c) + sum(tail($c))</eg>
          <p>where <code>$c</code> is the converted sequence.</p>
-         <p>The result of the function <phrase diff="chg" at="2023-01-17">when a single argument is supplied</phrase> is the result of the expression:
-               <code>fn:sum($arg, 0)</code>.</p>
+         
+         <p>This has the effect that a type error will occur unless one of the following
+         conditions is satisfied:</p>
+         
+          <olist>
+            <item><p>Every item in <code>$values</code> is an instance of <code>xs:yearMonthDuration</code>.</p></item>
+            <item><p>Every item in <code>$values</code> is an instance of <code>xs:dayTimeDuration</code>.</p></item>
+            <item><p>Every item in <code>$values</code> is an instance of <code>xs:numeric</code>.</p></item>
+         </olist>
+         
+         
 
       </fos:rules>
       <fos:errors>
@@ -17604,7 +17591,20 @@ else head($c) + sum(tail($c))</eg>
             the <code>$zero</code> argument is used only when the input sequence is empty, not
             when a non-empty sequence sums to zero. For example, <code>sum((-1, +1), xs:double('NaN'))</code>
             returns the <code>xs:integer</code> value <code>0</code>, not <code>NaN</code>.</p>
-         <p> If the converted sequence contains exactly one value then that value is returned.</p>
+         <p>The sum of a sequence of integers will be an integer, while the
+            sum of a numeric sequence that includes at least one <code>xs:double</code> will be an
+               <code>xs:double</code>.</p>
+         <p>If the converted sequence contains exactly one value then that value is returned.</p>
+         <p>If the converted sequence contains the value <code>NaN</code>, <code>NaN</code> is
+            returned.</p>
+         <p>In edge cases the fact that the input sequence may be reordered makes the result
+            slightly unpredictable. For example, if the input contains two <code>xs:decimal</code>
+            values and an <code>xs:float</code>, then the decimal values might be added using
+            decimal arithmetic, or they might both be converted to <code>xs:float</code> 
+            (potentially losing precision) before any arithmetic is performed.
+            </p>
+         
+         
       </fos:notes>
       <fos:examples>
          <fos:variable name="d1" id="v-sum-d1" select="xs:yearMonthDuration(&quot;P20Y&quot;)"/>
@@ -17678,6 +17678,16 @@ else head($c) + sum(tail($c))</eg>
                />. </p>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="1682" date="2025-01-27">
+            <p>In 3.1, given a mixed input sequence such as (1, 3, 4.2e0), the specification 
+            was unclear whether it was permitted to add the first two integer items using
+            integer arithmetic, rather than converting all items to doubles before
+            performing any arithmetic. The 4.0 specification is clear that this is
+            permitted; but since the items can be reordered before being added, this
+            is not required.</p>
+         </fos:change>
+      </fos:changes>
    </fos:function>
    <!--<fos:function name="to" prefix="op">
       <fos:signatures>
@@ -18249,7 +18259,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
          <p>If <code>$source</code> is the empty sequence, the result is an empty sequence.</p>
          <p>If <code>$source</code> is a relative URI reference, it is resolved relative to the value
             of the <term>static base URI</term> property from the static context. The resulting absolute URI is
-            promoted to an <code>xs:string</code>.</p>
+            cast to an <code>xs:string</code>.</p>
          <p>If the <term>available documents</term> described in <xspecref spec="XP31"
                ref="eval_context"
             /> provides a mapping from this string to a document node, the

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -692,33 +692,17 @@ Michael Sperberg-McQueen (1954–2024).</p>
          <div2 id="id-function-calls">
             <head>Function calls</head>
             
-            <p>Rules for passing parameters to operators are described in the relevant sections
+            <p>Rules for evaluating the operands of operators are described in the relevant sections
                     of <bibref ref="xquery-40"/> and <bibref ref="xpath-40"/>. For example, the rules for
-                    passing parameters to arithmetic operators are described in <xspecref spec="XP31" ref="id-arithmetic"/>. Specifically, rules for parameters of
+                    evaluating the operands of arithmetic operators are described in <xspecref spec="XP31" ref="id-arithmetic"/>. 
+               Specifically, rules for parameters of
                     type <code>xs:untypedAtomic</code> and the empty sequence are specified in this section.</p>
-            <p>As is customary, the parameter type name indicates that the function or operator
-                    accepts arguments of that type, or types derived from it, in that position. This
-                    is called <emph>subtype substitution</emph> (See <xspecref spec="XP31" ref="id-sequencetype-matching"/>). In addition, numeric type instances and
-                    instances of type <code>xs:anyURI</code> can be promoted to produce an argument
-                    of the required type. (See <xspecref spec="XP31" ref="promotion"/>).</p> 
-                  <olist>
-                  <item>
-                     <p><emph>Subtype Substitution</emph>: A derived type may substitute for
-                                its base type. In particular, <code>xs:integer</code> may be used
-                                where <code>xs:decimal</code> is expected.</p>
-                  </item>
-                  <item>
-                     <p><emph>Numeric Type Promotion</emph>: <code>xs:decimal</code> may be
-                                promoted to <code>xs:float</code> or <code>xs:double</code>. 
-								Promotion to <code>xs:double</code> should be done directly, not via
-								 <code>xs:float</code>, to avoid loss of precision.</p>
-                  </item>
-                  <item>
-                     <p><emph>anyURI Type Promotion</emph>: A value of
-                                type <code>xs:anyURI</code> can be promoted to the
-                                type <code>xs:string</code>. </p>
-                  </item>
-               </olist>
+            <p>For function calls, the required type of an argument is defined in the function
+               signature of each function, and the way in which a supplied value is converted to the
+               required type (or rejected if it cannot be converted) is defined by the
+               <xtermref spec="XP40" ref="dt-coercion-rules"/>.</p>
+               
+               
                 
             <p>Some functions accept a single value or the empty sequence as an argument and
                     some may return a single value or the empty sequence. This is indicated in the
@@ -1655,10 +1639,8 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
                The exceptions are <code>op:numeric-divide</code>, which returns
                     an <code>xs:decimal</code> if called with two <code>xs:integer</code> operands,
                     and <code>op:numeric-integer-divide</code> which always returns an <code>xs:integer</code>.</p>
-            <p>If the two operands of an arithmetic expression are not of the same type, <emph>subtype substitution</emph>
-                    and <emph>numeric type promotion</emph> are used to obtain two operands of the
-                    same type. <xspecref spec="XP31" ref="promotion"/> and <xspecref spec="XP31" ref="mapping"/> describe the semantics of these operations in
-                    detail. </p>
+            <p>If the two operands of an arithmetic expression are not of the same type, they
+               may be converted to a common type as described in <xspecref spec="XP40" ref="id-arithmetic-expressions"/>. </p>
             <p>The result type of operations depends on their argument datatypes and is defined
                     in the following table:</p>
             <table role="no-code-break data">
@@ -1735,7 +1717,7 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
                   </tr>
                </tbody>
             </table>
-            <p>These rules define any operation on any pair of arithmetic types. Consider the
+            <!--<p>These rules define any operation on any pair of arithmetic types. Consider the
                     following example:</p>
             <eg xml:space="preserve"><![CDATA[op:operation(xs:int, xs:double) => op:operation(xs:double, xs:double)]]></eg>
             <p>For this operation, <code>xs:int</code> must be converted to
@@ -1755,7 +1737,7 @@ This differs from <bibref ref="xmlschema-2"/>, which defines
                     <code>fenceHeight</code> can be substituted for its base type
                     <code>height</code> and <code>height</code> can be substituted for its base type
                     <code>xs:integer</code>. </p>
-
+-->
             <p>The basic rules for addition, subtraction, and multiplication
 			of ordinary numbers are not set out in this specification; they are taken as given. In the case of <code>xs:double</code>
 			and <code>xs:float</code> the rules are as defined in <bibref ref="ieee754-2019"/>. The rules for handling

--- a/specifications/xquery-40/src/back-matter.xml
+++ b/specifications/xquery-40/src/back-matter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<div1 id="id-type-promotion-and-operator-mapping">
+<!--<div1 id="id-type-promotion-and-operator-mapping">
 <head>Type Promotion and Operator Mapping</head>
 
 <div2 id="promotion">
@@ -315,7 +315,7 @@ operand must be of type <code>xs:gDay</code>.)</p>
 </div2>
   
 
-</div1>
+</div1>-->
 
 
 <div1 role="xquery" id="id-xq-context-components">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4207,6 +4207,13 @@ types</term> (such as <code>xs:integer</code>) and function types
                   <termref def="dt-enumeration-type">enumeration types</termref> cannot be
                   used as the target for schema validation.</p></note>
                
+               <p><termdef id="dt-numeric" term="numeric">The type <code>xs:numeric</code>
+               is defined as a union type with member types <code>xs:double</code>, 
+               <code>xs:float</code>, and <code>xs:decimal</code>. An item that
+               is an instance of any of these types is referred to as a <term>numeric value</term>,
+               and a type that is a subtype of <code>xs:numeric</code> is referred to
+               as a <term>numeric type</term>.</termdef></p>
+               
             </div3>
             <div3 id="id-namespace-sensitive">
                <head>Namespace-sensitive Types</head>
@@ -12891,6 +12898,7 @@ multiplication, division, and modulus, in their usual binary and unary
 forms.</p>
          <scrap>
             <prodrecap ref="AdditiveExpr"/>
+            <prodrecap ref="UnaryExpr"/>
          </scrap>
          <p>A subtraction operator must be preceded by whitespace if
 it could otherwise be interpreted as part of the previous token. For
@@ -12916,7 +12924,9 @@ is equivalent to
 Similarly, the operands of a <code>MultiplicativeExpr</code> are grouped from left to right.
 </p>
 
-         <p>The first step in evaluating an arithmetic expression is to evaluate its operands. The order in which the operands are evaluated is <termref
+         <p>The first step in evaluating an arithmetic expression is to evaluate its operand (for
+            a unary operator) or operands (for a binary operator). 
+            The order in which the operands are evaluated is <termref
                def="dt-implementation-dependent">implementation-dependent</termref>.</p>
          <p role="xpath">If <termref def="dt-xpath-compat-mode"
                >XPath 1.0 compatibility mode</termref> is <code>true</code>, each operand is evaluated by applying the following steps, in order:</p>
@@ -12990,23 +13000,130 @@ error</termref> is raised. <xerrorref
                </p>
             </item>
          </olist>
-         <p>After evaluation of the operands, if the types of the operands are a valid combination
-for the given arithmetic operator, the operator is applied to the operands,
-resulting in an atomic item or a <termref
-               def="dt-dynamic-error"
-               >dynamic error</termref> (for example, an error
-might result from dividing by zero). The combinations of atomic types
-that are accepted by the various arithmetic operators, and their
-respective result types, are listed in <specref
-               ref="mapping"/>
-together with the <termref def="dt-operator-function"
-               >operator functions</termref>
-that define the semantics of the operator for each
-type combination, including the dynamic errors that can be raised by the operator. The definitions of the operator functions are found in <bibref
+         
+         <p>If, after this process, both operands of a binary arithmetic operator
+            are instances of <code>xs:numeric</code>
+         but have different primitive types, they are coerced to a common type by applying
+         the following rules:</p>
+         
+         <olist>
+            <item><p>If either of the items is of type <code>xs:double</code>, then 
+            both the values are cast to type <code>xs:double</code>.</p></item>
+            <item><p>Otherwise, if either of the items is of type <code>xs:float</code>, then 
+              both the values are cast to type <code>xs:float</code>.</p></item>
+            <item><p>Otherwise, no casting takes place: the values remain as <code>xs:decimal</code>.</p></item>
+         </olist>
+         
+         <p>After this preparation, the arithmetic expression is evaluated by applying the appropriate
+         function listed in the table below. The definitions of these functions are found in <bibref
                ref="xpath-functions-40"/>.</p>
-         <p>If the types of the operands, after evaluation, are not a valid combination for the given operator, according to the rules in <specref
-               ref="mapping"/>, a <termref def="dt-type-error"
-               >type error</termref> is raised <errorref class="TY" code="0004"/>.</p>
+         
+         <table border="1" role="small">
+<caption>Unary Arithmetic Operators</caption>
+  <thead>
+    <tr>
+      <th>Expression</th>
+      <th>Type of A</th>
+      <th>Function</th>
+      <th>Result type</th>
+    </tr>
+  </thead>
+<tbody>
+
+
+
+<tr><td>+ A</td><td>xs:numeric</td><td><function>op:numeric-unary-plus</function><code>(A)</code></td><td>xs:numeric</td></tr>
+
+<tr><td>- A</td><td>xs:numeric</td><td><function>op:numeric-unary-minus</function><code>(A)</code></td><td>xs:numeric</td></tr>
+</tbody>
+</table>
+         
+         <table border="1" role="small">
+<caption>Binary Arithmetic Operators</caption>
+<tbody>
+
+<tr>
+<th>Expression</th>
+<th>Type of A</th>
+<th>Type of B</th>
+<th>Function</th>
+<th>Result type</th>
+</tr>
+
+<tr><td>A + B</td><td>xs:numeric</td><td>xs:numeric</td><td><function>op:numeric-add</function><code>(A, B)</code></td><td>xs:numeric</td></tr>
+
+<tr><td>A + B</td><td>xs:date</td><td>xs:yearMonthDuration</td><td><function>op:add-yearMonthDuration-to-date</function><code>(A, B)</code></td><td>xs:date</td></tr>
+
+<tr><td>A + B</td><td>xs:yearMonthDuration</td><td>xs:date</td><td><function>op:add-yearMonthDuration-to-date</function><code>(B, A)</code></td><td>xs:date</td></tr>
+<tr><td>A + B</td><td>xs:date</td><td>xs:dayTimeDuration</td><td><function>op:add-dayTimeDuration-to-date</function><code>(A, B)</code></td><td>xs:date</td></tr>
+<tr><td>A + B</td><td>xs:dayTimeDuration</td><td>xs:date</td><td><function>op:add-dayTimeDuration-to-date</function><code>(B, A)</code></td><td>xs:date</td></tr>
+
+<tr><td>A + B</td><td>xs:time</td><td>xs:dayTimeDuration</td><td><function>op:add-dayTimeDuration-to-time</function><code>(A, B)</code></td><td>xs:time</td></tr>
+<tr><td>A + B</td><td>xs:dayTimeDuration</td><td>xs:time</td><td><function>op:add-dayTimeDuration-to-time</function><code>(B, A)</code></td><td>xs:time</td></tr>
+
+
+<tr><td>A + B</td><td>xs:dateTime</td><td>xs:yearMonthDuration</td><td><function>op:add-yearMonthDuration-to-dateTime</function><code>(A, B)</code></td><td>xs:dateTime</td></tr>
+<tr><td>A + B</td><td>xs:yearMonthDuration</td><td>xs:dateTime</td><td><function>op:add-yearMonthDuration-to-dateTime</function><code>(B, A)</code></td><td>xs:dateTime</td></tr>
+
+<tr><td>A + B</td><td>xs:dateTime</td><td>xs:dayTimeDuration</td><td><function>op:add-dayTimeDuration-to-dateTime</function><code>(A, B)</code></td><td>xs:dateTime</td></tr>
+<tr><td>A + B</td><td>xs:dayTimeDuration</td><td>xs:dateTime</td><td><function>op:add-dayTimeDuration-to-dateTime</function><code>(B, A)</code></td><td>xs:dateTime</td></tr>
+
+<tr><td>A + B</td><td>xs:yearMonthDuration</td><td>xs:yearMonthDuration</td><td><function>op:add-yearMonthDurations</function><code>(A, B)</code></td><td>xs:yearMonthDuration</td></tr>
+<tr><td>A + B</td><td>xs:dayTimeDuration</td><td>xs:dayTimeDuration</td><td><function>op:add-dayTimeDurations</function><code>(A, B)</code></td><td>xs:dayTimeDuration</td></tr>
+
+
+<tr><td>A - B</td><td>xs:numeric</td><td>xs:numeric</td><td><function>op:numeric-subtract</function><code>(A, B)</code></td><td>xs:numeric</td></tr>
+
+
+<tr><td>A - B</td><td>xs:date</td><td>xs:date</td><td><function>op:subtract-dates</function><code>(A, B)</code></td><td>xs:dayTimeDuration</td></tr>
+<tr><td>A - B</td><td>xs:date</td><td>xs:yearMonthDuration</td><td><function>op:subtract-yearMonthDuration-from-date</function><code>(A, B)</code>
+</td><td>xs:date</td></tr>
+<tr><td>A - B</td><td>xs:date</td><td>xs:dayTimeDuration</td><td><function>op:subtract-dayTimeDuration-from-date</function><code>(A, B)</code></td><td>xs:date</td></tr>
+
+<tr><td>A - B</td><td>xs:time</td><td>xs:time</td><td><function>op:subtract-times</function><code>(A, B)</code></td><td>xs:dayTimeDuration</td></tr>
+
+<tr><td>A - B</td><td>xs:time</td><td>xs:dayTimeDuration</td><td><function>op:subtract-dayTimeDuration-from-time</function><code>(A, B)</code></td><td>xs:time</td></tr>
+
+
+<tr><td>A - B</td><td>xs:dateTime</td><td>xs:dateTime</td><td><function>op:subtract-dateTimes</function><code>(A, B)</code></td><td>xs:dayTimeDuration</td></tr>
+<tr><td>A - B</td><td>xs:dateTime</td><td>xs:yearMonthDuration</td><td><function>op:subtract-yearMonthDuration-from-dateTime</function><code>(A, B)</code></td><td>xs:dateTime</td></tr>
+<tr><td>A - B</td><td>xs:dateTime</td><td>xs:dayTimeDuration</td><td><function>op:subtract-dayTimeDuration-from-dateTime</function><code>(A, B)</code></td><td>xs:dateTime</td></tr>
+
+<tr><td>A - B</td><td>xs:yearMonthDuration</td><td>xs:yearMonthDuration</td><td><function>op:subtract-yearMonthDurations</function><code>(A, B)</code></td><td>xs:yearMonthDuration</td></tr>
+<tr><td>A - B</td><td>xs:dayTimeDuration</td><td>xs:dayTimeDuration</td><td><function>op:subtract-dayTimeDurations</function><code>(A, B)</code></td><td>xs:dayTimeDuration</td></tr>
+
+
+<tr><td>A * B</td><td>xs:numeric</td><td>xs:numeric</td><td><function>op:numeric-multiply</function><code>(A, B)</code></td><td>xs:numeric</td></tr>
+<tr><td>A * B</td><td>xs:yearMonthDuration</td><td>xs:numeric</td><td><function>op:multiply-yearMonthDuration</function><code>(A, B)</code></td><td>xs:yearMonthDuration</td></tr>
+<tr><td>A * B</td><td>xs:numeric</td><td>xs:yearMonthDuration</td><td><function>op:multiply-yearMonthDuration</function><code>(B, A)</code></td><td>xs:yearMonthDuration</td></tr>
+<tr><td>A * B</td><td>xs:dayTimeDuration</td><td>xs:numeric</td><td><function>op:multiply-dayTimeDuration</function><code>(A, B)</code></td><td>xs:dayTimeDuration</td></tr>
+<tr><td>A * B</td><td>xs:numeric</td><td>xs:dayTimeDuration</td><td><function>op:multiply-dayTimeDuration</function><code>(B, A)</code></td><td>xs:dayTimeDuration</td></tr> 
+
+<tr><td>A idiv B</td><td>xs:numeric</td><td>xs:numeric</td><td><function>op:numeric-integer-divide</function><code>(A, B)</code></td><td>xs:integer</td></tr>
+
+   <tr><td>A div B</td><td>xs:numeric</td><td>xs:numeric</td><td><function>op:numeric-divide</function><code>(A, B)</code></td><td>numeric; but xs:decimal if both operands are xs:integer</td></tr>
+<tr><td>A div B</td><td>xs:yearMonthDuration</td><td>xs:numeric</td><td><function>op:divide-yearMonthDuration</function><code>(A, B)</code></td><td>xs:yearMonthDuration</td></tr>
+<tr><td>A div B</td><td>xs:dayTimeDuration</td><td>xs:numeric</td><td><function>op:divide-dayTimeDuration</function><code>(A, B)</code></td><td>xs:dayTimeDuration</td></tr>
+<tr><td>A div B</td><td>xs:yearMonthDuration</td><td>xs:yearMonthDuration</td><td><function>op:divide-yearMonthDuration-by-yearMonthDuration</function><code>(A, B)</code></td><td>xs:decimal</td></tr>
+<tr><td>A div B</td><td>xs:dayTimeDuration</td><td>xs:dayTimeDuration</td><td><function>op:divide-dayTimeDuration-by-dayTimeDuration</function><code>(A, B)</code></td><td>xs:decimal</td></tr>
+ 
+<tr><td>A mod B</td><td>xs:numeric</td><td>xs:numeric</td><td><function>op:numeric-mod</function><code>(A, B)</code></td><td>xs:numeric</td></tr>
+</tbody>
+         </table>
+
+<note><p>The operator symbol <code>×</code> is a synonym of <code>*</code>, while <code>÷</code> is
+a synonym of <code>div</code>.</p></note>      
+         
+ <p>If there is no entry in the table for the combination of operator and operands,
+    then a <termref def="dt-type-error"/> is raised <errorref class="TY" code="0004"/>.</p>
+   
+ <p>Errors may also occur during coercion of the operands, or during evaluation of the
+ identified function (for example, an error
+might result from dividing by zero).</p>  
+         
+ 
+         
+      <note>
          <p>&language; provides three division operators:</p>
          <ulist>
             <item><p>The <code>div</code> and <code>÷</code> operators are synonyms, and implement
@@ -13015,6 +13132,7 @@ type combination, including the dynamic errors that can be raised by the operato
             <item><p>The <code>idiv</code> operator implements integer division; the semantics are defined
                in <xspecref spec="FO40" ref="func-numeric-integer-divide"/></p></item>
          </ulist> 
+      </note>
 
          <p>Here are some examples of arithmetic expressions:</p>
 
@@ -13487,33 +13605,101 @@ length greater than one, a <termref
                      </olist>
                   </p>
                </item>
+               
+               <item>
+                  <p>Expressions using operators other than <code>eq</code> and <code>lt</code>
+                  are rewritten as follows:</p>
+                  <slist>
+                     <sitem><code>A ne B</code> becomes <code>not(A eq B)</code></sitem>
+                     <sitem><code>A le B</code> becomes <code>A lt B or A eq B</code></sitem>
+                     <sitem><code>A gt B</code> becomes <code>B lt A</code></sitem>
+                     <sitem><code>A ge B</code> becomes <code>B lt A or B eq A</code></sitem>
+                  </slist>
+               </item>
 
                <item>
                   <p>Finally, if the types of the operands are a valid
   combination for the given operator, the operator is applied to the
-  operands.</p>
+  operands by applying the appropriate function from the table below.</p>
                </item>
 
             </olist>
+            
+            
+           <table border="1" role="small">
+<caption>Value Comparison Operators</caption>
+<tbody>
 
-            <p>The combinations of atomic types that are accepted by the various
-value comparison operators, and their respective result types, are
-listed in <specref
-                  ref="mapping"/> together with the <termref def="dt-operator-function"
-                  >operator functions</termref> that define
-the semantics of the operator for each type combination. The
-definitions of the operator functions are found in <bibref
+<tr>
+<th>Expression</th>
+<th>Type(A)</th>
+<th>Type(B)</th>
+<th>Function</th>
+<th>Result type</th>
+</tr>
+
+
+
+<tr><td>A eq B</td><td>xs:numeric</td><td>xs:numeric</td><td><function>op:numeric-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>xs:boolean</td><td>xs:boolean</td><td><function>op:boolean-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>xs:string</td><td>xs:string</td><td><function>op:numeric-equal</function><code>(</code><function>fn:compare</function><code>(A, B), 0)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>xs:date</td><td>xs:date</td><td><function>op:date-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>xs:time</td><td>xs:time</td><td><function>op:time-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>xs:dateTime</td><td>xs:dateTime</td><td><function>op:dateTime-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>xs:duration</td><td>xs:duration</td><td><function>op:duration-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>xs:gYear</td><td>xs:gYear</td><td><function>op:gYear-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+<tr><td>A eq B</td><td>xs:gYearMonth</td><td>xs:gYearMonth</td><td><function>op:gYearMonth-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+<tr><td>A eq B</td><td>xs:gMonth</td><td>xs:gMonth</td><td><function>op:gMonth-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+<tr><td>A eq B</td><td>xs:gMonthDay</td><td>xs:gMonthDay</td><td><function>op:gMonthDay-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+<tr><td>A eq B</td><td>xs:gDay</td><td>xs:gDay</td><td><function>op:gDay-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>(xs:hexBinary | xs:base64Binary)</td><td>(xs:hexBinary | xs:base64Binary)</td><td><function>op:binary-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+
+<tr><td>A eq B</td><td>xs:QName</td><td>xs:QName</td><td><function>op:QName-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A eq B</td><td>xs:NOTATION</td><td>xs:NOTATION</td><td><function>op:NOTATION-equal</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+
+
+
+<tr><td>A lt B</td><td>xs:numeric</td><td>xs:numeric</td><td><function>op:numeric-less-than</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A lt B</td><td>xs:boolean</td><td>xs:boolean</td><td><function>op:boolean-less-than</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A lt B</td><td>xs:string</td><td>xs:string</td><td><function>op:numeric-less-than</function><code>(</code><function>fn:compare</function><code>(A, B), 0)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A lt B</td><td>xs:date</td><td>xs:date</td><td><function>op:date-less-than</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A lt B</td><td>xs:time</td><td>xs:time</td><td><function>op:time-less-than</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A lt B</td><td>xs:dateTime</td><td>xs:dateTime</td><td><function>op:dateTime-less-than</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+<tr><td>A lt B</td><td>xs:yearMonthDuration</td><td>xs:yearMonthDuration</td><td><function>op:yearMonthDuration-less-than</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+<tr><td>A lt B</td><td>xs:dayTimeDuration</td><td>xs:dayTimeDuration</td><td><function>op:dayTimeDuration-less-than</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+<tr><td>A lt B</td><td>(xs:hexBinary | xs:base64Binary)</td><td>(xs:hexBinary | xs:base64Binary)</td><td><function>op:binary-less-than</function><code>(A, B)</code></td><td>xs:boolean</td></tr>
+
+
+
+
+</tbody>
+</table>
+
+
+            <p>The definitions of the operator functions are found in <bibref
                   ref="xpath-functions-40"/>.</p>
 
-            <p>Informally, if both atomized operands consist of exactly one atomic
-item, then the result of the comparison is <code>true</code> if the value of the
-first operand is (equal, not equal, less than, less than or equal,
-greater than, greater than or equal) to the value of the second
-operand; otherwise the result of the comparison is <code>false</code>.</p>
+ 
 
-            <p>If the types of the operands, after evaluation, are not a valid
-combination for the given operator, according to the rules in <specref
-                  ref="mapping"/>, a <termref def="dt-type-error"
+            <p>If the table contains no entry corresponding to the types of the operands, 
+               after evaluation, then a <termref def="dt-type-error"
                   >type error</termref>
 is raised <errorref class="TY" code="0004"/>.</p>
 

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -742,7 +742,7 @@
         <xsl:when test="$prefix = 'array'">func-array-</xsl:when>
         <xsl:when test="$prefix = 'map'">func-map-</xsl:when>
         <xsl:when test="$prefix = 'math'">func-math-</xsl:when>
-        <xsl:when test="$prefix = 'op'">func-op-</xsl:when>
+        <xsl:when test="$prefix = 'op'">func-</xsl:when>
         <xsl:otherwise>
           <xsl:message select="'Unexpected function prefix: ' || $prefix || ':'"/>
           <xsl:sequence select="'func-'"/>


### PR DESCRIPTION
Fix #1682 

Moves the relevant parts of the operator mapping table into the sections for Arithmetic Expressions and Value Comparisons. Adds links to the op: functions in F&O.

Drops the Type Promotion appendix, moving the rules inline; and drops the term "type promotion"

Adjusts the specs for sum() and avg() so they are now defined directly in terms of pairwise addition of values.