### PR TITLE
1823 Revise top-level headings in F+O spec

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1316,7 +1316,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
       </div1>
       
       <div1 id="node-functions">
-         <head>Functions on nodes and node sequences</head>
+         <head>Processing nodes</head>
          <div2 id="accessors">
             <head>Accessors</head>
             <p>Accessors and their semantics are described in <bibref ref="xpath-datamodel-31"/>. Some of
@@ -1515,7 +1515,7 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
 	     </div2>
       </div1>
       <div1 id="numeric-functions">
-         <head>Functions and operators on numerics</head>
+         <head>Processing numerics</head>
          <p>This section specifies arithmetic operators on the numeric datatypes defined in
                     <bibref ref="xmlschema-2"/>.</p>
          <div2 id="numeric-types">
@@ -2543,7 +2543,7 @@ string conversion of the number as obtained above, and the appropriate <var>suff
          </div2>
       </div1>
       <div1 id="string-functions">
-         <head>Functions on strings</head>
+         <head>Processing strings</head>
          <p>This section specifies functions and operators on the <bibref ref="xmlschema-2"/>
                 <code>xs:string</code> datatype and the datatypes derived from it.</p>
          <div2 id="string-types">
@@ -3540,7 +3540,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
          </div2>
       </div1>
       <div1 id="anyURI-functions">
-         <head>Functions that manipulate URIs</head>
+         <head>Processing URIs</head>
          <p>This section specifies functions that manipulate URI values, either as instances
             of <code>xs:anyURI</code> or as strings.</p>
          <?local-function-index?>
@@ -3618,7 +3618,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
          </div2>
       </div1>
       <div1 id="boolean-functions">
-         <head>Functions and operators on Boolean values</head>
+         <head>Processing booleans</head>
          <p>This section defines functions and operators on the <code>xs:boolean</code> datatype.</p>
          <div2 id="boolean-constructors">
             <head>Boolean constant functions</head>
@@ -3660,7 +3660,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
          </div2>
       </div1>
 	  <div1 id="durations">
-	  	<head>Functions and operators on durations</head>
+	  	<head>Processing durations</head>
             <p>Operators are defined on the following type:</p>
             <ulist>
                <item>
@@ -3867,7 +3867,7 @@ For <code>xs:duration</code> and its subtypes, including the two subtypes <code>
 
 
       <div1 id="dates-times">
-         <head>Functions and operators on dates and times</head>
+         <head>Processing dates and times</head>
          <p>This section defines operations on the <bibref ref="xmlschema-2"/> date and time types.</p>
          <p>
 See <bibref ref="Working-With-Timezones"/> for a disquisition on working with date and time values with and without timezones.
@@ -5464,7 +5464,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
 	
       </div1>
       <div1 id="QName-funcs">
-         <head>Functions related to QNames</head>
+         <head>Processing QNames</head>
          <div2 id="QName-constructors">
             <head>Functions to create a QName</head>
             <p>In addition to the <code>xs:QName</code> constructor function, QName values can
@@ -5516,7 +5516,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          </div2>
       </div1>
       <div1 id="binary-functions">
-         <head>Operators on base64Binary and hexBinary</head>
+         <head>Processing binary values</head>
          <div2 id="binary-value-comparisons">
             <head>Comparisons of base64Binary and hexBinary values</head>
             <p diff="chg" at="2023-11-03">The following comparison operators on 
@@ -5537,7 +5537,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          </div2>
       </div1>
       <div1 id="NOTATION-functions">
-         <head>Operators on NOTATION</head>
+         <head>Processing NOTATIONs</head>
             <p>This section specifies operators that take <code>xs:NOTATION</code> values as arguments.</p>
             <?local-function-index?>
             <div2 id="func-NOTATION-equal">
@@ -5547,7 +5547,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
       
 
       <div1 id="sequence-functions">
-         <head>Functions and operators on sequences</head>
+         <head>Processing sequences</head>
          <p>A <code>sequence</code> is an ordered collection of zero or more <code>items</code>.
                 An <code>item</code> is a node, an atomic item, or a function, such as a map or an array. The terms
                 <code>sequence</code> and <code>item</code> are defined formally in <bibref ref="xquery-40"/> and <bibref ref="xpath-40"/>. </p>
@@ -7479,7 +7479,7 @@ return <table>
       <div1 id="higher-order-functions">
          <head>Higher-order functions</head>
          <div2 id="functions-on-functions">
-            <head>Functions on functions</head>
+            <head>Processing function items</head>
             <p>The functions included in this section operate on function items, that is, values referring to a function.</p>
             
             <p><termdef id="dt-higher-order" term="higher-order">Functions that accept functions among their arguments,
@@ -7608,7 +7608,7 @@ return <table>
       </div1>
 
       <div1 id="maps">
-         <head>Maps</head>
+         <head>Processing maps</head>
          
          
          <p>Maps were introduced as a new datatype in XDM 3.1. This section describes functions that
@@ -9381,7 +9381,7 @@ return <table>
          </div2>
       </div1>
       <div1 id="arrays">
-         <head>Arrays</head>
+         <head>Processing arrays</head>
          
          <p>Arrays were introduced as a new datatype in XDM 3.1. This section describes functions that
             operate on arrays.</p>
@@ -9596,7 +9596,7 @@ return <table>
       </div1>
       
       <div1 id="functions-on-types">
-         <head>Functions on types</head>
+         <head>Processing types</head>
          <changes>
               <change issue="148">
                  New functions are provided to obtain information about built-in types and types defined in an
@@ -12920,7 +12920,7 @@ ISBN 0 521 77752 6.</bibl>
       </div1>
 
       <div1 id="error-summary">
-         <head>Error summary</head>
+         <head>Error codes</head>
          <p>The error text provided with these errors is non-normative.</p>
          <error-list>
             <error class="ER" code="0000" label="Unidentified error." type="dynamic">
@@ -13451,7 +13451,7 @@ ISBN 0 521 77752 6.</bibl>
       </inform-div1>
 
       <inform-div1 id="other-functions">
-         <head>Other Functions</head>
+         <head>Functions defined elsewhere</head>
          <p>This Appendix describes some sources of functions that fall outside the scope of the function library defined
          in this specification. It includes both function specifications and function implementations. Inclusion of a function
          in this appendix does not constitute any kind of recommendation or endorsement; neither is omission from this appendix
@@ -13634,12 +13634,12 @@ ISBN 0 521 77752 6.</bibl>
          
      </inform-div1>
 	  <inform-div1 id="impl-def">
-         <head>Checklist of implementation-defined features</head>
+         <head>Implementation-defined features</head>
 	      <?imp-def-features?>
 	     
       </inform-div1>
 	  <inform-div1 id="changelog" diff="chg" at="2022-11-16">
-          <head>Changes since version 3.1</head>
+          <head>Changes since 3.1</head>
         <div2 id="changes-summary">
            <head>Summary of Changes</head>
            <?change-log?>
@@ -13707,7 +13707,7 @@ ISBN 0 521 77752 6.</bibl>
 	     
 
      <inform-div1 id="back-compatibility" diff="chg" at="A">
-         <head>Compatibility with Previous Versions</head>
+         <head>Backward compatibility</head>
          
          <p>This section summarizes the extent to which this specification is compatible with previous versions.</p>
          


### PR DESCRIPTION
Revises the headings for consistency and brevity, to make the ToC easier to navigate at a glance

Fix #1823