### PR TITLE
1661 Introduce QName literals

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1968,6 +1968,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:choice name="NumericOrStringLit">
       <g:ref name="NumericLiteral"/>
       <g:ref name="StringLiteral"/>
+      <g:ref name="QNameLiteral"/>
     </g:choice>
   </g:production>
 
@@ -1979,6 +1980,11 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
       <g:ref name="DecimalLiteral"/>
       <g:ref name="DoubleLiteral" />
     </g:choice>
+  </g:production>
+  
+  <g:production name="QNameLiteral">
+    <g:string>#</g:string>
+    <g:ref name="EQName"/>
   </g:production>
 
   <g:production name="VarRef" node-type="void">

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -570,7 +570,7 @@
             </fos:test>
             <fos:test use="v-node-name-e" spec="XQuery">
                <fos:expression>node-name($e//*[@id = 'alpha']/@xml:id)</fos:expression>
-               <fos:result>xs:QName("xml:id")</fos:result>
+               <fos:result>#xml:id</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>
@@ -12700,7 +12700,7 @@ else QName("", $value)</eg>
                <code>fn:parse-QName("p:person")</code> returns an
                <code>xs:QName</code> with namespace URI obtained from the static context, local
                name <code>"person"</code> and prefix <code>"p"</code>
-               (The result is the same as <code>xs:QName("p:person")</code>).</p>
+               (The result is the same as the QName literal <code>#p:person</code>).</p>
          </fos:example>
 
       </fos:examples>
@@ -21504,9 +21504,9 @@ serialize(
             components of the static or dynamic context that are not present, or that have
             unsuitable values. For example <xerrorref spec="XP"
                class="DY" code="0002" type="type"/> is raised for the call
-            <code>function-lookup(xs:QName("fn:name"), 0)</code>
+            <code>function-lookup(#fn:name, 0)</code>
             if the context value is absent, and <errorref class="DC" code="0001" type="dynamic"
-            /> is raised for the call <code>function-lookup(xs:QName("fn:id"), 1)</code> if the
+            /> is raised for the call <code>function-lookup(#fn:id, 1)</code> if the
             context value is not a single node in a tree that is rooted at a document node.
             The error that is raised is the same as the error that would be raised by the
             corresponding function if called with the same static and dynamic context.</p>
@@ -24372,7 +24372,7 @@ let $one-of := fn($a, $b) {
 let $duplicates := $options?duplicates
 let $combine := if ($duplicates instance of xs:string) then (
   {
-    "reject":    fn($a, $b) { error(xs:QName("err:FOJS0003")) },
+    "reject":    fn($a, $b) { error(#err:FOJS0003) },
     "use-first": fn($a, $b) { $a },
     "use-last":  fn($a, $b) { $b },
     "use-any":   fn($a, $b) { $one-of($a, $b) },
@@ -28845,9 +28845,9 @@ return document {
             </fos:test>
             <fos:test>
                <fos:expression><eg>parse-json('[ "a", null, "b" ]',
-  { 'null': xs:QName("fn:null") }
+  { 'null': #fn:null }
 )</eg></fos:expression>
-               <fos:result>[ "a", xs:QName("fn:null"), "b" ]</fos:result>
+               <fos:result>[ "a", #fn:null, "b" ]</fos:result>
             </fos:test>
          </fos:example>
       </fos:examples>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -5808,6 +5808,11 @@ correctly in all browsers, depending on the system configuration.</emph></p>-->
          <head>Processing QNames</head>
          <div2 id="QName-constructors">
             <head>Functions to create a QName</head>
+            
+            <p>In XPath 4.0, statically-known QNames can be expressed using a QName literal such as
+            <code>#xml:space</code>. Where the QName is not known statically, 
+            the <code>xs:QName</code> constructor function can be used.</p>
+            
             <p>In addition to the <code>xs:QName</code> constructor function, QName values can
                be constructed by combining a namespace URI, prefix, and local name, or by resolving
                a lexical QName against the in-scope namespaces of an element node. This section
@@ -8434,7 +8439,7 @@ return <table>
                               which the JSON serialization method serializes as
                               <code>null</code>. For example the result of converting the element
                               <code>&lt;hr xsi:nil="true"/></code> becomes 
-                              <code>{ "hr": xs:QName("fn:null") }</code>, which is serialized in JSON
+                              <code>{ "hr": #fn:null }</code>, which is serialized in JSON
                                as <code>{ "hr": null }</code>.</p></td>
                         </tr>
                         <tr>
@@ -8479,10 +8484,10 @@ return <table>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>An additional key-value pair <code>"#content": xs:QName("fn:null")</code> is added, which
+                           <td><p>An additional key-value pair <code>"#content": #fn:null</code> is added, which
                               serializes in JSON as <code>"#content": null</code>. For example
                               <code>&lt;hr id="x" xsi:nil="true"/></code> becomes 
-                              <code>{ "hr": { "@id": "x", "#content": xs:QName("fn:null") } }</code>.</p></td>
+                              <code>{ "hr": { "@id": "x", "#content": #fn:null } }</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Errors</th>
@@ -8528,9 +8533,9 @@ return <table>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The content is represented by the value <code>xs:QName("fn:null")</code>, 
+                           <td><p>The content is represented by the value <code>#fn:null</code>, 
                               which is serialized as the JSON value <code>null</code>. For example.
-                              <code>&lt;name xsi:nil="true"/></code> becomes <code>{ "name": xs:QName("fn:null") }</code>.</p></td>
+                              <code>&lt;name xsi:nil="true"/></code> becomes <code>{ "name": #fn:null }</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Errors</th>
@@ -8585,7 +8590,7 @@ return <table>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The <code>"#content"</code> property is represented by the value <code>xs:QName("fn:null")</code>, 
+                           <td><p>The <code>"#content"</code> property is represented by the value <code>#fn:null</code>, 
                               which is serialized in JSON as <code>null</code>.</p></td>
                         </tr>
                         <tr>
@@ -8657,9 +8662,9 @@ return <table>
                         </tr>
                         <tr>
                            <th>Mapping for nilled elements</th>
-                           <td><p>The array is replaced by the value <code>xs:QName("fn:null")</code>, 
+                           <td><p>The array is replaced by the value <code>#fn:null</code>, 
                               which serializes to the JSON value 
-                              <code>null</code> (for example <code>{ "dates": xs:QName("fn:null") }</code>).</p></td>
+                              <code>null</code> (for example <code>{ "dates": #fn:null }</code>).</p></td>
                         </tr>
                         <tr>
                            <th>Errors</th>
@@ -8740,10 +8745,10 @@ return <table>
                         <tr>
                            <th>Mapping for nilled elements</th>
                            <td><p>The array-valued entry in the result is replaced by the entry
-                              <code>"#content": xs:QName("fn:null")</code>, 
+                              <code>"#content": #fn:null</code>, 
                               which serializes to the JSON value <code>null</code>. 
                               For example the element <code><![CDATA[<dates id="x" xsi:nil="true"/>]]></code>
-                              becomes <code>{"dates": { "@id": "x", "#content": xs:QName("fn:null") } }</code>.</p></td>
+                              becomes <code>{"dates": { "@id": "x", "#content": #fn:null } }</code>.</p></td>
                         </tr>
                         <tr>
                            <th>Errors</th>
@@ -8834,7 +8839,7 @@ return <table>
                         <tr>
                            <th>Mapping for nilled elements</th>
                            <td><p>Alongside any attributes, the value includes the additional entry
-                              <code>"#content": xs:QName("fn:null")</code>, which will be serialized 
+                              <code>"#content": #fn:null</code>, which will be serialized 
                               in JSON as <code>"#content": null</code>.</p></td>
                         </tr>
                         <tr>
@@ -8892,7 +8897,7 @@ return <table>
                         <tr>
                            <th>Mapping for nilled elements</th>
                            <td><p>A nilled element is indicated by including an additional map 
-                              <code>{ "#content" : xs:QName("fn:null")}</code> in the array, after
+                              <code>{ "#content" : #fn:null}</code> in the array, after
                               any attributes.</p></td>
                         </tr>
                         <tr>
@@ -8968,11 +8973,11 @@ return <table>
                         <tr>
                            <th>Mapping for nilled elements</th>
                            <td><p>A nilled element is indicated by including an additional map 
-                              <code>{ "#content" : xs:QName("fn:null")}</code> in the array, after
+                              <code>{ "#content" : #fn:null}</code> in the array, after
                               any attributes.
                               For example, <code><![CDATA[<para id="p2" xsi:nil="true"/>]]></code>
-                              becomes <code>{"para": [ { "id": "p2" }, { "#content": xs:QName("fn:null") } ] }</code>.
-                           In JSON the value <code>xs:QName("fn:null")</code> 
+                              becomes <code>{"para": [ { "id": "p2" }, { "#content": #fn:null } ] }</code>.
+                           In JSON the value <code>#fn:null</code> 
                               is serialized as <code>null</code>.</p></td>
                         </tr>
                         

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -2698,7 +2698,7 @@ function call raises a dynamic
 error, providing a QName that identifies the error, a descriptive string, and a diagnostic value (assuming that the prefix <code>app</code> is bound to a namespace containing application-defined error codes):</p>
 
             <eg role="parse-test"
-               ><![CDATA[error(xs:QName("app:err057"), "Unexpected value", string($v))]]></eg>
+               ><![CDATA[error(#app:err057, "Unexpected value", string($v))]]></eg>
 
          </div3>
          <div3 id="id-errors-and-opt">
@@ -8500,8 +8500,7 @@ and <nt def="OrExpr"
             <prodrecap ref="PrimaryExpr"/>
          </scrap>
  
-         <!--<p>The usage of the <nt def="TildeExpr"/> is described in <specref ref="id-arrow-operator"/>.</p>
--->
+         
          <div3 id="id-literals">
             <head>Literals</head>
             
@@ -8511,8 +8510,8 @@ and <nt def="OrExpr"
             <p>
                <termdef id="dt-literal" term="literal"
                   >A <term>literal</term> is a direct syntactic representation of an
-		atomic item.</termdef> &language; supports two kinds of literals: numeric literals and
-		string literals.</p>
+		atomic item.</termdef> &language; supports three kinds of literals: numeric literals,
+		string literals, and QName literals.</p>
             
             
             <div4 id="id-numeric-literals">
@@ -8782,6 +8781,42 @@ and <nt def="OrExpr"
                   (<char>U+0060</char>) have a reserved meaning in string templates.</p></item>
                </ulist></note>
             </div4>
+            
+            <div4 id="id-qname-literals">
+               <head>QName Literals</head>
+               
+               <changes>
+                  <change issue="1661">QName literals are new in 4.0.</change>
+               </changes>
+               
+               <p>A QName literal represents a value of type <code>xs:QName</code>.</p>
+               
+               <scrap>
+                  <prodrecap ref="QNameLiteral"/>
+               </scrap>
+               
+               <p>For example, the expression <code>node-name($node) = #xml:space</code>
+               returns true if the name of the node <code>$node</code> is the QName with local part <code>space</code>
+                  and namespace URI <code>http://www.w3.org/XML/1998/namespace</code>.</p>
+               
+               <p>If the <code>EQName</code> is an unprefixed <code>NCName</code>, then it is taken
+                  as being in no namespace. If it is a prefixed <code>QName</code>, then the prefix is
+                  resolved to a namespace URI using the <termref def="dt-static-namespaces"/>. If there
+                  is no binding for the prefix in the <termref def="dt-static-namespaces"/> then
+                  a static error is raised <errorref class="ST" code="0008"/>.
+               </p>
+               
+               <note><p>QNames are widely used in &language; to represent the names of constructs such as
+               functions, variables, and elements. A <code>QName</code> appearing on its own as an expression,
+               for example <code>my:invoice</code>, is an abbreviation for the axis step <code>child::my:step</code>,
+               which selects a child element of the context node having this particular element name. A different
+               construct is therefore needed to represent an atomic value of type <code>xs:QName</code>.
+               For example, the function <code>fn:error</code> expects an <code>xs:QName</code> value
+               as its first argument, so (provided that the prefix <code>err</code> is defined in the static
+               context) it is possible to use a call such as <code>error(#err:XPTY0004)</code> to raise an
+               error with this error code.</p></note>
+            </div4>
+            
             <div4 id="id-constants-other-types">
                <head>Constants of Other Types</head>
  
@@ -20223,7 +20258,7 @@ declare function recursive-content($item as item()) as record(key, value)* {
                <eg><![CDATA[declare function array-or-map($item as item()) {
   typeswitch ($item) {
     case array(*) | map(*) return $item
-    default return error(xs:QName("err:XPTY0004"))
+    default return error(#err:XPTY0004)
   }
 }]]></eg>
 


### PR DESCRIPTION
Fix #1661

See also #747

As discussed in the issue, I wasn't happy with the idea of changing the coercion rules to allow strings to be provided where a QName is expected, because of the need to keep the namespace context around at run-time, and because of potential confusion about exactly what namespace context is used.

Instead I have gone back to the idea of introducing QName literals, using the simple syntax #EQName.

Examples:

```
error(#err:XPTY0004)
node-name($node) = #xml:space
format-number($num, #de)
load-xquery-module($module)?variables?(#myvar)
transform({'initial-template':#xsl:initial-template})
{'last': 'Kay', 'first': 'Michael', 'suffix':#fn:null}
```