### PR TITLE
Relax the return type of the Invisible XML parsing function

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -33715,7 +33715,7 @@ let $scan-right := function(
     
    <fos:function name="invisible-xml" prefix="fn">
       <fos:signatures>
-         <fos:proto name="invisible-xml" return-type="fn(xs:string) as document-node()">
+         <fos:proto name="invisible-xml" return-type="fn(xs:string) as item()">
             <fos:arg name="grammar" type="(xs:string | element(ixml))?" default="()"/>
             <fos:arg name="options" type="map(*)?" default="{}"/>
          </fos:proto>
@@ -33810,7 +33810,9 @@ month = '0', d | '1', ['0'|'1'|'2'] .
          <p>The parsing function that is returned behaves as follows:</p>
          
          <olist>
-            <item><p>It takes a string as input and returns a document node as its result.</p></item>
+            <item><p>It takes a string as input and returns an item as its result, usually an
+            XML document containing the result of the parse. (The return type is <code>item()</code>
+            to allow implementations to provide other sorts of results.)</p></item>
             <item><p>It is <termref
                def="dt-nondeterministic">nondeterministic with respect to node identity</termref> (that
             is, if it is called twice with the same input string, it may or may not return the same


### PR DESCRIPTION
Fix #1796 

This change does not appear to change any test results. (In other words, none of our tests checked that the return type was explicitly a document node.)