### PR TITLE
1789 Fix singleton terminology

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1528,10 +1528,10 @@ values, only on keys. The semantics of equality when comparing keys are describe
   <p><termdef id="dt-entry" term="entry">The key/value pairs in a map are
     referred to as <term>entries</term>.</termdef></p>
   
-  <p><termdef id="dt-single-entry-map" term="entry">A map containing exactly
+  <p><termdef id="dt-single-entry-map" term="single-entry map">A map containing exactly
     one entry is referred to as a <term>single-entry map</term>.</termdef></p>
   
-  <p><termdef id="dt-empty-map" term="entry">A map containing no entries 
+  <p><termdef id="dt-empty-map" term="empty map">A map containing no entries 
     is referred to as an <term>empty map</term>.</termdef></p>
   
   <note>
@@ -1633,10 +1633,10 @@ any value (including a sequence or an array). The number of members in
 an array is called its size, and they are referenced by their
 position, in the range 1 to the size of the array.</p>
   
-  <p><termdef id="dt-single-member-array" term="entry">An array containing exactly
+  <p><termdef id="dt-single-member-array" term="single-member array">An array containing exactly
     one member is referred to as a <term>single-member array</term>.</termdef></p>
   
-  <p><termdef id="dt-empty-array" term="entry">An array containing no members 
+  <p><termdef id="dt-empty-array" term="empty array">An array containing no members 
     is referred to as an <term>empty array</term>.</termdef></p>
 
   <note><p>Arrays have no intrinsic identity separate from their content. An array can be given

--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -1514,6 +1514,7 @@ must equal the function’s arity.
   </changes>
 
 <p><termdef term="map item" id="dt-map-item">A <term>map item</term>
+(also called simply a <term>map</term>)
 is an item that represents an ordered sequence of key/value pairs,
 in which the keys are unique.</termdef> 
   In other languages this is sometimes 
@@ -1523,6 +1524,15 @@ to which it is equal). Each key is associated with a value that may be any seque
 of zero or more items. There is no uniqueness constraint on
 values, only on keys. The semantics of equality when comparing keys are described in
 <xspecref spec="FO40" ref="func-atomic-equal"/>.</p>
+  
+  <p><termdef id="dt-entry" term="entry">The key/value pairs in a map are
+    referred to as <term>entries</term>.</termdef></p>
+  
+  <p><termdef id="dt-single-entry-map" term="entry">A map containing exactly
+    one entry is referred to as a <term>single-entry map</term>.</termdef></p>
+  
+  <p><termdef id="dt-empty-map" term="entry">A map containing no entries 
+    is referred to as an <term>empty map</term>.</termdef></p>
   
   <note>
 <p>Maps have no intrinsic identity separate from their content. A map can be given
@@ -1549,9 +1559,10 @@ values, only on keys. The semantics of equality when comparing keys are describe
       <proto class="dm" name="empty-map" return-type="map(*)" returnSeq="no"/>     
     </example>
     
-    <p>The <code>dm:empty-map</code> constructor returns a map containing no key/value pairs.</p>
+    <p>The <code>dm:empty-map</code> constructor returns an <termref def="dt-empty-map"/>,
+      that is, a map containing no key/value pairs.</p>
     
-    <note><p>In XPath an empty map may be constructed using the expression <code>{}</code>
+    <note><p>In XPath an <termref def="dt-empty-map"/> may be constructed using the expression <code>{}</code>
     or <code>map {}</code>.</p></note>
   </div4>
   
@@ -1613,13 +1624,20 @@ values, only on keys. The semantics of equality when comparing keys are describe
     is now an iterator over the members of the array.</change>
   </changes>
 
-<p><termdef term="array item" id="dt-array-item">An <term>array item</term>
+<p><termdef term="array item" id="dt-array-item">An <term>array item</term> 
+  (also called simply an <term>array</term>)
 is a value that represents an array.</termdef>
-An array is an ordered list of values; these values are called the
-members of the array. Unlike sequences, a member of an array can be
+<termdef id="dt-member" term="member">An array is an ordered list of values; these values are called the
+<term>members</term> of the array.</termdef> Unlike sequences, a member of an array can be
 any value (including a sequence or an array). The number of members in
 an array is called its size, and they are referenced by their
 position, in the range 1 to the size of the array.</p>
+  
+  <p><termdef id="dt-single-member-array" term="entry">An array containing exactly
+    one member is referred to as a <term>single-member array</term>.</termdef></p>
+  
+  <p><termdef id="dt-empty-array" term="entry">An array containing no members 
+    is referred to as an <term>empty array</term>.</termdef></p>
 
   <note><p>Arrays have no intrinsic identity separate from their content. An array can be given
     a transient identity, represented by an <code>id</code> property in its label, by applying the
@@ -1635,7 +1653,8 @@ position, in the range 1 to the size of the array.</p>
       <proto class="dm" name="empty-array" return-type="array(*)"/>
     </example>
     
-    <p>The <code>dm:empty-array</code> constructor returns an array containing no members.</p>
+    <p>The <code>dm:empty-array</code> constructor returns an <termref def="dt-empty-array"/>,
+      that is, an array item containing no members.</p>
     
     <p>The function is exposed in XPath as an empty array constructor, written <code>[]</code>
     or <code>array {}</code>.</p>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -20774,11 +20774,13 @@ return function-arity($initial)</eg></fos:expression>
       </fos:summary>
       <fos:rules>
          <p>The <code>fn:function-annotations</code> function returns the annotations of
-            <code>$function</code> as a sequence of singleton maps, each associating
+            <code>$function</code> as a sequence of 
+            <termref def="dt-single-entry-map">single-entry maps</termref> maps, each associating
             the name of a function annotation with the value of the annotation.
             Note that several annotations on a function can share the same name. The order
             of the annotations is retained.</p>
-         <p>The result is a sequence of singleton maps, each being an instance of
+         <p>The result is a sequence of <termref def="dt-single-entry-map">single-entry maps</termref>, 
+            each being an instance of
             <code>map(xs:QName, xs:anyAtomicType*)</code>. 
             If a function (for example, a built-in function) has no annotations,
             the result of the function is an empty sequence.</p>
@@ -23655,13 +23657,13 @@ return map:keys-where($birthdays, fn($name, $date) {
       </fos:properties>
       <fos:summary>
          <p>Returns a sequence containing all the key-value pairs present in a map, each represented
-            as a <termref def="dt-singleton-map"/>.</p>
+            as a <termref def="dt-single-entry-map"/>.</p>
       </fos:summary>
       <fos:rules>
          <p>The function <function>map:entries</function> takes any <termref def="dt-map"
             >map</termref>
             as its <code>$map</code> argument and returns the key-value pairs that are present in the map as
-            a sequence of <termref def="dt-singleton-map">singleton maps</termref>, in 
+            a sequence of <termref def="dt-single-entry-map">single-entry maps</termref>, in 
             <xtermref spec="DM40" ref="dt-entry-order">entry order</xtermref>.</p>
          
          
@@ -24209,7 +24211,7 @@ declare function map:find($input as item()*,
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p><phrase>Returns</phrase> a <termref def="dt-singleton-map"/> that 
+         <p><phrase>Returns</phrase> a <termref def="dt-single-entry-map"/> that 
             represents a single key-value pair.</p>
       </fos:summary>
       <fos:rules>
@@ -26230,7 +26232,8 @@ return json-to-xml($json, $options)]]></eg>
         
          <p>In general, an element node maps to a key-value pair in which the key represents the element name, and the
          corresponding value represents the attributes and children of the element. In the case of a top-level element
-         (a node directly supplied in <code>$elements</code>), the result will be a singleton map containing this key-value
+         (a node directly supplied in <code>$elements</code>), the result will be a 
+            <termref def="dt-single-entry-map"/> containing this key-value
          pair as its only entry. In the case of a descendant element, the key-value pair for a child element will be added 
          to the content representing its parent element, in a way that depends on the parent element's layout.</p>
          
@@ -29782,11 +29785,12 @@ return deep-equal(
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Delivers the contents of an array as a sequence of singleton arrays.</p>
+         <p>Delivers the contents of an array as a sequence of single-member arrays.</p>
       </fos:summary>
       <fos:rules>
-         <p>The members of the array are delivered as a sequence of arrays. 
-            Each returned array encapsulates the value of a single array member.</p>
+         <p>The members of the array are delivered as a sequence of 
+            <xtermref spec="DM40" ref="dt-single-member-array">single-member arrays</xtermref>. 
+            Each returned array encapsulates the value of one member of <code>$array</code>.</p>
       </fos:rules>
       <fos:equivalent style="xpath-expression">
 array:for-each($array, fn($member) { [] => array:append($member) })
@@ -33584,7 +33588,8 @@ let $scan-left := fn(
         <fos:notes>
                 <olist>
                     <item>
-                        <p>Note that each intermediate result is placed in a separate singleton array.
+                        <p>Note that each intermediate result is placed in a separate 
+                           <xtermref spec="DM40" ref="dt-single-member-array"/>.
                            This is necessary because we cannot represent a sequence of results, some or all of which are
                            a sequence - that is "sequence of sequences" as just a single sequence.
                         </p>
@@ -33606,7 +33611,7 @@ let $scan-left := fn(
          </fos:example>      
          <fos:example>
             <p>Produce the intermediate results of mapping each number in a sequence to its doubled value. 
-            This example shows the necessity to place each intermediate result (sequence) into a singleton array - otherwise
+            This example shows the necessity to place each intermediate result (sequence) into a <xtermref spec="DM40" ref="dt-single-member-array"/> - otherwise
             the sequence of sequences (intermediate results) would not be possible to express as a single sequence
             without losing completely the intermediate results.</p>
             <fos:test>
@@ -33680,7 +33685,8 @@ let $scan-right := function(
         <fos:notes>
                 <olist>
                     <item>
-                        <p>Note that each intermediate result is placed in a separate singleton array.
+                        <p>Note that each intermediate result is placed in a separate 
+                           <xtermref spec="DM40" ref="dt-single-member-array"/>.
                            This is necessary because we cannot represent a sequence of results, some or all of which are
                            a sequence - that is "sequence of sequences" as just a single sequence.
                         </p>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7692,9 +7692,9 @@ return <table>
             These are described below:</p>
          
          <olist diff="add" at="2023-04-03">
-            <item><p><termdef id="dt-singleton-map" term="singleton map">A <term>singleton map</term> is a map containing a single
+            <item><p><termdef id="dt-single-entry-map" term="single-entry map">A <term>single-entry map</term> is a map containing a single
                entry.</termdef></p>
-               <p>It is possible to decompose any map into a sequence of <termref def="dt-singleton-map">singleton maps</termref>,
+               <p>It is possible to decompose any map into a sequence of <termref def="dt-single-entry-map">single-entry maps</termref>,
                   and to construct a map from a sequence of singleton maps.</p>
                <p>For example the map
                <code>{ "x": 1, "y": 2 }</code> can be decomposed to the sequence <code>({ "x": 1 }, { "y": 2 })</code>.</p></item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -2163,7 +2163,9 @@ data (step DQ4), and on the <termref
                      the sequence type <var>T</var>.</termdef></p>
                <p diff="chg" at="B">In many cases (but not all), one of the dynamic types that a value matches will 
                      be a subtype of all the others, in which case it makes sense to speak of “the dynamic type” of the value as 
-                     meaning this single most specific type. In other cases (examples are empty maps and empty arrays) none of the 
+                     meaning this single most specific type. In other cases (examples are 
+                     <xtermref spec="DM40" ref="dt-empty-map">empty maps</xtermref> and 
+                     <xtermref spec="DM40" ref="dt-empty-array">empty arrays</xtermref>) none of the 
                      dynamic types is more specific than all the others.</p>
                <note diff="chg" at="B"><p>An atomic item has a <termref def="dt-type-annotation"/> which will always be
                   a <termref def="dt-subtype"/> of all the other types that it matches; we can therefore refer to 
@@ -5545,7 +5547,7 @@ name.</p>
                <p>For generality:</p>
                <ulist>
                   <item><p>The syntax <code>record()</code> defines a record type that has no explicit fields and that
-                  is not extensible. The only thing it matches is an empty map.</p></item>
+                  is not extensible. The only thing it matches is an <xtermref spec="DM40" ref="dt-empty-map"/>.</p></item>
                   <item><p>The syntax <code>record(*)</code> defines an extensible record type that has no explicit
                   field declarations. It is equivalent to the item type
                   <code>map(*)</code>: that is, it matches any map.</p></item>
@@ -7437,8 +7439,8 @@ declare record Particle (
                      are instances of both types are one or more of the following:</termdef></p>
                      <ulist>
                         <item><p>The empty sequence, <code>()</code>.</p></item>
-                        <item><p>The empty map, <code>{}</code>.</p></item>
-                        <item><p>The empty array, <code>[]</code>.</p></item>
+                        <item><p>The <xtermref spec="DM40" ref="dt-empty-map"/>, <code>{}</code>.</p></item>
+                        <item><p>The <xtermref spec="DM40" ref="dt-empty-array"/>, <code>[]</code>.</p></item>
                      </ulist>
                <p role="closetermdef"/>
                      
@@ -7469,7 +7471,7 @@ declare record Particle (
                   <item><p><code>function($x as xs:integer) as array(xs:string) { array { 1 to $x } }</code>. The type
                   of the function body is <code>array(xs:integer)</code>, which is substantively disjoint with the
                   required type <code>array(xs:string)</code>: the function can succeed only in the exceptional case
-                  where the function body delivers an empty array.</p></item>
+                  where the function body delivers an <xtermref spec="DM40" ref="dt-empty-array"/>.</p></item>
                </ulist>
                   
             </div3>
@@ -16982,7 +16984,7 @@ for member $y in $expr2]]></eg>
             </note>
             <p>For a given input tuple, if the <termref def="dt-binding-collection" diff="chg" at="A"
                   >binding collection</termref> for the new variable in the <code>for</code> clause <phrase diff="add" at="A">is empty 
-               (that is, it is an empty sequence or an empty array depending on whether <code>member</code> is specified)</phrase>,
+               (that is, it is an empty sequence or an <xtermref spec="DM40" ref="dt-empty-array"/> depending on whether <code>member</code> is specified)</phrase>,
                and if <code>allowing empty</code> is not specified, the input tuple generates zero output tuples 
                (it is not represented in the output tuple stream.)</p>
             
@@ -19289,7 +19291,7 @@ processing with JSON processing.</p>
                   <item><p><function>map:build</function> takes any sequence as input, and for each
                   item in the sequence, it computes a key and a value, by calling user-supplied functions.</p></item>
                   <item><p><function>map:merge</function> takes a sequence of maps (often but not necessarily
-                  single-entry maps) and merges them into a single map.</p></item>
+                  <xtermref spec="DM40" ref="dt-single-entry-map"/>) and merges them into a single map.</p></item>
                   <item><p><function>map:of-pairs</function> takes a sequence of 
                      <xtermref spec="FO40" ref="dt-key-value-pair-map">key-value pair maps</xtermref>
                      and merges them into a single map.</p></item>
@@ -20023,7 +20025,8 @@ declare function recursive-content($item as item()) as record(key, value)* {
                
 
                <p>It is then useful to represent the recursive content as a sequence of
-               single-entry maps: so each pair <code>{ "key": $K, "value": $V }</code>
+               <xtermref spec="DM40" ref="dt-single-entry-map">single-entry-maps</xtermref>: 
+                  so each pair <code>{ "key": $K, "value": $V }</code>
                is converted to the form <code>{ $K: $V }</code>. This can be achieved
                using the expression <code>recursive-content($V) ! { ?key: ?value }</code>.</p>
                
@@ -20062,7 +20065,8 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   <p>The expression <code>$V??pairs::*</code> returns this sequence.</p>
                   <p>With some other <code>KeySpecifier</code> <code>KS</code>, <code>$V??pairs::KS</code> returns
                      selected items from this sequence that match <code>KS</code>.
-                     Formally this is achieved by converting the key-value pairs to single-entry maps,
+                     Formally this is achieved by converting the key-value pairs to 
+                     <xtermref spec="DM40" ref="dt-single-entry-map">single-entry maps</xtermref>,
                      applying the <code>KeySpecifier</code> to the sequence of single-entry maps,
                      and then converting the result back into a sequence of key-value pairs.</p>
                   <p>For example, given the expression <code>$V??pairs::first</code>, the selection from

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -3431,19 +3431,25 @@ defined in <xspecref
                </item>
 
                <item>
-                  <p>If its operand is a <termref def="dt-singleton"
-                        >singleton</termref> value of type <code>xs:boolean</code> or derived from <code>xs:boolean</code>, <function>fn:boolean</function> returns the value of its operand unchanged.</p>
+                  <p>If its operand is a <termref def="dt-singleton"/> value of 
+                     type <code>xs:boolean</code> or derived from <code>xs:boolean</code>, 
+                     <function>fn:boolean</function> returns the value of its operand unchanged.</p>
                </item>
 
                <item>
-                  <p>If its operand is a <termref def="dt-singleton"
-                        >singleton</termref> value of type <code>xs:string</code>, <code>xs:anyURI</code>, <code>xs:untypedAtomic</code>, or a type derived from one of these, <function>fn:boolean</function> returns <code>false</code> if the operand value has zero length; otherwise it returns <code>true</code>.</p>
+                  <p>If its operand is a <termref def="dt-singleton"/> value of 
+                     type <code>xs:string</code>, <code>xs:anyURI</code>, 
+                     <code>xs:untypedAtomic</code>, or a type derived from one of these,
+                     <function>fn:boolean</function> returns <code>false</code> 
+                     if the operand value has zero length; otherwise it returns <code>true</code>.</p>
                </item>
 
                <item>
-                  <p>If its operand is a <termref def="dt-singleton"
-                        >singleton</termref> value of any <termref def="dt-numeric"
-                        >numeric</termref> type or derived from a numeric type, <function>fn:boolean</function> returns <code>false</code> if the operand value is <code>NaN</code> or is numerically equal to zero; otherwise it returns <code>true</code>.</p>
+                  <p>If its operand is a <termref def="dt-singleton"/> value of 
+                     any <termref def="dt-numeric"/> type or derived from a numeric
+                     type, <function>fn:boolean</function> returns <code>false</code> 
+                     if the operand value is <code>NaN</code> or is numerically 
+                     equal to zero; otherwise it returns <code>true</code>.</p>
                </item>
 
                <item>
@@ -5513,8 +5519,8 @@ name.</p>
                <p>For example, the <code>RecordType</code>
                   <code>record(r as xs:double, i as xs:double)</code>
 		             matches a map if the map has exactly two entries: an entry with key <code>"r"</code>
-		                whose value is a singleton <code>xs:double</code> value, and an entry with key <code>"i"</code>
-		                whose value is also a singleton <code>xs:double</code> value.</p>
+		                whose value is a <termref def="dt-singleton"/> <code>xs:double</code> value, and an entry with key <code>"i"</code>
+		                whose value is also a <termref def="dt-singleton"/> <code>xs:double</code> value.</p>
                
                <p>Record types describe a subset of the value space of maps. They do not define any new kinds of
 		             values, or any additional operations. They are useful in many cases to describe more accurately the
@@ -12699,7 +12705,7 @@ every integer between the two operands, in increasing order. </p>
 
             <ulist>
                <item><p><code>1 to 4</code> returns the sequence <code>1, 2, 3, 4</code></p></item>
-               <item><p><code>10 to 10</code> returns the singleton sequence <code>10</code></p></item>
+               <item><p><code>10 to 10</code> returns the <termref def="dt-singleton"/> sequence <code>10</code></p></item>
                <item><p><code>10 to 1</code> returns the empty sequence</p></item>
                <item><p><code>-13 to -10</code> returns the sequence <code>-13, -12, -11, -10</code></p></item>
             </ulist>
@@ -19728,10 +19734,11 @@ processing with JSON processing.</p>
                
                <olist>
                   <item><p><var>E</var> is evaluated to produce a value <code>$V</code>.</p></item>
-                  <item><p>If <code>$V</code> is not a singleton (that is if <code>count($V) ne 1</code>),
+                  <item><p>If <code>$V</code> is not a <termref def="dt-singleton"/> 
+                     (that is if <code>count($V) ne 1</code>),
                   then the result (by recursive application of these rules) is the value of
                   <code>for $v in $V return $v?pairs::KS</code>.</p></item>
-                  <item><p>If <code>$V</code> is a singleton array (that is, 
+                  <item><p>If <code>$V</code> is a <termref def="dt-singleton"/> array item (that is, 
                      if <code>$V instance of array(*)</code>) then:</p>
                   <olist>
                      <item><p>If <code>KS</code> is a <code>ParenthesizedExpr</code>,
@@ -19768,7 +19775,8 @@ processing with JSON processing.</p>
                      </item>-->
                   </olist>
                   </item>
-                  <item><p>If <var>$V</var> is a singleton map (that is, if <code>$V instance of map(*)</code>)
+                  <item><p>If <var>$V</var> is a <termref def="dt-singleton"/> 
+                     map item (that is, if <code>$V instance of map(*)</code>)
                      then:</p>
                      <olist>
                         <item><p>If <code>KS</code> is a <code>ParenthesizedExpr</code>,
@@ -20015,7 +20023,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                
 
                <p>It is then useful to represent the recursive content as a sequence of
-               singleton maps: so each pair <code>{ "key": $K, "value": $V }</code>
+               single-entry maps: so each pair <code>{ "key": $K, "value": $V }</code>
                is converted to the form <code>{ $K: $V }</code>. This can be achieved
                using the expression <code>recursive-content($V) ! { ?key: ?value }</code>.</p>
                
@@ -20054,11 +20062,12 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   <p>The expression <code>$V??pairs::*</code> returns this sequence.</p>
                   <p>With some other <code>KeySpecifier</code> <code>KS</code>, <code>$V??pairs::KS</code> returns
                      selected items from this sequence that match <code>KS</code>.
-                     Formally this is achieved by converting the key-value pairs to singleton maps,
-                     applying the <code>KeySpecifier</code> to the sequence of singleton maps,
+                     Formally this is achieved by converting the key-value pairs to single-entry maps,
+                     applying the <code>KeySpecifier</code> to the sequence of single-entry maps,
                      and then converting the result back into a sequence of key-value pairs.</p>
                   <p>For example, given the expression <code>$V??pairs::first</code>, the selection from
-                     the converted sequence will include the two singleton maps 
+                     the converted sequence will include the two <xtermref spec="DM40" ref="dt-single-entry-map">single
+                     entry maps</xtermref>
                      <code>{ "first" : "John" }</code> and <code>{ "first" : "Mary" }</code>,
                   which will be delivered in key-value pair form as 
                      <code>{ "key": "first", "value": "John" }, { "key": "first", "value": "Mary" }</code>.</p>
@@ -20401,7 +20410,7 @@ return $array?[count(.) ge 2]</eg>
             <note><p>Numeric predicates are handled in the same way as with filter expressions for 
                sequences. However, the result is always an array, even if only one member
             is selected. For example, given the <code>$array</code> shown above, the result
-            of <code>$array?[3]</code> is the singleton array <code>[ (2, 3) ]</code>.
+            of <code>$array?[3]</code> is the <xtermref spec="DM40" ref="dt-single-member-array"/> <code>[ (2, 3) ]</code>.
             Contrast this with <code>$array?3</code> which delivers the sequence <code>2, 3</code>.</p>
             
             
@@ -20510,7 +20519,8 @@ return $map?[?key ge 2]</eg>
             version of the containing structure. In addition, the lookup operators <code>?</code>
             and <code>??</code> flatten their result to a single sequence, so any empty values
             are effectively discarded from the result. For this reason, pinned arrays and maps
-            work best when all values in arrays and maps are singleton items. An option is therefore provided
+            work best when all values in arrays and maps are <termref def="dt-singleton"/> 
+               items. An option is therefore provided
             on the <function>fn:parse-json</function> and <function>fn:json-doc</function> functions to change
             the representation of JSON <code>null</code> values (whose default is an empty
             sequence, <code>()</code>) to a user-supplied value.</p></note>
@@ -20748,7 +20758,7 @@ raised <errorref class="TY" code="0004"/>. In the absence of a switch comparand,
                the <term>switch value</term> is an empty sequence.</p>
             </item>
             <item>
-               <p diff="chg" at="2023-02-20">Otherwise, the singleton <term>switch value</term> is compared individually
+               <p>Otherwise, the <termref def="dt-singleton"/> <term>switch value</term> is compared individually
                with each item in the <term>case value</term> in turn, and a match
                occurs if and only if these two atomic items compare equal under the rules of
                the <function>fn:deep-equal</function> function with default options, using the default 
@@ -22176,7 +22186,8 @@ return string-join($chopped, '; ')
 => string-join(" ")]]></eg>
          
          <p diff="add" at="A">returns <code>"THE. CAT. SAT. ON. THE. MAT."</code>. The first arrow
-            could be written either as <code>=></code> or <code>=!></code> because the operand is a singleton; the next two
+            could be written either as <code>=></code> or <code>=!></code> because the operand is a 
+            <termref def="dt-singleton"/>; the next two
             arrows have to be <code>=!></code> because the function is applied to each item in the tokenized
             sequence individually; the final arrow must be <code>=></code> because the <code>string-join</code>
             function applies to the sequence as a whole.</p>


### PR DESCRIPTION
Replaces "singleton map" with "single-entry map" and "singleton array" with "single-member array"; the term "singleton" now always means count()=1, not size()=1.

Fix #1789