### PR TITLE
366 xsl:package-location

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14188,7 +14188,7 @@ ISBN 0 521 77752 6.</bibl>
               existing key, in the case where the existing key and the new key differ (for example,
               if they have different type annotations), it is no longer guaranteed that the new
               entry includes the new key rather than the existing key.</p>
-
+           </item> 
            <item>
               <p>In regular expressions, the assertions <code>^</code> and <code>$</code> can no longer be
               followed by a quantifier. This is because (a) a quantifier that allows zero occurrences means

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -161,7 +161,8 @@
             <e:data-type name="uri"/>
         </e:attribute>
         <e:attribute name="priority" required="yes">
-            <e:data-type name="integer"/>
+            <e:data-type name="positiveInteger"/>
+            <e:data-type name="negativeInteger"/>
         </e:attribute>
         <e:attribute name="format" required="no">
             <e:data-type name="string"/>

--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -77,6 +77,7 @@
          <e:data-type name="string"/>
       </e:attribute>
       <e:choice repeat="zero-or-more">
+         <e:element name="package-location"/>
          <e:element name="accept"/>
          <e:element name="override"/>
       </e:choice>
@@ -154,6 +155,24 @@
          <e:parent name="use-package"/>
       </e:allowed-parents>
    </e:element-syntax>
+
+    <e:element-syntax name="package-location">
+        <e:attribute name="href" required="yes">
+            <e:data-type name="uri"/>
+        </e:attribute>
+        <e:attribute name="priority" required="yes">
+            <e:data-type name="integer"/>
+        </e:attribute>
+        <e:attribute name="format" required="no">
+            <e:data-type name="string"/>
+        </e:attribute>
+        <e:empty/>
+        <e:allowed-parents>
+            <e:parent name="use-package"/>
+        </e:allowed-parents>
+    </e:element-syntax>
+    
+    
 
    <!-- Stylesheets -->
 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -3626,134 +3626,150 @@ Michael Sperberg-McQueen (1954–2024).</p>
 
             </div3>
              
-             <div3 id="package-locations">
-                 <head>Locating Packages</head>
-                 
+                <div3 id="package-locations">
+                    <head>Locating Packages</head>
+
                     <p>A package may be located either explicitly, through one or more
-                            <elcode>xsl:use-package</elcode>s, or implicitly, in an <termref
+                            <elcode>xsl:use-package</elcode> elements, or implicitly, in an <termref
                             def="dt-implementation-defined"/> mechanism. Multiple package locations,
-                        assigned different priority levels, allow developers to provide fallback
-                        mechanisms, or diagnose problems.</p>
-                 
-                 <?element xsl:package-location?>
-                    
-                    <p>The attribute <code>href</code> takes an absolute or relative URI reference, to be 
-                        resolved as described in <specref ref="uri-references"/>, to locate the 
-                        <termref def="dt-package-manifest">package manifest</termref>.</p>
-                    <p>The attribute <code>priority</code> takes an integer, default value 0 if the
-                        attribute is absent, indicating how significant the package location is.</p>
+                        assigned different priority levels, provide fallback mechanisms for
+                        packages that cannot be located at the preferred location, or enable
+                        developers to conduct diagnostic analysis.</p>
+
+                    <?element xsl:package-location?>
+
+                    <p>The attribute <code>href</code> takes an absolute or relative URI reference,
+                        resolved as described in <specref ref="uri-references"/>, to locate the
+                            <termref def="dt-package-manifest">package manifest</termref>.</p>
+                    <p>The attribute <code>priority</code> takes a unique integer, excluding 0,
+                        declaring how important the package location is relative to other 
+                        package locations. If two or more <elcode>xsl:package-location</elcode>
+                        declarations have the same priority value, a static error is raised.</p>
                     <p>The attribute <code>format</code> takes a string, default value
                             <code>xslt</code> if the attribute is absent, specifying the format of
                         the package. The value <code>xslt</code> indicates that the <termref
                             def="dt-package-manifest">package manifest</termref> is a standard XML
-                        file in the XSLT namespace. All other values are <termref
+                        file as described in these specifications. All other values are <termref
                             def="dt-implementation-defined"/>, allowing implementers to support a
-                        package manifest in a compiled or optimized format that differs from the
-                        XSLT format described in these specifications.</p>
-                    
-                    <p>A list of package locations is built as follows:</p>
+                        package manifest in an optimized format, be it a different XML format or a
+                        binary resource.</p>
+                    <p>In any <termref def="dt-implementation-defined"/> mechanism, user-configured
+                        package locations must be assigned a unique decimal priority greater than -1
+                        and less than 1. Assignment of that priority value is <termref
+                            def="dt-implementation-defined"/>. If two or more
+                            <elcode>xsl:package-location</elcode> declarations have the same
+                        priority value, a static error is raised.</p>
+
+                    <p>All package locations are sorted by priority value, in descending order. Each
+                        package location is processed in order of priority. <termdef
+                            id="dt-priority-package-location" term="priority package location">The
+                            first package location whose value of <code>href</code>, when resolved
+                            as described in <specref ref="uri-references"/>, allows the system to
+                            find the specified file, and its entry if the file is an archive, is
+                            the <term>priority package location</term>.</termdef> Once a priority
+                        package location is found, no other package locations are sought. </p>
+                    <p>For a package location to be accepted as a priority package location, one of
+                        the following conditions must be met:</p>
                     <olist>
                         <item>
-                            <p>Each <elcode>xsl:use-package</elcode> is assigned a priority, either
-                                through the explicit value of the attribute <code>priority</code> or
-                                0, if the attribute is absent. </p>
+                            <p>If the explicit or implicit URI scheme declared in attribute
+                                    <code>href</code> expects a single file or file fragment (e.g.,
+                                    <code>file:</code>, <code>http:</code>), the file must be
+                                available at that URI. That file is to be treated as the <termref
+                                    def="dt-package-manifest"/>.</p>
                         </item>
                         <item>
-                            <p>In any <termref def="dt-implementation-defined"/> mechanism,
-                                user-configured package locations must be assigned a unique decimal
-                                priority greater than negative 1 and less than zero. Assignment of that priority
-                                value is <termref def="dt-implementation-defined"/>.</p>
-                        </item>
-                        <item>
-                            <p>Package locations are sorted, highest priority first.</p>
+                            <p>If the explicit or implicit URI scheme declared in attribute
+                                    <code>href</code> points to an archive (e.g., <code>jar:</code>)
+                                the file must be located within the URL part of the URI, and the
+                                specified entry must be found within the archive. The entry is to be
+                                treated as the <termref def="dt-package-manifest"/>.</p>
                         </item>
                     </olist>
-                    <p>If after static analysis two or more <elcode>xsl:package-location</elcode>s
-                        have the same priority value, a <termref def="dt-static-error"/> is raised. </p>
-                    <p><termdef id="dt-priority-package-location" term="priority package location">The first package
-                            location whose value of <code>href</code>, when resolved as described in
-                                <specref ref="uri-references"/>, allows the system to find the file
-                            specified, is the <term>priority package location</term>.</termdef> Once a 
-                        priority package location is found, no other package locations are checked.</p>
-                    <p>In many cases the URI scheme will be <code>file:</code>, <code>http:</code>,
-                        or a similar protocol that points to a single file or fragment. In other
-                        cases, the URI scheme will be <code>jar:</code> or a similar protocol that
-                        points both to a compressed archive and a file within that archive. In the
-                        case of the latter, the resolution process described above must succeed in
-                        retrieving both a file that is a compressed archive and the component
-                        specified within that compressed archive. If either condition fails, the
-                        package location cannot be accepted as a <termref def="dt-priority-package-location"/>.
-                    </p>
-                    <p>The file returned from the priority package location is checked against the implicit
-                        or explicit value of the attribute <code>format</code>. If the file does
-                        not conform to the rules for the format type a <termref def="dt-dynamic-error"/> 
-                        is raised.</p>
-                 
-                    <p>The file is then checked against the the package
-                         name and version specified in an <elcode>xsl:use-package</elcode>implicit
-                        or explicit value of the attribute <code>format</code>. If the file does
-                        not conform to the rules for the format type a <termref def="dt-dynamic-error"/> 
-                        is raised.</p>
-                 
-                    <p>The <termref def="dt-package-manifest"/> is processed against the 
-                        base uri supplied by the <termref def="dt-priority-package-location"/>, whether 
-                        or not that package manifest is part of a compressed archive.</p>
+                    <p>The <termref def="dt-package-manifest"/> returned from the priority package
+                        location is checked against the implicit or explicit value of the attribute
+                            <code>format</code>. If the file does not conform to the rules for the
+                        format type a <termref def="dt-static-error"/> is raised.</p>
 
-                    <p>Use of the package name as a dereferenceable URI is <rfc2119>not
-                            recommended</rfc2119>, because the intent of the packaging feature is to
-                        allow a package to be distributed as reusable code and therefore to exist in
-                        many different locations.</p>
-                 
-                 <p><error spec="XT" type="static" class="SE" code="3000">
-                     <p>It is a <termref def="dt-static-error"/> if no package matching the package
-                         name and version specified in an <elcode>xsl:use-package</elcode>
-                         declaration can be located.</p>
-                 </error></p>
-                 
-                 <p><error spec="XT" type="static" class="SE" code="3002">
+                    <p>The <termref def="dt-package-manifest"/> is then checked against the the
+                        package name and version specified in the <elcode>xsl:use-package</elcode>
+                        declaration. If the file does not conform to the rules for the name and
+                        version, a <termref def="dt-static-error"/> is raised.</p>
+
+                    <p><error spec="XT" type="static" class="SE" code="3000">
+                            <p>It is a <termref def="dt-static-error"/> if after evaluating each
+                                    <elcode>xsl:package-location</elcode> declaration and <termref
+                                    def="dt-implementation-defined"/> package location, in priority
+                                order, no <termref def="dt-priority-package-location"/> is
+                                found.</p>
+                        </error></p>
+
+                    <p><error spec="XT" type="static" class="SE" code="3002">
                             <p>It is a <termref def="dt-static-error"/> if more than one
                                     <elcode>xsl:package-location</elcode> have the same implicit or
                                 explicit priority.</p>
-                 </error></p>
-                 
-                 <p><error spec="XT" type="static" class="SE" code="3003">
-                            <p>It is a <termref def="dt-dynamic-error"/> if the file returned by the 
-                                <termref def="dt-priority-package-location"/> does not conform to the rules
-                                of the implicit or explicit value of attribute <code>format</code>.</p>
-                 </error></p>
-                 
-                 <note>
-                     <p>Depending on the implementation architecture, there may be a need to locate
-                         used packages both during static analysis (for example, to get information
-                         about the names and type signatures of the components exposed by the used
-                         package), and also at evaluation time (to link to the implementation of these
-                         components so they can be invoked). A failure to locate a package may cause an
-                         error at either stage.</p>
-                 </note>
-                 
-                 <example id="example-of-package-locations">
-                     <head>Example configuration of <elcode>xsl:package-location</elcode>s.</head>
-                     
-                     
-                     <p>Consider a using package <var>Q</var>, invoked as follows:</p>
-                     
-                     <eg role="xslt-document" xml:space="preserve">&lt;xsl:use-package name="Q" version="3.0"
-xmlns:saxon="http://saxon.sf.net/"/&gt;
-     &lt;package-location href="q-dev.xsl" priority="1" use-when="$diagnostics-on"/&gt;
-     &lt;package-location href="jar:file:/{$prod-path}/q.zip!/q.sef" format="saxon:sef"/&gt;
+                        </error></p>
+
+                    <p><error spec="XT" type="static" class="SE" code="3003">
+                            <p>It is a <termref def="dt-static-error"/> if the <termref
+                                    def="dt-package-manifest"/> returned by the <termref
+                                    def="dt-priority-package-location"/> does not conform to the
+                                rules of the implicit or explicit value of attribute
+                                    <code>format</code>.</p>
+                        </error></p>
+
+                    <p><error spec="XT" type="static" class="SE" code="3004">
+                            <p>It is a <termref def="dt-static-error"/> if the <termref
+                                    def="dt-package-manifest"/> returned by the <termref
+                                    def="dt-priority-package-location"/> does not conform to the
+                                name and version specified in an <elcode>xsl:use-package</elcode>
+                                declaration.</p>
+                        </error></p>
+                    
+                    <note>
+                        <p>Use of the package name as a dereferenceable URI is <rfc2119>not
+                                recommended</rfc2119>, because the intent of the packaging feature
+                            is to allow a package to be distributed as reusable code and therefore
+                            to exist in many different locations.</p>
+                    </note>
+
+                    <note>
+                        <p>Depending on the implementation architecture, there may be a need to
+                            locate used packages both during static analysis (for example, to get
+                            information about the names and type signatures of the components
+                            exposed by the used package), and also at evaluation time (to link to
+                            the implementation of these components so they can be invoked). A
+                            failure to locate a package may cause an error at either stage.</p>
+                    </note>
+
+                    <example id="example-of-package-locations">
+                        <head>Example configuration of
+                            <elcode>xsl:package-location</elcode>s.</head>
+
+
+                        <p>Consider a using package <var>Q</var>, invoked as follows:</p>
+
+                        <eg role="xslt-document" xml:space="preserve">&lt;xsl:use-package name="Q" version="3.0" xmlns:saxon="http://saxon.sf.net/"/&gt;
+     &lt;package-location href="q-dev.xsl" priority="2" use-when="$diagnostics-on"/&gt;
+     &lt;package-location href="jar:file:/{$prod-path}/q.zip!/q.sef" 
+           priority="1" format="saxon:sef"/&gt;
      &lt;package-location href="file:/D:/fallback/q.xsl" format="xslt" priority="-1"/&gt;
 &lt;/xsl:package&gt;</eg>
-                     
-                        <p>The first <elcode>xsl:package-location</elcode> will not be evaluated if
-                            the static parameter is false. If it is true, then the package manifest
-                            will be looked for in the relative path <code>q-dev.xsl</code>, and
-                            become the priority package location if a file is found.</p>
-                     
-                     <p>Otherwise</p>
-                     
-                 </example>
-                 
-             </div3>
+
+                        <p>If the static parameter <code>$diagnostics-on</code> is false, the first
+                                <elcode>xsl:package-location</elcode> will not be evaluated,
+                            otherwise it will be the first <elcode>xsl:package-location</elcode> to
+                            be evaluated. Next in priority will be any file located by the relative
+                            path <code>q-dev.xsl</code>. Next will be any <termref
+                                def="dt-implementation-defined"/> package locations. Last will be
+                            the package location with priority <code>-1</code>. Each of these
+                            package locations will be evaluated in turn. Only the first successfully
+                            found resources will be further evaluated, to ensure it conforms to the
+                            file type and the file format.</p>
+
+                    </example>
+
+                </div3>
              
             <div3 id="named-components">
                <head>Named Components in Packages</head>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -3586,27 +3586,9 @@ Michael Sperberg-McQueen (1954–2024).</p>
                      match the version range given in the <code>package-version</code>
                      attribute.</p>
 
+               <p>Rules for determining the location of the package are described at 
+                   <specref ref="package-locations"/>.</p>
                
-
-               <p>This specification does not define how the implementation locates a package given
-                  its name and version. If several matching
-                     versions of a package are available, it does not define which of them is
-                     chosen. Nor does it define whether this process locates source code or
-                  some other representation of the package contents. Such mechanisms are <termref def="dt-implementation-defined"/>. Use of the package name as a dereferenceable
-                  URI is <rfc2119>not recommended</rfc2119>, because the intent of the packaging
-                  feature is to allow a package to be distributed as reusable code and therefore to
-                  exist in many different locations.</p>
-
-               <imp-def-feature id="idf-api-packageversions">It is <termref def="dt-implementation-defined"/> how a package is located given its name and
-                  version, and which version of a package is chosen if several are
-                  available.</imp-def-feature>
-
-               <p><error spec="XT" type="static" class="SE" code="3000">
-                     <p>It is a <termref def="dt-static-error"/> if no package matching the package
-                        name and version specified in an <elcode>xsl:use-package</elcode>
-                        declaration can be located.</p>
-                  </error></p>
-
                <p><error spec="XT" type="static" class="SE" code="3005">
                      <p>It is a <termref def="dt-static-error"/> if a package is dependent on
                         itself, where package <var>A</var> is defined as being dependent on package
@@ -3622,16 +3604,6 @@ Michael Sperberg-McQueen (1954–2024).</p>
                   same <termref def="dt-stylesheet-level"/> as the <termref def="dt-principal-stylesheet-module"/>
                   of the <termref def="dt-package"/>.</p>
                </error></p>
-
-               <note>
-                  <p>Depending on the implementation architecture, there may be a need to locate
-                     used packages both during static analysis (for example, to get information
-                     about the names and type signatures of the components exposed by the used
-                     package), and also at evaluation time (to link to the implementation of these
-                     components so they can be invoked). A failure to locate a package may cause an
-                     error at either stage.</p>
-               </note>
-
 
 
                <p>The <elcode>xsl:accept</elcode> and <elcode>xsl:override</elcode> elements are
@@ -3653,7 +3625,136 @@ Michael Sperberg-McQueen (1954–2024).</p>
                </note>
 
             </div3>
+             
+             <div3 id="package-locations">
+                 <head>Locating Packages</head>
+                 
+                    <p>A package may be located either explicitly, through one or more
+                            <elcode>xsl:use-package</elcode>s, or implicitly, in an <termref
+                            def="dt-implementation-defined"/> mechanism. Multiple package locations,
+                        assigned different priority levels, allow developers to provide fallback
+                        mechanisms, or diagnose problems.</p>
+                 
+                 <?element xsl:package-location?>
+                    
+                    <p>The attribute <code>href</code> takes an absolute or relative URI reference, to be 
+                        resolved as described in <specref ref="uri-references"/>, to locate the 
+                        <termref def="dt-package-manifest">package manifest</termref>.</p>
+                    <p>The attribute <code>priority</code> takes an integer, default value 0 if the
+                        attribute is absent, indicating how significant the package location is.</p>
+                    <p>The attribute <code>format</code> takes a string, default value
+                            <code>xslt</code> if the attribute is absent, specifying the format of
+                        the package. The value <code>xslt</code> indicates that the <termref
+                            def="dt-package-manifest">package manifest</termref> is a standard XML
+                        file in the XSLT namespace. All other values are <termref
+                            def="dt-implementation-defined"/>, allowing implementers to support a
+                        package manifest in a compiled or optimized format that differs from the
+                        XSLT format described in these specifications.</p>
+                    
+                    <p>A list of package locations is built as follows:</p>
+                    <olist>
+                        <item>
+                            <p>Each <elcode>xsl:use-package</elcode> is assigned a priority, either
+                                through the explicit value of the attribute <code>priority</code> or
+                                0, if the attribute is absent. </p>
+                        </item>
+                        <item>
+                            <p>In any <termref def="dt-implementation-defined"/> mechanism,
+                                user-configured package locations must be assigned a unique decimal
+                                priority greater than negative 1 and less than zero. Assignment of that priority
+                                value is <termref def="dt-implementation-defined"/>.</p>
+                        </item>
+                        <item>
+                            <p>Package locations are sorted, highest priority first.</p>
+                        </item>
+                    </olist>
+                    <p>If after static analysis two or more <elcode>xsl:package-location</elcode>s
+                        have the same priority value, a <termref def="dt-static-error"/> is raised. </p>
+                    <p><termdef id="dt-priority-package-location" term="priority package location">The first package
+                            location whose value of <code>href</code>, when resolved as described in
+                                <specref ref="uri-references"/>, allows the system to find the file
+                            specified, is the <term>priority package location</term>.</termdef> Once a 
+                        priority package location is found, no other package locations are checked.</p>
+                    <p>In many cases the URI scheme will be <code>file:</code>, <code>http:</code>,
+                        or a similar protocol that points to a single file or fragment. In other
+                        cases, the URI scheme will be <code>jar:</code> or a similar protocol that
+                        points both to a compressed archive and a file within that archive. In the
+                        case of the latter, the resolution process described above must succeed in
+                        retrieving both a file that is a compressed archive and the component
+                        specified within that compressed archive. If either condition fails, the
+                        package location cannot be accepted as a <termref def="dt-priority-package-location"/>.
+                    </p>
+                    <p>The file returned from the priority package location is checked against the implicit
+                        or explicit value of the attribute <code>format</code>. If the file does
+                        not conform to the rules for the format type a <termref def="dt-dynamic-error"/> 
+                        is raised.</p>
+                 
+                    <p>The file is then checked against the the package
+                         name and version specified in an <elcode>xsl:use-package</elcode>implicit
+                        or explicit value of the attribute <code>format</code>. If the file does
+                        not conform to the rules for the format type a <termref def="dt-dynamic-error"/> 
+                        is raised.</p>
+                 
+                    <p>The <termref def="dt-package-manifest"/> is processed against the 
+                        base uri supplied by the <termref def="dt-priority-package-location"/>, whether 
+                        or not that package manifest is part of a compressed archive.</p>
 
+                    <p>Use of the package name as a dereferenceable URI is <rfc2119>not
+                            recommended</rfc2119>, because the intent of the packaging feature is to
+                        allow a package to be distributed as reusable code and therefore to exist in
+                        many different locations.</p>
+                 
+                 <p><error spec="XT" type="static" class="SE" code="3000">
+                     <p>It is a <termref def="dt-static-error"/> if no package matching the package
+                         name and version specified in an <elcode>xsl:use-package</elcode>
+                         declaration can be located.</p>
+                 </error></p>
+                 
+                 <p><error spec="XT" type="static" class="SE" code="3002">
+                            <p>It is a <termref def="dt-static-error"/> if more than one
+                                    <elcode>xsl:package-location</elcode> have the same implicit or
+                                explicit priority.</p>
+                 </error></p>
+                 
+                 <p><error spec="XT" type="static" class="SE" code="3003">
+                            <p>It is a <termref def="dt-dynamic-error"/> if the file returned by the 
+                                <termref def="dt-priority-package-location"/> does not conform to the rules
+                                of the implicit or explicit value of attribute <code>format</code>.</p>
+                 </error></p>
+                 
+                 <note>
+                     <p>Depending on the implementation architecture, there may be a need to locate
+                         used packages both during static analysis (for example, to get information
+                         about the names and type signatures of the components exposed by the used
+                         package), and also at evaluation time (to link to the implementation of these
+                         components so they can be invoked). A failure to locate a package may cause an
+                         error at either stage.</p>
+                 </note>
+                 
+                 <example id="example-of-package-locations">
+                     <head>Example configuration of <elcode>xsl:package-location</elcode>s.</head>
+                     
+                     
+                     <p>Consider a using package <var>Q</var>, invoked as follows:</p>
+                     
+                     <eg role="xslt-document" xml:space="preserve">&lt;xsl:use-package name="Q" version="3.0"
+xmlns:saxon="http://saxon.sf.net/"/&gt;
+     &lt;package-location href="q-dev.xsl" priority="1" use-when="$diagnostics-on"/&gt;
+     &lt;package-location href="jar:file:/{$prod-path}/q.zip!/q.sef" format="saxon:sef"/&gt;
+     &lt;package-location href="file:/D:/fallback/q.xsl" format="xslt" priority="-1"/&gt;
+&lt;/xsl:package&gt;</eg>
+                     
+                        <p>The first <elcode>xsl:package-location</elcode> will not be evaluated if
+                            the static parameter is false. If it is true, then the package manifest
+                            will be looked for in the relative path <code>q-dev.xsl</code>, and
+                            become the priority package location if a file is found.</p>
+                     
+                     <p>Otherwise</p>
+                     
+                 </example>
+                 
+             </div3>
+             
             <div3 id="named-components">
                <head>Named Components in Packages</head>
 
@@ -12736,8 +12837,8 @@ return $tree =?> depth()]]></eg>
                   <p>As identifiers for resources such as stylesheet modules; these resources are
                      typically accessible using a protocol such as HTTP. Examples of such
                      identifiers are the URIs used in the <code>href</code> attributes of
-                        <elcode>xsl:import</elcode>, <elcode>xsl:include</elcode>, and
-                        <elcode>xsl:result-document</elcode>.</p>
+                        <elcode>xsl:import</elcode>, <elcode>xsl:include</elcode>, 
+                        <elcode>xsl:result-document</elcode>, and <elcode>xsl:package-location</elcode>.</p>
                </item>
             </ulist>
             <p>The rules for namespace URIs are given in <bibref ref="xml-names"/> and <bibref ref="xml-names11"/>. Those specifications deprecate the use of relative URI


### PR DESCRIPTION
First draft, for initial feedback.

Notes:
- Because the CG has little energy/resources to develop the EXPath Zip module, I have situated the question of archive (compressed or not) in the URI scheme itself. There are dozens of archives, dozens of URI schemes. The only case where I have found overlap is in the `jar:` scheme/archive. Yes, I've seen `zip:` used as an alias for `jar:`, but it's not an official IANA URI scheme. This may need discussion.
- I have opted to bind `@priority` to a non-zero integer. This is the first time the constraint for the union of positive and negative integers has been placed on an XSLT attribute, so I may not have correctly set up `element-catalog.xml`.
- I have opted to not make attribute values `format`, `name`, and `version` as criteria for the priority package location (new term), so that developers can be warned when the package is at odds with the declaration. To make them criteria would mean that inconsistencies between the declaration and the referenced packages would remain undetected.
- I adopted the terms "URL" and "entry" based upon the IANA nomenclature for the jar: scheme.
- I may have overthought the distinction between archive and non-archive URIs. Feedback is appreciated.
- Error code `3000` has been broken up into different possible errors.
- Suggestions on the type and number of tests that need to be written for the test suite are welcome.