### PR TITLE
Attempt to improve rendering of the dynamic ToC

### DIFF
--- a/specifications/css/w3c-base.css
+++ b/specifications/css/w3c-base.css
@@ -369,12 +369,6 @@
 			margin: 0 4em;
 		}
 	}
-	
-	#toc .toc-chg::after {
-    content: " Δ";
-    font-weight: normal;
-    color: blue;
-}
 
 /******************************************************************************/
 /*                                Sectioning                                  */

--- a/specifications/css/xpath-functions-40.css
+++ b/specifications/css/xpath-functions-40.css
@@ -4,18 +4,6 @@
   padding-top: 4em ! important;
 }
 
-#toc .toc-new::after {
-    content: " ➕";
-    font-weight: normal;
-    color: blue;
-}
-
-#toc .toc-chg::after {
-    content: " Δ";
-    font-weight: normal;
-    color: blue;
-}
-
 #function-finder {
   position: absolute;
   background-color: rgb(247, 248, 249);


### PR DESCRIPTION
This is an attempt to complete action QT4CG-116-03.

Part of the confusion in the rendering is that it’s partly done by CSS and partly done by JavaScript and those had gotten out of sync. Given that the JavaScript code has to do some of the work, I changed things so it does all of the work.

I also discovered that the weird Firefox bug where the font size changed was, wait for it, caused by the particular codepoint being used for “changed”. So I, uh, changed it.

We now get ✚ for new sections, ✭ for changed sections, and both when there are both new and changed sections. I spent a bit of time trying to find a third symbol, but gave up.

The markup in the XSLT specification isn’t quite the same as in other specifications, so the results are a tiny bit odd in places. There are some sections that get marked “both” in the ToC but when you expand the ToC, there’s only one mark. I haven’t tried to work out what’s going on there yet.