### PR TITLE
QT4-CG-115-01 xsl:next-match examples

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -15254,9 +15254,58 @@ return $tree =?> depth()]]></eg>
                <eg xml:space="preserve" role="xml">&lt;div style="border: solid red"&gt;&lt;pre&gt;...&lt;/pre&gt;&lt;/div&gt;</eg>
             </example>
             <p>An <elcode>xsl:fallback</elcode> instruction appearing as a child of an
-                  <elcode>xsl:next-match</elcode> instruction is ignored by an XSLT 2.0 or 3.0 processor, but can be used to define fallback
+                  <elcode>xsl:next-match</elcode> instruction is ignored by an XSLT 2.0, 3.0, or 4.0 processor, 
+               but can be used to define fallback
                behavior when the stylesheet is processed by an XSLT 1.0 processor with forwards
                compatible behavior.</p>
+            
+            <example>
+               <head>Using <elcode>xsl:next-match</elcode></head>
+               
+               <p>This example shows how an input element such as:</p>
+            
+               <eg><![CDATA[<phrase upper-case="true" italic="true" bold="false" underscore="true">Hannover</phrase>]]></eg>
+               
+               <p>might be transformed into:</p>
+               
+               <eg><![CDATA[<italic><underscore>HANNOVER</underscore></italic>]]></eg>
+               
+               <p>The following template rules achieve the required effect:</p>
+               
+               <eg><![CDATA[
+<xsl:template match="phrase" priority="10">
+  <xsl:next-match>
+     <xsl:with-param name="upper-case" select="xs:boolean(@upper-case)"/>
+  </xsl:next-match>
+</xsl:template>  
+
+<xsl:template match="phrase[xs:boolean(@italic)]" priority="8">
+  <italic>
+    <xsl:next-match/>
+  </italic>
+</xsl:template>
+
+<xsl:template match="phrase[xs:boolean(@bold)]" priority="6">
+  <bold>
+    <xsl:next-match/>
+  </bold>
+</xsl:template>
+
+<xsl:template match="phrase[xs:boolean(@underscore)]" priority="4">
+  <underscore>
+    <xsl:next-match/>
+  </underscore>
+</xsl:template>
+
+<xsl:template match="phrase" priority="2">
+  <xsl:param name="upper-case" as="xs:boolean?"/>
+  <xsl:if test="$upper-case" then="upper-case(.)" else="string(.)"/>
+</xsl:template>
+
+]]></eg>
+               
+        <p>Note how the <code>$upper-case</code> parameter is passed implicitly through the chain of template rules.</p>
+            </example>
          </div2>
          <div2 id="parameters-to-template-rules">
             <head>Passing Parameters to Template Rules</head>


### PR DESCRIPTION
Adds an example demonstrating passing of parameter through a chain of xsl:next-match instructions