### PR TITLE
1781 Drop obsolete material from XSLT spec

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -36726,58 +36726,7 @@ return ($m?price - $m?discount)</eg>
          
       </div1>
 
-      <div1 id="json">
-         <head>Processing JSON Data</head>
-         <p>JSON is a popular format for exchange of structured data on the web: it is specified in
-               <bibref ref="rfc7159"/>. This section
-            describes facilities allowing JSON data to be processed using XSLT.</p>
-
-         <note>
-            <p>RFC7159 is taken as the definitive specification of JSON for the purposes of this
-               document. The RFC explains its relationship with other JSON specifications such as
-                  <bibref ref="ECMA-404"/>.</p>
-         </note>
-
-         <note>
-            <p>XPath 3.1 incorporates the functions defined in this
-               section. It also provides additional JSON capability, in the form of functions
-                  <code>parse-json</code>, <code>json-doc</code>, and extensions to the
-                  <xfunction>serialize</xfunction> function. These facilities are incorporated in XSLT
-               3.0 only if the XPath 3.1 feature is supported. They depend on support for
-               arrays.</p>
-         </note>
-
-        
-
-         <div2 id="xml-to-json-transformation">
-            <head>Transforming XML to JSON</head>
-            <p>Given an XML structure that does not use the XML representation of JSON defined in
-                  <xspecref spec="FO40" ref="json-to-xml-mapping"/>, there are two practical ways to convert it
-               to JSON: either perform a transformation to the XML representation of JSON and then
-               call the <function>xml-to-json</function> function; or transform it to JSON directly
-               by using custom template rules.</p>
-
-            <p>To assist with the second approach, a stylesheet is provided in <specref ref="json-in-xml"/>. 
-               This stylesheet includes a function
-                  <code>j:xml-to-json</code> which, apart from being in a different namespace, is
-               functionally very similar to the <function>xml-to-json</function> function described in
-               the previous section. (It differs in doing less validation
-                  of the input than the function specification requires, and in the details of how
-                  special characters are escaped.)
-               The implementation of the function is exposed, using template
-               rules to perform a recursive descent of the supplied input, and the behavior of the
-               function can therefore be customized (typically by importing the stylesheet and
-               adding additional template rules) to handle arbitrary XML input.</p>
-
-            <p>The stylesheet is provided under the W3C software license for the convenience of
-               users. There is no requirement for any conformant XSLT processor to make this
-               stylesheet available. Processors <rfc2119>may</rfc2119> implement the
-               <function>xml-to-json</function> function by invoking this stylesheet (adapted
-               to achieve full conformance), but there is no requirement to do so.</p>
-         </div2>
-      </div1>
-
-     
+      
 
       <div1 id="diagnostics">
          <head>Diagnostics</head>
@@ -39200,7 +39149,7 @@ return ($m?price - $m?discount)</eg>
                <rfc2119>must</rfc2119> satisfy the requirements for processors that do not implement
             that feature.</p>
 
-         <note>
+         <!--<note>
             <p>There is no conformance level or feature defined in this specification that requires
                implementation of the static typing features described in <bibref ref="xpath-30"/>.
                An XSLT processor may provide a user option to invoke static typing, but to be
@@ -39208,7 +39157,7 @@ return ($m?price - $m?discount)</eg>
                static typing disabled. The interaction of XSLT stylesheets with the static typing
                feature of XPath 3.0 has not been specified, so
                the results of using static typing, if available, are implementation-defined.</p>
-         </note>
+         </note>-->
          <p>An XSLT processor takes as its inputs a stylesheet and zero or more XDM trees conforming to the data model defined in <bibref ref="xpath-datamodel-30"/>. It is not <rfc2119>required</rfc2119> that the processor
             supports any particular method of constructing XDM trees, but conformance can only be
             tested if it provides a mechanism that enables XDM trees representing the stylesheet and
@@ -39242,24 +39191,24 @@ return ($m?price - $m?discount)</eg>
          <p>A conforming processor <rfc2119>may</rfc2119> impose limits on the processing resources
             consumed by the processing of a stylesheet.</p>
 
-         <p>The mandatory requirements of this specification are taken to
+         <!--<p>The mandatory requirements of this specification are taken to
             include the mandatory requirements of <bibref ref="xpath-30"/>, <bibref ref="xpath-datamodel-30"/>, and <bibref ref="xpath-functions-40"/>. An XSLT 3.0
             processor <rfc2119>must</rfc2119> provide a mode of operation which conforms to the 3.0
             versions of those specifications as extended by <specref ref="map"/> and <specref ref="json"/>.</p>
-
-         <p diff="del" at="2022-01-01">A processor <rfc2119>may</rfc2119> also provide a mode of
+-->
+         <!--<p diff="del" at="2022-01-01">A processor <rfc2119>may</rfc2119> also provide a mode of
             operation which conforms to the 3.1 versions of those specifications; in this case it
             must do so as described in XPath 3.1 feature.</p>
-
-         <p>A processor <rfc2119>may</rfc2119> also provide a mode of
+-->
+         <!--<p>A processor <rfc2119>may</rfc2119> also provide a mode of
             operation which conforms to versions of those specifications later than the 3.1
             versions; in such cases the detail of how XSLT 3.0 interacts with new features
             introduced by such later versions (for example, extensions to the data model) is
-               <termref def="dt-implementation-defined"/>.</p>
+               <termref def="dt-implementation-defined"/>.</p>-->
 
-         <imp-def-feature id="idf-spec-xpath">It is <termref def="dt-implementation-defined"/>
+         <!--<imp-def-feature id="idf-spec-xpath">It is <termref def="dt-implementation-defined"/>
             whether (and if so how) an XSLT 3.0 processor is able to work with versions of XPath
-            later than XPath 3.1.</imp-def-feature>
+            later than XPath 3.1.</imp-def-feature>-->
 
 
 
@@ -39782,23 +39731,7 @@ See <loc href="http://www.w3.org/TR/xhtml11/"/>
             </blist>
          </div2>
       </div1>
-      <div1 id="json-in-xml">
-         <head>XML Representation of JSON</head>
-         <p>This appendix contains a stylesheet that can be used for converting the XML representation of JSON described in
-               <xspecref spec="FO40" ref="json-to-xml-mapping"/> into strings matching the JSON grammar.</p>
-         <p>This stylesheet is also available as a separate resource (links
-            are listed at the top of this document).</p>
-         <p>The schema for this XML representation of JSON is described at 
-            <xspecref spec="FO40" ref="json-to-xml-mapping"/>.</p>
-         
-            <p>The stylesheet contains the implementation of a function very similar to
-                  <function>xml-to-json</function>, but implemented in XSLT so that it can be
-               customized and extended. This stylesheet is provided for the benefit of users and
-               there are no conformance requirements associated with it; there is no requirement
-               that processors should make this stylesheet available. The stylesheet is reproduced
-               below:</p>
-            <?doc xml-to-json.xsl?>
-      </div1>
+      
       <inform-div1 id="glossary">
          <head>Glossary</head>
          <?glossary?>


### PR DESCRIPTION
Drops material mainly deriving from when XSLT 3.0 had to work with both XPath 3.0 and 3.1. Includes non-normative exposition and some obsolete conformance statements.