### PR TITLE
1770 Default priority of rules with a union pattern

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -13341,6 +13341,10 @@ return $tree =?> depth()]]></eg>
                   Default priorities are added for new forms of <code>ElementTest</code> and <code>AttributeTest</code>,
                   for example <code>element(p:*)</code> and <code>element(a|b)</code>.
                </change>
+               <change issue="1770">
+                  The default priority for a template rule using a union pattern has changed.
+                  This change may cause incompatible behavior.
+               </change>
             </changes>
             <p><termdef id="dt-default-priority" term="default priority">If no <code>priority</code>
                   attribute is specified on an <elcode>xsl:template</elcode> element, a
@@ -13354,7 +13358,33 @@ return $tree =?> depth()]]></eg>
                <item>
                   <p>If the top-level pattern is a <nt def="UnionExprP">UnionExprP</nt> consisting
                      of multiple alternatives separated by <code>|</code> or <code>union</code>,
-                     then the template rule is treated equivalently to a set of template rules, one
+                     then the default priority is the maximum of the default priorities
+                     of the alternatives.</p>
+                  
+                  <note>
+                     <p>This is a backwards incompatible change from XSLT 3.0 and earlier
+                     versions, which treated the template rule as equivalent to multiple
+                     template rules with different priorities.</p>
+                     <p>The change is made because of the increasing complexity of extending
+                     the rule to patterns like <code>@(a|b)</code>, or <code>attribute(a|b, xs:integer)</code>
+                     which are defined to be semantically identical to equivalent union patterns;
+                     and to prevent confusion with type patterns such as 
+                     <code>type(element(a)|element(b))</code>, where different rules apply.</p>
+                     <p>The change affects any template rule with a union pattern that 
+                        (a) has no explicit priority attribute, and (b) has multiple branches with
+                     different default priority. It is <rfc2119>recommended</rfc2119> that processors
+                     should output a compatibility warning when such template rules are encountered.</p>
+                     
+                     <p>The change has two effects. Firstly, if two alternatives 
+                        in a union pattern have different priority
+                     (for example in a pattern such as <code>a | b/c</code>, the priority of one of
+                     the branches will be raised to that of the other branch. Secondly, in cases where
+                     the same item matches both branches, a call on <code>xsl:next-match</code> will
+                     never cause the same template rule to be evaluated repeatedly.</p>
+                  </note>
+                     
+                     
+                     <!--the template rule is treated equivalently to a set of template rules, one
                      for each alternative. For example, a rule with <code>match="a|b"</code> is treated
                      as if there were one rule with <code>match="a"</code> and another with <code>match="b"</code>.
                      These template rules are adjacent to each
@@ -13393,7 +13423,7 @@ return $tree =?> depth()]]></eg>
                         (a) the alternatives have the same default priority,
                         and (b) the alternatives are disjoint &mdash; which is the case for some
                         of the examples given above.</p>
-                  </note>
+                  </note>-->
                </item>
                <item>
                   <p>If the top-level pattern is an <nt def="IntersectExceptExprP">IntersectExceptExprP</nt> containing two or more <nt def="PathExprP">PathExprP</nt> operands separated by <code>intersect</code> or
@@ -14934,14 +14964,15 @@ return $tree =?> depth()]]></eg>
                      mode, and to exclude those rules that appear before the current template rule in this ordering. The introduction
                      of type patterns makes this approach more challenging, since types are partially ordered.</p>
                   </note>
-                  <note>
+                  <!--<note>
                      <p>As explained in <specref ref="conflict"/>, a template rule with no <code>priority</code>
                            attribute, whose match pattern contains multiple alternatives
                         separated by <code>|</code>, is treated equivalently to a set of template
-                        rules, one for each alternative. This means that where the same item matches more than one alternative, it is possible for an <elcode>xsl:next-match</elcode>
+                        rules, one for each alternative. This means that where the same item matches 
+                        more than one alternative, it is possible for an <elcode>xsl:next-match</elcode>
                         instruction to cause the current template rule to be invoked recursively.
                         This situation does not occur when the template rule has an explicit priority.</p>
-                  </note>
+                  </note>-->
                   <note>
                      <p>Because a template rule declared as a child of <elcode>xsl:override</elcode>
                         has higher precedence than any template rule declared in the used package
@@ -40240,6 +40271,13 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
                <p>The rules for comparing values in <termref def="dt-key">keys</termref> have changed,
                to align with the rules for maps. The changes affect edge cases involving rounding of numeric values
                of different types, and the comparison of date/time values with and without timezones.</p>
+            </item>
+            <item>
+               <p>In previous versions, a template rule whose match pattern was a union pattern
+               and that had no explicity priority was treated as equivalent to a set of template
+               rules, one for each alternative in the union, each potentially with different default
+               priority. This rule has not been carried forward into XSLT 4.0: instead, the priority
+               of the rule is taken as being the highest priority of any of the alternatives.</p>
             </item>
             
             


### PR DESCRIPTION
Scraps the increasingly-complicated rules for handling priority of rules with a union pattern.

Fix #1770