### PR TITLE
Implement expanding/collapsing ToC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,6 +296,7 @@ task "publish-expath-40"(dependsOn: ["binary_40", "file_40"]) {
         from "${projectDir}/specifications/js"
         into "${wwwDir}/js"
         include "fo-datalist.js"
+        include "toc.js"
       }
     }
   
@@ -462,6 +463,7 @@ task fo_resources(
       from "${projectDir}/specifications/js"
       into "${buildDir}/www/xpath-functions-40/js"
       include "fo-datalist.js"
+      include "toc.js"
     }
   }
 
@@ -742,6 +744,7 @@ task xslt_resources(
       from "${projectDir}/specifications/js"
       into "${buildDir}/www/xslt-40/js"
       include "xsl-datalist.js"
+      include "toc.js"
     }
   }
 
@@ -1038,6 +1041,14 @@ task xquery_resources(
   }
 
   doLast {
+    copy {
+      from "${projectDir}/specifications/js"
+      into "${buildDir}/www/xquery-40/js"
+      include "toc.js"
+    }
+  }
+
+  doLast {
     // The W3C uses index files called Overview.html, so that's what the
     // build produces. But everyone else, including the GitHub pages that
     // back qt4cg.org, uses index.html. So redirect.
@@ -1216,6 +1227,14 @@ task datamodel_resources(
   }
 
   doLast {
+    copy {
+      from "${projectDir}/specifications/js"
+      into "${buildDir}/www/xpath-datamodel-40/js"
+      include "toc.js"
+    }
+  }
+
+  doLast {
     // The W3C uses index files called Overview.html, so that's what the
     // build produces. But everyone else, including the GitHub pages that
     // back qt4cg.org, uses index.html. So redirect.
@@ -1340,6 +1359,14 @@ task serialization_resources(
       include "qtspecs.css"
       include "showdiff.css"
       include "xslt-xquery-serialization-40.css"
+    }
+  }
+
+  doLast {
+    copy {
+      from "${projectDir}/specifications/js"
+      into "${buildDir}/www/xslt-xquery-serialization-40/js"
+      include "toc.js"
     }
   }
 

--- a/specifications/css/w3c-base.css
+++ b/specifications/css/w3c-base.css
@@ -1078,11 +1078,14 @@
 
 /** Table of Contents *********************************************************/
 
+.toc summary {
+    list-style: none;
+    font-weight: normal;
+}
+
 	.toc a {
 		/* More spacing; use padding to make it part of the click target. */
 		padding: 0.1rem 1px 0;
-		/* Larger, more consistently-sized click target */
-		display: block;
 		/* Switch to using border-bottom */
 		text-decoration: none;
 		border-bottom: 1px solid;
@@ -1133,14 +1136,25 @@
 	.toc > li li li li    { font-size:   90%;    }
 	.toc > li li li li li { font-size:   85%;    }
 
-	.toc > li             { margin: 1.5rem 0;    }
+	.toc > li             { margin: 0.5rem 0;    }
+/*
 	.toc > li li          { margin: 0.3rem 0;    }
 	.toc > li li li       { margin-left: 2rem;   }
+*/
+
+.exptoc { font-size: 80%; color: #7f7f7f; cursor: pointer; }
+.expalltoc { font-size: 80%; color: #7f7f7f; cursor: pointer; }
+.toc ol { margin-left: 3rem; }
+.toc ol summary {
+   padding-left: 3em;
+   text-indent: -3em;
+}
 
 	/* Section numbers in a column of their own */
+
 	.toc .secno {
 		float: left;
-		width: 4rem;
+		width: 3rem;
 		white-space: nowrap;
 	}
 	.toc > li li li li .secno {
@@ -1150,13 +1164,14 @@
 		font-size: 100%;
 	}
 
+/*
 	:not(li) > .toc              { margin-left:  5rem; }
 	.toc .secno                  { margin-left: -5rem; }
 	.toc > li li li .secno       { margin-left: -7rem; }
 	.toc > li li li li .secno    { margin-left: -9rem; }
 	.toc > li li li li li .secno { margin-left: -11rem; }
 
-	/* Tighten up indentation in narrow ToCs */
+
 	@media (max-width: 30em) {
 		:not(li) > .toc              { margin-left:  4rem; }
 		.toc .secno                  { margin-left: -4rem; }
@@ -1165,20 +1180,25 @@
 		.toc > li li li li .secno    { margin-left: -6rem; }
 		.toc > li li li li li .secno { margin-left: -7rem; }
 	}
+
 	@media screen and (min-width: 78em) {
-		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
-		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
-		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
-		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
-		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
-		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+		body:not(.toc-inline) :not(li) > .toc              { margin-left:  2rem; }
+		body:not(.toc-inline) .toc .secno                  { margin-left: -2rem; }
+		body:not(.toc-inline) .toc > li li li              { margin-left:  2rem; }
+		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -2rem; }
+		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -2rem; }
+		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -2rem; }
 	}
-	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
-	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
-	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
-	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
-	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
-	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+
+	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  2rem; }
+	body.toc-sidebar #toc .toc .secno                  { margin-left: -2rem; color: red; }
+	body.toc-sidebar #toc .toc > li li                 { margin-left:  2rem; color: cyan; }
+	body.toc-sidebar #toc .toc > li li .secno          { margin-left: -2rem; color: orange; }
+	body.toc-sidebar #toc .toc > li li li              { margin-left:  2rem; color: green; }
+	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -4rem; color: orange; }
+	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -2rem; }
+	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -2rem; }
+*/
 
 	.toc li {
 		clear: both;

--- a/specifications/css/xslt-40.css
+++ b/specifications/css/xslt-40.css
@@ -73,3 +73,7 @@ div.ffheader {
     font-weight: bold;
     color: hsla(203, 20%, 40%, .7);
 }                  
+
+#toc h2 {
+    padding-top: 4em !important;
+}

--- a/specifications/js/toc.js
+++ b/specifications/js/toc.js
@@ -1,0 +1,51 @@
+window.onload = function() {
+  document.querySelectorAll(".exptoc").forEach(span => {
+    span.addEventListener("click", (event) => {
+      let target = event.target;
+      if (target.classList.contains("collapsed")) {
+        target.classList.remove("collapsed")
+        target.classList.add("expanded")
+        target.innerHTML = "\u2009▼"
+      } else {
+        target.classList.remove("expanded")
+        target.classList.add("collapsed")
+        target.innerHTML = "\u2009▶"
+      }
+    });
+  });
+
+  const updateToc = function(open) {
+    document.querySelectorAll(".toc details").forEach(details => {
+      details.open = open
+    });
+    document.querySelectorAll(".exptoc").forEach(span => {
+      if (open) {
+        span.classList.remove("collapsed")
+        span.classList.add("expanded")
+        span.innerHTML = "\u2009▼"
+      } else {
+        span.classList.remove("expanded")
+        span.classList.add("collapsed")
+        span.innerHTML = "\u2009▶"
+      }
+    });
+  }
+
+  let expandAll = document.querySelector(".expalltoc")
+  if (expandAll) {
+    expandAll.addEventListener("click", (event) => {
+      let target = event.target;
+      if (target.classList.contains("collapsed")) {
+        target.classList.remove("collapsed")
+        target.classList.add("expanded")
+        target.innerHTML = "\u2009▼"
+        updateToc(true)
+      } else {
+        target.classList.remove("expanded")
+        target.classList.add("collapsed")
+        target.innerHTML = "\u2009▶"
+        updateToc(false)
+      }
+    });
+  }
+}

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -325,6 +325,7 @@
             <xsl:with-param name="default.id" select="'contents'"/>
           </xsl:call-template>
           <xsl:text>Table of Contents</xsl:text>
+          <span class="expalltoc collapsed">&#x2009;▶</span>
         </h2>
         <ol class="toc">
           <xsl:apply-templates select="div1|../back/inform-div1|../back/div1" mode="toc"/>
@@ -1793,6 +1794,7 @@
           <p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to top">↑</abbr></a></p>
         </xsl:if>
         <xsl:call-template name="make-script"/>
+        <script src="js/toc.js"></script>
       </body>
     </html>
   </xsl:template>
@@ -2735,124 +2737,164 @@
 
   <!-- mode: toc -->
   <xsl:template mode="toc" match="div1">
+    <xsl:variable name="more-toc" select="$toc.level gt 1 and div2"/>
     <li>
-    <a>
-      <xsl:attribute name="href">
-        <xsl:call-template name="href.target">
-          <xsl:with-param name="target" select="."/>
-        </xsl:call-template>
-      </xsl:attribute>
-      <span class="secno">
-        <xsl:apply-templates select="." mode="divnum"/>
-      </span>
-      <span>
-        <xsl:call-template name="toc-entry-class"/>
-        <xsl:apply-templates select="head" mode="text"/>
-      </span>
-    </a>
-    <xsl:text>&#10;</xsl:text>
-    <xsl:if test="$toc.level &gt; 1">
-      <ol class="toc">
-        <xsl:apply-templates select="div2" mode="toc"/>
-      </ol>
-    </xsl:if>
+      <details>
+        <summary>
+          <a>
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="target" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <span class="secno">
+              <xsl:apply-templates select="." mode="divnum"/>
+            </span>
+            <span>
+              <xsl:call-template name="toc-entry-class"/>
+              <xsl:apply-templates select="head" mode="text"/>
+            </span>
+          </a>
+          <xsl:if test="$more-toc">
+            <span class="exptoc collapsed">&#x2009;▶</span>
+          </xsl:if>
+        </summary>
+        <xsl:if test="$more-toc">
+          <ol class="toc">
+            <xsl:apply-templates select="div2" mode="toc"/>
+          </ol>
+        </xsl:if>
+      </details>
     </li>
   </xsl:template>
 
   <xsl:template mode="toc" match="div2">
+    <xsl:variable name="more-toc" select="$toc.level gt 2 and div3"/>
     <li>
-    <a>
-      <xsl:attribute name="href">
-        <xsl:call-template name="href.target">
-          <xsl:with-param name="target" select="."/>
-        </xsl:call-template>
-      </xsl:attribute>
-      <span class="secno">
-        <xsl:apply-templates select="." mode="divnum"/>
-      </span>
-      <span>
-        <xsl:call-template name="toc-entry-class"/>
-        <xsl:apply-templates select="head" mode="text"/>
-      </span>
-    </a>
-    <xsl:if test="$toc.level &gt; 2 and child::div3">
-      <ol class="toc">
-        <xsl:apply-templates select="div3" mode="toc"/>
-     </ol>
-    </xsl:if>
+      <details>
+        <summary>
+          <a>
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="target" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <span class="secno">
+              <xsl:apply-templates select="." mode="divnum"/>
+            </span>
+            <span>
+              <xsl:call-template name="toc-entry-class"/>
+              <xsl:apply-templates select="head" mode="text"/>
+            </span>
+          </a>
+          <xsl:if test="$more-toc">
+            <span class="exptoc">&#x2009;▶</span>
+          </xsl:if>
+        </summary>
+        <xsl:if test="$more-toc">
+          <ol class="toc">
+            <xsl:apply-templates select="div3" mode="toc"/>
+          </ol>
+        </xsl:if>
+      </details>
     </li>
   </xsl:template>
 
   <xsl:template mode="toc" match="div3">
-    <!--<xsl:text>&#10;</xsl:text>-->
+    <xsl:variable name="more-toc" select="$toc.level gt 3 and div4"/>
     <li>
-    <a>
-      <xsl:attribute name="href">
-        <xsl:call-template name="href.target">
-          <xsl:with-param name="target" select="."/>
-        </xsl:call-template>
-      </xsl:attribute>
-      <span class="secno">
-        <xsl:apply-templates select="." mode="divnum"/>
-      </span>
-      <span>
-        <xsl:call-template name="toc-entry-class"/>
-        <xsl:apply-templates select="head" mode="text"/>
-      </span>
-    </a>
-    <!--<xsl:text>&#10;</xsl:text>-->
-    <xsl:if test="$toc.level &gt; 3 and child::div4">
-      <xsl:apply-templates select="div4" mode="toc"/>
-    </xsl:if>
-   </li>
+      <details>
+        <summary>
+          <a>
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="target" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <span class="secno">
+              <xsl:apply-templates select="." mode="divnum"/>
+            </span>
+            <span>
+              <xsl:call-template name="toc-entry-class"/>
+              <xsl:apply-templates select="head" mode="text"/>
+            </span>
+          </a>
+          <xsl:if test="$more-toc">
+            <span class="exptoc">&#x2009;▶</span>
+          </xsl:if>
+        </summary>
+        <xsl:if test="$more-toc">
+          <ol class="toc">
+            <xsl:apply-templates select="div4" mode="toc"/>
+          </ol>
+        </xsl:if>
+      </details>
+    </li>
   </xsl:template>
 
   <xsl:template mode="toc" match="div4">
-    <!--<xsl:text>&#10;</xsl:text>-->
-    <a>
-      <xsl:attribute name="href">
-        <xsl:call-template name="href.target">
-          <xsl:with-param name="target" select="."/>
-        </xsl:call-template>
-      </xsl:attribute>
-      <span class="secno">
-        <xsl:apply-templates select="." mode="divnum"/>
-      </span>
-      <span>
-        <xsl:call-template name="toc-entry-class"/>
-        <xsl:apply-templates select="head" mode="text"/>
-      </span>
-    </a>
-    <xsl:text>&#10;</xsl:text>
-    <xsl:if test="$toc.level &gt; 4">
-      <xsl:apply-templates select="div5" mode="toc"/>
-    </xsl:if>
+    <xsl:variable name="more-toc" select="$toc.level gt 4 and div5"/>
+    <li>
+      <details>
+        <summary>
+          <a>
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="target" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <span class="secno">
+              <xsl:apply-templates select="." mode="divnum"/>
+            </span>
+            <span>
+              <xsl:call-template name="toc-entry-class"/>
+              <xsl:apply-templates select="head" mode="text"/>
+            </span>
+          </a>
+          <xsl:if test="$more-toc">
+            <span class="exptoc">&#x2009;▶</span>
+          </xsl:if>
+        </summary>
+        <xsl:if test="$more-toc">
+          <ol class="toc">
+            <xsl:apply-templates select="div5" mode="toc"/>
+          </ol>
+        </xsl:if>
+      </details>
+    </li>
   </xsl:template>
 
   <xsl:template mode="toc" match="div5">
-    <!--<xsl:text>&#10;</xsl:text>-->
-    <a>
-      <xsl:attribute name="href">
-        <xsl:call-template name="href.target">
-          <xsl:with-param name="target" select="."/>
-        </xsl:call-template>
-      </xsl:attribute>
-      <span class="secno">
-        <xsl:apply-templates select="." mode="divnum"/>
-      </span>
-      <span>
-        <xsl:call-template name="toc-entry-class"/>
-        <xsl:apply-templates select="head" mode="text"/>
-      </span>
-    </a>
-    <!--<xsl:text>&#10;</xsl:text>-->
-    <xsl:if test="$toc.level &gt; 5">
-      <xsl:apply-templates select="div6" mode="toc"/>
-    </xsl:if>
+    <xsl:variable name="more-toc" select="$toc.level gt 5 and div6"/>
+    <li>
+      <details>
+        <summary>
+          <a>
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="target" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <span class="secno">
+              <xsl:apply-templates select="." mode="divnum"/>
+            </span>
+            <span>
+              <xsl:call-template name="toc-entry-class"/>
+              <xsl:apply-templates select="head" mode="text"/>
+            </span>
+          </a>
+          <xsl:if test="$more-toc">
+            <span class="exptoc">&#x2009;▶</span>
+          </xsl:if>
+        </summary>
+        <xsl:if test="$more-toc">
+          <xsl:apply-templates select="div6" mode="toc"/>
+        </xsl:if>
+      </details>
+    </li>
   </xsl:template>
 
   <xsl:template mode="toc" match="div6">
-    <!--<xsl:text>&#10;</xsl:text>-->
     <a>
       <xsl:attribute name="href">
         <xsl:call-template name="href.target">
@@ -2867,32 +2909,38 @@
         <xsl:apply-templates select="head" mode="text"/>
       </span>
     </a>
-    <!--<xsl:text>&#10;</xsl:text>-->
   </xsl:template>
 
   <xsl:template mode="toc" match="inform-div1">
+    <xsl:variable name="more-toc" select="$toc.level gt 1 and div2"/>
     <li>
-    <a>
-      <xsl:attribute name="href">
-        <xsl:call-template name="href.target">
-          <xsl:with-param name="target" select="."/>
-        </xsl:call-template>
-      </xsl:attribute>
-     <span class="secno">
-        <xsl:apply-templates select="." mode="divnum"/>
-      </span>
-      <span>
-        <xsl:call-template name="toc-entry-class"/>
-        <xsl:apply-templates select="head" mode="text"/>
-      </span>
-    </a>
-    <xsl:text> (Non-Normative)</xsl:text>
-    <!--<xsl:text>&#10;</xsl:text>-->
-    <xsl:if test="$toc.level &gt; 2">
-      <ol class="toc">
-       <xsl:apply-templates select="div2" mode="toc"/>
-      </ol>
-    </xsl:if>
+      <details>
+        <summary>
+          <a>
+            <xsl:attribute name="href">
+              <xsl:call-template name="href.target">
+                <xsl:with-param name="target" select="."/>
+              </xsl:call-template>
+            </xsl:attribute>
+            <span class="secno">
+              <xsl:apply-templates select="." mode="divnum"/>
+            </span>
+            <span>
+              <xsl:call-template name="toc-entry-class"/>
+              <xsl:apply-templates select="head" mode="text"/>
+            </span>
+          </a>
+          <xsl:text> (Non-Normative)</xsl:text>
+          <xsl:if test="$more-toc">
+            <span class="exptoc">&#x2009;▶</span>
+          </xsl:if>
+        </summary>
+        <xsl:if test="$more-toc">
+          <ol class="toc">
+            <xsl:apply-templates select="div2" mode="toc"/>
+          </ol>
+        </xsl:if>
+      </details>
     </li>
   </xsl:template>
 


### PR DESCRIPTION
I'm just going to merge this one because

1. The CG agreed they wanted this
2. All of the changes are presentational, there are no technical changes
3. The PR build won't work anyway

I did make a couple of executive decisions.

The use of "..." as the target to click on didn't seem like a practical affordance. It's not a common use of ellipsis and it looked too much like it simply meant that part of the title was elided. I went with right and down triangles instead. And I added the few lines of JS required to make them "turn".

I added a top-level expand/collapse that does all of the sections. I wasn't happy that with the new UI, there was no way to get an overview of the document by seeing all of the section titles.

I tinkered with the CSS. I'm not uniformly happy with it, especially with the treatment of long titles, but I think the aesthetic failings are infrequent.

We need to review accessibility before we try to publish as a CG Report.

