### PR TITLE
Don't fix the function finder on small devices

### DIFF
--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -17,13 +17,19 @@
 }
 
 #function-finder {
-  position: fixed;
+  position: absolute;
   background-color: rgb(247, 248, 249);
   opacity 1;
   width: 23.5em;
   border-bottom: 1px solid rgb(135,149,159);
   padding-bottom: 0.5em;
   margin-bottom: 4px;
+}
+
+@media screen and (min-width: 78em) {
+  #function-finder {
+    position: fixed;
+  }
 }
 
 .return-varies {

--- a/specifications/css/xslt-40.css
+++ b/specifications/css/xslt-40.css
@@ -56,13 +56,19 @@ table.proto tr.name span.name {
 }
 
 #function-finder {
-  position: fixed;
+  position: absolute;
   background-color: rgb(247, 248, 249);
   opacity 1;
   width: 23.5em;
   border-bottom: 1px solid rgb(135,149,159);
   padding-bottom: 0.5em;
   margin-bottom: 4px;
+}
+
+@media screen and (min-width: 78em) {
+  #function-finder {
+    position: fixed;
+  }
 }
 
 div.ffheader {  


### PR DESCRIPTION
This is also related to 1747. It "fixes" the problem that @ChristianGruen reported where the function finder obscured content on mobile (narrow) devices. I've changed things so that it isn't at a fixed location on narrow devices. It still appears above the ToC, but it scrolls as normal.
