### PR TITLE
1953 (part) XSLT Worked example using methods to implement atomic sets

### DIFF
--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -877,6 +877,9 @@
       <e:attribute name="name" required="yes">
          <e:data-type name="eqname"/>
       </e:attribute>
+      <e:attribute name="constructor" default="'no'">
+         <e:data-type name="boolean"/>
+      </e:attribute>
       <e:attribute name="extensible" default="'no'">
          <e:data-type name="boolean"/>
       </e:attribute>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -136,7 +136,8 @@ of problems processing the schema using various tools
                       xsl:element 
                       xsl:evaluate 
                       xsl:expose 
-                      xsl:fallback 
+                      xsl:fallback
+                      xsl:field 
                       xsl:for-each 
                       xsl:for-each-group 
                       xsl:fork 
@@ -174,7 +175,9 @@ of problems processing the schema using various tools
                       xsl:param 
                       xsl:perform-sort 
                       xsl:preserve-space 
-                      xsl:processing-instruction 
+                      xsl:processing-instruction
+                      xsl:record 
+                      xsl:record-type 
                       xsl:result-document 
                       xsl:sequence 
                       xsl:sort 
@@ -827,6 +830,24 @@ of problems processing the schema using various tools
   <xs:element name="fallback"
               substitutionGroup="xsl:instruction"
               type="xsl:sequence-constructor"/>
+  
+  <xs:element name="field">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:attribute name="name" type="xs:NCName"/>
+          <xs:attribute name="as" type="xsl:sequence-type"/>
+          <xs:attribute name="required" type="xsl:yes-or-no"/>
+          <xs:attribute name="default" type="xsl:expression"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_as" type="xs:string"/>
+          <xs:attribute name="_required" type="xs:string"/>
+          <xs:attribute name="_default" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
 
   <xs:element name="for-each" substitutionGroup="xsl:instruction">
     <xs:complexType>
@@ -1614,6 +1635,25 @@ of problems processing the schema using various tools
         <xs:extension base="xsl:sequence-constructor-or-select">
           <xs:attribute name="name" type="xsl:avt"/>
           <xs:attribute name="_name" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="record-type" substitutionGroup="xsl:declaration">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="xsl:element-only-versioned-element-type">
+          <xs:sequence>
+            <xs:element ref="xsl:field" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+          <xs:attribute name="name" type="xsl:EQName"/>
+          <xs:attribute name="extensible" type="xsl:yes-or-no"/>
+          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="_name" type="xs:string"/>
+          <xs:attribute name="_extensible" type="xs:string"/>
+          <xs:attribute name="_visibility" type="xs:string"/>
           <xs:assert test="exists(@name | @_name)"/>
         </xs:extension>
       </xs:complexContent>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11813,9 +11813,9 @@ return $tree =?> depth()]]></eg>
       $A?values() - returns the items in $A, as a sequence
       $A?add($k) - returns a new atomic set containing an additional item
       $A?remove($k) - returns a new atomic set in which the given item is absent
-      $A?union($B) - returns a new atomic set holding the union of $A and $B
-      $A?intersect($B) - returns a new atomic set holding the intersection of $A and $B
-      $A?except($B) - returns a new atomic set holding the difference of $A and $B
+      $A?union($B) - returns a new atomic set containing the union of $A and $B
+      $A?intersect($B) - returns a new atomic set containing the intersection of $A and $B
+      $A?except($B) - returns a new atomic set containing the difference of $A and $B
    </xsl:note>
    
    <xsl:record-type name="set:atomic-set" 
@@ -11843,60 +11843,60 @@ return $tree =?> depth()]]></eg>
                  as="%method fn($value as set:atomic-set) as set:atomic-set"/> 
    </xsl:record-type>
    
+   <xsl:variable name="DATA" select="'_data'" visibility="private"/>
+   
+   <xsl:note>
+      The private function set:replaceData processes the internal map
+      by applying a supplied function, and returns a new atomic set
+      with the resulting internal map 
+   </xsl:note>
+   
+   <xsl:function name="set:replaceData" 
+                 visibility="private" 
+                 as="map(xs:anyAtomicType, xs:boolean)">
+      <xsl:param name="input" as="set:atomic-set"/>
+      <xsl:param name="update" as="fn(map(*)) as map(*)"/>
+      <xsl:sequence select="map:put($input, $DATA, $update($input?$DATA))"/>
+   </xsl:function>   
+   
    <xsl:function name="set:build" as="set:atomic-set" visibility="public">
       <xsl:param name="values" as="xs:anyAtomicType*" default="()"/>
-      <xsl:map>
-         <xsl:map-entry name="_data"
-               select="map:build($values, 
-                                 values:=true#0, 
-                                 {'duplicates': 'use-first'})"/>
-         <xsl:map-entry name="size"
-               select="%method fn() as xs:integer {
-                          map:size(?_data)
-                       }"/>
-         <xsl:map-entry name="empty"
-               select="%method fn() as xs:boolean {
-                          map:empty(?_data)
-                       }"/>
-         <xsl:map-entry name="contains"
-               select="%method fn($value as xs:anyAtomicType) as xs:boolean {
-                          map:contains(?_data, $value)
-                       }"/>
-         <xsl:map-entry name="contains-all"
-               select="%method fn($other as set:atomic-set) as xs:boolean {
-                          every($value, map:contains(?_data, ?))
-                       }"/>
-         <xsl:map-entry name="values"
-               select="%method fn() as xs:anyAtomicType* {
-                          keys(?_data)
-                       }"/>
-         <xsl:map-entry name="add"
-               select="%method fn($value as xs:anyAtomicType) as xs:anyAtomicType* {
-                          . => map:put("_data",
-                                       map:put(?_data, $value, true()))
-                       }"/>
-         <xsl:map-entry name="remove"
-               select="%method fn($value as xs:anyAtomicType) as xs:anyAtomicType* {
-                          . => map:put("_data",
-                                       map:remove(?_data, $value, true()))
-                       }"/>
-         <xsl:map-entry name="union"
-               select="%method fn($other as set:atomic-set) as set:atomic-set {
-                          . => map:put("_data",
-                                       map:merge((?_data, $other?_data),
-                                                 {'duplicates': 'use-first'}))
-                       }"/>
-         <xsl:map-entry name="intersect"
-               select="%method fn($other as set:atomic-set) as set:atomic-set {
-                          . => map:put("_data", 
-                                       map:filter(?_data, $other?contains)) 
-                       }"/>
-         <xsl:map-entry name="except"
-               select="%method fn($other as set:atomic-set) as set:atomic-set {
-                          . => map:put("_data", 
-                                       map:remove(?_data, $other?values())) 
-                       }"/>
-      </xsl:map>
+      <xsl:record as="set:atomic-set"
+         _data=
+            "map:build($values, values:=true#0, {'duplicates': 'use-first'})"
+         size=
+            "%method fn() as xs:integer 
+                     { map:size(?$DATA) }"
+         empty=
+            "%method fn() as xs:boolean 
+                     { map:empty(?$DATA) }"
+         contains=
+            "%method fn($value as xs:anyAtomicType) as xs:boolean 
+                     { map:contains(?$DATA, $value) }"
+         contains-all=
+            "%method fn($other as set:atomic-set) as xs:boolean 
+                     { every($value, map:contains(?$DATA, ?)) }"
+         values=
+            "%method fn() as xs:anyAtomicType* 
+                     { keys(?$DATA) }"
+         add=
+            "%method fn($value as xs:anyAtomicType) as xs:anyAtomicType*
+                     { set:replaceData(., map:put(?, $value, true())) }"
+         remove=
+            "%method fn($value as xs:anyAtomicType) as xs:anyAtomicType* 
+                     { set:replaceData(., map:remove(?, $value)) }"
+         union=
+            "%method fn($other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData(., fn($this) {map:merge(($this, $other?$DATA),
+                                                    {'duplicates': 'use-first'})})
+                     }"
+         intersect=
+            "%method fn($other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData(., map:filter(?, $other?contains)) }"
+         except=
+            "%method fn($other as set:atomic-set) as set:atomic-set 
+                     { set:replaceData(., map:remove(?, $other?values())) }"/>
+      
    </xsl:function>
    
    

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11851,48 +11851,48 @@ return $tree =?> depth()]]></eg>
                                  values:=true#0, 
                                  {'duplicates': 'use-first'})"/>
          <xsl:map-entry name="size"
-               select="$method fn() as xs:integer {
+               select="%method fn() as xs:integer {
                           map:size(?_data)
                        }"/>
          <xsl:map-entry name="empty"
-               select="$method fn() as xs:boolean {
+               select="%method fn() as xs:boolean {
                           map:empty(?_data)
                        }"/>
          <xsl:map-entry name="contains"
-               select="$method fn($value as xs:anyAtomicType) as xs:boolean {
+               select="%method fn($value as xs:anyAtomicType) as xs:boolean {
                           map:contains(?_data, $value)
                        }"/>
          <xsl:map-entry name="contains-all"
-               select="$method fn($other as set:atomic-set) as xs:boolean {
+               select="%method fn($other as set:atomic-set) as xs:boolean {
                           every($value, map:contains(?_data, ?))
                        }"/>
          <xsl:map-entry name="values"
-               select="$method fn() as xs:anyAtomicType* {
+               select="%method fn() as xs:anyAtomicType* {
                           keys(?_data)
                        }"/>
          <xsl:map-entry name="add"
-               select="$method fn($value as xs:anyAtomicType) as xs:anyAtomicType* {
+               select="%method fn($value as xs:anyAtomicType) as xs:anyAtomicType* {
                           . => map:put("_data",
                                        map:put(?_data, $value, true()))
                        }"/>
          <xsl:map-entry name="remove"
-               select="$method fn($value as xs:anyAtomicType) as xs:anyAtomicType* {
+               select="%method fn($value as xs:anyAtomicType) as xs:anyAtomicType* {
                           . => map:put("_data",
                                        map:remove(?_data, $value, true()))
                        }"/>
          <xsl:map-entry name="union"
-               select="$method fn($other as set:atomic-set) as set:atomic-set {
+               select="%method fn($other as set:atomic-set) as set:atomic-set {
                           . => map:put("_data",
                                        map:merge((?_data, $other?_data),
                                                  {'duplicates': 'use-first'}))
                        }"/>
          <xsl:map-entry name="intersect"
-               select="$method fn($other as set:atomic-set) as set:atomic-set {
+               select="%method fn($other as set:atomic-set) as set:atomic-set {
                           . => map:put("_data", 
                                        map:filter(?_data, $other?contains)) 
                        }"/>
          <xsl:map-entry name="except"
-               select="$method fn($other as set:atomic-set) as set:atomic-set {
+               select="%method fn($other as set:atomic-set) as set:atomic-set {
                           . => map:put("_data", 
                                        map:remove(?_data, $other?values())) 
                        }"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11813,9 +11813,9 @@ return $tree =?> depth()]]></eg>
       $A?values() - returns the items in $A, as a sequence
       $A?add($k) - returns a new atomic set containing an additional item
       $A?remove($k) - returns a new atomic set in which the given item is absent
-      $A?union($B) - returns a new atomic set containing the union of $A and $B
-      $A?intersect($B) - returns a new atomic set containing the intersection of $A and $B
-      $A?except($B) - returns a new atomic set containing the difference of $A and $B
+      $A?union($B) - returns a new atomic set holding the union of $A and $B
+      $A?intersect($B) - returns a new atomic set holding the intersection of $A and $B
+      $A?except($B) - returns a new atomic set holding the difference of $A and $B
    </xsl:note>
    
    <xsl:record-type name="set:atomic-set" 

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11902,6 +11902,9 @@ return $tree =?> depth()]]></eg>
    
 </xsl:package>                  
                   ]]></eg>
+               
+               <ednote><edtext><p>The example is not yet tested. It could also be written
+               using the new xsl:record instruction, which might be more concise.</p></edtext></ednote>
             </div3>
          </div2>
          <div2 id="defining-decimal-format">

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -11718,14 +11718,14 @@ and <code>version="1.0"</code> otherwise.</p>
    <xsl:field name="left" as="my:binary-tree?"/>
    <xsl:field name="payload" as="item()*"/>
    <xsl:field name="right" as="my:binary-tree?"/>
-   <xsl:field name="depth" as="fn(my:binary-tree) as xs:integer"
-      default="fn() {1 + max((?left =?> depth(), ?right =?> depth())) otherwise 0)}"/>
+   <xsl:field name="depth" as="%method fn(my:binary-tree) as xs:integer"
+      default="%method fn() {1 + max((?left ? depth(), ?right ? depth())) otherwise 0)}"/>
 </xsl:record-type>]]></eg>
                   
-                  <p>The <code>=?></code> operator is described in
-                  <xspecref spec="XP40" ref="lookup-arrow-expression"/>. Its effect
-                  is to make a dynamic call on a function item that is present as
-                  an entry in a map, passing that map implicitly as the first argument.
+                  <p>The <code>%method</code> annotation is described in
+                     <xspecref spec="XP40" ref="id-methods"/>. Its effect is to
+                     give a function item contained in a map access to the containing
+                     map.
                   It thus mimics method invocation in object-oriented languages, though
                   there is no inheritance or encapsulation.</p>
                   
@@ -11742,6 +11742,166 @@ return $tree =?> depth()]]></eg>
                
                   <p>Returning the result 3.</p>
                </example>
+               
+               <p>A more detailed example that uses a recursive named record type
+               appears in the following section.</p>
+            </div3>
+            <div3 id="id-atomic-set-example">
+               <head>Example: Defining an Atomic Set</head>
+               
+               <p>This example demonstrates a library package that provides a new data type
+               to manipulate sets of atomic items.</p>
+               
+               <p>A stylesheet that incorporates this package (by referencing
+               it in an <elcode>xsl:use-package</elcode> declaration) can use constructs such as:</p>
+               
+               <ulist>
+                  <item><p>
+                     <eg><![CDATA[<xsl:variable name="empty" 
+       as="set:atomic-set"
+       select="set:build(())"/>]]></eg>
+                  </p></item>
+                  
+                  <item><p>
+                     <eg><![CDATA[<xsl:variable name="evens"
+      as="set:atomic-set"                        
+      select="set:build((1 to 100)[. mod 2 = 0])"/>]]></eg>
+                  </p></item>
+                  
+                  <item><p>
+                     <eg><![CDATA[<xsl:variable name="odds"
+      as="set:atomic-set"
+      select="set:build((1 to 100)) ? except($evens)"/>]]></eg>
+                  </p></item>
+                  
+                  <item><p>
+                     <eg><![CDATA[<xsl:function name="my:is-even" as="xs:boolean">
+   <xsl:param name="n" as="xs:integer"/>
+   <xsl:sequence select="$evens ? contains($n)"/>
+</xsl:function>]]></eg>
+                  </p></item>
+                  
+               </ulist>
+               
+               <p>Here is the implementation of the package. It relies heavily
+               on the use of the function annotation <code>%method</code>, which
+               gives a function item contained in a map access to the containing
+               map: methods are described in <xspecref spec="XP40" ref="id-methods"/>.</p>
+               
+               <eg><![CDATA[
+<xsl:package name="http://qt4cg.org/atomic-set"
+             package-version="1.0.0"
+             xmlns:set="http://qt4cg.org/atomic-set"
+             xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema">
+   
+   <xsl:note>
+      This package defines a type set:atomic-set which represents
+      a set of distinct atomic items. Atomic items are considered
+      distinct based on the comparison function fn:atomic-equal.
+      
+      An instance of an atomic set can be constructed using a function
+      call such as set:build((1, 3, 5, 7, 9)).
+      
+      If $A and $B are instances of set:atomic-set, then they
+      can be manipulated using methods including:
+      
+      $A?size() - returns the number of items in the set
+      $A?empty() - returns true if the set is empty
+      $A?contains($k) - determines whether $k is a member of the set
+      $A?contains-all($B) - returns true if $B is a subset of $A
+      $A?values() - returns the items in $A, as a sequence
+      $A?add($k) - returns a new atomic set containing an additional item
+      $A?remove($k) - returns a new atomic set in which the given item is absent
+      $A?union($B) - returns a new atomic set holding the union of $A and $B
+      $A?intersect($B) - returns a new atomic set holding the intersection of $A and $B
+      $A?except($B) - returns a new atomic set holding the difference of $A and $B
+   </xsl:note>
+   
+   <xsl:record-type name="set:atomic-set" 
+                    visibility="public"
+                    extensible="yes">
+      <xsl:field name="_data" 
+                 as="map(xs:anyAtomicType, xs:boolean)"/>
+      <xsl:field name="size" 
+                 as="%method fn() as xs:integer"/>
+      <xsl:field name="empty" 
+                 as="%method fn() as xs:boolean"/>
+      <xsl:field name="contains" 
+                 as="%method fn($value as xs:anyAtomicType) as xs:boolean"/> 
+      <xsl:field name="contains-all" 
+                 as="%method fn($value as set:atomic-set) as xs:boolean"/> 
+      <xsl:field name="add" 
+                 as="%method fn($item as xs:anyAtomicType) as set:atomic-set"/> 
+      <xsl:field name="remove" 
+                 as="%method fn($item as xs:anyAtomicType) as set:atomic-set"/>
+      <xsl:field name="union" 
+                 as="%method fn($value as set:atomic-set) as set:atomic-set"/>
+      <xsl:field name="intersect" 
+                 as="%method fn($value as set:atomic-set) as set:atomic-set"/> 
+      <xsl:field name="except" 
+                 as="%method fn($value as set:atomic-set) as set:atomic-set"/> 
+   </xsl:record-type>
+   
+   <xsl:function name="set:build" as="set:atomic-set" visibility="public">
+      <xsl:param name="values" as="xs:anyAtomicType*" default="()"/>
+      <xsl:map>
+         <xsl:map-entry name="_data"
+               select="map:build($values, 
+                                 values:=true#0, 
+                                 {'duplicates': 'use-first'})"/>
+         <xsl:map-entry name="size"
+               select="$method fn() as xs:integer {
+                          map:size(?_data)
+                       }"/>
+         <xsl:map-entry name="empty"
+               select="$method fn() as xs:boolean {
+                          map:empty(?_data)
+                       }"/>
+         <xsl:map-entry name="contains"
+               select="$method fn($value as xs:anyAtomicType) as xs:boolean {
+                          map:contains(?_data, $value)
+                       }"/>
+         <xsl:map-entry name="contains-all"
+               select="$method fn($other as set:atomic-set) as xs:boolean {
+                          every($value, map:contains(?_data, ?))
+                       }"/>
+         <xsl:map-entry name="values"
+               select="$method fn() as xs:anyAtomicType* {
+                          keys(?_data)
+                       }"/>
+         <xsl:map-entry name="add"
+               select="$method fn($value as xs:anyAtomicType) as xs:anyAtomicType* {
+                          . => map:put("_data",
+                                       map:put(?_data, $value, true()))
+                       }"/>
+         <xsl:map-entry name="remove"
+               select="$method fn($value as xs:anyAtomicType) as xs:anyAtomicType* {
+                          . => map:put("_data",
+                                       map:remove(?_data, $value, true()))
+                       }"/>
+         <xsl:map-entry name="union"
+               select="$method fn($other as set:atomic-set) as set:atomic-set {
+                          . => map:put("_data",
+                                       map:merge((?_data, $other?_data),
+                                                 {'duplicates': 'use-first'}))
+                       }"/>
+         <xsl:map-entry name="intersect"
+               select="$method fn($other as set:atomic-set) as set:atomic-set {
+                          . => map:put("_data", 
+                                       map:filter(?_data, $other?contains)) 
+                       }"/>
+         <xsl:map-entry name="except"
+               select="$method fn($other as set:atomic-set) as set:atomic-set {
+                          . => map:put("_data", 
+                                       map:remove(?_data, $other?values())) 
+                       }"/>
+      </xsl:map>
+   </xsl:function>
+   
+   
+</xsl:package>                  
+                  ]]></eg>
             </div3>
          </div2>
          <div2 id="defining-decimal-format">


### PR DESCRIPTION
Provides an XSLT package that uses named record types and methods to implement an atomic set data type, as an example of how abstract data types can now be implemented.