### PR TITLE
1844 Arrow Expressions

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1517,9 +1517,10 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="UnaryExpr"/>
     <g:zeroOrMore>
       <g:choice>
-        <g:ref name="SequenceArrowTarget"/>
-        <g:ref name="MappingArrowTarget"/>
+        <g:string>=></g:string>
+        <g:string>=!></g:string>
       </g:choice>
+      <g:ref name="ArrowTarget"/>
     </g:zeroOrMore>
   </g:production>
   
@@ -1542,7 +1543,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   </g:production>
   
   
-  <g:production name="SequenceArrowTarget" if="xpath40 xquery40 xslt40-patterns">
+  <!--<g:production name="SequenceArrowTarget" if="xpath40 xquery40 xslt40-patterns">
     <g:string>=></g:string>
     <g:ref name="ArrowTarget"/>
   </g:production>
@@ -1550,7 +1551,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
   <g:production name="MappingArrowTarget" if="xpath40 xquery40 xslt40-patterns">
     <g:string>=!></g:string>
     <g:ref name="ArrowTarget"/>
-  </g:production>
+  </g:production>-->
   
   <g:production name="ArrowTarget" if="xpath40 xquery40 xslt40-patterns">
     <g:choice>

--- a/specifications/xquery-40/src/ebnf.xml
+++ b/specifications/xquery-40/src/ebnf.xml
@@ -700,7 +700,7 @@
       <head>Less-Than and Greater-Than Characters</head>
       
       <p>The operator symbols <code>&lt;</code>, <code>&lt;=</code>, <code>&gt;</code>, <code>&gt;=</code>,
-        <code>&lt;&lt;</code>, <code>&gt;&gt;</code>, <code>=&gt;</code>, <code>-&gt;</code>, <code>=!&gt;</code>, and <code>=?&gt;</code>
+        <code>&lt;&lt;</code>, <code>&gt;&gt;</code>, <code>=&gt;</code>, <code>-&gt;</code>, and <code>=!&gt;</code>
         have alternative representations using the characters <char>U+FF1C</char> and
         <char>U+FF1E</char> in place of <char>U+003C</char> 
         and <char>U+003E</char>. The alternative tokens are respectively

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -22391,9 +22391,18 @@ return string-join($chopped, '; ')
          <eg role="parse-test"
             ><![CDATA[$string => upper-case() => normalize-unicode() => tokenize("\s+")]]></eg>
          
-         <p diff="add" at="A">When the operator is written as <code>=!></code>, the function
-            is applied to each item in the sequence in turn. 
-            Assuming that <code>$string</code> is a single string, the above example could
+         <p>There are two forms of the arrow operator:</p>
+         
+         <ulist>
+            <item><p>The operator <code>=></code> (known as the <termref def="dt-sequence-arrow-operator"/>)
+            calls the target function once, supplying the value of the left-hand operand as
+            the first argument.</p></item>
+            <item><p>The operator <code>=!></code> (known as the <termref def="dt-mapping-arrow-operator"/>)
+            calls the target function repeatedly, once for each item in the value of the left-hand operand,
+            supplying that item as the first argument.</p></item>
+         </ulist>
+         
+         <p>Assuming that <code>$string</code> is a single string, the above example could
             equally be written:</p>
          
          <eg role="parse-test"
@@ -22408,8 +22417,26 @@ return string-join($chopped, '; ')
          
          <eg role="parse-test"><![CDATA[(1, 2, 3) =!> avg()]]></eg>
          
-         <p diff="add" at="2023-07-24">returns the original sequence of three items, <code>(1, 2, 3)</code>, 
-            each item being the average of itself. The following example:</p>
+         <p diff="add" at="2023-07-24">would return the original sequence of three items, <code>(1, 2, 3)</code>, 
+            each item being the average of itself.</p>
+         
+         <p>This example could also be written as using the <termref def="dt-pipeline-operator"/> as:</p>
+         
+         <eg><![CDATA[(1, 2, 3) -> avg(.)]]></eg>
+         
+         <p>There are two significant differences between the <termref def="dt-pipeline-operator"/> <code>-></code>
+            and the <termref def="dt-sequence-arrow-operator"/> <code>=></code>:</p>
+            
+         <ulist>
+            <item><p>The <code>-></code> operator takes an arbitrary expression as its right-hand operand,
+            whereas the <code>=></code> operator only accepts a function call.</p></item>
+            <item><p>When the right hand operand is a function call, the first argument
+            is omitted in the case of the <code>=></code> operator, but is included explicitly
+            (as a context value expression, <code>.</code>) in the case of the <code>-></code> operator.</p></item>
+               
+         </ulist>
+            
+            <p>The following example:</p>
          
          <eg role="parse-test"
             ><![CDATA["The cat sat on the mat"
@@ -22422,31 +22449,22 @@ return string-join($chopped, '; ')
          <p>returns <code>"THE. CAT. SAT. ON. THE. MAT."</code>. The first arrow
             could be written either as <code>=></code> or <code>=!></code> because the operand is a 
             <termref def="dt-singleton"/>; the next two
-
             arrows have to be <code>=!></code> because the function is applied to each item in the tokenized
             sequence individually; the final arrow must be <code>=></code> because the <code>string-join</code>
             function applies to the sequence as a whole.</p>
+        
          
          <note><p>It may be useful to think of this as a map/reduce pipeline. The functions
             introduced by <code>=!></code> are mapping operations; the function introduced by <code>=></code>
             is a reduce operation.</p></note>
          
          <p>The following example introduces an inline function to the pipeline:</p>
-         <eg role="parse-test" diff="add" at="A"
-            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn($a) { $a + 1 }() => sum()]]></eg>
+         <eg role="parse-test"><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn{ . + 1 }() => sum()]]></eg>
          
-         <p>This is equivalent to <code>sum((1 to 5) ! (math:sqrt(xs:double(.)) + 1))</code>.</p>
+         <p>This could also be written using the pipeline operator as:</p>
          
-         <p>The same effect can be achieved using a <termref def="dt-focus-function"/>:</p>
+         <eg role="parse-test"><![CDATA[(1 to 5) ! (xs:double(.) -> math:sqrt(.) -> (. + 1)) => sum()]]></eg>
          
-         <eg role="parse-test"
-            ><![CDATA[(1 to 5) =!> xs:double() =!> math:sqrt() =!> fn { . + 1 }() => sum()]]></eg>
-         
-
-         <p>It could also be expressed using the mapping operator <code>!</code>:</p>
-         
-         <eg role="parse-test"
-            ><![CDATA[(1 to 5) ! xs:double(.) ! math:sqrt(.) ! (. + 1) => sum()]]></eg>
          
         
         
@@ -22459,10 +22477,10 @@ return string-join($chopped, '; ')
             function is identified statically (that is, by name). For example,
             the following is valid: <code>$xml => xml-to-json(indent := true()) => parse-json(escape := false())</code>.</p></note>
          
-         <p diff="add" at="A">The sequence arrow operator thus applies the supplied function to 
+         <!--<p diff="add" at="A">The sequence arrow operator thus applies the supplied function to 
             the left-hand operand as a whole, while the mapping arrow operator applies the function to
             each item in the value of the left-hand operand individually. In the case where the result
-            of the left-hand operand is a single item, the two operators have the same effect.</p>
+            of the left-hand operand is a single item, the two operators have the same effect.</p>-->
          
          <note><p>The mapping arrow symbol <code>=!></code> is intended to suggest a combination of
             function application (<code>=></code>) and sequence mapping

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11713,13 +11713,13 @@ and <code>version="1.0"</code> otherwise.</p>
    <xsl:field name="payload" as="item()*"/>
    <xsl:field name="right" as="my:binary-tree?"/>
    <xsl:field name="depth" as="fn(my:binary-tree) as xs:integer"
-      default="fn() {1 + max((?left =?> depth(), ?right =?> depth())) otherwise 0)}"/>
+      default="fn() {1 + max((?left?depth(), ?right?depth())) otherwise 0)}"/>
 </xsl:record-type>]]></eg>
                   
-                  <p>The <code>=?></code> operator is described in
-                  <xspecref spec="XP40" ref="lookup-arrow-expression"/>. Its effect
-                  is to make a dynamic call on a function item that is present as
-                  an entry in a map, passing that map implicitly as the first argument.
+                  <p>The <code>%method</code> operator is described in
+                  <xspecref spec="XP40" ref="methods"/>. Its effect
+                  is that the expression <code>$M?depth()</code> evaluates the function item 
+                     <code>left?depth</code> with the map <code>$M</code> as the context item.
                   It thus mimics method invocation in object-oriented languages, though
                   there is no inheritance or encapsulation.</p>
                   
@@ -11731,7 +11731,7 @@ let $tree := my:binary-tree(
                18,
                my:binary-tree((), 19, 
                  my:binary-tree((), 20, ())))
-return $tree =?> depth()]]></eg>
+return $tree?depth()]]></eg>
                
                
                   <p>Returning the result 3.</p>


### PR DESCRIPTION
This PR doesn't do what issue #1844 suggests, namely dropping the mapping arrow. Instead it picks up a couple of points made in passing in that issue:

(a) drops remaining references to the obsolete `=?>` operator

(b) simplifies the grammar for arrow expressions

(c) improves the way arrow expressions are described, including their relationship to pipeline expressions.