### PR TITLE
1771 Add option for deep-equal to consider map order

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16284,6 +16284,12 @@ else error(parse-QName('Q{http://www.w3.org/2005/xqt-errors}FORG0005'))
                   <fos:type>fn(item(), item()) as xs:boolean?</fos:type>
                   <fos:default>fn:void#0</fos:default>
                </fos:option>
+               <fos:option key="map-order">
+                  <fos:meaning>Determines whether the order of entries in maps is significant.
+                  </fos:meaning>
+                  <fos:type>xs:boolean</fos:type>
+                  <fos:default>false</fos:default>
+               </fos:option>
                <fos:option key="namespace-prefixes">
                   <fos:meaning>Determines whether namespace prefixes in <code>xs:QName</code> values (particularly
                      the names of elements and attributes) are significant.
@@ -16498,8 +16504,13 @@ declare function equal-strings(
                         </item>
                      </olist>
                   </item>
+                  <item>
+                     <p>Either <code>map-order</code> is false, or the entries in both maps appear in the same order,
+                     that is, the <var>Nth</var> key in the first map is the <termref def="dt-same-key"
+                              >same key</termref> as the <var>Nth</var> key in the second map, for all <var>N</var>.</p>
+                  </item>
                </olist>
-               <note><p>It is not required that the order of entries in the two maps should be the same.</p></note>
+               
              </item>
             <item>
                <p>All the following conditions are true:</p>


### PR DESCRIPTION
Adds an option for deep-equal to treat order of entries in a map as significant.

Fix #1771