### PR TITLE
Actions from meeting 111

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -27712,11 +27712,12 @@ return document {
          takes a character string as input, the byte order mark serves no useful purpose.</p>
 
          <p>The possibility of the input containing characters that are not valid in XML (for example, unpaired surrogates)
-            arises only when such characters are expressed using JSON escape sequences. This is the only possibility, because the input to the function
-            is an instance of <code>xs:string</code>, which by definition can contain only those characters that are valid in XML.</p>
+            arises only when such characters are expressed using JSON escape sequences. This is because the input to the function
+            is an instance of <code>xs:string</code>, which by definition (see <xspecref spec="DM40" ref="xml-and-xsd-versions"/>)
+            cannot contain unpaired surrogates.</p>
          
-         <p>The serializer provides an option to ouput data in <term>json-lines</term> format. This is essentially a file
-            containing one JSON text on each line. There is no corresponding
+         <p>The serializer provides an option to output data in <term>json-lines</term> format. This is a format for structured data
+            containing one JSON value (usually but not necessarily a JSON object) on each line. There is no corresponding
          option to parse <term>json-lines</term> input, but this can be achieved using the expression
          <code>unparsed-text-lines($uri) => parse-json()</code>.</p>
       </fos:notes>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -10594,13 +10594,16 @@ return $a("A")]]></eg>
                      <item>
                            <p><term>annotations</term>: <phrase role="xquery">The annotations explicitly
                            included in the inline function expression.</phrase>
-                              <phrase role="xpath">An empty set.</phrase>.</p>
-                        <ednote><edtext>For XPath, add the %method annotation if that PR is approved.</edtext></ednote>
+                              <phrase role="xpath">If the keyword <code>%method</code> is present, then a list containing
+                                 a single annotation whose name is a QName with local name <code>"method"</code>
+                                 and namespace <code>"http://www.w3.org/2012/xquery"</code> and whose
+                                 value is an empty sequence; otherwise an empty set.</phrase>.</p>
+                        
                         </item>
                      <item>
                         <p>
                            <term>body</term>:
-              The <code>InlineFunctionExpr</code>’s <code>FunctionBody</code>.
+              The <code>FunctionBody</code> of the <code>InlineFunctionExpr</code>.
             </p>
                      </item>
                      <item>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -10665,7 +10665,7 @@ return $incrementors[2](4)]]></eg>
                <eg>
 let $rectangle := { 'height': 3,
                     'width': 4,
-                    'area': %method fn() { $this?height * $this?width }
+                    'area': %method fn() { $this?height × $this?width }
                   }
                </eg>
                
@@ -10717,7 +10717,7 @@ let $rectangle := { 'height': 3,
                   When <code>$this</code> is bound to a map, the result is not itself a method.
                   The means, for example that the expression:</p>
                   <eg>
-let $rectangle1 := { 'x':3, 'y':4, 'area': %method fn() {$this?x * $this?y} }
+let $rectangle1 := { 'x':3, 'y':4, 'area': %method fn() {$this?x × $this?y} }
 let $rectangle2 := { 'x':5, 'y':5, 'area': $rectangle1?area }
 return $rectangle2?area()
                   </eg>
@@ -10726,21 +10726,48 @@ return $rectangle2?area()
                   <p>If the same method is to be used in both variables, this can be written:
                   </p>
                   <eg>
-let $area := %method fn() {$this?x * $this?y}                     
+let $area := %method fn() {$this?x × $this?y}                     
 let $rectangle1 := { 'x':3, 'y':4, 'area': $area }
 let $rectangle2 := { 'x':5, 'y':5, 'area': $area }
 return $rectangle2?area()
                   </eg>
                   <p>which returns 25.</p>
+                  
+                  <p>In the case of a method that defines explicit parameters (beyond the implicit <code>$this</code>
+                  parameter), it is also possible to invoke the method using an arrow expression (see <specref ref="id-arrow-operator"/>).
+                  For example, the following code constructs a rectangle with height 6 and width 8:</p>
+                  
+                  <eg>                  
+let $rectangle := { 'height': 3,
+                    'width': 4,
+                    'expand': %method fn($ratio) { 
+                       { 'height': $this?height × $ratio,
+                         'width': $this?width × $ratio,
+                         'expand': map:get($this, 'expand') }
+                  }
+return 2 => $rectangle?expand()                  
+               </eg>
+                  
+                  <p>Note the use of <code>map:get($this, 'expand')</code> here in preference to <code>$this?expand</code>.
+                  Using <code>map:get</code> ensures that the <code>expand</code> method is not partially applied, which would
+                  bind the value of <code>$this</code> to the wrong rectangle. <phrase role="xquery">In practice,
+                  this problem can be avoided by defining <code>rectangle</code> as a named record type (see
+                  <specref ref="id-named-record-types"/>) and using its constructor function.</phrase></p>
+                  
                   <p>Since a method is a function item with an implicitly declared parameter named
                      <code>$this</code>, it is also possible to invoke it directly. The method
                      <code>%method fn() {$this?x * $this?y}</code> is equivalent to the function
                      item <code>fn($this as map(*)) {$this?x * $this?y}</code>, which means it
                      may be invoked using a call such as:</p>
                   <eg>
-let $area := %method fn() {$this?x * $this?y}                     
+let $area := %method fn() {$this?x × $this?y}                     
 return $area( { 'x':3, 'y':4 } )
                   </eg>
+                  <p>The following syntax is equivalent:</p>
+                  <eg>
+let $area := %method fn() {$this?x × $this?y}                     
+return { 'x':3, 'y':4 } => $area()
+                  </eg>                  
                </note>
                <note>
                   <p>Methods can be useful when there is a need to write inline recursive
@@ -10750,7 +10777,7 @@ let $lib := {
    'product': %method fn($in as xs:double*) {
                         if (empty( $in ))
                         then 1
-                        else head( $in ) * $this?product( tail($in) )
+                        else head( $in ) × $this?product( tail($in) )
                       }
 }
 return $lib?product( (1.2, 1.3, 1.4) )

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2242,11 +2242,11 @@ local:depth(doc("partlist.xml"))
                },
   perimeter as fn() as xs:double := 
                %method fn() {
-                  2 * ($this?width + $this?height)
+                  2 × ($this?width + $this?height)
                },
   expand    as fn($factor as xs:double) as geom:rectangle := 
                %method fn() {
-                  geom:rectangle($this?width * $factor, $this?height * $factor)
+                  geom:rectangle($this?width × $factor, $this?height × $factor)
                }   
 );</eg>
        


### PR DESCRIPTION
[ ] QT4CG-111-01: MK to review the editorial comments on PR #1837 and then merge the PR.

Done (along with a couple of other minor corrections noted in passing)

[ ] QT4CG-111-02: MK to fix the typo $in as xs:double+ and 1.3. 1.4 that middle “.” should be a “,”

Already done before the PR was merged

[ ] QT4CG-111-03: MK to add a %method example that uses the arrow syntax.

Done (though the example isn't especially convincing).

Also added another couple of examples and notes in passing.
