### PR TITLE
Fix broken markup

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -14188,6 +14188,7 @@ ISBN 0 521 77752 6.</bibl>
               existing key, in the case where the existing key and the new key differ (for example,
               if they have different type annotations), it is no longer guaranteed that the new
               entry includes the new key rather than the existing key.</p>
+		   </item>
 
            <item>
               <p>In regular expressions, the assertions <code>^</code> and <code>$</code> can no longer be


### PR DESCRIPTION
I cannot imagine how we got a merged PR that included broken markup, but it's probably made a mess of the diffs recently.