### PR TITLE
Inline SVG images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -848,6 +848,15 @@ task xquery_40(
 
     String style = "${projectDir}/style/xsl-query-2016.xsl"
 
+    // Hack for SVG diagrams
+    doFirst {
+      copy {
+        from "${projectDir}/specifications/xquery-40/images"
+        into "${buildDir}/xquery-40/images"
+        include "*.svg"
+      }
+    }
+
     doLast {
       transform("${buildDir}/xquery-40/src/${shortName}-assembled.xml",
                 style,

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -809,12 +809,25 @@
   <!-- reference external graphic file with alt text -->
   <xsl:template match="graphic">
     <img src="{@source}">
+      <xsl:if test="contains-token(@role, 'full-width')">
+        <xsl:attribute name="style" select="'width:100%'"/>
+      </xsl:if>
       <xsl:if test="@alt">
         <xsl:attribute name="alt">
           <xsl:value-of select="@alt"/>
         </xsl:attribute>
       </xsl:if>
     </img>
+  </xsl:template>
+
+  <!-- Inline SVG -->
+  <xsl:template match="graphic[ends-with(@source, '.svg')]">
+    <div class="svg-image">
+      <xsl:if test="contains-token(@role, 'full-width')">
+        <xsl:attribute name="style" select="'width:100%'"/>
+      </xsl:if>
+      <xsl:sequence select="doc(resolve-uri('../images/' || @source, base-uri(.)))"/>
+    </div>
   </xsl:template>
 
   <!-- group: -->

--- a/style/xsl-query-2016.xsl
+++ b/style/xsl-query-2016.xsl
@@ -1878,18 +1878,6 @@
     <xsl:value-of select="normalize-unicode(., 'NFC')"/>
   </xsl:template>
   
-  <!-- recognize graphic role="full-width" -->
-  
-  <xsl:template match="graphic[@role='full-width']">
-    <img src="{@source}" style="width:100%">
-      <xsl:if test="@alt">
-        <xsl:attribute name="alt">
-          <xsl:value-of select="@alt"/>
-        </xsl:attribute>
-      </xsl:if>
-    </img>
-  </xsl:template>
-
   <!-- ================================================================= -->
 
   <xsl:function name="my:diff-markup-effect" as="xs:string">


### PR DESCRIPTION
In order for links to work in the browser, the SVG has to be inline, not loaded from a separate file. For self-document links, I guess this makes sense.

This is a tools-only change.