### PR TITLE
1725b Further elaboration of duplicates handling in maps

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -5739,18 +5739,41 @@ values, only on keys. The semantics of equality when comparing keys are describe
     </example>
     
     <p>The <code>dm:map-put</code> constructor returns a map based on the contents of a supplied map.</p>
-    <p>The key/value pairs in the returned map are as follows:</p>
-    <ulist>
-      <item><p>One key/value pair for every key/value pair present in <code>$map</code> whose key is
-      not equal to <code>$key</code>; plus</p></item>
-      <item><p>One key/value pair whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p></item>
-    </ulist>
+    <p>The key/value pairs in the returned map are as follows, in order:</p>
+    <olist>
+      <item><p>If <code>$map</code> includes a key/value pair (call it <var>E0</var>) whose key is
+      atomic-equal to <code>$key</code>, then:</p>
+      <olist>
+        <item><p>All the key/value pairs in <code>$map</code> that precede <var>E0</var> in 
+        <termref def="dt-entry-order"/>.</p></item>
+        <item><p>A key/value pair whose key is either <code>$key</code> or the existing key of <var>E0</var>, and
+        whose value part is <code>$value</code>. It is <termref def="dt-implementation-dependent"/>
+        which key is chosen.</p>
+        <note><p>Most commonly, the two keys will be indistinguishable. However, they may
+        have different type annotations (for example, <code>xs:string</code> versus <code>xs:untypedAtomic</code>,
+        or they may be date/time values in different timezones.</p></note></item>
+        <item><p>All the key/value pairs in <code>$map</code> that follow <var>E0</var> in 
+        <termref def="dt-entry-order"/>.</p></item>
+      </olist></item>
+      
+      <item>
+        <p>Otherwise:</p>
+        <olist>
+        <item><p>All the key/value pairs in <code>$map</code>.</p></item>
+          <item><p>A key/value pair whose key is <code>$key</code> and
+        whose value part is <code>$value</code>.</p></item>
+        </olist>
+      </item>
+      
+      
+    </olist>
     
-    
+    <note>
     <p>The <termref def="dt-entry-order"/> in the returned
       map reflects the <termref def="dt-entry-order"/> in the supplied <code>$map</code>. If the key of
       the new entry was present in <code>$map</code> then the new entry replaces that entry retaining
       its current position; otherwise, the new entry is added after all existing entries.</p>
+    </note>
     
     <p>The function is exposed in XPath through the function <function>map:put</function>.</p>
   </div3>
@@ -6223,22 +6246,22 @@ depth-first order.</p>
 
 &ChangeLog;
 
-<inform-div1>
+<inform-div1 id="id-accessor-summary">
 <head>Accessor Summary</head>
 <?xdm-accessor-summary?>
 </inform-div1>
 
-<inform-div1>
+<inform-div1 id="id-infoset-construction-summary">
 <head>Infoset Construction Summary</head>
 <?xdm-infoset-construction-summary?>
 </inform-div1>
 
-<inform-div1>
+<inform-div1 id="id-psvi-construction-summary">
 <head>PSVI Construction Summary</head>
 <?xdm-psvi-construction-summary?>
 </inform-div1>
 
-<inform-div1>
+<inform-div1 id="id-infoset-mapping-summary">
 <head>Infoset Mapping Summary</head>
 <?xdm-infoset-mapping-summary?>
 </inform-div1>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23187,8 +23187,9 @@ xs:QName('xs:double')</eg></fos:result>
                   <item><p>The position of that entry in the <xtermref spec="DM40"
                   ref="dt-entry-order"/> of the result map will correspond to the
                   position of the first of the duplicates.</p></item>
-                  <item><p>The key of that entry will be the key used
-                     in the <emph>last</emph> of the duplicates. (Keys may be 
+                  <item><p>The key of the combined entry 
+                  will correspond to the key of one of the duplicates: it is
+                  <termref def="implementation-dependent"/> which one is chosen. (Keys may be 
                   duplicates even though they differ: for example, they may have
                   different type annotations, or they may be <code>xs:dateTime</code>
                   values in different timezones.)</p></item>
@@ -23201,7 +23202,7 @@ xs:QName('xs:double')</eg></fos:result>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 map:of-pairs($maps =!> map:pairs(), 
-             $options[exists((?duplicates, ?combine))]
+             $options[exists(?duplicates)]
                otherwise { "duplicates": "use-first" });  
       </fos:equivalent>
      
@@ -23353,7 +23354,7 @@ map:of-pairs($maps =!> map:pairs(),
       <fos:rules>
          
          <p>The function <function>map:of-pairs</function>
-            <phrase>returns a map</phrase> that
+            <phrase>returns a map</phrase> which
             is formed by combining <termref def="dt-key-value-pair-map">key-value pair maps</termref> supplied in the 
             <code>$input</code>
             argument.</p>
@@ -23482,8 +23483,10 @@ return fold-left( $input, {},
                of the result map, the position of the entry containing the result
                of combining a set of entries with duplicate keys corresponds to 
                the position of the first of the duplicates in the input sequence.</p></item>
-            <item><p>The key of the entry containing the combined value is the <emph>last</emph> of
-            the several duplicates. (Keys may be duplicates even though they differ: 
+            <item><p>The key of the combined entry 
+                  will correspond to the key of one of the duplicates: it is
+                  <termref def="implementation-dependent"/> which one is chosen.
+               (Keys may be duplicates even though they differ: 
             for example they may have different type annotations, or they might be
             <code>xs:dateTime</code> values in different timezones.)</p></item>
          </ulist>
@@ -24259,20 +24262,18 @@ declare function map:find($input as item()*,
          any existing entry for the same key.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function <function>map:put</function> returns <phrase>a <termref def="dt-map"
-               >map</termref> that</phrase> contains all entries from the supplied <code>$map</code>,
-            with the exception of any entry whose key is the <termref
-               def="dt-same-key"
-               >same key</termref> as <code>$key</code>, together with a new
-         entry whose key is <code>$key</code> and whose associated value is <code>$value</code>.</p>
+         <p>If <code>$map</code> contains an entry whose key is the <termref
+               def="dt-same-key">same key</termref> as <code>$key</code>, the function returns
+         a map in which that entry is replaced (at the same relative position)
+         with a new entry whose value is <code>$value</code>. It is 
+         <termref def="implementation-dependent"/> whether the key in the new entry
+         takes its original value or is replaced by the supplied <code>$key</code>.
+         All other entries in the map are unchanged, and retain their relative order.</p>
          
-         <p>The <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref> 
-            of the entries in the returned map is as follows:
-            if <code>$map</code> contains an entry whose key is <code>$key</code>,
-                  then the new value replaces the old value and the position of the entry is not changed;
-                  otherwise, the new entry is added after all existing entries.</p>
-
-        
+         <p>Otherwise, when <code>$map</code> contains no such entry, the function
+         returns a map containing all entries from the supplied <code>$map</code>
+         (retaining their relative position) followed by a new entry whose key
+         is <code>$key</code> and whose associated value is <code>$value</code>.</p>
 
       </fos:rules>
       
@@ -24293,8 +24294,9 @@ declare function map:find($input as item()*,
             as some existing key present in <code>$map</code>, but nevertheless 
             differs from the existing key in some way:
          for example, it might have a different type annotation, or it might be an <code>xs:dateTime</code>
-         value in a different timezone. In this situation the key that appears in the result map
-         is always the supplied <code>$key</code>, not the existing key.</p>
+         value in a different timezone. In this situation it is 
+         <termref def="implementation-dependent"/> whether the key that appears in the result map
+         is the supplied <code>$key</code> or the existing key.</p>
 
       </fos:notes>
 
@@ -24330,7 +24332,12 @@ declare function map:find($input as item()*,
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change  issue="1651" PR="1703" date="2025-01-14"><p>Enhanced to allow for ordered maps.</p></fos:change>
+         <fos:change issue="1651" PR="1703" date="2025-01-14">
+            <p>Enhanced to allow for ordered maps.</p>
+         </fos:change>
+         <fos:change issue="1725">
+            <p>It is no longer guaranteed that the new key replaces the existing key.</p>
+         </fos:change>
       </fos:changes>
    </fos:function>
    
@@ -24707,9 +24714,9 @@ map:for-each($map, fn($key, $value) {
                   <item><p>The position of the combined entry in the
                   <xtermref spec="DM40" ref="dt-entry-order"/> of the result map
                   will correspond to the position of the first of the duplicates.</p></item>
-                  <item><p>The key of the combined entry in the
-                  <xtermref spec="DM40" ref="dt-entry-order"/> of the result map
-                  will correspond to the key of the <emph>last</emph> of the duplicates.
+                  <item><p>The key of the combined entry 
+                  will correspond to the key of one of the duplicates: it is
+                  <termref def="implementation-dependent"/> which one is chosen.
                   (It is possible for two keys to be considered duplicates even if they differ:
                   for example, they may have different type annotations, or they may
                   be <code>xs:dateTime</code> values in different timezones.) </p></item>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23206,9 +23206,7 @@ map:of-pairs($maps =!> map:pairs(),
       </fos:equivalent>
      
       <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="RG" code="0013"
-               /> if both the <code>combine</code> and <code>duplicates</code>
-            options are present.</p>
+
          
          <p>An error is raised <errorref spec="FO" class="JS" code="0003"
                /> if the value of 
@@ -23253,6 +23251,12 @@ map:of-pairs($maps =!> map:pairs(),
 ))</eg></fos:expression>
                <fos:result>{ 0: "no", 1: "yes" }</fos:result>
                <fos:postamble>Returns a map with two entries</fos:postamble>
+            </fos:test>
+            <fos:test>
+               <fos:expression><eg>map:merge(({ "red": 0 }, { "green": 1}, { "blue": 2 })) 
+                  => map:keys()</eg></fos:expression>
+               <fos:result>"red", "green", "blue"</fos:result>
+               <fos:postamble>Note the order of the result.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-merge-week">
                <fos:expression><eg>map:merge(
@@ -23303,21 +23307,26 @@ map:of-pairs($maps =!> map:pairs(),
                   entry that appears in the result is the <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> of the entries
                   in the input maps, retaining order.</fos:postamble>
             </fos:test>
-           
             <fos:test>
-               <fos:expression><eg>map:merge(({ "red": 0 }, { "green": 1}, { "blue": 2 })) 
-                  => map:keys()</eg></fos:expression>
-               <fos:result>"red", "green", "blue"</fos:result>
+               <fos:expression>map:merge(
+  ({ "oxygen": 0.22, "hydrogen": 0.68, "nitrogen": 0.1 },
+   { "oxygen": 0.24, "hydrogen": 0.70, "nitrogen": 0.06 }), 
+  { "duplicates": fn($a, $b){ max(($a, $b)) } })
+               </fos:expression>
+               <fos:result>{ "oxygen": 0.24, "hydrogen": 0.70, "nitrogen": 0.1 }</fos:result>
+               <fos:postamble>The result map holds, for each distinct key, the maximum of the values
+               for that key in the input.</fos:postamble>
             </fos:test>
+            
 
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="1725">
+         <fos:change issue="1725" PR="1727" date="2025-01-31">
             <p>For consistency with the new functions <function>map:build</function>
             and <function>map:of-pairs</function>, the handling of duplicates
-            may now be controlled by the <code>combine</code> option as an alternative
-            to the existing <code>duplicates</code> option.</p>
+            may now be controlled by supplying a user-defined callback function as an alternative
+            to the fixed values for the earlier <code>duplicates</code> option.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -23364,54 +23373,49 @@ map:of-pairs($maps =!> map:pairs(),
                   taken if two entries in the input sequence have key values
                   <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
                   <termref
-                     def="dt-same-key">same key</termref>. This option and the <code>combine</code>
-                  option are mutually exclusive.
+                     def="dt-same-key">same key</termref>. 
                </fos:meaning>
-               <fos:type>xs:string</fos:type>
-               <fos:default>combine</fos:default>
+               <fos:type>(enum( "reject", "use-first", "use-last", "use-any", "combine") | fn(item()*, item()*) as item()*)?</fos:type>
+               <fos:default>"combine"</fos:default>
                <fos:values>
-                  <fos:value value="reject">
-                     Equivalent to specifying <code>"combine": fn(){error(xs:QName("err:FOJS0003"), ...)</code>
-                     (the remaining arguments to <function>fn:error</function> being
-                     <termref def="implementation-defined"/>).
+                  <fos:value value='"reject"'>
+                     Equivalent to supplying a function that raises a dynamic error
+                     with error code "FOJS0003". The effect is that duplicate keys
+                     result in an error.
                   </fos:value>
-                  <fos:value value="use-first"
-                        >Equivalent to specifying <code>"combine": fn($a, $b){ $a }</code>.
+                  <fos:value value='"use-first"'
+                        >Equivalent to supplying the function <code>fn($a, $b){ $a }</code>.
+                     The effect is that the first of the duplicates is chosen.
                   </fos:value>
-                  <fos:value value="use-last"
-                        >Equivalent to specifying <code>"combine": fn($a, $b){ $b }</code>.
+                  <fos:value value='"use-last"'
+                        >Equivalent to supplying the function <code>fn($a, $b){ $b }</code>.
+                     The effect is that the last of the duplicates is chosen.
                   </fos:value>
-                  <fos:value value="use-any"
-                        >Equivalent to specifying <code>"combine": fn($a, $b){ one-of($a, $b) }</code>
+                  <fos:value value='"use-any"'
+                        >Equivalent to supplying the function <code>fn($a, $b){ one-of($a, $b) }</code>
                      where <code>one-of</code> chooses either <code>$a</code> or <code>$b</code> in
-                     an <termref def="implementation-defined"/> way.
+                     an <termref def="implementation-dependent"/> way. The effect is that it is
+                     <termref def="implementation-dependent"/> which of the duplicates is chosen.
                   </fos:value>
-                  <fos:value value="combine"
-                        >Equivalent to specifying <code>"combine": fn($a, $b){ $a, $b }</code>.
+                  <fos:value value='"combine"'
+                        >Equivalent to supplying the function <code>fn($a, $b){ $a, $b }</code>
+                     (or equivalently, the function <code>op(",")</code>).
+                     The effect is that the result contains the <xtermref spec="XP40" ref="dt-sequence-concatenation"/>
+                     of the values having the same key, retaining order.
+                  </fos:value>
+                  <fos:value value="function(*)">
+                     A function with signature <code>fn(item()*, item()*) as item()*</code>.
+                     The function is called for any entry in the input sequence that has the 
+                     <termref def="dt-same-key"/> as a previous entry. The first argument
+                     is the existing value associated with the key; the second argument
+                     is the value associated with the key in the duplicate input entry,
+                     and the result is the new value to be associated with the key. The effect
+                     is cumulative: for example if there are three values <var>X</var>, <var>Y</var>,
+                     and <var>Z</var> associated with the same key, and the supplied function is
+                     <var>F</var>, then the result is an entry whose value is 
+                     <code><var>X</var> => <var>F</var>(<var>Y</var>) => <var>F</var>(<var>Z</var>)</code>.
                   </fos:value>
                </fos:values>
-            </fos:option>
-
-            <fos:option key="combine">
-                  <fos:meaning>Supplies a function for handling duplicate keys: specifically, the action to be
-                     taken if entries in the input sequence contain entries with key values
-                     <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
-                     <termref
-                        def="dt-same-key">same key</termref>. This option and the <code>duplicates</code>
-                     option are mutually exclusive.
-                  </fos:meaning>
-                  <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
-                  <fos:default>fn($a, $b){ $a, $b }</fos:default>
-                  <fos:values>
-                     <fos:value value="User-supplied function">
-                        A function with signature <code>fn(item()*, item()*) as item()*</code>.
-                        The function is called for any entry in the input sequence that has the 
-                        <termref def="dt-same-key"/> as a previous entry. The first argument
-                        is the existing value associated with the key; the second argument
-                        is the value associated with the key in the duplicate input entry,
-                        and the result is the new value to be associated with the key.
-                     </fos:value>
-                  </fos:values>
                         
              </fos:option>
 
@@ -23426,15 +23430,19 @@ let $one-of := fn($a, $b) {
    (: select either $a or $b at implementation option :)
    if (environment-variable("X")) then $a else $b
 }
+let $duplicates := $options ? duplicates
 let $combine as function(item()*, item()*) as item()* :=
-  { "reject":    fn($a, $b){ error(xs:QName("err:FOJS0003")) },
-    "use-first": fn($a, $b){ $a },
-    "use-last":  fn($a, $b){ $b },
-    "use-any":   fn($a, $b){ $one-of($a, $b) },
-    "combine":   fn($a, $b){ $a, $b }
-  } ? ($options?duplicates)
-  otherwise $options?combine
-  otherwise fn($a, $b) { $a, $b }
+  if ($duplicates instance of xs:string)
+  then 
+      { "reject":    fn($a, $b){ error(xs:QName("err:FOJS0003")) },
+        "use-first": fn($a, $b){ $a },
+        "use-last":  fn($a, $b){ $b },
+        "use-any":   fn($a, $b){ $one-of($a, $b) },
+        "combine":   fn($a, $b){ $a, $b }
+      } ? $duplicates
+  else if ($duplicates instance of function(*))    
+  then $duplicates
+  else fn($a, $b) { $a, $b }
 return fold-left( $input, {},
          fn ( $out, $next ) {
            let $newVal :=
@@ -23445,17 +23453,11 @@ return fold-left( $input, {},
          })
       </fos:equivalent>
       <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="RG" code="0013"
-               /> if both the <code>combine</code> and <code>duplicates</code>
-            options are present.</p>
          
          <p>An error is raised <errorref spec="FO" class="JS" code="0003"
                /> if the value of 
           <code>$options</code> indicates that duplicates are to be rejected, and a duplicate key is encountered.</p>
-         <p>An error is raised <errorref spec="FO" class="JS" code="0005"
-               /> if the value of 
-          <code>$options</code> includes an entry whose key is defined 
-          in this specification, and whose value is not a permitted value for that key.</p>
+         
          
       </fos:errors>
 
@@ -23543,25 +23545,36 @@ return fold-left( $input, {},
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs(
   (map:pairs($week), { "key": 6, "value": "Sonnabend" }),
-  { "combine": fn($old, $new) { $new } }
+  { "duplicates": "use-last" }
 )</eg></fos:expression>
                <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
   4: "Donnerstag", 5: "Freitag", 6: "Sonnabend" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map
                   contains all the entries from <code>$week</code>, with one entry replaced by a
                   new entry. Both input maps contain an entry with the key <code>6</code>; the
-                  supplied <code>$combine</code> function ensures that the one used in the result 
+                  supplied <code>$duplicates</code> option ensures that the one used in the result 
                   is the one that comes last in the input sequence.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs(
   (map:pairs($week), { "key": 6, "value": "Sonnabend" }),
-  { "combine": concat(?, '|', ?) }
+  { "duplicates": concat(?, '|', ?) }
 )</eg></fos:expression>
                <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
   4: "Donnerstag", 5: "Freitag", 6: "Samstag|Sonnabend" }</fos:result>
                <fos:postamble>In the result map, the value for key <code>6</code> is obtained by concatenating the values
                   from the two input maps, with a separator character.</fos:postamble>
+            </fos:test>
+            
+            <fos:test>
+               <fos:expression><eg>map:of-pairs(
+   (  map:pairs({ "England": 2, "Germany": 1 }),
+      map:pairs({ "France": 2, "Germany": 2 })
+      map:pairs({ "England": 0, "France": 1 }) ), 
+   { "duplicates": op("+") })</eg></fos:expression>
+            
+            <fos:result>{ "England": 2, "Germany": 3, "France": 3 }</fos:result>
+               <fos:postamble>The values for each distinct key are summed.</fos:postamble>
             </fos:test>
             
             <fos:test>
@@ -24683,8 +24696,8 @@ map:for-each($map, fn($key, $value) {
             <item><p>If the key is not already present in the target map, the processor adds a
                new key-value pair to the map, with that key and that value. </p></item>
             <item><p>If the key is already present, the processor combines the new value for the key
-               with the existing value as determined by the <code>combine</code>
-               and <code>duplicates</code> options.</p>
+               with the existing value as determined by the 
+               and <code>duplicates</code> option.</p>
                <p>By default, when two duplicate entries occur:</p>
                <ulist>
                   <item><p>A single combined entry will be present in the result.</p></item>
@@ -24724,9 +24737,6 @@ map:for-each($map, fn($key, $value) {
 ) => map:of-pairs($options)      
       </fos:equivalent>
       <fos:errors>
-         <p>An error is raised <errorref spec="FO" class="RG" code="0013"
-               /> if both the <code>combine</code> and <code>duplicates</code>
-            options are present.</p>
          
          <p>An error is raised <errorref spec="FO" class="JS" code="0003"
                /> if the value of 
@@ -24789,7 +24799,7 @@ map:for-each($map, fn($key, $value) {
   ("apple", "apricot", "banana", "blueberry", "cherry"), 
   substring(?, 1, 1),
   string-length#1,
-  { "combine": op("+") }
+  { "duplicates": op("+") }
 )</eg></fos:expression>
                <fos:result>{ "a": 12, "b": 15, "c": 6 }</fos:result>
                <fos:postamble>Constructs a map where the key is the first character of an input item, and where the corresponding value
@@ -24845,7 +24855,7 @@ return map:build($titles/title, fn($title) { $title/ix })
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose
                corresponding values represent the number of employees at each distinct location. Any employees that
                lack an <code>@location</code> attribute will be excluded from the result.</p>
-            <eg>map:build(//employee, fn { @location }, fn { 1 }, { "combine": op("+") })</eg>
+            <eg>map:build(//employee, fn { @location }, fn { 1 }, { "duplicates": op("+") })</eg>
          </fos:example>
          <fos:example>
             <p>The following expression creates a map whose keys are employee <code>@location</code> values, and whose

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23231,6 +23231,11 @@ map:of-pairs($maps =!> map:pairs(),
             types. The type of a map (for example <code>map(xs:integer, xs:string)</code>) is
             descriptive of the entries it currently contains, but is not a constraint on how the map
             may be combined with other maps.</p>
+         <p>The XSLT 3.0 recommendation included a specification of this function that incorrectly used
+            the option value <code>{'duplicates':'unspecified'}</code> in place of
+            <code>{'duplicates':'use-any'}</code>. XSLT implementations wishing to
+            preserve backwards compatibility <rfc2119>may</rfc2119> choose to retain support
+            for this setting.</p>
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-merge-week"
@@ -24718,7 +24723,20 @@ map:for-each($map, fn($key, $value) {
   return map:pair($key, $val)
 ) => map:of-pairs($options)      
       </fos:equivalent>
-      
+      <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="RG" code="0013"
+               /> if both the <code>combine</code> and <code>duplicates</code>
+            options are present.</p>
+         
+         <p>An error is raised <errorref spec="FO" class="JS" code="0003"
+               /> if the value of 
+          <code>$options</code> indicates that duplicates are to be rejected, and a duplicate key is encountered.</p>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0005"
+               /> if the value of 
+          <code>$options</code> includes an entry whose key is defined 
+          in this specification, and whose value is not a permitted value for that key.</p>
+         
+      </fos:errors>
       
       <fos:notes>
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23148,8 +23148,7 @@ xs:QName('xs:double')</eg></fos:result>
       </fos:summary>
       <fos:rules>
          <p>The function <function>map:merge</function>
-            <phrase>returns a map</phrase> that
-            is formed by combining the contents of the maps supplied in the <code>$maps</code>
+            returns a map that is formed by combining the contents of the maps supplied in the <code>$maps</code>
             argument.</p>
 
 
@@ -23158,130 +23157,52 @@ xs:QName('xs:double')</eg></fos:result>
          <olist>
             <item>
                <p>There is one entry in the returned map for each distinct key present in the union
-                  of the input maps, where two keys are distinct if they are not the <phrase><termref
-                        def="dt-same-key">same key</termref></phrase>.</p>
+                  of the input maps, where two keys are distinct if they are not the <termref
+                        def="dt-same-key">same key</termref>. The order of the input maps,
+               and of the entries within these input maps, is retained in the 
+               <xtermref spec="DM40" ref="dt-entry-order"/> of the result map.</p>
             </item>
             <item>
                <p>If there are duplicate keys, that is, if two or more maps contain entries having the
                   <termref
                      def="dt-same-key"
-                     >same key</termref>, then the way this is handled is
-                  controlled by the <code>$options</code> argument.</p>
-            </item>
-         </olist>
-
-
-         <p>The definitive specification is as follows.</p>
-
-         <olist>
-            <item>
-               <p>If the second argument is omitted or an empty sequence, the effect is the same as
-                  calling the two-argument function with an empty map as the value of <code>$options</code>.</p>
-            </item>
-            <item>
-               <p>The <code>$options</code> argument can be used to control the way in which duplicate keys are handled.
-               The <termref
-                     def="option-parameter-conventions"
-                  >option parameter conventions</termref> apply.
-            </p>
-            </item>
-            <item><p>In the event that two or more entries in the input maps have the 
-               <termref def="dt-same-key"/>:</p>
-               <olist>
-                  <item><p>A single entry is created by combining the values of the duplicates,
-                  in a way determined by the supplied <code>$options</code>.</p></item>
-                  <item><p>The key of the combined entry is one of the duplicate keys: 
-                     which one is chosen is <termref def="implementation-defined"/>.
-                  (Two keys that are deemed duplicates may differ: for example they may have
-                  different type annotations, or they may be <code>xs:dateTime</code>
-                   values with different timezones.)</p></item>
-                  <item><p>The position of the combined entry in the <xtermref spec="DM40" ref="dt-entry-order"/>
-                  of the result map corresponds to the position of the first appearance of
-                  the corresponding key value in the input.</p></item>
-               </olist>
+                     >same key</termref>, then the relevant entries are combined in a way
+                   that is controlled by the supplied <code>$options</code>.</p>
             
-            </item>
-            <item>
-               <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
-
-               <fos:options>
-                  <fos:option key="duplicates">
-                     <fos:meaning>Determines the policy for handling duplicate keys: specifically, the action to be
-                        taken if two maps in the input sequence <code>$maps</code> contain entries with key values
-                        <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
-                        <termref
-                           def="dt-same-key">same key</termref>. This option and the <code>combine</code>
-                        option are mutually exclusive.
-                     </fos:meaning>
-                     <fos:type>xs:string</fos:type>
-                     <fos:default>use-first</fos:default>
-                     <fos:values>
-                        <fos:value value="reject">
-                           Equivalent to specifying <code>"combine": fn(){error(xs:QName("err:FOJS0003"), ...)</code>
-                           (the remaining arguments to <function>fn:error</function> being
-                           <termref def="implementation-defined"/>).
-                        </fos:value>
-                        <fos:value value="use-first"
-                              >Equivalent to specifying <code>"combine": fn($a, $b){ $a }</code>.
-                        </fos:value>
-                        <fos:value value="use-last"
-                              >Equivalent to specifying <code>"combine": fn($a, $b){ $b }</code>.
-                        </fos:value>
-                        <fos:value value="use-any"
-                              >Equivalent to specifying <code>"combine": fn($a, $b){ one-of($a, $b) }</code>
-                           where <code>one-of</code> chooses either <code>$a</code> or <code>$b</code> in
-                           an <termref def="implementation-defined"/> way.
-                        </fos:value>
-                        <fos:value value="combine"
-                              >Equivalent to specifying <code>"combine": fn($a, $b){ $a, $b }</code>.
-                        </fos:value>
-                     </fos:values>
-                  </fos:option>
- 
-                  <fos:option key="combine">
-                        <fos:meaning>Supplies a function for handling duplicate keys: specifically, the action to be
-                           taken if two maps in the input sequence <code>$maps</code> contain entries with key values
-                           <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
-                           <termref
-                              def="dt-same-key">same key</termref>. This option and the <code>duplicates</code>
-                           option are mutually exclusive.
-                        </fos:meaning>
-                        <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
-                        <fos:default>fn($a, $b){ $a }</fos:default>
-                        <fos:values>
-                           <fos:value value="User-supplied function">
-                              A function with signature <code>fn(item()*, item()*) as item()*</code>.
-                              The function is called for any entry in an input map that has the 
-                              <termref def="dt-same-key"/> as a previous entry. The first argument
-                              is the existing value associated with the key; the second argument
-                              is the value associated with the key in the duplicate input entry,
-                              and the result is the new value to be associated with the key.
-                           </fos:value>
-                        </fos:values>
-                              
-                     </fos:option>
-
-               </fos:options>
-
+         
+               <p>The <code>$options</code> argument takes the same values (with the same meanings)
+               as the <function>map:of-pairs</function> function, except that the default is different:
+               for <code>map:merge</code>, the default for duplicate keys is <code>use-first</code>.</p>
                
-            </item>
+               <note><p>The difference is for backwards compatibility reasons.</p></note>
+               
+               <p>With the default options, when duplicate entries occur:</p>
+               
+               <olist>
+                  <item><p>There will be a single entry in the result 
+                     corresponding to a set of duplicate entries in the input.
+                  </p></item>
+                  <item><p>The value of that entry will be taken from the first
+                  of the duplicates.</p></item>
+                  <item><p>The position of that entry in the <xtermref spec="DM40"
+                  ref="dt-entry-order"/> of the result map will correspond to the
+                  position of the first of the duplicates.</p></item>
+                  <item><p>The key of that entry will be the key used
+                     in the <emph>last</emph> of the duplicates. (Keys may be 
+                  duplicates even though they differ: for example, they may have
+                  different type annotations, or they may be <code>xs:dateTime</code>
+                  values in different timezones.)</p></item>
+               </olist>
+
+           </item>
+
          </olist>
- 
 
       </fos:rules>
-      <fos:equivalent style="xpath-expression" covers-error-cases="false">
-let $FOJS0003 := QName("http://www.w3.org/2005/xqt-errors", "FOJS0003")
-let $combiner := $options?combine
-  otherwise {
-      "use-first": fn($a, $b) { $a },
-      "use-last":  fn($a, $b) { $b },
-      "combine":   fn($a, $b) { $a, $b },
-      "reject":    fn($a, $b) { fn:error($FOJS0003) },
-      "use-any":   fn($a, $b) { fn:random-number-generator()?permute(($a, $b))[1] }
-    } ($options?duplicates)
-  otherwise        fn($a, $b) { $a }
-  
-return map:of-pairs($maps =!> map:pairs(), { "combine": $combiner });  
+      <fos:equivalent style="xpath-expression">
+map:of-pairs($maps =!> map:pairs(), 
+             $options[exists((?duplicates, ?combine))]
+               otherwise { "duplicates": "use-first" });  
       </fos:equivalent>
      
       <fos:errors>
@@ -23300,32 +23221,11 @@ return map:of-pairs($maps =!> map:pairs(), { "combine": $combiner });
       </fos:errors>
 
       <fos:notes>
-         <note>
-            <p>By way of explanation, the function first reduces the sequence of input maps
-               to a sequence of key-value pairs, retaining order of both the maps and of the
-               entries within each map. It then combines key-value pairs having the
-               <termref def="dt-same-key"/> by applying the <code>$combine</code> function
-               successively to pairs of duplicates. The position in the <xtermref spec="DM40" ref="dt-entry-order"/>
-               of the result map of an entry formed by combining duplicates corresponds to the
-               position of the first occurrence of the key in the input sequence. This is true
-               even whien the option <code>use-last</code> is used: the value of the resulting
-               entry corresponds to the last entry with a given key, but the position of the entry
-               in the result map corresponds to the position of the first entry with that key.
-            </p>
-            
-            <p>The use of <function>fn:random-number-generator</function> represents one possible conformant
-         implementation for <code>"duplicates": "use-any"</code>, but it is not the only conformant
-         implementation and is not intended to be a realistic implementation. The purpose of this
-         option is to allow the implementation to use whatever strategy is most efficient; for example,
-         if the input maps are processed in parallel, then specifying <code>"duplicates": "use-any"</code>
-         means that the implementation does not need to keep track of the original order of the sequence of input
-         maps.</p>
-
-         </note>
+         
 
          <p>If the input is an empty sequence, the result is an empty map.</p>
          <p>If the input is a sequence of length one, the result map is 
-            <phrase>indistinguishable from the supplied map</phrase>.</p>
+            indistinguishable from the input map.</p>
          <p>There is no requirement that 
             the supplied input maps should have the same or compatible
             types. The type of a map (for example <code>map(xs:integer, xs:string)</code>) is
@@ -23447,55 +23347,139 @@ return map:of-pairs($maps =!> map:pairs(), { "combine": $combiner });
          <p>The <code>$options</code> argument can be used to control 
             the way in which duplicate keys are handled.
             The <termref def="option-parameter-conventions">option parameter conventions</termref> apply.
-            The handling of duplicates is defined to be the same as in an equivalent call of
-            the <function>map:build</function> function: see the formal equivalent below.
+            
          </p>
  
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
 
          <fos:options>
-            <fos:option key="combine">
-               <fos:meaning>A function that is used to combine two different values that are supplied
-                  for the same key. The default is to combine the two values using
-                  <xtermref spec="XP40" ref="dt-sequence-concatenation"/>, retaining their order
-                  in the input sequence.
+  
+            <fos:option key="duplicates">
+               <fos:meaning>Determines the policy for handling duplicate keys: specifically, the action to be
+                  taken if two entries in the input sequence have key values
+                  <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
+                  <termref
+                     def="dt-same-key">same key</termref>. This option and the <code>combine</code>
+                  option are mutually exclusive.
                </fos:meaning>
-               <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
-               <fos:default>fn:op(',')</fos:default>
+               <fos:type>xs:string</fos:type>
+               <fos:default>combine</fos:default>
                <fos:values>
-                  <fos:value value="User-supplied function">
-                        The function is called for any entry in an input map that has the 
+                  <fos:value value="reject">
+                     Equivalent to specifying <code>"combine": fn(){error(xs:QName("err:FOJS0003"), ...)</code>
+                     (the remaining arguments to <function>fn:error</function> being
+                     <termref def="implementation-defined"/>).
+                  </fos:value>
+                  <fos:value value="use-first"
+                        >Equivalent to specifying <code>"combine": fn($a, $b){ $a }</code>.
+                  </fos:value>
+                  <fos:value value="use-last"
+                        >Equivalent to specifying <code>"combine": fn($a, $b){ $b }</code>.
+                  </fos:value>
+                  <fos:value value="use-any"
+                        >Equivalent to specifying <code>"combine": fn($a, $b){ one-of($a, $b) }</code>
+                     where <code>one-of</code> chooses either <code>$a</code> or <code>$b</code> in
+                     an <termref def="implementation-defined"/> way.
+                  </fos:value>
+                  <fos:value value="combine"
+                        >Equivalent to specifying <code>"combine": fn($a, $b){ $a, $b }</code>.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+
+            <fos:option key="combine">
+                  <fos:meaning>Supplies a function for handling duplicate keys: specifically, the action to be
+                     taken if entries in the input sequence contain entries with key values
+                     <var>K1</var> and <var>K2</var> where <var>K1</var> and <var>K2</var> are the 
+                     <termref
+                        def="dt-same-key">same key</termref>. This option and the <code>duplicates</code>
+                     option are mutually exclusive.
+                  </fos:meaning>
+                  <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
+                  <fos:default>fn($a, $b){ $a, $b }</fos:default>
+                  <fos:values>
+                     <fos:value value="User-supplied function">
+                        A function with signature <code>fn(item()*, item()*) as item()*</code>.
+                        The function is called for any entry in the input sequence that has the 
                         <termref def="dt-same-key"/> as a previous entry. The first argument
                         is the existing value associated with the key; the second argument
                         is the value associated with the key in the duplicate input entry,
                         and the result is the new value to be associated with the key.
                      </fos:value>
                   </fos:values>
-            </fos:option>
-            
+                        
+             </fos:option>
+
          </fos:options>
 
 
-        
+               
 
       </fos:rules>
-      <fos:equivalent style="xpath-expression">
-map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
+      <fos:equivalent style="xpath-expression" covers-error-cases="false">
+let $one-of := fn($a, $b) {
+   (: select either $a or $b at implementation option :)
+   if (environment-variable("X")) then $a else $b
+}
+let $combine as function(item()*, item()*) as item()* :=
+  { "reject":    fn($a, $b){ error(xs:QName("err:FOJS0003")) },
+    "use-first": fn($a, $b){ $a },
+    "use-last":  fn($a, $b){ $b },
+    "use-any":   fn($a, $b){ $one-of($a, $b) },
+    "combine":   fn($a, $b){ $a, $b }
+  } ? ($options?duplicates)
+  otherwise $options?combine
+  otherwise fn($a, $b) { $a, $b }
+return fold-left( $input, {},
+         fn ( $out, $next ) {
+           let $newVal :=
+             if (map:contains( $out, $next?key ))
+             then $combine( $out?($next?key), $next?value )
+             else $next?value
+           return map:put( $result, $next?key, $newVal )
+         })
       </fos:equivalent>
       <fos:errors>
+         <p>An error is raised <errorref spec="FO" class="RG" code="0013"
+               /> if both the <code>combine</code> and <code>duplicates</code>
+            options are present.</p>
          
+         <p>An error is raised <errorref spec="FO" class="JS" code="0003"
+               /> if the value of 
+          <code>$options</code> indicates that duplicates are to be rejected, and a duplicate key is encountered.</p>
+         <p>An error is raised <errorref spec="FO" class="JS" code="0005"
+               /> if the value of 
+          <code>$options</code> includes an entry whose key is defined 
+          in this specification, and whose value is not a permitted value for that key.</p>
          
-         <p>The function can be made to fail with a dynamic error in the event that
-         duplicate keys are present in the input sequence by supplying a <code>$combine</code>
-         function that invokes the <function>fn:error</function> function.</p>
       </fos:errors>
 
       <fos:notes>
+         <p>In the formal equivalent shown above:</p>
+         <ulist>
+            <item><p>The call on <code>error()</code> is indicative; the implementation
+            is free to raise the error in its own way.</p></item>
+            <item><p>The function <code>$one-of($a, $b)</code> is intended to
+            illustrate that either <code>$a</code> or <code>$b</code> is returned,
+            at the discretion of the implementation. A function body is provided
+            for completeness, but it is not intended as a realistic implementation.</p></item>
+         </ulist>
          <p>If the input is an empty sequence, the result is an empty map.</p>
          <p>There is no requirement that the supplied key-value pairs should have the same or compatible
             types. The type of a map (for example <code>map(xs:integer, xs:string)</code>) is
             descriptive of the entries it currently contains, but is not a constraint on how the map
             may be combined with other maps.</p>
+         <p>When duplicate keys are encountered, the effect is that:</p>
+         <ulist>
+            <item><p>In the <xtermref spec="DM40" ref="dt-entry-order"/> 
+               of the result map, the position of the entry containing the result
+               of combining a set of entries with duplicate keys corresponds to 
+               the position of the first of the duplicates in the input sequence.</p></item>
+            <item><p>The key of the entry containing the combined value is the <emph>last</emph> of
+            the several duplicates. (Keys may be duplicates even though they differ: 
+            for example they may have different type annotations, or they might be
+            <code>xs:dateTime</code> values in different timezones.)</p></item>
+         </ulist>
       </fos:notes>
       <fos:examples>
          <fos:variable name="week" id="v-map-of-week"
@@ -23536,8 +23520,8 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
                <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
   4: "Donnerstag", 5: "Freitag", 6: "Samstag", 7: "Unbekannt" }</fos:result>
                <fos:postamble>The value of the existing map is unchanged; the returned map 
-                  contains all the entries from <code>$week</code>, supplemented with an additional
-                  entry.</fos:postamble>
+                  contains all the entries from <code>$week</code>, supplemented 
+                  with an additional entry.</fos:postamble>
             </fos:test>
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs((
@@ -23554,7 +23538,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs(
   (map:pairs($week), { "key": 6, "value": "Sonnabend" }),
-  fn($old, $new) { $new }
+  { "combine": fn($old, $new) { $new } }
 )</eg></fos:expression>
                <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
   4: "Donnerstag", 5: "Freitag", 6: "Sonnabend" }</fos:result>
@@ -23567,7 +23551,7 @@ map:build($input, map:get(?, 'key'), map:get(?, 'value'), $combine)
             <fos:test use="v-map-of-week">
                <fos:expression><eg>map:of-pairs(
   (map:pairs($week), { "key": 6, "value": "Sonnabend" }),
-  fn($old, $new) { `{ $old }|{ $new }` }
+  { "combine": concat(?, '|', ?) }
 )</eg></fos:expression>
                <fos:result>{ 0: "Sonntag", 1: "Montag", 2: "Dienstag", 3: "Mittwoch",
   4: "Donnerstag", 5: "Freitag", 6: "Samstag|Sonnabend" }</fos:result>
@@ -24270,28 +24254,7 @@ declare function map:find($input as item()*,
                   then the new value replaces the old value and the position of the entry is not changed;
                   otherwise, the new entry is added after all existing entries.</p>
 
-         <!--<p>The effect of the function call <code>map:put($MAP, $KEY, $VALUE)</code> is equivalent
-         to the result of the following steps:</p>
-
-         <olist>
-            <item>
-               <p>
-                  <code>let $MAP2 := map:remove($MAP, $KEY)</code>
-               </p>
-               <p>This returns a map in which all entries with the same key as <code>$KEY</code> have been removed.</p>
-            </item>
-            <item>
-               <p>Construct and return a map containing:</p>
-               <olist>
-                  <item>
-                     <p>All the entries (key/value pairs) in <code>$MAP2</code>, and</p>
-                  </item>
-                  <item>
-                     <p>The entry <code>map:entry($KEY, $VALUE)</code></p>
-                  </item>
-               </olist>
-            </item>
-         </olist>-->
+        
 
       </fos:rules>
       
@@ -24307,6 +24270,13 @@ declare function map:find($input as item()*,
          
          <p>It is possible to force the new entry to go at the end of the sequence by calling
          <code>map:remove</code> before calling <code>map:put</code>.</p>
+         
+         <p>It can happen that the supplied <code>$key</code> is the <termref def="dt-same-key"/>
+            as some existing key present in <code>$map</code>, but nevertheless 
+            differs from the existing key in some way:
+         for example, it might have a different type annotation, or it might be an <code>xs:dateTime</code>
+         value in a different timezone. In this situation the key that appears in the result map
+         is always the supplied <code>$key</code>, not the existing key.</p>
 
       </fos:notes>
 
@@ -24680,9 +24650,6 @@ map:for-each($map, fn($key, $value) {
       </fos:changes>
    </fos:function>
 
-   
-
-   
 
    <fos:function name="build" prefix="map">
       <fos:signatures>
@@ -24710,65 +24677,46 @@ map:for-each($map, fn($key, $value) {
          <ulist>
             <item><p>If the key is not already present in the target map, the processor adds a
                new key-value pair to the map, with that key and that value. </p></item>
-            <item><p>If the key is already present, the processor calls the <code>combine</code>
-               function in the <code>$options</code> argument to combine the existing value for the key with the new value,
-               and replaces the entry with this combined value.</p>
-               <p>The key of the combined entry is taken from one of the duplicate entries:
-                  it is <termref def="implementation-defined"/> which one is used. (It is
-                  possible for two keys to be considered duplicates even if they differ:
+            <item><p>If the key is already present, the processor combines the new value for the key
+               with the existing value as determined by the <code>combine</code>
+               and <code>duplicates</code> options.</p>
+               <p>By default, when two duplicate entries occur:</p>
+               <ulist>
+                  <item><p>A single combined entry will be present in the result.</p></item>
+                  <item><p>This entry will contain the 
+                     <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref>
+                  of the supplied values.</p></item>
+                  <item><p>The position of the combined entry in the
+                  <xtermref spec="DM40" ref="dt-entry-order"/> of the result map
+                  will correspond to the position of the first of the duplicates.</p></item>
+                  <item><p>The key of the combined entry in the
+                  <xtermref spec="DM40" ref="dt-entry-order"/> of the result map
+                  will correspond to the key of the <emph>last</emph> of the duplicates.
+                  (It is possible for two keys to be considered duplicates even if they differ:
                   for example, they may have different type annotations, or they may
-                  be <code>xs:dateTime</code> values with different timezones.)
-               </p>
-               <p>The position of the combined entry in the <xtermref spec="DM40" ref="dt-entry-order"/>
-               of the result map is based on the position of the first entry having that key
-               in the input sequence (that is, the order of keys in the result is the order
-               of first appearance in the input.</p>
+                  be <code>xs:dateTime</code> values in different timezones.) </p></item>
+               </ulist>
+               <p>The <code>$options</code> argument can be used to control the 
+            way in which duplicate keys are handled. The allowed options, and their
+            meanings, are the same as for the <function>map:of-pairs</function>
+            function.
+            The <termref def="option-parameter-conventions">option parameter conventions</termref> apply.
+         </p>
             </item>
          </ulist>
          
-         <p>The <code>$options</code> argument can be used to control the 
-            and the way in which duplicate keys are handled.
-            The <termref def="option-parameter-conventions">option parameter conventions</termref> apply.
-         </p>
+         
  
-         <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
-
-         <fos:options>
-            <fos:option key="combine">
-               <fos:meaning>A function that is used to combine two different values that are supplied
-                  for the same key. The default is to combine the two values using
-                  <xtermref spec="XP40" ref="dt-sequence-concatenation"/>, retaining their order
-                  in the input sequence.
-               </fos:meaning>
-               <fos:type>(fn($existing-value as item()*, $new-value as item()*) as item()*)?</fos:type>
-               <fos:default>fn:op(',')</fos:default>
-               <fos:values>
-                  <fos:value value="User-supplied function">
-                        The function is called for any entry in an input map that has the 
-                        <termref def="dt-same-key"/> as a previous entry. The first argument
-                        is the existing value associated with the key; the second argument
-                        is the value associated with the key in the duplicate input entry,
-                        and the result is the new value to be associated with the key.
-                     </fos:value>
-                  </fos:values>
-            </fos:option>
-            
-         </fos:options>
-
+         
          
          
       </fos:rules>
       <fos:equivalent style="xpath-expression">
-fold-left($input, {}, fn($map, $item, $pos) {
-  let $v := $value($item, $pos)
-  return fold-left($keys($item, $pos), $map, fn($m, $k) {
-    if (map:contains($m, $k)) then (
-      map:put($m, $k, $combine($m($k), $v))
-    ) else (
-      map:put($m, $k, $v)
-    )
-  })
-})            
+( for $item at $pos in $input
+  let $val := $value($item, $pos)
+  for $key in $keys($item, $pos)
+  return map:pair($key, $val)
+) => map:of-pairs($options)      
       </fos:equivalent>
       
       
@@ -24777,21 +24725,7 @@ fold-left($input, {}, fn($map, $item, $pos) {
          <p>The default function for both <code>$keys</code> and <code>$value</code> is the identity function.
             Although it is permitted to default both, this serves little purpose: usually at least one of these arguments
             will be supplied.</p>
-         <p>The default action for combining entries with duplicate keys is to perform a 
-            <xtermref spec="XP40" ref="dt-sequence-concatenation">sequence concatenation</xtermref> 
-            of the corresponding values,
-            equivalent to the <code>duplicates: combine</code> option on <function>map:merge</function>. Other potentially useful
-            functions for combining duplicates include:</p>
-         <ulist>
-            <item><p><code>fn($a, $b) { $a }</code> Use the first value and discard the remainder</p></item>
-            <item><p><code>fn($a, $b) { $b }</code> Use the last value and discard the remainder</p></item>
-            <item><p><code>fn:concat(?, ",", ?)</code> Form the string-concatenation of the values, comma-separated</p></item>
-            <item><p><code>fn:op('+')</code> Compute the sum of the values</p></item>
-         </ulist>
-         <p>The <xtermref spec="DM40" ref="dt-entry-order">order of entries</xtermref> in the result reflects
-         the order of the items in <code>$input</code> from which they were derived. In the
-         event that two entries have duplicate keys, the position of the combined entry
-         in the result reflects the position of the first input item with that key.</p>
+         
       </fos:notes>
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -13792,6 +13792,12 @@ ISBN 0 521 77752 6.</bibl>
               longer possible to supply an instance of <code>xs:anyURI</code> or (when XPath 1.0 compatibility
               mode is in force) an instance of <code>xs:boolean</code> or <code>xs:duration</code>.</p>
            </item>
+           <item diff="add" at="issue1725">
+              <p>When <function>fn:put</function> replaces an entry in a map with a new value for an
+              existing key, in the case where the existing key and the new key differ (for example,
+              if they have different type annotations), it is no longer guaranteed that the new
+              entry includes the new key rather than the existing key.</p>
+           </item>
         </olist>
  
          <p>For compatibility issues regarding earlier versions, see the 3.1 version of this specification.</p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -771,8 +771,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                <item><p>The type of the options parameter in the function signature is always
                given as <code>map(*)</code>.</p></item>
                <item><p>Although option names are described above as strings, the actual key may be
-                  any value that compares equal to the required string (using the <code>eq</code> operator
-                  with Unicode codepoint collation; or equivalently, the <code diff="chg" at="2023-01-25">fn:atomic-equal</code> relation). 
+                  any value that is the <termref def="dt-same-key"/> as the required string. 
                   For example, instances of <code>xs:untypedAtomic</code>
                   or <code>xs:anyURI</code> are equally acceptable.</p>
                   <note><p>This means that the implementation of the function can check for the
@@ -805,6 +804,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   A dynamic error occurs if the supplied value 
                after conversion is not one of the permitted values for the option in question: the error codes
                for this error are defined in the specification of each function.</p>
+                  
                <note><p>It is the responsibility of each function implementation to invoke this conversion; it
                does not happen automatically as a consequence of the function-calling rules.</p></note></item>
 
@@ -13274,12 +13274,12 @@ ISBN 0 521 77752 6.</bibl>
                <p>Raised when the digits in the string supplied to <function>fn:parse-integer</function> are not in the range appropriate
                   to the chosen radix.</p>
             </error>
-            <error class="RG" code="0013"
+            <!--<error class="RG" code="0013"
                label="Inconsistent options."
                type="dynamic">
                <p>Raised if an inconsistent set of options is supplied
                   in an <termref def="options">option map</termref>.</p>
-            </error>
+            </error>-->
             
             <error class="RX" code="0001" label="Invalid regular expression flags." type="static">
                <p>Raised by regular expression functions such as <function>fn:matches</function> and <function>fn:replace</function> if the

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1702,7 +1702,7 @@
       <e:attribute name="select">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="on-duplicates" required="no" default="error(xs:QName(err:XTDE3365))">
+      <e:attribute name="on-duplicates" required="no" default="fn($a, $b) { error(xs:QName(err:XTDE3365)) }">
          <e:data-type name="expression"/>
       </e:attribute>
       <!--<e:attribute name="ordered" default="no">

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1702,7 +1702,7 @@
       <e:attribute name="select">
          <e:data-type name="expression"/>
       </e:attribute>
-      <e:attribute name="on-duplicates" required="no" default="fn($a, $b) { error(xs:QName(err:XTDE3365)) }">
+      <e:attribute name="duplicates" required="no" default="fn($a, $b) { error(xs:QName(err:XTDE3365)) }">
          <e:data-type name="expression"/>
       </e:attribute>
       <!--<e:attribute name="ordered" default="no">

--- a/specifications/xslt-40/src/schema-for-xslt40.rnc
+++ b/specifications/xslt-40/src/schema-for-xslt40.rnc
@@ -1125,10 +1125,9 @@ map.element =
    element map {
       extension.atts,
       global.atts,
-      sequence-constructor.model
+      select-or-sequence-constructor.model
    }
-# TODO: add @on-duplicates
-# TODO: add @ordering
+# TODO: add @duplicates
 
 map-entry.element =
    element map-entry {

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -1128,11 +1128,9 @@ of problems processing the schema using various tools
               substitutionGroup="xsl:instruction">
     <xs:complexType>
       <xs:complexContent mixed="true">
-        <xs:extension base="xsl:sequence-constructor">
-          <xs:attribute name="on-duplicates" type="xsl:expression"/>
-          <xs:attribute name="ordering" type="xsl:avt"/>
-          <xs:attribute name="_on-duplicates" type="xs:string"/>
-          <xs:attribute name="_ordering" type="xs:string"/>
+        <xs:extension base="xsl:sequence-constructor-and-select">
+          <xs:attribute name="duplicates" type="xsl:expression"/>
+          <xs:attribute name="_duplicates" type="xs:string"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -15349,7 +15349,7 @@ return $tree =?> depth()]]></eg>
 }</eg>
                <p>The following code processes this map to produce an XML representation of the same information. The
                   cities are sorted by name:</p>
-               <eg><![CDATA[<xsl:for-each select="map:key-value-pairs(json-doc('input.json'))">
+               <eg><![CDATA[<xsl:for-each select="map:pairs(json-doc('input.json'))">
    <xsl:sort select="?key"/>
    <city number="{position()}" 
          name="{?key}" 
@@ -36196,7 +36196,7 @@ the same group, and the-->
                   all the keys to upper case. A dynamic error occurs if this results in duplicate
                   keys:</p>
                <eg role="xslt-declaration" xml:space="preserve">&lt;xsl:map&gt;
-  &lt;xsl:for-each select="map:key-value-pairs($map)"&gt;
+  &lt;xsl:for-each select="map:pairs($map)"&gt;
     &lt;xsl:map-entry key="upper-case(?key)" select="?value"/&gt;
   &lt;/xsl:for-each&gt;
 &lt;/xsl:map&gt; 
@@ -36208,7 +36208,7 @@ the same group, and the-->
                <p>The following example modifies a supplied map <code>$input</code> by wrapping
                   each of the values in an array:</p>
                <eg role="xslt-declaration" xml:space="preserve">&lt;xsl:map&gt;
-  &lt;xsl:for-each select="map:key-value-pairs($map)"&gt;
+  &lt;xsl:for-each select="map:pairs($map)"&gt;
     &lt;xsl:map-entry key="?key"&gt;
        &lt;xsl:array select="?value"/&gt;
     &lt;/xsl:map-entry>
@@ -36217,7 +36217,7 @@ the same group, and the-->
 </eg>
                <p>This could also be written:</p>
                <eg role="xslt-declaration" xml:space="preserve"><![CDATA[<xsl:map select="
-  map:key-value-pairs($map) ! { ?key : array{ ?value } }"/>
+  map:pairs($map) ! { ?key : array{ ?value } }"/>
 ]]></eg>
             </example>
             
@@ -36235,7 +36235,7 @@ the same group, and the-->
                <p>This section describes what happens when two or more maps in the input sequence of
                within an <elcode>xsl:map</elcode> instruction contain duplicate keys: that is, when one of these
                maps contains an entry with key <var>K</var>, and another contains an entry with key <var>L</var>,
-                  and <code diff="chg" at="2023-01-25">fn:atomic-equal(K, L)</code> returns <code>true</code>.</p>
+                  and <code>fn:atomic-equal(<var>K</var>, <var>L</var>)</code> returns <code>true</code>.</p>
                
                <p><error spec="XT" class="DE" code="3365" type="dynamic">
                   <p>In the absence of the <code>on-duplicates</code> attribute, 
@@ -36250,6 +36250,15 @@ the same group, and the-->
                map entries having the same key, the two values associated with this key are passed as
                arguments to this function, and the function returns the value that should be associated
                with this key in the final map.</p>
+               
+               <p>More formally, the result of the <elcode>xsl:map</elcode> instruction is defined by reference to 
+               the function <xfunction>map:merge</xfunction>. Specifically, if <code>$maps</code>
+               is the input sequence to <elcode>xsl:map</elcode>, and <code>$combine</code>
+               is the <termref def="dt-effective-value"/> of the <code>on-duplicates</code>
+               attribute, then the result of the instruction is the result of the function
+               call <code>map:merge($maps, { "combine": $combine })</code>.</p>
+               
+       <!--        
                
                <p>The order of the arguments passed to the function reflects the order of the maps in which
                the duplicate entries appear: if map <var>M</var> and map <var>N</var> contain values <var>V/M</var>
@@ -36272,9 +36281,9 @@ the same group, and the-->
                
                <p>Thus, if the values are all singleton items (which is not necessarily the case), and if the sequence
                of values is <var>S</var>, then the final result is <code>fold-left(tail(S), head(S), F)</code>.</p>
-               
-               <p>For example, the following table shows some useful callback functions that might be supplied,
-                  and explains their effect:</p>
+               -->
+               <p>For example, the following table shows some useful callback functions that might be supplied
+                  as the value of the <code>on-duplicates</code> attribute, and explains their effect:</p>
                
                <table>
                   <thead>
@@ -36294,9 +36303,9 @@ the same group, and the-->
                      </tr>
                      <tr>
                         <td><code>fn($a, $b) { $a, $b }</code></td>
-                        <td>The sequence-concatenation of the duplicate values is used. 
-                           <phrase diff="add" at="2023-04-04">This could
-                        also be expressed as <code>on-duplicates="op(',')"</code>.</phrase></td>
+                        <td>The <xtermref spec="XP40" ref="dt-sequence-concatenation"/> 
+                           of the duplicate values is used. This could
+                        also be expressed as <code>on-duplicates="op(',')"</code>.</td>
                      </tr>
                      <tr>
                         <td><code>fn($a, $b) { max(($a, $b)) }</code></td>
@@ -36307,7 +36316,7 @@ the same group, and the-->
                         <td>The lowest of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>fn($a, $b) { string-join(($a, $b), ', ') }</code></td>
+                        <td><code>concat(?, ', ', ?) }</code></td>
                         <td>The comma-separated string concatenation of the duplicate values is used.</td>
                      </tr>
                      <tr diff="add" at="2023-04-04">
@@ -36318,8 +36327,8 @@ the same group, and the-->
                      </tr>
                      <tr>
                         <td><code>fn($a, $b) { error() }</code></td>
-                        <td>Duplicates are rejected as an error (this is the default in the absence of a
-                           callback function).</td>
+                        <td>Duplicates are rejected as an error (this is the default in the absence of the
+                           <code>on-duplicates</code> attribute).</td>
                      </tr>
                   </tbody>
                </table>
@@ -36344,6 +36353,21 @@ the same group, and the-->
    </xsl:map>
    </xsl:template>]]></eg>
                </example>
+               
+               <note>
+                  <p>Specifying the effect by reference to <xfunction>map:merge</xfunction> has
+                  the following consequences when duplicates are combined
+                  into a merged entry:</p>
+                  <ulist>
+                     <item><p>The position of the merged entry in the result corresponds
+                     to the position of the first of the duplicate keys in the input.</p></item>
+                     <item><p>The key used for the merged entry in the result corresponds
+                     to the last of the duplicate keys in the input. This is relevant when
+                     the duplicate keys differ in some way, for example when they have
+                     different type annotations, or when they are <code>xs:dateTime</code>
+                     values in different timezones.</p></item>
+                  </ulist>
+               </note>
                
                
             </div3>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -36226,7 +36226,7 @@ the same group, and the-->
                
                <changes>
                   <change issue="169" date="2023-11-28">
-                     A new attribute <code>xsl:map/@on-duplicates</code> is available,
+                     A new attribute <code>xsl:map/@duplicates</code> is available,
                   allowing control over how duplicate keys are handled by the <elcode>xsl:map</elcode>
                   instruction.
                   </change>
@@ -36238,25 +36238,26 @@ the same group, and the-->
                   and <code>fn:atomic-equal(<var>K</var>, <var>L</var>)</code> returns <code>true</code>.</p>
                
                <p><error spec="XT" class="DE" code="3365" type="dynamic">
-                  <p>In the absence of the <code>on-duplicates</code> attribute, 
+                  <p>In the absence of the <code>duplicates</code> attribute, 
                      a <termref def="dt-dynamic-error">dynamic error</termref> occurs if the set of
                      keys in the maps making up the input sequence
                      <error.extra>of an <elcode>xsl:map</elcode> instruction</error.extra>
                      contains duplicates.</p>
                </error></p>
                
-               <p>The result of evaluating the <code>on-duplicates</code> attribute, if present, <rfc2119>must</rfc2119>
-               be a function with arity 2. When the <elcode>xsl:map</elcode> instruction encounters two
-               map entries having the same key, the two values associated with this key are passed as
-               arguments to this function, and the function returns the value that should be associated
-               with this key in the final map.</p>
+               <p>The result of evaluating the <code>duplicates</code> attribute, if present, <rfc2119>must</rfc2119>
+               be either one of the strings <code>"use-first"</code>, <code>"use-last"</code>,
+                  <code>"use-any"</code>, <code>"combine"</code>, or <code>"reject"</code>,
+                  or a function with arity 2. These values correspond to the permitted
+                  values of the <code>duplicates</code> option of the 
+                  <xfunction>map:of-pairs</xfunction> function.</p>
                
-               <p>More formally, the result of the <elcode>xsl:map</elcode> instruction is defined by reference to 
-               the function <xfunction>map:merge</xfunction>. Specifically, if <code>$maps</code>
-               is the input sequence to <elcode>xsl:map</elcode>, and <code>$combine</code>
-               is the <termref def="dt-effective-value"/> of the <code>on-duplicates</code>
+               <p>The result of the <elcode>xsl:map</elcode> instruction is defined by reference to 
+               the function <xfunction>map:of-pairs</xfunction>. Specifically, if <code>$maps</code>
+               is the input sequence to <elcode>xsl:map</elcode>, and <code>$duplicates</code>
+               is the <termref def="dt-effective-value"/> of the <code>duplicates</code>
                attribute, then the result of the instruction is the result of the function
-               call <code>map:merge($maps, { "combine": $combine })</code>.</p>
+               call <code>map:of-pairs(map:pairs($maps), { "duplicates": $duplicates })</code>.</p>
                
        <!--        
                
@@ -36282,8 +36283,8 @@ the same group, and the-->
                <p>Thus, if the values are all singleton items (which is not necessarily the case), and if the sequence
                of values is <var>S</var>, then the final result is <code>fold-left(tail(S), head(S), F)</code>.</p>
                -->
-               <p>For example, the following table shows some useful callback functions that might be supplied
-                  as the value of the <code>on-duplicates</code> attribute, and explains their effect:</p>
+               <p>The following table shows some possible values 
+                  of the <code>duplicates</code> attribute, and explains their effect:</p>
                
                <table>
                   <thead>
@@ -36294,41 +36295,47 @@ the same group, and the-->
                   </thead>
                   <tbody>
                      <tr>
-                        <td><code>fn($a, $b) { $a }</code></td>
+                        <td><code>duplicates="use-first"</code></td>
                         <td>The first of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>fn($a, $b) { $b }</code></td>
+                        <td><code>duplicates="use-last"</code></td>
                         <td>The last of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>fn($a, $b) { $a, $b }</code></td>
+                        <td><code>duplicates="combine"</code></td>
                         <td>The <xtermref spec="XP40" ref="dt-sequence-concatenation"/> 
                            of the duplicate values is used. This could
                         also be expressed as <code>on-duplicates="op(',')"</code>.</td>
                      </tr>
                      <tr>
-                        <td><code>fn($a, $b) { max(($a, $b)) }</code></td>
+                        <td><code>duplicates="fn($a, $b) { max(($a, $b)) }"</code></td>
                         <td>The highest of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>fn($a, $b) { min(($a, $b)) }</code></td>
+                        <td><code>duplicates="fn($a, $b) { min(($a, $b)) }"</code></td>
                         <td>The lowest of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>concat(?, ', ', ?) }</code></td>
+                        <td><code>duplicates="concat(?, ', ', ?) }"</code></td>
                         <td>The comma-separated string concatenation of the duplicate values is used.</td>
                      </tr>
-                     <tr diff="add" at="2023-04-04">
-                        <td><code>fn($a, $b) { $a + $b }</code></td>
-                        <td>The sum of the duplicate values is used.
-                           This could also be expressed as <code>on-duplicates="op('+')"</code>
+                     <tr>
+                        <td><code>duplicates="op('+')"</code></td>
+                        <td>The sum of the duplicate values is used.</td>
+                     </tr>
+                     <tr>
+                        <td><code>duplicates="fn($a, $b) { subsequence(($a, $b), 1, 4) }"</code></td>
+                        <td>The first four of the duplicates are retained; any further duplicates
+                           are discarded.
                         </td>
                      </tr>
                      <tr>
-                        <td><code>fn($a, $b) { error() }</code></td>
-                        <td>Duplicates are rejected as an error (this is the default in the absence of the
-                           <code>on-duplicates</code> attribute).</td>
+                        <td><code>duplicates="fn($a, $b) { distinct-values(($a, $b)) }"</code></td>
+                        <td>When multiple entries have the same key, the corresponding values
+                           are retained only if they are distinct from other values having the
+                           same key.
+                        </td>
                      </tr>
                   </tbody>
                </table>
@@ -36346,7 +36353,7 @@ the same group, and the-->
                   <eg><![CDATA[{ "A23": [ 12, 2 ], "A24": [ 5 ], "A23": [ 9 ] }]]></eg>
                   <p>The logic is:</p>
                   <eg><![CDATA[<xsl:template match="data">
-   <xsl:map on-duplicates="fn($a, $b) { array:join(($a, $b)) }">
+   <xsl:map duplicates="fn($a, $b) { array:join(($a, $b)) }">
      <xsl:for-each select="event">
         <xsl:map-entry key="@id" select="[xs:integer(@value)]"/>
      </xsl:for-each>
@@ -36355,14 +36362,16 @@ the same group, and the-->
                </example>
                
                <note>
-                  <p>Specifying the effect by reference to <xfunction>map:merge</xfunction> has
+                  <p>Specifying the effect by reference to <xfunction>map:of-pairs</xfunction> has
                   the following consequences when duplicates are combined
                   into a merged entry:</p>
                   <ulist>
                      <item><p>The position of the merged entry in the result corresponds
                      to the position of the first of the duplicate keys in the input.</p></item>
                      <item><p>The key used for the merged entry in the result corresponds
-                     to the last of the duplicate keys in the input. This is relevant when
+                     to one of the duplicate keys in the input: it is 
+                        <termref def="dt-implementation-dependent"/> which one is chosen.
+                        This is relevant when
                      the duplicate keys differ in some way, for example when they have
                      different type annotations, or when they are <code>xs:dateTime</code>
                      values in different timezones.</p></item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11461,7 +11461,7 @@ and <code>version="1.0"</code> otherwise.</p>
       </xsl:if>           
       
       <!-- function body: construct a map -->
-      <t:map on-duplicates="fn($first, $second){{$first}}">
+      <t:map duplicates="fn($first, $second){{$first}}">
          <xsl:for-each select="xsl:field">
             <xsl:variable name="optional" 
                           select="normalize-space(@required) = ('no', 'false', '0')"/>
@@ -11542,7 +11542,7 @@ and <code>version="1.0"</code> otherwise.</p>
     <xsl:param name="r" as="xs:double"/>
     <xsl:param name="i" as="xs:double"/>
     <xsl:param name="options" as="map(*)" required="no" default="{}"/>
-    <xsl:map on-duplicates="fn($first, $second){$first}">
+    <xsl:map duplicates="fn($first, $second){$first}">
        <xsl:map-entry key="'r'" select="$r"/>
        <xsl:map-entry key="'i'" select="$i"/>
        <xsl:sequence select="$options"/>   
@@ -14695,7 +14695,7 @@ return $tree =?> depth()]]></eg>
 </xsl:array>  
     ]]></eg>
                
-               <note><p>A <term>value record</term> is a singleton map: it has a single entry with the key <code>"value"</code>,
+               <note><p>A <term>value record</term> is a single-entry map: it has a single key-value pair with the key <code>"value"</code>,
                the corresponding value being a member of the original array. The default processing for a value
                record, unless specified otherwise, is to apply templates to the value, as indicated by the rules
                that follow.</p></note>
@@ -14782,31 +14782,31 @@ return $tree =?> depth()]]></eg>
                      <p>The result of applying templates to these value records is expected to comprise a new sequence
                         of value records, which is used to construct the final output array.</p></item>
                      
-                     <item><p>Each of the value records is processed using the rule for singleton maps. This rule
+                     <item><p>Each of the value records is processed using the rule for single-entry maps. This rule
                         produces a new value record by applying templates to the value, that is, to a map of the form
                         <code>map: { "Title": ..., "Author": ..., ... }</code> representing a book.</p></item>
                      
                      <item><p>Each of these books, being represented by a map with more than two entries, is processed by
                      a template rule that splits the map into its multiple entries, each represented as a singleton
-                     map (a map with one key and one value). One of these singleton maps, for example, would be
+                     map (a map with one key and one value). One of these single-entry maps, for example, would be
                      <code>{"Title": "Steppenwolf"}</code>.</p></item>
                      
-                     <item><p>The default processing for a singleton map of the form 
+                     <item><p>The default processing for a single-entry map of the form 
                         <code>{ "Title": "Steppenwolf" }</code> is to return the value unchanged.
                         This is achieved by applying templates to the string <code>"Steppenwolf"</code>;
                      the default template rule for strings returns the string unchanged.</p></item>
                      
-                     <item><p>When a singleton map in the form <code>{ "Note": "out of print" }</code> is encountered, no output
+                     <item><p>When a single-entry map in the form <code>{ "Note": "out of print" }</code> is encountered, no output
                      is produced, meaning that entry in the parent map is effectively dropped. This is because there
-                     is an explicit template rule with <code>match="record(Note)"</code> that matches such singleton maps.</p></item>
+                     is an explicit template rule with <code>match="record(Note)"</code> that matches such single-entry maps.</p></item>
                      
-                     <item><p>When a singleton map in the form <code>"Authors": [ "Bruce Betts", "Erica Colon" ]</code> 
-                        is encountered, a new singleton map is produced; it has the same key (<code>"Authors"</code>),
+                     <item><p>When a single-entry map in the form <code>"Authors": [ "Bruce Betts", "Erica Colon" ]</code> 
+                        is encountered, a new single-entry map is produced; it has the same key (<code>"Authors"</code>),
                         and a value obtained by applying templates to the array <code>[ "Bruce Betts", "Erica Colon" ]</code>.
                         The default processing for an array, in which none of the constituents are matched by explicit
                         template rules, ends up delivering a copy of the array.</p></item>
                      
-                     <item><p>When the singleton map <code>"Authors": [ "Enid Blyton", { "Note": "possibly misattributed" } ]</code>
+                     <item><p>When the single-entry map <code>"Authors": [ "Enid Blyton", { "Note": "possibly misattributed" } ]</code>
                         is encountered, the recursive processing results in templates being applied to the map
                         <code>{ "Note": "possibly misattributed" }</code>. This matches the template rule having
                         <code>match="record(Note)"</code>, which returns no output, so the entry is effectively deleted.</p>
@@ -36089,10 +36089,10 @@ the same group, and the-->
                a constraint on how the map may be combined with other maps.</p>
 
             <note diff="add" at="2023-04-04">
-               <p>A common coding pattern is to supply the input as a set of singleton maps, that is,
-               maps containing a single entry. Moreover, it is often convenient to construct these
+               <p>A common coding pattern is to supply the input as a set of single-entry maps, that is,
+               maps containing a single key-value pair. Moreover, it is often convenient to construct these
                using the <elcode>xsl:map-entry</elcode> instruction. However, it is not required that
-               the input maps should be singletons, nor is it required that they should be constructed
+               the input maps should be single-entry maps, nor is it required that they should be constructed
                using this instruction.</p>
             </note>
 
@@ -36250,14 +36250,14 @@ the same group, and the-->
                   <code>"use-any"</code>, <code>"combine"</code>, or <code>"reject"</code>,
                   or a function with arity 2. These values correspond to the permitted
                   values of the <code>duplicates</code> option of the 
-                  <xfunction>map:of-pairs</xfunction> function.</p>
+                  <xfunction>map:merge</xfunction> function.</p>
                
                <p>The result of the <elcode>xsl:map</elcode> instruction is defined by reference to 
-               the function <xfunction>map:of-pairs</xfunction>. Specifically, if <code>$maps</code>
+               the function <xfunction>map:merge</xfunction>. Specifically, if <code>$maps</code>
                is the input sequence to <elcode>xsl:map</elcode>, and <code>$duplicates</code>
                is the <termref def="dt-effective-value"/> of the <code>duplicates</code>
                attribute, then the result of the instruction is the result of the function
-               call <code>map:of-pairs(map:pairs($maps), { "duplicates": $duplicates })</code>.</p>
+               call <code>map:merge($maps, { "duplicates": $duplicates })</code>.</p>
                
        <!--        
                
@@ -36289,24 +36289,24 @@ the same group, and the-->
                <table>
                   <thead>
                      <tr>
-                        <th>Function</th>
+                        <th>Attribute</th>
                         <th>Effect</th>
                      </tr>
                   </thead>
                   <tbody>
                      <tr>
-                        <td><code>duplicates="use-first"</code></td>
+                        <td><code>duplicates="'use-first'"</code></td>
                         <td>The first of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>duplicates="use-last"</code></td>
+                        <td><code>duplicates="'use-last'"</code></td>
                         <td>The last of the duplicate values is used.</td>
                      </tr>
                      <tr>
-                        <td><code>duplicates="combine"</code></td>
+                        <td><code>duplicates="'combine'"</code></td>
                         <td>The <xtermref spec="XP40" ref="dt-sequence-concatenation"/> 
                            of the duplicate values is used. This could
-                        also be expressed as <code>on-duplicates="op(',')"</code>.</td>
+                        also be expressed as <code>duplicates="op(',')"</code>.</td>
                      </tr>
                      <tr>
                         <td><code>duplicates="fn($a, $b) { max(($a, $b)) }"</code></td>
@@ -36362,7 +36362,7 @@ the same group, and the-->
                </example>
                
                <note>
-                  <p>Specifying the effect by reference to <xfunction>map:of-pairs</xfunction> has
+                  <p>Specifying the effect by reference to <xfunction>map:merge</xfunction> has
                   the following consequences when duplicates are combined
                   into a merged entry:</p>
                   <ulist>


### PR DESCRIPTION
Actions QT4CG-107-02 and QT4CG-107-03.

The three functions map:build, map:of-pairs, and map:merge now all have the same options parameters, and avoid duplication in the specification. The xsl:map instruction is defined by reference to map:merge.

Although the action suggested specifying these functions to use the first key from a set of duplicates, I found this was not possible because of the way map:put is defined. They therefore use the last key from the set of duplicates.

Fix #1725