### PR TITLE
1820 Attempt to add change markup in collapsed ToC

### DIFF
--- a/specifications/js/toc.js
+++ b/specifications/js/toc.js
@@ -1,4 +1,38 @@
 (function() {
+  const updateDelta = function(target) {
+    if (target.classList.contains("expanded")) {
+      return;
+    }
+
+    let anchor = target;
+    while (anchor && anchor.tagName !== "A") {
+      anchor = anchor.previousSibling;
+    }
+    if (anchor && (anchor.querySelector("span.toc-chg")
+                   || anchor.querySelector("span.toc-new"))) {
+      return;
+    }
+
+    let delta = null;
+    let details = target;
+    while (details && details.tagName !== "DETAILS") {
+      details = details.parentNode;
+    }
+    if (details) {
+      delta = (details.querySelector("span.toc-chg")
+               || details.querySelector("span.toc-new"))
+    }
+
+    // We're assuming innerHTML is a single text node...
+    let inner = `${target.innerHTML}`;
+    inner = inner.substring(inner.length - 1)
+    if (delta) {
+      inner = "★" + inner;
+    }
+
+    target.innerHTML = inner;
+  }
+
   const updateToc = function(open) {
     document.querySelectorAll(".toc details").forEach(details => {
       details.open = open
@@ -13,22 +47,28 @@
         span.classList.add("collapsed")
         span.innerHTML = "\u2009▶"
       }
+      updateDelta(span);
     });
   }
 
   window.addEventListener("load", () => {
     document.querySelectorAll(".exptoc").forEach(span => {
-      span.addEventListener("click", (event) => {
-        let target = event.target;
+      updateDelta(span)
+    });
+
+    document.querySelectorAll(".toc details summary").forEach(summary => {
+      summary.addEventListener("click", (event) => {
+        let target = event.target.querySelector(".exptoc")
         if (target.classList.contains("collapsed")) {
-          target.classList.remove("collapsed")
-          target.classList.add("expanded")
-          target.innerHTML = "\u2009▼"
+          target.classList.remove("collapsed");
+          target.classList.add("expanded");
+          target.innerHTML = `\u2009▼`;
         } else {
-          target.classList.remove("expanded")
-          target.classList.add("collapsed")
-          target.innerHTML = "\u2009▶"
+          target.classList.remove("expanded");
+          target.classList.add("collapsed");
+          target.innerHTML = `\u2009▶`;
         }
+        updateDelta(target);
       });
     });
 

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -2775,7 +2775,7 @@
             </span>
           </a>
           <xsl:if test="$more-toc">
-            <span class="exptoc">&#x2009;▶</span>
+            <span class="exptoc collapsed">&#x2009;▶</span>
           </xsl:if>
         </summary>
         <xsl:if test="$more-toc">
@@ -2807,7 +2807,7 @@
             </span>
           </a>
           <xsl:if test="$more-toc">
-            <span class="exptoc">&#x2009;▶</span>
+            <span class="exptoc collapsed">&#x2009;▶</span>
           </xsl:if>
         </summary>
         <xsl:if test="$more-toc">
@@ -2839,7 +2839,7 @@
             </span>
           </a>
           <xsl:if test="$more-toc">
-            <span class="exptoc">&#x2009;▶</span>
+            <span class="exptoc collapsed">&#x2009;▶</span>
           </xsl:if>
         </summary>
         <xsl:if test="$more-toc">
@@ -2871,7 +2871,7 @@
             </span>
           </a>
           <xsl:if test="$more-toc">
-            <span class="exptoc">&#x2009;▶</span>
+            <span class="exptoc collapsed">&#x2009;▶</span>
           </xsl:if>
         </summary>
         <xsl:if test="$more-toc">
@@ -2918,7 +2918,7 @@
             </span>
           </a>
           <xsl:if test="$more-toc">
-            <span class="exptoc">&#x2009;▶</span>
+            <span class="exptoc collapsed">&#x2009;▶</span>
           </xsl:if>
         </summary>
         <xsl:if test="$more-toc">


### PR DESCRIPTION
Fix #1820 

This PR updates the styling so that a small "Δ" is added to the expand arrow when there are changes or additions in the concealed subsections. It's smaller and not blue. I could argue that this is on purpose so that the marking is different and perhaps more subtle. But the truth is, it was just easier to add the Δ without any markup that would make it larger or blue.

I've opted to conceal the Δ when the ToC is "open" on the grounds that you can see what is or isn't marked new on the revealed subsctions.
