### PR TITLE
882 Drop fn:chain

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -22261,7 +22261,7 @@ return fold-right(
       </fos:changes>
    </fos:function>
    
-       <fos:function name="chain" prefix="fn">
+       <!--<fos:function name="chain" prefix="fn">
         <fos:signatures>
             <fos:proto name="chain" return-type="item()*">
                 <fos:arg name="input" type="item()*"/>
@@ -22573,7 +22573,7 @@ chain((1, 2, 3, 4), $product3)
           <fos:changes>
             <fos:change issue="517" PR="734 1233" date="2022-10-20"><p>New in 4.0</p></fos:change>
           </fos:changes>            
-        </fos:function>
+        </fos:function>-->
 
    <fos:function name="while-do" prefix="fn">
       <fos:signatures>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -7896,11 +7896,11 @@ return <table>
             <div3 id="func-apply">
                <head><?function fn:apply?></head>
             </div3>
-            <div3 id="func-chain" diff="add" at="A">
+            <!--<div3 id="func-chain" diff="add" at="A">
                <head>
                   <?function fn:chain?>
                </head>
-            </div3>
+            </div3>-->
             <div3 id="func-do-until">
                <head><?function fn:do-until?></head>
             </div3>


### PR DESCRIPTION
Fix #882

Supersedes PR #1883

There has been a great deal of discussion about the relative merits of the status-quo fn:chain function and the proposed replacement fn:compose. The CG was polled on whether it preferred to have fn:chain only, fn:compose only, or both, or neither. There was no clear consensus. The only option which no-one seemed to favour was to have fn:chain only -- which is the status quo. Since no-one is happy with the status quo I am therefore proposing that we drop this function. We can then start with a clean slate.

For the record the main criticisms of the fn:chain function as currently specified were:

(a) it is more useful to have a function that combines several functions into a single function, without actually applying that function to a set of supplied arguments

(b) The function has special-case behaviour for arrays (if the input is not an array and the function has arity > 1 then the input sequence is converted to an array).

(c) The need for the function is not clearly motivated; the examples given can all be achieved in some simpler more intuitive way.