### PR TITLE
1889 Tidy up handling of HTML serialization version, default to HTML5

### DIFF
--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -663,21 +663,21 @@ is the responsibility of the <termref def="host-language">host language</termref
 <p>The following serialization parameters are defined:</p>
 
 <table role="medium no-code-break" border="1" summary="Serialization parameters">
-<col span="1"/>
+<col span="1" width="30%"/>
 <col span="1"/>
 <thead>
 <tr><th align="left" rowspan="1" colspan="1">Serialization parameter name</th><th align="left" rowspan="1" colspan="1">Permitted values for parameter</th></tr>
 </thead>
 <tbody>
 <tr>
-<td rowspan="1" colspan="1"><code>allow-duplicate-names</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>allow-duplicate-names</code></td>
 <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 This parameter indicates
 whether a map item serialized as a JSON object using the JSON output method is 
 allowed to contain duplicate member names.  If the value <code>false</code>
 is specified, a serialization error <errorref code="0022" class="RE"/> may be raised under certain conditions.</td>
 </tr>
-<tr><td rowspan="1" colspan="1"><code>byte-order-mark</code></td><td rowspan="1" colspan="1">A boolean value, 
+<tr><td rowspan="1" colspan="1" valign="top"><code>byte-order-mark</code></td><td rowspan="1" colspan="1">A boolean value, 
   <code>true</code> or <code>false</code>.
           This parameter indicates
           whether the serialized sequence of octets is to be preceded by
@@ -687,13 +687,13 @@ is specified, a serialization error <errorref code="0022" class="RE"/> may be ra
           If the encoding defines no Byte Order Mark, or if the Byte Order Mark is
           prohibited for the specific Unicode encoding or implementation environment, then
           this parameter is ignored.</td></tr>
-<tr><td rowspan="1" colspan="1"><code>cdata-section-elements</code></td><td rowspan="1" colspan="1">A list of expanded QNames, possibly empty.</td></tr>
-<tr><td rowspan="1" colspan="1"><code>doctype-public</code></td><!--Text replaced by erratum E10 change 1"-->
+<tr><td rowspan="1" colspan="1" valign="top"><code>cdata-section-elements</code></td><td rowspan="1" colspan="1">A list of expanded QNames, possibly empty.</td></tr>
+<tr><td rowspan="1" colspan="1" valign="top"><code>doctype-public</code></td><!--Text replaced by erratum E10 change 1"-->
 <td>A string of
 <xnt spec="XML" ref="NT-PubidChar">PubidChar</xnt> characters.
 This parameter <rfc2119>MAY</rfc2119> be absent.</td>
 	      <!--End of text replaced by erratum E10--></tr>
-<tr><td rowspan="1" colspan="1"><code>doctype-system</code></td><!--Text replaced by erratum E10 change 2"-->
+<tr><td rowspan="1" colspan="1" valign="top"><code>doctype-system</code></td><!--Text replaced by erratum E10 change 2"-->
 	<td>A string of Unicode characters
 	that does not include both the characters <char>U+0027</char> and 
 	  <char>U+0022</char>.
@@ -701,7 +701,7 @@ This parameter <rfc2119>MAY</rfc2119> be absent.</td>
       <!--End of text replaced by erratum E10--></tr>
 
 <tr>
-<td rowspan="1" colspan="1"><code>encoding</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>encoding</code></td>
 <td rowspan="1" colspan="1">A string of Unicode characters in the range <char>U+0021</char> 
   through <char>U+007E</char> (that is,
           printable ASCII characters); the value <rfc2119>SHOULD</rfc2119> be a charset
@@ -711,30 +711,30 @@ This parameter <rfc2119>MAY</rfc2119> be absent.</td>
 </tr>
 
   <tr diff="add" at="2023-03-31">
-    <td rowspan="1" colspan="1"><code>escape-solidus</code></td>
+    <td rowspan="1" colspan="1" valign="top"><code>escape-solidus</code></td>
     <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
     </td></tr>
 
 <tr>
-<td rowspan="1" colspan="1"><code>escape-uri-attributes</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>escape-uri-attributes</code></td>
 <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
 <tr>
-<td rowspan="1" colspan="1"><code>html-version</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>html-version</code></td>
 <td rowspan="1" colspan="1">A decimal value.  This parameter <rfc2119>MAY</rfc2119> be absent.</td></tr>
-<tr><td rowspan="1" colspan="1"><code>include-content-type</code></td>
+<tr><td rowspan="1" colspan="1" valign="top"><code>include-content-type</code></td>
   <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
-<tr><td rowspan="1" colspan="1"><code>indent</code></td><td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
+<tr><td rowspan="1" colspan="1" valign="top"><code>indent</code></td><td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
-<tr><td rowspan="1" colspan="1"><code>item-separator</code></td><td rowspan="1" colspan="1">A string of Unicode characters.  This
+<tr><td rowspan="1" colspan="1" valign="top"><code>item-separator</code></td><td rowspan="1" colspan="1">A string of Unicode characters.  This
 parameter <rfc2119>MAY</rfc2119> be absent.</td></tr>
 
-<tr><td rowspan="1" colspan="1"><code>json-lines</code></td><td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
+<tr><td rowspan="1" colspan="1" valign="top"><code>json-lines</code></td><td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
 
 <tr>
-<td rowspan="1" colspan="1"><code>json-node-output-method</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>json-node-output-method</code></td>
 <td rowspan="1" colspan="1">An expanded QName 
 with a 
 <termref def="non-null-namespace-URI">non-null
@@ -750,7 +750,7 @@ specifies an <termref def="impdef">implementation-defined</termref>
 output method.</td>
 </tr>
 
-<tr><td rowspan="1" colspan="1"><code>media-type</code></td><td rowspan="1" colspan="1">A string of Unicode characters specifying the media type (MIME
+<tr><td rowspan="1" colspan="1" valign="top"><code>media-type</code></td><td rowspan="1" colspan="1">A string of Unicode characters specifying the media type (MIME
           content type) <bibref ref="RFC2046"/>;
           the charset parameter of
           the media type <rfc2119>MUST NOT</rfc2119> be specified explicitly in the value of
@@ -761,7 +761,7 @@ output method.</td>
           the media type in an HTTP header.</td></tr>
 
 <tr>
-<td rowspan="1" colspan="1"><code>method</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>method</code></td>
 <td rowspan="1" colspan="1">An expanded QName with a 
 <termref def="non-null-namespace-URI">non-null
 namespace URI</termref>,
@@ -777,33 +777,34 @@ specifies an <termref def="impdef">implementation-defined</termref>
 output method; its behavior is not specified by this document.</td>
 </tr>
 
-<tr><td rowspan="1" colspan="1"><code>normalization-form</code></td><td rowspan="1" colspan="1">One of the enumerated values <code>NFC</code>, <code>NFD</code>,
+<tr><td rowspan="1" colspan="1" valign="top"><code>normalization-form</code></td><td rowspan="1" colspan="1">One of the enumerated values <code>NFC</code>, <code>NFD</code>,
           <code>NFKC</code>, <code>NFKD</code>, <code>fully-normalized</code>
           or <code>none</code>, or an
           <termref def="impdef">implementation-defined</termref> value
          of type
          <code>NMTOKEN</code>.</td></tr>
-<tr><td rowspan="1" colspan="1"><code>omit-xml-declaration</code></td>
+<tr><td rowspan="1" colspan="1" valign="top"><code>omit-xml-declaration</code></td>
   <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
-<tr><td rowspan="1" colspan="1"><code>standalone</code></td>
+<tr><td rowspan="1" colspan="1" valign="top"><code>standalone</code></td>
   <td rowspan="1" colspan="1">Either a boolean value, <code>true</code> or <code>false</code>, or the value
 or <code>omit</code>.</td></tr>
 <tr>
-<td rowspan="1" colspan="1"><code>suppress-indentation</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>suppress-indentation</code></td>
 <td rowspan="1" colspan="1">A list of expanded QNames, possibly empty.</td>
 </tr>
 <tr>
-<td rowspan="1" colspan="1"><code>undeclare-prefixes</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>undeclare-prefixes</code></td>
 <td rowspan="1" colspan="1">A boolean value, <code>true</code> or <code>false</code>.
 </td></tr>
 <tr>
-<td rowspan="1" colspan="1"><code>use-character-maps</code></td>
+<td rowspan="1" colspan="1" valign="top"><code>use-character-maps</code></td>
 <td rowspan="1" colspan="1">A list of pairs, possibly empty, with each pair consisting of
           a single Unicode character and a string of Unicode characters.</td></tr>
 <tr>
-<td rowspan="1" colspan="1"><code>version</code></td>
-<td rowspan="1" colspan="1">A string of Unicode characters.</td>
+<td rowspan="1" colspan="1" valign="top"><code>version</code></td>
+<td rowspan="1" colspan="1">A string of Unicode characters. This
+parameter <rfc2119>MAY</rfc2119> be absent.</td>
 </tr>
 </tbody>
 </table>
@@ -1691,7 +1692,8 @@ by ignoring the request to output a document type declaration or
     <div3 id="XML_VERSION"><head>XML Output Method: the <code>version</code> Parameter</head><p>The 
   <code>version</code> parameter specifies the version of XML
 and the version of Namespaces in XML to
-be used <phrase diff="chg" at="2023-11-01">in the serialized output</phrase>.   
+be used <phrase diff="chg" at="2023-11-01">in the serialized output</phrase>.
+      The default value is <code>1.0</code>.
 The version output in the XML declaration (if an XML declaration is not omitted) 
 <rfc2119>MUST</rfc2119> correspond to the version of XML used by
 the <termref def="serializer">serializer</termref>. The value of the
@@ -2087,6 +2089,8 @@ is described in <specref ref="serdm"/>.</p>
       <code>meta</code> elements have been revised to take account of the new HTML5 syntax,
       for example <code>&lt;meta charset="utf-8"></code>.
     </change>
+    <change issue="1889">The default HTML version is now 5. This may result in changes to the serialized
+    output in cases where no explicit HTML version is requested.</change>
   </changes>
 
   <p>The XHTML output method serializes the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> as
@@ -2095,41 +2099,44 @@ specification
 (<bibref ref="xhtml1"/>
 or the XHTML syntax of HTML5
 (see <bibref ref="html5"/>).</p>
+  <p>The default value of the <code>html-version</code> serialization parameter for this method
+  is <code>5.0</code>, and all references to the value of this parameter assume this default when
+  the parameter is absent. The value of the parameter is a decimal, so the values <code>5</code>
+  and <code>5.0</code> are equivalent.</p>
+  
+  <p><termdef id="id-with-html5" term="with HTML5">The term <term>with HTML5</term> is used
+  in this specification to qualify rules that apply only when the effective version of the
+  <code>html-version</code> serialization parameter is <code>5.0</code>.</termdef></p>
+  
+  <p><termdef id="id-prior-to-html5" term="prior to HTML5">The term <term>prior to HTML5</term> is used
+  in this specification to qualify rules that apply only when the effective version of the
+  <code>html-version</code> serialization parameter is less than <code>5.0</code>.</termdef></p>
 <p>
 <termdef id="recognized-as-HTML" term="recognized as an HTML element" open="true">An element node is <term>recognized as an
-HTML element</term> by the XHTML output method if</termdef>
+HTML element</term> by the XHTML output method if either of the following conditions is true:</termdef>
 </p>
 <ulist>
 <item><p>the element node is in the
-<termref def="xhtml-namespace">XHTML namespace</termref>,
-regardless of the value of the
-<code>html-version</code>
-serialization parameter
-or if the <code>html-version</code>
-serialization parameter is absent; or</p></item>
-<item><p>the value of the
-<code>html-version</code>
-serialization parameter is
-<code>5.0</code>, the element has a
-<termref def="null-namespace-URI">null namespace URI</termref>, and
+<termref def="xhtml-namespace">XHTML namespace</termref>; or</p></item>
+<item><p><termref def="id-with-html5">With HTML5</termref>: the element has a
+<termref def="null-namespace-URI">null namespace URI</termref> and
 the local part of the name is equal
 to the name of an element defined by HTML5 <bibref ref="html5"/>,
 making the comparison
 <termref def="caseless-compare">without regard to case</termref>.</p></item>
 </ulist><p role="closetermdef"/>
 <p>It is entirely the responsibility of the
-  person or process that creates the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/>
-to ensure that it conforms to the <bibref ref="xhtml1"/> or
-<bibref ref="xhtml11"/> specification
-if the <code>html-version</code>
-serialization parameter is absent or has a value less than
-<code>5.0</code>
-or the XHTML syntax of
-HTML5 if the value of the
-<code>html-version</code> serialization parameter is <code>5.0</code>.
-It is not an error if the
-instance of the data model is invalid XHTML. Equally, it is entirely under the
-control of the person or process that creates the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> 
+  supplier of the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/>
+to ensure that it conforms to the relevant specification, this being:</p>
+  <ulist>
+    <item><p><termref def="id-with-html5">With HTML5</termref>, the XHTML syntax of HTML5;</p></item>
+    <item><p><termref def="id-prior-to-html5">Prior to HTML5</termref>, the <bibref ref="xhtml1"/> or
+<bibref ref="xhtml11"/> specification.</p></item>
+  </ulist>
+
+  <p>It is not an error if the
+<termref def="dt-input-tree"/> is invalid XHTML. Equally, it is entirely under the
+control of the supplier of the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> 
   whether the output conforms to XHTML 1.0
 Strict, XHTML 1.0 Transitional,
 the XHTML syntax of HTML5 (see
@@ -2144,8 +2151,7 @@ and on <bibref ref="html-polyglot"/>,
 both of which are designed
 to ensure that as far as possible, XHTML is rendered correctly on user
 agents designed originally to handle HTML.</p>
-<p>If the value of the <code>html-version</code>
-  serialization parameter is <code>5.0</code>, the 
+<p><termref def="id-with-html5">With HTML5</termref> the 
   <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> is first subjected to
 <termref def="PREFIXNORMALIZATION">prefix normalization</termref>.</p>
 <p>
@@ -2248,18 +2254,17 @@ never provided a definition or reference.  Must rectify that.</edtext></ednote>
 <code>hr</code>, <code>img</code>, <code>input</code>,
 <code>keygen</code>, <code>link</code>, <code>meta</code>,
 <code>param</code>, <code>source</code>, <code>track</code> and
-<code>wbr</code>.</termdef>
+<code>wbr</code>.</termdef></p>
 <!-- Start of text added for bug 20245 -->
-<termdef term="expected-empty" id="XHTMLEXPECTEDEMPTY" open="true">An element node is <term>expected to be empty</term> if
+<p><termdef term="expected-empty" id="XHTMLEXPECTEDEMPTY" open="true">An element node is <term>expected to be empty</term> if
 it is <termref def="recognized-as-HTML">recognized as an HTML element</termref>
-and if either</termdef></p>
+and:</termdef></p>
 <ulist>
-<item><p>the <code>html-version</code> serialization parameter is
-absent or has a value less than <code>5.0</code> and the content model is
-<termref def="XHTMLEMPTY">EMPTY</termref>, or</p></item>
-<item><p>the <code>html-version</code> serialization parameter has the value
-<code>5.0</code> and the element is a <termref def="XHTMLVOID">void</termref>
+  <item><p><termref def="id-with-html5">With HTML5</termref>, the element is a <termref def="XHTMLVOID">void</termref>
 element.</p></item>
+<item><p><termref def="id-prior-to-html5">Prior to HTML5</termref>, the content model is
+<termref def="XHTMLEMPTY">EMPTY</termref>.</p></item>
+
 </ulist><p role="closetermdef"/>
 <!-- End of text added for bug 20245 -->
 <p>
@@ -2272,23 +2277,18 @@ not
 <!-- End of text added for bug 20245 -->
 </p>
 <ulist>
-<item><p>
-the
-<code>html-version</code>
-serialization parameter is
-absent or has a value
-less than <code>5.0</code>, and the
+
+<item><p><termref def="id-with-html5">With HTML5</termref>, the
+HTML element is not a <termref def="XHTMLVOID">void</termref> element, or
+</p></item>
+  <item><p>
+<termref def="id-prior-to-html5">Prior to HTML5</termref>, the
 content model of the HTML element
 is not <termref def="XHTMLEMPTY">EMPTY</termref>
-(for example, an empty title or paragraph); or</p></item>
-<item><p>the value of the
-<code>html-version</code>
-serialization parameter is <code>5.0</code>, and the
-HTML element is not a <termref def="XHTMLVOID">void</termref> element,
-</p></item>
+(for example, an empty title or paragraph)</p></item>
 </ulist>
 <p>
-the <termref def="serializer">serializer</termref> 
+then the <termref def="serializer">serializer</termref> 
 <rfc2119>MUST NOT</rfc2119> use the minimized form.
 That is, it 
 <rfc2119>MUST</rfc2119>
@@ -2310,8 +2310,7 @@ legacy
 user agents.
 If the
 <code>html-version</code>
-serialization parameter is
-absent or has a value
+serialization parameter has a value
 less than <code>5.0</code>,
 the <termref def="serializer">serializer</termref>
 <rfc2119>MUST</rfc2119> include a
@@ -2320,41 +2319,22 @@ space before the trailing <code>/&gt;</code>, e.g.
 <code>&lt;img src="karen.jpg" alt="Karen" /&gt;</code>.
 </p>
 <!--End of text replaced by erratum E7--></item>
+  
 <item><p>
-If the
-<code>html-version</code>
-serialization parameter is
-absent or has a value
-less than <code>5.0</code>,
-the <termref def="serializer">serializer</termref> 
-<rfc2119>MUST NOT</rfc2119> use the entity reference
-<code>&amp;apos;</code> which, although
-defined
-in XML and therefore in
-XHTML, is not defined in
-versions of HTML
-prior to HTML5,
-and is not recognized by all HTML user
-agents.</p></item>
-<item><p>If the
-<code>html-version</code>
-serialization parameter is
-absent or has a value
-less than
-<code>5.0</code>,
+<termref def="id-prior-to-html5">Prior to HTML5</termref>, the <termref def="serializer">serializer</termref> 
+<rfc2119>MUST NOT</rfc2119> use the entity reference <code>&amp;apos;</code> which, although
+defined in XML and therefore in XHTML, is not defined in
+versions of HTML prior to HTML5, and is not recognized by all HTML user agents.</p></item>
+  
+<item><p><termref def="id-with-html5">With HTML5</termref>, the <termref def="serializer">serializer</termref> <rfc2119>SHOULD</rfc2119>
+output namespace declarations in a way that is consistent with the requirements
+of <bibref ref="html-polyglot"/>.</p> 
+  <p><termref def="id-prior-to-html5">Prior to HTML5</termref>,
 the <termref def="serializer">serializer</termref> <rfc2119>SHOULD</rfc2119> output namespace declarations
 in a way that is consistent with the requirements of the XHTML DTD if this is
-possible.
-If the value of the
-<code>html-version</code>
-serialization parameter is
-<code>5.0</code>,
-the <termref def="serializer">serializer</termref> <rfc2119>SHOULD</rfc2119>
-output namespace declarations in a way that is consistent with the requirements
-of
-<bibref ref="html-polyglot"/>.
+possible. </p>
 
-The XHTML 1.0 DTDs require the declaration
+<p>The XHTML 1.0 DTDs require the declaration
 <code>xmlns="http://www.w3.org/1999/xhtml"</code>
 to appear on the <code>html</code> element, and only on the <code>html</code> element.
 The <bibref ref="html-polyglot"/> specification permits namespace declarations
@@ -2410,14 +2390,14 @@ with the guidelines.  No <termref def="serial-err">serialization error</termref>
 Parameter</head>
 <p>The behavior for the <code>version</code>
 parameter for the XHTML output method is described in
-<specref ref="XML_VERSION"/>.</p>
+<specref ref="XML_VERSION"/>. Note that this affects the version of XML used, not the version of HTML.</p>
 </div3>
 <div3 id="XHTML_HTML_VERSION">
 <head>XHTML Output Method: the <code>html-version</code> Parameter</head>
 <p>The <code>html-version</code> parameter specifies whether the XHTML
 output method will produce a serialized document following rules that
-are tailored to the requirements of the XHTML syntax of <bibref ref="html5"/>
-or the requirements of <bibref ref="xhtml1"/> and <bibref ref="xhtml11"/>.</p>
+are tailored to the requirements of the XHTML syntax of <bibref ref="html5"/>,
+or to the requirements of <bibref ref="xhtml1"/> and <bibref ref="xhtml11"/>.</p>
 <p>The differences are described in detail throughout
 <specref ref="xhtml-output"/>.</p>
 </div3>
@@ -2437,8 +2417,8 @@ after an element, or adjacent to an existing whitespace character.</p></item>
 an inline element. The inline elements are those elements
 <termref def="recognized-as-HTML">recognized
 as HTML elements</termref> that are
-in the %inline category of any of the XHTML 1.0 DTDs, in the
-%inline.class category of the XHTML 1.1 DTD,
+in the <code>%inline</code> category of any of the XHTML 1.0 DTDs, in the
+<code>%inline.class</code> category of the XHTML 1.1 DTD,
 those elements defined to be phrasing
 elements in HTML5
  and elements
@@ -2456,14 +2436,12 @@ with local names <code>pre</code>, <code>script</code>, <code>style</code>,
 </p></item>
 <item><p>Whitespace characters
 <rfc2119>MUST NOT</rfc2119> be added in the content of an element
-whose expanded QName matches a
-member of the list of expanded QNames in the
+whose expanded QName matches a member of the list of expanded QNames in the
 value of the <code>suppress-indentation</code> parameter.
-The expanded QName of an element node
-is considered to match a member of the list of expanded QNames
+The expanded QName of an element node is considered to match a member of the list of expanded QNames
 if:</p>
 <ulist>
-<item><p>the two expanded QNames are equal;</p></item>
+<item><p>the two expanded QNames are equal; or</p></item>
 <item><p>the expanded QNames both have <termref def="null-namespace-URI">null
 namespace URIs</termref>, and the local parts of the two QNames are
 equal <termref def="caseless-compare">without regard to case</termref>; or
@@ -2498,9 +2476,7 @@ the <code>omit-xml-declaration</code> parameter. Appendix C.1 of
 provides advice on the consequences of including,
 or omitting, the XML declaration.</p></note></div3>
 <div3 id="XHTML_DOCTYPE"><head>XHTML Output Method: the <code>doctype-system</code> and <code>doctype-public</code> Parameters</head>
-<p>If the value of the
-<code>html-version</code>
-serialization parameter is <code>5.0</code>, the
+<p><termref def="id-with-html5">With HTML5</termref>, if the
 <!-- Start of text removed in response to bug 20264 -->
 <!-- <code>doctype-public</code> and <code>doctype-system</code>
 serialization parameters are both -->
@@ -2566,7 +2542,8 @@ used. The <code>meta</code> element <rfc2119>SHOULD</rfc2119>
       content="text/html; charset=EUC-JP" /&gt;
 ...</eg></example>
   
-<p diff="add" at="2023-02-09">For HTML5, the alternative form <code>&lt;meta charset="EUC-JP"/&gt;</code> 
+<p diff="add" at="2023-02-09"><termref def="id-with-html5">With HTML5</termref>, 
+  the alternative form <code>&lt;meta charset="EUC-JP"/&gt;</code> 
   <rfc2119>MAY</rfc2119> be used.</p> 
   <imp-def-feature><phrase diff="add" at="2023-02-16">In the XHTML output method, for HTML5, when <code>meta</code> elements are added
   to the output according to the rules of the <code>include-content-type</code> parameter, it
@@ -2618,6 +2595,8 @@ is described in <specref ref="serdm"/>.</p>
     <change issue="318" PR="342" date="2023-02-14">In the HTML and XHTML output methods, the rules for adding and replacing
       <code>meta</code> elements have been revised to take account of the new HTML5 syntax,
       for example <code>&lt;meta charset="utf-8"></code>.</change>
+    <change issue="1889">The default HTML version is now 5. This may result in changes to the serialized
+    output in cases where no explicit HTML version is requested.</change>
   </changes>
   <p>The HTML output method serializes
   the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> as
@@ -2632,63 +2611,72 @@ HTML.</p><example><p>For example, the following XSL stylesheet generates html ou
 &lt;/xsl:template&gt;
 ...
 &lt;/xsl:stylesheet&gt;</eg></example><p>In the example, the <code>version</code> attribute of the <code>xsl:output</code> element indicates the version of the HTML Recommendation <bibref ref="html401"/> to which the serialized result is to conform.</p>
-<p>It is entirely the responsibility of the person or process that creates 
-  the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> to ensure that it conforms to the HTML Recommendation <bibref ref="html401"/>. 
+
+  <p><termdef id="req-html-ver" term="requested HTML version">The <term>requested HTML version</term> is the
+    value of the <code>html-version</code> serialization parameter if present; otherwise the value of the
+    <code>version</code> serialization parameter if present; otherwise <code>5.0</code>.</termdef></p>
+    
+    
+<p>This document provides the normative
+definition of serialization for the HTML output method if the
+<termref def="req-html-ver">requested HTML version</termref>
+has the lexical form of a value of type decimal whose value
+is 1.0 or greater, but no greater than
+5.0.  For any other requested HTML version, the behavior is
+<termref def="impdef">implementation-defined</termref>.
+In that case the
+<termref def="impdef">implementation-defined</termref>
+behavior <rfc2119>MAY</rfc2119> supersede all other requirements
+of this recommendation.</p>
+<imp-def-feature>If an implementation
+supports a value of the <code>version</code> parameter for the HTML output
+method for which this document does not provide a normative definition, the
+behavior is <termref def="impdef">implementation-defined</termref>.</imp-def-feature>
+<!-- End:  added for Bug 6732 -->
+  
+  <p>An implementation is required to behave as specified in this document when the requested
+  version is <code>5.0</code>. If the requested version is greater than or equal to <code>1</code>
+  but less than <code>5.0</code>, then the processor <rfc2119>may</rfc2119> behave as if the
+  requested version were <code>5.0</code>.</p>
+  
+  
+  <p>It is entirely the responsibility of the supplier of
+  the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> to ensure that it conforms to the relevant HTML specification. 
   It is not an error if the <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> is invalid HTML. 
-  Equally, it is entirely under the control of the person or process that creates the 
+  Equally, it is entirely under the control of the supplier of the
   <termref diff="chg" at="2023-11-01" def="dt-input-tree"/> whether the output conforms to HTML.
 <!--Start of text added for Bug 6723-->
 If the result tree is valid HTML, the
 <termref def="serializer">serializer</termref> <rfc2119>MUST</rfc2119> serialize the result in a way that
-conforms with the version of HTML specified by the
-<termref def="req-html-ver">requested HTML
-version</termref>.</p>
+conforms with the <termref def="req-html-ver">requested HTML version</termref>.</p>
 <!--End of text added for Bug 6723-->
-<!--
-<ednote><edtext></edtext></ednote>
--->
+
 <div2 id="HTML_MARKUP"><head>Markup for Elements</head>
-<!--
-<ednote>
-<edtext>
-Open issue;  The working groups talked about the possibility of 
-automatically "normalizing" data model instances so that an entire
-tree had XHTML namespace stripped out.
-</edtext>
-</ednote>
--->
-<p>As is described in detail below,
+
+<p>As described in detail below,
 the HTML output method
 will not
 output an element
 differently from the XML output method unless the
 element is to be
 <termref def="serialize-as-HTML">serialized as an HTML
-element</termref>.
-<termdef id="XML-ISLAND" term="XML Island">The
-portion of the serialized document representing the result of serializing 
-an element
+element</termref>.</p>
+
+  <p><termdef id="XML-ISLAND" term="XML Island">The
+portion of the serialized document representing the result of serializing an element
 that is not to be
 <termref def="serialize-as-HTML">serialized as an HTML
-element</termref>
-is known as an
-<term>XML Island.</term></termdef>
-<termdef id="serialize-as-HTML" term="serialized as an HTML element"
+element</termref> is known as an <term>XML Island.</term></termdef></p>
+  
+<p><termdef id="serialize-as-HTML" term="serialized as an HTML element"
 open="true">An element node is <term>serialized as an
 HTML element</term> if</termdef></p>
 <ulist>
 <item><p>the expanded QName of the element has a
-<termref def="null-namespace-URI">null namespace URI</termref>,
-regardless of the value of the
-<termref def="req-html-ver">requested HTML
-version</termref>, or
+<termref def="null-namespace-URI">null namespace URI</termref>, or
 </p></item>
-<item><p>the value of the
-<termref def="req-html-ver">requested HTML
-version</termref>
-is <code>5.0</code> or
-greater, and
-the element node is in the
+<item><p>the <termref def="req-html-ver">requested HTML version</termref> is <code>5.0</code> or
+greater, and the element node is in the
 <termref def="xhtml-namespace">XHTML namespace</termref>.</p></item>
 </ulist>
 <p role="closetermdef"/>
@@ -2994,7 +2982,9 @@ instructions with <code>&gt;</code> rather than
 <div3 id="HTML_VERSION"><head>HTML Output Method: the <code>version</code>
 and <code>html-version</code>
 Parameters</head>
-<p>The
+  
+  <p>These two parameters are used to determine the <termref def="req-html-ver"/>.</p>
+<!--<p>The
 <code>html-version</code> or the
 <code>version</code> 
 serialization parameter
@@ -3016,7 +3006,7 @@ the <termref def="req-html-ver">requested
 HTML version</termref>, it
 <rfc2119>MUST</rfc2119> raise a
 <termref def="serial-err">serialization error</termref> <errorref code="0013" class="SU"/>.</p>
-<!-- Start:  added for Bug 6732 -->
+<!-\- Start:  added for Bug 6732 -\->
 <p>This document provides the normative
 definition of serialization for the HTML output method if the
 <termref def="req-html-ver">requested HTML version</termref>
@@ -3033,7 +3023,7 @@ of this recommendation.</p>
 supports a value of the <code>version</code> parameter for the HTML output
 method for which this document does not provide a normative definition, the
 behavior is <termref def="impdef">implementation-defined</termref>.</imp-def-feature>
-<!-- End:  added for Bug 6732 -->
+<!-\- End:  added for Bug 6732 -\->-->
 </div3>
 <div3 id="HTML_ENCODING"><head>HTML Output Method: the <code>encoding</code> Parameter</head><p>The <code>encoding</code> parameter specifies the encoding to be used.
 <termref def="serializer">Serializers</termref> are

--- a/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-40/src/xslt-xquery-serialization.xml
@@ -2089,7 +2089,7 @@ is described in <specref ref="serdm"/>.</p>
       <code>meta</code> elements have been revised to take account of the new HTML5 syntax,
       for example <code>&lt;meta charset="utf-8"></code>.
     </change>
-    <change issue="1889">The default HTML version is now 5. This may result in changes to the serialized
+    <change issue="1889" PR="1977" date="2025-05-02">The default HTML version is now 5. This may result in changes to the serialized
     output in cases where no explicit HTML version is requested.</change>
   </changes>
 
@@ -2595,7 +2595,7 @@ is described in <specref ref="serdm"/>.</p>
     <change issue="318" PR="342" date="2023-02-14">In the HTML and XHTML output methods, the rules for adding and replacing
       <code>meta</code> elements have been revised to take account of the new HTML5 syntax,
       for example <code>&lt;meta charset="utf-8"></code>.</change>
-    <change issue="1889">The default HTML version is now 5. This may result in changes to the serialized
+    <change issue="1889" PR="1977" date="2025-05-02">The default HTML version is now 5. This may result in changes to the serialized
     output in cases where no explicit HTML version is requested.</change>
   </changes>
   <p>The HTML output method serializes


### PR DESCRIPTION
Does some general tidying up of the serialization text, but the main substantive changes are (a) to make HTML5 the default version, and (b) to make support for earlier versions effectively optional.

Please review carefully. Marking as editorial because I'm not sure any test cases need to change, but I might be wrong.

Fix #1889