### PR TITLE
GH action remove-label-on-reopen.yml

### DIFF
--- a/.github/workflows/remove-label-on-reopen.yml
+++ b/.github/workflows/remove-label-on-reopen.yml
@@ -1,0 +1,15 @@
+name: Remove Label "Propose Closing" on Reopen
+
+on:
+  issues:
+    types: [reopened]
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Remove "Propose Closing with No Action" label if it exists
+      uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: "Propose Closing with No Action"


### PR DESCRIPTION
In response to the mailing list post by @ndw: https://lists.w3.org/Archives/Public/public-xslt-40/2025Feb/0024.html

This is untested, but it might at least serve as an inspiration how to avoid the unwanted tag in an automated manner.