### PR TITLE
add zero-width assertions to regular expressions

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3351,6 +3351,205 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
                   </p>
                   
                </div4>
+               <div4 diff="add" at="issue998" id="regex-look-assertions">
+                  <head>Lookahead and Lookbehind Assertions</head>
+               
+		   <!--* There is something to be said for what some libraries do,
+		       * and documenting all the zero-width assertions together,
+		       * including ^ ! \b \B \< \> and so on, as well as  lookahead/behind.
+		       * But that would not be a clean change. - LQ
+		       *-->
+		   <p>A lookahead assertion allows matching of a pattern only when followed by a match to the assertion.
+		   Similarly, a lookbehind assertion matches something only when it comes immediately after another item.
+		   The input matches by an assertion is not included in the match, and for this reason in some systems
+		   these are considered examples of zero-width assertions.</p>
+
+		   <p>It is conventional in regular expression languages to provide multiple forms of asserrtions.
+		   One form uses an abbreviated syntax, and another a longer more readable version.  Some languages
+		   provide additional forms not included here. The short forms, although most widely supported and described
+		   elsewhere, use <code>&lt;</code> and <code>&gt;</code> characters which can be inconvenient in XML-based
+		   host languages such as XML, where those characters must be escaped. In those cases, the longer forms are
+		   likely to be more convenient; in all cases the abbreviated form and the long form are identical in function
+		   and entirely interchangable.</p>
+
+		   <p>There are some restrictions on lookbehind assertions. Lookbehind assertions must not contain capture groups.
+		   Implementations MAY firther restrict the pattern, forbidding occurrence indicators
+		   such as <code>*</code>, <code>?</code>, <code>+</code>, or <code>{...}</code>,
+		   and may limit the length of what is matched by a lookbehind assertion to, for example, 100 characters.
+		   A positive lookbehind that matches a single character, such as <code>\s</code>, MUST be supported.
+		   See also <code>\K</code> for a way to avoid these restrictions.</p>
+
+		   <p>In streaming modes, Lookahead and lookbehind assertions must only be applied to input that is grounded.</p>
+
+
+		   <div5 id="regex-positive-lookahead">
+		       <head>Positive Lookahead Assertions</head>
+
+		       <p><code>a(?=b)</code></p>
+		       <p><code>a(*positive_lookahead:b)</code></p>
+
+		       <p>A pattern <code>a</code> followed by a positive lookahead assertion <code>b</code>
+		       matches <code>a</code> only if the lookahead assertion <code>b</code> also matches.</p>
+
+		       <p>The two forms are equivalent. The longer form is provided partly for clarity and partly
+		       because the conventional character <code>&lt;</code> for this purpose must be escaped in XML-based
+		       host languages such as XSLT.</p>
+
+		       <p>Input matched by an assertion is not itself included in the match unless it is explicitly
+		       matched. However, Capture buffers within positive lookahead assertions are populated with
+		       whatever they match.</p>
+
+		       <p>Examples:</p>
+
+		       <p><code>boy(?=girl)</code> will match <code>boy</code> only if immediately
+		       followed by the string <code>girl</code>.</p>
+
+		       <p><code>replace("high school antics", "high(?=\s*school)", "low")</code> results
+		       in <code>low school antics</code>.</p>
+
+		       <p><code>replace("crawl, crawling, crawled", "(crawl|fly)(*positive_lookahead:ing)", "leap")</code>
+		       produces <code>crawl, leaping, crawled</code>.</p>
+
+		       <p><code>replace("very high towers sway", "high(?=\s+towers)", "tall")</code></p>
+		       <p>This results in <code>very tall towers sway</code>. The pattern matches “high” when it is
+		       followed by one or more space characters and then the word “towers”, but
+		       only “high” is replaced because the remainder, which part of the lookahead
+		       assertion, is not captured.</p>
+
+		       <p><code>replace("very high buildings sway", "high(?=\s+towers)", "tall")</code></p>
+		       <p>This will not replace anything because although <code>high</code> is matched,
+		       the lookahead portion does not match, which means that the pattern as a whole fails to match.</p>
+
+		       <p><code>replace("very high towers", "high\s(?=(a-z][a-z+)", "tall $1-$1-")</code></p>
+		       <p>This results in <code>very tall t-t-towers</code>, replacing only the word <code>high</code> and
+		       the following space.</p>
+
+		       <note><p>Note: a positive lookahead assertion can be thought of as a gernalization of <code>$</code> at
+		       the end of a regular expression: assertions can occur anywhere,
+		       not only at the end, and can match arbitrary content.</p></note>
+		    </div5>
+		    <div5 id="regex-positive-lookbehind">
+		       <head>Positive lookbehind Assertions</head>
+		       <p><code>a(&lt;=b)</code></p>
+		       <p><code>a(*positive_lookbehind:b)</code></p>
+
+		       <p>Lookbehind assertions provide a way to match expressions only if they appear in the input immediately
+		       after a match of the expression inside the assertion. As with other assertions, positive lookbehind assertions
+		       do not affect <emph>what</emph> is matched, but only <emph>whether</emph> it matches.</p>
+
+		       <p>Example:</p>
+
+		       <p><code>replace("are we lower", "(?&lt;=\s)we", "they")</code></p>
+		       <p>This results in <code>are they lower</code>,
+		       replacing only the occurence of “we” preceded by a space,
+		       but not the characters “we” inside the word “lower”.
+		       The space character within the assertion is not consumed or captured.</p>
+
+		       <note><p>The <code>&lt;</code> must be escaped in XML-based host languages such as XSLT,
+		       for example as <code>&lt;lt;</code>. The longer form may be preferred in this case:</p>
+		       <p><code>replace("are we lower", "(*positive_lookbehind:\s)we", "they")</code></p></note>
+		    </div5>
+		    <div5 id="regex-keep-assertion">
+		       <head>Keep Assertion</head>
+
+		       <p><code>\K</code></p>
+
+		       <p>If <code>\K</code> appears in a regular expression. Everything before it is discarded
+		       for the purpose of replacement text and the <code>$&amp;</code> replacement escape.</p>
+		       
+		       <p>The <code>\K</code> construct is technically easier to implement than unrestricted
+		       positive lookbehind assertions. Capture buffers are also permitted, and the pattern before
+		       <code>\K</code> does not need to match a fixed-length string.</p>
+
+		       <p>If <code>\K</code> appears in one or more branches of an alternation (<code>|</code>),
+		       it takes effect only when it appears in the matched branch.</p>
+
+		       <p>Example:</p>
+		       <p><code>replace("happy boy", "(happy) \Kboy", "the child is $1")</code></p>
+		       <p>This produces <code>happy the child is happy</code>; the first “happy’ is retained
+		       because of the <code>\K</code> (Keep).</p>
+		    </div5>
+		    <div5 id="regex-negative-lookahead-assertion">
+		       <head>Negative lookahead Assertion</head>
+
+		       <p><code>(?&lt;!a)b</code></p>
+		       <p><code>(*negative_lookahead:a)b</code></p>
+
+		       <p>A negative lookbehind assertion matches pattern <code>b</code> only if it
+		       is <emph>not</emph> preceded by a match to pattern <code>a</code>.</p>
+
+		       <p>Capture groups are allowed for the purpose of counting <code>$1</code>, <code>$2</code>, and
+		       so forth, but their resulting content is undefined and implementation dependent.</p>
+
+		       <p>Example</p>
+
+		       <p><code>replace("they go to the theatre.", "(?&lt;!\w)the(?&lt;=\w)", "a")</code></p>
+		       <p>This evaluates to <code>they go to a theatre</code>.
+		       The pattern matches “the” only if it is neither preceded nor followed by a word character, such as a letter,
+		       but it does not consume any adjacent non-word characters.
+		       Compare to <code>\Wthe\W</code>, which would match and consume the adjacent non-word characters, 
+		       valuating to <code>they go toatheatre</code> instead. </p>
+
+		       <note><p>Implementations may choose not to support non-greedy quantifiers
+		       such as <code>.*?</code> in negative lookbehind assertions,
+		       in addition to the restrictions already mentioned. If they are supported, however,
+		       their use can lead to unexpected results.</p></note>
+		    </div5>
+		</div4>
+		<div4 diff="add" at="issue1006" id="regex-boundary-assertions">
+		    <head>Boundary Assertions</head>
+
+		    <p><code>\b</code>, <code>\B</code>, <code>\&lt;</code>, <code>\&gt;</code></p>
+
+		    <p>These sequences are zero-width assertions: that is, like <code>^</code> and <code>$</code>,
+		    they match <emph>between</emph> two characters in the input, or at the start or end of
+		    the input.</p>
+
+		    <p><code>\&lt;</code> matches between a non-word character (<code>\W</code>) and a word character (<code>\w</code>);
+		    conceptually it matches at the start of a word. <code>\&lt;</code> also matches at the start of the input,
+		    if the first input character matches <code>\w</code>.</p>
+
+		    <p><code>\&gt;</code> matches between a word character (<code>\w</code>) and a non-word character (<code>\W</code>);
+		    conceptually it matches at the end of a word. <code>\&gt;</code> also matches at the end of the input,
+		    if the last input character matches <code>\w</code>: that is, it matches at the end of the last
+		    human-language word in the input.</p>
+
+		    <p><code>\b</code> matches between two characters when there is a word character on
+		    one side and a non-word character on the other, in either order.</p>
+
+		    <note><p><code>\b</code> can be rewritten to an equivalent form in terms of lookbehind and lookahead assertions:</p>
+		    <p><code> ( (*positive_lookbehind:\w)(*positvie_lookahead:\W) ) |
+			( (*positive_lookbehind:\W)(*positvie_lookahead:\w) )</code></p>
+		    <p>Similar rewrites are possible for the other boundary assertions defined in this section.</p></note>
+
+		    <p><code>\B</code> matches when input characters on either side are both word
+		    characters or both non-word characters. In other words, it matches a non-boundary.</p>
+
+		    <p>The combination of <code>\b</code> or <code>\B</code>, immediately followed by <code>{</code>,
+		    is a syntax error, <errorref class="RX" code="0002"/>.
+		    This is for compatibility with other systems that assign a meaning to <code>\b{...}</code>.</p>
+
+		    <!--* This is so that people who copy/paste complex expressions don't get different
+		        * semantics - should we say that more explicitly?
+			* E.g. in Perl (but not libpcre yet) \p{gcb} matches a Unicode grapheme cluster boundary.
+			* This has been requested as a feature, but a lot of underlying mechanism would be needed to
+			* support it usefully. If a graphemes() function is added it would be reasonable to consider.
+			*
+			* \b{wb} uses Unicode Technical Note 29 to define word
+			* boundaries, for example treating “barney’s” as a single word. Again, it would need locale
+			* mechanisms.
+			*
+			* There are some other names that can go in the braces.
+			*
+			* https://www.effectiveperlprogramming.com/2016/06/perl-v5-22-adds-fancy-unicode-word-boundaries/
+			* has a brief intro, or see perldoc perlrebackslash.
+			*
+			* This comment is to explain the rationale behind omitting \b{...} but still making it an error.
+			*-->
+
+		    <note><p>These boundary assertions are defined in terms of `\w` and `\W` as defined in
+		    <bibref ref="xmlschema-2"/>.</p></note>
+		</div4>
             </div3>
                
                <div3 id="flags">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3488,8 +3488,8 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 		       <p>This evaluates to “very high towers sway”, with no change because the negative
 		       lookahead expression matches.</p>
 
-		       <p><code>replace("very high towers sway", "high(?!\s+drunkards)", "tall")</code>
-		       <p>This evaluates to <code>very tall towers sway<c/ode>.</p>
+		       <p><code>replace("very high towers sway", "high(?!\s+drunkards)", "tall")</code></p>
+		       <p>This evaluates to <code>very tall towers sway</code>.</p>
 		    </div5>
 		    <div5 id="regex-negative-lookbehind-assertion">
 		       <head>Negative Lookbehind Assertion</head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -3367,8 +3367,8 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 		   <p>It is conventional in regular expression languages to provide multiple forms of asserrtions.
 		   One form uses an abbreviated syntax, and another a longer more readable version.  Some languages
 		   provide additional forms not included here. The short forms, although most widely supported and described
-		   elsewhere, use <code>&lt;</code> and <code>&gt;</code> characters which can be inconvenient in XML-based
-		   host languages such as XML, where those characters must be escaped. In those cases, the longer forms are
+		   elsewhere, use the <code>&lt;</code> character, which can be inconvenient in XML-based
+		   host languages such as XML where those characters must be escaped. In those cases, the longer forms are
 		   likely to be more convenient; in all cases the abbreviated form and the long form are identical in function
 		   and entirely interchangable.</p>
 
@@ -3429,8 +3429,8 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 		       not only at the end, and can match arbitrary content.</p></note>
 		    </div5>
 		    <div5 id="regex-positive-lookbehind">
-		       <head>Positive lookbehind Assertions</head>
-		       <p><code>a(&lt;=b)</code></p>
+		       <head>Positive Lookbehind Assertions</head>
+		       <p><code>a(?&lt;=b)</code></p>
 		       <p><code>a(*positive_lookbehind:b)</code></p>
 
 		       <p>Lookbehind assertions provide a way to match expressions only if they appear in the input immediately
@@ -3470,10 +3470,32 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 		       because of the <code>\K</code> (Keep).</p>
 		    </div5>
 		    <div5 id="regex-negative-lookahead-assertion">
-		       <head>Negative lookahead Assertion</head>
+		       <head>Negative Lookahead Assertion</head>
+
+		       <p><code>b(?!a)</code></p>
+		       <p><code>(*negative_lookahead:a)b</code></p>
+
+		       <p>A negative lookahead assertion matches pattern <code>b</code> only if it
+		       is <emph>not</emph> followed by a match to pattern <code>a</code>.</p>
+
+		       <p>Embedded capturing parentheses in a negative lookahead assertion are counted
+		       for the purpose of numbering capture groups,
+		       but they cannot capture any result because the pattern in the assertion must fail to match.</p>
+
+		       <p>Examples:</p>
+
+		       <p><code>replace("very high towers sway", "high(?!\s+towers)", "tall")</code></p>
+		       <p>This evaluates to “very high towers sway”, with no change because the negative
+		       lookahead expression matches.</p>
+
+		       <p><code>replace("very high towers sway", "high(?!\s+drunkards)", "tall")</code>
+		       <p>This evaluates to <code>very tall towers sway<c/ode>.</p>
+		    </div5>
+		    <div5 id="regex-negative-lookbehind-assertion">
+		       <head>Negative Lookbehind Assertion</head>
 
 		       <p><code>(?&lt;!a)b</code></p>
-		       <p><code>(*negative_lookahead:a)b</code></p>
+		       <p><code>(*negative_lookbehind:a)b</code></p>
 
 		       <p>A negative lookbehind assertion matches pattern <code>b</code> only if it
 		       is <emph>not</emph> preceded by a match to pattern <code>a</code>.</p>
@@ -3483,7 +3505,7 @@ It is recommended that implementers consult <bibref ref="UNICODE-TR18"/> for inf
 
 		       <p>Example</p>
 
-		       <p><code>replace("they go to the theatre.", "(?&lt;!\w)the(?&lt;=\w)", "a")</code></p>
+		       <p><code>replace("they go to the theatre.", "(?&lt;!\w)the(?!\w)", "a")</code></p>
 		       <p>This evaluates to <code>they go to a theatre</code>.
 		       The pattern matches “the” only if it is neither preceded nor followed by a word character, such as a letter,
 		       but it does not consume any adjacent non-word characters.


### PR DESCRIPTION
Proposal for issues !998 and !1006 to add zero-width assertions - lookahead, lookbehind, and word boundary.

Word boundaries use the already-defined \w and \W from XML Schema.

The syntax for lookahead and lookbehind assertions supports the two most common variants, one using < and > and the other using `(*positive_lookahead:expr)`, which is at least amenable to Web searches, and doesn’t need escaping in XSLT or XQuery.

Note that word boundary \< \b \B \> assertions can be rewritten in terms of lookahead and lookbehind assertions.

Perl has a more powerful form of \b and \B that can match grapheme clusters, the Unicode linebreaking algorithm, and more, but supporting that would require language and script based mechanisms; if the graphemes() function is added, it would be worth considering. For now, i made it an error to write \b{...} so that the support could be added later if wanted, and also so that copying regular expressions into XPath would raise an error for the unsupported feature.

I will reopen !998 - if this is accepted i can produce test cases. Of course, i’m also happy to edit/rewrite etc.  The syntax is widely supported, although \K is i think not in libpcre (but, libpcre has looser restrictions on negative backward assertions).