### PR TITLE
1797 elements-to-maps-conversion-plan function

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26739,7 +26739,55 @@ return json-to-xml($json, $options)]]></eg>
       </fos:changes>
    </fos:function>
    
-   
+   <fos:function name="elements-to-maps-conversion-plan" prefix="fn">
+      <fos:signatures>
+         <fos:proto name="elements-to-maps-conversion-plan" return-type="map(*)*">
+            <fos:arg name="input" type="(document-node() | element(*)) *"/>
+         </fos:proto>
+      </fos:signatures>
+      <fos:properties>
+         <fos:property>deterministic</fos:property>
+         <fos:property>context-independent</fos:property>
+         <fos:property>focus-independent</fos:property>
+      </fos:properties>
+      <fos:summary>
+         <p>Analyzes sample data to generate a conversion plan suitable for use by the <function>elements-to-maps</function>
+            function.</p>
+      </fos:summary>
+      <fos:rules>
+         <p>The function takes as input a collection of document and element nodes and analyzes the trees rooted at these
+         nodes to determine a conversion plan for converting elements in these trees to maps, suitable for serialization
+         in JSON format. The conversion plan can be used <emph>as-is</emph> by supplying it directly to the 
+            <function>elements-to-maps</function> function; alternatively it can be amended before use. The plan can also
+         be serialized to a file (in JSON format) allowing the same plan to be used repeatedly for transforming documents
+         with a similar structure to those in the sample provided.</p>
+         <p>The rules followed by the function, and the detailed format of the conversion plan, are described
+         in <specref ref="id-creating-a-conversion-plan"/>.</p>
+      </fos:rules>
+      <fos:notes>
+         <p>The conversion plan is organized by element and attribute name, so its effectiveness depends on the 
+         <code>$input</code> collection being homogenous in its structure, and representative of the documents
+         that will subsequently be converted using the <function>elements-to-maps</function> function.</p>
+         <p>This function is separate from the <function>elements-to-maps</function> function for a number
+         of reasons:</p>
+         <ulist>
+            <item><p>The collection of documents that need to be analyzed to establish an effective
+            conversion plan might be much smaller than the set of documents actually being converted.</p></item>
+            <item><p>Conversely, it might be that only a small number of documents need to be converted at 
+            a particular time, but the conversion plan used needs to take into account variations that might
+            exist within a larger corpus.</p></item>
+            <item><p>If JSON output is required in a particular format, it might be necessary to fine-tune
+            the automatically generated conversion plan to take account of these requirements.</p></item>
+            <item><p>It might be necessary to devise a conversion plan that can be used to convert individual
+            documents as they arrive over a period of time, and to ensure that the same conversion rules
+            are applied to each document even though documents might exhibit variations in structure.</p></item>
+         </ulist>
+      </fos:notes>
+      <fos:changes>
+         <fos:change issue="1797" PR=""><p>New in 4.0</p></fos:change>
+      </fos:changes>
+   </fos:function>
+      
    <fos:function name="elements-to-maps" prefix="fn">
       <fos:signatures>
          <fos:proto name="elements-to-maps" return-type="map(*)*">
@@ -26768,24 +26816,14 @@ return json-to-xml($json, $options)]]></eg>
          
          <fos:options>
             
-            <fos:option key="uniform">
-               <fos:meaning>Indicates that all elements with the same name, at any level in any of the
-                  input trees should use the same conversion rules (known as a layout). 
-                  Setting this option requires the processor to analyze the entire input
-               before deciding what layout to use for each element; but by ensuring consistency across elements, it may
-               make the resulting maps easier to process.</fos:meaning>
-               <fos:type>xs:boolean</fos:type>
-               <fos:default>false()</fos:default>
-               <fos:values>
-                  <fos:value value="false">
-                     The layout for each element node is decided independently, based on its individual content.
-                  </fos:value>
-                  <fos:value value="true">
-                     In the absence of schema type information, and in the absence of an explicit entry in the <code>layouts</code>
-                     property, the layout chosen for a given element node must be the same as that for all other
-                     elements of the same name.
-                  </fos:value>
-               </fos:values>
+            <fos:option key="plan">
+               <fos:meaning>A conversion plan, supplied as a map whose keys represent element
+                  and attribute names. The plan might be generated using the function
+                  <function>elements-to-maps-conversion-plan</function>, or it might be constructed
+                  in some other way. The format of the plan is described in <specref ref="id-creating-a-conversion-plan"/>.
+               </fos:meaning>
+               <fos:type>map(xs:string, record(*))</fos:type>
+               <fos:default>{}</fos:default>
             </fos:option>
             <fos:option key="attribute-marker">
                <fos:meaning>A string that is prefixed to any key value in the output that represents
@@ -26813,21 +26851,6 @@ return json-to-xml($json, $options)]]></eg>
                      is one that appears explicitly in the sequence of elements passed in the <code>$elements</code> argument,
                      as distinct from a descendant of such an element.</fos:value>
                </fos:values>
-            </fos:option>
-            <fos:option key="layouts">
-               <fos:meaning>A mapping from element names to layout names, used to override the default
-               formatting rules for a particular element name.</fos:meaning>
-               <fos:type>map(xs:QName, enum("empty", "empty-plus", "simple", "simple-plus", "list", "list-plus", 
-                  "record", "sequence", "mixed", "xml"))</fos:type>
-               <fos:default>map{}</fos:default>
-            </fos:option>
-            <fos:option key="disable-layouts">
-               <fos:meaning>A list of layouts that will not be used for elements unless they are
-                  selected explicitly. (Note that <code>mixed</code> and <code>xml</code>
-                  layout cannot be disabled.)</fos:meaning>
-               <fos:type>enum("empty", "empty-plus", "simple", "simple-plus", "list", "list-plus", 
-                  "record", "sequence")*</fos:type>
-               <fos:default>()</fos:default>
             </fos:option>
          </fos:options>
          

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26766,7 +26766,7 @@ return json-to-xml($json, $options)]]></eg>
          <p>The rules followed by the function, and the detailed format of the conversion plan, are described
          in <specref ref="id-creating-a-conversion-plan"/>.</p>
       </fos:rules>
-      <fos:equivalent style="xpath-expression">
+      <fos:equivalent style="xquery-expression">
 let $data-type := fn($nodes as node()*) {
   if (every($nodes ! (. castable as xs:boolean))) then "boolean"
   else if (every($nodes ! (. castable as xs:numeric))) then "numeric"
@@ -26991,7 +26991,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
                <fos:result>()</fos:result>
             </fos:test>
             <fos:test spec="XQuery">
-               <fos:expression><![CDATA[element-to-map(foo>bar</foo>)]]></fos:expression>
+               <fos:expression><![CDATA[element-to-map(<foo>bar</foo>)]]></fos:expression>
                <fos:result>{ "foo": "bar" }</fos:result>
             </fos:test>
             <fos:test spec="XQuery">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26972,6 +26972,16 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
          
          
       </fos:rules>
+      <fos:errors>
+         <p>A dynamic error <errorref class="JS" code="0008"/> occurs if any element cannot
+            be processed using the selected layout for that element, unless fallback processing
+            is defined; or if error action is explicitly requested for an element.</p>
+         <p>Any error in the conversion plan is treated as a type error <xerrorref
+               spec="XP" class="TY" code="0004"/> whether or not it is technically
+            a contravention of the defined type for the value. This relieves users and implementers
+            of the burden of distinguishing different kinds of error in the plan.</p>
+ 
+      </fos:errors>
  
       <fos:examples>
          <fos:example>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26960,7 +26960,8 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
          
          <p>The principles for conversion from elements to maps are described
             in <specref ref="id-element-layouts"/>, and the rules for selecting
-         an element layout for each element are given in <specref ref="id-selecting-element-layout"/>.</p>
+         an element layout for each element are given in 
+            <specref ref="id-selecting-element-layout"/>.</p>
          
         
          <p>In general, every descendant element within the tree rooted at the supplied

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26533,7 +26533,7 @@ return json-to-xml($json, $options)]]></eg>
             </item>
          </ulist>
 
-         <p>Nodes in the input tree are handled by applying the following rules, recursively. In these rules the term
+         <p>Nodes in the input tree are handled by applying the following rules, recursively. In these rules the phrase
             “an element named <var>N</var>” means “an element node whose local name is <var>N</var> and whose namespace URI is 
             <code>http://www.w3.org/2005/xpath-functions</code>”.</p>
 
@@ -26739,9 +26739,9 @@ return json-to-xml($json, $options)]]></eg>
       </fos:changes>
    </fos:function>
    
-   <fos:function name="elements-to-maps-conversion-plan" prefix="fn">
+   <fos:function name="element-to-map-conversion-plan" prefix="fn">
       <fos:signatures>
-         <fos:proto name="elements-to-maps-conversion-plan" return-type="map(*)*">
+         <fos:proto name="element-to-map-conversion-plan" return-type="map(xs:string, record(*))">
             <fos:arg name="input" type="(document-node() | element(*)) *"/>
          </fos:proto>
       </fos:signatures>
@@ -26751,14 +26751,14 @@ return json-to-xml($json, $options)]]></eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Analyzes sample data to generate a conversion plan suitable for use by the <function>elements-to-maps</function>
+         <p>Analyzes sample data to generate a conversion plan suitable for use by the <function>element-to-map</function>
             function.</p>
       </fos:summary>
       <fos:rules>
          <p>The function takes as input a collection of document and element nodes and analyzes the trees rooted at these
          nodes to determine a conversion plan for converting elements in these trees to maps, suitable for serialization
          in JSON format. The conversion plan can be used <emph>as-is</emph> by supplying it directly to the 
-            <function>elements-to-maps</function> function; alternatively it can be amended before use. The plan can also
+            <function>element-to-map</function> function; alternatively it can be amended before use. The plan can also
          be serialized to a file (in JSON format) allowing the same plan to be used repeatedly for transforming documents
          with a similar structure to those in the sample provided.</p>
          <p>The rules followed by the function, and the detailed format of the conversion plan, are described
@@ -26767,8 +26767,8 @@ return json-to-xml($json, $options)]]></eg>
       <fos:notes>
          <p>The conversion plan is organized by element and attribute name, so its effectiveness depends on the 
          <code>$input</code> collection being homogenous in its structure, and representative of the documents
-         that will subsequently be converted using the <function>elements-to-maps</function> function.</p>
-         <p>This function is separate from the <function>elements-to-maps</function> function for a number
+         that will subsequently be converted using the <function>element-to-map</function> function.</p>
+         <p>This function is separate from the <function>element-to-map</function> function for a number
          of reasons:</p>
          <ulist>
             <item><p>The collection of documents that need to be analyzed to establish an effective
@@ -26781,17 +26781,66 @@ return json-to-xml($json, $options)]]></eg>
             <item><p>It might be necessary to devise a conversion plan that can be used to convert individual
             documents as they arrive over a period of time, and to ensure that the same conversion rules
             are applied to each document even though documents might exhibit variations in structure.</p></item>
+            <item><p>The conversion plan is human-readable, which can help in understanding why the
+            output of <function>element-to-map</function> is in a particular form.</p></item>
          </ulist>
       </fos:notes>
+      <fos:examples>
+         <fos:example>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[
+element-to-map-conversion-plan(<a><b>3</b><b>4</b></a>)
+               ]]></eg></fos:expression>
+               <fos:result><eg>
+{ 'a': { 'layout': 'list', 'child': 'b' },
+  'b': { 'layout': 'simple', 'type': 'numeric' }
+}
+               </eg></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[
+element-to-map-conversion-plan((<a x="2">red</a>, <a x="3">blue</a>))
+               ]]></eg></fos:expression>
+               <fos:result><eg>
+{ 'a': { 'layout': 'simple-plus' },
+  '@x': { 'type': 'numeric' }
+}
+               </eg></fos:result>
+            </fos:test>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[
+element-to-map-conversion-plan(
+   <a xmlns="http://example.ns">H<sub>2</sub>SO<sub>4</sub></a>
+)
+               ]]></eg></fos:expression>
+               <fos:result><eg>
+{ 'Q{http://example.ns}a': { 'layout': 'mixed' },
+  'Q{http://example.ns}sub': { 'layout': 'simple', 'type': 'numeric' }
+}
+               </eg></fos:result>
+            </fos:test>   
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[
+element-to-map-conversion-plan((<a><b/><b/></a>, <a><b/><c/></a>))
+               ]]></eg></fos:expression>
+               <fos:result><eg>
+{ 'a': { 'layout': 'sequence' },
+  'b': { 'layout': 'empty' },
+  'c': { 'layout': 'empty' }
+}
+               </eg></fos:result>
+            </fos:test>   
+         </fos:example>
+      </fos:examples>
       <fos:changes>
          <fos:change issue="1797" PR="1906"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
       
-   <fos:function name="elements-to-maps" prefix="fn">
+   <fos:function name="element-to-map" prefix="fn">
       <fos:signatures>
-         <fos:proto name="elements-to-maps" return-type="map(*)*">
-            <fos:arg name="elements" type="element()*"/>
+         <fos:proto name="element-to-map" return-type="map(xs:string, item()?)?">
+            <fos:arg name="element" type="element()?"/>
             <fos:arg name="options" type="map(*)" usage="inspection"  default="map{}"/>
          </fos:proto>
       </fos:signatures>
@@ -26801,14 +26850,18 @@ return json-to-xml($json, $options)]]></eg>
          <fos:property>focus-independent</fos:property>
       </fos:properties>
       <fos:summary>
-         <p>Converts a sequence of element nodes into maps that are suitable for
+         <p>Converts an element node into a map that is suitable for
             JSON serialization.</p>
       </fos:summary>
       <fos:rules>
-         <p>This function returns a sequence of maps corresponding one to one with
-            the element nodes supplied in <code>$elements</code>. Each map is in a form
+         <p>This function returns a map derived from
+            the element node supplied in <code>$element</code>. The map is in a form
             that is suitable for JSON serialization, thus providing a mechanism for conversion
             of arbitrary XML to JSON.</p>
+         
+         <p>The map that is returned will always be a <termref def="dt-single-entry-map"/>;
+         the key of this entry will be a string representing the element name, and the value of the
+         entry will be a representation of the element's attributes and children.</p>
          
          
          <p>The entries that may appear in the <code>$options</code> map are as follows.
@@ -26819,7 +26872,7 @@ return json-to-xml($json, $options)]]></eg>
             <fos:option key="plan">
                <fos:meaning>A conversion plan, supplied as a map whose keys represent element
                   and attribute names. The plan might be generated using the function
-                  <function>elements-to-maps-conversion-plan</function>, or it might be constructed
+                  <function>element-to-map-conversion-plan</function>, or it might be constructed
                   in some other way. The format of the plan is described in <specref ref="id-creating-a-conversion-plan"/>.
                </fos:meaning>
                <fos:type>map(xs:string, record(*))</fos:type>
@@ -26855,7 +26908,7 @@ return json-to-xml($json, $options)]]></eg>
          </fos:options>
          
          
-         
+         <p>If <code>$element</code> is an empty sequence, the result is an empty sequence.</p>
          
          
          <p>The principles for conversion from elements to maps are described
@@ -26863,12 +26916,10 @@ return json-to-xml($json, $options)]]></eg>
          an element layout for each element are given in <specref ref="id-selecting-element-layout"/>.</p>
          
         
-         <p>In general, an element node maps to a key-value pair in which the key represents the element name, and the
-         corresponding value represents the attributes and children of the element. In the case of a top-level element
-         (a node directly supplied in <code>$elements</code>), the result will be a 
-            <termref def="dt-single-entry-map"/> containing this key-value
-         pair as its only entry. In the case of a descendant element, the key-value pair for a child element will be added 
-         to the content representing its parent element, in a way that depends on the parent element’s layout.</p>
+         <p>In general, every descendant element within the tree rooted at the supplied
+            <code>$element</code> maps to a key-value pair in which the key represents the element name, and the
+         corresponding value represents the attributes and children of the element. This key-value pair will be added 
+         to the content representing its parent element, in a way that depends on the parent element's layout.</p>
          
          <p>The representation of other kinds of node depends on the layout chosen for its parent element.</p>
          
@@ -26878,63 +26929,62 @@ return json-to-xml($json, $options)]]></eg>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>elements-to-maps(())</fos:expression>
+               <fos:expression>element-to-map(())</fos:expression>
                <fos:result>()</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression><eg><![CDATA[elements-to-maps(parse-xml("
-  <foo>bar</foo>
-")/*)]]></eg></fos:expression>
+            <fos:test spec="XQuery">
+               <fos:expression><![CDATA[element-to-map(foo>bar</foo>)]]></fos:expression>
                <fos:result>{ "foo": "bar" }</fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression><eg><![CDATA[elements-to-maps(parse-xml("
-  <list>
-    <item value='1'/>
-    <item value='2'/>
-  </list>
-")/*)]]></eg></fos:expression>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[element-to-map(
+    <list>
+      <item value='1'/>
+      <item value='2'/>
+    </list>, { 'attribute-marker': '' }
+  )]]></eg></fos:expression>
                <fos:result><eg>{ "list": [ 
-  { "@value": "1" },
-  { "@value": "2" }
-] }</eg></fos:result>
+    { "value": "1" },
+    { "value": "2" }
+  ] }</eg></fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression><eg><![CDATA[elements-to-maps(parse-xml("
-  <name>
-    <first>Jane</first>
-    <last>Smith</last>
-  </name>
-")/*)]]></eg></fos:expression>
+            <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[element-to-map(
+    <name>
+      <first>Jane</first>
+      <last>Smith</last>
+    </name>
+  )]]></eg></fos:expression>
                <fos:result><eg>{ "name": { 
   "first": "Jane",
   "last": "Smith" 
 } }</eg></fos:result>
             </fos:test>
-            <!--<fos:test>
-
-               <fos:expression>items-to-json(map{"a":1,"b":number('NaN'),"c":(1,2,3)})</fos:expression>
-
-               <fos:result>'{"a":1,"b":"NaN","c":[1,2,3]}'</fos:result>
-               <fos:postamble>(or some permutation thereof)</fos:postamble>
+    "first": "Jane",
+    "last": "Smith" 
+  } 
+}</eg></fos:result>
             </fos:test>
-            <fos:test>
-               <fos:expression><eg><![CDATA[items-to-json(<a x="2">banana</a>)]]></eg></fos:expression>
-               <fos:result>'{"a":{"@x":"2","#content":"banana"}}'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><eg><![CDATA[items-to-json(<a><b/><c>2</c></a>)]]></eg></fos:expression>
-               <fos:result>'{"a":{"#content":{"b":"","c":"2"}}'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><eg><![CDATA[items-to-json(<a>A <i>nice</i> one!</a>)]]></eg></fos:expression>
-               <fos:result>'{"a":{"#content":["A ",{"i":"nice"}," one!"]}}'</fos:result>
-            </fos:test>
-            <fos:test>
-               <fos:expression><eg><![CDATA[items-to-json(<a>A <i>nice</i> one!</a>, 
-              map { 'layouts': map{QName('', 'a'): 'xml'}, 'escape-solidus': false() })]]></eg></fos:expression>
-               <fos:result>'{"a":"<a>A <i>nice</i> one!</a>"}'</fos:result>
-            </fos:test>-->
+           <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[element-to-map(
+    <name xmlns="http://example.ns">
+      <first>Jane</first>
+      <middle>Elizabeth</middle>
+      <middle>Mary</middle>
+      <last>Smith</last>
+    </name>, 
+    { 'plan': {'name': { 'layout': 'record' }},
+      'name-format' : 'local'
+    }
+  )]]></eg></fos:expression>
+               <fos:result><eg>{ "name": { 
+    "first": "Jane",
+    "middle": ["Elizabeth", "Mary"]
+    "last": "Smith" 
+  } 
+}</eg></fos:result>
+            </fos:test>            
+ 
          </fos:example>
       </fos:examples>
       <fos:changes>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -475,6 +475,8 @@
       </fos:field>
    </fos:record-type>
    
+ 
+   
    <fos:function name="node-name" prefix="fn">
       <fos:signatures>
          <fos:proto name="node-name" return-type="xs:QName?">
@@ -26739,9 +26741,9 @@ return json-to-xml($json, $options)]]></eg>
       </fos:changes>
    </fos:function>
    
-   <fos:function name="element-to-map-conversion-plan" prefix="fn">
+   <fos:function name="element-to-map-plan" prefix="fn">
       <fos:signatures>
-         <fos:proto name="element-to-map-conversion-plan" return-type="map(xs:string, record(*))">
+         <fos:proto name="element-to-map-plan" return-type="map(xs:string, record(*))">
             <fos:arg name="input" type="(document-node() | element(*)) *"/>
          </fos:proto>
       </fos:signatures>
@@ -26764,6 +26766,51 @@ return json-to-xml($json, $options)]]></eg>
          <p>The rules followed by the function, and the detailed format of the conversion plan, are described
          in <specref ref="id-creating-a-conversion-plan"/>.</p>
       </fos:rules>
+      <fos:equivalent style="xpath-expression">
+let $data-type := fn($nodes as node()*) {
+  if (every($nodes ! (. castable as xs:boolean))) then "boolean"
+  else if (every($nodes ! (. castable as xs:numeric))) then "numeric"
+  else ()
+}
+let $name := fn($node as node()) {
+  if (namespace-uri($node)) 
+  then expanded-QName(node-name($node))
+  else local-name($node)
+}  
+return (
+  for $ee in $input/descendant-or-self::*
+  group by $n := $name($ee)
+  return { $n :
+           if (empty($ee/(*|text())))
+             then { 'layout' : if (empty($ee/@*)) 
+                               then 'empty' 
+                               else 'empty-plus' } 
+           else if (empty($ee/*)) 
+             then map:merge((
+                    if (empty($ee/@*)) 
+                      then {'layout': 'simple'}
+                      else {'layout': 'simple-plus'},
+                    $data-type($ee) ! { 'type': . }
+                 ))
+           else if (empty($ee/text()[normalize-space()])) 
+             then if (all-equal($ee/*/node-name()) and exists($ee/*[2]))
+                    then { 'layout': if (empty($ee/@*)) 
+                                     then 'list' 
+                                     else 'list-plus',
+                           'child': $name(head($ee/*))
+                         }
+                    else { 'layout' : if (every($ee ! all-different(*/node-name())))
+                                      then 'record'
+                                      else 'sequence'
+                         }             
+           else {'layout': 'mixed'}
+        },
+  for $a in $input//@*
+  group by $n := $name($a)
+  let $t := $data-type($a)
+  return $t ! { `@{$n}`: { 'type': $t } }
+) => map:merge()        
+      </fos:equivalent>
       <fos:notes>
          <p>The conversion plan is organized by element and attribute name, so its effectiveness depends on the 
          <code>$input</code> collection being homogenous in its structure, and representative of the documents
@@ -26789,7 +26836,7 @@ return json-to-xml($json, $options)]]></eg>
          <fos:example>
             <fos:test spec="XQuery">
                <fos:expression><eg><![CDATA[
-element-to-map-conversion-plan(<a><b>3</b><b>4</b></a>)
+element-to-map-plan(<a><b>3</b><b>4</b></a>)
                ]]></eg></fos:expression>
                <fos:result><eg>
 { 'a': { 'layout': 'list', 'child': 'b' },
@@ -26799,7 +26846,7 @@ element-to-map-conversion-plan(<a><b>3</b><b>4</b></a>)
             </fos:test>
             <fos:test spec="XQuery">
                <fos:expression><eg><![CDATA[
-element-to-map-conversion-plan((<a x="2">red</a>, <a x="3">blue</a>))
+element-to-map-plan((<a x="2">red</a>, <a x="3">blue</a>))
                ]]></eg></fos:expression>
                <fos:result><eg>
 { 'a': { 'layout': 'simple-plus' },
@@ -26809,7 +26856,7 @@ element-to-map-conversion-plan((<a x="2">red</a>, <a x="3">blue</a>))
             </fos:test>
             <fos:test spec="XQuery">
                <fos:expression><eg><![CDATA[
-element-to-map-conversion-plan(
+element-to-map-plan(
    <a xmlns="http://example.ns">H<sub>2</sub>SO<sub>4</sub></a>
 )
                ]]></eg></fos:expression>
@@ -26821,7 +26868,7 @@ element-to-map-conversion-plan(
             </fos:test>   
             <fos:test spec="XQuery">
                <fos:expression><eg><![CDATA[
-element-to-map-conversion-plan((<a><b/><b/></a>, <a><b/><c/></a>))
+element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
                ]]></eg></fos:expression>
                <fos:result><eg>
 { 'a': { 'layout': 'sequence' },
@@ -26872,14 +26919,14 @@ element-to-map-conversion-plan((<a><b/><b/></a>, <a><b/><c/></a>))
             <fos:option key="plan">
                <fos:meaning>A conversion plan, supplied as a map whose keys represent element
                   and attribute names. The plan might be generated using the function
-                  <function>element-to-map-conversion-plan</function>, or it might be constructed
+                  <function>element-to-map-plan</function>, or it might be constructed
                   in some other way. The format of the plan is described in <specref ref="id-creating-a-conversion-plan"/>.
                </fos:meaning>
-               <fos:type>map(xs:string, record(*))</fos:type>
+               <fos:type>map(xs:string, record(layout?, child?, type?, *))</fos:type>
                <fos:default>{}</fos:default>
             </fos:option>
             <fos:option key="attribute-marker">
-               <fos:meaning>A string that is prefixed to any key value in the output that represents
+               <fos:meaning>A string that is prepended to any key value in the output that represents
                an XDM attribute node in the input. The string may be empty. If, after applying the requested
                prefix (or no prefix) there is a conflict between the names of attributes and child elements,
                then the requested prefix (or lack thereof) is ignored and the default prefix <code>"@"</code>
@@ -26921,7 +26968,7 @@ element-to-map-conversion-plan((<a><b/><b/></a>, <a><b/><c/></a>))
          corresponding value represents the attributes and children of the element. This key-value pair will be added 
          to the content representing its parent element, in a way that depends on the parent element's layout.</p>
          
-         <p>The representation of other kinds of node depends on the layout chosen for its parent element.</p>
+         <p>The representation of a node of any other kind depends on the layout chosen for its parent element.</p>
          
          
       </fos:rules>
@@ -26960,11 +27007,6 @@ element-to-map-conversion-plan((<a><b/><b/></a>, <a><b/><c/></a>))
   "last": "Smith" 
 } }</eg></fos:result>
             </fos:test>
-    "first": "Jane",
-    "last": "Smith" 
-  } 
-}</eg></fos:result>
-            </fos:test>
            <fos:test spec="XQuery">
                <fos:expression><eg><![CDATA[element-to-map(
     <name xmlns="http://example.ns">
@@ -26984,7 +27026,25 @@ element-to-map-conversion-plan((<a><b/><b/></a>, <a><b/><c/></a>))
   } 
 }</eg></fos:result>
             </fos:test>            
- 
+ <fos:test spec="XQuery">
+               <fos:expression><eg><![CDATA[element-to-map(
+    <name xmlns="http://example.ns">
+      <first>Jane</first>
+      <middle>Elizabeth</middle>
+      <middle>Mary</middle>
+      <last>Smith</last>
+    </name>, 
+    { 'plan': {'name': { 'layout': 'record' },
+               'middle': { 'layout': 'deep-skip' },
+      'name-format' : 'local'
+    }
+  )]]></eg></fos:expression>
+               <fos:result><eg>{ "name": { 
+    "first": "Jane",
+    "last": "Smith" 
+  } 
+}</eg></fos:result>
+            </fos:test> 
          </fos:example>
       </fos:examples>
       <fos:changes>

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -26784,7 +26784,7 @@ return json-to-xml($json, $options)]]></eg>
          </ulist>
       </fos:notes>
       <fos:changes>
-         <fos:change issue="1797" PR=""><p>New in 4.0</p></fos:change>
+         <fos:change issue="1797" PR="1906"><p>New in 4.0</p></fos:change>
       </fos:changes>
    </fos:function>
       
@@ -26938,7 +26938,7 @@ return json-to-xml($json, $options)]]></eg>
          </fos:example>
       </fos:examples>
       <fos:changes>
-         <fos:change><p>New in 4.0.</p></fos:change>
+         <fos:change PR="1906"><p>New in 4.0.</p></fos:change>
       </fos:changes>
    </fos:function>
 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8199,9 +8199,9 @@ return <table>
          </div2>
          
          <div2 id="xml-to-json-mappings">
-            <head>Converting Elements to Maps</head>
+            <head>Converting elements to maps</head>
             <changes>
-               <change issue="528" PR="1575" date="2024-11-19">
+               <change issue="528 1797" PR="1575 1906" date="2024-11-19">
                   A new function <function>fn:elements-to-maps</function> is provided for converting XDM trees
                   to maps suitable for serialization as JSON. Unlike the <function>fn:xml-to-json</function> function
                   retained from 3.1, this can handle arbitrary XML as input.
@@ -8214,8 +8214,8 @@ return <table>
             <ulist>
                <item><p>It should be possible to represent any XML element as a map suitable for JSON serialization.</p></item>
                <item><p>The resulting JSON should be intuitive and easy to use.</p></item>
-               <item><p>The JSON should be consistent and stable: small changes in the input should not result
-               in large changes in the output.</p></item>
+               <item><p>The JSON should be consistent and stable: small variations in the input should not result
+               in large variations in the output.</p></item>
             </ulist>
             
             <p>Achieving all three objectives requires design compromises. It also requires sacrificing some other
@@ -8238,11 +8238,12 @@ return <table>
             <ulist>
                <item><p>The function makes use of schema information where available, so it considers
                not just the structure of an individual element instance, but the rules governing the element type.</p></item>
-               <item><p>It is possible to request <code>uniform</code> layout for all elements sharing the same name,
-               so the decision is based on the structure of all elements with a given name, not just an individual
-               element.</p></item>
-               <item><p>It is possible to override the choice made by the system, and explicitly specify a layout
-               to be used for elements having a given name.</p></item>
+               <item><p>It is possible to analyze a corpus of XML documents to develop a conversion plan, which can then
+               be applied consistently to individual input documents, whether or not these documents were present in the corpus. The
+               conversion plan can be serialized and subsequently reused, so that it can be applied to input documents that
+               might not have existed at the time the conversion plan was formulated.</p></item>
+               <item><p>It is possible to override the choices made by the system, and explicitly specify a the format
+               to be used for elements or attributes having a given name.</p></item>
             </ulist>
             
             
@@ -8309,39 +8310,38 @@ return <table>
              
                <p>This specification defines a
                number of named mappings, called <term>layouts</term>, and allows the layout for a particular
-               element to be selected in four different ways:</p>
+               element to be selected in a number of different ways:</p>
                
                <ulist>
-                  <item><p>The layout to be used for a specific element name can be explicitly selected in the options
-                  to the <function>fn:elements-to-maps</function> function.</p></item>
-                  <item><p>In the absence of an explicit selection, if the data has been schema-validated, the layout is 
+                  <item><p>The layout to be used for a specific elements can be explicitly selected by
+                     supplying a conversion plan as input
+                     to the <function>fn:elements-to-maps</function> function.</p></item>
+                  <item><p>It is possible to construct a conversion plan by analyzing a corpus of documents
+                  using the <function>fn:elements-to-maps-conversion-plan</function> function.</p></item>
+                  <item><p>It is also possible to construct a conversion plan manually, or to modify
+                  the conversion plan produced by the <function>fn:elements-to-maps-conversion-plan</function> function
+                     before use.</p></item>
+                  <item><p>In the absence of an explicit conversion plan, if the data has been schema-validated, the layout is 
                      inferred from the content model for the element type as defined in the schema.</p></item>
                   <item>
                      <p>When the data is untyped and no specific layout has been selected, 
                      a default layout is chosen based on the properties of the individual element instance.</p>
-                  </item>
-                  <item>                    
-                     <p>If the <code>uniform</code> option is set to <code>true</code>, then the same layout
-                     will be used for all elements with a given name. This means that all elements need to be
-                     examined before any element is converted.</p>
-                  </item>              
+                  </item>             
                </ulist>
                
-               <p>It is possible to disable some of the layouts so they will never be chosen by the automatic rules,
-               but only when explicitly selected.</p>
                
                <p>The advantage of using schema information is that it gives a consistent representation for all
                elements of a particular type, even if they vary in content: for example if an element type allows optional
                attributes, the JSON representation will be consistent between those elements that have attributes and those
-               without. In the absence of a schema, consistency can be achieved either by using the <code>uniform</code>
-               option, or by selecting a layout explicitly in the <code>layouts</code> option.</p>
+               without. In the absence of a schema, consistency can be achieved by supplying a conversion plan that
+               applies uniformly to multiple documents.</p>
                
                <p>The different layouts available are defined in the following sections. For each layout
                there is a table showing:</p>
                
                <ulist>
                   <item><p><term>Layout name</term>: the name to be used to select this layout in
-                  the <code>$options</code> parameter of the <function>fn:elements-to-maps</function> function.</p></item>
+                  a conversion plan supplied to the <function>fn:elements-to-maps</function> function.</p></item>
                   <item><p><term>Usage</term>: the situations for which this layout is designed.</p></item>
                   <item><p><term>Example input</term>: an example of a typical element for which this layout is appropriate,
                      shown as serialized XML.</p></item>
@@ -8365,9 +8365,14 @@ return <table>
                <p>The rules for selecting the layout for a particular element are given later, 
                   in <specref ref="id-selecting-element-layout"/>.</p>
                
-               <p>Note that it is possible to use any layout for any element. Use of an inappropriate layout
-               may result in information being discarded; but in some cases, discarding information may be the 
-               desired outcome.</p>
+               <p>Note that it is possible to use any layout for any element. If an inappropriate layout
+               is chosen for a particular element (for example, <code>empty</code> layout for an element
+                  that is not empty), then in general the conversion falls back to using <code>xml</code> layout, which
+                  outputs the element as a string containing serialized XML. This ensures that no information
+                  is lost, and might act as an indication that the conversion plan needs to be revised.
+                  This will never happen when converting a document that was used as input to the
+                  conversion plan. There is an exception to this rule: if a layout is chosen that does not
+                  allow attributes, then any attribute that is present on the element is discarded.</p>
                
                <note><p>Acknowledgements for this categorization: see <bibref ref="Goessner"/>. Although
                Goessner's categories have been used, the actual mappings vary from his proposal.</p></note>
@@ -8394,20 +8399,7 @@ return <table>
                            <th>Example output</th>
                            <td><eg>{ "hr": "" }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a complex type with {variety} <code>empty</code>, 
-                              or a simple type with
-                              {variety} <code>list</code> and <code>maxLength="0"</code>, or a type 
-                              derived from <code>xs:string</code>
-                              with an <code>enumeration</code> or <code>length</code> or <code>maxLength</code>
-                              facet that restricts it to be zero-length; and the type does not allow 
-                              any attributes.</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>empty( * | text() | @* )</code></p></td>
-                        </tr>-->
+
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The content is represented by the zero-length <code>xs:string</code>
@@ -8425,7 +8417,10 @@ return <table>
                         </tr>
                         <tr>
                            <th>Notes</th>
-                           <td><p>If any child nodes or attributes are present, they are discarded. (This can happen
+                           <td><p>Attributes are discarded, along with child comment nodes, 
+                              processing instructions, and whitespace-only text nodes.</p>
+                              <p>If any other child nodes are present, the converter falls
+                              back to using <code>xml</code> layout. (This can happen
                            when this layout is explicitly selected for elements that are not actually empty.)</p></td>
                         </tr>
                      </tbody>
@@ -8452,19 +8447,7 @@ return <table>
                            <th>Example output</th>
                            <td><eg>{ "hr": { "@class": "ccc", "@id": "zzz" } }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a complex type with {variety} <code>empty</code>, or a simple type with
-                              {variety} <code>list</code> and <code>maxLength="0"</code>, 
-                              or a type derived from <code>xs:string</code>
-                              with an <code>enumeration</code> or <code>length</code> or <code>maxLength</code>
-                              facet that restricts it to be zero-length; 
-                              and the type allows attributes to appear.</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>exists(@*) and empty(*|text())</code></p></td>
-                        </tr>-->
+                        
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The content is represented by a map containing one entry for each
@@ -8483,7 +8466,10 @@ return <table>
                         </tr>
                         <tr>
                            <th>Notes</th>
-                           <td><p>If any child nodes are present in the element, they are discarded.
+                           <td><p>Child comment nodes, processing instructions, and whitespace-only text
+                           nodes are discarded.</p>
+                              <p>If any other child nodes are present in the element, the converter falls
+                              back to using <code>xml</code> layout.
                               (This can happen
                               when this layout is explicitly selected for elements that are not actually empty.)</p></td>
                         </tr>
@@ -8511,18 +8497,11 @@ return <table>
                            <th>Example output</th>
                            <td><eg>{ "date": "2023-05-30" }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a simple type.</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>empty( * | @* )</code></p></td>
-                        </tr>-->
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The element is atomized and the resulting atomized value is handled
-                              as described in <specref ref="element-and-attribute-content"/>.</p>
+                              as described in <specref ref="element-and-attribute-content"/>.
+                              If atomization fails, the element is treated as if it were untyped.</p>
                               
                               <note>
                                  <p>If the element is untyped, the atomized value will always 
@@ -8538,13 +8517,11 @@ return <table>
                         </tr>
                         <tr>
                            <th>Notes</th>
-                           <td><p>If any attributes are present, they are discarded. If the element has a type
-                           annotation that is a complex type with element-only content, atomization will fail and
-                           the string value is used in its place. In the case of mixed content, 
-                           atomization produces essentially the same result as the string value, which
-                           means that the internal structure is lost.</p>
-                           <p>Comments and processing instructions in the content are discarded. Whitespace is
-                           retained.</p></td>
+                           <td><p>Attributes are discarded, along with child comment nodes and processing instructions;
+                              whitespace is retained.</p>
+                              <p>If any child elements are present, the converter falls
+                              back to using <code>xml</code> layout.</p>
+                           </td>
                         </tr>
                      </tbody>
                   </table>
@@ -8570,14 +8547,6 @@ return <table>
                            <th>Example output</th>
                            <td><eg>{ "price": { "@currency": "USD", "#content": 23.50 } }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a complex type with simple content.</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>empty(*)</code></p></td>
-                        </tr>-->
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The element is represented by a map containing one entry for each
@@ -8603,11 +8572,10 @@ return <table>
                         </tr>
                         <tr>
                            <th>Notes</th>
-                           <td><p>In the case of mixed content, 
-                           atomization produces essentially the same result as the string value, which
-                           means that the internal structure is lost.</p>
-                              <p>Comments and processing instructions in the content are discarded. Whitespace is
-                                 retained.</p></td>
+                           <td><p>Child comment nodes and processing instructions are discarded;
+                              whitespace is retained.</p>
+                              <p>If any child elements are present, the converter falls
+                              back to using <code>xml</code> layout.</p></td>
                         </tr>
                      </tbody>
                   </table>
@@ -8624,8 +8592,10 @@ return <table>
                         <tr>
                            <th>Usage</th>
                            <td><p>Intended for XML elements that act as wrappers for a list of child elements,
-                              all having the same element name. 
-                              The name of the child elements is not retained in the output.</p></td>
+                              all having the same element name; neither the element itself nor any of its
+                              children should have any attributes. The expected child element name may
+                              be present in the conversion plan.
+                              The names of the child elements are not retained in the output.</p></td>
                         </tr>
                         <tr>
                            <th>Example input (1)</th>
@@ -8655,29 +8625,9 @@ return <table>
     { "year": "2023", "month": "05", "day": "30" }
   ] }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a complex type with element-only content, containing a single
-                              element particle, whose <code>maxOccurs</code> value is greater than one (including
-                              <code>maxOccurs="unbounded"</code>); attributes are not allowed either on 
-                              the outer element or on the inner elements.</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>count(*) gt 1 and all-equal(*!node-name()) and 
-                              empty(text()[normalize-space()]) and empty(@*) and empty(*/@*)</code></p>
-                           <p>That is, there are at least two child elements; all child elements have the same name; 
-                           there are no text node children other than whitespace-only text nodes; and there
-                           are no attributes either on the outer element or on the inner elements.</p></td>
-                        </tr>-->
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>If the element has element children with names that are not all equal, or
-                              if it has non-whitespace text node children, then it is output
-                              as if <code>mixed</code> layout were chosen (see <specref ref="id-mixed-layout"/>). 
-                              This is fallback behavior for use
-                              when this layout is chosen inappropriately.</p>
-                              <p>In other cases, the content is represented by an array,
+                           <td><p>The content is represented by an array,
                                  whose members correspond one-to-one with the children of the element.
                                  Each child element is converted to a map as if it were a top-level element:
                                  the resulting map contains a single key-value pair. The key part is discarded,
@@ -8695,24 +8645,17 @@ return <table>
                         </tr>
                         <tr>
                            <th>Notes</th>
-                           <td><p>Comments and processing instructions in the content are discarded.</p></td>
+                           <td><p>Attributes are discarded for both the element itself, and its children.
+                              Comments, processing instructions, and whitespace text nodes in the content are discarded.
+                           If the conversion plan names the expected child element, then the converter
+                           falls back to <code>xml</code> layout if there is a child element whose name
+                           differs from this expected name. Fallback also occurs if there are non-whitespace
+                           text node children.</p></td>
                         </tr>
                      </tbody>
                   </table>
                   
-                  <!--<example>
-                     <head>Conversion of a list of elements with complex content</head>
-                     <p>Consider the following XML:</p>
-                     <eg><![CDATA[<items>
-  <item nr="n1"><p>One</p></item>
-  <item nr="n2"><p>Two</p></item>
-</items>]]></eg>
-                     <p>When this is converted using list layout and serialized as JSON, the result is:</p>
-                     <eg><![CDATA[{"items":[
-   {"@nr":"n1", "p":"One"},
-   {"@nr":"n2", "p":"Two"}
-]}   ]]></eg>
-                  </example>-->
+ 
                </div4>
                <div4 id="id-list-plus-layout">
                   <head>Layout: List with Attributes</head>
@@ -8727,6 +8670,7 @@ return <table>
                            <th>Usage</th>
                            <td><p>Intended for XML elements that act as wrappers for a list of child elements,
                               all having the same element name. The wrapper element may have attributes,
+                              but the children should not.
                               and the name of the child elements is retained in the output.</p></td>
                         </tr>
                         <tr>
@@ -8759,27 +8703,10 @@ return <table>
     { "year": "2023", "month": "05", "day": "30" }
   ] } }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a complex type with element-only content, containing a single
-                              element particle, whose <code>maxOccurs</code> value is greater than one (including
-                              <code>maxOccurs="unbounded"</code>).</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>count(*) gt 1 and all-equal(*!node-name()) and empty(text()[normalize-space()])]</code></p>
-                              <p>That is, there are at least two child elements; all child elements have the same name; and
-                                 there are no text node children other than whitespace-only text nodes.</p></td>
-                        </tr>-->
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>If the element has element children with names that are not all equal, or
-                              if it has non-whitespace text node children, then it is output
-                              as if <code>mixed</code> layout were chosen (see <specref ref="id-mixed-layout"/>. 
-                              This is fallback behavior for use
-                              when this layout is chosen inappropriately.</p>
-                              <p>In other cases,
-                                 the content is represented by a map containing one entry for each
+                           <td>
+                              <p>The content is represented by a map containing one entry for each
                                  attribute in the XML element, plus a property named after the 
                                  child elements (the <term>content property</term>), whose value is an array 
                                  containing the results of formatting the content in the same way as the 
@@ -8803,23 +8730,17 @@ return <table>
                         </tr>
                         <tr>
                            <th>Notes</th>
-                           <td><p>Comments and processing instructions in the content are discarded.</p></td>
+                           <td><p>Any attributes on the element's children are discarded.
+                              Comments, processing instructions, and whitespace text nodes in the content are discarded.
+                           If the conversion plan names the expected child element, then the converter
+                           falls back to <code>xml</code> layout if there is a child element whose name
+                           differs from this expected name. Fallback also occurs if there are non-whitespace
+                           text node children.</p>
+                           </td>
                         </tr>
                      </tbody>
                   </table>
- <!--                 <example>
-                     <head>Conversion of a list of elements with complex content</head>
-                     <p>Consider the following XML:</p>
-                     <eg><![CDATA[<items format="bullets">
-  <item nr="1"><p>One</p></item>
-  <item nr="2"><p>Two</p></item>
-</items>]]></eg>
-                     <p>When this is converted using list layout, the result is:</p>
-                     <eg><![CDATA["items": {"@format":"bullets", "item": [
-   {"@nr":"1, "p":"One"},
-   {"@nr":"2, "p":"Two"}
-]   ]]></eg>
-                  </example>-->
+ 
                </div4>
                <div4 id="id-record-layout">
                   <head>Layout: Record</head>
@@ -8874,25 +8795,6 @@ return <table>
               }
 }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a complex type with element-only content, and either:</p>
-                              <olist>
-                                 <item><p>The content model contains
-                                 a single term, whose compositor is <term>all</term> 
-                                    (that is, the element is validated against a complex type 
-                                    defined using <code>xs:all</code>); or</p></item>
-                              <item><p>The content model allows at most one child element (it may allow a choice
-                                 of child elements but must not allow multiple children).</p></item>
-                              </olist>
-                           </td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>exists(*) and all-different(*!node-name()) and empty(text()[normalize-space()])]</code></p>
-                              <p>That is, there is at least one child element; all child elements have different names; and
-                                 there are no text node children other than whitespace-only text nodes.</p></td>
-                        </tr>-->
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>If the element has non-whitespace text node children, then it is output
@@ -8928,7 +8830,10 @@ return <table>
                            <td><p>Although this layout is intended primarily for elements whose children are unordered
                               and uniquely named, it is also viable to use it in cases where elements can repeat, so
                               long as order relative to other elements is not significant.</p>
-                              <p>Comments and processing instructions in the content are discarded.</p></td>
+                              <p>Comments, processing instructions, and whitespace text nodes in the content are discarded.</p>
+                              <p>If any non-whitespace text nodes are present, the converter falls
+                              back to using <code>xml</code> layout.</p>
+                           </td>
                         </tr>
                      </tbody>
                   </table>
@@ -8965,16 +8870,6 @@ return <table>
       { "p": "Dolor sit amet" }
    ] }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a complex type with element-only content that does not meet
-                              the criteria for the <code>list</code> or <code>record</code> layout.</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>empty(text()[normalize-space()])</code></p>
-                           <p>That is, the element has no text node children other than whitespace nodes.</p></td>
-                        </tr>-->
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The mapping rules are identical to the rules for the <code>mixed</code> layout (see 
@@ -8991,7 +8886,9 @@ return <table>
                         <tr>
                            <th>Notes</th>
                            <td><p>Because whitespace text nodes are stripped, this layout should not normally be used
-                              with mixed content.</p></td>
+                              with mixed content.</p>
+                           <p>If any non-whitespace text nodes are present, the converter falls
+                              back to using <code>xml</code> layout.</p></td>
                         </tr>
                      </tbody>
                   </table>
@@ -9024,15 +8921,6 @@ return <table>
      "mess!"
    ] }</eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>The element has a complex type that does not satisfy the criteria for any other
-                              layout to be used.</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p><code>exists(*)</code></p></td>
-                        </tr>-->
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The content is represented by an XDM array containing one entry for each
@@ -9076,6 +8964,12 @@ return <table>
                            In JSON the value <code>xs:QName("fn:null")</code> 
                               is serialized as <code>null</code>.</p></td>
                         </tr>
+                        
+                        <tr>
+                           <th>Notes</th>
+                           <td><p>All children are retained, including comments, processing instructions, and
+                           text nodes, whether or not they are whitespace-only.</p></td>
+                        </tr>
 
                      </tbody>
                   </table>
@@ -9095,7 +8989,9 @@ return <table>
                            <th>Usage</th>
                            <td><p>This layout is useful when the input contains a mix of
                               structured data and marked-up textual content. It allows the
-                              textual content to be output as serialized XML.</p></td>
+                              textual content to be output as serialized XML. It is also used
+                           as a fallback representation when the selected element layout is
+                           inappropriate for a particular element.</p></td>
                         </tr>
                         <tr>
                            <th>Example input</th>
@@ -9105,16 +9001,6 @@ return <table>
                            <th>Example output</th>
                            <td><eg><![CDATA[{ "p": "<p>That was <i>awesome</i></p>" }]]></eg></td>
                         </tr>
-                        <!--<tr>
-                           <th>XSD conditions</th>
-                           <td><p>Not applicable. Serialized XML layout will only be used if 
-                           explicitly selected in the options parameter.</p></td>
-                        </tr>
-                        <tr>
-                           <th>Match predicate</th>
-                           <td><p>Not applicable. Serialized XML layout will only be used if
-                              explicitly selected in the options parameter.</p></td>
-                        </tr>-->
                         <tr>
                            <th>Mapping rules</th>
                            <td><p>The element node is serialized as if by the <function>fn:serialize</function>
@@ -9142,19 +9028,357 @@ return <table>
                </div4>
             </div3>
             
+            <div3 id="id-creating-a-conversion-plan">
+               <head>Creating a conversion plan</head>
+               
+               <p>It is possible to create a conversion plan by analyzing a collection of sample input documents.
+               The function <function>fn:elements-to-maps-conversion-plan</function> is supplied with a collection
+               of nodes (which will normally be element or document nodes), and it examines all the elements within
+               the trees rooted at these nodes, looking for commonalities among like-named elements.</p>
+               
+               <p>The output of this function (the conversion plan) holds information about how elements and attributes
+                  (identified by name) should be converted.</p>
+               
+               <p>For elements, the information is primarily a mapping from element names
+               (<code>xs:QName</code> instances) to layout names. In some cases additional information beyond
+               the layout name is also included. The conversion plan is represented as an XDM map, whose structure
+               is defined in this specification. A conversion plan can be constructed directly, or the plan
+               produced by calling <function>fn:elements-to-maps-conversion-plan</function> can be modified
+               before use. The plan can be serialized using the JSON output method and reloaded so that the same
+               plan is used whenever a query or stylesheet is executed.</p>
+               
+               <p>The <function>fn:elements-to-maps-conversion-plan</function> function selects a layout for a given
+               element name <var>N</var> by applying the following rules:</p>
+               
+               <olist>
+                  <item><p>Let <code>$EE</code> be
+                  the set of all elements named <var>N</var>, specifically
+                  <code>$input/descendant-or-self::*[node-name(.) eq <var>N</var>]</code>.</p>
+                  </item>
+                  
+                  <item>
+                     <p>If <code>empty($EE/(* | text())</code> (that is, if there 
+                        are no child elements or text nodes) then:</p>
+                     <olist>
+                        <item><p>If <code>empty($EE/@*)</code> (that is, if there 
+                           are no attributes),
+                           then the layout is <code>empty</code>: see <specref ref="id-empty-layout"/>.</p></item>
+                        <item><p>Otherwise, the layout is <code>empty-plus</code>: see <specref ref="id-empty-plus-layout"/>.</p></item>
+                     </olist> 
+                  </item>
+                  <item>
+                     <p>If <code>empty($EE/*)</code> (that is, if there are no child elements) then:</p>
+                     <olist>
+                        <item><p>If <code>empty($EE/@*)</code> (that is, if there 
+                           are no attributes)
+                           then the layout is <code>simple</code>: see <specref ref="id-simple-layout"/>.</p></item>
+                        <item><p>Otherwise, <code>simple-plus</code>: see <specref ref="id-simple-plus-layout"/>.</p></item>
+                        <item><p>The plan also includes the property <code>type</code>. If all the elements
+                        in <code>$EE</code> are castable as <code>xs:boolean</code>, then the type is <code>boolean</code>;
+                        otherwise, if all the elements in <code>$EE</code> as castable as <code>xs:numeric</code>,
+                        then the type is <code>numeric</code>; otherwise, the type is <code>string</code>.</p></item>
+                     </olist>
+                  </item>
+                  <item>
+                     <p>If <code>empty($EE/text()[normalize-space()])</code> (that is, there are no text node
+                     children other than whitespace), then:</p>
+                     <olist>
+                        <item>
+                           <p>If <code>all-equal($EE/*/node-name()) and exists($EE/*[2])</code>
+                           (that is, if all child elements have the same name, and at least one element has multiple child
+                           elements), then:</p>
+                           <olist>
+                              <item><p>If <code>empty($EE/@*)</code> (that is, if there 
+                                 are no attributes)
+                                 then <code>list</code>: see <specref ref="id-list-layout"/>.</p></item>
+                              <item><p>Otherwise, <code>list-plus</code>: see <specref ref="id-list-plus-layout"/>.</p></item>
+                           </olist>
+                        </item>
+                        <item>
+                           <p>If <code>every $e in $EE satisfies all-different($e/*/node-name())</code>
+                           (that is, the child elements are uniquely named among their siblings),
+                           then <code>record</code>: see <specref ref="id-record-layout"/>.</p>
+                        </item>
+                        <item>
+                           <p>Otherwise, <code>sequence</code>: see <specref ref="id-sequence-layout"/>.</p>
+                        </item>
+                     </olist>
+                  </item>
+                  <item>
+                     <p>Otherwise, <code>mixed</code>: see <specref ref="id-mixed-layout"/>.</p>
+                  </item>
+
+               </olist>
+               
+               <p>For elements with simple content (more specifically, elements where the chosen layout is
+               <code>simple</code> or <code>simple-plus</code>) the conversion plan also includes an entry indicating
+               whether the content should be represented as a boolean, a number, or a string. If every instance of
+               the element name has content that is castable to <code>xs:boolean</code>, the plan indicates
+               <code>"type": "boolean"</code>. If every instance of
+               the element name has content that is castable to <code>xs:numeric</code>, the plan indicates
+               <code>"type": "numeric"</code>. In other cases, the plan indicates <code>"type": "string"</code>; however,
+               this may be omitted because it is the default.</p>
+               
+               <p>For attributes, the conversion plan identifies whether attributes (with a given name)
+               should be represented as booleans, numbers, or strings. For every distinct attribute name present
+               in the input, an entry is output associating the attribute name with one of the types
+               <code>boolean</code>, <code>numeric</code>, or <code>string</code>. An entry with type <code>boolean</code>
+               is output for an attribute name if all the attributes with that name are castable as <code>xs:boolean</code>.
+               Similarly, an entry with type <code>numeric</code> is output for an attribute name if all the 
+               attributes with that name are castable as <code>xs:numeric</code>. In other case, the attributes are
+               treated as being of type <code>string</code>. Entries with type
+               <code>string</code> may be omitted, since that is the default.</p>
+               
+               <p>The plan that is produced can then be customized by the user if required. For example:</p>
+               
+               <ulist>
+                  <item><p>If <code>simple</code> layout is chosen for a particular element name, but
+                  it is known that some documents might be encountered in which that element
+                  has attributes, then <code>simple</code> might be changed to <code>simple-plus</code>.</p></item>
+                  <item><p>If <code>record</code> layout is chosen for a particular element name, but
+                  it is known that some documents might be encountered in which child elements
+                  can be repeated, then <code>record</code> might be changed to <code>sequence</code>.</p></item>
+                  <item><p>If the plan determines that phone numbers should be represented as numbers,
+                  it might be modified to treat them as strings.</p></item>
+               </ulist>
+               
+               <p>The conversion plan is a map of type <code>map(xs:string, record(*))</code>.
+                  The key is an element or attribute name, representing element names in the form <code>Q{uri}local</code>,
+                  and attributes in the form <code>@Q{uri}local</code>notation: in both cases the <code>Q{uri}</code>
+                  part <rfc2119>must</rfc2119> be omitted for a name in no namespace. Strings
+                  are used as keys in preference to <code>xs:QName</code> instances to allow the plan to be serialized
+                  in JSON format.</p>
+               
+               <p>The corresponding value for an element will always be an instance of type:</p>
+               
+               <eg>
+record(layout as enum("empty", "empty-plus", "simple", "simple-plus", "list", 
+                      "list-plus", "record", "sequence", "mixed", "xml"), 
+       type? as enum("boolean", "numeric", "string"),
+       child? as xs:string,
+       *)</eg> 
+               
+               <p>The <code>type</code> entry is allowed only if the layout is <code>simple</code>
+               or <code>simple-plus</code>, and <rfc2119>may</rfc2119> be omitted if the type is <code>string</code>.</p>
+               
+               <p>The <code>child</code> entry is present only if the layout is <code>list</code>
+               or <code>list-plus</code>; its value is the expected element name of the child element of the list, 
+               expressed again using <code>Q{uri}local</code> notation following the same rules.</p>
+               
+               <p>The record type is extensible, so additional <termref def="implementation-defined"/>
+               entries <rfc2119>may</rfc2119> be present.</p>
+               
+               <p>For an entry representing an attribute, the value will always be an instance of type:</p>
+               
+               <eg>
+record(type? as enum("boolean", "numeric", "string"),
+       *)</eg>
+               
+               <p>The entry <rfc2119>may</rfc2119> be omitted if the type is <code>string</code>.</p>
+               
+               <p>A small example might be (in its JSON serialization):</p>
+               
+               <eg>
+{ "bookList": { "layout": "list", "child": "book" },
+  "book": { "layout": "record" },
+  "author: { "layout": "simple", "type": "string" }
+  "title: { "layout": "simple", "type": "string" }
+  "price: { "layout": "simple", "type": "numeric" }
+  "hardback: { "layout": "simple", "type": "boolean" }
+  "@out-of-print: { "type": "boolean" }
+}  
+               </eg>
+               
+               
+            </div3>
             
+            <div3 id="id-schema-based-conversion">
+               <head>Schema-based conversion</head>
+               
+               <p>As an alternative to constructing a conversion plan by analyzing a corpus of specimen documents,
+               conversion may be controlled using type annotations derived from schema validation.</p>
+               
+               <p>If the function <function>elements-to-maps</function> encounters an element whose name is
+               not present in the conversion plan (including the case where no plan is supplied), and if the
+               element has a type annotation <var>T</var> other than <code>xs:anyType</code> or <code>xs:untyped</code>, then
+               the following rules apply:</p>
+               
+               <note><p>This section uses the notation <code>{prop}</code> to refer to properties
+                     of schema components, as defined in <bibref ref="xmlschema11-1"/>. The schema component model
+                     from XSD 1.1 is used; when XSD 1.0 is used for validation, some properties
+                     such as <code>{open content}</code> will inevitably be absent.</p></note>
+               
+               
+               
+                     
+               <olist>
+                  <item>
+                     <p>Let <code>zeroLength(ST)</code> be true for a simple type <code>ST</code>
+                     if any of the following conditions is true:</p>
+                     <olist>
+                        <item>
+                           <p><code>ST.{variety} = list</code>, and <code>ST.{facets}</code> includes
+                           a <code>length</code> or <code>maxLength</code> facet whose value is 0 (zero).</p>
+                        </item>
+                        <item>
+                           <p><code>ST.{variety} = atomic</code>, and <code>ST.{facets}</code> includes
+                           a <code>length</code> or <code>maxLength</code> facet whose value is 0 (zero).</p>
+                        </item>
+                        <item>
+                           <p><code>ST.{variety} = atomic</code>, and <code>ST.{facets}</code> includes
+                           an <code>enumeration</code> facet constraining the value to be zero-length.</p>
+                        </item>
+                        <item>
+                           <p><code>ST.{variety} = atomic</code>, and <code>ST.{facets}</code> includes
+                           a <code>pattern</code> facet with the value <code>""</code> (a zero-length string).</p>
+                        </item>
+                     </olist>
+                  </item>
+                  <item>
+                     <p>If <var>T</var> is a simple type:</p>
+                     <olist>
+                        <item>
+                           <p>If <code>zeroLength(T)</code>, then the selected layout is <code>empty</code> 
+                              (see <specref ref="id-empty-layout"/>).</p>
+                        </item>
+                        <item>
+                           <p>Otherwise, 
+                              the selected layout is <code>simple</code> (see <specref ref="id-simple-layout"/>),
+                              and the selected type is <code>boolean</code> if <var>T</var> is derived from
+                              <code>xs:boolean</code>; <code>numeric</code> if <var>T</var> is derived from
+                              <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code>;
+                              or <code>string</code> otherwise.</p>
+                        </item>
+                        <!--<item>
+                           <p>Otherwise, <code>mixed</code>: see <specref ref="id-mixed-layout"/>.</p>
+                        </item>-->
+                     </olist>
+                  </item>
+                  <item>
+                     <p>Otherwise (if <var>T</var> is a complex type):</p>
+                     <olist>
+                        <item>
+                           <p>Let <code>$noAttributes</code> be true if 
+                           <code>T.{attribute uses}</code> is empty and <code>T.{attribute wildcard}</code>
+                           is absent.</p>
+                        </item>
+                        <item>
+                           <p>If <code>T.{content type}.{variety} = empty</code>, then:</p>
+                           <olist>
+                              <item><p>If <code>$noAttributes</code> and if <code>empty</code> layout is not disabled,
+                                 then the selected layout is <code>empty</code> (see <specref ref="id-empty-layout"/>).</p></item>
+                              <item><p>Otherwise, the selected layout is <code>empty-plus</code> (see <specref ref="id-empty-plus-layout"/>).</p></item>
+                           </olist>
+                        </item>
+                        <item>
+                           <p>If <code>T.{content type}.{variety} = simple</code> 
+                              (a complex type with simple content), then:</p>
+                           <olist>
+                              <item><p>Let <code>ST</code> be <code>T.{content type}.{simple type definition}</code>
+                              (the corresponding simple type).</p>
+                              </item>
+                              <item>
+                                 <p>If <code>zeroLength(ST)</code>, then:</p>
+                                 <olist>
+                                    <item><p>If <code>$noAttributes</code>, the selected layout is <code>empty</code> 
+                                       (see <specref ref="id-empty-layout"/>).</p></item>
+                                    <item><p>Otherwise, the selected layout is <code>empty-plus</code> 
+                                       (see <specref ref="id-empty-plus-layout"/>).</p></item>
+                                 </olist>
+                              </item>
+                              <item>
+                                 <p>Otherwise:</p>
+                                 <olist>
+                                    <item><p>If <code>$noAttributes</code>, the selected layout is 
+                                       <code>simple</code> (see <specref ref="id-simple-layout"/>).</p></item>
+                                    <item><p>Otherwise the selected layout is <code>simple-plus</code> 
+                                       (see <specref ref="id-simple-plus-layout"/>).</p></item>
+                                    <item><p>In both cases the selected type is one of <code>boolean</code>
+                                    <code>numeric</code>, or <code>string</code>, chosen in the same way
+                                    as for elements having a simple type.</p></item>
+                                 </olist>
+                              </item>
+                           </olist>
+                        </item>
+                        <item>
+                           <p>If <code>T.{content type}.{variety} = element-only</code> (a complex type with
+                           an element-only content model):</p>
+                           <olist>
+                              <item><p>Let <code>$noWildcards</code> be true if <code>T.{content type}.{open content}</code>
+                              is absent, and <code>T.{content type}.{particle}</code>, expanded recursively, contains
+                              no wildcard term.</p></item>
+                              <item><p>Let <code>$childCardinalities</code> be a set of (<code>xs:QName</code>, 
+                                 <code>xs:double</code>) pairs
+                              representing the expanded names of the element declaration terms within 
+                                 <code>T.{content type}.{particle}</code>,
+                              expanded recursively, and for each one, the maximum number of occurrences of elements
+                              with that name, computed
+                              using the value of the <code>{maxOccurs}</code> property of the particles at each level, taking the value
+                              <code>unbounded</code> as positive infinity.</p></item>
+                              <item>
+                                 <p>If <code>$noWildcards</code> is true, and if <code>$childCardinalities</code>
+                                    contains a single entry, and that entry has a cardinality greater than one, then:</p>
+                                 <olist>
+                                    <item><p>If <code>$noAttributes</code> then 
+                                       the selected layout is <code>list</code> (see <specref ref="id-list-layout"/>).</p></item>
+                                    <item><p>Otherwise, the selected layout is <code>list-plus</code> 
+                                       (see <specref ref="id-list-plus-layout"/>).</p></item>
+                                 </olist>
+                              </item>
+                              <item>
+                                 <p>If <code>$noWildcards</code> is true, and if every entry in <code>$childCardinalities</code>
+                                    has a cardinality of one, then the selected layout is
+                                    <code>record</code> (see <specref ref="id-record-layout"/>).</p>
+                              </item>
+                              <item>
+                                 <p>Otherwise, the selected layout is <code>sequence</code> (see <specref ref="id-sequence-layout"/>).</p>
+                              </item>
+                           </olist>
+                        </item>
+                        <item>
+                           <p>Otherwise (that is, when <code>T.{content type}.{variety} = mixed</code>, the
+                              selected layout is <code>mixed</code> (see <specref ref="id-mixed-layout"/>).</p>
+                        </item>
+                     </olist>
+                  </item>
+               </olist>
+               
+               <p>For attribute nodes, the selected type is <code>boolean</code> if the type annotation is derived from
+                  <code>xs:boolean</code>; <code>numeric</code> if the type annotation is derived from
+                  <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code>;
+                  and <code>string</code> otherwise.</p>
+               
+               
+            </div3>
+               
+               
             
             <div3 id="id-selecting-element-layout">
-               <head>Selecting an Element Layout</head>
+               <head>Selecting an element layout</head>
                <p>The various layouts available for elements are described in <specref ref="id-element-layouts"/>.
-               This section defines the rules for selecting an element layout for a given element <code>$E</code>.
+               This section defines the rules for selecting an element layout for a given element <var>E</var>.
                The rules are applied in order.</p>
                
                <olist>
-                  <item><p>If an explicit layout is given for the element name of <code>$E</code> in the
-                  options argument of the <function>fn:elements-to-maps</function> function call, then that layout is used.</p></item>
+                  <item><p>If an explicit layout is given for the element name of <var>E</var> in the
+                  conversion plan supplied to the <function>fn:elements-to-maps</function> function call, 
+                  then that layout is used. If the layout is unsuitable for the element instance, then
+                  the general approach is to fall back to a different layout (as opposed to raising an error
+                  or dropping data): but the rules are defined on a case-by-case basis.</p></item>
                   
-                  <item><p>Let <code>$elements</code> be the value of the first argument to the
+                  <item><p>Otherwise (when no explicit layout is given for <var>E</var>), if the
+                  type annotation of the element is something other than <code>xs:untyped</code>
+                  or <code>xs:anyType</code>, then a schema-determined layout is used as defined
+                  in <specref ref="id-schema-based-conversion"/>.</p></item>
+                  
+                  <item><p>If the above rules do not provide a layout for <var>E</var>, then
+                  a conversion plan for <var>E</var> is determined by applying the rules in 
+                  <specref ref="id-creating-a-conversion-plan"/>, with an input that contains
+                  the single element <var>E</var> and no others.</p></item>
+               </olist>
+            </div3>
+                  
+                  <!--<item><p>Let <code>$elements</code> be the value of the first argument to the
                   <function>fn:elements-to-maps</function> function call.</p></item>
                   
                   <item><p>A layout is said to be disabled if its name is listed in the <code>disable-layouts</code>
@@ -9358,7 +9582,7 @@ return <table>
                      </olist>
                   </item>
                </olist>
-            </div3>
+            </div3>-->
             
              <div3 id="element-and-attribute-names">
                <head>Element and Attribute Names</head>
@@ -9418,10 +9642,28 @@ return <table>
             
             <div3 id="element-and-attribute-content">
                <head>Element and Attribute Content</head>
-               <p>If an input node is untyped, the atomized content of elements, attributes,
-               and text nodes is always of type <code>xs:untypedAtomic</code>, and it is represented
-               as such in the corresponding map entries in the result.</p>
-               <p>Where the content is schema-validated, however:</p>
+               <p>The conversion plan may indicate that element content is to be output
+               as type <code>string</code>, <code>numeric</code>, or <code>boolean</code>: the default
+               is <code>string</code>. In the case of untyped elements and attributes, the value is
+               output as an instance of a string, numeric, or boolean type, according to this
+               prescription. Specifically:</p>
+               
+               <ulist>
+                  <item><p>If the prescribed type is <code>boolean</code> and the value is castable
+                  as <code>xs:boolean</code>, then it is output as an instance of <code>xs:boolean</code>.</p></item>
+                  <item><p>If the prescribed type is <code>numeric</code> and the value is castable
+                  as <code>xs:numeric</code>, then it is output as an instance of <code>xs:integer</code>,
+                  <code>xs:decimal</code>, or <code>xs:double</code> depending on the lexical form of the
+                  value, following the same rules as for XPath numeric literals. For example, <code>"-1"</code>
+                  becomes an <code>xs:integer</code>, <code>12.00</code> becomes an <code>xs:decimal</code>,
+                  and <code>1e-3</code> becomes an <code>xs:double</code>. The special <code>xs:double</code>
+                  values <code>NaN</code> and <code>INF</code> (which cannot be used as numeric literals)
+                  are also recognized.</p></item>
+                  <item><p>In all other cases the value is output as an instance of <code>xs:untypedAtomic</code>,
+                     retaining its original lexical form.</p></item>
+               </ulist>
+               
+               <p>Where the element or attribute is schema-validated, however:</p>
                <olist>
                   <item><p>Let <var>AV</var> be the typed value of the node (that is, the result
                   of atomization).</p></item>
@@ -9443,7 +9685,7 @@ return <table>
                </olist>
                
                <note><p>Atomic items in the result of the <function>fn:elements-to-maps</function> function
-                  may be of any atomic type. The type information is lost if the result is 
+                  may thus be of any atomic type. The type information is lost if the result is 
                   subsequently serialized as JSON.</p></note>
             </div3>
             
@@ -9476,27 +9718,24 @@ return <table>
                   
                   <item><p><emph>Comments and processing instructions: </emph> Comments and processing instructions
                      are lost except when they appear as children of elements that are mapped using the
-                     <code>mixed</code> or <code>xml</code> layouts.</p></item>
+                     <code>sequence</code>, <code>mixed</code> or <code>xml</code> layouts.</p></item>
                   
-                  <item><p><emph>Text nodes: </emph> Text nodes, both whitespace and non-whitespace,
-                  are lost except when they appear as children of elements that are mapped using the
-                     <code>simple</code>, <code>simple-plus</code>, <code>mixed</code>, or 
-                     <code>xml</code> layouts, or when they appear as grandchildren of elements that are
-                  mapped using the <code>list</code> or <code>list-plus</code> layouts.</p></item>
+                  <item><p><emph>Text nodes: </emph>Whitespace text nodes are discarded with they
+                     appear as children of elements that are mapped using the <code>empty</code>,
+                     <code>empty-plus</code>, <code>list</code>, <code>list-plus</code>, <code>record</code>,
+                     or <code>sequence</code> layouts. Non-whitespace text nodes are never discarded. 
+                     </p>
+                  </item>
                   
                   <item><p><emph>Additional node properties: </emph> The values of the <code>is-id</code>,
                      <code>is-idref</code>, and <code>is-nilled</code> properties of a node are lost.</p></item>
                   
                   <item><p><emph>Type annotations: </emph> The values of type annotations on elements are lost.
-                  Type annotations on atomized values of nodes, however, are retained.</p></item>
-                  
-                  <item><p><emph>Element and attribute nodes: </emph> The entire content of element and attribute nodes
-                     is lost if their parent element is mapped using a layout unsuited to that kind of content,
-                     for example if the layout <code>empty</code> or <code>simple</code> is selected for an element that
-                     has attributes or element children.</p></item>
+                  Type annotations on atomized values of schema-validated nodes, however, are retained.</p></item>
+                 
                   
                   <item><p><emph>Element order: </emph> The order of child elements is lost when
-                  <code>record</code> layout is used.</p></item>
+                  <code>record</code> layout is used and the element has multiple children with the same name.</p></item>
                </ulist>
             </div3>
             

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8208,8 +8208,10 @@ return <table>
                </change>
             </changes>
             <p>The <function>fn:element-to-map</function> function converts a tree rooted at an XML element node to 
-               a corresponding tree of maps, in a form
-               suitable for serialization as JSON. This section describes the mappings used by this function.</p>
+               a corresponding tree of maps, in a form suitable for serialization as JSON. In effect it provides
+               a mechanism for converting XML to JSON.</p>
+               
+            <p>This section describes the mappings used by this function.</p>
             
             <p>This mapping is designed with three objectives:</p>
             <ulist>
@@ -8237,12 +8239,13 @@ return <table>
                but this imposes unwanted complexity on the simplest cases. The solution adopted is threefold:</p>
             
             <ulist>
-               <item><p>The function makes use of schema information where available, so it considers
-               not just the structure of an individual element instance, but the rules governing the element type.</p></item>
+               
                <item><p>It is possible to analyze a corpus of XML documents to develop a conversion plan, which can then
                be applied consistently to individual input documents, whether or not these documents were present in the corpus. The
                conversion plan can be serialized and subsequently reused, so that it can be applied to input documents that
                might not have existed at the time the conversion plan was formulated.</p></item>
+               <item><p>Alternatively, the function can make use of schema information where available, so it considers
+               not just the structure of an individual element instance, but the rules governing the element type.</p></item>
                <item><p>It is possible to override the choices made by the system, and explicitly specify the format
                to be used for elements or attributes having a given name.</p></item>
             </ulist>
@@ -8376,24 +8379,19 @@ return <table>
                         a dynamic error.</p> </item>                   
                      </olist>
                   </item>   
-                  <item><p><term>Notes</term>: General observations, especially concerning what information is retained
-                  by this mapping and what information is lost.</p></item>
                </ulist>
                
                <p>The rules for selecting the layout for a particular element are given later, 
                   in <specref ref="id-selecting-element-layout"/>.</p>
                
-               <p>Note that it is possible to use any layout for any element. If an inappropriate layout
+               <p>Note that it is possible to request any layout for any element. If an inappropriate layout
                is chosen for a particular element (for example, <code>empty</code> layout for an element
-                  that is not empty), then in general the conversion falls back to using <code>xml</code> layout, which
-                  outputs the element as a string containing serialized XML. This ensures that no information
-                  is lost, and might act as an indication that the conversion plan needs to be revised.
-                  This will never happen when converting a document that was used as input to the
-                  conversion plan. There is an exception to this rule: if a layout is chosen that does not
-                  allow attributes, then any attribute that is present on the element is discarded.</p>
+                  that is not empty), then the rules for that layout specify what happens.
+               It is possible to specify a fallback layout for use when the selected layout fails: this will typically
+               be a layout such as <code>xml</code> or <code>mixed</code> that can handle any element.</p>
                
                <note><p>Acknowledgements for this categorization: see <bibref ref="Goessner"/>. Although
-               Goessner's categories have been used, the actual mappings vary from his proposal.</p></note>
+               Goessner's categories have been used, the detailed mappings vary from his proposal.</p></note>
                
                
                <div4 id="id-empty-layout">
@@ -8529,11 +8527,13 @@ return <table>
                               <code>&lt;name xsi:nil="true"/></code> becomes <code>{ "name": xs:QName("fn:null") }</code>.</p></td>
                         </tr>
                         <tr>
-                           <th>Notes</th>
+                           <th>Errors</th>
                            <td><p>Attributes are discarded, along with child comment nodes and processing instructions;
                               whitespace is retained.</p>
                               <p>If any child elements are present, this layout fails.</p>
+                              
                            </td>
+                           
                         </tr>
                      </tbody>
                   </table>
@@ -8586,7 +8586,8 @@ return <table>
                            <th>Errors</th>
                            <td><p>Child comment nodes and processing instructions are discarded;
                               whitespace is retained.</p>
-                              <p>If any child elements are present, this layout fails.</p></td>
+                              <p>If any child elements are present, this layout fails.</p>
+                           </td>
                         </tr>
                      </tbody>
                   </table>
@@ -8806,12 +8807,8 @@ return <table>
                         </tr>
                         <tr>
                            <th>Mapping rules</th>
-                           <td><p>If the element has non-whitespace text node children, then it is output
-                              as if <term>mixed</term> layout were chosen (see <specref ref="id-mixed-layout"/>). 
-                              This is fallback behavior for use
-                              when this layout is chosen inappropriately.</p>
-                              <p>In other cases,
-                                 the content is represented by a map containing one entry for each
+                           <td>
+                              <p>The content is represented by a map containing one entry for each
                                  attribute in the XML element, plus one entry for each
                                  child element, whose value is formatted according to the rules for that element.</p>
                               
@@ -8875,8 +8872,8 @@ return <table>
                            <td><eg>{ "section": [
       { "@id": "x" },                        
       { "head": "Introduction" },
-      { "p": "Lorem ipsum" },
-      { "p": "Dolor sit amet" }
+      { "p": "Lorem ipsum." },
+      { "p": "Dolor sit amet." }
    ] }</eg></td>
                         </tr>
                         <tr>
@@ -9133,16 +9130,22 @@ return <table>
                this may be omitted because it is the default.</p>
                
                <p>For attributes, the conversion plan identifies whether attributes (with a given name)
-               should be represented as booleans, numbers, or strings. For every distinct attribute name present
+               should be represented as booleans, numbers, or strings; alternatively, it may indicate
+               that attributes with a given name should be discarded. For every distinct attribute name present
                in the input, an entry is output associating the attribute name with one of the types
-               <code>boolean</code>, <code>numeric</code>, or <code>string</code>. An entry with type <code>boolean</code>
-               is output for an attribute name if all the attributes with that name are castable as <code>xs:boolean</code>.
-               Similarly, an entry with type <code>numeric</code> is output for an attribute name if all the 
+               <code>boolean</code> or <code>numeric</code>; the entry is generally omitted when the values are to 
+               be represented as strings, though the type can also be given explicitly as <code>string</code>. 
+               An entry with type <code>boolean</code>
+               is generated for an attribute name if all the attributes with that name are castable as <code>xs:boolean</code>.
+               Similarly, an entry with type <code>numeric</code> is generated for an attribute name if all the 
                attributes with that name are castable as <code>xs:numeric</code>. In other case, the attributes are
                treated as being of type <code>string</code>. Entries with type
-               <code>string</code> may be omitted, since that is the default.</p>
+               <code>string</code> may be omitted, since that is the default.
+               The entry for an attribute may also specify <code>"type": "skip"</code>
+               to indicate that the attribute should be discarded.</p>
                
-               <p>The plan that is produced can then be customized by the user if required. For example:</p>
+               <p>A plan that is produced by analyzing a corpus of input documents
+                  can then be customized by the user if required. For example:</p>
                
                <ulist>
                   <item><p>If <code>simple</code> layout is chosen for a particular element name, but
@@ -9151,7 +9154,7 @@ return <table>
                   <item><p>If <code>record</code> layout is chosen for a particular element name, but
                   it is known that some documents might be encountered in which child elements
                   can be repeated, then <code>record</code> might be changed to <code>sequence</code>.</p></item>
-                  <item><p>If the plan determines that phone numbers should be represented as numbers,
+                  <item><p>If a generated plan determines that phone numbers should be represented as numbers,
                   it might be modified to treat them as strings.</p></item>
                </ulist>
                
@@ -9164,42 +9167,18 @@ return <table>
                
                <p>A more detailed definition of the structure is given in <specref ref="id-conversion-plan-structure"/>.</p>
                
-               <!--<p>The corresponding value for an element will always be an instance of type:</p>-->
                
-               <!--<eg>
-record(layout as enum("empty", "empty-plus", "simple", "simple-plus", "list", 
-                      "list-plus", "record", "sequence", "mixed", "xml"), 
-       type? as enum("boolean", "numeric", "string"),
-       child? as xs:string,
-       *)</eg> 
-               
-               <p>The <code>type</code> entry is allowed only if the layout is <code>simple</code>
-               or <code>simple-plus</code>, and <rfc2119>may</rfc2119> be omitted if the type is <code>string</code>.</p>
-               
-               <p>The <code>child</code> entry is present only if the layout is <code>list</code>
-               or <code>list-plus</code>; its value is the expected element name of the child element of the list, 
-               expressed again using <code>Q{uri}local</code> notation following the same rules.</p>
-               
-               <p>The record type is extensible, so additional <termref def="implementation-defined"/>
-               entries <rfc2119>may</rfc2119> be present.</p>
-               
-               <p>For an entry representing an attribute, the value will always be coercible to the type:</p>
-               
-               <eg>
-record(type? as enum("boolean", "numeric"), *)</eg>
-               
-               <p>The entry <rfc2119>may</rfc2119> be omitted if the type is <code>string</code>.</p>
-               -->
                <p>A small example might be (in its JSON serialization):</p>
                
                <eg>
 { "bookList": { "layout": "list", "child": "book" },
   "book": { "layout": "record" },
-  "author: { "layout": "simple" }
-  "title: { "layout": "simple" }
-  "price: { "layout": "simple", "type": "numeric" }
-  "hardback: { "layout": "simple", "type": "boolean" }
-  "@out-of-print: { "type": "boolean" }
+  "author": { "layout": "simple" },
+  "title": { "layout": "simple" },
+  "price": { "layout": "simple", "type": "numeric" },
+  "hardback": { "layout": "simple", "type": "boolean" },
+  "@out-of-print": { "type": "boolean" },
+  "@Q{http://www.w3.org/2001/XMLSchema-instance}nil": { "type": "skip" }
 }  
                </eg>
                
@@ -9223,7 +9202,7 @@ map( xs:string,
                               "record", "sequence", "mixed",
                               "xml", "error", "deep-skip"),
               child? as xs:string,
-              type? as enum("boolean", "numeric")
+              type? as enum("boolean", "numeric", "string", "skip")
               * )
 )                                             
                </eg>
@@ -9257,7 +9236,8 @@ map( xs:string,
                      applies:</p>
                      <olist>
                         <item><p>The key represents the name of an attribute.</p></item>
-                        <item><p>The <code>layout</code> is <code>simple</code> or <code>simple-plus</code>.</p></item>
+                        <item><p>The <code>layout</code> is <code>simple</code> or <code>simple-plus</code>. In this
+                        case the value must not be <code>"skip"</code>.</p></item>
                      </olist>
                   </item>
                </olist>
@@ -9340,9 +9320,6 @@ map( xs:string,
                               <code>xs:decimal</code>, <code>xs:double</code>, or <code>xs:float</code>;
                               or <code>string</code> otherwise.</p>
                         </item>
-                        <!--<item>
-                           <p>Otherwise, <code>mixed</code>: see <specref ref="id-mixed-layout"/>.</p>
-                        </item>-->
                      </olist>
                   </item>
                   <item>
@@ -9471,7 +9448,8 @@ map( xs:string,
                   <item><p>If the above rules do not provide a layout for <var>E</var>, then
                   a conversion plan for <var>E</var> is determined by applying the rules in 
                   <specref ref="id-creating-a-conversion-plan"/>, with an input that contains
-                  the single element <var>E</var> and no others.</p></item>
+                  the single element <var>E</var> and no others. (Only the element <var>E</var> itself
+                  is considered, not its descendants.)</p></item>
                </olist>
             </div3>
                   
@@ -9502,6 +9480,10 @@ map( xs:string,
                   prefix to be associated with a namespace URI, so this format is suitable only when prefixes 
                   in the input documents are used predictably.</p></item>
                </ulist>
+                
+                <p>Regardless of the chosen <code>name-format</code>, and regardless of the above rules, 
+                  attributes in the <code>xml</code> namespace (<code>http://www.w3.org/XML/1998/namespace</code>)
+                  are output using a lexical QName, with the prefix <code>xml</code>.</p>
               
                
                <p>Attribute names in the output are typically prefixed with the character <code>"@"</code>.
@@ -9515,17 +9497,6 @@ map( xs:string,
                <code>{ "data": { "@val": ["3", "4"] } }</code> or (because attribute order is unpredictable)
                <code>{ "data": { "@val": ["4", "3"] } }</code>.</p>
                
-               <p>Regardless of the chosen <code>name-format</code>, and regardless of the above rules:</p>
-               
-               <ulist>
-                  <item><p>Attributes in the <code>xsi</code> namespace (<code>http://www.w3.org/2001/XMLSchema-instance</code>)
-                     are discarded.</p>
-                     <note><p>This is because these attributes can appear even when the schema does not allow the element
-                     to have attributes, which means that a layout might be chosen that does not accommodate attributes.</p></note>
-                  </item>
-                  <item><p>Attributes in the <code>xml</code> namespace (<code>http://www.w3.org/XML/1998/namespace</code>)
-                  are output using a lexical QName, with the prefix <code>xml</code>.</p></item>
-               </ulist>
                
                
   
@@ -9558,6 +9529,8 @@ map( xs:string,
                
                <p>Where the element or attribute is schema-validated, however:</p>
                <olist>
+                  <item><p>If an element has the <code>nilled</code> property (that is, <code>xsi:nil="true"</code>),
+                  then the mapping for nilled elements with the chosen layout is used.</p></item>
                   <item><p>Let <var>AV</var> be the typed value of the node (that is, the result
                   of atomization).</p></item>
                   <item><p>If, however, an element is annotated with a type that does not allow atomization
@@ -9605,15 +9578,11 @@ map( xs:string,
                   (and in particular, bindings for namespaces that are declared but not used in element
                   and attribute names) is lost.</p></item>
                   
-                  <item><p><emph>The <code>xsi</code> namespace: </emph> All attributes in the <code>xsi</code>
-                     namespace (<code>http://www.w3.org/2001/XMLSchema-instance</code>) are lost,
-                  except when <code>xml</code> layout is selected.</p></item>
-                  
                   <item><p><emph>Comments and processing instructions: </emph> Comments and processing instructions
                      are lost except when they appear as children of elements that are mapped using the
                      <code>sequence</code>, <code>mixed</code> or <code>xml</code> layouts.</p></item>
                   
-                  <item><p><emph>Text nodes: </emph>Whitespace text nodes are discarded with they
+                  <item><p><emph>Text nodes: </emph>Whitespace text nodes are discarded when they
                      appear as children of elements that are mapped using the <code>empty</code>,
                      <code>empty-plus</code>, <code>list</code>, <code>list-plus</code>, <code>record</code>,
                      or <code>sequence</code> layouts. Non-whitespace text nodes are never discarded. 

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8243,7 +8243,7 @@ return <table>
                be applied consistently to individual input documents, whether or not these documents were present in the corpus. The
                conversion plan can be serialized and subsequently reused, so that it can be applied to input documents that
                might not have existed at the time the conversion plan was formulated.</p></item>
-               <item><p>It is possible to override the choices made by the system, and explicitly specify a the format
+               <item><p>It is possible to override the choices made by the system, and explicitly specify the format
                to be used for elements or attributes having a given name.</p></item>
             </ulist>
             
@@ -8318,9 +8318,9 @@ return <table>
                      supplying a conversion plan as input
                      to the <function>fn:element-to-map</function> function.</p></item>
                   <item><p>It is possible to construct a conversion plan by analyzing a corpus of documents
-                  using the <function>fn:element-to-map-conversion-plan</function> function.</p></item>
+                  using the <function>fn:element-to-map-plan</function> function.</p></item>
                   <item><p>It is also possible to construct a conversion plan manually, or to modify
-                  the conversion plan produced by the <function>fn:element-to-map-conversion-plan</function> function
+                  the conversion plan produced by the <function>fn:element-to-map-plan</function> function
                      before use.</p></item>
                   <item><p>In the absence of an explicit conversion plan, if the data has been schema-validated, the layout is 
                      inferred from the content model for the element type as defined in the schema.</p></item>
@@ -8351,7 +8351,7 @@ return <table>
                   for the top-level elements supplied in the <code>$elements</code> argument; when used to convert
                      a descendant element, the corresponding key-value pair may appear as part of a larger map, depending
                      on the layout chosen for its parent element..</p>
-                  <note><p>The <function>fn:element-to-map</function> function produces maps as its result, but it is convenient
+                  <note><p>The <function>fn:element-to-map</function> function produces a map as its result, but it is convenient
                   to illustrate the form of the map by showing the effect of serializing the map as JSON.</p></note></item>
                   
                   <item><p><term>Mapping rules</term>: The rules for mapping the XML element to an XDM map
@@ -8359,6 +8359,23 @@ return <table>
                   <item><p><term>Mapping for nilled elements</term>: special rules that apply to an
                   element having the attribute <code>xsi:nil="true"</code>. These rules only apply if the
                   element has been schema-validated.</p></item>
+                  <item><p><term>Errors</term>: situations where the layout cannot be used, and where attempting
+                     to use it will fail. For example, the <code>empty</code> layout cannot be used for
+                     an element that is not empty. In such a situation the recovery action is as follows, in order:</p>
+                     <olist>
+                        <item><p>Attributes are dropped, and if this is sufficient to enable the layout
+                        to be used, then the element is converted without its attributes.</p></item>
+                        <item><p>If the <code>type</code> of an element or attribute in the conversion
+                        plan is given as <code>boolean</code> or <code>numeric</code>, but the actual
+                        value of the element or attribute is not castable to <code>xs:boolean</code>
+                        or <code>xs:numeric</code> respectively, then the node is output ignoring
+                        the <code>type</code> property, that is, as an instance of <code>xs:untypedAtomic</code>.</p></item>
+                        <item><p>If the conversion plan supplies a fallback layout (an entry with key
+                        <code>"*"</code>), then the fallback layout is used.</p></item>
+                        <item><p>The <function>element-to-map</function> function fails with
+                        a dynamic error.</p> </item>                   
+                     </olist>
+                  </item>   
                   <item><p><term>Notes</term>: General observations, especially concerning what information is retained
                   by this mapping and what information is lost.</p></item>
                </ulist>
@@ -8417,12 +8434,10 @@ return <table>
                                as <code>{ "hr": null }</code>.</p></td>
                         </tr>
                         <tr>
-                           <th>Notes</th>
+                           <th>Errors</th>
                            <td><p>Attributes are discarded, along with child comment nodes, 
                               processing instructions, and whitespace-only text nodes.</p>
-                              <p>If any other child nodes are present, the converter falls
-                              back to using <code>xml</code> layout. (This can happen
-                           when this layout is explicitly selected for elements that are not actually empty.)</p></td>
+                              <p>If any other child nodes are present, this layout fails.</p></td>
                         </tr>
                      </tbody>
                   </table>
@@ -8466,13 +8481,10 @@ return <table>
                               <code>{ "hr": { "@id": "x", "#content": xs:QName("fn:null") } }</code>.</p></td>
                         </tr>
                         <tr>
-                           <th>Notes</th>
+                           <th>Errors</th>
                            <td><p>Child comment nodes, processing instructions, and whitespace-only text
                            nodes are discarded.</p>
-                              <p>If any other child nodes are present in the element, the converter falls
-                              back to using <code>xml</code> layout.
-                              (This can happen
-                              when this layout is explicitly selected for elements that are not actually empty.)</p></td>
+                              <p>If any other child nodes are present, this layout fails.</p></td>
                         </tr>
                      </tbody>
                   </table>
@@ -8520,8 +8532,7 @@ return <table>
                            <th>Notes</th>
                            <td><p>Attributes are discarded, along with child comment nodes and processing instructions;
                               whitespace is retained.</p>
-                              <p>If any child elements are present, the converter falls
-                              back to using <code>xml</code> layout.</p>
+                              <p>If any child elements are present, this layout fails.</p>
                            </td>
                         </tr>
                      </tbody>
@@ -8572,11 +8583,10 @@ return <table>
                               which is serialized in JSON as <code>null</code>.</p></td>
                         </tr>
                         <tr>
-                           <th>Notes</th>
+                           <th>Errors</th>
                            <td><p>Child comment nodes and processing instructions are discarded;
                               whitespace is retained.</p>
-                              <p>If any child elements are present, the converter falls
-                              back to using <code>xml</code> layout.</p></td>
+                              <p>If any child elements are present, this layout fails.</p></td>
                         </tr>
                      </tbody>
                   </table>
@@ -8645,13 +8655,12 @@ return <table>
                               <code>null</code> (for example <code>{ "dates": xs:QName("fn:null") }</code>).</p></td>
                         </tr>
                         <tr>
-                           <th>Notes</th>
+                           <th>Errors</th>
                            <td><p>Attributes are discarded for both the element itself, and its children.
-                              Comments, processing instructions, and whitespace text nodes in the content are discarded.
-                           If the conversion plan names the expected child element, then the converter
-                           falls back to <code>xml</code> layout if there is a child element whose name
-                           differs from this expected name. Fallback also occurs if there are non-whitespace
-                           text node children, or if the names of the child elements are non-uniform.</p></td>
+                              Comments, processing instructions, and whitespace text nodes in the content are discarded.</p>
+                              <p>This layout fails if any child element is present with a name that
+                                 differs from the expected child element name, or if there are non-whitespace
+                                 text node children.</p></td>
                         </tr>
                      </tbody>
                   </table>
@@ -8730,13 +8739,12 @@ return <table>
                               becomes <code>{"dates": { "@id": "x", "#content": xs:QName("fn:null") } }</code>.</p></td>
                         </tr>
                         <tr>
-                           <th>Notes</th>
+                           <th>Errors</th>
                            <td><p>Any attributes on the element's children are discarded.
-                              Comments, processing instructions, and whitespace text nodes in the content are discarded.
-                           If the conversion plan names the expected child element, then the converter
-                           falls back to <code>xml</code> layout if there is a child element whose name
-                           differs from this expected name. Fallback also occurs if there are non-whitespace
-                           text node children.</p>
+                              Comments, processing instructions, and whitespace text nodes in the content are discarded.</p>
+                              <p>This layout fails if any child element is present with a name that
+                                 differs from the expected child element name, or if there are non-whitespace
+                                 text node children.</p>
                            </td>
                         </tr>
                      </tbody>
@@ -8827,13 +8835,13 @@ return <table>
                               in JSON as <code>"#content": null</code>.</p></td>
                         </tr>
                         <tr>
-                           <th>Notes</th>
+                           <th>Errors</th>
                            <td><p>Although this layout is intended primarily for elements whose children are unordered
                               and uniquely named, it is also viable to use it in cases where elements can repeat, so
                               long as order relative to other elements is not significant.</p>
                               <p>Comments, processing instructions, and whitespace text nodes in the content are discarded.</p>
-                              <p>If any non-whitespace text nodes are present, the converter falls
-                              back to using <code>xml</code> layout.</p>
+                              <p>This layout fails if there are non-whitespace
+                                 text node children.</p>
                            </td>
                         </tr>
                      </tbody>
@@ -8885,11 +8893,10 @@ return <table>
                               any attributes.</p></td>
                         </tr>
                         <tr>
-                           <th>Notes</th>
-                           <td><p>Because whitespace text nodes are stripped, this layout should not normally be used
-                              with mixed content.</p>
-                           <p>If any non-whitespace text nodes are present, the converter falls
-                              back to using <code>xml</code> layout.</p></td>
+                           <th>Errors</th>
+                           <td><p>This layout fails if there are non-whitespace
+                                 text node children.</p>
+                           </td>
                         </tr>
                      </tbody>
                   </table>
@@ -8967,9 +8974,10 @@ return <table>
                         </tr>
                         
                         <tr>
-                           <th>Notes</th>
+                           <th>Errors</th>
                            <td><p>All children are retained, including comments, processing instructions, and
-                           text nodes, whether or not they are whitespace-only.</p></td>
+                           text nodes, whether or not they are whitespace-only.</p>
+                           <p>This layout never fails.</p></td>
                         </tr>
 
                      </tbody>
@@ -9023,6 +9031,10 @@ return <table>
                               that is, the output serialization includes the attribute <code>xsi:nil="true"</code>,
                               together with a declaration of the <code>xsi</code> namespace prefix.</p></td>
                         </tr>
+                        <tr>
+                           <th>Errors</th>
+                           <td><p>This layout never fails.</p></td>
+                        </tr>
        
                      </tbody>
                   </table>
@@ -9033,7 +9045,7 @@ return <table>
                <head>Creating a conversion plan</head>
                
                <p>It is possible to create a conversion plan by analyzing a collection of sample input documents.
-               The function <function>fn:element-to-map-conversion-plan</function> is supplied with a collection
+               The function <function>fn:element-to-map-plan</function> is supplied with a collection
                of nodes (which will normally be element or document nodes), and it examines all the elements within
                the trees rooted at these nodes, looking for commonalities among like-named elements.</p>
                
@@ -9044,11 +9056,11 @@ return <table>
                (<code>xs:QName</code> instances) to layout names. In some cases additional information beyond
                the layout name is also included. The conversion plan is represented as an XDM map, whose structure
                is defined in this specification. A conversion plan can be constructed directly, or the plan
-               produced by calling <function>fn:element-to-map-conversion-plan</function> can be modified
+               produced by calling <function>fn:element-to-map-plan</function> can be modified
                before use. The plan can be serialized using the JSON output method and reloaded so that the same
                plan is used whenever a query or stylesheet is executed.</p>
                
-               <p>The <function>fn:element-to-map-conversion-plan</function> function selects a layout for a given
+               <p>The <function>fn:element-to-map-plan</function> function selects a layout for a given
                element name <var>N</var> by applying the following rules:</p>
                
                <olist>
@@ -9150,9 +9162,11 @@ return <table>
                   are used as keys in preference to <code>xs:QName</code> instances to allow the plan to be serialized
                   in JSON format.</p>
                
-               <p>The corresponding value for an element will always be an instance of type:</p>
+               <p>A more detailed definition of the structure is given in <specref ref="id-conversion-plan-structure"/>.</p>
                
-               <eg>
+               <!--<p>The corresponding value for an element will always be an instance of type:</p>-->
+               
+               <!--<eg>
 record(layout as enum("empty", "empty-plus", "simple", "simple-plus", "list", 
                       "list-plus", "record", "sequence", "mixed", "xml"), 
        type? as enum("boolean", "numeric", "string"),
@@ -9169,21 +9183,20 @@ record(layout as enum("empty", "empty-plus", "simple", "simple-plus", "list",
                <p>The record type is extensible, so additional <termref def="implementation-defined"/>
                entries <rfc2119>may</rfc2119> be present.</p>
                
-               <p>For an entry representing an attribute, the value will always be an instance of type:</p>
+               <p>For an entry representing an attribute, the value will always be coercible to the type:</p>
                
                <eg>
-record(type? as enum("boolean", "numeric", "string"),
-       *)</eg>
+record(type? as enum("boolean", "numeric"), *)</eg>
                
                <p>The entry <rfc2119>may</rfc2119> be omitted if the type is <code>string</code>.</p>
-               
+               -->
                <p>A small example might be (in its JSON serialization):</p>
                
                <eg>
 { "bookList": { "layout": "list", "child": "book" },
   "book": { "layout": "record" },
-  "author: { "layout": "simple", "type": "string" }
-  "title: { "layout": "simple", "type": "string" }
+  "author: { "layout": "simple" }
+  "title: { "layout": "simple" }
   "price: { "layout": "simple", "type": "numeric" }
   "hardback: { "layout": "simple", "type": "boolean" }
   "@out-of-print: { "type": "boolean" }
@@ -9191,6 +9204,83 @@ record(type? as enum("boolean", "numeric", "string"),
                </eg>
                
                
+            </div3>
+            
+            <div3 id="id-conversion-plan-structure">
+               <head>Structure of the conversion plan</head>
+               
+               <p>This section provides a definition of the structure of the
+               conversion plan that is output by the <function>fn:element-to-map-plan</function>
+               function, and used as input to the <function>fn:element-to-map</function>
+               function.</p>
+               
+               <p>The structure is defined by the following item type:</p>
+               
+               <eg>
+map( xs:string,
+     record ( layout? as enum("empty", "empty-plus", "simple", "simple-plus",
+                              "list", list-plus",
+                              "record", "sequence", "mixed",
+                              "xml", "error", "deep-skip"),
+              child? as xs:string,
+              type? as enum("boolean", "numeric")
+              * )
+)                                             
+               </eg>
+               
+               <p>The rules relating to this structure are as follows:</p>
+               
+               <olist>
+                  <item><p>The keys of the map entries are strings of the form:</p>
+                     <olist>
+                        <item><p><code>local-name</code> representing the name of an element in no namespace.</p></item>
+                        <item><p><code>Q{uri}local-name</code> representing the name of an element in a namespace.</p></item>
+                        <item><p><code>*</code> representing a fallback rule for use with elements where either
+                        (a) there is no more specific rule, or (b) processing using the selected layout
+                        fails.</p></item>
+                        <item><p><code>@local-name</code> representing the name of an attribute in no namespace.</p></item>
+                        <item><p><code>@Q{uri}local-name</code> representing the name of an attribute in a namespace.</p></item>
+                     </olist>
+                     <p>Any entries whose keys are not in this format will be ignored.</p>
+                  </item>
+                  <item>
+                     <p>The <code>layout</code> entry is present if and only if the key represents the name of an element.</p>
+                  </item>
+                  <item>
+                     <p>The <code>child</code> entry is present if and only if the value of <code>layout</code> is
+                     <code>list</code> or <code>list-plus</code>. It represents an element name in the format
+                     <code>local-name</code> for a name in no namespace, or <code>Q{uri}local-name</code> for a
+                     name in a namespace.</p>
+                  </item>
+                  <item>
+                     <p>The <code>type</code> entry is present if, and only if, one of the following conditions
+                     applies:</p>
+                     <olist>
+                        <item><p>The key represents the name of an attribute.</p></item>
+                        <item><p>The <code>layout</code> is <code>simple</code> or <code>simple-plus</code>.</p></item>
+                     </olist>
+                  </item>
+               </olist>
+               
+               <p>If additional entries (beyond those described above) are present in any of the maps, they
+               are ignored, provided that the map is coercible to the given type definition.</p>
+               
+               <p>The fallback rule (with key <code>"*"</code>) is used to process elements whose name has no
+               specific entry, and also for elements where normal processing fails (for example when the
+               selected layout is <code>"empty"</code>, but the element has children). If no fallback rule
+               is present then <code>"error"</code> is assumed: this causes processing to fail with a dynamic
+               error. The fallback rule will typically set the <code>layout</code> property to one of the following:</p>
+               
+               <ulist>
+                  <item><p><code>error</code>: this causes the function to fail with a dynamic error.</p></item>
+                  <item><p><code>deep-skip</code>: this causes the element and its content (recursively)
+                  to be omitted from the output.</p></item>
+                  <item><p><code>mixed</code>: this causes the element to be output using layout <code>mixed</code></p></item>
+                  <item><p><code>xml</code>: this outputs the element to be output using layout <code>xml</code>,
+                     which represents the content as a string containing serialized XML.</p></item>
+               </ulist>
+               
+               <p>However, any layout may be used as the fallback; if it fails, the error is unrecoverable.</p>
             </div3>
             
             <div3 id="id-schema-based-conversion">
@@ -9363,14 +9453,20 @@ record(type? as enum("boolean", "numeric", "string"),
                <olist>
                   <item><p>If an explicit layout is given for the element name of <var>E</var> in the
                   conversion plan supplied to the <function>fn:element-to-map</function> function call, 
-                  then that layout is used. If the layout is unsuitable for the element instance, then
-                  the general approach is to fall back to a different layout (as opposed to raising an error
-                  or dropping data): but the rules are defined on a case-by-case basis.</p></item>
+                  then that layout is used. If the selected layout is <code>deep-skip</code>,
+                     then no output is produced for that element. If the selected layout is <code>error</code>,
+                     then the function fails with a dynamic error.
+                     If the selected layout fails for the element instance, then
+                     the fallback layout (identified with the key <code>"*"</code> in the conversion plan)
+                     is used; in the absence of a fallback layout, the function fails with a dynamic error.</p></item>
                   
                   <item><p>Otherwise (when no explicit layout is given for <var>E</var>), if the
                   type annotation of the element is something other than <code>xs:untyped</code>
                   or <code>xs:anyType</code>, then a schema-determined layout is used as defined
                   in <specref ref="id-schema-based-conversion"/>.</p></item>
+                  
+                  <item><p>Otherwise, if the conversion plan supplies a fallback layout 
+                  (identified with the key <code>"*"</code>), then the fallback layout is used.</p></item>
                   
                   <item><p>If the above rules do not provide a layout for <var>E</var>, then
                   a conversion plan for <var>E</var> is determined by applying the rules in 
@@ -9379,211 +9475,7 @@ record(type? as enum("boolean", "numeric", "string"),
                </olist>
             </div3>
                   
-                  <!--<item><p>Let <code>$elements</code> be the value of the first argument to the
-                  <function>fn:element-to-map</function> function call.</p></item>
-                  
-                  <item><p>A layout is said to be disabled if its name is listed in the <code>disable-layouts</code>
-                  option.</p></item>
-                  
-                  <item><p>If the <code>uniform</code> option is true, then let <code>$EE</code> be
-                  the set of all elements with the same name as <code>$E</code>, specifically
-                  <code>$elements/descendant-or-self::*[node-name(.) eq node-name($E)]</code>.</p>
-                  <p>If the <code>uniform</code> option is false, then let <code>$EE</code> be <code>$E</code>.</p></item>
-                  
-                  <item><p>Let <var>T</var> be the type identified by the type annotation of <code>$E</code>.</p></item>
-                  
-                  <item><p>If <var>T</var> is <code>xs:untyped</code> or <code>xs:anyType</code>, then:</p>
-                     <olist>
-                        <item>
-                           <p>If <code>empty($EE/(* | text())</code> (that is, if there 
-                              are no child elements or text nodes) then:</p>
-                           <olist>
-                              <item><p>If <code>empty($EE/@*)</code> (that is, if there 
-                                 are no attributes) and if <code>empty</code> layout is not disabled,
-                                 then <code>empty</code>: see <specref ref="id-empty-layout"/>.</p></item>
-                              <item><p>Otherwise, if <code>empty-plus</code> layout is not disabled,
-                                 then <code>empty-plus</code>: see <specref ref="id-empty-plus-layout"/>.</p></item>
-                           </olist> 
-                        </item>
-                        <item>
-                           <p>If <code>empty($EE/*)</code> (that is, if there are no child elements) then:</p>
-                           <olist>
-                              <item><p>If <code>empty($EE/@*)</code> (that is, if there 
-                                 are no attributes), and if <code>simple</code> layout is not disabled,
-                                 then <code>simple</code>: see <specref ref="id-simple-layout"/>.</p></item>
-                              <item><p>Otherwise, if <code>simple-plus</code> layout is not disabled,
-                                 then <code>simple-plus</code>: see <specref ref="id-simple-plus-layout"/>.</p></item>
-                           </olist>
-                        </item>
-                        <item>
-                           <p>If <code>empty($EE/text()[normalize-space()])</code> (that is, there are no text node
-                           children other than whitespace), then:</p>
-                           <olist>
-                              <item>
-                                 <p>If <code>all-equal($EE/*/node-name()) and exists($EE/*[2])</code>
-                                 (that is, if all child elements have the same name, and at least one element has multiple child
-                                 elements), then:</p>
-                                 <olist>
-                                    <item><p>If <code>empty($EE/@*)</code> (that is, if there 
-                                       are no attributes), and if <code>list</code> layout is not disabled,
-                                       then <code>list</code>: see <specref ref="id-list-layout"/>.</p></item>
-                                    <item><p>Otherwise, if <code>list-plus</code> layout is not disabled,
-                                       then <code>list-plus</code>: see <specref ref="id-list-plus-layout"/>.</p></item>
-                                 </olist>
-                              </item>
-                              <item>
-                                 <p>If <code>every $e in $EE satisfies all-different($e/*/node-name())</code>
-                                 (that is, the child elements are uniquely named among their siblings),
-                                 and if <code>record</code> layout is not disabled,
-                                 then <code>record</code>: see <specref ref="id-record-layout"/>.</p>
-                              </item>
-                              <item>
-                                 <p>Otherwise, if <code>sequence</code> layout is not disabled,
-                                    then <code>sequence</code>: see <specref ref="id-sequence-layout"/>.</p>
-                              </item>
-                           </olist>
-                        </item>
-                        <item>
-                           <p>Otherwise, <code>mixed</code>: see <specref ref="id-mixed-layout"/>.</p>
-                        </item>
-                     </olist>          
-                  </item>
-                  <item>
-                     <p>Otherwise (for an element <code>$E</code> that is schema-validated with 
-                        type annotation <var>T</var>):</p>
-                     <note><p>This section uses the notation <code>{prop}</code> to refer to properties
-                     of schema components, as defined in <bibref ref="xmlschema11-1"/>. The schema component model
-                     from XSD 1.1 is used; when XSD 1.0 is used for validation, some properties
-                     such as <code>{open content}</code> will inevitably be absent.</p></note>
-                     <olist>
-                        <item>
-                           <p>Let <code>zeroLength(ST)</code> be true for a simple type <code>ST</code>
-                           if any of the following conditions is true:</p>
-                           <olist>
-                              <item>
-                                 <p><code>ST.{variety} = list</code>, and <code>ST.{facets}</code> includes
-                                 a <code>length</code> or <code>maxLength</code> facet whose value is 0 (zero).</p>
-                              </item>
-                              <item>
-                                 <p><code>ST.{variety} = atomic</code>, and <code>ST.{facets}</code> includes
-                                 a <code>length</code> or <code>maxLength</code> facet whose value is 0 (zero).</p>
-                              </item>
-                              <item>
-                                 <p><code>ST.{variety} = atomic</code>, and <code>ST.{facets}</code> includes
-                                 an <code>enumeration</code> facet constraining the value to be zero-length.</p>
-                              </item>
-                              <item>
-                                 <p><code>ST.{variety} = atomic</code>, and <code>ST.{facets}</code> includes
-                                 a <code>pattern</code> facet with the value <code>""</code> (a zero-length string).</p>
-                              </item>
-                           </olist>
-                        </item>
-                        <item>
-                           <p>If <var>T</var> is a simple type:</p>
-                           <olist>
-                              <item>
-                                 <p>If <code>zeroLength(T)</code>, and if <code>empty</code> layout is 
-                                    not disabled, then <code>empty</code>: see <specref ref="id-empty-layout"/>.</p>
-                              </item>
-                              <item>
-                                 <p>Otherwise, if <code>simple</code> layout is not disabled, then 
-                                    <code>simple</code>: see <specref ref="id-simple-layout"/>.</p>
-                              </item>
-                              <item>
-                                 <p>Otherwise, <code>mixed</code>: see <specref ref="id-mixed-layout"/>.</p>
-                              </item>
-                           </olist>
-                        </item>
-                        <item>
-                           <p>Otherwise (if <var>T</var> is a complex type):</p>
-                           <olist>
-                              <item>
-                                 <p>Let <code>$noAttributes</code> be true if 
-                                 <code>T.{attribute uses}</code> is empty and <code>T.{attribute wildcard}</code>
-                                 is absent.</p>
-                              </item>
-                              <item>
-                                 <p>If <code>T.{content type}.{variety} = empty</code>, then:</p>
-                                 <olist>
-                                    <item><p>If <code>$noAttributes</code> and if <code>empty</code> layout is not disabled,
-                                       then <code>empty</code>: see <specref ref="id-empty-layout"/>.</p></item>
-                                    <item><p>Otherwise, if <code>empty-plus</code> layout is not disabled, 
-                                       then <code>empty-plus</code>: see <specref ref="id-empty-plus-layout"/>.</p></item>
-                                 </olist>
-                              </item>
-                              <item>
-                                 <p>If <code>T.{content type}.{variety} = simple</code> 
-                                    (a complex type with simple content), then:</p>
-                                 <olist>
-                                    <item><p>Let <code>ST</code> be <code>T.{content type}.{simple type definition}</code>
-                                    (the corresponding simple type).</p>
-                                    </item>
-                                    <item>
-                                       <p>If <code>zeroLength(ST)</code>, then:</p>
-                                       <olist>
-                                          <item><p>If <code>$noAttributes</code> and if <code>empty</code> layout is 
-                                             not disabled, then <code>empty</code>: see <specref ref="id-empty-layout"/>.</p></item>
-                                          <item><p>Otherwise, if <code>empty-plus</code> layout is not disabled,
-                                             then <code>empty-plus</code>: see <specref ref="id-empty-plus-layout"/>.</p></item>
-                                       </olist>
-                                    </item>
-                                    <item>
-                                       <p>Otherwise:</p>
-                                       <olist>
-                                          <item><p>If <code>$noAttributes</code> and if <code>simple</code> layout 
-                                             is not disabled, then <code>simple</code>: see <specref ref="id-simple-layout"/>.</p></item>
-                                          <item><p>Otherwise, if <code>simple-plus</code> layout is not disabled,
-                                             then <code>simple-plus</code>: see <specref ref="id-simple-plus-layout"/>.</p></item>
-                                       </olist>
-                                    </item>
-                                 </olist>
-                              </item>
-                              <item>
-                                 <p>If <code>T.{content type}.{variety} = element-only</code> (a complex type with
-                                 an element-only content model):</p>
-                                 <olist>
-                                    <item><p>Let <code>$noWildcards</code> be true if <code>T.{content type}.{open content}</code>
-                                    is absent, and <code>T.{content type}.{particle}</code>, expanded recursively, contains
-                                    no wildcard term.</p></item>
-                                    <item><p>Let <code>$childCardinalities</code> be a set of (<code>xs:QName</code>, 
-                                       <code>xs:double</code>) pairs
-                                    representing the expanded names of the element declaration terms within 
-                                       <code>T.{content type}.{particle}</code>,
-                                    expanded recursively, and for each one, the maximum number of occurrences of elements
-                                    with that name, computed
-                                    using the value of the <code>{maxOccurs}</code> property of the particles at each level, taking the value
-                                    <code>unbounded</code> as positive infinity.</p></item>
-                                    <item>
-                                       <p>If <code>$noWildcards</code> is true, and if <code>$childCardinalities</code>
-                                          contains a single entry, and that entry has a cardinality greater than one, then:</p>
-                                       <olist>
-                                          <item><p>If <code>$noAttributes</code>, and if <code>list</code> layout 
-                                             is not disabled, then <code>list</code>: see <specref ref="id-list-layout"/>.</p></item>
-                                          <item><p>Otherwise, if <code>list-plus</code> layout is not disabled, 
-                                             then <code>list-plus</code>: see <specref ref="id-list-plus-layout"/>.</p></item>
-                                       </olist>
-                                    </item>
-                                    <item>
-                                       <p>If <code>$noWildcards</code> is true, and if every entry in <code>$childCardinalities</code>
-                                          has a cardinality of one, and if <code>record</code> layout is not disabled,
-                                          then <code>record</code>: see <specref ref="id-record-layout"/>.</p>
-                                    </item>
-                                    <item>
-                                       <p>Otherwise, if <code>sequence</code> layout is not disabled,
-                                          then <code>sequence</code>: see <specref ref="id-sequence-layout"/>.</p>
-                                    </item>
-                                 </olist>
-                              </item>
-                              <item>
-                                 <p>Otherwise (that is, when <code>T.{content type}.{variety} = mixed</code>, or when all other
-                                    applicable layouts have been disabled), then <code>mixed</code>: see <specref ref="id-mixed-layout"/>.</p>
-                              </item>
-                           </olist>
-                        </item>
-                     </olist>
-                  </item>
-               </olist>
-            </div3>-->
+ 
             
              <div3 id="element-and-attribute-names">
                <head>Element and Attribute Names</head>
@@ -9902,8 +9794,8 @@ record(type? as enum("boolean", "numeric", "string"),
             
             <!--<?local-function-index?>-->
             
-            <div3 id="func-element-to-map-conversion-plan">
-               <head><?function fn:element-to-map-conversion-plan?></head>
+            <div3 id="func-element-to-map-plan">
+               <head><?function fn:element-to-map-plan?></head>
             </div3>
             
             <div3 id="func-element-to-map">

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -8201,8 +8201,8 @@ return <table>
          <div2 id="xml-to-json-mappings">
             <head>Converting elements to maps</head>
             <changes>
-               <change issue="528 1797" PR="1575 1906" date="2024-11-19">
-                  A new function <function>fn:elements-to-maps</function> is provided for converting XDM trees
+               <change issue="528 1645 1646 1647 1648 1658 1658 1797" PR="1575 1906" date="2024-11-19">
+                  A new function <function>fn:element-to-map</function> is provided for converting XDM trees
                   to maps suitable for serialization as JSON. Unlike the <function>fn:xml-to-json</function> function
                   retained from 3.1, this can handle arbitrary XML as input.
                </change>
@@ -9900,6 +9900,10 @@ record(type? as enum("boolean", "numeric", "string"),
             </div3>
             
             <!--<?local-function-index?>-->
+            
+            <div3 id="func-elements-to-maps-conversion-plan">
+               <head><?function fn:elements-to-maps-conversion-plan?></head>
+            </div3>
             
             <div3 id="func-elements-to-maps">
                <head><?function fn:elements-to-maps?></head>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -13646,6 +13646,13 @@ ISBN 0 521 77752 6.</bibl>
                   or key contains an invalid JSON escape sequence.</p>
             </error>
             
+            <error class="JS" code="0008" label="Cannot convert element to map." type="dynamic">
+               <p>Raised by <function>fn:element-to-map</function> if the layout selected for converting
+                  elements of a given name is unsuitable for an element node with that name, or
+                  if the conversion plan explicitly defines the processing of a particular
+               element as an error.</p>
+            </error>
+            
 
             
             

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7003,7 +7003,7 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
                <item><p>The function <function>fn:serialize</function> has an option to generate
                   JSON output from a structure of maps and arrays.</p>
                </item>
-               <item><p>The function <function>fn:elements-to-maps</function> enables
+               <item><p>The function <function>fn:element-to-map</function> enables
                   arbitrary XML node trees to be converted to trees of maps and arrays
                   suitable for serializing as JSON.</p>
                </item>
@@ -8207,7 +8207,8 @@ return <table>
                   retained from 3.1, this can handle arbitrary XML as input.
                </change>
             </changes>
-            <p>The <function>fn:elements-to-maps</function> function converts XML element nodes to maps, in a form
+            <p>The <function>fn:element-to-map</function> function converts a tree rooted at an XML element node to 
+               a corresponding tree of maps, in a form
                suitable for serialization as JSON. This section describes the mappings used by this function.</p>
             
             <p>This mapping is designed with three objectives:</p>
@@ -8315,11 +8316,11 @@ return <table>
                <ulist>
                   <item><p>The layout to be used for a specific elements can be explicitly selected by
                      supplying a conversion plan as input
-                     to the <function>fn:elements-to-maps</function> function.</p></item>
+                     to the <function>fn:element-to-map</function> function.</p></item>
                   <item><p>It is possible to construct a conversion plan by analyzing a corpus of documents
-                  using the <function>fn:elements-to-maps-conversion-plan</function> function.</p></item>
+                  using the <function>fn:element-to-map-conversion-plan</function> function.</p></item>
                   <item><p>It is also possible to construct a conversion plan manually, or to modify
-                  the conversion plan produced by the <function>fn:elements-to-maps-conversion-plan</function> function
+                  the conversion plan produced by the <function>fn:element-to-map-conversion-plan</function> function
                      before use.</p></item>
                   <item><p>In the absence of an explicit conversion plan, if the data has been schema-validated, the layout is 
                      inferred from the content model for the element type as defined in the schema.</p></item>
@@ -8341,7 +8342,7 @@ return <table>
                
                <ulist>
                   <item><p><term>Layout name</term>: the name to be used to select this layout in
-                  a conversion plan supplied to the <function>fn:elements-to-maps</function> function.</p></item>
+                  a conversion plan supplied to the <function>fn:element-to-map</function> function.</p></item>
                   <item><p><term>Usage</term>: the situations for which this layout is designed.</p></item>
                   <item><p><term>Example input</term>: an example of a typical element for which this layout is appropriate,
                      shown as serialized XML.</p></item>
@@ -8350,7 +8351,7 @@ return <table>
                   for the top-level elements supplied in the <code>$elements</code> argument; when used to convert
                      a descendant element, the corresponding key-value pair may appear as part of a larger map, depending
                      on the layout chosen for its parent element..</p>
-                  <note><p>The <function>fn:elements-to-maps</function> function produces maps as its result, but it is convenient
+                  <note><p>The <function>fn:element-to-map</function> function produces maps as its result, but it is convenient
                   to illustrate the form of the map by showing the effect of serializing the map as JSON.</p></note></item>
                   
                   <item><p><term>Mapping rules</term>: The rules for mapping the XML element to an XDM map
@@ -8650,7 +8651,7 @@ return <table>
                            If the conversion plan names the expected child element, then the converter
                            falls back to <code>xml</code> layout if there is a child element whose name
                            differs from this expected name. Fallback also occurs if there are non-whitespace
-                           text node children.</p></td>
+                           text node children, or if the names of the child elements are non-uniform.</p></td>
                         </tr>
                      </tbody>
                   </table>
@@ -8713,7 +8714,7 @@ return <table>
                                  <code>list</code> layout.</p> 
                               
                               <p>If there are no children and the element is untyped (which can occur when 
-                                 this layout is chosen explicitly via the options to <function>fn:elements-to-maps</function>)
+                                 this layout is chosen explicitly via the options to <function>fn:element-to-map</function>)
                                  then the content property is omitted (since the child element name is unknown).
                                  But if the element is typed, then the content property is included and set to
                                  an empty array.</p>
@@ -9032,7 +9033,7 @@ return <table>
                <head>Creating a conversion plan</head>
                
                <p>It is possible to create a conversion plan by analyzing a collection of sample input documents.
-               The function <function>fn:elements-to-maps-conversion-plan</function> is supplied with a collection
+               The function <function>fn:element-to-map-conversion-plan</function> is supplied with a collection
                of nodes (which will normally be element or document nodes), and it examines all the elements within
                the trees rooted at these nodes, looking for commonalities among like-named elements.</p>
                
@@ -9043,11 +9044,11 @@ return <table>
                (<code>xs:QName</code> instances) to layout names. In some cases additional information beyond
                the layout name is also included. The conversion plan is represented as an XDM map, whose structure
                is defined in this specification. A conversion plan can be constructed directly, or the plan
-               produced by calling <function>fn:elements-to-maps-conversion-plan</function> can be modified
+               produced by calling <function>fn:element-to-map-conversion-plan</function> can be modified
                before use. The plan can be serialized using the JSON output method and reloaded so that the same
                plan is used whenever a query or stylesheet is executed.</p>
                
-               <p>The <function>fn:elements-to-maps-conversion-plan</function> function selects a layout for a given
+               <p>The <function>fn:element-to-map-conversion-plan</function> function selects a layout for a given
                element name <var>N</var> by applying the following rules:</p>
                
                <olist>
@@ -9198,7 +9199,7 @@ record(type? as enum("boolean", "numeric", "string"),
                <p>As an alternative to constructing a conversion plan by analyzing a corpus of specimen documents,
                conversion may be controlled using type annotations derived from schema validation.</p>
                
-               <p>If the function <function>elements-to-maps</function> encounters an element whose name is
+               <p>If the function <function>element-to-map</function> encounters an element whose name is
                not present in the conversion plan (including the case where no plan is supplied), and if the
                element has a type annotation <var>T</var> other than <code>xs:anyType</code> or <code>xs:untyped</code>, then
                the following rules apply:</p>
@@ -9361,7 +9362,7 @@ record(type? as enum("boolean", "numeric", "string"),
                
                <olist>
                   <item><p>If an explicit layout is given for the element name of <var>E</var> in the
-                  conversion plan supplied to the <function>fn:elements-to-maps</function> function call, 
+                  conversion plan supplied to the <function>fn:element-to-map</function> function call, 
                   then that layout is used. If the layout is unsuitable for the element instance, then
                   the general approach is to fall back to a different layout (as opposed to raising an error
                   or dropping data): but the rules are defined on a case-by-case basis.</p></item>
@@ -9379,7 +9380,7 @@ record(type? as enum("boolean", "numeric", "string"),
             </div3>
                   
                   <!--<item><p>Let <code>$elements</code> be the value of the first argument to the
-                  <function>fn:elements-to-maps</function> function call.</p></item>
+                  <function>fn:element-to-map</function> function call.</p></item>
                   
                   <item><p>A layout is said to be disabled if its name is listed in the <code>disable-layouts</code>
                   option.</p></item>
@@ -9684,7 +9685,7 @@ record(type? as enum("boolean", "numeric", "string"),
                   
                </olist>
                
-               <note><p>Atomic items in the result of the <function>fn:elements-to-maps</function> function
+               <note><p>Atomic items in the result of the <function>fn:element-to-map</function> function
                   may thus be of any atomic type. The type information is lost if the result is 
                   subsequently serialized as JSON.</p></note>
             </div3>
@@ -9693,7 +9694,7 @@ record(type? as enum("boolean", "numeric", "string"),
                <head>Lost XDM Information</head>
                
                <p>This section is non-normative. Its purpose is to explain what information available
-               in the XDM nodes supplied as input to the <function>fn:elements-to-maps</function> function
+               in the XDM nodes supplied as input to the <function>fn:element-to-map</function> function
                is missing from the output.</p>
                
                <ulist>
@@ -9740,7 +9741,7 @@ record(type? as enum("boolean", "numeric", "string"),
             </div3>
             
             
-            <div3 id="id-elements-to-maps-examples">
+            <div3 id="id-element-to-map-examples">
                <head>Examples</head>
                <p>The following examples show the effect of transforming some simple XML documents with default options,
                and then serializing the result as JSON with <code>indent</code> is set to <code>true</code>. 
@@ -9901,12 +9902,12 @@ record(type? as enum("boolean", "numeric", "string"),
             
             <!--<?local-function-index?>-->
             
-            <div3 id="func-elements-to-maps-conversion-plan">
-               <head><?function fn:elements-to-maps-conversion-plan?></head>
+            <div3 id="func-element-to-map-conversion-plan">
+               <head><?function fn:element-to-map-conversion-plan?></head>
             </div3>
             
-            <div3 id="func-elements-to-maps">
-               <head><?function fn:elements-to-maps?></head>
+            <div3 id="func-element-to-map">
+               <head><?function fn:element-to-map?></head>
             </div3>
          </div2>
          


### PR DESCRIPTION
The PR drops the "uniform" option of `elements-to-maps` into a separate function `elements-to-maps-conversion-plan`, which can be used to analyze a corpus of data and generate a conversion plan for use by `elements-to-maps`. This is useful when the conversion is to be applied to documents that are not part of the corpus, for example when new documents arrive for conversion every day and need to be converted in a consistent way. It also provides a more general mechanism for users to override the system decisions on what layouts to use for what elements.

The PR is not entirely complete at this stage: the technical detail is all there, but examples need to be reviewed. Comments are welcome at this stage.

There are a few other minor changes. The most notable are:

- More consistent fallback when an inappropriate layout is chosen. If the layout does not allow attributes, then attributes are discarded; if there is any other mismatch, the converter falls back to serialized XML layout.
- Better handling of boolean and numeric element and attribute content.