### PR TITLE
1363 fallback becomes a value not a function

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -329,7 +329,7 @@
          
          <p>Except in error cases (described below), 
                   the function call <code>$csv?get($R, $C)</code>, where <code>$C</code>
-                  is an integer, returns the value of <code>$csv?rows[$R] => array:get($C, fn { "" })</code>,
+                  is an integer, returns the value of <code>$csv?rows[$R] => array:get($C, "")</code>,
                   and the function call <code>$csv?get($R, $K)</code>, where <code>$K</code>
                   is a string, returns the value of <code>$csv?get($R, $csv?column-index($K))</code>.</p>
 
@@ -16247,8 +16247,8 @@ return contains-subsequence(
          <p>The function can be used to discard unneeded output of expressions
             (functions, third-party libraries, etc.).</p>
          <p>It can also be used to discard results during development.</p>
-         <p>The function is utilized by built-in functions such as <function>map:get</function>
-            to return an empty sequence for arbitrary input.</p>
+         <!--<p>The function is utilized by built-in functions such as <function>map:get</function>
+            to return an empty sequence for arbitrary input.</p>-->
          <p>It is <termref def="implementation-dependent">implementation-dependent</termref>
             whether the supplied argument is evaluated or ignored. An implementation may decide to
             evaluate <termref def="dt-nondeterministic">nondeterministic</termref> expressions and
@@ -16260,11 +16260,11 @@ return contains-subsequence(
                <fos:expression>void(1 to 1000000)</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
-            <fos:test>
+            <!--<fos:test>
                <fos:expression>array:get(array { 1, 2, 3 }, 4, void#1)</fos:expression>
                <fos:result>()</fos:result>
                <fos:postamble>Without the third argument, an error would be raised.</fos:postamble>
-            </fos:test>
+            </fos:test>-->
             <fos:test>
                <fos:expression>for $f in (identity#1, void#1) return $f(123)</fos:expression>
                <fos:result>123</fos:result>
@@ -24531,7 +24531,7 @@ map:size($map) eq 0
          <fos:proto name="get" return-type="item()*">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
             <fos:arg name="key" type="xs:anyAtomicType"/>
-            <fos:arg name="fallback" type="(fn($key as xs:anyAtomicType) as item()*)?" default="void#1"/>
+            <fos:arg name="fallback" type="item()*" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24549,9 +24549,7 @@ map:size($map) eq 0
             the <termref
                def="dt-same-key"
                >same key</termref> as <code>$key</code>. If there is such an entry, it returns the associated value;
-            <phrase diff="chg" at="2022-12-16">if not, it invokes the supplied <code>$fallback</code> function, supplying
-            the requested <code>$key</code> value as the argument, and returns the result of this call.
-               The default <code>$fallback</code> function always returns an empty sequence.</phrase></p>
+            if not, it returns the supplied <code>$fallback</code> value, which defaults to the empty sequence.</p>
 
       </fos:rules>
       <fos:equivalent style="dm-primitive">
@@ -24563,17 +24561,17 @@ let $entry := dm:iterate-map($map, fn($k, $v) {
 return (
   if (exists($entry))
   then map:items($entry)
-  else $fallback($key)
+  else $fallback
 )
       </fos:equivalent>
       <fos:notes>
-         <p>A return value of <code>()</code> from <function>map:get</function> could indicate that
+         <p>A return value of <code>()</code> from <function>map:get#2</function> could indicate that
             the key is present in the map with an associated value of <code>()</code>, or it could
             indicate that the key is not present in the map. The two cases can be distinguished by
-            calling <function>map:contains</function><phrase diff="add" at="2022-12-16">, or by using
-            a <code>$fallback</code> function to return a value known never to appear in the map</phrase>.</p>
+            either by calling <function>map:contains</function> to test whether an entry is present, or by using
+            a <code>$fallback</code> value to return a value known never to appear in the map.</p>
          
-         <p diff="add" at="2022-12-16">The <code>$fallback</code> function can be used in a number of ways:</p>
+         <!--<p diff="add" at="2022-12-16">The <code>$fallback</code> function can be used in a number of ways:</p>
          
          <ulist diff="add" at="2022-12-16">
             <item><p>It might return a conventional value such as <code>NaN</code> to indicate that no matching
@@ -24583,12 +24581,12 @@ return (
             abbreviations, such as <code>{ 'CA': 'Canada', 'UK': 'United Kingdom', 'US': 'United States' }</code>,
             then specifying <code>fallback := fn:identity#1</code> has the effect that the key value is returned
             unchanged if it is not found in the map.</p></item>
-         </ulist>
+         </ulist>-->
 
          <p>Invoking the <termref def="dt-map"
                >map</termref> as a function item has the same effect
-            as calling <code>get</code> <phrase diff="add" at="2022-12-16">with no <code>$fallback</code>
-            function</phrase>: that is, when <code>$map</code> is a map, the expression
+            as calling <code>get</code> with no <code>$fallback</code>
+            argument: that is, when <code>$map</code> is a map, the expression
                <code>$map($K)</code> is equivalent to <code>map:get($map, $K)</code>. Similarly, the
             expression <code>map:get(map:get(map:get($map, 'employee'), 'name'), 'first')</code> can
             be written as <code>$map('employee')('name')('first')</code>.</p>
@@ -24615,15 +24613,20 @@ return (
                   present and the associated value is an empty sequence.</fos:postamble>
             </fos:test>
             <fos:test>
+               <fos:expression>map:get($week, 7, "n/a")</fos:expression>
+               <fos:result>"n/a"</fos:result>
+               <fos:postamble>The third argument supplies a default value.</fos:postamble>
+            </fos:test>
+            <!--<fos:test>
                <fos:expression><eg>{ 1: "single", 2: "double", 3: "triple" }
 => map:get(10, fn { . || "-fold" })</eg></fos:expression>
                <fos:result>"10-fold"</fos:result>
                <fos:postamble>The map holds special cases; the fallback function handles other cases.</fos:postamble>
-            </fos:test>
+            </fos:test>-->
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change><p>A third argument is added, allowing user control of how absent keys should be handled.</p></fos:change>
+         <fos:change issue="1363" PR="289"><p>A third argument is added, allowing user control of how absent keys should be handled.</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -28769,8 +28772,11 @@ array:size($array) eq 0
          <fos:proto name="get" return-type="item()*">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
             <fos:arg name="position" type="xs:integer"/>
-            <fos:arg name="fallback" type="(fn(xs:integer) as item()*)?" 
-               default="fn($i) { fn:error(fn:QName('', 'FOAY0001')) }"/>
+         </fos:proto>
+         <fos:proto name="get" return-type="item()*">
+            <fos:arg name="array" type="array(*)" usage="inspection"/>
+            <fos:arg name="position" type="xs:integer"/>
+            <fos:arg name="fallback" type="item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -28783,22 +28789,31 @@ array:size($array) eq 0
             (counting from 1).</p>
       </fos:summary>
       <fos:rules>
-         <p diff="chg" at="2022-12-16">Informally, the function returns the member at a specified position in the array.
-         If <code>$position</code> is less than one or greater than <code>array:size($array)</code>,
-         then the <code>$fallback</code> function is called, supplying the value of <code>$position</code>
+         <p diff="chg" at="2022-12-16">Informally, the function returns the member at a specified position in the array.</p>
+         
+         <p>If <code>$position</code> is out of bounds (that is, if
+         it is less than one or greater than <code>array:size($array)</code>), then the effect 
+            depends on the number of arguments:</p>
+         
+         <ulist>
+            <item><p>When there are two arguments, an error is raised (<errorref class="AY" code="0001"/>).</p></item>
+            <item><p>When there are three arguments, the value of <code>$fallback</code> is returned.</p></item>
+         </ulist>
+         <!--then the <code>$fallback</code> function is called, supplying the value of <code>$position</code>
          as the argument value; and the result of this call is returned.</p>
          <p diff="chg" at="2022-12-16">The default <code>$fallback</code> function raises a dynamic error. The call on <function>fn:error</function>
          shown as the default is for illustrative purposes only; apart from the error code (<code>err:FOAY0001</code>)
             the details of the error (such as the error message) are <termref def="implementation-dependent">implementation-dependent</termref>.</p>
-        
+        -->
+         <ednote><edtext>Provide separate "formal equivalents" for the two variants.</edtext></ednote>
       </fos:rules>
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
 if ($position = (1 to array:size($array)))
 then items-at(array:members($array), $position) => map:get('value'))
-else $fallback($position)
+else $fallback
       </fos:equivalent>
       <fos:errors>
-         <p><phrase diff="add" at="2022-12-16">In the absence of a <code>$fallback</code> function</phrase>,
+         <p>In the absence of a <code>$fallback</code> argument,
             a dynamic error occurs <errorref class="AY" code="0001"
                /> if <code>$position</code> is not in the range <code>1 to
                array:size($array)</code> inclusive.</p>
@@ -28814,17 +28829,17 @@ else $fallback($position)
                <fos:result>[ "b", "c" ]</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>[ "a" ] => array:get(1, void#1)</fos:expression>
+               <fos:expression>[ "a" ] => array:get(1, ())</fos:expression>
                <fos:result>"a"</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>[] => array:get(1, void#1)</fos:expression>
+               <fos:expression>[ "a" ] => array:get(2, ())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change>
+         <fos:change issue="1363" PR="289">
             <p>A third argument is added, allowing user control of how index-out-of-bounds
             conditions should be handled.</p>
          </fos:change>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24626,7 +24626,7 @@ return (
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="1363" PR="289"><p>A third argument is added, allowing user control of how absent keys should be handled.</p></fos:change>
+         <fos:change issue="1363" PR="289 1901"><p>A third argument is added, allowing user control of how absent keys should be handled.</p></fos:change>
       </fos:changes>
    </fos:function>
 
@@ -28839,7 +28839,7 @@ else $fallback
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change issue="1363" PR="289">
+         <fos:change issue="1363" PR="289 1901">
             <p>A third argument is added, allowing user control of how index-out-of-bounds
             conditions should be handled.</p>
          </fos:change>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -24531,7 +24531,7 @@ map:size($map) eq 0
          <fos:proto name="get" return-type="item()*">
             <fos:arg name="map" type="map(*)" usage="inspection"/>
             <fos:arg name="key" type="xs:anyAtomicType"/>
-            <fos:arg name="fallback" type="item()*" default="()"/>
+            <fos:arg name="default" type="item()*" default="()"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -24549,7 +24549,7 @@ map:size($map) eq 0
             the <termref
                def="dt-same-key"
                >same key</termref> as <code>$key</code>. If there is such an entry, it returns the associated value;
-            if not, it returns the supplied <code>$fallback</code> value, which defaults to the empty sequence.</p>
+            if not, it returns the supplied <code>$default</code> value, which defaults to the empty sequence.</p>
 
       </fos:rules>
       <fos:equivalent style="dm-primitive">
@@ -24561,7 +24561,7 @@ let $entry := dm:iterate-map($map, fn($k, $v) {
 return (
   if (exists($entry))
   then map:items($entry)
-  else $fallback
+  else $default
 )
       </fos:equivalent>
       <fos:notes>
@@ -24569,23 +24569,13 @@ return (
             the key is present in the map with an associated value of <code>()</code>, or it could
             indicate that the key is not present in the map. The two cases can be distinguished by
             either by calling <function>map:contains</function> to test whether an entry is present, or by using
-            a <code>$fallback</code> value to return a value known never to appear in the map.</p>
+            a <code>$default</code> value to return a value known never to appear in the map.</p>
          
-         <!--<p diff="add" at="2022-12-16">The <code>$fallback</code> function can be used in a number of ways:</p>
-         
-         <ulist diff="add" at="2022-12-16">
-            <item><p>It might return a conventional value such as <code>NaN</code> to indicate that no matching
-            key was found.</p></item>
-            <item><p>It might raise a dynamic error, by means of a call on <function>fn:error</function>.</p></item>
-            <item><p>It might compute a result algorithmically. For example, if the map holds a table of
-            abbreviations, such as <code>{ 'CA': 'Canada', 'UK': 'United Kingdom', 'US': 'United States' }</code>,
-            then specifying <code>fallback := fn:identity#1</code> has the effect that the key value is returned
-            unchanged if it is not found in the map.</p></item>
-         </ulist>-->
+
 
          <p>Invoking the <termref def="dt-map"
                >map</termref> as a function item has the same effect
-            as calling <code>get</code> with no <code>$fallback</code>
+            as calling <code>get</code> with no <code>$default</code>
             argument: that is, when <code>$map</code> is a map, the expression
                <code>$map($K)</code> is equivalent to <code>map:get($map, $K)</code>. Similarly, the
             expression <code>map:get(map:get(map:get($map, 'employee'), 'name'), 'first')</code> can
@@ -28776,7 +28766,7 @@ array:size($array) eq 0
          <fos:proto name="get" return-type="item()*">
             <fos:arg name="array" type="array(*)" usage="inspection"/>
             <fos:arg name="position" type="xs:integer"/>
-            <fos:arg name="fallback" type="item()*"/>
+            <fos:arg name="default" type="item()*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -28797,23 +28787,23 @@ array:size($array) eq 0
          
          <ulist>
             <item><p>When there are two arguments, an error is raised (<errorref class="AY" code="0001"/>).</p></item>
-            <item><p>When there are three arguments, the value of <code>$fallback</code> is returned.</p></item>
+            <item><p>When there are three arguments, the value of <code>$default</code> is returned.</p></item>
          </ulist>
-         <!--then the <code>$fallback</code> function is called, supplying the value of <code>$position</code>
-         as the argument value; and the result of this call is returned.</p>
-         <p diff="chg" at="2022-12-16">The default <code>$fallback</code> function raises a dynamic error. The call on <function>fn:error</function>
-         shown as the default is for illustrative purposes only; apart from the error code (<code>err:FOAY0001</code>)
-            the details of the error (such as the error message) are <termref def="implementation-dependent">implementation-dependent</termref>.</p>
-        -->
+
          <ednote><edtext>Provide separate "formal equivalents" for the two variants.</edtext></ednote>
       </fos:rules>
       <fos:equivalent style="xpath-expression" covers-error-cases="false">
-if ($position = (1 to array:size($array)))
-then items-at(array:members($array), $position) => map:get('value'))
-else $fallback
+(: For the two-argument form: :)           
+    if ($position = (1 to array:size($array)))
+    then items-at(array:members($array), $position) => map:get('value'))
+    else error(),
+(: For the three-argument form: :)           
+    if ($position = (1 to array:size($array)))
+    then items-at(array:members($array), $position) => map:get('value'))
+    else $default
       </fos:equivalent>
       <fos:errors>
-         <p>In the absence of a <code>$fallback</code> argument,
+         <p>In the absence of a <code>$default</code> argument,
             a dynamic error occurs <errorref class="AY" code="0001"
                /> if <code>$position</code> is not in the range <code>1 to
                array:size($array)</code> inclusive.</p>


### PR DESCRIPTION
Issue #1363 generated a large amount of discussion on how to handle absent keys in map:get() and out-of-range indexes in array:get().

I felt that one of the simplest proposals was to change the $fallback argument to be a simple default value, rather than a function. This eliminates some of the more "clever" use cases, but these can always be achieved in other ways, as the discussion thread demonstrates. Meanwhile reducing `$fallback` to a simple default value makes life easier for the 90% of cases where this is all that is needed (especially for arrays, when the desire is to return a default value rather than throwing an error).

This PR therefore implements that simple proposal.

Fix #1363