### PR TITLE
1844b Arrow Expressions

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -22371,13 +22371,36 @@ return string-join($chopped, '; ')
             operand evaluates to a sequence:</p>
          
          <eg role="parse-test"><![CDATA[(1, 2, 3) => avg()]]></eg>
+        
          
-         <p diff="add" at="2023-07-24">returns a value of only one item, <code>2</code>, the average of all three items, whereas </p>
+         <p diff="add" at="2023-07-24">returns a value of only one item, <code>2</code>, the average of all three items. </p>
+         
+         <p>This example could also be written as using the <termref def="dt-pipeline-operator"/> as:</p>
+         
+         <eg><![CDATA[(1, 2, 3) -> avg(.)]]></eg>
+         
+         <p>By contrast, an expression using the <termref def="dt-mapping-arrow-operator"/>:</p>
          
          <eg role="parse-test"><![CDATA[(1, 2, 3) =!> avg()]]></eg>
          
-         <p diff="add" at="2023-07-24">returns the original sequence of three items, <code>(1, 2, 3)</code>, 
-            each item being the average of itself. The following example:</p>
+         <p diff="add" at="2023-07-24">would return the original sequence of three items, <code>(1, 2, 3)</code>, 
+            each item being the average of itself.</p>
+         
+         
+         
+         <p>There are two significant differences between the <termref def="dt-pipeline-operator"/> <code>-></code>
+            and the <termref def="dt-sequence-arrow-operator"/> <code>=></code>:</p>
+            
+         <ulist>
+            <item><p>The <code>-></code> operator takes an arbitrary expression as its right-hand operand,
+            whereas the <code>=></code> operator only accepts a function call.</p></item>
+            <item><p>When the right hand operand is a function call, the first argument
+            is omitted in the case of the <code>=></code> operator, but is included explicitly
+            (as a context value expression, <code>.</code>) in the case of the <code>-></code> operator.</p></item>
+               
+         </ulist>
+            
+            <p>The following example:</p>
          
          <eg role="parse-test"
             ><![CDATA["The cat sat on the mat"


### PR DESCRIPTION
This PR doesn't do what issue https://github.com/qt4cg/qtspecs/issues/1844 suggests, namely dropping the mapping arrow. Instead it picks up a couple of points made in passing in that issue:

(a) drops remaining references to the obsolete =?> operator

(b) simplifies the grammar for arrow expressions

(c) improves the way arrow expressions are described, including their relationship to pipeline expressions.