### PR TITLE
1881 Function identity for maps and arrays

### DIFF
--- a/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
+++ b/specifications/xpath-datamodel-40/src/xpath-datamodel.xml
@@ -5673,7 +5673,7 @@ must equal the function’s arity.
 
 <p><termdef term="map item" id="dt-map-item">A <term>map item</term>
 (also called simply a <term>map</term>)
-is an item that represents an ordered sequence of key/value pairs,
+is a <termref def="dt-function-item"/> that represents an ordered sequence of key/value pairs,
 in which the keys are unique.</termdef> 
   In other languages this is sometimes 
 called a hash, dictionary, or associative array.
@@ -5685,6 +5685,53 @@ values, only on keys. The semantics of equality when comparing keys are describe
   
   <p><termdef id="dt-entry" term="entry">The key/value pairs in a map are
     referred to as <term>entries</term>.</termdef></p>
+  
+    <p>Considered as a <termref def="dt-function-item"/>, a map is a function from
+  atomic items to values: if <var>M</var> is a map and <var>K</var> is an atomic item,
+  then the function call <code><var>M</var>(<var>K</var>)</code> returns the
+  value associated with the key <var>K</var>, if present, or an empty sequence otherwise. More specifically,
+    the properties of a map when considered as a function item are:</p>
+  
+  <ulist>
+  <item>
+    <p>
+      <term>name</term>:
+      <termref def="dt-absent">absent</termref>. 
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>identity</term>: <termref def="dt-implementation-dependent"/>.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>parameter names</term>: A single parameter named <code>key</code>, in no namespace.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>signature</term>: <code>function(xs:anyAtomicType) as item()*</code>.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>annotations</term>: none.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>body</term>: equivalent to a call on <function>map:get</function>.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>captured context</term>: empty.
+    </p>
+  </item>
+</ulist>
+  
+  
   
   <p><termdef id="dt-single-entry-map" term="single-entry map">A map containing exactly
     one entry is referred to as a <term>single-entry map</term>.</termdef></p>
@@ -5807,13 +5854,64 @@ values, only on keys. The semantics of equality when comparing keys are describe
 
 <p><termdef term="array item" id="dt-array-item">An <term>array item</term> 
   (also called simply an <term>array</term>)
-is a value that represents an array.</termdef>
+is a <termref def="dt-function-item"/> that represents an array.</termdef>
 <termdef id="dt-member" term="member">An array is an ordered list of values; these values are called the
 <term>members</term> of the array.</termdef> Unlike sequences, a member of an array can be
 any value (including a sequence or an array). The number of members in
 an array is called its size, and they are referenced by their
 position, in the range 1 to the size of the array.</p>
   
+  <p>Considered as a <termref def="dt-function-item"/>, an array is a function from
+  integers to values: if <var>A</var> is an array and <var>N</var> is an integer,
+  then the function call <code><var>A</var>(<var>N</var>)</code> returns the
+  <var>N</var>th member of the array (counting from one). More specifically,
+  the properties of an array, considered as a function item, are:</p>
+  
+  <p>Considered as a <termref def="dt-function-item"/>, a map is a function from
+  atomic items to values: if <var>M</var> is a map and <var>K</var> is an atomic item,
+  then the function call <code><var>M</var>(<var>K</var>)</code> returns the
+  value associated with the key <var>K</var>, if present, or an empty sequence otherwise. More specifically,
+    the properties of a map when considered as a function item are:</p>
+  
+  <ulist>
+  <item>
+    <p>
+      <term>name</term>:
+      <termref def="dt-absent">absent</termref>. 
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>identity</term>: <termref def="dt-implementation-dependent"/>.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>parameter names</term>: A single parameter named <code>index</code>, in no namespace.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>signature</term>: <code>function(xs:integer) as item()*</code>.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>annotations</term>: none.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>body</term>: equivalent to a call on <function>array:get</function>.
+    </p>
+  </item>
+  <item>
+    <p>
+      <term>captured context</term>: empty.
+    </p>
+  </item>
+</ulist>
+ 
   <p><termdef id="dt-single-member-array" term="single-member array">An array containing exactly
     one member is referred to as a <term>single-member array</term>.</termdef></p>
   

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -16532,7 +16532,9 @@ declare function equal-strings(
 }]]></eg>
          <p>The rules for deciding whether two items <code>$i1</code> and <code>$i2</code> are deep-equal
             are as follows.</p>
-         <p>The two items are first compared using the function supplied in the <code>items-equal</code>
+         <p>Labels (see <xspecref spec="DM40" ref="id-LabeledItems"/>) are ignored. Specifically, if
+         <code>$i1</code> or <code>$i2</code> is a labeled item then it is replaced by its subject.</p>
+         <p>The two items are next compared using the function supplied in the <code>items-equal</code>
             option. If this returns <code>true</code> then the items are deep-equal. If it returns
             <code>false</code> then the items are not deep-equal. If it returns an empty sequence
             (which is always the case if the option is not explicitly specified)
@@ -20987,19 +20989,39 @@ return function-arity($initial)</eg></fos:expression>
 	      and <code>fn:function-identity($f2)</code> are codepoint-equal if and only if <code>$f1</code>
 	      and <code>$f2</code> have the same function identity. Apart from this property, the
 	      result is <termref def="implementation-dependent"/>.</p>
+	     <p>Any label attached to a function item is ignored (see <xspecref spec="DM40" ref="id-LabeledItems"/>).
+	     Specifically, if <var>L</var> is a labeled item then <code>fn:function-identity(<var>L</var>)</code> returns
+	     the function identity of the subject of <var>L</var>.</p>
+	     <p>In the case of maps and arrays, the result follows the following rule:
+	        If <code>$X</code> are both maps or arrays then <code>fn:function-identity($X)</code>
+	        <rfc2119>must not</rfc2119> be codepoint-equal to <code>fn:function-identity($Y)</code> unless
+	        <code>$X</code> and <code>$Y</code> are indistinguishable, that is unless every operator or function applied
+	        to <code>$X</code> returns the same result as for <code>$Y</code>. Even in this case, however, the
+	        result of the comparison <code>fn:function-identity($X) eq fn:function-identity($Y)</code>
+	        is <termref def="implementation-dependent"/>.</p>
       </fos:rules>
 	  <fos:notes>
 	     <p>This function enables applications to test whether two expressions or variables
-	        reference the same function. This may be useful, for example, to allow caching
+	        reference the same function item. This may be useful, for example, to allow caching
 	        of function results to avoid repeated evaluation. The results of previous function
 	        invocations might be held in a map whose key is the function identity.</p>
-		<p>The function identity, by definition, is generated upon the creation of a function. 
-		   It is not meaningful to store or compare the result 
+		<p>The function identity, by definition, is generated upon the creation of a function item.
+		   Specific expressions that create function items have their own rules for the identity
+		   of the returned functions: for example, it is guaranteed that evaluation of a function
+		   reference to a system function with no captured context (such as <code>fn:abs#1</code>)
+		   will always return the same function item.</p>
+		   <p>It is not meaningful to store or compare the result of calling <function>fn:function-identity</function> 
 		   across different <termref def="execution-scope">execution scopes</termref>, because the string used 
 		   to represent the function identity will generally vary from one execution scope to another.</p>
 	     <p>The result of an expression such as <code>function-identity(abs#1) eq function-identity(abs(?))</code>
 	     may be either <code>true</code> or <code>false</code>, because it is <termref def="implementation-dependent"/> 
-	        whether <code>abs#1</code> and <code>abs(?)</code> return the same function.</p>
+	        whether <code>abs#1</code> and <code>abs(?)</code> return the same function item.</p>
+	     <p>Similarly, <code>function-identity({1:()}) eq function-identity(map:entry(1, ()))</code>
+	     may be either <code>true</code> or <code>false</code>.</p>
+	     <p>Labels on function items are ignored because they typically represent information about how the
+	     function item was retrieved, rather than about the item itself. For example, a function item held in a map
+	     might be retrieved using a variety of lookup expressions, which may return the same function item but with
+	     different labels.</p>
 	  </fos:notes>
       <fos:examples>
          <fos:example>
@@ -21009,6 +21031,14 @@ return function-arity($initial)</eg></fos:expression>
             </fos:test>
             <fos:test>
                <fos:expression>function-identity(abs#1) eq function-identity(round#1)</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>function-identity({1:0}) eq function-identity({1:1})</fos:expression>
+               <fos:result>false()</fos:result>
+            </fos:test>
+            <fos:test>
+               <fos:expression>function-identity([0]) eq function-identity([1]})</fos:expression>
                <fos:result>false()</fos:result>
             </fos:test>
          </fos:example>


### PR DESCRIPTION
Supplies rules for how `fn:function-identity()` should handle maps and arrays.

Also makes the point that labels are ignored. There's a general statement to the effect in XDM that labels are ignored except where otherwise specified, but it's useful to avoid any doubt here.

Fix #1881