### PR TITLE
1857, 1860: Add more options to parse-xml

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19289,19 +19289,22 @@ return $lines[not(position() = last() and . = '')]
                </fos:values>
             </fos:option>
             <fos:option key="entity-expansion-limit">
-               <fos:meaning>Determines the maximum number of entity references that may be expanded.
+               <fos:meaning>Places a limit on the maximum number of entity references that may be expanded,
+                  or on the size of the expanded entities.
                The limit applies both to internal and external entities, but not to built-in entity references,
                nor to character references.</fos:meaning>
                <fos:type>xs:integer?</fos:type>
                <fos:default>()</fos:default>
                <fos:values>
-                  <fos:value value="()">No limits are imposed.</fos:value>
-                  <fos:value value="integer">The processor must impose a limit on the number of
-                     entity references that are expanded; the limit must be commensurate with
-                     the value requested, though it may be an approximation. 
-                     If the XML parser does not offer the ability to impose
-                     a limit then entity expansion should be disabled entirely, leading to a dynamic
-                     error if the input contains any entity references.
+                  <fos:value value="()">The limit (if any) is <termref def="implementation-dependent"/>.</fos:value>
+                  <fos:value value="integer">The processor should impose a limit on the number of
+                     entity references that are expanded, or on the size of the expanded entities,
+                     depending on the options available in the underlying XML parser; the limit should be 
+                     commensurate with the value requested, but the precise effect may be . 
+                     <termref def="implementation-dependent"/>. If the XML parser does not offer the ability to impose
+                     a limit, or if the value is zero, then entity expansion should if possible be disabled entirely, 
+                     leading to a dynamic error if the input contains any entity references. A negative value should
+                     be interpreted as placing no limits on entity expansion.
                   </fos:value>
                </fos:values>
             </fos:option>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19262,6 +19262,48 @@ return $lines[not(position() = last() and . = '')]
                <fos:meaning>Determines whether DTD validation takes place.</fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false()</fos:default>
+               <fos:values>
+                  <fos:value value="true">The input is parsed using a validating XML parser.
+                  The input must contain a <code>DOCTYPE</code> declaration to identify
+                  the DTD to be used for validation. The DTD may be internal or external.
+                  </fos:value>
+                  <fos:value value="false">DTD validation does not take place. However, if a
+                     <code>DOCTYPE</code> declaration is present, then it is read, for example
+                     to perform entity expansion.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="allow-external-entities">
+               <fos:meaning>Determines whether references to external entities
+                  (including a DTD entity) are permitted.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>true()</fos:default>
+               <fos:values>
+                  <fos:value value="true">References to external entities are permitted, and are resolved
+                  relative to the base URI.
+                  </fos:value>
+                  <fos:value value="false">References to external entities (including an external DTD)
+                     are not permitted, and result in the call on <code>parse-xml</code> failing
+                     with a dynamic error if present.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="entity-expansion-limit">
+               <fos:meaning>Determines the maximum number of entity references that may be expanded.
+               The limit applies both to internal and external entities, but not to built-in entity references,
+               nor to character references.</fos:meaning>
+               <fos:type>xs:integer?</fos:type>
+               <fos:default>()</fos:default>
+               <fos:values>
+                  <fos:value value="()">No limits are imposed.</fos:value>
+                  <fos:value value="integer">The processor must impose a limit on the number of
+                     entity references that are expanded; the limit must be commensurate with
+                     the value requested, though it may be an approximation. 
+                     If the XML parser does not offer the ability to impose
+                     a limit then entity expansion should be disabled entirely, leading to a dynamic
+                     error if the input contains any entity references.
+                  </fos:value>
+               </fos:values>
             </fos:option>
             <fos:option key="strip-space">
                <fos:meaning>Determines whether whitespace-only text nodes are removed
@@ -19277,6 +19319,21 @@ return $lines[not(position() = last() and . = '')]
                   <fos:value value="false">All whitespace-only text nodes are preserved,
                   unless either (a) DTD validation marks them as ignorable, or (b) XSD validation recognizes
                   the containing element as having element-only or empty content.
+                  </fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="xinclude">
+               <fos:meaning>Determines whether any <code>xi:include</code> elements in the input
+                  are to be processed using an XInclude processor.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false()</fos:default>
+               <fos:values>
+                  <fos:value value="true">Any <code>xi:include</code> elements are expanded. If there are
+                     <code>xi:include</code> elements and no XInclude processor is available then 
+                     a dynamic error is raised.
+                  </fos:value>
+                  <fos:value value="false">Any <code>xi:include</code> elements are handled as
+                     ordinary elements without expansion.
                   </fos:value>
                </fos:values>
             </fos:option>
@@ -19310,6 +19367,10 @@ return $lines[not(position() = last() and . = '')]
                def="implementation-dependent"
             >implementation-dependent</termref> whether the same node is returned on both
             occasions.</p>
+         <p>Options set in <code>$options</code> may be supplemented or modified based on 
+            configuration options defined externally using <termref def="implementation-defined"/> 
+            mechanisms.</p>
+         
       </fos:rules>
       <fos:errors>
          <p>A dynamic error is raised <errorref class="DC" code="0006"
@@ -19329,8 +19390,9 @@ return $lines[not(position() = last() and . = '')]
          and XQuery 4.0 define schema-awareness as an optional feature; other host languages
          may set their own rules.)</p>
          <p>A dynamic error is raised <errorref class="DC" code="0013"
-               /> if DTD validation is requested and the processor does not have
-            access to a validating XML parser.</p>
+               /> if processor does not have
+            access to an XML parser supporting the requested options, for example the ability
+            to perform DTD validation or XInclude processing or to prevent access to external entities.</p>
          
          <p>A dynamic error is raised <errorref class="DC" code="0014"
                /> if XSD validation is
@@ -19376,6 +19438,9 @@ return $lines[not(position() = last() and . = '')]
          </fos:change>
          <fos:change issue="1287" PR="1288" date="2024-06-25">
             <p>Additional error conditions have been defined.</p>
+         </fos:change>
+         <fos:change issue="1857 1860">
+            <p>Additional options to control DTD and XInclude processing have been added.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -19438,9 +19503,11 @@ return $lines[not(position() = last() and . = '')]
             </fos:option>
            
          </fos:options>
-         <p>DTD validation is <emph>not</emph> invoked.</p>
+         <p>DTD validation is <emph>not</emph> invoked (an external general parsed entity cannot contain
+            a <code>DOCTYPE</code> declaration.</p>
          <p>Schema validation is <emph>not</emph> invoked, which means that the nodes in the
             returned document will all be untyped.</p>
+         <p>XInclude processing is <emph>not</emph> invoked.</p>
          <p>Except as explicitly defined, the precise process used to construct the XDM instance is <termref
                def="implementation-defined"
             >implementation-defined</termref>. In particular, it is implementation-defined whether

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -19245,6 +19245,11 @@ return $lines[not(position() = last() and . = '')]
       </fos:summary>
       <fos:rules>
          <p>If <code>$value</code> is the empty sequence, the function returns the empty sequence.</p>
+         
+         <p>Because the input is supplied as a string, not as an octet stream, the encoding specified
+         in the XML declaration (if present) <rfc2119>should</rfc2119> be ignored. For similar reasons, 
+         any initial byte order mark (codepoint <char>U+FEFF</char>) <rfc2119>should</rfc2119> be ignored.</p>
+         
          <p>The <code>$options</code> argument, if present and non-empty, defines the detailed behavior of the
          function. The <termref def="option-parameter-conventions"/> apply. The options available
          are as follows:</p>
@@ -19310,7 +19315,8 @@ return $lines[not(position() = last() and . = '')]
             </fos:option>
             <fos:option key="strip-space">
                <fos:meaning>Determines whether whitespace-only text nodes are removed
-                  from the resulting document.</fos:meaning>
+                  from the resulting document. (Note: in XSLT, the <code>xsl:strip-space</code>
+                  and <code>xsl:preserve-space</code> declarations are ignored.)</fos:meaning>
                <fos:type>xs:boolean</fos:type>
                <fos:default>false()</fos:default>
                <fos:values>


### PR DESCRIPTION
Add options to control entity expansion and XInclude processing.

Fix #1857 
Fix #1860