### PR TITLE
1704 Add rules/notes for BOM and related topics

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -4819,6 +4819,16 @@ translate(value := '٢٠٢٣', replace := '٠١٢٣٤٥٦٧٨٩', with := '01234
             </fos:test>
          </fos:example>
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="414" PR="546" date="2023-07-25">
+            <p>It is no longer automatically an error if the input
+               contains a codepoint that is not valid in XML. Instead, the codepoint
+            must be a <termref def="dt-permitted-character"/>. The set of permitted
+            characters is <termref def="implementation-defined"/>, but it is
+            <rfc2119>recommended</rfc2119> that all Unicode characters should 
+               be accepted.</p>
+         </fos:change>
+      </fos:changes>
    </fos:function>
    <fos:function name="string-to-codepoints" prefix="fn">
       <fos:signatures>
@@ -19056,13 +19066,13 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
             an XML declaration. The only values which every
             implementation is <rfc2119>required</rfc2119> to recognize are
                <code>utf-8</code> and <code>utf-16</code>.</p>
-         <p>The encoding of the external resource is determined as follows:</p>
+         <p>The encoding of the external resource is determined by applying the following rules, in order:</p>
          <olist>
             <item>
-               <p>external encoding information is used if available, otherwise</p>
+               <p>External encoding information is used if available.</p>
             </item>
             <item>
-               <p>if the media type of the resource is <code>text/xml</code> or
+               <p>If the media type of the resource is <code>text/xml</code> or
                      <code>application/xml</code> (see <bibref
                      ref="rfc2376"
                      />), or if it matches
@@ -19071,22 +19081,32 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
                      ref="rfc7303"
                      /> and/or its successors), then the encoding is recognized
                   as specified in <bibref
-                     ref="xml"/>, otherwise</p>
+                     ref="xml"/>.</p>
             </item>
             <item>
-               <p>the <code>encoding</code> option is used if present, otherwise</p>
+               <p>The <code>encoding</code> option is used if present.</p>
             </item>
             <item>
-               <p>the processor <rfc2119>may</rfc2119> use <termref def="implementation-defined"
-                     >implementation-defined</termref> heuristics to determine the likely encoding,
-                  otherwise</p>
+               <p>If the initial octets represent a byte order mark in a known encoding,
+               then the corresponding encoding is used: specifically:</p>
+               <ulist>
+                  <item><p>Initial octets <code>FE FF</code> imply UTF-16LE.</p></item>
+                  <item><p>Initial octets <code>FF FE</code> imply UTF-16BE.</p></item>
+                  <item><p>Initial octets <code>EF BB BF</code> imply UTF-8.</p></item>
+               </ulist>
+            </item>
+            <item>
+               <p>The processor <rfc2119>may</rfc2119> use <termref def="implementation-defined"
+                     >implementation-defined</termref> heuristics to determine the likely encoding.</p>
             </item>
             <item>
                <p>UTF-8 is assumed.</p>
             </item>
          </olist>
          <p>The result of the function is a string containing the string representation of the
-            resource retrieved using the URI, decoded according to the specified encoding.</p>
+            resource retrieved using the URI, decoded according to the specified encoding.
+            If the first codepoint, after decoding, is <char>U+FEFF</char>, then it is assumed
+            to represent a byte order mark and is discarded from the result.</p>
          
          
          
@@ -19204,6 +19224,17 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:changes>
          <fos:change issue="1116" PR="1117" date="2024-05-21">
             <p>The <code>$options</code> parameter has been added.</p>
+         </fos:change>
+         <fos:change issue="414" PR="546" date="2023-07-25">
+            <p>It is no longer automatically an error if the resource (after decoding) 
+               contains a codepoint that is not valid in XML. Instead, the codepoint
+            must be a <termref def="dt-permitted-character"/>. The set of permitted
+            characters is <termref def="implementation-defined"/>, but it is
+            <rfc2119>recommended</rfc2119> that all Unicode characters should 
+               be accepted.</p>
+         </fos:change>
+         <fos:change issue="1704">
+            <p>The specification now describes how an initial BOM should be handled.</p>
          </fos:change>
       </fos:changes>
    </fos:function>
@@ -19878,6 +19909,11 @@ return $lines[not(position() = last() and . = '')]
             /> for namespace-well-formed documents with
             the exception that the rule requiring it to be a well-formed document is replaced by the
             rule requiring it to be a well-formed external general parsed entity.</p>
+         
+         <p>Because the input is supplied as a string, not as an octet stream, the encoding specified
+         in the text declaration (if present) <rfc2119>should</rfc2119> be ignored. For similar reasons, 
+         any initial byte order mark (codepoint <char>U+FEFF</char>) <rfc2119>should</rfc2119> be ignored.</p>
+         
          <p>The string is parsed to form a sequence of nodes which become children of the new
             document node, in the same way as the content of any element is converted into a
             sequence of children for the resulting element node.</p>
@@ -20518,59 +20554,6 @@ serialize(
          <p>The entries that may appear in the <code>$options</code> map are as follows:</p>
          
          <fos:options>
-            <!--<fos:option key="method">
-               <fos:meaning>
-                                    <p>The approach used to parse the HTML document into XDM nodes.</p>
-                                    <note>
-                                       <p>An implementation may use this to specify a specific algorithm, tool, or
-                                          library that is used, such as <code>tidy</code> or <code>tagsoup</code>.</p>
-                                       <p>An implementation may also use this to specify a non-standard variant of
-                                          HTML to support, such as <code>word</code> for the Microsoft Word HTML variant.</p>
-                                    </note>
-               </fos:meaning>
-               <fos:type>xs:string</fos:type>
-            </fos:option>-->
-            <!--<fos:option key="html-version">
-               <fos:meaning>
-                                    <p>The version of HTML to support when parsing HTML strings or sequences of octets.</p>
-                                    <p>Valid values an implementation must support for the <code>html</code> method are:</p>
-                                    <olist>
-                                       <item>
-                                          <p><code>3</code>, <code>3.2</code> for HTML 3.2 W3C Recommendation, 14 January 1997</p>
-                                       </item>
-                                       <item>
-                                          <p><code>4</code>, <code>4.01</code> for HTML 4.01 W3C Recommendation, 24 December 1999</p>
-                                       </item>
-                                       <item>
-                                          <p><code>5.0</code> for HTML5 W3C Recommendation, 28 October 2014</p>
-                                       </item>
-                                       <item>
-                                          <p><code>5.1</code> for HTML 5.1 W3C Recommendation, 1 November 2016</p>
-                                       </item>
-                                       <item>
-                                          <p><code>5.2</code> for HTML 5.2 W3C Recommendation, 14 December 2017</p>
-                                       </item>
-                                       <item>
-                                          <p><code>LS</code> for HTML Living Standard, WHATWG</p>
-                                       </item>
-                                       <item>
-                                          <p><code>5</code> may be equivalent to any of <code>5.0</code>, <code>5.1</code>, <code>5.2</code>, or <code>LS</code></p>
-                                       </item>
-                                    </olist>
-                                    <p>Valid values an implementation must support for the <code>xhtml</code> method are:</p>
-                                    <olist>
-                                       <item>
-                                          <p><code>1.0</code> for XHTML 1.0 W3C Recommendation, 26 January 2000</p>
-                                       </item>
-                                       <item>
-                                          <p><code>1.1</code> for XHTML 1.1 W3C Recommendation, 31 May 2001</p>
-                                       </item>
-                                    </olist>
-                                    <p>Any other <code>method</code> and <code>html-version</code> combinations are
-                                       <termref def="implementation-defined">implementation-defined</termref>.</p>
-               </fos:meaning>
-               <fos:type>(enum('LS') | xs:decimal)</fos:type>
-            </fos:option>-->
             <fos:option key="encoding">
                <fos:meaning>
                   <p>The character encoding to use to decode a sequence of octets that
@@ -20631,11 +20614,14 @@ serialize(
          <p>If <code>$html</code> is not the empty sequence, an input byte stream is constructed as follows:</p>
          <olist>
             <item>
-               <p>If <code>$html</code> is an <code>xs:string</code>, the encoding of the input byte stream
-                  is determined in a way consistent with <bibref ref="html5"/> section 13.2.3.1,
-                  <emph>Parsing with a known character encoding</emph> to generate the bytes for that string.
-                  The specific character encoding is the <termref def="implementation-dependent"/>
-                  encoding corresponding to the implementation’s string representation.</p>
+               <p>If <code>$html</code> is an <code>xs:string</code>, then in principle no decoding is needed.
+                  Conceptually, however, the HTML parsing algorithm always starts by decoding an octet
+                  stream. The string is therefore first encoded using UTF-8, and the resulting octet
+                  stream is then passed to the HTML parser with a <term>known definite encoding</term>
+                  of UTF-8, as described in <bibref ref="html5"/> section 13.2.3.1,
+                  <emph>Parsing with a known character encoding</emph>.</p>
+               <p>If the first codepoint of the string is <char>U+FEFF</char>, this should be stripped, since
+               it might otherwise lead to an incorrect encoding inference.</p>
             </item><item>
                <p>If the type of <code>$html</code> is a sequence of octets (<code>xs:hexBinary</code> or
                   <code>xs:base64Binary</code>) the encoding of the input byte stream is determined in a
@@ -20682,66 +20668,6 @@ serialize(
          <p>The implementation <rfc2119>should</rfc2119> recognize and process XHTML (referred to
             in <bibref ref="html5"/> as the XML concrete syntax of HTML).</p>
          
-         <!--<p>For any given <code>method</code> key of <code>$options</code> the implementation must
-            use a parser and validator consistent with the <code>html-version</code> key of
-            <code>$options</code>. These are:</p>
-         <table border="0" role="data">
-            <caption>Valid method and html version combinations</caption>
-            <thead>
-               <tr>
-                  <th>method</th>
-                  <th>html-version</th>
-                  <th>Description</th>
-               </tr>
-            </thead>
-            <tbody>
-               <tr>
-                  <td>html</td>
-                  <td>3, 3.2, 4, 4.01</td>
-                  <td>An <termref def="implementation-dependent"/> parsing algorithm, tree construction,
-                     and validation consistent with the specified HTML version.</td>
-               </tr>
-               <tr>
-                  <td>html</td>
-                  <td>5, 5.0, 5.1, 5.2</td>
-                  <td>An HTML5 conformant parsing algorithm, tree construction, and validation consistent
-                     with the specified HTML version. An implementation may choose to use <code>LS</code>
-                     for all these HTML versions.</td>
-               </tr>
-               <tr>
-                  <td>html</td>
-                  <td>LS</td>
-                  <td>A parsing algorithm, tree construction, and validation consistent with the
-                     <bibref ref="html5"/>.</td>
-               </tr>
-               <tr>
-                  <td>xhtml</td>
-                  <td>1.0, 1.1</td>
-                  <td>
-                     <p>An implementation may choose to use an XML parser to directly construct the
-                        XDM nodes, and then use an <termref def="implementation-dependent"/> validation
-                        mechanism (such as DTD or XMLSchema) to validate the XHTML DOM tree.</p>
-                     <p>An implementation may also choose to use <bibref ref="html5"/> for all these
-                        XHTML versions, or some other HTML parser capable of processing XHTML
-                        documents.</p>
-                  </td>
-               </tr>
-               <tr>
-                  <td>*</td>
-                  <td>*</td>
-                  <td>
-                     <p>An <termref def="implementation-defined"/> parsing algorithm, tree construction,
-                     and validation consistent with the specified HTML version.</p>
-                     <example>
-                        <p>This allows an implementation to provide their own <code>method</code> and
-                           <code>html-version</code> combinations. For example, an implementation could
-                           use the values <code>"whatwg"</code> and <code>"2023-01-28"</code> for an
-                           implementation of the WHATWG HTML Living Standard at a given date.</p>
-                     </example>
-                  </td>
-               </tr>
-            </tbody>
-         </table>-->
          <p>The function is <termref def="dt-nondeterministic">nondeterministic with respect to node identity</termref>:
             that is, if the function is called twice with the same arguments, it is
             <termref def="implementation-dependent"/> whether the same node is returned on both
@@ -28352,29 +28278,11 @@ return document {
             calling the two-argument form with an empty map as the value of the <code>$options</code>
             argument.</p>
          <p>The effect of the two-argument function call <code>fn:json-doc($H, $M)</code>is equivalent to the function composition
-            <code>fn:unparsed-text($H) => fn:parse-json($M)</code>; except that:</p>
-
-         <olist>
-            <item>
-               <p>The function <rfc2119>may</rfc2119> accept a resource in any encoding. <bibref
-                     ref="rfc7159"
-                     /> requires
-               UTF-8, UTF-16, or UTF-32 to be accepted, but it is not an error if a different encoding is used. 
-               Unless external encoding information is available, the function <rfc2119>must</rfc2119>
-               assume that the encoding is one of UTF-8, UTF-16, or UTF-32, and <rfc2119>must</rfc2119> distinguish these cases by examination 
-               of the initial octets of the resource.</p>
-            </item>
-            <item>
-               <p diff="chg" at="2023-06-12">If the resource contains characters that are not
+            <code>fn:unparsed-text($H) => fn:parse-json($M)</code>; except that if the resource contains characters that are not
                <termref def="dt-permitted-character">permitted characters</termref>,
             then rather than raising an error as <code>fn:unparsed-text#1</code> does, the function replaces such characters by the equivalent
             JSON escape sequence prior to parsing.</p>
-               <note>
-                  <p>Equivalently, the implementation can use some other internal representation of strings that allows non-XML characters to
-            be manipulated.</p>
-               </note>
-            </item>
-         </olist>
+
 
          <p>If <code>$source</code> is the empty sequence, the function returns the empty sequence.</p>
 
@@ -28386,16 +28294,35 @@ return document {
          functions.</p>
       </fos:errors>
       <fos:notes>
+         <p>An initial byte order mark is dropped, as with the <function>fn:unparsed-text</function> function.</p>
          <p>If the input cannot be decoded (that is, converted into a sequence of Unicode codepoints, which may or may not represent characters),
             then a dynamic error occurs as with the <function>fn:unparsed-text</function> function.</p>
          <p>If the input can be decoded,
-            then the possibility still arises that the resulting sequence of codepoints includes codepoints that do not represent characters that are valid in the
-            version of XML that the processor supports. Such codepoints are translated into JSON escape sequences (for example, <code>\uFFFF</code>),
+            then the possibility still arises that the resulting sequence of codepoints includes codepoints that are
+            not <termref def="dt-permitted-character">permitted characters</termref>. Such codepoints are translated into JSON escape sequences (for example, <code>\uFFFF</code>),
             and the JSON escape sequence is then passed to the fallback function specified in the <code>$options</code> argument, which in turn
             defaults to a function that returns the Unicode <code>REPLACEMENT CHARACTER</code> (<code>xFFFD</code>).</p>
+         
+         <p>The function <rfc2119>may</rfc2119> accept a resource in any encoding. <bibref ref="rfc7159"/> requires
+               UTF-8, UTF-16, or UTF-32 to be accepted, but it is not an error if a different encoding is used.
+               The function detects the encoding using the same rules as the <function>unparsed-text</function>
+               function, except that the special handling of media types such as <code>text/xml</code>
+            and <code>application/xml</code> may be skipped.</p>
+         
+         
+         
       </fos:notes>
       <fos:changes>
          <fos:change><p>Additional options are available, as defined by <function>fn:parse-json</function>.</p></fos:change>
+
+         <fos:change issue="414" PR="546" date="2023-07-25">
+            <p>It is no longer automatically an error if the input
+               contains a codepoint that is not valid in XML. Instead, the codepoint
+            must be a <termref def="dt-permitted-character"/>. The set of permitted
+            characters is <termref def="implementation-defined"/>, but it is
+            <rfc2119>recommended</rfc2119> that all Unicode characters should 
+               be accepted.</p>
+         </fos:change>
       </fos:changes>
       
    </fos:function>


### PR DESCRIPTION
Fix #1704

The main substantive change is that unparsed-text() now explicitly discards any leading BOM.

Other functions that involve decoding of octets to strings are updated to reflect the changes that we made to reference the concept of "permitted characters".