### PR TITLE
Make DeltaXML diffs on the main build too

### DIFF
--- a/.github/workflows/build-specs.yml
+++ b/.github/workflows/build-specs.yml
@@ -50,6 +50,8 @@ jobs:
             sh tools/autodiff.sh build/www/xquery-40/shared-40.html shared-40-autodiff.html
             sh tools/autodiff.sh build/www/xpath-datamodel-40/Overview.html
             sh tools/autodiff.sh build/www/xslt-xquery-serialization-40/Overview.html
+            sh tools/autodiff.sh build/www/expath-binary-40/Overview.html
+            sh tools/autodiff.sh build/www/expath-file-40/Overview.html
 
       - name: Cleanup DeltaXML
         if: ${{ env.AUTODIFF == 'true' }}


### PR DESCRIPTION
This PR should build DeltaXML diffs of the EXPath specs...and when merged, should build them on the main build as well.