### PR TITLE
1779 Make CharRef XQuery-only

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -3841,7 +3841,9 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="NCNameToken"/>
   </g:token>
 
-  <g:token name="CharRef" inline="false" is-xml="yes" xhref="http://www.w3.org/TR/REC-xml#NT-CharRef" xgc-id="xml-version" delimiter-type="hide">
+  <g:token name="CharRef" inline="false" is-xml="yes"
+           if="xquery40"
+           xhref="http://www.w3.org/TR/REC-xml#NT-CharRef" xgc-id="xml-version" delimiter-type="hide">
     <g:string>&amp;#</g:string>
     <g:choice name="CharRefChars">
       <g:ref name="Digits"/>


### PR DESCRIPTION
Fix #1779 

Makes the CharRef token XQuery-only.