### PR TITLE
1902b bin:unpack out of range error

### DIFF
--- a/specifications/EXPath/binary/src/binary-functions.xml
+++ b/specifications/EXPath/binary/src/binary-functions.xml
@@ -310,7 +310,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 <p>In this specification these codes use the
                     <code>http://expath.org/ns/binary</code> namespace with a local part
                     in the form of a descriptive string, for example
-                    <code>bin:index-out-of-range</code>. This convention is used in place of
+                    <code role="example">bin:index-out-of-range</code>. This convention is used in place of
                    the <code>http://www.w3.org/2005/xqt-errors</code> namespace and alpha-numeric local
                     part, e.g. <code>err:FOCH0004</code> used in <bibref ref="xpath-functions-40"
                     />. These error codes have been largely retained from the 1.0 version of the
@@ -701,7 +701,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <div2 id="func-bin-hex">
                 <head><?function bin:hex?></head>
             </div2>
-            <div2 id="func-bin-binary">
+            <div2 id="func-bin-bin">
                 <head><?function bin:bin?></head>
             </div2>
             <div2 id="func-bin-octal">
@@ -718,7 +718,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
         <div1 id="basic-operations">
             <head>Basic operations</head>
             <changes>
-                <change>The function <code>find-all</code> in the example for <code>bin:find</code>
+                <change>The function <code>find-all</code> in the example for <function>bin:find</function>
                     has been moved into a differing namespace prefix (<code>f:</code>) to avoid
                     suggesting that it is part of the supported function set.</change>
 
@@ -977,19 +977,19 @@ Michael Sperberg-McQueen (1954–2024).</p>
             <head>Error summary</head>
             <p>The error text provided with these errors is non-normative.</p>
             <error-list>
-                <error spec="BIN40" code="differing-length-arguments"
-                    label="Arguments of different length" id="error.differentLengthArguments">
+                <error spec="BIN40" code="differing-length-arguments">
                     <p>The two arguments to a bitwise operation are of differing lengths.</p>
                 </error>
                 <error spec="BIN40" code="index-out-of-range">
                     <p>Attempting to retrieve data outside the meaningful range of a binary data
                         type.</p>
                 </error>
+                <error spec="BIN40" code="integer-too-large">
+                    <p>Attempting to unpack a signed or unsigned integer whose length exceeds
+                        the implementation-defined maximum.</p>
+                </error>
                 <error spec="BIN40" code="negative-size">
                     <p>Size of binary portion, required numeric size or padding is negative.</p>
-                </error>
-                <error spec="BIN40" code="octet-out-of-range">
-                    <p>Attempting to pack binary value with octet outside range 0-255.</p>
                 </error>
                 <error spec="BIN40" code="non-numeric-character">
                     <p>Wrong character in binary 'numeric constructor' string.</p>
@@ -999,9 +999,6 @@ Michael Sperberg-McQueen (1954–2024).</p>
                 </error>
                 <error spec="BIN40" code="conversion-error">
                     <p>Error in converting to/from a string.</p>
-                </error>
-                <error spec="BIN40" code="unknown-significance-order">
-                    <p>Unknown octet-order value.</p>
                 </error>
             </error-list>
         </div1>
@@ -1123,10 +1120,10 @@ Michael Sperberg-McQueen (1954–2024).</p>
             </div2>
         </inform-div1>
 
-        <inform-div1 id="impl-def">
+        <!--<inform-div1 id="impl-def">
             <head>Checklist of implementation-defined features</head>
             <?imp-def-features?>
-        </inform-div1>
+        </inform-div1>-->
 
         <inform-div1 id="changelog" diff="chg" at="2024-11-22">
             <head>Changes since version 1.0</head>
@@ -1147,19 +1144,7 @@ Michael Sperberg-McQueen (1954–2024).</p>
 
                 </olist>
             </div2>
-            <!--<div2 id="miscellaneous-changes">
-                <head>Miscellaneous Changes</head>
-                <olist>
-                    <item>
-                        <p>The semantics of the HTML case-insensitive collation
-                            <code>"http://www.w3.org/2005/xpath-functions/collation/html-ascii-case-insensitive"</code>
-                            are now defined normatively in this specification rather than by
-                            reference to the living HTML5 specification (which has changed since
-                            3.1); and the rules now make ordering explicit rather than leaving it
-                            implementation-defined.</p>
-                    </item>                    
-                </olist>
-            </div2>-->
+
             <div2 id="editorial-changes">
                 <head>Editorial Changes</head>
                 <p>These changes are not highlighted in the change-marked version of the
@@ -1200,12 +1185,12 @@ Michael Sperberg-McQueen (1954–2024).</p>
                         sequence denotes default behaviour, that is decoding all octets after
                         <code>$offset</code>
                     </p>
-                    <p>The functions <code>bin:decode-string</code>,<code>bin:encode-string</code>,
-                        <code>bin:pack-double</code>, <code>bin:pack-float</code>,
-                        <code>bin:pack-integer</code>, <code>bin:pad-left</code>,
-                        <code>bin:pad-right</code>, <code>bin:part</code>,
-                        <code>bin:unpack-double</code>, <code>bin:unpack-float</code>,
-                        <code>bin:unpack-integer</code> and <code>bin:unpack-unsigned-integer</code>
+                    <p>The functions <function>bin:decode-string</function>,<function>bin:encode-string</function>,
+                        <function>bin:pack-double</function>, <function>bin:pack-float</function>,
+                        <function>bin:pack-integer</function>, <function>bin:pad-left</function>,
+                        <function>bin:pad-right</function>, <function>bin:part</function>,
+                        <function>bin:unpack-double</function>, <function>bin:unpack-float</function>,
+                        <function>bin:unpack-integer</function> and <function>bin:unpack-unsigned-integer</function>
                         all have similar incompatibilities.</p>
                 </item>
                 <item>

--- a/specifications/EXPath/binary/src/function-catalog.xml
+++ b/specifications/EXPath/binary/src/function-catalog.xml
@@ -66,10 +66,7 @@
             <p>If <code>$in</code> is the empty sequence, the function returns a 
                 <termref def="dt-zero-length"/> binary value.</p>
         </fos:rules>
-        <!--<fos:errors>
-            <p><errorref spec="BIN40" code="octet-out-of-range"/> is raised if one of the octets lies
-                outside the range 0 – 255. </p>
-        </fos:errors>-->
+ 
         <fos:examples>
             <fos:example>
                 <fos:test>
@@ -91,7 +88,7 @@
                 coercion rules defined in XPath 4.0. A consequence of the change
                 is that supplying an out-of-range integer value is now a type error
                 with the standard error code <code>XPTY0004</code>, rather than the
-                custom error code <code>bin:octet-out-of-range</code> previously used.</p>
+                custom error code <code role="example">bin:octet-out-of-range</code> previously used.</p>
             </fos:change>
         </fos:changes>
     </fos:function>
@@ -633,8 +630,7 @@ $in =!> bin:to-octets() => bin:from-octets()
         <fos:errors>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
-            <!--<p><errorref spec="BIN40" code="octet-out-of-range"/> is raised if <code>$octet</code>
-                lies outside the range 0 – 255. </p>-->
+ 
         </fos:errors>
         <fos:examples>
             <fos:example>
@@ -698,8 +694,7 @@ $in =!> bin:to-octets() => bin:from-octets()
         <fos:errors>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
-            <!--<p><errorref spec="BIN40" code="octet-out-of-range"/> is raised if <code>$octet</code>
-                lies outside the range 0 – 255. </p>-->
+
         </fos:errors>
         <fos:examples>
             <fos:example>
@@ -1087,8 +1082,8 @@ $in =!> bin:to-octets() => bin:from-octets()
                 of <code>$in</code>.</p>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
-            <!--<p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>-->
+            <p><errorref spec="BIN40" code="integer-too-large"/> is raised if <code>$size</code> is
+                too large for the implementation-defined maximum integer size.</p>
         </fos:errors>
         <fos:notes>
             <p>For discussion on integer range see <specref ref="integer"/>.</p>
@@ -1158,8 +1153,8 @@ $in =!> bin:to-octets() => bin:from-octets()
                 of <code>$in</code>.</p>
             <p><errorref spec="BIN40" code="negative-size"/> is raised if <code>$size</code> is
                 negative.</p>
-            <!--<p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>-->
+            <p><errorref spec="BIN40" code="integer-too-large"/> is raised if <code>$size</code> is
+                too large for the implementation-defined maximum integer size.</p>
         </fos:errors>
         <fos:notes>
             <p>For discussion on integer range see <specref ref="integer"/>.</p>
@@ -1227,8 +1222,7 @@ $in =!> bin:to-octets() => bin:from-octets()
             <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$offset</code> is
                 negative or <code>$offset + 8</code> (octet-length of <code>xs:double</code>) is
                 larger than the size of the binary data of <code>$in</code>.</p>
-            <!--<p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>-->
+
         </fos:errors>
     </fos:function>
     
@@ -1268,8 +1262,7 @@ $in =!> bin:to-octets() => bin:from-octets()
             <p><errorref spec="BIN40" code="index-out-of-range"/> is raised if <code>$offset</code> is
                 negative or <code>$offset + 4</code> (octet-length of <code>xs:float</code>) is
                 larger than the size of the binary data of <code>$in</code>.</p>
-            <!--<p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>-->
+ 
         </fos:errors>
     </fos:function>
 
@@ -1297,10 +1290,7 @@ $in =!> bin:to-octets() => bin:from-octets()
                 64-bit floating point type <bibref ref="ieee754"/>. For more details see <specref
                     ref="floating"/>.</p>
         </fos:rules>
-        <!--<fos:errors>
-            <p><errorref spec="BIN40" code="unknown-significance-order"/> is raised if the value
-                <code>$octet-order</code> is unrecognized.</p>
-        </fos:errors>-->
+ 
     </fos:function>
 
     <fos:function name="pack-float" prefix="bin">

--- a/style/xmlspec-2016.xsl
+++ b/style/xmlspec-2016.xsl
@@ -718,6 +718,9 @@
                         else ()"/>
   <xsl:variable name="FO40uri" select="'https://qt4cg.org/specifications/xpath-functions-40/'"/>
   <xsl:variable name="XT40uri" select="'https://qt4cg.org/specifications/xslt-40/'"/>
+  <!--<xsl:variable name="BIN40uri" select="'https://qt4cg.org/specifications/expath-binary-40/'"/>-->
+  <xsl:variable name="BIN40uri" select="'https://qt4cg.org/specifications/EXPath/binary-40/'"/>
+                                         
 
   <!-- Function: name of a function -->
   <!-- format as HTML <code> for monospaced presentation -->
@@ -744,6 +747,7 @@
         <xsl:when test="$prefix = 'map'">func-map-</xsl:when>
         <xsl:when test="$prefix = 'math'">func-math-</xsl:when>
         <xsl:when test="$prefix = 'op'">func-</xsl:when>
+        <xsl:when test="$prefix = 'bin'">func-bin-</xsl:when>
         <xsl:otherwise>
           <xsl:message select="'Unexpected function prefix: ' || $prefix || ':'"/>
           <xsl:sequence select="'func-'"/>
@@ -754,7 +758,8 @@
     <xsl:variable name="targets" select="key('divids', $id-prefix || $name, $database)"/>
     <xsl:variable name="target"
                   select="($targets[ancestor::document-summary/@uri = $FO40uri],
-                           $targets[ancestor::document-summary/@uri = $XT40uri])[1]"/>
+                           $targets[ancestor::document-summary/@uri = $XT40uri],
+                           $targets[ancestor::document-summary/@uri = $BIN40uri])[1]"/>
     <xsl:variable name="target-uri" select="$target/ancestor::document-summary/@uri/string()"/>
 
     <xsl:choose>


### PR DESCRIPTION
Replaces PR #1909

Adds error conditions for unpacking an integer that is too large for the implementation