### PR TITLE
1911 Clarifications for regular expressions

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -7362,6 +7362,11 @@ Tak, tak, tak! - da kommen sie.
                <code>$input</code>, then the match that is chosen is the one matched by the first
             alternative. For example:</p>
          <eg xml:space="preserve"> replace("abcd", "(ab)|(a)", "[1=$1][2=$2]") returns "[1=ab][2=]cd"</eg>
+         <p>The rules for <termref def="dt-disjoint-matching-segments"/> allow a zero-length matching
+            segment to immediately follow a non-zero-length matching segment (they are not considered to
+            overlap). This means, for example, that the regular expression <code>.*</code>
+         will typically produce two matches: one matching segment containing all the characters in the 
+         input string, and a second zero-length matching seqment at the end position of the string.</p>
 
       </fos:notes>
       <fos:examples>
@@ -7678,7 +7683,7 @@ Tak, tak, tak! - da kommen sie.
             For each such segment it constructs an <code>fn:match</code> child, whose string value is
             the string value of the segment. Before, between, or after these <code>fn:match</code>
             elements, as required to ensure that the string value of the <code>fn:analyze-string-result</code>
-            element is the the same as <code>$value</code>, it inserts <code>fn:non-match</code> elements.
+            element is the same as <code>$value</code>, it inserts <code>fn:non-match</code> elements.
             The content of an <code>fn:non-match</code> element is always a single (non-empty) text node,
             and two <code>fn:non-match</code> elements never appear as adjacent siblings.</p>  
             
@@ -7771,6 +7776,11 @@ Tak, tak, tak! - da kommen sie.
          to be atomized, which is potentially useful (the atomized value will be the original input string),
          and the capability has therefore been retained for compatibility with the 3.0 version of this
          specification.</p>
+         <p>The rules for <termref def="dt-disjoint-matching-segments"/> allow a zero-length matching
+            segment to immediately follow a non-zero-length matching segment (they are not considered to
+            overlap). This means, for example, that the regular expression <code>.*</code>
+         will typically produce two matches: one matching segment containing all the characters in the 
+         input string, and a second zero-length matching seqment at the end position of the string.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
@@ -21119,7 +21129,7 @@ return function-arity($initial)</eg></fos:expression>
             the result of the function is an empty sequence.</p>
          <p>For each annotation, a map is returned, with a single entry. The
             key of the map entry is the name of the annotation as an <code>xs:QName</code>.
-            The value of the entry is the the value of the annotation as a sequence of atomic items.
+            The value of the entry is the value of the annotation as a sequence of atomic items.
             If the annotation has no values, the associated value is an empty sequence.</p>
       </fos:rules>
       <fos:notes>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -1198,59 +1198,11 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   context of the construct that created the function item. This captured context forms 
                part of the closure of the function item.</phrase></p>
                
-               <p diff="add" at="2023-03-12">The result of a dynamic call to a function item never 
+               <p>The result of a dynamic call to a function item never 
                   depends on the static or dynamic context of the dynamic function call, only (where relevant) 
-                  on the the captured context held within the function item itself.</p>
+                  on the captured context held within the function item itself.</p>
               
                
-               <p diff="del" at="2023-03-12">Context-dependent functions fall into a number of categories:</p>
-               
-               <olist diff="del" at="2023-03-12">
-               
-               <item><p>The functions <function>fn:current-date</function>, <function>fn:current-dateTime</function>, <function>fn:current-time</function>, 
-                  <function>fn:default-language</function>, <function>fn:implicit-timezone</function>,
-               <function>fn:adjust-date-to-timezone</function>, <function>fn:adjust-dateTime-to-timezone</function>, and
-               <function>fn:adjust-time-to-timezone</function> depend on properties of the dynamic context that are
-               fixed within the <termref def="execution-scope">execution scope</termref>. The same applies to a
-               number of functions in the <code>op:</code> namespace that manipulate dates and times and
-               that make use of the implicit timezone. These functions will return the same
-               result if called repeatedly during a single <termref def="execution-scope">execution scope</termref>.</p></item>
-               
-                  <item><p>A number of functions including <function>fn:base-uri#0</function>, <function>fn:data#0</function>, 
-                     <function>fn:document-uri#0</function>, <function>fn:element-with-id#1</function>, <function>fn:id#1</function>, 
-                     <function>fn:idref#1</function>, <function>fn:lang#1</function>, <function>fn:last#0</function>, <function>fn:local-name#0</function>,
-                     <function>fn:name#0</function>, <function>fn:namespace-uri#0</function>, <function>fn:normalize-space#0</function>, 
-                     <function>fn:number#0</function>, <function>fn:path#0</function>, <function>fn:position#0</function>, 
-                     <function>fn:root#0</function>, <function>fn:string#0</function>, and
-               <function>fn:string-length#0</function> depend on the <xtermref ref="dt-focus" spec="XP31">focus</xtermref>. 
-                     These functions will in general return
-               different results on different calls if the focus is different.</p>
-                  <p>A function is <term>focus-dependent</term>
-                     if its result depends on the <xtermref ref="dt-focus" spec="XP31">focus</xtermref>
-                     (that is, the context value, position, or size).</p>
-                     <p>A function that
-                        is not <termref def="dt-focus-dependent">focus-dependent</termref> is called
-                        <term>focus-independent</term></p></item>
-                        
- 
-               
-                  <item><p>The function <function>fn:default-collation</function> and many 
-                     string-handling operators and functions depend
-               on the default collation and the in-scope collations, which are both properties
-               of the static context. If a particular call of one of these functions is
-               evaluated twice with the same arguments then it will return the same result
-               each time (because the static context, by definition, does not change at run
-               time). However, two distinct calls (that is, two calls on the function
-               appearing in different places in the source code) may produce different results
-               even if the explicit arguments are the same.</p></item>
-               
-                  <item><p>Functions such as <function>fn:static-base-uri</function>, <function>fn:doc</function>, and <function>fn:collection</function> depend on
-               other aspects of the static context. As with functions that depend on
-               collations, a single call will produce the same results on each call if the
-               explicit arguments are the same, but two calls appearing in different places in
-               the source code may produce different results.</p></item>
-               
-               </olist>
                
                <p>The <function>fn:function-lookup</function> function is a special case because it is
                potentially dependent on everything in the static and dynamic context. This is because the static and dynamic
@@ -1258,16 +1210,12 @@ This includes all the built-in datatypes defined in <bibref ref="xmlschema-2"/>.
                   <phrase diff="chg" at="2023-03-12">form the captured context of the
                function item</phrase> that <function>fn:function-lookup</function> returns.</p>
                
-               <p diff="del" at="2023-03-12"><termdef id="dt-implicit-arguments" term="implicit argument">For a
-                  <termref def="dt-context-dependent">context-dependent</termref> function, 
-                  the parts of the context on which it depends are
-               referred to as <term>implicit arguments</term>.</termdef></p>
                
                
                
                <p><termdef id="dt-deterministic" term="deterministic">A function that is guaranteed to produce <termref def="dt-identical">identical</termref> results 
                   from repeated calls within a single <termref def="execution-scope">execution scope</termref>
-               if the explicit and <termref def="dt-implicit-arguments">implicit</termref> arguments are identical is referred to as
+               if the explicit and implicit arguments are identical is referred to as
                <term>deterministic</term>.</termdef></p>
                
                <p><termdef id="dt-nondeterministic" term="nondeterministic">A function that is not
@@ -3132,6 +3080,8 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                         Segments of a string are uniquely identified by 
                      their start position and length. The sequence of characters making up a segment
                      is referred to as the <term>string value</term> of the segment.</p></item>
+                     <item><p><termdef id="dt-end-position" term="end position">The <term>end position</term> 
+                        of a segment is the start position of the segment plus its length.</termdef></p></item>
                      
                   </ulist>   
                   
@@ -3185,8 +3135,16 @@ string conversion of the number as obtained above, and the appropriate <var>suff
                      <item><p>A matching segment is not included in the result if it overlaps an earlier matching
                      segment: specifically, a segment with start position <var>S1</var> is excluded if there
                      is a segment that has start position <var>S0</var> and length <var>L0</var>, where
-                     <code><var>S0</var> &lt; <var>S1</var> &lt; <var>S0</var>+<var>L0</var></code>.</p></item>
+                     <code><var>S0</var> &lt; <var>S1</var> &lt; <var>S0</var>+<var>L0</var></code>.</p>
+                     </item>
                   </ulist>
+                  
+                  <note><p>Two segments can be adjacent: that is, the start position of one <termref def="dt-segment"/>
+                  can be equal to the <termref def="dt-end-position"/> of the previous segment. This is true even when
+                  the second segment is zero-length (the two segments are not considered to be overlapping, even
+                  though they have the same <termref def="dt-end-position"/>). This means,
+                  for example, that the regular expression <code>a*(?=x)</code> has two non-overlapping matches against
+                  the string <code>aaax</code>, one at position 1 and the other at position 4.</p></note>
                      
                   <p><termdef id="dt-disjoint-matching-segments" term="disjoint matching segments">The
                   <term>disjoint matching segments</term> obtained by applying a regular expression <var>R</var>
@@ -3248,7 +3206,7 @@ quantity            ::= quantRange | quantMin | QuantExact
 quantRange          ::= QuantExact ',' QuantExact
 quantMin            ::= QuantExact ','
 QuantExact          ::= 【0➜9】+
-§atom               ::= NormalChar | charClass | ( '(' regExp ')' ) | backReference 
+§atom               ::= NormalChar | charClass | ( '(' '?:'? regExp ')' ) | backReference 
 NormalChar          ::= ¬【.\?*+{}()|[]】	
 charClass           ::= SingleCharEsc | charClassEsc | charClassExpr | WildcardEsc
 charClassExpr       ::= '[' charGroup ']'
@@ -3304,7 +3262,7 @@ WildcardEsc         ::= '.'
                </div3>
                
                <div3 id="reluctant-quantifiers">
-                  <head>Reluctant Quantifiers</head>
+                  <head>Reluctant quantifiers</head>
                
                      <p><emph>Reluctant quantifiers</emph> are supported. They are
                                     indicated by a  <code>?</code>
@@ -3360,7 +3318,7 @@ WildcardEsc         ::= '.'
  
                
                <div3 id="captured-subexpressions">
-                  <head>Captured Groups</head>
+                  <head>Captured groups</head>
                
                <p>The regular expression syntax defined by <bibref ref="xmlschema-2"/> 
 						      allows a regular expression to contain parenthesized subexpressions, but attaches no special
@@ -3421,7 +3379,7 @@ WildcardEsc         ::= '.'
                         within a regular expression.</p>
                   </div3>
                <div3 id="back-references">
-                  <head>Back-References</head>
+                  <head>Back-references</head>
                <!--Text replaced by erratum E24 change 1"--><p> Back-references are allowed 
 			    outside a character class expression. 
 				A back-reference is an additional kind of atom.
@@ -3457,7 +3415,7 @@ WildcardEsc         ::= '.'
                      <!--End of text replaced by erratum E24-->
                </div3>
                  <div3 id="unicode-block-names">
-                    <head>Unicode Block Names</head>
+                    <head>Unicode block names</head>
                  
               
                      <p>A regular expression that uses a Unicode block name that is not defined in the version(s) of Unicode
@@ -3519,7 +3477,7 @@ WildcardEsc         ::= '.'
  </div4>
               
               <div4 diff="add" at="issue1006" id="regex-boundary-assertions">
-		    <head>Boundary Assertions</head>
+		    <head>Boundary assertions</head>
                  
           <p>The assertion <code>\b</code> matches at any position where one of the following conditions is true:</p>
                  
@@ -3544,12 +3502,7 @@ WildcardEsc         ::= '.'
 		    
 		    
 
-		    <note><p><code>\b</code> can be rewritten to an equivalent form in terms of lookbehind and lookahead assertions:</p>
-		    <p><code> ( (*positive_lookbehind:\w)(*positive_lookahead:\W) ) |
-			( (*positive_lookbehind:\W)(*positive_lookahead:\w) )</code></p>
-		       
-		    <p>A similar rewrite is possible for <code>\B</code>.</p></note>
-
+		    
 		   
 		    
 		    


### PR DESCRIPTION
1. Reinstates the non-capturing group syntax `(?: xxx )`
2. Clarifies that a zero-length matching segment does not overlap an immediately preceding adjacent (but non-zero-length) segment.