### PR TITLE
1750 Overhaul of EXPath binary spec

### DIFF
--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -933,7 +933,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
 
 
 
-                    <bibl id="xquery-40" key="XQuery 4.1: An XML Query Language">
+                    <bibl id="xquery-40" key="XQuery 4.0: An XML Query Language">
                         <emph>CITATION: T.B.D.</emph>
                     </bibl>
 

--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -215,13 +215,12 @@ for transition to Proposed Recommendation. </p>'>
                     Group</loc>, defined for <bibref ref="xpath20"/> and published in 2013.</p>
             <p>The principal semantic alteration is use of functional argument defaults available in
                 XPath 4.0.</p>
-            <p>These functions are defined for use in <bibref ref="xpath-40"/> and <bibref
-                    ref="xquery-40"/> and <bibref ref="xslt-40"/> and other related XML standards.
-                The signatures and summaries of functions defined in this document are available at:
-                    <loc href="&doc.publoc;">&doc.publoc;</loc>.</p>
+            <p>These functions are defined for use in <bibref ref="xpath-40"/>, <bibref
+                    ref="xquery-40"/>, <bibref ref="xslt-40"/>, and other related XML standards.
+                </p>
 
 
-            <p>A summary of changes since published version 1.0 (the XPath 2.0 version) is provided
+            <p>A summary of changes since published version 1.0 is provided
                 at <specref ref="changelog"/>.</p>
         </abstract>
 
@@ -230,7 +229,7 @@ for transition to Proposed Recommendation. </p>'>
             <p>This version of the specification is work in progress. It is produced by the QT4
                 Working Group, officially the W3C XSLT 4.0 Extensions Community Group. Individual
                 functions specified in the document may be at different stages of review, reflected
-                in their <term>History</term> notes. Comments are invited, in the form of GitHub
+                in their <term>Changes</term> notes. Comments are invited, in the form of GitHub
                 issues at <loc href="https://github.com/qt4cg/qtspecs"
                     >https://github.com/qt4cg/qtspecs</loc>.</p>
 
@@ -265,12 +264,12 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 inclusion in XPath 4.0, XQuery 4.0, and XSLT 4.0. The binary data is represented by
                 the type <code>xs:base64Binary</code> as defined by <xspecref spec="XS2"
                     ref="base64Binary"/>.</p>
-            <p>The exact syntax used to call these functions and operators is specified in <bibref
-                    ref="xpath-40"/>, <bibref ref="xquery-40"/> and <bibref ref="xslt-40"/>. </p>
+            <p>The syntax used to call these functions and operators is specified in <bibref
+                    ref="xpath-40"/> and <bibref ref="xquery-40"/>. </p>
             <p>This document defines several classes of functions:</p>
             <ulist>
                 <item>
-                    <p>Functions to create binary 'constants' and convert between the binary forms
+                    <p>Functions to create constant binary values and convert between the binary forms
                         and sequences of octets. </p>
                 </item>
                 <item>
@@ -281,11 +280,10 @@ Michael Sperberg-McQueen (1954–2024).</p>
                     <p>Functions to perform bitwise operations.</p>
                 </item>
                 <item>
-                    <p>Functions to pack or unpack numeric values from within or into binary
-                        data.</p>
+                    <p>Functions to convert between binary data and numeric values.</p>
                 </item>
                 <item>
-                    <p>Functions to decode or encode strings from within or into binary data>.</p>
+                    <p>Functions to decode or encode strings.</p>
                 </item>
             </ulist>
 
@@ -300,23 +298,26 @@ Michael Sperberg-McQueen (1954–2024).</p>
 
 
             <div2 id="error.management">
-                <head>Error management</head>
-                <p>Error conditions are identified by a code (a <code>QName</code>.) When such an
+                <head>Error codes</head>
+                <p>Error conditions are identified by a code (a QName). When such an
                     error condition is reached in the evaluation of an expression, a dynamic error
                     is thrown, with the corresponding error code (as if the standard XPath function
-                    <code>error()</code> had been called.)</p>
+                    <code>error()</code> had been called).</p>
                 <p>In this specification these codes use the
-                    <code>http://expath.org/ns/binary</code> namespace and a 'descriptive string'
-                    local part, e.g. <code>bin:index-out-of-range</code>, rather than the
-                    <code>http://www.w3.org/2005/xqt-errors</code> namespace and alpha-numeric local
-                    part, e.g. <code>err:FOCH0004</code>, used in <bibref ref="xpath-functions-40"
-                    />. These error codes were chosen originally in the 1.0 version of 2013.</p>
+                    <code>http://expath.org/ns/binary</code> namespace with a local part
+                    in the form of a descriptive string, for example
+                    <code>bin:index-out-of-range</code>. This convention is used in place of
+                   the <code>http://www.w3.org/2005/xqt-errors</code> namespace and alpha-numeric local
+                    part, e.g. <code>err:FOCH0004</code> used in <bibref ref="xpath-functions-40"
+                    />. These error codes have been largely retained from the 1.0 version of the
+                    EXPath specification.</p>
+                <p>Error codes are summarized in <specref ref="error-summary"/>.</p>
             </div2>
 
             <div2 id="type">
-                <head>Binary type</head>
+                <head>Binary types</head>
                 <changes>
-                    <change>Binary 'data' arguments to the functions are now declared to be either
+                    <change>Binary arguments to the functions are now declared to be either
                         <code>xs:hexBinary</code> or <code>xs:base64Binary</code>, but binary
                         function results remain of type <code>xs:base64Binary</code>. This should
                         not cause any backward incompatibilities as casting back and forth between
@@ -324,29 +325,44 @@ Michael Sperberg-McQueen (1954–2024).</p>
                         2.0</change>
 
                 </changes>
-                <p>The principal binary type within this module is <code>xs:base64Binary</code> as
-                    defined by <xspecref spec="XS2" ref="base64Binary"/>.</p>
-                <p>In general, for the functions defined in this specification, if the result return
-                    is binary data, it will <emph>always</emph> be of type
-                    <code>xs:base64Binary</code>. Any arguments to a function which are considered
-                    to be binary data can be either of type <code>xs:base64Binary</code> or
-                    <code>xs:hexBinary</code>. </p>
+                <p>XML Schema, and therefore the XDM data model, defines two primitive atomic
+                types holding binary data: <xspecref spec="XS2" ref="base64Binary"/> and 
+                    <xspecref spec="XS2" ref="hexBinary"/>.
+                In both cases the value space is a sequence of octets; the two types differ only
+                in how the binary value is converted to or from a string. Although most functions
+                in this specification are not concerned with the string representation of the value,
+                they need to distinguish these two types, and <code>xs:base64Binary</code>
+                has been chosen arbitrarily as the result type for functions that return
+                binary values. Where binary data is supplied as input to a function, however,
+                both <code>xs:base64binary</code> and <code>xs:hexBinary</code> are accepted.</p>
+                
+                <p><termdef id="dt-binary-value" term="binary value">The term <term>binary value</term>
+                is used to mean a sequence of octets represented as an instance of 
+                    <code>xs:base64Binary</code> or <code>xs:hexBinary</code>.</termdef></p>
+                
                 <p>Conversion to and from <code>xs:hexBinary</code> can be performed by casting with
                     <code>xs:hexBinary()</code> and <code>xs:base64Binary()</code>.</p>
                 <note>
-                    <p>As these types are normally implemented as wrappers around byte array
-                        structures containing the data, and differ only when being serialized to or
-                        parsed from text, such casting in-process should not involve data
-                        copying.</p>
+                    <p>Internally it is likely that implementations will use the same byte
+                        array representation for both data types, and that casting
+                        will merely involve a change in the type annotation; it should not 
+                        require data to be copied.</p>
                 </note>
 
-                <p>An item of type <code>xs:base64Binary</code> can be <emph>empty</emph>, i.e.
+                <p><termdef id="dt-zero-length" term="zero-length">A <termref def="dt-binary-value"/>
+                that contains no octets is referred to as being <term>zero-length</term>.
+                A zero-length binary value is an item, and as such is a sequence of length
+                one, which is not the same thing as an empty sequence.</termdef></p>
+                
+                <!--<p>An item of type <code>xs:base64Binary</code> can be <emph>empty</emph>, i.e.
                     contain no data, (in the same way that items of type <code>xs:string</code> can
                     contain no characters.) Where 'data' arguments to functions that return binary
                     data are optional (i.e. <code><emph>$arg as type</emph>?</code>) and any of
                     those optional arguments is set to the empty sequence, in general an empty
                     sequence is returned, rather than an empty item of type
-                    <code>xs:base64Binary</code>. </p>
+                    <code>xs:base64Binary</code>. </p>-->
+                
+                
             </div2>
 
             <div2 id="testing">
@@ -366,14 +382,13 @@ Michael Sperberg-McQueen (1954–2024).</p>
 
             <div2 id="namespace-prefixes">
                 <head>Namespaces and prefixes</head>
-                <p>The functions defined in this document are contained exclusively in the namespace
-                    <code>http://expath.org/ns/binary</code> and referenced using a
-                    <code>xs:QName</code> binding to that namespace.</p>
+                <p>The functions defined in this document are contained in the namespace
+                    <code>http://expath.org/ns/binary</code>. The conventional
+                    prefix for this namespace is <code>bin</code>.</p>
+                
                 <p>This document uses the prefix <code>bin</code> to refer to this namespace.
                     User-written applications can choose a different prefix to refer to the
-                    namespace, so long as it is bound to the correct URI. In accordance with current
-                    practice, it is recommended that the prefix <code>bin</code> be reserved for use
-                    with this namespace.</p>
+                    namespace, so long as it is bound to the correct URI.</p>
 
 
                 <!--<note>
@@ -390,10 +405,21 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 <head>Function signatures and descriptions</head>
                 <p>Each function (or group of functions having the same name) is defined in this
                     specification using a standard proforma, full details of which can be found in
-                        <xspecref spec="FO40" ref="func-signatures"/>. In particular in this update
+                        <xspecref spec="FO40" ref="func-signatures"/>. In particular in this version
                     (trailing) optional arguments for functions (introduced in XPath 4.0) are used
                     where appropriate in the signatures, rather than multiple-arity signatures as
                     previously. </p>
+                
+                <p>All the functions defined in this specification are deterministic and independent
+                of the static and dynamic context.</p>
+                
+                <p>All the functions described in this specification can in principle be defined
+                in terms of two primitives: <function>bin:to-octets</function> and 
+                <function>bin:from-octets</function>, which convert between a <termref def="dt-binary-value"/>
+                and a sequence of <code>xs:unsignedByte</code> values (integers in the range 0 to 255).
+                In many cases functions are specified with reference to a formal equivalent
+                that defines the semantics of the function directly or indirectly in terms of these
+                two primitives.</p>
             </div2>
         </div1>
 
@@ -424,18 +450,29 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 <head>Example – finding JPEG size</head>
                 <p>As an example, the following code reads the binary form of a JPEG image file,
                     searches for the 'Start of Frame/DCT' segment, and unpacks the relevant binary
-                    sections to integers of height and width:</p>
+                    sections to integer-valued attributes <code>height</code> and <code>width</code>:</p>
                 <example>
                     <eg xml:space="preserve"><![CDATA[
-<xsl:variable name="binary" select="file:read-binary(@href)" as="xs:base64Binary"/>
-<xsl:variable name="location" select="bin:find($binary,0,bin:hex('FFC0'))"/>
-<size width="{bin:unpack-unsigned-integer($binary,$location+5,2,'most-significant-first')}"
-      height="{bin:unpack-unsigned-integer($binary,$location+7,2,'most-significant-first')}"/>
-               
-      → <size width="377" height="327"/>]]></eg>
+<xsl:variable name="binary" 
+              select="file:read-binary(@href)" 
+              as="xs:base64Binary"/>
+<xsl:variable name="location" 
+              select="bin:find($binary, 0, bin:hex('FFC0'))"/>
+<size width="{bin:unpack-unsigned-integer($binary, 
+                                          $location+5,
+                                          2, 
+                                          'most-significant-first')}"
+      height="{bin:unpack-unsigned-integer($binary,
+                                           $location+7,
+                                           2,
+                                           'most-significant-first')}"/>
+]]></eg>
+                    <p>The result is an element such as:</p>
+<eg><![CDATA[<size width="377" height="327"/>]]></eg>
                 </example>
-                <p>(The <code>'most-significant-first'</code> argument ensures the numeric
-                    conversion is 'big-endian', which is the format in JPEG.)</p>
+                <note><p>The <code>'most-significant-first'</code> argument could
+                    be omitted, because it is the default. This is the numeric format used in JPEG:
+                    for further information see <specref ref="endianness"/>.</p></note>
             </div2>
             <div2 id="example-ASN1">
                 <head>Example – reading and writing variable length ASN.1 integers</head>
@@ -445,23 +482,25 @@ Michael Sperberg-McQueen (1954–2024).</p>
                         supported function set.</change>
 
                 </changes>
-                <p><bibref ref="asn1"/> defines several formats for identifying and encoding
-                    arbitrary-sized telecommunications data as streams of octets. Many of these
-                    forms specify the length of data as part of their encoding. For example, in the
-                    Basic Encoding Rules, an integer is represented as the following series of
-                    octets:</p>
+                <p><bibref ref="asn1"/>, used in a number of telecommunications industry standards,
+                    defines a binary data syntax (the <term>basic encoding rules</term>)
+                    for identifying and encoding
+                    arbitrary data as streams of octets. Many of these
+                    forms specify the length of data as part of their encoding. For example, 
+                    an integer has a variable-length representation 
+                    as a sequence of octets:</p>
                 <ulist>
                     <item>
-                        <p>Type – 1 octet – in this case the value <code>0x02</code></p>
+                        <p>The first octet has the value <code>0x02</code> to indicate
+                        that this is an integer.</p>
                     </item>
                     <item>
-                        <p>Length – ≥ 1 octet – the number of octets in the integer value. The
-                            length field itself can be variable in length – to accommodate VERY
-                            large integers (requiring more than 127 octets to represent, e.g.
-                            2048-bit crypto keys.)</p>
+                        <p>Next, a variable-length length field to indicate
+                            the length of the payload. (This is designed to accommodate very
+                            large integers, such as those found in cryptography.)</p>
                     </item>
                     <item>
-                        <p>Payload – ≥ 0 octets – the octets of the integer value in
+                        <p>Finally, the payload itself: the octets of the integer value in
                             most-significant-first order.</p>
                     </item>
                 </ulist>
@@ -471,20 +510,26 @@ Michael Sperberg-McQueen (1954–2024).</p>
                     <eg xml:space="preserve"><![CDATA[
  <xsl:function name="asn:int-octets" as="xs:integer*">
     <xsl:param name="value" as="xs:integer"/>
-    <xsl:sequence
-            select="if($value ne 0) then (bin:int-octets($value idiv 256),$value mod 256) else ()"/>
+    <xsl:sequence select="if ($value ne 0) 
+                          then (bin:int-octets($value idiv 256), $value mod 256) 
+                          else ()"/>
  </xsl:function>
+ 
  <xsl:function name="asn:encode-ASN-integer" as="xs:base64Binary">
-     <xsl:param name="int" as="xs:integer"/>
-     <xsl:variable name="octets" select="bin:int-octets($int)"/>
-     <xsl:variable name="length-octets"
-         select="let $l := count($octets) return
-         (if($l le 127) then $l 
-         else (let $lo := bin:int-octets($l) return (128+count($lo),$lo)))"/>
-     <xsl:sequence select="bin:from-octets((2,$length-octets,$octets))"/>
+    <xsl:param name="int" as="xs:integer"/>
+    <xsl:variable name="octets" select="bin:int-octets($int)"/>
+    <xsl:variable name="length-octets"
+       select="let $l := count($octets) 
+               return ( if ($l le 127) 
+                        then $l 
+                        else ( let $lo := bin:int-octets($l) 
+                               return (128+count($lo), $lo)
+                             )
+                      )"/>
+    <xsl:sequence select="bin:from-octets((2,$length-octets,$octets))"/>
  </xsl:function>]]></eg>
                     <p>The function <code>asn:int-octets</code> returns a sequence of all the
-                        'significant' octets of the integer (i.e. eliminating leading 'zeroes') in
+                        significant octets of the integer (i.e. eliminating leading zeroes) in
                         most-significant order. Examples of the encoding are: </p>
                     <eg xml:space="preserve"><![CDATA[
  asn:encode-ASN-integer(0) → "AgA="
@@ -493,25 +538,30 @@ Michael Sperberg-McQueen (1954–2024).</p>
                
  asn:encode-ASN-integer(123456789.. 900 digits... 123456789) → "AoIBdgaTo....EBF8V"]]></eg>
                     <p>The first example requires no octets to encode zero, hence its octets are
-                        <code>2,0</code>. Both the second and third examples can be represented in
+                        <code>2, 0</code>. Both the second and third examples can be represented in
                         less than 128 octets (2 and 15 respectively), so length is encoded as a
                         single octet. The first three octets of the result for the last example,
-                        which encodes a 900-digit integer, are: <code>2,130,1</code> indicating that
+                        which encodes a 900-digit integer, are: <code>2, 130, 1</code> indicating that
                         the data is represented by (130-128) * 256 + 1 = 513 octets and the length
                         required two octets to encode.</p>
                     <p>Decoding is a matter of compound use of the integer decoding function:</p>
                     <eg xml:space="preserve"><![CDATA[
  <xsl:function name="asn:decode-ASN-integer" as="xs:integer">
-     <xsl:param name="in" as="xs:base64Binary"/>
-     <xsl:sequence
-         select="let $lo := bin:unpack-unsigned-integer($in,1,1,'BE') return (
-         if($lo le 127) then bin:unpack-unsigned-integer($in,2,$lo,'BE') 
-            else (let $lo2 := $lo - 128, $lo3 := bin:unpack-unsigned-integer($in,2,$lo2,'BE') return
-            bin:unpack-unsigned-integer($in,2+$lo2,$lo3,'BE')))"
-      />
- </xsl:function>               ]]></eg>
-                    <p>(all numbers in ASN are 'big-endian') and the examples from above
-                        reverse:</p>
+    <xsl:param name="in" as="xs:base64Binary"/>
+    <xsl:sequence
+       select="let $lo := bin:unpack-unsigned-integer($in, 1, 1, 'BE') 
+               return (
+                  if ($lo le 127) 
+                  then bin:unpack-unsigned-integer($in, 2, $lo, 'BE') 
+                  else ( let $lo2 := $lo - 128, 
+                             $lo3 := bin:unpack-unsigned-integer($in, 2 ,$lo2, 'BE') 
+                         return bin:unpack-unsigned-integer($in, 2+$lo2, $lo3, 'BE')
+                        )
+               )"
+    />
+ </xsl:function>]]></eg>
+                    <note><p>All numbers in ASN are 'big-endian'.</p></note>
+                    <p>This function is the inverse of the encoding function above:</p>
                     <eg xml:space="preserve"><![CDATA[
  asn:decode-ASN-integer(xs:base64Binary("AgA=")) → 0
  asn:decode-ASN-integer(xs:base64Binary("AgIE0g==")) → 1234
@@ -522,58 +572,128 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 </example>
             </div2>
         </div1>
-
-        <div1 id="loading">
-            <head>Loading and saving binary data</head>
-            <changes>
-                <change>The <bibref ref="xpath-functions-40"/> function
-                    <code>fn:binary-resource</code> has been added to the list of useful
-                    functions.</change>
-
-            </changes>
-            <p>This module defines no specific functions for reading and writing binary data from
-                resources, but other specifications provide some suitable mechanisms.</p>
-            <p><bibref ref="xpath-functions-40"/> provides a function to retrieve binary
-                resources:</p>
-            <example role="signature">
-                <proto role="example" name="fn:binary-resource" return-type="xs:base64Binary">
-                    <arg name="filesource" type="xs:string?"/>
-                </proto>
-            </example>
-            <p>The EXPath File Module <bibref ref="expath-file-40"/> provides three functions
-                suitable for use in file-based situations:</p>
-            <example role="signature">
-                <proto role="example" name="file:read-binary" return-type="xs:base64Binary">
-                    <arg name="file" type="xs:string"/>
-                    <arg name="offset" type="xs:integer?" default="0"/>
-                    <arg name="size" type="xs:integer?" default="()"/>
-                </proto>
-            </example>
-            <p>which reads binary data from an existing file, with an optional offset and size.</p>
-            <example role="signature">
-                <proto role="example" name="file:write-binary" return-type="empty-sequence()">
-                    <arg name="file" type="xs:string"/>
-                    <arg name="value" type="xs:base64Binary"/>
-                </proto>
-            </example>
-            <p>which writes binary data into a new or existing file.</p>
-            <example role="signature">
-                <proto role="example" name="file:append-binary" return-type="empty-sequence()">
-                    <arg name="file" type="xs:string"/>
-                    <arg name="value" type="xs:base64Binary"/>
-                </proto>
-            </example>
-            <p>which appends binary data onto the end of an extant file.</p>
-
-            <!-- <p>There may be an argument for a positioned file:read-binary($file as
-                    <ex:type>xs:string</ex:type>,$offset as <ex:type>xs:integer</ex:type>), for
-                access into large files without total read.</p>-->
+ 
+ 
+        <div1 id="id-other-operations">
+            <head>Other Operations on Binary Values</head>
+        
+             <p>This section provides a summary of operations on binary values beyond those 
+             defined in this document.</p>
+            
+            <div2 id="conversion">
+                <head>Conversions</head>
+                
+                <p>Casting is defined:</p>
+                
+                <ulist>
+                    <item><p>Between <code>xs:hexBinary</code> and <code>xs:base64Binary</code>,
+                    in either direction. Since the two types have the same value space,
+                    conversion is lossless, and can be expected in most implementations
+                    to have very low cost.</p></item>
+                    <item><p>From <code>xs:string</code> to <code>xs:hexBinary</code>
+                    or <code>xs:base64Binary</code>. The semantics correspond to the
+                    XSD rules for validation of simple types. The two binary
+                    types have different lexical representation, so conversion from
+                    strings requires different input.</p></item>
+                    <item><p>From <code>xs:hexBinary</code>
+                    or <code>xs:base64Binary</code> to <code>xs:string</code>. 
+                        The rules are defined in <xspecref spec="XP40" ref="casting-to-string"/>. 
+                        The two binary types have different lexical representation, so the output
+                    in the two cases is different.</p></item>
+                </ulist>
+                
+            </div2>
+            
+            <div2 id="comparison">
+                <head>Comparison</head>
+                
+                <p>Comparison of binary values is defined using any of the value comparison
+                operators <code>eq</code>, <code>ne</code>, <code>le</code>, <code>lt</code>,
+                <code>ge</code>, or <code>gt</code>. It is therefore defined also for the
+                general comparison operators <code>=</code>, <code>!=</code>, <code>&lt;=</code>, <code>&lt;</code>,
+                <code>>=</code>, and <code>></code>.</p>
+                
+                <p>The semantics are defined in <function>op:binary-equal</function>
+                and <function>op:binary-less-than</function>.</p>
+                
+                <p>The two types <code>xs:hexBinary</code> and <code>xs:base64Binary</code>
+                can be compared interchangeably.</p>
+                
+                <p>Because binary values are ordered, sequences of binary values can be sorted
+                using the function <function>fn:sort</function>, or by using the <code>xsl:sort</code>
+                instruction in XSLT or the <code>order by</code> clause in XQuery.</p>
+            </div2>
+            
+            <div2 id="numeric-representation">
+                <head>Numeric representation</head>
+                
+                <p>Integers can be converted to a string representation using any radix
+                in the range 2 to 36 using the function <function>fn:format-integer</function>.</p>
+                
+                <p>Conversely, strings representing an integer using any radix in the range
+                2 to 36 can be converted to an integer using the function <function>fn:parse-integer</function>.</p>
+                
+                <p>These functions do not directly involve binary values, but they can be used to
+                convert between numbers and binary values by using a string representation as an intermediate
+                format.</p>
+                
+                <p>See also the functions <function>bin:pack-integer</function>, 
+                    <function>bin:unpack-integer</function>, and <function>bin:unpack-unsigned-integer</function>
+                defined in this specification.</p>
+            </div2>
+            
+            <div2 id="loading">
+                <head>Loading and saving binary data</head>
+                <changes>
+                    <change>The <bibref ref="xpath-functions-40"/> function
+                        <code>fn:binary-resource</code> has been added to the list of useful
+                        functions.</change>
+    
+                </changes>
+                <p>This module defines no specific functions for reading and writing binary data from
+                    external resources, but other specifications provide some suitable mechanisms.</p>
+                <p><bibref ref="xpath-functions-40"/> provides a function to retrieve binary
+                    resources:</p>
+                <example role="signature">
+                    <proto role="example" name="binary-resource" return-type="xs:base64Binary">
+                        <arg name="filesource" type="xs:string?"/>
+                    </proto>
+                </example>
+                <p>The EXPath File Module <bibref ref="expath-file-40"/> provides three functions
+                    suitable for use in file-based situations:</p>
+                <example role="signature">
+                    <proto role="example" name="file:read-binary" return-type="xs:base64Binary">
+                        <arg name="file" type="xs:string"/>
+                        <arg name="offset" type="xs:integer?" default="0"/>
+                        <arg name="size" type="xs:integer?" default="()"/>
+                    </proto>
+                </example>
+                <p>which reads binary data from an existing file, with an optional offset and size.</p>
+                <example role="signature">
+                    <proto role="example" name="file:write-binary" return-type="empty-sequence()">
+                        <arg name="file" type="xs:string"/>
+                        <arg name="value" type="xs:base64Binary"/>
+                    </proto>
+                </example>
+                <p>which writes binary data into a new or existing file.</p>
+                <example role="signature">
+                    <proto role="example" name="file:append-binary" return-type="empty-sequence()">
+                        <arg name="file" type="xs:string"/>
+                        <arg name="value" type="xs:base64Binary"/>
+                    </proto>
+                </example>
+                <p>which appends binary data onto the end of an existing file.</p>
+    
+                <!-- <p>There may be an argument for a positioned file:read-binary($file as
+                        <ex:type>xs:string</ex:type>,$offset as <ex:type>xs:integer</ex:type>), for
+                    access into large files without total read.</p>-->
+            </div2>
         </div1>
 
         <div1 id="constants">
-            <head>Defining 'constants' and conversions</head>
-            <p>Users of the package may need to define binary 'constants' within their code or
-                examine the basic octets. The following functions support these:</p>
+            <head>Defining constants and conversions</head>
+            <p>The functions in this section can be used to define constant binary values
+                or to perform simple conversions to string representations:</p>
             <div2 id="func-bin-hex">
                 <head><?function bin:hex?></head>
             </div2>
@@ -643,7 +763,16 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <div2 id="number-rep">
                 <head>Numeric representation</head>
                 <div3 id="endianness">
-                    <head>Number 'endianness'</head>
+                    <head>Octet order</head>
+                    <changes>
+                        <change issue="1750">
+                            The <code>octet-order</code> parameter of relevant functions now
+                            has an <code>enum</code> type rather than a string type. In consequence,
+                            supplying an incorrect value is now a type error 
+                            (<xerrorref spec="XP40" class="TY" code="0004"/>) and no longer
+                            has a custom error code.
+                        </change>
+                    </changes>
                     <p>Packing and unpacking numeric values within binary data can be performed in
                         'most-significant-first' ('big-endian') or 'least-significant-first'
                         ('little-endian') octet order. The default is
@@ -654,6 +783,19 @@ Michael Sperberg-McQueen (1954–2024).</p>
                         <code>LE</code>. Most-significant-first order is indicated by any of the
                         values <code>most-significant-first</code>, <code>big-endian</code> or
                         <code>BE</code>.</p>
+                    
+                    <p>The type of the <code>octet-order</code> argument to the relevant function
+                    is given as <code>enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')</code>.</p>
+                    
+                    <p>By default, functions that convert numeric values to binary use
+                    most-significant-first ordering. This corresponds to the order
+                    most commonly used in network protocols, and is often referred to as
+                    <term>network order</term>. If least-significant-first ordering is requested,
+                    the order of octets in the result is reversed. This ordering, although
+                    often used internally within computer hardware, is less commonly encountered
+                    in network protocol standards: two places where it is used are the DICOM standard for
+                    medical imaging, and the Bitcoin standard for cryptocurrency.</p>
                 </div3>
                 <div3 id="integer">
                     <head>Integer representation</head>
@@ -667,33 +809,37 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 </div3>
                 <div3 id="floating">
                     <head>Representation of floating point numbers</head>
-                    <p>Care should be taken with the packing and unpacking of floating point numbers
-                        (<code>xs:float</code> and <code>xs:double</code>). The binary
+                    <p>When packing and unpacking floating point numbers
+                        (<code>xs:float</code> and <code>xs:double</code>), the binary
                         representations are expected to correspond with those of the IEEE
                         single/double-precision 32/64-bit floating point types <bibref ref="ieee754"
                         />. Consequently they will occupy 4 or 8 octets when packed.</p>
-                    <p>Positive and negative infinities are supported. <code>INF</code> maps to
-                        <code>0x7f80
-            0000</code> (float), <code>0x7ff0 0000 0000 0000</code>
-                        (double). <code>-INF</code> maps to <code>0xff80 0000</code> (float),
-                        <code>0xfff0 0000 0000 0000</code> (double).</p>
-                    <p>Negative zero (<code>0x8000 0000 0000 0000</code> double,
-                        <code>0x8000 0000</code> float) encountered during unpacking will yield
-                        negative zero forms (e.g. <code>-xs:double(0.0)</code>) and negative zeros
-                        will be written as a result of packing.</p>
-                    <p><bibref ref="xmlschema-2"/> provides only one form of <code>NaN</code> which
-                        corresponds to a 'quiet' <code>NaN</code> with zero payload of <bibref
-                            ref="ieee754"/> with forms <code>0x7fc0 0000</code> (float),
-                        <code>0x7ff8 0000 0000 0000</code> (double). These are the bit forms that
-                        will be packed.</p>
-                    <p> 'Signalling' <code>NaN</code> values (<code>0x7f80 0001</code> →
-                        <code>0x7fbf ffff</code> or <code>0xff80 0001</code> →
-                        <code>0xffbf ffff</code>, <code>0x7ff0 0000 0000
-            0001</code> → <code>0x7ff7 ffff ffff ffff</code> or
-                        <code>0xfff0 0000 0000
-            0001</code> → <code>0xfff7 ffff ffff ffff</code>) encountered
-                        during unpacking will be replaced by 'quiet' <code>NaN</code>. Any low-order
-                        payload in a unpacked 'quiet' <code>NaN</code> is also zeroed. </p>
+                    
+                    <p>Special float and double formats are represented in IEEE format as follows:</p>
+                 
+                    <ulist>
+                        <item><p><code>INF</code> maps to
+                        <code>0x7f80_0000</code> (float), or <code>0x7ff0_0000_0000_0000</code>
+                        (double). </p></item>
+                        <item><p><code>-INF</code> maps to <code>0xff80_0000</code> (float),
+                        or <code>0xfff0_0000_0000_0000</code> (double).</p></item>
+                        <item><p>Negative zero maps to <code>0x8000_0000</code> (float),
+                            or <code>0x8000_0000_0000_0000</code> (double).</p></item>
+                        <item><p><code>NaN</code> in the XSD and XDM type system corresponds to a 
+                            <term>quiet NaN</term> as defined in <bibref
+                            ref="ieee754"/>, and therefore maps to <code>0x7fc0_0000</code> (float),
+                            or <code>0x7ff8_0000_0000_0000</code> (double). These are the bit forms that
+                            will be packed.</p></item>
+                        <item><p>IEEE <term>signalling NaN</term> values may be encountered in binary
+                        data, with the value range <code>0x7f80_0001</code> to
+                        <code>0x7fbf_ffff</code> (float), or <code>0x7ff0_0000_0000_0001</code>
+                            to <code>0x7ff7_ffff_ffff_ffff</code> or
+                        <code>0xfff0_0000_0000_0001</code> to <code>0xfff7_ffff_ffff_ffff</code>
+                        (double). Any such value encountered during unpacking will be replaced by a 
+                        quiet <code>NaN</code>. Any low-order
+                        payload in an unpacked quiet <code>NaN</code> is also zeroed.</p></item>
+
+                    </ulist>
                 </div3>
             </div2>
             <div2 id="func-bin-pack-double">
@@ -1057,6 +1203,13 @@ Michael Sperberg-McQueen (1954–2024).</p>
                         <code>bin:unpack-double</code>, <code>bin:unpack-float</code>,
                         <code>bin:unpack-integer</code> and <code>bin:unpack-unsigned-integer</code>
                         all have similar incompatibilities.</p>
+                </item>
+                <item diff="add" at="2025-02-02">
+                    <p>The use of the type <code>xs:unsignedByte</code> for octet arguments,
+                    and of an <code>enum</code> type for octet order, means that invalid values
+                    for these arguments will now result in a type error 
+                        <xerrorref spec="XP40" class="TY" code="0004"/>, rather than a dynamic
+                    error with a code in the <code>bin</code> namespace.</p>
                 </item>
             </olist>
         </inform-div1>

--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -774,7 +774,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                             The <code>octet-order</code> parameter of relevant functions now
                             has an <code>enum</code> type rather than a string type. In consequence,
                             supplying an incorrect value is now a type error 
-                            (<xerrorref spec="XP40" class="TY" code="0004"/>) and no longer
+                            (<xerrorref spec="XP" class="TY" code="0004"/>) and no longer
                             has a custom error code.
                         </change>
                     </changes>

--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -188,13 +188,18 @@ for transition to Proposed Recommendation. </p>'>
                 >https://www.w3.org/TR/2017/REC-xpath-functions-31-20170321/</loc>-->
         </prevrec>
         <authlist>
-            <author role="4.0">
+            <author role="1.0">
                 <name>Jirka Kosek</name>
                 <!--<affiliation>??</affiliation>-->
                 <email href="http://www.saxonica.com/">http://kosek.com/</email>
             </author>
-            <author role="4.0">
+            <author role="1.0">
                 <name>John Lumley</name>
+                <!--<affiliation>Saxonica</affiliation>-->
+                <email href="http://www.saxonica.com/">http://www.saxonica.com/</email>
+            </author>
+            <author role="4.0">
+                <name>Michael Kay</name>
                 <!--<affiliation>Saxonica</affiliation>-->
                 <email href="http://www.saxonica.com/">http://www.saxonica.com/</email>
             </author>
@@ -207,7 +212,7 @@ for transition to Proposed Recommendation. </p>'>
 
         <abstract>
             <p>This document defines an API for XPath 4.0 to handle the manipulation of binary data.
-                It defines extension functions to process data from, and generate date for, binary
+                It defines extension functions to process data from, and generate data for, binary
                 resources, including extracting subparts, searching, basic binary operations and
                 conversion between binary and structured forms of XDM numbers and strings.</p>
             <p>The document is an update of the original <bibref ref="expath-bin"/> specification,
@@ -565,9 +570,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
                     <eg xml:space="preserve"><![CDATA[
  asn:decode-ASN-integer(xs:base64Binary("AgA=")) → 0
  asn:decode-ASN-integer(xs:base64Binary("AgIE0g==")) → 1234
- asn:encode-ASN-integer(xs:base64Binary("Ag8XxuPAMviQRa10ZoQEXxU=")) 
+ asn:decode-ASN-integer(xs:base64Binary("Ag8XxuPAMviQRa10ZoQEXxU=")) 
      → 123456789123456789123456789123456789              
- asn:encode-ASN-integer(xs:base64Binary("AoIBdgaTo....EBF8V")) 
+ asn:decode-ASN-integer(xs:base64Binary("AoIBdgaTo....EBF8V")) 
      → 123456789.. 900 digits... 123456789                ]]></eg>
                 </example>
             </div2>
@@ -662,7 +667,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 <p>The EXPath File Module <bibref ref="expath-file-40"/> provides three functions
                     suitable for use in file-based situations:</p>
                 <example role="signature">
-                    <proto role="example" name="file:read-binary" return-type="xs:base64Binary">
+                    <proto role="example" prefix="file" name="read-binary" return-type="xs:base64Binary">
                         <arg name="file" type="xs:string"/>
                         <arg name="offset" type="xs:integer?" default="0"/>
                         <arg name="size" type="xs:integer?" default="()"/>
@@ -670,14 +675,14 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 </example>
                 <p>which reads binary data from an existing file, with an optional offset and size.</p>
                 <example role="signature">
-                    <proto role="example" name="file:write-binary" return-type="empty-sequence()">
+                    <proto role="example" prefix="file" name="write-binary" return-type="empty-sequence()">
                         <arg name="file" type="xs:string"/>
                         <arg name="value" type="xs:base64Binary"/>
                     </proto>
                 </example>
                 <p>which writes binary data into a new or existing file.</p>
                 <example role="signature">
-                    <proto role="example" name="file:append-binary" return-type="empty-sequence()">
+                    <proto role="example" prefix="file" name="append-binary" return-type="empty-sequence()">
                         <arg name="file" type="xs:string"/>
                         <arg name="value" type="xs:base64Binary"/>
                     </proto>
@@ -895,10 +900,10 @@ Michael Sperberg-McQueen (1954–2024).</p>
                     <bibl id="expath-bin" key="EXPath Binary 1.0">
                         <loc href="http://expath.org/spec/binary">Binary Module 1.0</loc>. Jirka
                         Kosek and John Lumley, editors. EXPath Module. 3 December 2013.</bibl>
-                    <bibl id="expath-file" key="EXPath File 1.0">
+                    <!--<bibl id="expath-file" key="EXPath File 1.0">
                         <loc href="http://expath.org/spec/file">File Module 1.0</loc>. Christian
                         Grün, Matthias Brantner and Gabriel Petrovay, editors. EXPath Module 20
-                        February 2015.</bibl>
+                        February 2015.</bibl>-->
                     <bibl id="expath-file-40" key="EXPath File 4.0"/>
 
 
@@ -1204,12 +1209,19 @@ Michael Sperberg-McQueen (1954–2024).</p>
                         <code>bin:unpack-integer</code> and <code>bin:unpack-unsigned-integer</code>
                         all have similar incompatibilities.</p>
                 </item>
-                <item diff="add" at="2025-02-02">
+                <item>
                     <p>The use of the type <code>xs:unsignedByte</code> for octet arguments,
                     and of an <code>enum</code> type for octet order, means that invalid values
                     for these arguments will now result in a type error 
-                        <xerrorref spec="XP40" class="TY" code="0004"/>, rather than a dynamic
+                        <xerrorref spec="XP" class="TY" code="0004"/>, rather than a dynamic
                     error with a code in the <code>bin</code> namespace.</p>
+                </item>
+                <item>
+                    <p>The way in which <function>bin:octal</function> adjusts the supplied
+                        value to a whole number of octets is now specified much more precisely, and the result
+                        might differ from the interpretation adopted by existing implementations.
+                        Specifically, the result might differ through the presence or absence of
+                        leading zero octets.</p>
                 </item>
             </olist>
         </inform-div1>

--- a/specifications/EXPath/binary/src/function-catalog.xml
+++ b/specifications/EXPath/binary/src/function-catalog.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <fos:functions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.w3.org/xpath-functions/spec/namespace fos.xsd"
+    xsi:schemaLocation="http://www.w3.org/xpath-functions/spec/namespace ../../../xpath-functions-40/src/fos.xsd"
     xmlns:fos="http://www.w3.org/xpath-functions/spec/namespace">
     
-    <fos:global-variables>
+    <!--<fos:global-variables>
     </fos:global-variables>
-
+-->
     <fos:function name="to-octets" prefix="bin">
         <fos:signatures>
-            <fos:proto name="to-octets" return-type="xs:integer*">
+            <fos:proto name="to-octets" return-type="xs:unsignedByte*">
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)"/>
             </fos:proto>
         </fos:signatures>
@@ -21,16 +21,39 @@
             <p>Returns binary data as a sequence of integer octets.</p>
         </fos:summary>
         <fos:rules>
-            <p>If <code>$in</code> is a zero length binary data then the empty sequence is
+            <p>If <code>$in</code> is a <termref def="dt-zero-length"/> 
+                <termref def="dt-binary-value"/> then the empty sequence is
                 returned.</p>
-            <p>Octets are returned as integers from 0 to 255.</p>
+            <p>Octets are returned in sequence, as instances of
+                <code>xs:unsignedByte</code> (integers ranging from 0 to 255).</p>
         </fos:rules>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:to-octets(bin:hex('1122AAFF')</fos:expression>
+                    <fos:result>17, 34, 170, 255</fos:result>
+                </fos:test>
+            </fos:example>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:to-octets(bin:hex(''))</fos:expression>
+                    <fos:result>()</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
+        <fos:changes>
+            <fos:change>
+                <p>The result type is changed from <code>xs:integer</code> to
+                <code>xs:unsignedByte</code>. This is made possible by the more liberal
+                coercion rules defined in XPath 4.0.</p>
+            </fos:change>
+        </fos:changes>
     </fos:function>
 
     <fos:function name="from-octets" prefix="bin">
         <fos:signatures>
             <fos:proto name="from-octets" return-type="xs:base64Binary">
-                <fos:arg name="in" type="xs:integer*"/>
+                <fos:arg name="in" type="xs:unsignedByte*"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -43,13 +66,37 @@
         </fos:summary>
         <fos:rules>
             <p>Octets are integers from 0 to 255.</p>
-            <p>If <code>$in</code> is the empty sequence, the function returns zero-sized binary
-                data.</p>
+            <p>If <code>$in</code> is the empty sequence, the function returns a 
+                <termref def="dt-zero-length"/> binary value.</p>
         </fos:rules>
-        <fos:errors>
+        <!--<fos:errors>
             <p><errorref spec="BIN40" code="octet-out-of-range"/> is raised if one of the octets lies
                 outside the range 0 – 255. </p>
-        </fos:errors>
+        </fos:errors>-->
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:from-octets((17, 34, 170, 255))</fos:expression>
+                    <fos:result>bin:hex('1122AAFF')</fos:result>
+                </fos:test>
+            </fos:example>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:from-octets(())</fos:expression>
+                    <fos:result>bin:hex('')</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
+        <fos:changes>
+            <fos:change>
+                <p>The argument type is changed from <code>xs:integer</code> to
+                <code>xs:unsignedByte</code>. This is made possible by the more liberal
+                coercion rules defined in XPath 4.0. A consequence of the change
+                is that supplying an out-of-range integer value is now a type error
+                with the standard error code <code>XPTY0004</code>, rather than the
+                custom error code <code>bin:octet-out-of-range</code> previously used.</p>
+            </fos:change>
+        </fos:changes>
     </fos:function>
 
     <fos:function name="hex" prefix="bin">
@@ -64,36 +111,56 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the binary form of the set of octets written as a sequence of (ASCII) hex
-                digits ([0-9A-Fa-f]).</p>
+            <p>Constructs a binary value from a string of hexadecimal digits (<code>[0-9A-Fa-f]*</code>).</p>
         </fos:summary>
         <fos:rules>
-            <p>
-                <code>$in</code> will be effectively zero-padded from the left to generate an
-                integral number of octets, i.e. an even number of hexadecimal digits.</p>
-            <p>Byte order in the result follows (per-octet) character order in the string.</p>
-            <p> If <code>$in</code> is an empty string, then the result will be a
-                <code>xs:base64Binary</code> with no embedded data.</p>
             <p>If <code>$in</code> is the empty sequence, the function returns an empty
                 sequence.</p>
+            <p>Any whitespace and underscore characters are stripped from <code>$in</code>.</p>            
+            <p>
+                If the length of of the resulting string is an odd number, then 
+                a single "0" digit is prepended to the value, so that it contains an 
+                even number of hexadecimal digits.</p>
+            <p>The resulting string is then cast to type <code>xs:hexBinary</code>,
+            which is then cast to <code>xs:base64Binary</code>.</p>
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+   $in ! ( replace(., '[_\s]', '') 
+           -> concat(if (string-length(.) mod 2) eq 1 then "0" else "", .)
+           -> xs:hexBinary(.)
+           -> xs:base64Binary(.) )
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="non-numeric-character"/> is raised if <code>$in</code>
                 cannot be parsed as a hexadecimal number.</p>
         </fos:errors>
         <fos:notes>
-            <p>When the input string has an even number of characters, this function behaves
-                similarly to the double cast
+            <p>The order of octets in the result follows the order of characters in the string.</p>
+            <p>If <code>$in</code> is an empty string, the result will be a
+                <termref def="dt-zero-length"/> <code>xs:base64Binary</code> value.</p>
+            <p>When the input string has an even number of characters, this function delivers the same
+                result as the expression
                 <code>xs:base64Binary(xs:hexBinary(<emph>$string</emph>))</code>.</p>
         </fos:notes>
         <fos:examples>
             <fos:example>
-                <eg xml:space="preserve">bin:hex('11223F4E') → "ESI/Tg=="</eg>
+                <fos:test>
+                    <fos:expression>bin:hex('1122_3F4E')</fos:expression>
+                    <fos:result>xs:base64Binary("ESI/Tg==")</fos:result>
+                </fos:test>
             </fos:example>
             <fos:example>
-                <eg xml:space="preserve">bin:hex('1223F4E') → "ASI/Tg=="</eg>
+                <fos:test>
+                    <fos:expression>bin:hex('122 3F4E')</fos:expression>
+                    <fos:result>xs:base64Binary("ASI/Tg==")</fos:result>
+                </fos:test>
             </fos:example>
         </fos:examples>
+        <fos:changes>
+            <fos:change issue="1750">
+                <p>The input string is now allowed to include embedded underscores and whitespace.</p>
+            </fos:change>
+        </fos:changes>
     </fos:function>
 
     <fos:function name="bin" prefix="bin">
@@ -108,32 +175,71 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the binary form of the set of octets written as a sequence of (8-wise)
-                (ASCII) binary digits ([01]).</p>
+            <p>Constructs a binary value from a string of zeroes and ones (<code>[01]*</code>)</p>
         </fos:summary>
         <fos:rules>
-            <p>
-                <code>$in</code> will be effectively zero-padded from the left to generate an
-                integral number of octets (i.e. the number of characters in <code>$in</code> will be
-                a multiple of 8).</p>
-            <p>Byte order in the result follows (per-octet) character order in the string.</p>
-            <p> If <code>$in</code> is an empty string, then the result will be a
-                <code>xs:base64Binary</code> with no embedded data.</p>
             <p>If <code>$in</code> is the empty sequence, the function returns an empty
                 sequence.</p>
+            <p>Any whitespace and underscore characters are stripped from <code>$in</code>.</p>
+            <p>As many zero digits (<char>U+0030</char>) as necessary are prepended
+                to <code>$in</code> to make its string length a multiple of 8.</p>
+            <p>The string is then partitioned into substrings of length 8, and each such
+            substring <var>B</var> is converted to an integer in the range 0 to 255
+            by applying the function <code>fn:parse-integer(<var>B</var>, 2)</code>.
+            The resulting sequence of integers is then converted to a <termref def="dt-binary-value"/>
+            by applying the function <function>bin:from-octets</function>.</p>           
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+    
+   $in ! ( (: process input if present, otherwise return () :)
+               (: strip underscores and whitespace :)
+           replace(., '[_\s]', '')
+               (: extend to a multiple of 8 binary digits :)
+       ->  concat((1 to (8 - string-length(.) mod 8) ! "0"), .)
+               (: insert a separator after every 8 digits :)
+       ->  replace(., "(.{8})", "$1/")
+               (: split into groups of 8 digits :)
+       ->  tokenize(., "/")
+               (: parse each group of 8 binary digits as a radix-2 integer :)
+       =!> parse-integer(2)
+               (: construct a binary value from these octets :)
+       ->  bin:from-octets(.) 
+   )
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="non-numeric-character"/> is raised if <code>$in</code>
                 cannot be parsed as a binary number.</p>
         </fos:errors>
+        <fos:notes>
+            <p>The order of octets in the result follows the order of characters in the string.</p>
+            <p>If <code>$in</code> is an empty string, the result will be a
+                <termref def="dt-zero-length"/> <code>xs:base64Binary</code> value.</p>
+        </fos:notes>
         <fos:examples>
             <fos:example>
-                <eg xml:space="preserve">bin:bin('1101000111010101') → "0dU="</eg>
+                <fos:test>
+                    <fos:expression>bin:bin('1101_0001_1101_0101')</fos:expression>
+                    <fos:result>bin:hex("D1D5")</fos:result>
+                </fos:test>
             </fos:example>
             <fos:example>
-                <eg xml:space="preserve">bin:bin('1000111010101') → "EdU="</eg>
+                <fos:test>
+                    <fos:expression>bin:bin('1 0001 1101 0101')</fos:expression>
+                    <fos:result>bin:hex("11D5")</fos:result>
+                </fos:test>
+            </fos:example>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:bin(' 101 ')</fos:expression>
+                    <fos:result>bin:hex("05")</fos:result>
+                </fos:test>
             </fos:example>
         </fos:examples>
+        <fos:changes>
+            <fos:change issue="1750">
+                <p>The input string is now allowed to include embedded underscores and whitespace.</p>
+            </fos:change>
+        </fos:changes>
     </fos:function>
 
     <fos:function name="octal" prefix="bin">
@@ -148,28 +254,75 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the binary form of the set of octets written as a sequence of (ASCII) octal
-                digits ([0-7]).</p>
+            <p>Constructs a binary value from a string of octal digits (<code>[0-7]*</code>)</p>
         </fos:summary>
         <fos:rules>
-            <p>
-                <code>$in</code> will be effectively zero-padded from the left to generate an
-                integral number of octets.</p>
-            <p>Byte order in the result follows (per-octet) character order in the string.</p>
-            <p> If <code>$in</code> is an empty string, then the result will be a
-                <code>xs:base64Binary</code> with no embedded data.</p>
             <p>If <code>$in</code> is the empty sequence, the function returns an empty
                 sequence.</p>
+            <p>Otherwise:</p>
+            <olist>
+                <item><p>Any whitespace and underscore characters are stripped from <code>$in</code>.</p></item>
+                <item><p>Each octal digit in <code>$in</code> is replaced by its binary equivalent
+                (<code>"0"</code> → <code>"000"</code>, <code>"1"</code> → <code>"001"</code>, 
+                    <code>"2"</code> → <code>"010"</code>, <code>"3"</code> → <code>"011"</code>, 
+                    <code>"4"</code> → <code>"100"</code>,
+                <code>"5"</code> → <code>"101"</code>, <code>"6"</code> → <code>"110"</code>, 
+                    <code>"7"</code> → <code>"111"</code>).</p></item>
+                <item><p>The resulting string
+                is converted to a <termref def="dt-binary-value"/> by applying
+                the function <function>bin:bin</function> to the result.</p></item>
+            </olist>
+                
+            <p>The order of octets in the result follows the order of characters in the string.</p>
+            
+            
         </fos:rules>
+          <fos:equivalent style="xpath-expression" covers-error-cases="false">
+   $in ! ( replace(., '[_\s]', '') 
+           =>  characters()
+           =!> {"0":"000", "1":"001", "2":"010", "3":"011", 
+                "4":"100", "5":"101", "6":"110", "7":"111"}()
+           =>  string-join()
+           =>  bin:bin() )
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="non-numeric-character"/> is raised if <code>$in</code>
                 cannot be parsed as an octal number.</p>
         </fos:errors>
+        <fos:notes>
+            <p>The order of octets in the result follows the order of characters in the string.</p>
+            <p>If <code>$in</code> is a zero-length string, the result will be a
+                <termref def="dt-zero-length"/> <code>xs:base64Binary</code> value.</p>
+            <p>There are <termref def="dt-binary-value">binary values</termref> that cannot
+            be constructed using this function. For example, it is not possible to 
+            construct the value <code>bin:hex("7F")</code>, because the apparent
+            equivalent <code>bin:octal("177")</code> represents a 9-bit value, 
+                which is padded to the two-octet value <code>bin:hex("007F")</code>.
+            If it is known that octal values will always represent single octets, 
+            the required octet can be extracted by an expression such as
+            <code>bin:octal($in) => bin:to-octets() => foot() => bin:from-octets()</code></p>
+        </fos:notes>
         <fos:examples>
             <fos:example>
-                <eg xml:space="preserve">bin:octal('11223047') → "JSYn"</eg>
+                <fos:test>
+                    <fos:expression>bin:octal('')</fos:expression>
+                    <fos:result>bin:hex('')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:octal('11223047')</fos:expression>
+                    <fos:result>bin:hex('252627')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:octal(' 177 ')</fos:expression>
+                    <fos:result>bin:hex('007F')</fos:result>
+                </fos:test>
             </fos:example>
         </fos:examples>
+        <fos:changes>
+            <fos:change issue="1750">
+                <p>The input string is now allowed to include embedded underscores and whitespace.</p>
+            </fos:change>
+        </fos:changes>
     </fos:function>
 
     <fos:function name="part" prefix="bin">
@@ -186,21 +339,26 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns a specified part of binary data.</p>
+            <p>Selects a specified range of octets from a binary value.</p>
         </fos:summary>
         <fos:rules>
-            <p>Returns a section of binary data starting at the <code>$offset</code> octet. If
-                <code>$size</code> is defined, the size of the returned binary data is
-                <code>$size</code> octets. If <code>$size</code> is absent, all remaining data from
-                <code>$offset</code> is returned.</p>
+            <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
+                sequence.</p>
+            <p>Otherwise, the function returns a section of binary data starting 
+                at <code>$offset</code>. The offset is zero-based. If
+                <code>$size</code> is present and non-empty, the size of the returned binary data is
+                <code>$size</code> octets. If <code>$size</code> is absent or empty, 
+                all remaining data from <code>$offset</code> is returned.</p>
             <p>The <code>$offset</code> is zero based.</p>
             <p>The values of <code>$offset</code> and <code>$size</code>
                 <rfc2119>must</rfc2119> be non-negative integers.</p>
             <p>It is a dynamic error if <code>$offset</code> + <code>$size</code> is larger than the
                 size of the binary data in <code>$in</code>.</p>
-            <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
-                sequence.</p>
+            
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+   $in => bin:to-octets() => subsequence($offset + 1, $size) => bin:from-octets()         
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$offset</code> is
                 negative or <code>$offset + $size</code> is larger than the size of the binary data
@@ -209,18 +367,44 @@
                 negative.</p>
         </fos:errors>
         <fos:notes>
-            <p>Note that <code>fn:subsequence()</code> and <code>fn:substring()</code>
-                <!--<bibref ref="fo11"/>--> both use <code>xs:double</code> for offset and size –
-                this is a legacy from XPath 1.0.</p>
+            <p>The function differs in several ways from <function>fn:subsequence()</function> 
+                and <function>fn:substring()</function>:</p>
+            <ulist>
+                <item><p>The <code>$offset</code> and <code>$size</code> are supplied
+                as integers, not doubles.</p></item>
+                <item><p>The <code>$offset</code> is zero-based, not one-based.</p></item>
+                <item><p>An error is raised if the selection goes outside the bounds
+                of the value.</p></item>
+            </ulist>
+            
         </fos:notes>
         <fos:examples>
             <fos:example>
-                <p>Testing whether <code>$data</code> variable starts with binary content consistent
+                <fos:test>
+                    <fos:expression>bin:part(bin:hex('11223344556677'), 0, 4)</fos:expression>
+                    <fos:result>bin:hex('11223344')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:part(bin:hex('11223344556677'), 4)</fos:expression>
+                    <fos:result>bin:hex('556677')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:part(bin:hex('11223344556677'), 7)</fos:expression>
+                    <fos:result>bin:hex('')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:part(bin:hex('11223344556677'), 5, 0)</fos:expression>
+                    <fos:result>bin:hex('')</fos:result>
+                </fos:test>
+            </fos:example>
+            <fos:example>
+                <p>This example tests whether <code>$data</code> starts with binary content consistent
                     with a PDF file:</p>
                 <eg xml:space="preserve">bin:part($data, 0, 4) eq bin:hex("25504446")</eg>
-                <p><code>25504446</code> is the magic number for PDF files: it is the US-ASCII
-                    encoded hexadecimal value for <code>%PDF</code>.
-                    <code>bin:encode-string</code><!--<specref ref="encode-string"/>--> can be used
+                <p><code>25504446</code> is the magic number for PDF files: it is the hexadecimal 
+                    representation of the result of encoding the string <code>"%PDF"</code>
+                    in UTF-8 (or US-ASCII). Note that the function
+                    <function>bin:encode-string</function> can be used
                     to convert a string to its binary representation.</p>
             </fos:example>
         </fos:examples>
@@ -240,35 +424,51 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Inserts additional binary data at a given point in other binary data.</p>
+            <p>Inserts octets at a given point in a binary value.</p>
         </fos:summary>
         <fos:rules>
-            <p>Returns binary data consisting sequentially of the data from <code>$in</code> upto
-                and including the <code>$offset - 1</code> octet, followed by all the data from
-                <code>$extra</code>, and then the remaining data from <code>$in</code>.</p>
-            <p>The <code>$offset</code> is zero based.</p>
-            <p>The value of <code>$offset</code>
-                <rfc2119>must</rfc2119> be a non-negative integer.</p>
-
-
             <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
                 sequence.</p>
             <p>If the value of <code>$extra</code> is the empty sequence, the function returns
                 <code>$in</code>.</p>
-            <p>If <code>$offset eq 0</code> the result is the binary concatenation of
-                <code>$extra</code> and <code>$in</code>, i.e. equivalent to
-                <code>bin:join(($extra,$in))</code>.</p>
+            <p>Otherwise, the function returns a binary value formed
+                by concatenating the <code>bin:part($in, 0, $offset)</code>, then
+                <code>$extra</code>, then <code>bin:part($in, $offset)</code>
+                <code>$extra</code>, and then the remaining data from <code>$in</code>.</p>
+            <p>The <code>$offset</code> is zero based, and 
+                <rfc2119>must</rfc2119> be non-negative.</p>
+
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+$in => bin:to-octets() 
+    => insert-before($offset + 1, bin:to-octets($extra)) 
+    => bin:from-octets()         
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$offset</code> is
                 negative or <code>$offset</code> is larger than the size of the binary data of
                 <code>$in</code>.</p>
         </fos:errors>
         <fos:notes>
-            <p>Note that when <code>$offset gt 0 and $offset lt bin:size($in)</code> the function is
-                equivalent to:</p>
-            <eg>bin:join((bin:part($in,0,$offset - 1),$extra,bin:part($in,$offset)))</eg>
+            <p>If <code>$offset</code> is zero, the result is the binary concatenation of
+                <code>$extra</code> and <code>$in</code>.</p>
         </fos:notes>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:insert-before(bin:hex('FFFF'), 1, bin:hex('00'))</fos:expression>
+                    <fos:result>bin:hex('FF00FF')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:insert-before(bin:hex('FFFF'), 0, bin:hex('00'))</fos:expression>
+                    <fos:result>bin:hex('00FFFF')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:insert-before(bin:hex('FFFF'), 2, bin:hex('00'))</fos:expression>
+                    <fos:result>bin:hex('FFFF00')</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
 
     <fos:function name="length" prefix="bin">
@@ -283,13 +483,26 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the size of binary data, measured in octets.</p>
+            <p>Returns the size of a binary value, measured in octets.</p>
         </fos:summary>
         <fos:rules>
-            <p>Returns the size of binary data in octets.</p>
+            <p>Returns the number of octets in the binary value <code>$in</code>.</p>
         </fos:rules>
         <fos:equivalent style="xpath-expression" covers-error-cases="true">
-            count(bin:to-octets($in)) </fos:equivalent>
+            count(bin:to-octets($in)) 
+        </fos:equivalent>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:length(bin:hex('FFFF'))</fos:expression>
+                    <fos:result>2</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:length(bin:hex(''))</fos:expression>
+                    <fos:result>0</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
 
     <fos:function name="join" prefix="bin">
@@ -304,25 +517,43 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the binary data created by concatenating the binary data items in a
-                sequence.</p>
+            <p>Concatenates a sequence of binary values in order.</p>
         </fos:summary>
         <fos:rules>
-            <p>The function returns an <code>xs:base64Binary</code> created by concatenating the
-                items in the sequence <code>$in</code>, in order.</p>
-            <p>If the value of <code>$in</code> is the empty sequence, the function returns a binary
-                item containing no data bytes.</p>
+            <p>The function returns an <code>xs:base64Binary</code> value created by concatenating the
+                binary values in the sequence <code>$in</code>, in order.</p>            
         </fos:rules>
-        <fos:equivalent style="xpath-expression" covers-error-cases="true"> bin:from-octets($in !
-            bin:to-octets(.)) </fos:equivalent>
+        <fos:equivalent style="xpath-expression" covers-error-cases="true"> 
+$in =!> bin:to-octets() => bin:from-octets() 
+        </fos:equivalent>
+        <fos:notes>
+            <p>If <code>$in</code> is the empty sequence, the function returns a 
+                <termref def="dt-zero-length"/> binary value.</p>
+        </fos:notes>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:join((bin:hex('0000'), bin:hex('FFFF'), bin:hex('0000'))</fos:expression>
+                    <fos:result>bin:hex('0000FFFF0000')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:join(())</fos:expression>
+                    <fos:result>bin:hex('')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:join( (1 to 4) ! bin:hex('F0') )</fos:expression>
+                    <fos:result>bin:hex('F0F0F0F0')</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
 
     <fos:function name="pad-left" prefix="bin">
         <fos:signatures>
             <fos:proto name="pad-left" return-type="xs:base64Binary?">
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)?"/>
-                <fos:arg name="size" type="xs:integer"/>
-                <fos:arg name="octet" type="xs:integer?" default="0"/>
+                <fos:arg name="count" type="xs:integer"/>
+                <fos:arg name="octet" type="xs:unsigned-byte?" default="0"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -331,41 +562,52 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the binary data created by padding <code>$in</code> with <code>$size</code>
-                octets from the left. The padding octet values are <code>$octet</code> or zero if
-                omitted.</p>
+            <p>Returns a binary value created by padding <code>$in</code> on the left with <code>$count</code>
+                occurrences of <code>$octet</code>.</p>
         </fos:summary>
         <fos:rules>
-            <p>The function returns an <code>xs:base64Binary</code> created by padding the input
-                with <code>$size</code> octets <emph>in front of</emph> the input. If
-                <code>$octet</code> is specified, the padding octets each have that value, otherwise
-                they are initialized to 0.</p>
-            <p><code>$size</code>
-                <rfc2119>must</rfc2119> be a non-negative integer.</p>
             <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
                 sequence.</p>
+            <p>Otherwise, the function returns a binary value consisting of
+                <code>$count</code> instances of <code>$octet</code>, followed by <code>$in</code>. 
+            The default for <code>$octet</code> is zero (0).</p>
+            <p><code>$size</code>
+                <rfc2119>must</rfc2119> be a non-negative integer.</p>
+            
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+(((1 to $count) ! $octet), bin:to-octets($in)) 
+=> bin:from-octets()         
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
-            <p><errorref spec="BIN40" code="octet-out-of-range"/> is raised if <code>$octet</code>
-                lies outside the range 0 – 255. </p>
+            <!--<p><errorref spec="BIN40" code="octet-out-of-range"/> is raised if <code>$octet</code>
+                lies outside the range 0 – 255. </p>-->
         </fos:errors>
-        <fos:equivalent style="xpath-expression" covers-error-cases="false">
-            bin:join((bin:from-octets((1 to $size) ! $octet), $in)) </fos:equivalent>
-        <!--<fos:notes>
-            <p>Padding with a non-zero octet value can also be accomplished by the XPath
-                expressions:</p>
-            <eg xml:space="preserve">bin:join((bin:from-octets((1 to $pad-length) ! $pad-octet), $in)) [XPath 3.0]</eg>
-            <eg xml:space="preserve">bin:join((bin:from-octets(for $ i in (1 to $pad-length) return $pad-octet), $in)) [XPath 2.0]</eg>
-        </fos:notes>-->
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:pad-left(bin:hex('FFFF'), 3)</fos:expression>
+                    <fos:result>bin:hex('000000FFFF')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pad-left(bin:hex('0000'), 3, 255)</fos:expression>
+                    <fos:result>bin:hex('FFFFFF0000')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pad-left(bin:hex(''), 8)</fos:expression>
+                    <fos:result>bin:hex('0000000000000000')</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
     
     <fos:function name="pad-right" prefix="bin">
         <fos:signatures>
             <fos:proto name="pad-right" return-type="xs:base64Binary?">
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)?"/>
-                <fos:arg name="size" type="xs:integer"/>
+                <fos:arg name="count" type="xs:integer"/>
                 <fos:arg name="octet" type="xs:integer?" default="0"/>
             </fos:proto>
         </fos:signatures>
@@ -375,34 +617,45 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the binary data created by padding <code>$in</code> with <code>$size</code>
-                blank octets from the right. The padding octet values are <code>$octet</code> or
-                zero if omitted.</p>
+            <p>Returns a binary value created by padding <code>$in</code> on the 
+                right with <code>$count</code> occurrences of <code>$octet</code>.</p>
         </fos:summary>
         <fos:rules>
-            <p>The function returns an <code>xs:base64Binary</code> created by padding the input
-                with <code>$size</code> blank octets <emph>after</emph> the input. If
-                <code>$octet</code> is specified, the padding octets each have that value, otherwise
-                they are initialized to 0.</p>
-            <p><code>$size</code>
-                <rfc2119>must</rfc2119> be a non-negative integer.</p>
             <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
                 sequence.</p>
+            <p>Otherwise, the function returns a binary value consisting of
+                <code>$in, followed by </code><code>$count</code> instances of <code>$octet</code>. 
+            The default for <code>$octet</code> is zero (0).</p>
+            <p><code>$size</code>
+                <rfc2119>must</rfc2119> be a non-negative integer.</p>
+            
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+(bin:to-octets($in), (1 to $count) ! $octet) 
+=> bin:from-octets()         
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
-            <p><errorref spec="BIN40" code="octet-out-of-range"/> is raised if <code>$octet</code>
-                lies outside the range 0 – 255. </p>
+            <!--<p><errorref spec="BIN40" code="octet-out-of-range"/> is raised if <code>$octet</code>
+                lies outside the range 0 – 255. </p>-->
         </fos:errors>
-        <fos:equivalent style="xpath-expression" covers-error-cases="false">
-            bin:join((bin:from-octets($in,(1 to $size) ! $octet))) </fos:equivalent>
-       <!-- <fos:notes>
-            <p>Padding with a non-zero octet value can also be accomplished by the XPath
-                expressions:</p>
-            <eg xml:space="preserve">bin:join(($in,bin:from-octets((1 to $pad-length) ! $pad-octet)))  [XPath 3.0]</eg>
-            <eg xml:space="preserve">bin:join(($in,bin:from-octets(for $ i in (1 to $pad-length) return $pad-octet)))  [XPath 2.0]</eg>
-        </fos:notes>-->
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:pad-right(bin:hex('FFFF'), 3)</fos:expression>
+                    <fos:result>bin:hex('FFFF000000')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pad-right(bin:hex('0000'), 3, 255)</fos:expression>
+                    <fos:result>bin:hex('0000FFFFFF')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pad-right(bin:hex(''), 8)</fos:expression>
+                    <fos:result>bin:hex('0000000000000000')</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
 
     <fos:function name="find" prefix="bin">
@@ -419,21 +672,30 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the first location in <code>$in</code> of <code>$search</code>, starting at
-                the <code>$offset</code> octet.</p>
+            <p>Returns the position of the first occurrence of <code>$search</code> within
+                <code>$in</code>, starting at <code>$offset</code>.</p>
         </fos:summary>
         <fos:rules>
-            <p>The function returns the first location of the binary search sequence in the input,
-                or if not found, the empty sequence.</p>
-            <p>If <code>$search</code> is empty <code>$offset</code> is returned.</p>
+            <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
+                sequence.</p>
+            <p>Otherwise, the function returns the lowest value of <var>P</var> that is greater than
+                or equal to <code>$offset</code>,
+                such that <code>bin:part($in, <var>P</var>, bin:length($search)) eq <var>P</var></code>.
+                If there is no such value (that is, if <code>$search</code> is not found), 
+                the function returns the empty sequence.</p>
+            <p>If <code>$search</code> is <termref def="dt-zero-length"/> 
+                then <code>$offset</code> is returned.</p>
 
             <p>The value of <code>$offset</code>
                 <rfc2119>must</rfc2119> be a non-negative integer.</p>
             <p>The <code>$offset</code> is zero based.</p>
             <p>The returned location is zero based.</p>
-            <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
-                sequence.</p>
+            
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+($offset to (bin:length($in) - bin:length($search)))
+       [bin:part($in, 0, bin:length($search)) eq $search][1] 
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$offset</code> is
                 negative or <code>$offset</code> is larger than the size of the binary data of
@@ -447,13 +709,37 @@
      <xsl:param name="offset" as="xs:integer"/>
      <xsl:param name="pattern" as="xs:base64Binary"/>
      <xsl:sequence
-         select="if(bin:length($pattern) = 0) then ()
-         else let $found := bin:find($data,$offset,$pattern) return
-         if($found) then ($found,
-             if($found + 1 lt bin:length($data)) then f:find-all($data,$found + 1,$pattern) else ())
-             else ()"/>
+         select="if (bin:length($pattern) eq 0) 
+                 then ()
+                 else let $found := bin:find($data,$offset,$pattern) 
+                      return if ($found) 
+                             then ($found,
+                                   if ($found + 1 lt bin:length($data)) 
+                                   then f:find-all($data, $found + 1, $pattern) 
+                                   else ())
+                             else ()"/>
 </xsl:function>]]></eg>
         </fos:notes>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:find((bin:hex('AABBCCDD'), 0, bin:hex('DD'))</fos:expression>
+                    <fos:result>3</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:find((bin:hex('AABBCCDD'), 0, bin:hex('FF'))</fos:expression>
+                    <fos:result>()</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:find((bin:hex('AABBCCDDBBCC'), 2, bin:hex('BBCC'))</fos:expression>
+                    <fos:result>4</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:find((bin:hex('AABBCCDD'), 2, bin:hex(''))</fos:expression>
+                    <fos:result>2</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
 
     <fos:function name="decode-string" prefix="bin">
@@ -471,23 +757,27 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Decodes binary data as a string in a given encoding.</p>
+            <p>Decodes a binary value as a string in a given encoding.</p>
         </fos:summary>
         <fos:rules>
+            <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
+                sequence.</p>
             <p>If <code>$offset</code> and <code>$size</code> are provided, the <code>$size</code>
                 octets from <code>$offset</code> are decoded. If <code>$offset</code> alone is
                 provided, octets from <code>$offset</code> to the end are decoded, otherwise the
-                entire octet sequence is used.</p>
-            <p>The <code>$encoding</code> argument is the name of an encoding. The values for this
-                attribute follow the same rules as for the <code>encoding</code> attribute in an XML
+                entire octet sequence is decoded.</p>
+            <p>The function returns the string obtained by decoding the selected octets using
+                the specified <code>$encoding</code> name.</p>
+            <p>The <code>$encoding</code> argument is the name of an encoding. The values for 
+                <code>$encoding</code> follow the same rules as for the 
+                <code>encoding</code> attribute in an XML
                 declaration. The only values which every implementation is
                     <rfc2119>required</rfc2119> to recognize are <code>utf-8</code> and
                 <code>utf-16</code>.</p>
             <p>If <code>$encoding</code> is omitted, <code>utf-8</code> encoding is assumed.</p>
-            <p>The values of <code>$offset</code> and <code>$size</code>
+            <p>The values of <code>$offset</code> and <code>$size</code>, if present,
                 <rfc2119>must</rfc2119> be non-negative integers.</p>
-            <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
-                sequence.</p>
+            
             <p><code>$offset</code> is zero based.</p>
         </fos:rules>
         <fos:errors>
@@ -505,10 +795,21 @@
         </fos:errors>
         <fos:examples>
             <fos:example>
-                <p>Testing whether <code>$data</code> variable starts with binary content consistent
-                    with a PDF file:</p>
+                <fos:test>
+                    <fos:expression>bin:decode-string(bin:hex('414243'))</fos:expression>
+                    <fos:result>"ABC"</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:decode-string(bin:hex('FEFF004100420043'), 'utf-16')</fos:expression>
+                    <fos:result>"ABC"</fos:result>
+                    <fos:postamble>TODO: See issue 1751 regarding the BOM.</fos:postamble>
+                </fos:test>
+            </fos:example>
+            <fos:example>
+                <p>The following tests whether the binary value <code>$data</code> starts
+                with four octets that decode to the string '%PDF' (which always appears at the start
+                of a PDF file)</p>
                 <eg xml:space="preserve">bin:decode-string($data, 'UTF-8', 0, 4) eq '%PDF'</eg>
-                <p>The first four characters of a PDF file are <code>'%PDF'</code>.</p>
             </fos:example>
         </fos:examples>
     </fos:function>
@@ -526,17 +827,21 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Encodes a string into binary data using a given encoding.</p>
+            <p>Encodes a string into a binary value using a given encoding.</p>
         </fos:summary>
         <fos:rules>
-            <p>The <code>$encoding</code> argument is the name of an encoding. The values for this
-                attribute follow the same rules as for the <code>encoding</code> attribute in an XML
+            <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
+                sequence.</p>
+            <p>The <code>$encoding</code> argument is the name of an encoding. The values for 
+                <code>$encoding</code> follow the same rules as for the 
+                <code>encoding</code> attribute in an XML
                 declaration. The only values which every implementation is
                     <rfc2119>required</rfc2119> to recognize are <code>utf-8</code> and
                 <code>utf-16</code>.</p>
+            <p>The function returns the binary value obtained by encoding the string <code>$in</code> using
+                the specified <code>$encoding</code> name.</p>
             <p>If <code>$encoding</code> is omitted, <code>utf-8</code> encoding is assumed.</p>
-            <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
-                sequence.</p>
+            
         </fos:rules>
         <fos:errors>
             <p><errorref spec="BIN40" code="unknown-encoding"/> is raised if <code>$encoding</code> is
@@ -546,6 +851,19 @@
                 may be passed through suitable error reporting mechanisms – this is
                 implementation-dependant.</p>
         </fos:errors>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:encode-string('ABC')</fos:expression>
+                    <fos:result>bin:hex('414243')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:encode-string('ABC', 'utf-16')</fos:expression>
+                    <fos:result>bin:hex('FEFF004100420043')</fos:result>
+                    <fos:postamble>TODO: The result has a BOM. See issue 1751.</fos:postamble>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
 
     <fos:function name="pack-integer" prefix="bin">
@@ -553,7 +871,8 @@
             <fos:proto name="pack-integer" return-type="xs:base64Binary">
                 <fos:arg name="in" type="xs:integer"/>
                 <fos:arg name="size" type="xs:integer"/>
-                <fos:arg name="octet-order" type="xs:string?" default="'most-significant-first'"/>
+                <fos:arg name="octet-order" type="enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -563,14 +882,20 @@
         </fos:properties>
         <fos:summary>
             <p>Returns the <emph>twos-complement</emph> binary representation of an integer value
-                treated as <code>$size</code> octets long. Any 'excess' high-order bits are
-                discarded.</p>
+                as a binary value of a given size.</p>
         </fos:summary>
         <fos:rules>
-            <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$octet-order</code> parameter is specified. Acceptable values for
-                <code>$octet-order</code> are described in <specref ref="endianness"/>.</p>
-            <p>Specifying a <code>$size</code> of zero yields an empty binary data.</p>
+            <p>The function produces a binary value containing the twos-complement
+            representation of <code>$in mod math:pow(256, $size)</code>, padded on the
+            left to <code>$size</code> octets with zero bits if the value is positive,
+            or one bits if it is negative.</p>
+            <p>The order of octets in the result is most-significant-first unless
+                <code>$octet-order</code> specifies otherwise.
+            Acceptable values for <code>$octet-order</code> are described in <specref ref="endianness"/>.
+            If least-significant-first ordering is requested then the order of octets
+            in the result is reversed.</p>
+            <p>Specifying a <code>$size</code> of zero yields a <termref def="dt-zero-length"/>
+                binary value.</p>
         </fos:rules>
         <fos:errors>
             <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
@@ -585,10 +910,43 @@
                 positive (<code>2^(8 *$size - 1)</code>) meaning. If it is considered to be a signed
                 value, then the MSB and all the higher order, discarded bits will be '1' for a
                 negative value and '0' for a positive or zero. If this function were to check the
-                'sizing' of the supplied integer against the packing size, then any values of MSB
+                sizing of the supplied integer against the packing size, then any values of MSB
                 and the discarded higher order bits other than 'all 1' or 'all 0' would constitute
                 an error. <emph>This function does not perform such checking.</emph></p>
+            <p>Least-significant-first byte ordering simply reverses the octets in the result.</p>
         </fos:notes>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:pack-integer(256, 2)</fos:expression>
+                    <fos:result>bin:hex('0100')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pack-integer(256, 4)</fos:expression>
+                    <fos:result>bin:hex('00000100')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pack-integer(65536, 2)</fos:expression>
+                    <fos:result>bin:hex('0000')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pack-integer(256, 2, "LE")</fos:expression>
+                    <fos:result>bin:hex('0001')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pack-integer(-1, 2)</fos:expression>
+                    <fos:result>bin:hex('FFFF')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pack-integer(-2, 4)</fos:expression>
+                    <fos:result>bin:hex('FFFFFFFE')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:pack-integer(-2, 4, 'LE')</fos:expression>
+                    <fos:result>bin:hex('FEFFFFFF')</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
     
     <fos:function name="unpack-integer" prefix="bin">
@@ -597,7 +955,8 @@
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)"/>
                 <fos:arg name="offset" type="xs:integer"/>
                 <fos:arg name="size" type="xs:integer"/>
-                <fos:arg name="octet-order" type="xs:string?" default="'most-significant-first'"/>
+                <fos:arg name="octet-order" type="enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -607,14 +966,16 @@
         </fos:properties>
         <fos:summary>
             <p>Returns a signed integer value represented by the <code>$size</code> octets starting
-                from <code>$offset</code> in the input binary representation. Necessary sign
-                extension is performed (i.e. the result is negative if the high order bit is
-                '1').</p>
+                from <code>$offset</code> in the input binary value.</p>
         </fos:summary>
         <fos:rules>
-            <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$octet-order</code> parameter is specified. Acceptable values for
-                <code>$octet-order</code> are described in <specref ref="endianness"/>.</p>
+            <p>The function produces an integer represented by the binary value
+                <code>bin:part($in, $offset, $size)</code>. This is interpreted
+            as a twos-complement representation of a signed integer, with the most significant
+            octet first unless the <code>$octet-order</code> option specifies otherwise.</p>
+            <p>Acceptable values for <code>$octet-order</code> are described in <specref ref="endianness"/>.
+            If least-significant-first ordering is requested then the order of octets
+            in the input is reversed.</p>
             <p>The values of <code>$offset</code> and <code>$size</code>
                 <rfc2119>must</rfc2119> be non-negative integers.</p>
             <p><code>$offset</code> is zero based.</p>
@@ -626,12 +987,36 @@
                 of <code>$in</code>.</p>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
-            <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>
+            <!--<p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
+                <code>$octet-order</code> is unrecognized.</p>-->
         </fos:errors>
         <fos:notes>
             <p>For discussion on integer range see <specref ref="integer"/>.</p>
         </fos:notes>
+        <fos:examples>
+            <fos:example>
+                <fos:test>
+                    <fos:expression>bin:unpack-integer(bin:hex('0100'), 0, 2)</fos:expression>
+                    <fos:result>256</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:unpack-integer(bin:hex('00000100'), 0, 4)</fos:expression>
+                    <fos:result>256</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:unpack-integer(bin:hex('FFFF'), 0, 2)</fos:expression>
+                    <fos:result>-1</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:unpack-integer(bin:hex('00FFFFFFFF'), 1, 4)</fos:expression>
+                    <fos:result>-1</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:unpack-integer(bin:hex('FEFF'), 0, 2, "LE")</fos:expression>
+                    <fos:result>-2</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
 
     <fos:function name="unpack-unsigned-integer" prefix="bin">
@@ -640,7 +1025,8 @@
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)"/>
                 <fos:arg name="offset" type="xs:integer"/>
                 <fos:arg name="size" type="xs:integer"/>
-                <fos:arg name="octet-order" type="xs:string?" default="'most-significant-first'"/>
+                <fos:arg name="octet-order" type="enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -653,13 +1039,18 @@
                 starting from <code>$offset</code> in the input binary representation.</p>
         </fos:summary>
         <fos:rules>
-            <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$octet-order</code> parameter is specified. Acceptable values for
-                <code>$octet-order</code> are described in <specref ref="endianness"/>.</p>
+            <p>The function produces an integer represented by the binary value
+                <code>bin:part($in, $offset, $size)</code>. This is interpreted
+            as a representation of an unsigned integer, with the most significant
+            octet first unless the <code>$octet-order</code> option specifies otherwise.</p>
+            <p>Acceptable values for <code>$octet-order</code> are described in <specref ref="endianness"/>.
+            If least-significant-first ordering is requested then the order of octets
+            in the input is reversed.</p>
             <p>The values of <code>$offset</code> and <code>$size</code>
                 <rfc2119>must</rfc2119> be non-negative integers.</p>
-            <p>The <code>$offset</code> is zero based.</p>
+            <p><code>$offset</code> is zero based.</p>
             <p>Specifying a <code>$size</code> of zero yields the integer <code>0</code>.</p>
+        
         </fos:rules>
         <fos:errors>
             <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$offset</code> is
@@ -667,12 +1058,36 @@
                 of <code>$in</code>.</p>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
-            <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>
+            <!--<p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
+                <code>$octet-order</code> is unrecognized.</p>-->
         </fos:errors>
         <fos:notes>
             <p>For discussion on integer range see <specref ref="integer"/>.</p>
         </fos:notes>
+        <fos:examples>
+           <fos:example>
+                <fos:test>
+                    <fos:expression>bin:unpack-unsigned-integer(bin:hex('0100'), 0, 2)</fos:expression>
+                    <fos:result>256</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:unpack-unsigned-integer(bin:hex('00000100'), 0, 4)</fos:expression>
+                    <fos:result>256</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:unpack-unsigned-integer(bin:hex('FFFF'), 0, 2)</fos:expression>
+                    <fos:result>65535</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:unpack-unsigned-integer(bin:hex('00FFFFFFFF'), 1, 4)</fos:expression>
+                    <fos:result>4294967295</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:unpack-integer(bin:hex('FEFF'), 0, 2, "LE")</fos:expression>
+                    <fos:result>65279</fos:result>
+                </fos:test>
+            </fos:example>
+        </fos:examples>
     </fos:function>
 
 
@@ -681,7 +1096,8 @@
             <fos:proto name="unpack-double" return-type="xs:double">
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)"/>
                 <fos:arg name="offset" type="xs:integer"/>
-                <fos:arg name="octet-order" type="xs:string?" default="'most-significant-first'"/>
+                <fos:arg name="octet-order" type="enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -690,15 +1106,15 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Extract <loc href="http://www.w3.org/TR/xmlschema-2/#double">double</loc> value
-                stored at the particular offset in binary data.</p>
+            <p>Extracts an <code>xs:double</code> value
+                held in IEEE format at the given offset in a binary value.</p>
         </fos:summary>
         <fos:rules>
             <p>Extract the <loc href="http://www.w3.org/TR/xmlschema-2/#double">double</loc> value
                 stored in the 8 successive octets from the <code>$offset</code> octet of the binary
                 data of <code>$in</code>.</p>
-            <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$octet-order</code> parameter is specified. Acceptable values for
+            <p>Most-significant-first number representation is assumed unless the
+                <code>$octet-order</code> parameter specifies otherwise. Acceptable values for
                 <code>$octet-order</code> are described in <specref ref="endianness"/>.</p>
             <p>The value of <code>$offset</code>
                 <rfc2119>must</rfc2119> be a non-negative integer.</p>
@@ -711,8 +1127,8 @@
             <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$offset</code> is
                 negative or <code>$offset + 8</code> (octet-length of <code>xs:double</code>) is
                 larger than the size of the binary data of <code>$in</code>.</p>
-            <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>
+            <!--<p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
+                <code>$octet-order</code> is unrecognized.</p>-->
         </fos:errors>
     </fos:function>
     
@@ -721,7 +1137,8 @@
             <fos:proto name="unpack-float" return-type="xs:float">
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)"/>
                 <fos:arg name="offset" type="xs:integer"/>
-                <fos:arg name="octet-order" type="xs:string?" default="'most-significant-first'"/>
+                <fos:arg name="octet-order" type="enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -738,7 +1155,7 @@
                 stored in the 4 successive octets from the <code>$offset</code> octet of the binary
                 data of <code>$in</code>.</p>
             <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$octet-order</code> parameter is specified. Acceptable values for
+                <code>$octet-order</code> parameter specifies otherwise. Acceptable values for
                 <code>$octet-order</code> are described in <specref ref="endianness"/>.</p>
             <p>The value of <code>$offset</code>
                 <rfc2119>must</rfc2119> be a non-negative integer.</p>
@@ -751,8 +1168,8 @@
             <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$offset</code> is
                 negative or <code>$offset + 4</code> (octet-length of <code>xs:float</code>) is
                 larger than the size of the binary data of <code>$in</code>.</p>
-            <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>
+            <!--<p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
+                <code>$octet-order</code> is unrecognized.</p>-->
         </fos:errors>
     </fos:function>
 
@@ -760,7 +1177,8 @@
         <fos:signatures>
             <fos:proto name="pack-double" return-type="xs:base64Binary">
                 <fos:arg name="in" type="xs:double"/>
-                <fos:arg name="octet-order" type="xs:string?" default="'most-significant-first'"/>
+                <fos:arg name="octet-order" type="enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -769,28 +1187,28 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the 8-octet binary representation of a <loc
-                    href="http://www.w3.org/TR/xmlschema-2/#double">double</loc> value.</p>
+            <p>Returns the 8-octet binary representation of an <code>xs:double</code> value.</p>
         </fos:summary>
         <fos:rules>
             <p>Most-significant-octet-first number representation is assumed unless the
-                <code>$octet-order</code> parameter is specified. Acceptable values for
+                <code>$octet-order</code> parameter specifies otherwise. Acceptable values for
                 <code>$octet-order</code> are described in <specref ref="endianness"/>.</p>
             <p>The binary representation will correspond with that of the IEEE double-precision
                 64-bit floating point type <bibref ref="ieee754"/>. For more details see <specref
                     ref="floating"/>.</p>
         </fos:rules>
-        <fos:errors>
+        <!--<fos:errors>
             <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
                 <code>$octet-order</code> is unrecognized.</p>
-        </fos:errors>
+        </fos:errors>-->
     </fos:function>
 
     <fos:function name="pack-float" prefix="bin">
         <fos:signatures>
             <fos:proto name="pack-float" return-type="xs:base64Binary">
                 <fos:arg name="in" type="xs:float"/>
-                <fos:arg name="octet-order" type="xs:string?" default="'most-significant-first'"/>
+                <fos:arg name="octet-order" type="xs:enum('least-significant-first', 'little-endian', 'LE',
+                    'most-significant-first', 'big-endian', 'BE')?" default="'most-significant-first'"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -830,12 +1248,28 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the "bitwise or" of two binary arguments.</p>
+            <p>Returns the bitwise OR of two binary values.</p>
         </fos:summary>
         <fos:rules>
-            <p>Returns "bitwise or" applied between <code>$a</code> and <code>$b</code>.</p>
             <p>If either argument is the empty sequence, an empty sequence is returned.</p>
+            <p>Otherwise, <code>$a</code> and <code>$b</code> must have the same length.</p>
+            <p>The function converts <code>$a</code> and <code>$b</code> to sequences
+            of bits <var>A</var> and <var>B</var>, and returns a binary value in which 
+                the <var>N</var>th bit is set to 1 if either or both of the <var>N</var>th bit of <var>A</var>
+            and the <var>N</var>th bit of <var>B</var> are 1, and is set to 0 otherwise.</p>
+            
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+let $toBin := fn($x) { bin:to-octets($x) 
+                        =!> format-integer('2^xxxxxxxx') 
+                        => string-join() } 
+let $A := $toBin($a) => characters(),
+    $B := $toBin($b) => characters()
+       
+let $R := for-each-pair($A, $B, fn($p, $q) { if ($p eq '1' or $q eq '1')
+                                             then '1' else '0 } )
+return bin:bin($R)
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="differing-length-arguments"/> is raised if the input
                 arguments are of differing length.</p>
@@ -855,13 +1289,29 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the "bitwise xor" of two binary arguments.</p>
+            <p>Returns the bitwise exclusive-OR of two binary arguments.</p>
         </fos:summary>
         <fos:rules>
-            <p>Returns "bitwise exclusive or" applied between <code>$a</code> and
-                <code>$b</code>.</p>
             <p>If either argument is the empty sequence, an empty sequence is returned.</p>
+            <p>Otherwise, <code>$a</code> and <code>$b</code> must have the same length.</p>
+            <p>The function converts <code>$a</code> and <code>$b</code> to sequences
+            of bits <var>A</var> and <var>B</var>, and returns a binary value in which 
+                the <var>N</var>th bit is set to 1 if the <var>N</var>th bit of <var>A</var>
+            differs from the <var>N</var>th bit of <var>B</var>, and is set to 0 if they are
+                the same.</p>
+            
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+let $toBin := fn($x) { bin:to-octets($x) 
+                        =!> format-integer('2^xxxxxxxx') 
+                        => string-join() } 
+let $A := $toBin($a) => characters(),
+    $B := $toBin($b) => characters()
+       
+let $R := for-each-pair($A, $B, fn($p, $q) { if ($p ne $q)
+                                             then '1' else '0' } )
+return bin:bin($R)
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="differing-length-arguments"/> is raised if the input
                 arguments are of differing length.</p>
@@ -881,12 +1331,28 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Returns the "bitwise and" of two binary arguments.</p>
+            <p>Returns the bitwise AND of two binary arguments.</p>
         </fos:summary>
         <fos:rules>
-            <p>Returns "bitwise and" applied between <code>$a</code> and <code>$b</code>.</p>
             <p>If either argument is the empty sequence, an empty sequence is returned.</p>
+            <p>Otherwise, <code>$a</code> and <code>$b</code> must have the same length.</p>
+            <p>The function converts <code>$a</code> and <code>$b</code> to sequences
+            of bits <var>A</var> and <var>B</var>, and returns a binary value in which 
+                the <var>N</var>th bit is set to 1 if both the <var>N</var>th bit of <var>A</var>
+            and the <var>N</var>th bit of <var>B</var> are 1, and is set to 0 otherwise.</p>
+            
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+let $toBin := fn($x) { bin:to-octets($x) 
+                        =!> format-integer('2^xxxxxxxx') 
+                        => string-join() } 
+let $A := $toBin($a) => characters(),
+    $B := $toBin($b) => characters()
+       
+let $R := for-each-pair($A, $B, fn($p, $q) { if ($p eq '1' and $q eq '1')
+                                             then '1' else '0 } )
+return bin:bin($R)
+        </fos:equivalent>
         <fos:errors>
             <p><errorref spec="BIN40" code="differing-length-arguments"/> is raised if the input
                 arguments are of differing length.</p>
@@ -911,6 +1377,14 @@
             <p>Returns "bitwise not" applied to <code>$in</code>.</p>
             <p>If the argument is the empty sequence, an empty sequence is returned.</p>
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+   let $toBin := fn($x) { bin:to-octets($x) 
+                           =!> format-integer('2^xxxxxxxx') 
+                           => string-join() } 
+   return $toBin($in) 
+          => translate('01', '10') 
+          => bin:bin()      
+        </fos:equivalent>
     </fos:function>
 
 
@@ -927,22 +1401,47 @@
             <fos:property>focus-independent</fos:property>
         </fos:properties>
         <fos:summary>
-            <p>Shift bits in binary data.</p>
+            <p>Shift the bits of a binary value left or right.</p>
         </fos:summary>
         <fos:rules>
-            <p>If <code>$by</code> is positive then bits are shifted <code>$by</code> times to the
-                left.</p>
-            <p>If <code>$by</code> is negative then bits are shifted <code>-$by</code> times to the
-                right.</p>
-            <p>If <code>$by</code> is zero, the result is identical to <code>$in</code>.</p>
-            <p>If <code>|$by|</code> is greater than the bit-length of <code>$in</code> then an
-                all-zeros result, of the same length as <code>$in</code>, is returned.</p>
-            <p><code>|$by|</code> can be greater than 8, implying multi-byte shifts.</p>
-            <p>The result always has the same size as <code>$in</code>.</p>
-            <p>The shifting is logical: zeros are placed into discarded bits.</p>
             <p>If the value of <code>$in</code> is the empty sequence, the function returns an empty
-                sequence.</p>
+                sequence.</p> 
+            <p>In other cases the length of the result is always the same as the
+                length of <code>$in</code>.</p>
+            <p>If <code>$by</code> is positive then bits are shifted <code>$by</code> times to the
+                left. The first <code>$by</code> bits are discarded, and <code>$by</code>
+                zero bits are injected at the end.</p>
+            <p>If <code>$by</code> is negative then bits are shifted <code>-$by</code> times to the
+                right. The last <code>-$by</code> bits are discarded, and <code>-$by</code>
+                zero bits are injected at the start.</p>           
+            <p>If <code>$by</code> is zero, the result is identical to <code>$in</code>.</p>
+            <p>If <code>abs($by)</code> is greater than the bit-length of <code>$in</code> then an
+                all-zeros result, of the same length as <code>$in</code>, is returned.</p>
+            <p><code>abs($by)</code> can be greater than 8, implying multi-byte shifts.</p>
+            
         </fos:rules>
+        <fos:equivalent style="xpath-expression" covers-error-cases="false">
+   (: convert to a string of 1s and 0s :)
+   let $s := bin:to-octets($in) 
+             =!> format-integer('2^xxxxxxxx') 
+             => string-join()
+   
+   (: the length of the input in bits :)          
+   let $len := string-length($s)
+   
+   (: a string of zeros equal in length to the size of the shift :)
+   let $padding := string-join((1 to abs($by)) ! '0')
+   
+   (: the binary value as a string, padded left and right :)
+   let $padded-string := $padding || $s || $padding
+   
+   (: the relevant substring of the padded string :)
+   let $shifted := substring($padded-string, $len - $by, $len)
+   
+   (: the result of converting back to a binary value :)
+   return bin:bin($shifted)
+   
+        </fos:equivalent>
         <fos:notes>
             <p>Bit shifting across byte boundaries implies 'big-endian' treatment, i.e. the leftmost
                 (high-order) bit when shifted left becomes the low-order bit of the preceding

--- a/specifications/EXPath/binary/src/function-catalog.xml
+++ b/specifications/EXPath/binary/src/function-catalog.xml
@@ -157,7 +157,7 @@
             </fos:example>
         </fos:examples>
         <fos:changes>
-            <fos:change issue="1750">
+            <fos:change issue="1750" PR="1753" date="2025-02-03">
                 <p>The input string is now allowed to include embedded underscores and whitespace.</p>
             </fos:change>
         </fos:changes>
@@ -236,7 +236,7 @@
             </fos:example>
         </fos:examples>
         <fos:changes>
-            <fos:change issue="1750">
+            <fos:change issue="1750" PR="1753" date="2025-02-03">
                 <p>The input string is now allowed to include embedded underscores and whitespace.</p>
             </fos:change>
         </fos:changes>
@@ -268,6 +268,8 @@
                     <code>"4"</code> → <code>"100"</code>,
                 <code>"5"</code> → <code>"101"</code>, <code>"6"</code> → <code>"110"</code>, 
                     <code>"7"</code> → <code>"111"</code>).</p></item>
+                <item><p>A maximum of two leading zero digits are stripped.</p>
+                </item>
                 <item><p>The resulting string
                 is converted to a <termref def="dt-binary-value"/> by applying
                 the function <function>bin:bin</function> to the result.</p></item>
@@ -282,6 +284,7 @@
            =>  characters()
            =!> {"0":"000", "1":"001", "2":"010", "3":"011", 
                 "4":"100", "5":"101", "6":"110", "7":"111"}()
+           =!> replace("^0?0?", "")     
            =>  string-join()
            =>  bin:bin() )
         </fos:equivalent>
@@ -293,14 +296,42 @@
             <p>The order of octets in the result follows the order of characters in the string.</p>
             <p>If <code>$in</code> is a zero-length string, the result will be a
                 <termref def="dt-zero-length"/> <code>xs:base64Binary</code> value.</p>
-            <p>There are <termref def="dt-binary-value">binary values</termref> that cannot
+            
+           
+            <p>The rule for padding to a whole number of octets ensures that leading zeroes
+            are significant in determining the length of the final binary value, while also
+            allowing a value of any length to be constructed. For example (underscores added
+            for readability):</p>
+                
+            <ulist>
+                <item><p>An input of <code>"0"</code> translates first to the string <code>"000"</code>; two
+                leading zeros are removed producing <code>"0"</code>, which <function>bin:bin</function>
+                converts to <code>bin:hex("00")</code>.</p></item>
+                <item><p>An input of <code>"155"</code> translates to the 
+                    binary string <code>"001_101_101"</code>. The first two zeroes
+                    are removed, and <function>bin:bin</function> converts the result to 
+                    <code>bin:hex("6D")</code></p></item>
+                <item><p>An input of <code>"355"</code> translates to the 
+                    binary string <code>"011_101_101"</code>. The first zero is removed,
+                    and <function>bin:bin</function> converts the result to 
+                    <code>bin:hex("ED")</code>.</p></item>
+                <item><p>An input of <code>"555"</code> translates to the 
+                    string <code>"101_101_101"</code>, which <function>bin:bin</function> converts to 
+                    <code>bin:hex("016D")</code>.</p></item>
+                <item><p>An input of <code>"0155"</code> translates to the 
+                    string <code>"000_001_101_101"</code>. The first two zeros are
+                    stripped giving <code>"0_001_101_101"</code>, which <function>bin:bin</function> converts to 
+                    <code>bin:hex("006D")</code>.</p></item>
+             
+            </ulist>
+            <!--<p>There are <termref def="dt-binary-value">binary values</termref> that cannot
             be constructed using this function. For example, it is not possible to 
             construct the value <code>bin:hex("7F")</code>, because the apparent
             equivalent <code>bin:octal("177")</code> represents a 9-bit value, 
                 which is padded to the two-octet value <code>bin:hex("007F")</code>.
             If it is known that octal values will always represent single octets, 
             the required octet can be extracted by an expression such as
-            <code>bin:octal($in) => bin:to-octets() => foot() => bin:from-octets()</code></p>
+            <code>bin:octal($in) => bin:to-octets() => foot() => bin:from-octets()</code></p>-->
         </fos:notes>
         <fos:examples>
             <fos:example>
@@ -309,18 +340,35 @@
                     <fos:result>bin:hex('')</fos:result>
                 </fos:test>
                 <fos:test>
-                    <fos:expression>bin:octal('11223047')</fos:expression>
-                    <fos:result>bin:hex('252627')</fos:result>
+                    <fos:expression>bin:octal('0')</fos:expression>
+                    <fos:result>bin:hex('00')</fos:result>
                 </fos:test>
                 <fos:test>
-                    <fos:expression>bin:octal(' 177 ')</fos:expression>
-                    <fos:result>bin:hex('007F')</fos:result>
+                    <fos:expression>bin:octal('377')</fos:expression>
+                    <fos:result>bin:hex('FF')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:octal('777')</fos:expression>
+                    <fos:result>bin:hex('01FF')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:octal('0377')</fos:expression>
+                    <fos:result>bin:hex('00FF')</fos:result>
+                </fos:test>
+                <fos:test>
+                    <fos:expression>bin:octal('11_223_047')</fos:expression>
+                    <fos:result>bin:hex('252627')</fos:result>
                 </fos:test>
             </fos:example>
         </fos:examples>
         <fos:changes>
-            <fos:change issue="1750">
+            <fos:change issue="1750" PR="1753" date="2025-02-03">
                 <p>The input string is now allowed to include embedded underscores and whitespace.</p>
+            </fos:change>
+            <fos:change issue="1750" PR="1753" date="2025-02-03">
+                <p>The way in which the value is adjusted to a whole number of octets has
+                    been clarified. The rules have been made more precise, and might not
+                    match the interpretation adopted by existing implementations.</p>
             </fos:change>
         </fos:changes>
     </fos:function>
@@ -415,7 +463,7 @@
             <fos:proto name="insert-before" return-type="xs:base64Binary?">
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)?"/>
                 <fos:arg name="offset" type="xs:integer"/>
-                <fos:arg name="extra" type="xs:base64Binary?"/>
+                <fos:arg name="extra" type="(xs:hexBinary | xs:base64Binary)?"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -601,6 +649,16 @@ $in =!> bin:to-octets() => bin:from-octets()
                 </fos:test>
             </fos:example>
         </fos:examples>
+        <fos:changes>
+            <fos:change issue="1750" PR="1753" date="2025-02-03">
+                <p>The argument type for <code>$octet</code> is changed from <code>xs:integer</code> to
+                <code>xs:unsignedByte</code>. This is made possible by the more liberal
+                coercion rules defined in XPath 4.0. A consequence of the change
+                is that supplying an out-of-range integer value is now a type error
+                with the standard error code <code>XPTY0004</code>, rather than the
+                custom error code <code>bin:octet-out-of-range</code> previously used.</p>
+            </fos:change>
+        </fos:changes>
     </fos:function>
     
     <fos:function name="pad-right" prefix="bin">
@@ -608,7 +666,7 @@ $in =!> bin:to-octets() => bin:from-octets()
             <fos:proto name="pad-right" return-type="xs:base64Binary?">
                 <fos:arg name="in" type="(xs:hexBinary | xs:base64Binary)?"/>
                 <fos:arg name="count" type="xs:integer"/>
-                <fos:arg name="octet" type="xs:integer?" default="0"/>
+                <fos:arg name="octet" type="xs:unsignedByte?" default="0"/>
             </fos:proto>
         </fos:signatures>
         <fos:properties>
@@ -656,6 +714,16 @@ $in =!> bin:to-octets() => bin:from-octets()
                 </fos:test>
             </fos:example>
         </fos:examples>
+        <fos:changes>
+            <fos:change issue="1750" PR="1753" date="2025-02-03">
+                <p>The argument type for <code>$octet</code> is changed from <code>xs:integer</code> to
+                <code>xs:unsignedByte</code>. This is made possible by the more liberal
+                coercion rules defined in XPath 4.0. A consequence of the change
+                is that supplying an out-of-range integer value is now a type error
+                with the standard error code <code>XPTY0004</code>, rather than the
+                custom error code <code>bin:octet-out-of-range</code> previously used.</p>
+            </fos:change>
+        </fos:changes>
     </fos:function>
 
     <fos:function name="find" prefix="bin">
@@ -898,8 +966,6 @@ $in =!> bin:to-octets() => bin:from-octets()
                 binary value.</p>
         </fos:rules>
         <fos:errors>
-            <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
         </fos:errors>
@@ -1228,10 +1294,6 @@ $in =!> bin:to-octets() => bin:from-octets()
                 32-bit floating point type <bibref ref="ieee754"/>. For more details see <specref
                     ref="floating"/>.</p>
         </fos:rules>
-        <fos:errors>
-            <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>
-        </fos:errors>
     </fos:function>
 
 

--- a/specifications/xpath-functions-40/src/fos.xsd
+++ b/specifications/xpath-functions-40/src/fos.xsd
@@ -19,7 +19,7 @@
   <xs:element name="functions">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="fos:global-variables"/>
+        <xs:element ref="fos:global-variables" minOccurs="0"/>
         <xs:element ref="fos:record-type" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="fos:function" maxOccurs="unbounded"/>
       </xs:sequence>
@@ -29,7 +29,7 @@
   <xs:element name="global-variables">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="fos:variable" maxOccurs="unbounded"/>
+        <xs:element ref="fos:variable" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
Apart from general copy-editing, the main changes are:

* A lot more examples, presented in executable markup format (though they are not yet tested)
* Many functions now have formal equivalents (again, currently untested)
* Allow underscores and spaces in input to bin:hex, bin:octal, and bin:bin
* Use type xs:unsignedByte for octet arguments
* Use an enum() type for the octet-order argument

Fix #1750