### PR TITLE
Attempt to show that xsl:record allows extra attributes

### DIFF
--- a/specifications/xslt-40/src/element-catalog.xml
+++ b/specifications/xslt-40/src/element-catalog.xml
@@ -1753,17 +1753,9 @@
         <e:attribute name="xsl:duplicates" required="no" default="fn($a, $b) { error(xs:QName(err:XTDE3365)) }">
             <e:data-type name="expression"/>
         </e:attribute>
-        <!--<e:attribute name="select">
-            <e:data-type name="expression"/>
+        <e:attribute name="*" required="yes">
+           <e:data-type name="expression"/>
         </e:attribute>
-        <e:attribute name="on-duplicates" required="no" default="error(xs:QName(err:XTDE3365))">
-            <e:data-type name="expression"/>
-        </e:attribute>-->
-        <!--<e:attribute name="ordered" default="no">
-         <e:attribute-value-template>
-            <e:data-type name="boolean"/>
-         </e:attribute-value-template>
-      </e:attribute>-->
         <e:model name="sequence-constructor"/>
         <e:allowed-parents>
             <e:parent-category name="sequence-constructor"/>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -36460,6 +36460,9 @@ the same group, and the-->
                  </changes>
 
              <?element xsl:record?>
+
+             <p>(The notation <code>* = expression</code> indicates that this instruction accepts
+             any number of additional attributes in no namespace.)</p>
              
                  <p><ednote><edtext>There needs to be a construct available within <code>element-catalog.xml</code>
                              to declare 'any permitted attribute of a given name type/pattern', in this case <code>xs:NCName</code>


### PR DESCRIPTION
By the simple expedient of adding 

```xml
<e:attribute name="*" required="yes">
   <e:data-type name="expression"/>
</e:attribute>
```

to the syntax summary we get

![Screenshot 2025-04-25 at 12-25-57 XSL Transformations (XSLT) Version 4 0](https://github.com/user-attachments/assets/0eaab6d7-9b0e-4b67-92e2-fd3cd6d6ce9e)

With some additional prose, would that be sufficient?