### PR TITLE
1456 Lookup expressions filtered by type

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1914,6 +1914,19 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="VarRef"/>
       <g:ref name="ParenthesizedExpr"/>
       <g:ref name="LookupWildcard"/>
+      <g:ref name="TypeSpecifier"/>
+    </g:choice>
+  </g:production>
+  
+  <g:production name="TypeSpecifier">
+    <g:string>~</g:string>
+    <g:choice>
+      <g:ref name="ItemType"/>
+      <g:sequence>
+        <g:string>(</g:string>
+        <g:ref name="SequenceType"/>
+        <g:string>)</g:string>
+      </g:sequence>
     </g:choice>
   </g:production>
   
@@ -2389,15 +2402,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
 
   <g:production name="UnaryLookup" if="xpath40 xquery40 xslt40-patterns">
-    <g:choice>
-      <g:string>?</g:string>
-      <g:string>??</g:string>
-    </g:choice>
-    <g:optional>
-      <g:ref name="Modifier"/>
-      <g:string>::</g:string>
-    </g:optional>
-    <g:ref name="KeySpecifier"/>
+    <g:ref name="Lookup"/>
   </g:production>
   
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19644,6 +19644,11 @@ processing with JSON processing.</p>
                   they can be qualified with a type to select only the results that
                   match that type.-->
                </change>
+               <change issue="1456">
+                  The key specifier can reference an item type or sequence type, to select
+                  values of that type only. This is especially useful when processing
+                  trees of maps and arrays, as encountered when processing JSON input.
+               </change>
             </changes>
 
             <p>&language; provides two lookup operators <code>?</code> and <code>??</code>
@@ -19672,7 +19677,7 @@ processing with JSON processing.</p>
                which delivers the result as a flattened sequence of items.</p>
                
                <p>To take a simple example, given <code>$A</code> as an array
-                  <code>[ ("a", "b"), ("c", "d"), ("e", "f") ]</code>, some example Lookup expressions
+                  <code>[ ("a", "b"), ("c", "d"), ("e", "f"), 42 ]</code>, some example Lookup expressions
                   are:</p>
                
                <table width="100%">
@@ -19686,21 +19691,22 @@ processing with JSON processing.</p>
                   <tbody>
                      <tr>
                         <td><code>$A?*</code> (or <code>$A?items::*)</code></td>
-                        <td><eg>("a", "b", "c", "d", "e", "f")</eg></td>
+                        <td><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
                      </tr>
                      <tr>
                         <td><code>$A?pairs::*</code></td>
                         <td><eg>({ "key": 1, "value": ("a", "b") }, 
  { "key": 2, "value": ("c", "d") }, 
- { "key": 3, "value": ("e", "f") })</eg></td>
+ { "key": 3, "value": ("e", "f") },
+ { "key": 4, "value": 42 })</eg></td>
                      </tr>
                      <tr>
                         <td><code>$A?values::*</code></td>
-                        <td><eg>([ "a", "b" ], [ "c", "d" ], [ "e", "f" ])</eg></td>
+                        <td><eg>([ "a", "b" ], [ "c", "d" ], [ "e", "f" ], [42])</eg></td>
                      </tr>
                      <tr>
                         <td><code>$A?keys::*</code></td>
-                        <td><eg>(1, 2, 3)</eg></td>
+                        <td><eg>(1, 2, 3, 4)</eg></td>
                      </tr>
                      <tr>
                         <td><code>$A?2</code> (or <code>$A?items::2)</code></td>
@@ -19735,13 +19741,28 @@ processing with JSON processing.</p>
                         <td><code>$A?keys::(3, 1)</code></td>
                         <td><eg>(3, 1)</eg></td>
                      </tr>
+                     <tr>
+                        <td><code>$A?keys::(3, 1)</code></td>
+                        <td><eg>(3, 1)</eg></td>
+                     </tr>
+                     <tr>
+                        <td><code>$A?~xs:integer</code></td>
+                        <td><eg>42</eg></td>
+                     </tr>
+                     <tr>
+                        <td><code>$A?keys::~xs:integer</code></td>
+                        <td><eg>4</eg></td>
+                     </tr>
+                     <tr>
+                        <td><code>$A?keys::~(xs:string+)</code></td>
+                        <td><eg>(1, 2, 3)</eg></td>
+                     </tr>
                   </tbody>
                </table>
                
                <p>Similarly, given <code>$M</code> as a map
-                  <code>{ "X": ("a", "b"), "Y": ("c", "d"), "Z": ("e", "f") }</code>, 
-                  some example lookup expressions are as follows. Note that because maps are unordered,
-                  the results are not necessarily in the order shown.</p>
+                  <code>{ "X": ("a", "b"), "Y": ("c", "d"), "Z": ("e", "f"), "N": 42 }</code>, 
+                  some example lookup expressions are as follows.</p>
                
                <table width="100%">
                   <caption>Example Lookup Expressions on a Map</caption>
@@ -19754,21 +19775,22 @@ processing with JSON processing.</p>
                   <tbody>
                      <tr>
                         <td><code>$M?*</code> (or <code>$M?items::*)</code></td>
-                        <td><eg>("a", "b", "c", "d", "e", "f")</eg></td>
+                        <td><eg>("a", "b", "c", "d", "e", "f", 42)</eg></td>
                      </tr>
                      <tr>
                         <td><code>$M?pairs::*</code></td>
                         <td><eg>({ "key": "X", "value": ("a", "b") }, 
  { "key": "Y", "value": ("c", "d") }, 
- { "key": "Z", "value": ("e", "f") })</eg></td>
+ { "key": "Z", "value": ("e", "f") },
+ { "key": "N", "value": 42 })</eg></td>
                      </tr>
                      <tr>
                         <td><code>$M?values::*</code></td>
-                        <td><eg>([ "a", "b" ], [ "c", "d" ], [ "e", "f" ])</eg></td>
+                        <td><eg>([ "a", "b" ], [ "c", "d" ], [ "e", "f" ], [42])</eg></td>
                      </tr>
                      <tr>
                         <td><code>$M?keys::*</code></td>
-                        <td><eg>("X", "Y", "Z")</eg></td>
+                        <td><eg>("X", "Y", "Z", "N")</eg></td>
                      </tr>
                      <tr>
                         <td><code>$M?Y</code> (or <code>$M?items::Y)</code></td>
@@ -19803,11 +19825,23 @@ processing with JSON processing.</p>
                         <td><code>$M?keys::("Z", "X")</code></td>
                         <td><eg>("Z", "X")</eg></td>
                      </tr>
+                     <tr>
+                        <td><code>$M?~xs:integer</code></td>
+                        <td><eg>42</eg></td>
+                     </tr>
+                     <tr>
+                        <td><code>$M?keys::~xs:integer</code></td>
+                        <td><eg>"N"</eg></td>
+                     </tr>
+                     <tr>
+                        <td><code>$M?keys::~(xs:string+)</code></td>
+                        <td><eg>("X", "Y", "Z")</eg></td>
+                     </tr>
                   </tbody>
                </table>
  
                
-               <p>The semantics of a postfix lookup expression <code>E?pairs::KS</code> are defined as follows.
+               <p>The semantics of a postfix lookup expression <code><var>E</var>?pairs::<var>KS</var></code> are defined as follows.
                The results with other modifiers can be derived from this result, as explained below.</p>
                
                <olist>
@@ -19815,11 +19849,12 @@ processing with JSON processing.</p>
                   <item><p>If <code>$V</code> is not a <termref def="dt-singleton"/> 
                      (that is if <code>count($V) ne 1</code>),
                   then the result (by recursive application of these rules) is the value of
-                  <code>for $v in $V return $v?pairs::KS</code>.</p></item>
-                  <item><p>If <code>$V</code> is a <termref def="dt-singleton"/> array item (that is, 
+                  <code>for $v in $V return $v?pairs::<var>KS</var></code>.</p></item>
+                  <item><p>If <code>$V</code> is a <termref def="dt-singleton"/> array item (that is,
                      if <code>$V instance of array(*)</code>) then:</p>
                   <olist>
-                     <item><p>If <code>KS</code> is a <code>ParenthesizedExpr</code>,
+                     <item><p>If <nt def="KeySpecifier">KeySpecifier</nt> 
+                        <var>KS</var> is a <code>ParenthesizedExpr</code>,
                         then it is evaluated to produce a value <code>$K</code>
                         and the result is:</p> 
                         <eg><![CDATA[data($K) ! { "key": ., "value": array:get($V, .) }]]></eg>
@@ -19828,18 +19863,18 @@ processing with JSON processing.</p>
                               same as the focus for the <code>Lookup</code> expression itself.</p>
                         </note></item>
                      <item>
-                        <p>If the  <nt def="KeySpecifier">KeySpecifier</nt> is an <nt
+                        <p>If <var>KS</var> is an <nt
                            def="IntegerLiteral">IntegerLiteral</nt> with value <code>$i</code>, 
                         the result is the same as <code>$V?pairs::($i)</code>.</p>
                      </item>
                      
                      <item>
-                        <p>If the <nt def="KeySpecifier">KeySpecifier</nt> is an <code>NCName</code>
+                        <p>If <var>KS</var> is an <code>NCName</code>
                            <phrase diff="add" at="A">or <code>StringLiteral</code></phrase>, 
                            the expression raises a type error <errorref class="TY" code="0004"/>.</p>
                      </item>
                      <item>
-                        <p diff="chg" at="2023-11-15">If <code>KS</code> is a wildcard
+                        <p>If <var>KS</var> is a wildcard
                            (<code>*</code>), 
                            the result is the same as <code>$V?pairs::(1 to array:size($V))</code>:</p>
 
@@ -19847,17 +19882,21 @@ processing with JSON processing.</p>
                            <p>Note that array items are returned in order.</p>
                         </note>
                      </item>
-                     <!--<item>
-                        <p>If <code>KS</code> is a <nt def="TypeQualifier">TypeQualifier</nt> <code>~T</code>,
-                           the result is the same as <code>$V?pairs::*[?value instance of T]</code>.</p>
-                     </item>-->
+                     <item>
+                        <p>If <var>KS</var> is a <nt def="TypeSpecifier">TypeSpecifier</nt> <code>~<var>T</var></code>,
+                           the result is the same as <code>$V?pairs::*[?value instance of <var>T</var>]</code>.
+                           Note that <var>T</var> is in general a sequence type: if there is an occurrence
+                           indicator, then it must be written within parentheses, but if it is a plain
+                           item type with no occurrence indicator, then the parentheses may be omitted.
+                        </p>
+                     </item>
                   </olist>
                   </item>
                   <item><p>If <var>$V</var> is a <termref def="dt-singleton"/> 
                      map item (that is, if <code>$V instance of map(*)</code>)
                      then:</p>
                      <olist>
-                        <item><p>If <code>KS</code> is a <code>ParenthesizedExpr</code>,
+                        <item><p>If <var>KS</var> is a <code>ParenthesizedExpr</code>,
                            then it is evaluated to produce a value <code>$K</code>
                            and the result is:</p>
                            <eg><![CDATA[data($K) ! { "key": ., "value": map:get($V, .) }]]></eg>
@@ -19867,17 +19906,17 @@ processing with JSON processing.</p>
                            </note>
                         </item>
                         <item>
-                           <p>If <code>KS</code> is an <code>NCName</code>
+                           <p>If <var>KS</var> is an <code>NCName</code>
                               or a <code>StringLiteral</code>, with value <code>$S</code>, 
                               the result is the same as <code>$V?pairs::($S)</code></p>
                         </item>
                         <item>
-                           <p>If <code>KS</code> is an <code>IntegerLiteral</code>
+                           <p>If <var>KS</var> is an <code>IntegerLiteral</code>
                               with value <code>$N</code>, 
                               the result is the same as <code>$V?pairs::($N)</code>.</p>
                         </item>
                         <item>
-                           <p>If <code>KS</code> is a wildcard (<code>*</code>), 
+                           <p>If <var>KS</var> is a wildcard (<code>*</code>), 
                               the result is the same as <code>$V?pairs::(map:keys($V))</code>.</p>
                           <note>
                               <p>The order of entries in the result sequence 
@@ -19885,10 +19924,14 @@ processing with JSON processing.</p>
                                  of the map.</p>
                            </note>
                         </item>
-                        <!--<item>
-                           <p>If <code>KS</code> is a <nt def="TypeQualifier">TypeQualifier</nt> <code>~T</code>,
-                              the result is the same as <code>$V?pairs::*[?value instance of T]</code>.</p>
-                        </item>-->
+                        <item>
+                           <p>If <var>KS</var> is a <nt def="TypeSpecifier">TypeSpecifier</nt> <code>~<var>T</var></code>,
+                              the result is the same as <code>$V?pairs::*[?value instance of <var>T</var>]</code>.
+                              Note that <var>T</var> is in general a sequence type: if there is an occurrence
+                              indicator, then it must be written within parentheses, but if it is a plain
+                              item type with no occurrence indicator, then the parentheses may be omitted.
+                           </p>
+                        </item>
                      </olist>
                   </item>
                   <item><p>Otherwise (that is, if <code>$V</code> is neither a map nor an array)
@@ -19896,6 +19939,7 @@ processing with JSON processing.</p>
                            code="0004"/>.</p></item>
                </olist>
                
+
                <p>For modifiers other than <code>pairs</code>, the resulting key-value pair
                is post-processed as follows:</p>
                
@@ -19912,27 +19956,26 @@ return if ($value instance of %method function(*))
                      <note><p>The effect of this is that if any of the selected values is a 
                      <termref def="dt-singleton"/> <termref def="dt-method"/>, the selected
                      function item is partially applied by binding the first argument to
-                     the containing map <var>$V</var>.</p></note>
+                     the containing map <var>$V</var>. In other cases the result is
+                     the <termref def="dt-sequence-concatenation"/> of the value parts.</p></note>
                      
                      
                   </item>
                   <item><p>If the modifier is <code>values</code>, the result of
                   <code>$V?values::KS</code> is the same as the result of 
-                  <code>$V?pairs::KS ! array { map:get(., "value") }</code>.</p></item>
+                  <code>$V?pairs::KS ! array { map:get(., "value") }</code>.
+                  This returns each value as an array.</p></item>
                   
                   <item><p>If the modifier is <code>keys</code>, the result of
                   <code>$V?keys::KS</code> is the same as the result of 
-                  <code>$V?pairs::KS ! map:get(., "key")</code>.</p></item>
+                  <code>$V?pairs::KS ! map:get(., "key")</code>.
+                   This returns the keys (integer indexes in the case of an array)
+                     without the values.</p></item>
                </ulist>
 
-               
-               
-               
-               
-               
 
-
-               <p>Examples:</p>
+               
+               <p>More examples:</p>
 
 
                <ulist>
@@ -20202,8 +20245,9 @@ declare function recursive-content($item as item()) as record(key, value)* {
                         returns the sequence <code>"Smith", "Evans"</code>.</p></item>
                      <item><p>The expression <code>$V ?? 1</code> 
                         returns the sequence <code>{ "first": "John", "last": "Smith" }</code>.</p></item>
-                     <item><p>The expression <code>$V ?? *[. instance of record(first, last)] ! `{ ?first } { ?last }`</code> 
-                        returns the sequence <code>"John Smith", "Mary Evans"</code>.</p></item>
+                     <item><p>The expression <code>$V ?? ~record(first, last) ! `{ ?first } { ?last }`</code> 
+                        returns the sequence <code>"John Smith", "Mary Evans"</code>. This expression
+                     selects all values of type <code>record(first, last)</code> at any level in the tree.</p></item>
                  </ulist>
                </note>
                <note>
@@ -20289,7 +20333,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   two cities can be obtained with the expression:</p> 
                      
 
-                     <eg>$tree ?? $from ?? *[. instance of record(to, distance)][?to = $to] ? distance</eg>
+                     <eg>$tree ?? $from ?? ~record(to, distance) [?to = $to] ? distance</eg>
                  
                   <p>The names of all pairs of cities whose distance is represented in the data
                   can be obtained with the expression:</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -19886,7 +19886,7 @@ processing with JSON processing.</p>
                         <p>If <var>KS</var> is a <nt def="TypeSpecifier">TypeSpecifier</nt> <code>~<var>T</var></code>,
                            the result is the same as <code>$V?pairs::*[?value instance of <var>T</var>]</code>.
                            Note that <var>T</var> is in general a sequence type: if there is an occurrence
-                           indicator, then it must be written within parentheses, but if it is a plain
+                           indicator, then the sequence type must be written within parentheses, but if it is a plain
                            item type with no occurrence indicator, then the parentheses may be omitted.
                         </p>
                      </item>


### PR DESCRIPTION
Fix #1456

Allows selection of records by type within a JSON tree, for example `$json ?? ~record(first, last) ? last`.

I'm aware that the use of the tilde here is controversial but I think this kind of query is going to be very common; it needs something simple and I think people will get used to it. No-one has suggested anything that is obviously better, and I propose to also use `~` in other similar contexts, for example type patterns in XSLT, which will increase familiarity.

I suggest reading `~` as "of type".