### PR TITLE
1954 (part) Private variables and functions don't need to be in the module namespace

### DIFF
--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1161,6 +1161,9 @@ return $node/xx:bing]]>
          In earlier versions, the static context for the <termref def="dt-initializing-expression"/>
          excluded the variable being declared. This restriction has been lifted.
       </change>
+      <change issue="1954" date="2025-04-24">
+        Private variables declared in a library module are no longer required to be in the module namespace.
+      </change>
     </changes>
 
     <scrap>
@@ -1213,8 +1216,7 @@ return $node/xx:bing]]>
       </item>
     </ulist>
 
-    <p>All variable names declared in a library module must (when expanded) be in the target
-      namespace of the library module <errorref class="ST" code="0048"/>. A variable declaration may
+    <p>A variable declaration may
       use annotations to specify that the variable is <code>%private</code> or <code>%public</code>
       (which is the default). <termdef id="dt-private-variable" term="private
   variable">A
@@ -1233,6 +1235,9 @@ return $node/xx:bing]]>
           <code>%private</code> and a <code>%public</code> annotation, more than one
           <code>%private</code> annotation, or more than one <code>%public</code>
         annotation.</termdef></p>
+    
+    <p>All <termref def="dt-public-variable"/> names declared in a library module must (when expanded) be in the target
+      namespace of the library module <errorref class="ST" code="0048"/>.</p>
 
 
     <p>Variable names that have no namespace prefix are in no namespace. Variable declarations that
@@ -1644,13 +1649,21 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
     <div3 id="id-function-names">
       <head>Function Names</head>
       
+      <changes>
+        <change issue="1954" date="2025-04-24">
+          Private functions declared in a library module are no longer required to be in the module namespace.
+        </change>
+      </changes>
+      
       
       <p>Every declared function must be in a namespace; that is, every declared function name must
-        (when expanded) have a non-null namespace URI <errorref class="ST" code="0060"/>. If the
-        function name in a function declaration has no namespace prefix, it is considered to be in the
-        <term diff="chg" at="A">default function namespace</term>. Every function name
-        declared in a <termref def="dt-library-module">library module</termref> must (when expanded)
-        be in the <termref def="dt-target-namespace">target namespace</termref> of the library module
+        (when expanded) have a non-null namespace URI <errorref class="ST" code="0060"/>.</p>
+      
+      
+        
+        <p>A <termref def="dt-public-function"/> 
+        declared in a <termref def="dt-library-module">library module</termref> must be in
+        the <termref def="dt-target-namespace">target namespace</termref> of the library module
         <errorref class="ST" code="0048"/>. </p>
       
       <p><termdef term="reserved namespaces" id="dt-reserved-namespaces">A <term>reserved namespace</term> is a namespace that must not be used in the name of a function declaration.</termdef>  It is a <termref def="dt-static-error">static error</termref> <errorref class="ST" code="0045"/> if the function name in a function declaration (when expanded) is in a <termref def="dt-reserved-namespaces">reserved namespace</termref>. The following namespaces are reserved namespaces:
@@ -1698,10 +1711,17 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         </ulist>
       </p>
       
-      <p>In order to allow main modules to declare functions for local use within the module without
+      <p>If the function name in a function declaration has no namespace prefix, it is considered to be in the
+        <term>default function namespace</term>. This will result in a static error if the default function
+        namespace is a <termref def="dt-reserved-namespaces">reserved namespace</termref>.</p>
+               
+      
+      <p>In order to allow modules to declare functions for local use within the module without
         defining a new namespace, XQuery predefines the namespace prefix <code>local</code> to the
         namespace <code>http://www.w3.org/2005/xquery-local-functions</code>. It is suggested (but not
-        required) that this namespace be used for defining local functions.</p>
+        required) that this namespace be used for defining local functions, including 
+        <termref def="dt-private-function">private functions</termref> declared in 
+        <termref def="dt-library-module">library modules</termref>.</p>
       
     </div3>
     

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1161,7 +1161,7 @@ return $node/xx:bing]]>
          In earlier versions, the static context for the <termref def="dt-initializing-expression"/>
          excluded the variable being declared. This restriction has been lifted.
       </change>
-      <change issue="1954" date="2025-04-24">
+      <change issue="1954" PR="1956" date="2025-04-24">
         Private variables declared in a library module are no longer required to be in the module namespace.
       </change>
     </changes>
@@ -1650,7 +1650,7 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       <head>Function Names</head>
       
       <changes>
-        <change issue="1954" date="2025-04-24">
+        <change issue="1954" PR="1956" date="2025-04-24">
           Private functions declared in a library module are no longer required to be in the module namespace.
         </change>
       </changes>

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -2032,7 +2032,7 @@ local:depth(doc("partlist.xml"))
     <olist>
        <item><p>Its name must not be the same as the name of any other named item type, or any
          generalized atomic type, that is present in the same static context <errorref class="ST" code="0048"/>.</p></item>
-       <item><p>If the declaration appears within a <termref def="dt-library-module"/> then its name
+       <item><p>If the declaration is public and is within a <termref def="dt-library-module"/>, then its name
        must be in the <termref def="dt-target-namespace"/> of the library module <errorref class="ST" code="0048"/>.
        </p></item>
        <item><p>As a function, it must not have an arity range that overlaps the arity range of any


### PR DESCRIPTION
See issue #1954 

The PR removes the requirement for private variables and functions declared in library modules to be in the module namespace. There has never been any sensible reason for this restriction. 

The restriction is retained for public variables and functions; one could argue that it is unnecessary in that case also, but it does no harm and enforces good coding discipline.