### PR TITLE
982 Editorial rewrite of scan-left and scan-right

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -33569,7 +33569,7 @@ fold-left($input, (), fn($partitions, $next, $pos) {
        <fos:signatures>
          <fos:proto name="scan-left" return-type="array(*)*">
             <fos:arg name="input" type="item()*" usage ="navigation"/>           
-            <fos:arg name="zero" type="item()*"/>           
+            <fos:arg name="accum" type="item()*"/>           
             <fos:arg name="action" type="fn(item()*, item()) as item()*" usage="inspection"/>   
          </fos:proto>
        </fos:signatures>
@@ -33579,82 +33579,47 @@ fold-left($input, (), fn($partitions, $next, $pos) {
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-        <p>Produces the complete (ordered) sequence of all partial results from every new value 
-        the accumulator is assigned to during the evaluation of fn:fold-left.</p>
+        <p>Produces the sequence of successive partial results from 
+           the evaluation of <function>fn:fold-left</function> with the same arguments.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is equivalent to the following implementation in XPath (return clause added in comments for completeness):</p>
-         <eg><![CDATA[
-let $scan-left-inner := fn(
-  $input  as item()*, 
-  $zero   as item()*, 
-  $action as fn(item()*, item()) as item()*,
-  $self   as fn(*)
-) as array(*)* {
-  let $result := [$zero]
-  return if (empty($input)) then (
-    $result
-  ) else (
-    $result, $self(tail($input), $action($zero, head($input)), $action, $self)
-  )
-}
-let $scan-left := fn(
-  $input  as item()*, 
-  $zero   as item()*, 
-  $action as fn(item()*, item()) as item()*
-) as array(*)*  {
-  $scan-left-inner($input, $zero, $action, $scan-left-inner)
-}
-(: return $scan-left(1 to 10, 0, op('+'))  :)    
-]]></eg>         
+         <p>The function returns a sequence of <var>N</var>+1 
+            <xtermref spec="DM40" ref="dt-single-member-array">single-member arrays</xtermref>, where <var>N</var> is the number of 
+         items in <code>$input</code>. For values of <code>$n</code> in the range 0 to <var>N</var>,
+            the value of the single member of array <code>$n+1</code> in the result sequence is the value of the expression
+            <code>fold-left( subsequence($input, 1, $n), $accum, $action )</code>.</p>
       </fos:rules>
-      <fos:errors>
-         <p>As a consequence of the function signature and the function calling rules, a type error
-            occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
-            the first argument is either the value of <code>$zero</code> or the result of a previous
-            application of <code>$action</code>, and the second 
-            is any single item from the sequence <code>$input</code>.</p>      
-      </fos:errors>
-        <fos:notes>
-                <olist>
-                    <item>
-                        <p>Note that each intermediate result is placed in a separate 
-                           <xtermref spec="DM40" ref="dt-single-member-array"/>.
-                           This is necessary because we cannot represent a sequence of results, some or all of which are
-                           a sequence - that is "sequence of sequences" as just a single sequence.
-                        </p>
-                    </item>
-                </olist>
-        </fos:notes>                
+      <fos:equivalent style="xpath-expression">
+(0 to count($input)) 
+  ! [fold-left( subsequence($input, 1, .), $accum, $action )]
+      </fos:equivalent>
+      <fos:notes>
+         <p>A practical implementation is likely to compute each array in the result sequence based on the value
+         of the previous item, rather than computing each item independently as implied by the specification.</p>
+      </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 5, 0, op('+'))</eg></fos:expression>
-               <fos:result>[ 0 ], [ 1 ], [ 3 ], [ 6 ], [ 10 ], [ 15 ]</fos:result>
+               <fos:result><eg>[ 0 ], [ 1 ], [ 3 ], [ 6 ], [ 10 ], [ 15 ]</eg></fos:result>
             </fos:test>
          </fos:example>         
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 3, 0, op('-'))</eg></fos:expression>
-               <fos:result>[ 0 ], [ -1 ], [ -3 ], [ -6 ]</fos:result>
+               <fos:result><eg>[ 0 ], [ -1 ], [ -3 ], [ -6 ]</eg></fos:result>
             </fos:test>
-         </fos:example>      
+         </fos:example>
          <fos:example>
-            <p>Produce the intermediate results of mapping each number in a sequence to its doubled value. 
-            This example shows the necessity to place each intermediate result (sequence) into a <xtermref spec="DM40" ref="dt-single-member-array"/> - otherwise
-            the sequence of sequences (intermediate results) would not be possible to express as a single sequence
-            without losing completely the intermediate results.</p>
-            <fos:test>
-               <fos:expression><eg>let $double := fn($x) { 2 * $x }
-return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:expression>
-               <fos:result>[ () ], [ 2 ], [ (2, 4) ], [ (2, 4, 6) ] ]</fos:result>
-            </fos:test>
-         </fos:example>  
-         <fos:example>
-            <p> Produce the factorials of all numbers from 0 to 5</p>
             <fos:test>
                <fos:expression><eg>scan-left(1 to 5, 1, op('*'))</eg></fos:expression>
                <fos:result>[ 1 ], [ 1 ], [ 2 ], [ 6 ], [ 24 ], [ 120 ]</fos:result>
+            </fos:test>
+         </fos:example>  
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>scan-left(1 to 3, (), fn($a, $b) { $b, $a })</eg></fos:expression>
+               <fos:result><eg>[ () ], [ 1 ], [ (2, 1) ], [ (3, 2, 1) ] ]</eg></fos:result>
             </fos:test>
          </fos:example>           
       </fos:examples>          
@@ -33667,7 +33632,7 @@ return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:ex
        <fos:signatures>
          <fos:proto name="scan-right" return-type="array(*)*">
             <fos:arg name="input" type="item()*" usage ="navigation"/>           
-            <fos:arg name="zero" type="item()*"/>           
+            <fos:arg name="accum" type="item()*"/>           
             <fos:arg name="action" type="fn(item()*, item()) as item()*" usage="inspection"/>   
          </fos:proto>
        </fos:signatures>
@@ -33677,52 +33642,24 @@ return scan-left(1 to 3, (), fn($seq, $it) { $seq , $double($it) })</eg></fos:ex
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-        <p>Produces the complete (ordered) sequence of all partial results from every new value 
-        the accumulator is assigned to during the evaluation of fn:fold-right.</p>
+        <p>Produces the sequence of successive partial results from 
+           the evaluation of <function>fn:fold-right</function> with the same arguments.</p>
       </fos:summary>
       <fos:rules>
-         <p>The function is equivalent to the following implementation in XPath (return clause in comments added for completeness):</p>
-         <eg><![CDATA[
-let $scan-right-inner := fn(
-  $input  as item()*,
-  $zero   as item()*,
-  $action as fn(item()*, item()) as item()*, $self as fn(*)
-) as array(*)* {
-  if (empty($input)) then (
-    [ $zero ]
-  ) else (
-    let $rightResult := $self(tail($input), $zero, $action, $self)
-    return ([ $action(head($input), head($rightResult)) ], $rightResult)
-  )
-}
-let $scan-right := function(
-  $input as item()*,
-  $zero  as item()*,
-  $f     as fn(item()*, item()) as item()*
-) as array(*)* {
-  $scan-right-inner($input, $zero, $f, $scan-right-inner)
-}        
-(: return $scan-right(1 to 10, 0, op('+')) :)  
-]]></eg>         
+         <p>The function returns a sequence of <var>N</var>+1 
+            <xtermref spec="DM40" ref="dt-single-member-array">single-member arrays</xtermref>, where <var>N</var> is the number of 
+         items in <code>$input</code>. For values of <code>$n</code> in the range 0 to <var>N</var>,
+            the value of the single member of array <code>$n+1</code> in the result sequence is the value of the expression
+            <code>fold-right( subsequence($input, count($input)-$n+1), $accum, $action )</code>.</p>
       </fos:rules>
-      <fos:errors>
-         <p>As a consequence of the function signature and the function calling rules, a type error
-            occurs if the supplied function <code>$action</code> cannot be applied to two arguments, where
-            the first argument is any item in the sequence <code>$input</code>, and the second is either
-            the value of <code>$zero</code> or the result of a previous application of
-            <code>$action</code>.</p>
-      </fos:errors>
-        <fos:notes>
-                <olist>
-                    <item>
-                        <p>Note that each intermediate result is placed in a separate 
-                           <xtermref spec="DM40" ref="dt-single-member-array"/>.
-                           This is necessary because we cannot represent a sequence of results, some or all of which are
-                           a sequence - that is "sequence of sequences" as just a single sequence.
-                        </p>
-                    </item>
-                </olist>
-        </fos:notes>                
+      <fos:equivalent style="xpath-expression">
+(0 to count($input)) 
+  ! [fold-right( subsequence($input, count($input)-.+1), $accum, $action )]
+      </fos:equivalent>
+      <fos:notes>
+         <p>A practical implementation is likely to compute each array in the result sequence based on the value
+         of the previous item, rather than computing each item independently as implied by the specification.</p>
+      </fos:notes>  
       <fos:examples>
          <fos:example>
             <fos:test>
@@ -33734,9 +33671,15 @@ let $scan-right := function(
          <fos:example>
             <fos:test>
                <fos:expression><eg>scan-right(1 to 3, 0, op('-'))</eg></fos:expression>
-               <fos:result>[ 2 ], [ -1 ], [ 3 ], [ 0 ]</fos:result>
+               <fos:result><eg>[ 2 ], [ -1 ], [ 3 ], [ 0 ]</eg></fos:result>
             </fos:test>
-         </fos:example>         
+         </fos:example>  
+         <fos:example>
+            <fos:test>
+               <fos:expression><eg>scan-right(1 to 5, (), fn($a, $b) { $b, $a })</eg></fos:expression>
+               <fos:result><eg>[(5,4,3,2,1)], [(5,4,3,2)], [(5,4,3)], [(5,4)], [5], [()]</eg></fos:result>
+            </fos:test>
+         </fos:example>  
       </fos:examples>      
       <fos:changes>
          <fos:change><p>New in 4.0</p></fos:change>


### PR DESCRIPTION
This is intended to be purely an editorial rewrite, it does not change the functionality.

Replaces #1296.

Addresses #982, but we still need to add corresponding functions for arrays.