### PR TITLE
1851 Make ?variety optional; explain namespace-sensitive

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -131,14 +131,16 @@
          </fos:meaning>
       </fos:field>
       <fos:field name="variety" 
-                 required="true" 
+                 required="false" 
                  type='enum("atomic", "list", "union", "empty", "simple", "element-only", "mixed")'>
          <fos:meaning>
             <p>For a simple type, one of <code>"atomic"</code>, <code>"list"</code>, or <code>"union"</code>, corresponding to the
                <xtermref spec="XS11-1" ref="std-variety">{variety}</xtermref> of the simple type in the XSD component model. For a complex type, one of
             <code>"empty"</code>, <code>"simple"</code>, <code>"element-only"</code>, or <code>"mixed"</code>, 
                corresponding to the <xtermref spec="XS11-1" ref="ctd-content_type">{content type}</xtermref>.<xtermref spec="XS11-1" ref="ct-variety">{variety}</xtermref> 
-               of the complex type in the XSD component model.</p>
+               of the complex type in the XSD component model. The value is absent in cases where the 
+            <xtermref spec="XS11-1" ref="std-variety">{variety}</xtermref> in the XSD component model is absent, for example
+            for the type <code>xs:anySimpleType</code>.</p>
          </fos:meaning>
       </fos:field>
       <fos:field name="members" required="false" type="fn() as schema-type-record*">
@@ -178,8 +180,7 @@
                anonymous types, and for types that might not be present in the dynamic context. 
                The field is absent for complex types and for the abstract types <code>xs:anyAtomicType</code>,
                <code>xs:anySimpleType</code>, and
-               <code>xs:NOTATION</code>. It is also absent for all namespace-sensitive types, that is, types
-               derived from <code>xs:QName</code> or <code>xs:NOTATION</code>.
+               <code>xs:NOTATION</code>. It is also absent for all <xtermref spec="XP40" ref="dt-namespace-sensitive"/> types.
             </p>
          </fos:meaning>
       </fos:field>


### PR DESCRIPTION
Fix #1851

Allow ?variety to be absent e.g. for xs:anySimpleType

Define namespace-sensitive by an xtermref to the definition in the XP/XQ spec.