### PR TITLE
QT4-CG-116-02 improve description of validation

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -18574,7 +18574,10 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             </fos:option>
             <fos:option key="xsd-validation">
                <fos:meaning>Determines whether XSD validation takes place, using the
-                  schema definitions present in the static context.</fos:meaning>
+                  schema definitions present in the static context. The effect of requesting
+               validation is the same as invoking the <function>doc</function> function without
+               validation, and then applying an XQuery <code>validate</code> expression to the result,
+               with corresponding options.</fos:meaning>
                <fos:type>xs:string</fos:type>
                <fos:default>"skip"</fos:default>
                <fos:values>
@@ -19719,7 +19722,11 @@ return $lines[not(position() = last() and . = '')]
                </fos:values>
             </fos:option>
             <fos:option key="xsd-validation">
-               <fos:meaning>Determines whether XSD validation takes place.</fos:meaning>
+               <fos:meaning>Determines whether XSD validation takes place, using the
+                  schema definitions present in the static context. The effect of requesting
+               validation is the same as invoking the <function>parse-xml</function> function without
+               validation, and then applying an XQuery <code>validate</code> expression to the result,
+               with corresponding options.</fos:meaning>
                <fos:type>xs:string</fos:type>
                <fos:default>"skip"</fos:default>
                <fos:values>
@@ -19729,6 +19736,23 @@ return $lines[not(position() = last() and . = '')]
                   <fos:value value="type Q{uri}local">XSD validation takes place against the
                   schema-defined type, present in the static context, that has the given URI
                   and local name.</fos:value>
+               </fos:values>
+            </fos:option>
+            <fos:option key="xsi-schema-location">
+               <fos:meaning>When XSD validation takes place, determines whether
+                  schema components referenced using <code>xsi:schemaLocation</code> or <code>xsi:noNamespaceSchemaLocation</code>
+                  attributes within the source document are to be used. The option is ignored
+                  if XSD validation does not take place.</fos:meaning>
+               <fos:type>xs:boolean</fos:type>
+               <fos:default>false</fos:default>
+               <fos:values>
+                  <fos:value value="true">XSD validation uses the schema components referenced 
+                  using <code>xsi:schemaLocation</code> or <code>xsi:noNamespaceSchemaLocation</code>
+                  attributes in addition to the schema components present in the static context;
+                  these components must be compatible as described in <xspecref spec="DM40" ref="schema-consistency"/>.</fos:value>
+                  <fos:value value="false">Any <code>xsi:schemaLocation</code> and <code>xsi:noNamespaceSchemaLocation</code>
+                  attributes in the document are ignored.</fos:value>
+                 
                </fos:values>
             </fos:option>
          </fos:options>


### PR DESCRIPTION
Improves the description of the semantics of the `xsd-validation` option on `parse-xml()` and `doc()`. Also brings the two functions into line by adding the `xsi-schema-location` option from `doc()` to `parse-xml()`.