### PR TITLE
1985 Tidy up namespace terminology

### DIFF
--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -57,7 +57,7 @@
 
       <error spec="XP" code="0008" class="ST" type="static">
          <p> It is a <termref def="dt-static-error">static error</termref> if an expression refers
-            to an element name, attribute name, schema type name, namespace prefix, or variable name
+            to an element name, attribute name, schema type name, or variable name
             that is not defined in the <termref def="dt-static-context">static context</termref>,
             except for an ElementName in an <nt def="ElementTest">ElementTest</nt> or an
             AttributeName in an <nt def="AttributeTest">AttributeTest</nt>.</p>

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -180,10 +180,25 @@ Each node has a unique <term>node identity</term>, a <term>typed value</term>, a
 
 
 
+
+
+      <!-- -->
+
+      </div3>
+      <div3 id="id-namespaces-and-qnames">
+         <head>Namespaces and QNames</head>
+         
+         <p><termdef id="dt-namespace-binding" term="namespace binding">A <term>namespace binding</term>
+         is a pair comprising a namespace prefix (which is either an <code>xs:NCName</code> or empty),
+         and a namespace URI.</termdef></p>
+      
+
       <p>Element nodes have a property called <term>in-scope namespaces</term>. <termdef
             term="in-scope namespaces" id="dt-in-scope-namespaces"
-               >The <term>in-scope namespaces</term> property of an element node is a set of namespace bindings, each of which associates a namespace prefix with a URI.</termdef>
-For a given element, one namespace binding may have an empty prefix; the URI of this namespace binding is the default namespace within the scope of the element.</p>
+               >The <term>in-scope namespaces</term> property of an element node is a set of 
+         <termref def="dt-namespace-binding">namespace bindings</termref>, each of which associates a namespace prefix with a URI.</termdef>
+For a given element, one namespace binding may have an empty prefix; the URI of this namespace binding is 
+referred to as the <termref def="dt-default-in-scope-namespace"/> for the element.</p>
       <p role="xpath">In <bibref ref="xpath"
             />, the in-scope namespaces of an element node are represented by a collection of <term>namespace nodes</term> arranged on a <term>namespace axis</term>. 
 As of XPath 2.0, the namespace axis is deprecated and need not be supported by a host language. A host language that does not support the namespace axis need not represent namespace bindings in the form of nodes.</p>
@@ -194,7 +209,10 @@ As of XPath 2.0, the namespace axis is deprecated and need not be supported by a
             />. XQuery does not support the namespace axis and does not represent namespace bindings in the form of nodes.</p>
 
          <p>However, where other specifications such as <bibref ref="xslt-xquery-serialization-40"
-               /> refer to namespace nodes, these nodes may be synthesized from the in-scope namespaces of an element node by interpreting each namespace binding as a namespace node. An application that needs to create a set of namespace nodes to represent these bindings for an element bound to <code>$e</code> can do so using the following code.
+               /> refer to namespace nodes, these nodes may be synthesized from the in-scope namespaces of 
+            an element node by interpreting each <termref def="dt-namespace-binding"/> as a namespace node. An application that 
+            needs to create a set of namespace nodes to represent these bindings for an element bound to 
+            <code>$e</code> can do so using the following code.
 
 
 <eg
@@ -203,15 +221,11 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
 ]]></eg>
          </p>
       </note>
-
-
-      <!-- -->
-
-      </div3>
-      <div3 id="id-namespaces-and-qnames">
-         <head>Namespaces and QNames</head>
-      
-
+         
+         <p><termdef id="dt-default-in-scope-namespace" term="default in-scope namespace">The <term>default in-scope namespace</term>
+         of an element node</termdef> is the namespace URI to which the empty prefix is bound in the element’s 
+         <termref def="dt-in-scope-namespaces"/>. In the absence of an explicit binding for the empty prefix, the
+         default in-scope namespace is <xtermref spec="DM40" ref="dt-absent"/>.</p>
 
 
       <p>
@@ -227,6 +241,13 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
       and the namespace URI parts must either both be
       absent, or must be equal under the Unicode codepoint
       collation.</p>
+         
+         <note><p>The <xtermref spec="DM40" ref="dt-datum"/> of 
+            an <termref def="dt-atomic-item"/> of type <code>xs:QName</code>
+            is an <termref def="dt-expanded-qname"/>. However, the
+            term <termref def="dt-expanded-qname"/> is also used for
+            the names of constructs such as functions, variables, and types
+            that are not themselves atomic items.</p></note>
 
       <p>In the &language;
       grammar, QNames representing the names of
@@ -237,11 +258,6 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
 
       <scrap>
          <prodrecap ref="EQName"/>
-         <!--<prodrecap id="QName" ref="QNameToken"/>
-         <prodrecap ref="URILiteral" id="URILiteral" role="xquery"/>
-         <prodrecap id="URIQualifiedName" ref="URIQualifiedName"/>
-         <prodrecap id="BracedURILiteral" ref="BracedURILiteral"/>
-         <prodrecap ref="NCNameTok"/>-->
       </scrap>
 
 
@@ -252,14 +268,15 @@ in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)}
                <p>local-name only (for example, <code>invoice</code>).</p>
                <p>A name written in this form has no prefix, and the rules
         for determining the namespace depend on the context in which
-        the name appears. This form is a <termref
-                     def="dt-qname">lexical QName</termref>.</p>
+        the name appears: the various rules used are summarized
+        in <specref ref="id-expanding-unprefixed-qnames"/>.
+                  This form is a <termref def="dt-qname">lexical QName</termref>.</p>
             </item>
             <item>
                <p>prefix plus local-name (for example, <code>my:invoice</code>).</p>
                <p>In this case the prefix and local name of the QName are as
         written, and the namespace URI is inferred from the prefix by
-        examining the in-scope namespaces in the static context where
+        examining the <termref def="dt-static-namespaces"/> in the static context where
         the QName appears; the context must include a binding for the
         prefix. This form is a <termref
                      def="dt-qname">lexical
@@ -411,6 +428,73 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
       </note>
       </div3>
          
+         <div3 id="id-expanding-unprefixed-qnames">
+            <head>Expanding Lexical QNames</head>
+            
+            <p>When a <termref def="dt-qname"/> appearing in an &language; expression is expanded, the rules are as follows.</p>
+            
+            <p>If the name contains a colon, then the prefix (the substring before the colon) is used to establish the 
+               corresponding URI by reference to the <termref def="dt-static-namespaces"/>
+            in the <termref def="dt-static-context"/>. If there
+                  is no binding for the prefix in the <termref def="dt-static-namespaces"/> then
+                  a static error is raised <errorref class="ST" code="0081"/>.
+            </p>
+            
+            <p>If the <termref def="dt-qname">lexical QName</termref> contains no colon (and therefore no prefix),
+            the namespace URI part of the QName is inferred in one of a number of ways, depending on the syntactic context
+            in which the name appears. The various rules are defined below, and are referred to throughout the specification.</p>
+            
+            <ulist>
+               <item><p><termdef id="dt-no-namespace-rule" term="no-namespace rule">When an unprefixed lexical QName
+               is expanded using the <term>no-namespace rule</term>, it is interpreted as having an absent namespace URI.</termdef>
+               </p></item>
+               <item><p><termdef id="dt-default-function-namespace-rule" term="default function namespace rule">When 
+                  an unprefixed lexical QName
+               is expanded using the <term>default function namespace rule</term>, it uses the <termref def="dt-default-function-namespace"/>
+                  from the <termref def="dt-static-context"/>.</termdef>
+               </p></item>
+               <item><p><termdef id="dt-default-type-namespace-rule" term="default type namespace rule">When 
+                  an unprefixed lexical QName
+               is expanded using the <term>default type namespace rule</term>, it uses the 
+                  <termref def="dt-default-namespace-elements-and-types"/>. If this is absent, the <termref def="dt-no-namespace-rule"/>
+                  is used. If the <termref def="dt-default-namespace-elements-and-types"/> has the special value <code>##any</code>,
+                  then the lexical QName refers to a name in the namespace <code>http://www.w3.org/2001/XMLSchema</code>.</termdef>
+               </p></item>
+               <item><p><termdef id="dt-default-element-namespace-rule" term="default element namespace rule">When 
+                  an unprefixed lexical QName
+               is expanded using the <term>default element namespace rule</term>, then it uses the 
+                  <termref def="dt-default-namespace-elements-and-types"/>. If this is absent, or if it takes
+                  the special value <code>##any</code>, then the <termref def="dt-no-namespace-rule"/>
+                  is used.</termdef>
+               </p></item>
+               <item role="xquery">
+                  <p><termdef id="dt-constructed-element-namespace-rule" term="constructed element namespace rule">
+                  When  an unprefixed lexical QName
+               is expanded using the <term>constructed element namespace rule</term>, then it uses the namespace URI
+                     that is bound to the empty (zero-length) prefix in the <termref def="dt-static-namespaces"/> of the
+                     <termref def="dt-static-context"/>. If there is no such <termref def="dt-namespace-binding"/>
+                  then it uses the <termref def="dt-no-namespace-rule"/>.</termdef>   
+                 </p></item>
+               <item role="xquery">
+                  <p><termdef id="dt-default-annotation-namespace-rule" term="default annotation namespace rule">
+                  When  an unprefixed lexical QName
+               is expanded using the <term>annotation namespace rule</term>, then it uses the namespace URI
+                     <code>http://www.w3.org/2012/xquery</code>.</termdef>   
+                 </p></item>
+               <item><p><termdef id="dt-element-name-matching-rule" term="element name matching rule">When 
+                  an unprefixed lexical QName
+               is expanded using the <term>element name matching rule</term> rule, then it uses the 
+                  <termref def="dt-default-namespace-elements-and-types"/>. If this is absent, then 
+                  it uses the <termref def="dt-no-namespace-rule"/>. But if it takes the special value <code>##any</code>,
+                  then the name is taken as matching any <termref def="dt-expanded-qname"/> with the corresponding local part,
+                  regardless of namespace: that is, the  unprefixed name <code>local</code> is interpreted
+                  as <code>*:local</code>.</termdef>
+               </p></item>
+            </ulist>
+            
+            
+         </div3>
+         
       </div2>
 
       <div2 id="context">
@@ -548,9 +632,8 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
                   <p>The URI value is whitespace normalized according to the rules for the
                      <code>xs:anyURI</code> type in <xspecref spec="XS1-2" ref="anyURI"/> or 
                      <xspecref spec="XS11-2" ref="anyURI"/>.</p>
-                  <p diff="add" at="A">The statically known namespaces may include a binding for the zero-length prefix;
-                  however, this is used only in limited circumstances because the rules for resolving
-                  unprefixed QNames depend on how such a name is used.</p>
+                  <p role="xquery">The statically known namespaces may include a binding for the zero-length prefix:
+                  however, this is used only by the <termref def="dt-constructed-element-namespace-rule"/>.</p>
                   <p>Note the difference between <termref def="dt-in-scope-namespaces"
                         >in-scope namespaces</termref>, which is a dynamic property of an element node, and <termref
                         def="dt-static-namespaces"
@@ -727,16 +810,14 @@ schemas.</phrase>
                   <p>
                      <termdef id="dt-in-scope-variables" term="in-scope variables">
                         <term>In-scope variables.</term> 
-This is a mapping from <termref
-                           def="dt-expanded-qname"
-                           >expanded QName</termref> to type. It defines the
-set of variables that are available for reference within an
-expression. The <termref
+                           This is a mapping from <termref def="dt-expanded-qname"
+                           >expanded QNames</termref> to sequence types. It defines the
+                           set of variables that are available for reference within an
+                           expression. The <termref
                            def="dt-expanded-qname"
                            >expanded QName</termref> is the name of the variable, and the type is the
-<termref
-                           def="dt-static-type">static type</termref> of the
-variable.</termdef>
+                           <termref def="dt-static-type">static type</termref> of the
+                           variable.</termdef>
                   </p>
 
                   <p>
@@ -768,7 +849,7 @@ inferred by static type inference as discussed in  <specref
 
                      <termdef id="dt-in-scope-named-item-types" term="in-scope named item types">
                         <term>In-scope named item types.</term> This is a mapping from 
-                        <termref def="dt-expanded-qname">expanded QName</termref> to 
+                        <termref def="dt-expanded-qname">expanded QNames</termref> to 
                         <termref def="dt-named-item-type">named item types</termref>.</termdef></p>
                    <p><termdef id="dt-named-item-type" term="named item type">A <term>named item type</term>
                       is an <code>ItemType</code> identified by an <termref def="dt-expanded-qname"/>.</termdef>
@@ -858,8 +939,9 @@ inferred by static type inference as discussed in  <specref
                <item role="xquery">
                   <p>
                      <termdef id="dt-copy-namespaces-mode" term="copy-namespaces mode">
-                        <term>Copy-namespaces mode.</term> This component controls the namespace bindings that
-are assigned when an existing element node is copied by an element
+                        <term>Copy-namespaces mode.</term> This component controls the <termref def="dt-in-scope-namespaces"/>
+                        property that
+is assigned when an existing element node is copied by an element
 constructor, as described in <specref
                            ref="id-element-constructor"
                            />. Its value consists of two parts: <code>preserve</code> or <code>no-preserve</code>, and <code>inherit</code> or <code>no-inherit</code>.</termdef>
@@ -1493,7 +1575,7 @@ the number of items in the sequence obtained by evaluating <var
                         <term>Variable values</term>. 
         This is a mapping from <termref
                            def="dt-expanded-qname"
-                           >expanded QName</termref> to value. 
+                           >expanded QNames</termref> to values. 
         It contains the
 				same <termref
                            def="dt-expanded-qname">expanded QNames</termref> as the <termref
@@ -3997,12 +4079,8 @@ types</term> (such as <code>xs:integer</code>) and function types
       <p>
                <termref def="dt-qname">Lexical QNames</termref> appearing in an <termref
                   def="dt-item-type-designator"/> <phrase role="xquery">(other than within
-                  a <termref def="dt-function-assertion"/>)</phrase> have their
-		  prefixes expanded to namespace URIs by means of the
-		  <termref
-                  def="dt-static-namespaces"
-                  >statically known namespaces</termref> and (where applicable) the
-		    <termref def="dt-default-namespace-elements-and-types"/>.
+                  a <termref def="dt-function-assertion"/>)</phrase> are expanded using the 
+                  <termref def="dt-default-type-namespace-rule"/>.
       Equality of QNames is defined by the <code>eq</code> operator.</p>
 
 
@@ -4030,10 +4108,8 @@ types</term> (such as <code>xs:integer</code>) and function types
             
             <olist diff="add" at="A">
                <item><p>If the name is written as a lexical QName, then it is expanded using the
-               <termref def="dt-in-scope-namespaces"/> in the <termref def="dt-static-context"/>. If the
-               name is an unprefixed <code>NCName</code>, then it is expanded according to the
-                  <termref def="dt-default-namespace-elements-and-types"/>.</p></item>
-               <item><p>If the name matches a <termref def="dt-named-item-type"/> in the <termref def="dt-static-context"/>,
+               <termref def="dt-default-type-namespace-rule"/>.</p></item>
+               <item><p>If the expanded name matches a <termref def="dt-named-item-type"/> in the <termref def="dt-static-context"/>,
                   then it is taken as a reference to the corresponding item type. The rules that
                apply are the rules for the expanded item type definition.</p></item>
                <item><p>Otherwise, it must match the name of a type in the <termref def="dt-is-types">in-scope schema types</termref>
@@ -4234,7 +4310,9 @@ types</term> (such as <code>xs:integer</code>) and function types
                
                
                <p>It is not possible to preserve the type of a <termref def="dt-namespace-sensitive"
-                  >namespace-sensitive</termref> value without also preserving the namespace binding that defines the meaning of each namespace prefix used in the value. Therefore, &language; defines some error conditions that occur only with <termref
+                  >namespace-sensitive</termref> value without also preserving the <termref def="dt-namespace-binding"/> 
+                  that defines the meaning of each namespace prefix used in the value. Therefore, &language; defines 
+                  some error conditions that occur only with <termref
                      def="dt-namespace-sensitive"
                      >namespace-sensitive</termref> values. For instance, casting to a <termref
                         def="dt-namespace-sensitive"
@@ -4444,10 +4522,8 @@ declare variable $orange-fruit as my:fruit := "orange";
                   <item><p><code>document-node(element(N, T))</code></p></item>
                </ulist>
                
-               <p>Like other lexical QNames, the type name <var>T</var> is expanded using the <termref def="dt-in-scope-namespaces"/>
-                  in the <termref def="dt-static-context"/>, using the <termref def="dt-default-namespace-elements-and-types"/> 
-                  if it is unprefixed. The resulting
-               QName must identify a type in the <termref def="dt-issd"/>. This can be any <termref def="dt-schema-type"/>: either a simple type,
+               <p>The type name <var>T</var> is expanded using the <termref def="dt-default-type-namespace-rule"/>. The resulting
+               <termref def="dt-expanded-qname"/> must identify a type in the <termref def="dt-issd"/>. This can be any <termref def="dt-schema-type"/>: either a simple type,
                or (except in the case of attributes) a complex type. If it is a simple type then it can be an atomic, union, or
                list type. It can be a built-in type (such as <code>xs:integer</code>) or a user-defined type. It must however
                be the name of a type defined in a schema; it cannot be a <termref def="dt-named-item-type"/>.</p>
@@ -4611,28 +4687,30 @@ declare variable $orange-fruit as my:fruit := "orange";
   </p>
                
                <p diff="chg" at="Issue372">An unprefixed <nt def="EQName">EQName</nt>
-                  within the <code>NameTestUnion</code> is interpreted according to the
-                  <termref def="dt-default-namespace-elements-and-types"/>.
+                  within the <code>NameTestUnion</code> is expanded using the
+                  <termref def="dt-element-name-matching-rule"/>.
                   The name need not be present in the <termref
                      def="dt-is-attrs">in-scope element declarations</termref>.
                </p>
-               <p>If the <termref def="dt-default-namespace-elements-and-types"/>
-               has the special value <code>##any</code>, then an unprefixed name
+               <note><p>This means that when the 
+                  <termref def="dt-default-namespace-elements-and-types"/>
+               has the special value <code>##any</code>, an unprefixed name
                <var>N</var> is interpreted as a wildcard <code>*:<var>N</var></code>.</p>
                <p>It is always possible to match no-namespace names explicitly
                by using the form <code>Q{}<var>N</var></code></p>
+               </note>
                
                <p diff="chg" at="Issue23">An unprefixed <nt def="TypeName"
-                  >TypeName</nt> is interpreted according to the
-                  <termref def="dt-default-namespace-elements-and-types"/>.
+                  >TypeName</nt> is expanded using the
+                  <termref def="dt-default-type-namespace-rule"/>.
                   The <nt def="TypeName">TypeName</nt> must be present in the <termref def="dt-is-types"
                      >in-scope schema types</termref>
                   <errorref class="ST" code="0008"/>                 
                   
                   </p>
-               <p>If the <termref def="dt-default-namespace-elements-and-types"/>
+               <note><p>If the <termref def="dt-default-namespace-elements-and-types"/>
                   has the special value <code>##any</code>, then an unprefixed type name
-                  <var>T</var> is interpreted as <code>Q{http://www.w3.org/2001/XMLSchema}<var>T</var></code>.</p>
+                  <var>T</var> is interpreted as <code>Q{http://www.w3.org/2001/XMLSchema}<var>T</var></code>.</p></note>
                      
                <note><p><termref
                      def="dt-substitution-group"
@@ -4938,14 +5016,14 @@ in the following two situations:
                      def="dt-type-annotation">type annotation</termref>.
   </p>
 
-               <p diff="chg" at="Issue23">An unprefixed <nt def="EQName">EQName</nt>
-               within the <code>NameTestUnion</code> refers to a name in no namespace.
+               <p>An unprefixed <nt def="EQName">EQName</nt>
+               within the <code>NameTestUnion</code> is expanded using the
+                  <termref def="dt-no-namespace-rule"/>.
                   The name need not be present in the <termref
                      def="dt-is-attrs">in-scope attribute declarations</termref>.</p>
                
-               <p diff="chg" at="Issue23">An unprefixed <nt def="TypeName"
-                  >TypeName</nt> is interpreted according to the
-                  <termref def="dt-default-namespace-elements-and-types"/>.
+               <p>An unprefixed <nt def="TypeName"
+                  >TypeName</nt> is expanded using the <termref def="dt-default-type-namespace-rule"/>.
                   The <nt def="TypeName">TypeName</nt> must be present in the <termref def="dt-is-types"
                         >in-scope schema types</termref>
                   <errorref class="ST" code="0008"/>
@@ -5283,13 +5361,18 @@ name.</p>
     specifications in the XQuery family may also use function
     assertions in the future.</p>
                
-               <p role="xquery">An unprefixed QName used 
+               <p role="xquery">If the name of a function assertion is written as a <termref def="dt-qname"/>,
+                  then it is expanded using the <termref def="dt-default-annotation-namespace-rule"/>.</p>
+               
+               
+               <note role="xquery">
+               <p>An unprefixed QName used 
                   within a <termref def="dt-function-assertion"/> is taken to refer to the namespace
                   <code>http://www.w3.org/2012/xquery</code>. Since this is a 
                   <termref def="dt-reserved-namespaces">reserved namespace</termref>,
                   and no assertions are currently defined in this namespace, this means that
                   in practice, use of an unprefixed QName is always an error.
-               </p>
+               </p></note>
 
                <p role="xquery"
                   >Implementations are free to define their own function
@@ -8785,11 +8868,10 @@ and <nt def="OrExpr"
                returns true if the name of the node <code>$node</code> is the QName with local part <code>space</code>
                   and namespace URI <code>http://www.w3.org/XML/1998/namespace</code>.</p>
                
-               <p>If the <code>EQName</code> is an unprefixed <code>NCName</code>, then it is taken
-                  as being in no namespace. If it is a prefixed <code>QName</code>, then the prefix is
-                  resolved to a namespace URI using the <termref def="dt-static-namespaces"/>. If there
+               <p>If the <code>EQName</code> is an unprefixed <code>NCName</code>, then it is expanded using
+                  the <termref def="dt-no-namespace-rule"/>. If there
                   is no binding for the prefix in the <termref def="dt-static-namespaces"/> then
-                  a static error is raised <errorref class="ST" code="0008"/>.
+                  a static error is raised <errorref class="ST" code="0081"/>.
                </p>
                
                <note><p>QNames are widely used in &language; to represent the names of constructs such as
@@ -8889,8 +8971,9 @@ string in its lexical space.</p>
             </scrap>
             <p>
                <termdef id="dt-variable-reference" term="variable reference"
-                     >A <term>variable reference</term> is an EQName preceded by a $-sign.</termdef> 
-An unprefixed variable reference is in no namespace. Two variable references are equivalent if their  <termref
+                     >A <term>variable reference</term> is an EQName preceded by a $-sign.</termdef>
+                The variable name is expanded using the <termref def="dt-no-namespace-rule"/>.
+                Two variable references are equivalent if their  <termref
                   def="dt-expanded-qname"
                   >expanded QNames</termref>  are equal (as defined by the <code>eq</code> operator). The scope of a variable binding is defined separately for each kind of
 expression that can bind variables.</p>
@@ -9248,11 +9331,7 @@ At evaluation time, the value of a variable reference is the value to which the 
             
             <head>Static Function Calls</head>
             
-            <!--<changes>
-               <change PR="1137" issue="161" date="2024-04-23">
-                  Functions may be declared to be variadic.
-               </change>
-            </changes>-->
+
 
                <p>The <termref def="dt-static-context"/> for an expression includes a set 
                   of <termref def="dt-statically-known-function-definitions"/>. Every <termref def="dt-function-definition"/>
@@ -9307,7 +9386,9 @@ At evaluation time, the value of a variable reference is the value to which the 
             </scrap>
             
             <p><termdef term="static function call" id="dt-static-function-call">A <term>static function call</term> 
-               consists of an EQName followed by a parenthesized list of zero or more arguments.</termdef></p>
+               consists of an EQName followed by a parenthesized list of zero or more arguments.</termdef>.</p>
+            
+            <p>The EQName is expanded using the <termref def="dt-default-function-namespace-rule"/>.</p>
             <p diff="add" at="A">The argument list consists of zero or more positional arguments,
                followed by zero or more keyword arguments.</p>
             
@@ -9319,11 +9400,8 @@ At evaluation time, the value of a variable reference is the value to which the 
                <nt def="ArgumentPlaceholder">ArgumentPlaceholders</nt>. 
                Calls using one or more <nt def="ArgumentPlaceholder">ArgumentPlaceholders</nt> are covered in the 
                section <specref ref="id-partial-function-application"/>.</p>
-            <p>If the function name supplied in a static function call is an unprefixed <termref def="dt-qname"
-               >lexical QName</termref>, it is expanded using the <termref def="dt-default-function-namespace"/> 
-               in the <termref def="dt-static-context">static context</termref>.
-            </p>
-            <p><phrase diff="del" at="A">In other cases, </phrase>The <termref def="dt-expanded-qname"
+
+            <p>The <termref def="dt-expanded-qname"
                >expanded QName</termref> used as the function name and the number of arguments used in the static function call 
                (the required arity) must match the name and arity range of a <termref def="dt-function-definition"/> 
                in the <termref def="dt-static-context">static context</termref> 
@@ -9421,9 +9499,9 @@ At evaluation time, the value of a variable reference is the value to which the 
                
             </ulist>
             
-            <p>An <code>EQName</code> in a <code>KeywordArgument</code> is expanded to a QName value; if there
-            is no prefix, then the name is in no namespace (otherwise the prefix is resolved in the usual way).
-            The keywords used in a function call (after expansion to QNames) must be distinct 
+            <p>An <code>EQName</code> in a <code>KeywordArgument</code> is expanded 
+               using the <termref def="dt-no-namespace-rule"/>.
+            The keywords used in a function call (after expansion) must be distinct 
                <errorref class="ST" code="0017"/>; <errorref class="ST" code="0017"/>.</p>
          </div4> 
          
@@ -9457,7 +9535,7 @@ At evaluation time, the value of a variable reference is the value to which the 
                            <p>
                               There can be at most one <termref def="dt-function-definition"/> <var>FD</var> in the 
                               <termref def="dt-statically-known-function-definitions"/> component of <var>SC</var> whose function name
-                              matches the expanded QName in <var>FC</var> and whose <termref def="dt-arity-range"/>
+                              matches the <termref def="dt-expanded-qname"/> in <var>FC</var> and whose <termref def="dt-arity-range"/>
                               includes the arity of <var>FC</var>’s <code>ArgumentList</code>.
                            </p>
                      
@@ -10407,10 +10485,9 @@ return $a("A")]]></eg>
             
             <p>The name and arity of the required function are known statically.</p>
           
-            <p diff="chg" at="A">If the EQName is a <termref def="dt-qname">lexical QName</termref>, it is expanded using the 
-               <termref def="dt-default-function-namespace"/> in the <termref def="dt-static-context">static context</termref>.</p>
+            <p>The EQName is expanded using the <termref def="dt-default-function-namespace-rule"/>.</p>
             
-            <p>The expanded QName and arity must correspond to a <termref def="dt-function-definition"/>
+            <p>The <termref def="dt-expanded-qname"/> and arity must correspond to a <termref def="dt-function-definition"/>
                present in the <termref def="dt-static-context">static context</termref>.
             <phrase diff="add" at="variadicity">More specifically, for a named function reference <code>F#N</code>,
                there must be a <termref def="dt-function-definition"/> in the <termref def="dt-statically-known-function-definitions"/>
@@ -11654,13 +11731,7 @@ return if (every $r in $R satisfies $r instance of node())
 				about the <termref
                            def="dt-in-scope-namespaces"
                            >in-scope namespaces</termref> of an element
-				should use the functions
-				<xspecref
-                           spec="FO40" ref="func-in-scope-prefixes"/>, 
-				and
-				<xspecref
-                           spec="FO40" ref="func-namespace-uri-for-prefix"
-                        />.
+				should use the function <function>fn:in-scope-namespaces</function>.
                                 </p>
 
                   </item>
@@ -11743,17 +11814,26 @@ return if (every $r in $R satisfies $r instance of node())
                <p>
                   <termdef id="dt-name-test" term="name test"
                         >A node test that consists only of an EQName or a
-		  Wildcard is called a <term>name test</term>.</termdef> A name
-                  test that consists of an EQName matches a node <var>N</var> if and only if the <term>kind</term> of
+		  Wildcard is called a <term>name test</term>.</termdef></p>
+               
+               <p>A node test written as an EQName is expanded as follows:</p>
+               <ulist>
+                  <item><p>If the principal node kind of the axis step is <code>element</code>, 
+                  using the <termref def="dt-element-name-matching-rule"/>.</p>
+                  <note><p>If the <termref def="dt-default-namespace-elements-and-types"/> has the
+                     special value <code>"##any</code>, the result of the expanding an unprefixed name
+                  <var>NN</var> is the wildcard <code>*:<var>NN</var></code>.</p></note></item>
+                  <item><p>Otherwise, using the <termref def="dt-no-namespace-rule"/>.</p></item>
+               </ulist>
+               
+               <p>If the expanded node test is an <termref def="dt-expanded-qname"/> <var>Q</var>, then it
+               matches a node <var>N</var> if and only if the <term>kind</term> of
                   node <var>N</var> is the <termref
                      def="dt-principal-node-kind"
                      >principal node kind</termref> for the step axis and the
 		  <termref
                      def="dt-expanded-qname"
-                     >expanded QName</termref> of the node is equal (as defined by the <code>eq</code> operator) to the
-		  <termref
-                     def="dt-expanded-qname"
-                     >expanded QName</termref> specified by the name test. For
+                     >expanded QName</termref> of the node is equal (as defined by the <code>eq</code> operator) to <var>Q</var>. For
 		  example, <code
                      role="parse-test"
                      >child::para</code>
@@ -11767,39 +11847,17 @@ return if (every $r in $R satisfies $r instance of node())
 		  <code>abc:href</code>; if the context node has no
 		  such attribute, it selects an empty set of
 		  nodes.</p>
-               <p>If the EQName is a <termref def="dt-qname"
-                     >lexical QName</termref>, it is resolved into an <termref
-                     def="dt-expanded-qname">expanded QName</termref> using the
-		  <termref
-                     def="dt-static-namespaces"
-                     >statically known namespaces</termref> in the expression
-		  context. It is a <termref
-                     def="dt-static-error">static error</termref>
-                  <errorref class="ST" code="0081"
-                     /> if the QName has a prefix that does not
-		  correspond to any statically known namespace.
-
-          An unprefixed QName, when used as a
-		  name test on an axis whose <termref
-                     def="dt-principal-node-kind"
-                     >principal node kind</termref> is <code>element</code>, is interpreted as follows:</p>
-               <ulist>
-                  <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is a namespace URI,
-                  then the name is interpreted as having that namespace URI.</p></item>
-                  <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is the
-                     special value <code>"##any</code>,
-                     then the name is interpreted as a wildcard that matches any element with
-                     the specified local name, in any namespace or none.</p></item>
-                  <item><p>If the <termref def="dt-default-namespace-elements-and-types"/> is absent,
-                     then the name is interpreted as being in no namespace.</p></item>
-                  
-               </ulist>
-               <p>A name test is not satisfied by an element node whose name does not match the <termref
+               
+               <note><p>A name test is not satisfied by an element node whose name does not match the <termref
                      def="dt-expanded-qname"
                      >expanded QName</termref> of the name test, even if it is in a <termref
                      def="dt-substitution-group"
-                  >substitution group</termref> whose head is the named element.</p>
-               <p>A node test <code>*</code> is true for any node of the
+                  >substitution group</termref> whose head is the named element.</p></note>
+         
+         <p>Wildcard node tests are interpreted as follows:</p>
+          <ulist>
+             <item>
+               <p>The node test <code>*</code> is true for any node of the
 		  <termref
                      def="dt-principal-node-kind"
                      >principal node
@@ -11810,7 +11868,8 @@ return if (every $r in $R satisfies $r instance of node())
                      role="parse-test"
                   >attribute::*</code> will select all
 		  attributes of the context node.</p>
-
+             </item>
+             <item>
                <p>A node test can have the form
 		  <code role="parse-test"
                      >NCName:*</code>. In this case, the prefix is
@@ -11835,13 +11894,15 @@ return if (every $r in $R satisfies $r instance of node())
                   >expanded QName</termref> has the namespace URI
 		  to which the prefix is bound, regardless of the
 		  local part of the name.</p>
-
+             </item>
+             <item>
                <p>A node test can contain a <nt def="BracedURILiteral">BracedURILiteral</nt>, for example
 		  <code role="parse-test"
                      >Q{http://example.com/msg}*</code>. Such a node test is true for any node of the principal 
-                  node kind of the step axis whose expanded QName has the namespace URI specified in 
+                  node kind of the step axis whose <termref def="dt-expanded-qname"/> has the namespace URI specified in 
                   the <nt def="BracedURILiteral">BracedURILiteral</nt>, regardless of the local part of the name.</p>
-
+             </item>
+             <item>
                <p>A node test can also
 		  have the form <code role="parse-test"
                      >*:NCName</code>. In this case,
@@ -11850,6 +11911,9 @@ return if (every $r in $R satisfies $r instance of node())
                   >principal
 		  node kind</termref> of the step axis whose local name matches the given NCName,
 		  regardless of its namespace or lack of a namespace.</p>
+             </item>
+          </ulist>
+               
                <p>
                   <termdef term="kind test" id="dt-kind-test"
                         >An alternative
@@ -14487,8 +14551,10 @@ encountered in finding the effective boolean value of its operand,
             <head>Direct Element Constructors</head>
             <p>An <term>element constructor</term> creates an element node. <termdef
                   term="direct element constructor" id="dt-direct-elem-const"
-                     >A <term>direct element constructor</term> is a form of element constructor in which the name of the constructed element is a constant.</termdef> Direct element constructors are based on standard XML notation. For example, the following expression is a direct element constructor
-that creates a <code>book</code> element containing an attribute and some nested elements:</p>
+                     >A <term>direct element constructor</term> is a form of element constructor in which the name 
+               of the constructed element is a constant.</termdef> Direct element constructors are based on 
+               standard XML notation. For example, the following expression is a direct element constructor
+               that creates a <code>book</code> element containing an attribute and some nested elements:</p>
             <eg role="parse-test"><![CDATA[<book isbn="isbn-0060229357">
   <title>Harold and the Purple Crayon</title>
   <author>
@@ -14496,11 +14562,13 @@ that creates a <code>book</code> element containing an attribute and some nested
     <last>Johnson</last>
   </author>
 </book>]]></eg>
-            <p>If the element name in a direct element constructor has a namespace prefix, the namespace prefix
+            <p>The element name, written as a lexical QName, is expanded using the
+            <termref def="dt-constructed-element-namespace-rule"/>.</p>
+            <!--<p>If the element name in a direct element constructor has a namespace prefix, the namespace prefix
                is resolved to a namespace URI using the <termref def="dt-static-namespaces"/>. 
                If the element name has no namespace prefix, <phrase diff="chg" at="2023-10-16">the 
-                  namespace binding for the zero-length prefix in the <termref def="dt-static-namespaces"/>
-               is used; if there is no such binding, the element name will be in no namespace</phrase>.</p>
+                  <termref def="dt-namespace-binding"/> for the zero-length prefix in the <termref def="dt-static-namespaces"/>
+               is used; if there is no such binding, the element name will be in no namespace</phrase>.</p>-->
             <note><p>The statically known namespaces 
                may be affected by <termref def="dt-namespace-decl-attr"
                   >namespace declaration attributes</termref> 
@@ -14512,7 +14580,7 @@ that creates a <code>book</code> element containing an attribute and some nested
                   ref="xpath-datamodel-40"/>. The resulting <termref def="dt-expanded-qname"
                   >expanded QName</termref> 
                becomes the <code>node-name</code> property of the constructed element node.</p>
-            <p>In a direct element constructor, the name used in the end tag must exactly match the name
+            <p>The name used in the end tag must exactly match the name
 used in the corresponding start tag, including its prefix or absence of a prefix  <errorref
                   class="ST" code="0118"/>.</p>
 
@@ -14563,11 +14631,17 @@ character (that is, the pair <code>"{{"</code> represents the
                      def="dt-namespace-decl-attr"
                      >namespace declaration attributes</termref> (see <specref ref="id-namespaces"
                   />) do not create attribute nodes.</p>
-               <p>If an attribute name has a namespace prefix, the prefix is resolved to a namespace URI using the <termref
+               <p>The attribute name, written as a lexical QName, is expanded using the <termref def="dt-no-namespace-rule"/>.</p>
+               <!--<p>If an attribute name has a namespace prefix, the prefix is resolved to a namespace URI using the <termref
                      def="dt-static-namespaces"
-                     >statically known namespaces</termref>. If the attribute name  has no namespace prefix, the attribute is in no namespace. Note that the statically known namespaces used in  resolving an attribute name may be affected by <termref
+                     >statically known namespaces</termref>. If the attribute name  has no namespace prefix, the attribute is in no namespace. -->
+               <note><p>
+                  The <termref def="dt-static-namespaces"/> used in resolving an attribute name may be affected by <termref
                      def="dt-namespace-decl-attr"
-                     >namespace declaration attributes</termref> that are found inside the same element constructor. The namespace prefix of the attribute name is retained after expansion of the <termref
+                     >namespace declaration attributes</termref> that are found inside the same element constructor.
+               </p></note>
+               <p>
+                  The namespace prefix of the attribute name is retained after expansion of the <termref
                      def="dt-qname">lexical QName</termref>, as described in <bibref
                      ref="xpath-datamodel-40"/>. The resulting <termref def="dt-expanded-qname"
                      >expanded QName</termref> becomes the <code>node-name</code> property of the constructed attribute node.</p>
@@ -14577,7 +14651,8 @@ character (that is, the pair <code>"{{"</code> represents the
 			        QNames</termref> as their respective <code>node-name</code> properties, a <termref
                      def="dt-static-error">static error</termref> is raised <errorref class="ST"
                      code="0040"/>.</p>
-               <p>Conceptually, an attribute (other than a namespace declaration attribute) in a direct element constructor is processed by the following steps:</p>
+               <p>Conceptually, an attribute (other than a namespace declaration attribute) in a 
+                  direct element constructor is processed by the following steps:</p>
 
                <olist>
 
@@ -14778,7 +14853,7 @@ attribute is processed as follows:</p>
                      <termref def="dt-static-namespaces"
                            >statically known namespaces</termref>
                      of the constructor expression (overriding any existing binding of
-                     the given prefix), and are also added as a namespace binding to the
+                     the given prefix), and are also added as a <termref def="dt-namespace-binding"/> to the
                      <termref def="dt-in-scope-namespaces"
                            >in-scope namespaces</termref>
                         of the constructed element. If the namespace URI is a zero-length
@@ -14814,9 +14889,8 @@ attribute is processed as follows:</p>
                      <ulist>
                         <item><p>If the namespace URI is a zero-length string, then:</p>
                            <ulist>
-                              <item><p>Any no-prefix namespace binding is removed from the
-                                 <termref def="dt-in-scope-namespaces"
-                                    >in-scope namespaces</termref> of the constructed element
+                              <item><p>Any <termref def="dt-default-in-scope-namespace"/> is removed from the
+                                 <termref def="dt-in-scope-namespaces"/> of the constructed element
                                  and from the <termref def="dt-static-namespaces"
                                     >statically known namespaces</termref>
                                  of the constructor expression.</p></item>
@@ -14892,8 +14966,8 @@ attribute is processed as follows:</p>
                      <ulist>
                         <item><p>The expanded name of the constructed element will be 
                            <code>Q{http://example.org/animals}cat</code>.</p></item>
-                        <item><p>The constructed element will have a namespace binding
-                           that associates the empty prefix with the namespace URI 
+                        <item><p>The constructed element will have the
+                           <termref def="dt-default-in-scope-namespace"/>
                            <code>http://example.org/animals</code>.</p></item>
                         <item><p>The static context for evaluation of any expressions within the
                         element constructor will include a binding of the empty prefix
@@ -15064,32 +15138,41 @@ node.</p>
                                        <p>On the other hand, if <termref def="dt-construction-mode"
                                              >construction mode</termref> in the <termref
                                              def="dt-static-context"
-                                             >static context</termref> is <code>preserve</code>, the <code>type-name</code>, <code>nilled</code>, <code>string-value</code>, <code>typed-value</code>, <code>is-id</code>, and <code>is-idrefs</code> properties of the copied nodes are preserved.</p>
+                                             >static context</termref> is <code>preserve</code>, the <code>type-name</code>, <code>nilled</code>, 
+                                          <code>string-value</code>, <code>typed-value</code>, <code>is-id</code>, and <code>is-idrefs</code> 
+                                          properties of the copied nodes are preserved.</p>
                                     </item>
 
                                     <item>
-                                       <p>The <code>in-scope-namespaces</code> property of a copied element node is
-determined by the following rules. In applying these rules, the default
-namespace or absence of a default namespace is treated like any other
-namespace binding:</p>
+                                       <p>The <termref def="dt-in-scope-namespaces"/> property of a copied element node is
+                                          determined by the following rules. In applying these rules, the 
+                                          <termref def="dt-default-in-scope-namespace"/>
+                                          or absence of a default in-scope namespace is treated like any other
+                                          <termref def="dt-namespace-binding"/>:</p>
 
                                        <olist>
 
                                           <item>
                                              <p>If <termref def="dt-copy-namespaces-mode"
-                                                  >copy-namespaces mode</termref> specifies <code>preserve</code>, all in-scope-namespaces of the original element are
-retained in the new copy.
-If <termref
-                                                  def="dt-copy-namespaces-mode"
-                                                  >copy-namespaces mode</termref> specifies <code>no-preserve</code>, the new copy retains only those in-scope namespaces of the original element that are used in the names of the element and its
-attributes.</p>
+                                                  >copy-namespaces mode</termref> specifies <code>preserve</code>, 
+                                                all <termref def="dt-in-scope-namespaces"/> of the original element are
+                                                   retained in the new copy.
+                                                   If <termref def="dt-copy-namespaces-mode"
+                                                  >copy-namespaces mode</termref> specifies <code>no-preserve</code>, 
+                                                the new copy retains only those in-scope namespaces of the original 
+                                                element that are used in the names of the element and its
+                                                 attributes.</p>
                                           </item>
 
                                           <item>
                                              <p>If <termref def="dt-copy-namespaces-mode"
-                                                  >copy-namespaces mode</termref> specifies <code>inherit</code>, the copied node inherits all the in-scope namespaces of the constructed node, augmented and overridden by the in-scope namespaces of the original element that were preserved by the preceding rule. If <termref
+                                                  >copy-namespaces mode</termref> specifies <code>inherit</code>, 
+                                                the copied node inherits all the <termref def="dt-in-scope-namespaces"/> of the constructed node,
+                                                augmented and overridden by the in-scope namespaces of the original element 
+                                                that were preserved by the preceding rule. If <termref
                                                   def="dt-copy-namespaces-mode"
-                                                  >copy-namespaces mode</termref> specifies <code>no-inherit</code>, the copied node does not inherit any in-scope namespaces from the constructed node.</p>
+                                                  >copy-namespaces mode</termref> specifies <code>no-inherit</code>, 
+                                                the copied node does not inherit any in-scope namespaces from the constructed node.</p>
                                           </item>
 
                                        </olist>
@@ -15098,30 +15181,22 @@ attributes.</p>
 
 
                                     <item>
-                                       <p>An enclosed expression in the content of an element constructor may cause one or more existing nodes to be copied. Type error
-<errorref
-                                             class="TY" code="0086"
-                                          />
-is raised in the following cases:</p>
+                                       <p>An enclosed expression in the content of an element constructor may cause 
+                                          one or more existing nodes to be copied. Type error
+                                          <errorref class="TY" code="0086"/>
+                                          is raised in the following cases:</p>
                                        <olist>
                                           <item>
                                              <p>
-An element node is copied, and the
-<termref
-                                                  def="dt-typed-value"
-                                                  >typed value</termref> of the element node or one of its attributes is
-<termref
-                                                  def="dt-namespace-sensitive"
-                                                  >namespace-sensitive</termref>,
-and <termref
-                                                  def="dt-construction-mode"
-                                                  >construction mode</termref>
-is <code>preserve</code>, and
-<termref
-                                                  def="dt-copy-namespaces-mode"
-                                                  >copy-namespaces mode</termref>
-is <code>no-preserve</code>.
-</p>
+                                                An element node is copied, and the
+                                                <termref def="dt-typed-value">typed value</termref> of the element node 
+                                                or one of its attributes is
+                                                <termref def="dt-namespace-sensitive">namespace-sensitive</termref>,
+                                                and <termref def="dt-construction-mode">construction mode</termref>
+                                                is <code>preserve</code>, and
+                                                <termref def="dt-copy-namespaces-mode">copy-namespaces mode</termref>
+                                                is <code>no-preserve</code>.
+                                                </p>
                                           </item>
                                           <item>
                                              <p>
@@ -15146,7 +15221,7 @@ is <code>preserve</code>.</p>
                                                 class="TY" code="0086"
                                              /> is as follows:
                 It is not possible to preserve the type of a QName without also preserving
-                the namespace binding that defines the prefix of the QName.</p>
+                the <termref def="dt-namespace-binding"/> that defines the prefix of the QName.</p>
                                        </note>
                                     </item>
 
@@ -15254,7 +15329,9 @@ raised <errorref class="TY"
 
                         <item>
                            <p>
-                              <code>in-scope-namespaces</code> consist of all the namespace bindings resulting from namespace declaration attributes as described in <specref
+                              The <termref def="dt-in-scope-namespaces"/> comprise all 
+                              the <termref def="dt-namespace-binding">namespace bindings</termref> 
+                              resulting from namespace declaration attributes as described in <specref
                                  ref="id-namespaces"
                                  />, and possibly additional namespace bindings as described in <specref
                                  ref="id-ns-nodes-on-elements"/>.</p>
@@ -15584,6 +15661,7 @@ same result as the first example in <specref
                      namespace declaration.</p>
                   </item>
                   
+
                   <item><p>As a simple <nt def="EQName">EQName</nt>, for example:</p>
                      <slist>
                         <sitem><code>element table {}</code></sitem>
@@ -15598,6 +15676,7 @@ same result as the first example in <specref
                      is added to turn the EQName into a QName literal.</p>
                      <p>This syntax is retained for compatibility, but is deprecated.</p>
                   </item>
+
                   
                   <item><p>As an expression in curly brackets. This is processed as follows:</p>
                   
@@ -15631,13 +15710,9 @@ same result as the first example in <specref
                            >expanded QName</termref> <phrase diff="add" at="A">as follows:</phrase></p>
                      <olist>
                         <item><p>Leading and trailing whitespace is removed.</p></item>
-                        <item><p>If the value is an unprefixed <code>NCName</code>, 
-                           the name is implicitly qualified by the namespace URI that is bound
-                  to the zero-length prefix in the <termref def="dt-static-namespaces">statically known namespaces</termref>;
-                     if there is no such binding, the expanded name will be in no namespace..</p></item>
-                        <item><p>If the value is a lexical QName with a prefix, that prefix is <termref
-                           def="dt-resolve-relative-uri">resolved to a namespace URI</termref> using the <termref
-                              def="dt-static-namespaces">statically known namespaces</termref>.</p></item>
+                        
+                        <item><p>If the value is a lexical QName with a prefix, it is expanded
+                           using the <termref def="dt-constructed-element-namespace-rule"/>.</p></item>
                         <item><p>If the value is a URI-qualified name (<code>Q{uri}local</code>), it
                            is converted to an <termref def="dt-expanded-qname"/> with the supplied namespace URI and
                            local name, and with no prefix.</p></item>
@@ -15781,7 +15856,7 @@ same result as the first example in <specref
 
                         <item>
                            <p>
-                              <code>in-scope-namespaces</code> are computed as described in <specref
+                              The <termref def="dt-in-scope-namespaces"/> are computed as described in <specref
                                  ref="id-ns-nodes-on-elements"/>.</p>
                         </item>
 
@@ -15900,6 +15975,7 @@ element {
                      constructed attribute having a system-generated prefix.</p>
                   </item>
                   
+
                   <item><p>As a simple <nt def="EQName">EQName</nt>, for example:</p>
                      <slist>
                         <sitem><code>attribute width {}</code></sitem>
@@ -15914,7 +15990,7 @@ element {
                      is added to turn the EQName into a QName literal.</p>
                      <p>This syntax is retained for compatibility, but is deprecated.</p>
                   </item>
-                  
+
                   
                   <item><p>As an expression in curly brackets. This is processed as follows:</p>
                   
@@ -15972,31 +16048,17 @@ attribute node.</p>
                      
                      <olist>
                         <item><p>Leading and trailing whitespace is removed.</p></item>
-                        <item><p>If the value is an unprefixed <code>NCName</code>, it is treated as a local name 
-                           in no namespace.</p></item>
-                        <item><p>If the value is a lexical QName with a prefix, that prefix is <termref
-                           def="dt-resolve-relative-uri">resolved to a namespace URI</termref> using the <termref
-                              def="dt-static-namespaces">statically known namespaces</termref>.</p></item>
+                        <item><p>If the value is a lexical QName, it is expanded
+                           using the <termref def="dt-no-namespace-rule"/>.</p></item>
                         <item><p>If the value is a URI-qualified name (<code>Q{uri}local</code>), it
                            is converted to an <termref def="dt-expanded-qname"/> with the supplied namespace URI and
                            local name, and with an <termref def="dt-implementation-dependent"/> prefix.</p></item>
-                        <item><p>If conversion of the atomized name expression to an expanded QName is not successful, 
+                        <item><p>If conversion of the atomized name expression to an <termref def="dt-expanded-qname"/> is not successful, 
                            a dynamic error is raised <errorref class="DY" code="0074"/>.</p></item>
                      </olist>
                      <note diff="add" at="A"><p>This was under-specified in XQuery 3.1.</p></note>
                      
-                     <!--<p>The resulting <termref def="dt-expanded-qname">expanded
-                        QName</termref> (including its prefix) is used as the
-                        <code>node-name</code> property of the constructed attribute. If
-                        conversion of the atomized <termref
-                           def="dt-name-expression">name
-                           expression</termref> to an <termref
-                              def="dt-expanded-qname"
-                              >expanded QName</termref> is not
-                        successful, a <termref
-                           def="dt-dynamic-error">dynamic
-                           error</termref> is raised <errorref
-                              class="DY" code="0074"/>.</p>-->
+                     
                   </item>
 
                </olist>
@@ -16557,7 +16619,7 @@ return comment { concat($homebase, ", we have a problem.") }]]></eg>
                             <item>
                                <p>If the result is castable to <code>xs:NCName</code>, then it is used as the local name
          of the newly constructed namespace node. (The local name of a namespace node
-         represents the prefix part of the namespace binding.)</p>
+         represents the prefix part of the <termref def="dt-namespace-binding"/>.)</p>
                             </item>
     
                             <item>
@@ -16627,9 +16689,8 @@ return comment { concat($homebase, ", we have a problem.") }]]></eg>
 
                <p>By itself, a computed namespace constructor has no effect on
     in-scope namespaces, but if an element constructor’s content
-    sequence contains a namespace node, the namespace binding it
-    represents is added to the element’s <termref
-                     def="dt-in-scope-namespaces">in-scope namespaces</termref>.</p>
+    sequence contains a namespace node, the <termref def="dt-namespace-binding"/> it
+    represents is added to the element’s <termref def="dt-in-scope-namespaces"/>.</p>
 
                <p>A computed namespace constructor has no effect on the statically
     known namespaces.</p>
@@ -16669,7 +16730,7 @@ return comment { concat($homebase, ", we have a problem.") }]]></eg>
                </ulist>
 
                <p>Computed namespace constructors are generally used to add to the
-in-scope namespaces of elements created with element constructors:</p>
+<termref def="dt-in-scope-namespaces"/> of elements created with element constructors:</p>
                <eg role="parse-test"><![CDATA[
 <age xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"> {
   namespace xs { "http://www.w3.org/2001/XMLSchema" },
@@ -16678,11 +16739,14 @@ in-scope namespaces of elements created with element constructors:</p>
 }</age>
 ]]></eg>
 
-               <p>In the above example, note that the <code>xsi</code> namespace binding is created for the element because it is used in an attribute name. The attribute’s content is simply character data, and has no effect on namespace bindings. The computed namespace constructor ensures that the <code>xs</code> binding is created.</p>
+               <p>In the above example, note that the <code>xsi</code> <termref def="dt-namespace-binding"/> 
+                  is created for the element because it is used in an attribute name. The attribute’s 
+                  content is simply character data, and has no effect on namespace bindings. 
+                  The computed namespace constructor ensures that the <code>xs</code> binding is created.</p>
 
-               <p>Computed namespace constructors have no effect on the statically known
-namespaces. If the prefix a is not already defined in the statically
-known namespaces, the following expression results in a static error
+               <p>Computed namespace constructors have no effect on the <termref def="dt-static-namespaces"/>. 
+                  If the prefix a is not already defined in the <termref def="dt-static-namespaces"/>, 
+                  the following expression results in a static error
 <errorref
                      class="ST" code="0081"/>.</p>
                <eg role="parse-test"><![CDATA[
@@ -16702,11 +16766,8 @@ known namespaces, the following expression results in a static error
 
             <p>An element node constructed by a direct or computed element
 constructor has an <termref
-                  def="dt-in-scope-namespaces"
-                  >in-scope
-namespaces</termref> property that consists of a set of <termref
-                  def="dt-in-scope-namespaces"
-                  >namespace bindings</termref>.  The
+                  def="dt-in-scope-namespaces"/> property that consists of a set of 
+               <termref def="dt-namespace-binding">namespace bindings</termref>.  The
 in-scope namespaces of an element node may affect the way the node is
 serialized (see <specref
                   ref="id-serialization"
@@ -16718,18 +16779,18 @@ as <function>fn:name</function>. Note the difference between <termref
 dynamic property of an element node, and <termref
                   def="dt-static-namespaces"
                >statically known namespaces</termref>,
-which is a static property of an expression.  Also note that one of
-the namespace bindings in the in-scope namespaces may have no prefix
-(denoting the default namespace for the given element). The in-scope
+which is a static property of an expression.  One of
+the namespace bindings in the in-scope namespaces may have an empty prefix:
+this is referred to as the <termref def="dt-default-in-scope-namespace"/> of the element. The in-scope
 namespaces of a constructed element node consist of the following
-namespace bindings:</p>
+<termref def="dt-namespace-binding">namespace bindings</termref>:</p>
 
 
             <ulist>
 
 
                <item>
-                  <p>A namespace binding is created for each namespace declared
+                  <p>A <termref def="dt-namespace-binding"/> is created for each namespace declared
   in the current element constructor by a <termref
                         def="dt-namespace-decl-attr"
                      >namespace declaration
@@ -16739,14 +16800,14 @@ namespace bindings:</p>
 
 
                <item>
-                  <p>A namespace binding is created for each namespace node in
+                  <p>A <termref def="dt-namespace-binding"/> is created for each namespace node in
   the content sequence of the current element constructor.</p>
                </item>
 
 
 
                <item>
-                  <p>A namespace binding is created for each namespace that is
+                  <p>A <termref def="dt-namespace-binding"/> is created for each namespace that is
   declared in a <termref
                         def="dt-namespace-decl-attr"
                         >namespace
@@ -16760,7 +16821,7 @@ namespace bindings:</p>
 
 
                <item>
-                  <p>A namespace binding is always created to bind the prefix
+                  <p>A <termref def="dt-namespace-binding"/> is always created to bind the prefix
   <code>xml</code> to the namespace URI
   <code>http://www.w3.org/XML/1998/namespace</code>.</p>
                </item>
@@ -16769,22 +16830,21 @@ namespace bindings:</p>
 
                <item>
                   <p>For each prefix used in the name of the
-  constructed element or in the names of its attributes, a namespace
-  binding must exist.
+  constructed element or in the names of its attributes, a <termref def="dt-namespace-binding"/> must exist.</p>
 
-  If a namespace binding does not already exist for one of these
-  prefixes, a new namespace binding is created for it.
+  <p>If a <termref def="dt-namespace-binding"/> does not already exist for one of these
+  prefixes, a new namespace binding is created for it.</p>
 
-  If this would result in a conflict, because it would require two
+  <p>If this would result in a conflict, because it would require two
   different bindings of the same prefix, then the prefix used in the
   node name is changed to an arbitrary <termref
                         def="dt-implementation-dependent"
                      >implementation-dependent</termref>
-  prefix that does not cause such a conflict, and a namespace binding
-  is created for this new prefix.
+  prefix that does not cause such a conflict, and a <termref def="dt-namespace-binding"/>
+  is created for this new prefix.</p>
 
-  If there is an in-scope default namespace, then a binding is created
-  between the empty prefix and that URI.</p>
+  <p>If there is a <termref def="dt-default-in-scope-namespace"/>, then 
+                     a binding is created between the empty prefix and that URI.</p>
                </item>
             </ulist>
 
@@ -16793,13 +16853,13 @@ namespace bindings:</p>
                <p>
                   <termref def="dt-copy-namespaces-mode"
                   >Copy-namespaces
-mode</termref> does not affect the namespace bindings of a newly
+mode</termref> does not affect the <termref def="dt-in-scope-namespaces"/> of a newly
 constructed element node. It applies only to existing nodes that are
 copied by a constructor expression.</p>
             </note>
 
-            <p>In an element constructor, if two or more namespace bindings in the
-in-scope bindings would have the same prefix, then an error is raised
+            <p>In an element constructor, if two or more <termref def="dt-namespace-binding">namespace bindings</termref> in the
+<termref def="dt-in-scope-namespaces"/> would have the same prefix, then an error is raised
 if they have different URIs <errorref
                   class="DY" code="0102"
                   />; if they
@@ -16809,11 +16869,12 @@ If the name of an element in an element constructor is in no namespace,
 creating a default namespace for that element using a computed namespace constructor is an error <errorref
                   class="DY" code="0102"
                />. 
-For instance, the following computed constructor raises an error because the element’s name is not in a namespace, but a default namespace is defined.</p>
+For instance, the following computed constructor raises an error because the element’s name is not in a namespace, 
+but a default namespace is defined.</p>
 
             <eg role="parse-test"><![CDATA[element e { namespace { '' } { 'u' } }]]></eg>
 
-            <p>The following query illustrates the in-scope namespaces of a constructed element:</p>
+            <p>The following query illustrates the <termref def="dt-in-scope-namespaces"/> of a constructed element:</p>
 
             <eg role="parse-test">declare namespace p = "http://example.com/ns/p";
 declare namespace q = "http://example.com/ns/q";
@@ -16821,8 +16882,8 @@ declare namespace f = "http://example.com/ns/f";
 
 &lt;p:a q:b="{ f:func(2) }" xmlns:r="http://example.com/ns/r"/&gt;
 </eg>
-            <p>The <termref def="dt-in-scope-namespaces"
-                  >in-scope namespaces</termref> of the resulting <code>p:a</code> element consists of the following namespace bindings:</p>
+            <p>The <termref def="dt-in-scope-namespaces"/> of the resulting <code>p:a</code> element compirse 
+               the following <termref def="dt-namespace-binding">namespace bindings</termref>:</p>
             <ulist>
 
                <item>
@@ -16851,21 +16912,30 @@ declare namespace f = "http://example.com/ns/f";
                </item>
             </ulist>
 
-            <p>The namespace bindings for <code>p</code> and <code>q</code> are added to the result element because their respective namespaces
+            <p>The <termref def="dt-namespace-binding">namespace bindings</termref> for <code>p</code> and <code>q</code> 
+               are added to the result element because their respective namespaces
 are used in the names of the element and its attributes. The namespace binding <code>r="http://example.com/ns/r"</code> is added to the in-scope namespaces of the constructed
 element because it is defined by a <termref
                   def="dt-namespace-decl-attr"
                >namespace declaration attribute</termref>, even though it is not used in a name.</p>
 
-            <p>No  namespace binding corresponding to <code>f="http://example.com/ns/f"</code> is created, because the namespace prefix <code>f</code> appears only in the query prolog and is not used in an element or attribute name of the constructed node. This namespace binding does not appear in the query result, even though it is present in the <termref
-                  def="dt-static-namespaces"
-               >statically known namespaces</termref> and is available for use during processing of the query.</p>
+            <p>No <termref def="dt-namespace-binding"/> corresponding to <code>f="http://example.com/ns/f"</code> is created, 
+               because the namespace prefix <code>f</code> appears only in the query prolog and is not used in an element 
+               or attribute name of the constructed node. This namespace binding does not appear in the query result, 
+               even though it is present in the <termref def="dt-static-namespaces"/> and is available for use 
+               during processing of the query.</p>
 
             <p>Note that the following constructed element, if nested within a <code>validate</code> expression, cannot be validated:
 </p>
             <eg role="parse-test">&lt;p xsi:type="xs:integer"&gt;3&lt;/p&gt;</eg>
 
-            <p>The constructed element will have namespace bindings for the prefixes <code>xsi</code> (because it is used in a name) and <code>xml</code> (because it is defined for every constructed element node). During validation of the constructed element, the validator will be unable to interpret the namespace prefix <code>xs</code> because it is has no namespace binding. Validation of this constructed element could be made possible by providing a <termref
+            <p>The constructed element will have <termref def="dt-namespace-binding">namespace bindings</termref> 
+               for the prefixes <code>xsi</code> 
+               (because it is used in a name) and <code>xml</code> (because it is defined for every 
+               constructed element node). During validation of the constructed element, the validator 
+               will be unable to interpret the namespace prefix <code>xs</code> because it is has 
+               no namespace binding. Validation of this constructed element could be made possible 
+               by providing a <termref
                   def="dt-namespace-decl-attr"
                >namespace declaration attribute</termref>, as in the following example:</p>
 
@@ -18952,7 +19022,7 @@ return ($i, $j)]]></eg>
             </item>
             <item>
                <p>If a <term>position variable</term> is declared, its type is implicitly
-                  <code>xs:integer</code>. Its name (as a QName) must be
+                  <code>xs:integer</code>. Its name (as an <termref def="dt-expanded-qname"/>) must be
                different from the name of a <term>range variable</term> declared in the same
                 <nt def="ForBinding">ForBinding</nt>.  
                   <errorref spec="XQ" class="ST" code="0089"/>.
@@ -21857,8 +21927,10 @@ The target type must be a <termref def="dt-generalized-atomic-type"/>. In practi
 sequence is permitted.</p> 
             
 
-            <p>Casting a node to <code>xs:QName</code> can cause surprises because it uses the static context of the cast expression to provide the namespace bindings for this operation. 
-Instead of casting to <code>xs:QName</code>, it is generally preferable to use the <function>fn:QName</function> function, which allows the namespace context to be taken from the document containing the QName.</p>
+            <p>Casting a node to <code>xs:QName</code> can cause surprises because it uses the <termref def="dt-static-context"/>
+               of the cast expression to provide the <termref def="dt-namespace-binding">namespace bindings</termref> for this operation. 
+               Instead of casting to <code>xs:QName</code>, it is generally preferable to use the <function>fn:QName</function> 
+               function, which allows the namespace context to be taken from the document containing the QName.</p>
 
 
             <p>The semantics of the <code>cast</code> expression
@@ -23015,13 +23087,14 @@ recognize a particular extension.</p>
                term="pragma" id="dt-pragma"
                   >A <term>pragma</term> is denoted by the delimiters <code>(#</code> and <code>#)</code>, and consists of an identifying EQName followed by <termref
                   def="dt-implementation-defined"
-               >implementation-defined</termref> content.</termdef> The content of a pragma may consist of any string of characters that does not contain the ending delimiter <code>#)</code>.  If the EQName of a
-pragma is a  <termref
-               def="dt-qname"
-               >lexical QName</termref>, it must resolve to a namespace URI and local name, using the <termref
-               def="dt-static-namespaces">statically known namespaces</termref>
-            <errorref class="ST" code="0081"
-            />. If the EQName is an unprefixed NCName, it is interpreted as a name in no namespace (and the pragma is therefore ignored).</p>
+               >implementation-defined</termref> content.</termdef></p>
+         
+         <p>The identifying EQName is expanded using the <termref def="dt-no-namespace-rule"/>.</p>
+         <note>
+            <p>If the EQName is an unprefixed NCName, it is interpreted as a name in no namespace, and the pragma is therefore ignored.</p>
+         </note>
+         <p>The content of a pragma may consist of any string of characters 
+            that does not contain the ending delimiter <code>#)</code>.</p>
 
 
 

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -217,7 +217,8 @@ As of XPath 2.0, the namespace axis is deprecated and need not be supported by a
 
 <eg
                role="parse-test"><![CDATA[
-in-scope-prefixes($e) ! namespace {.}{ namespace-uri-for-prefix(., $e)} 
+for key $k value $v in in-scope-namespaces($e)
+return namespace {$k}{$v} 
 ]]></eg>
          </p>
       </note>
@@ -15711,7 +15712,7 @@ same result as the first example in <specref
                      <olist>
                         <item><p>Leading and trailing whitespace is removed.</p></item>
                         
-                        <item><p>If the value is a lexical QName with a prefix, it is expanded
+                        <item><p>If the value is a lexical QName, it is expanded
                            using the <termref def="dt-constructed-element-namespace-rule"/>.</p></item>
                         <item><p>If the value is a URI-qualified name (<code>Q{uri}local</code>), it
                            is converted to an <termref def="dt-expanded-qname"/> with the supplied namespace URI and
@@ -16688,12 +16689,13 @@ return comment { concat($homebase, ", we have a problem.") }]]></eg>
                </ulist>
 
                <p>By itself, a computed namespace constructor has no effect on
-    in-scope namespaces, but if an element constructor’s content
-    sequence contains a namespace node, the <termref def="dt-namespace-binding"/> it
-    represents is added to the element’s <termref def="dt-in-scope-namespaces"/>.</p>
+                  the <termref def="dt-in-scope-namespaces"/> of any element,
+                  but if an element constructor’s content
+                  sequence contains a namespace node, the <termref def="dt-namespace-binding"/> it
+                  represents is added to that element’s <termref def="dt-in-scope-namespaces"/>.</p>
 
-               <p>A computed namespace constructor has no effect on the statically
-    known namespaces.</p>
+               <p>A computed namespace constructor has no effect on the <termref def="dt-static-namespaces"/>
+                  in the <termref def="dt-static-context"/>.</p>
 
                <note>
                   <p>The newly created namespace node has all properties defined

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -647,14 +647,14 @@ return (
     <eg role="frag-prolog-parse-test">import schema namespace soap="http://www.w3.org/2003/05/soap-envelope" 
   at "http://www.w3.org/2003/05/soap-envelope/";</eg>
     <p>The following example imports a schema by specifying only its target namespace, and makes it
-      the <phrase diff="chg" at="A">default namespace for elements and types</phrase>:</p>
+      the <termref def="dt-default-namespace-elements-and-types"/>:</p>
     <eg role="frag-prolog-parse-test">import schema default element namespace "http://example.org/abc";</eg>
     <p>The following example imports a schema that has no target namespace, providing a location
-      hint, and sets the <phrase diff="chg" at="A">default namespace for elements and types</phrase> to “no namespace” so that the definitions in
+      hint, and sets the <termref def="dt-default-namespace-elements-and-types"/> to “no namespace” so that the definitions in
       the imported schema can be referenced:</p>
     <eg role="frag-prolog-parse-test">import schema default element namespace "" at "http://example.org/xyz.xsd";</eg>
     <p>The following example imports a schema that has no target namespace and sets the 
-      <phrase diff="chg" at="A">default namespace for elements and types</phrase> to “no namespace”. 
+      <termref def="dt-default-namespace-elements-and-types"/> to “no namespace”. 
       Since no location hint is provided, it is up to the
       implementation to find the schema to be imported.</p>
     <eg role="frag-prolog-parse-test">import schema default element namespace "";</eg>
@@ -990,7 +990,7 @@ return $node/xx:bing]]>
             that specifies a default element namespace</phrase> <errorref class="ST" code="0066"/>.</p>
           <p>The <code>URILiteral</code> may take one of the following forms:</p>
           <ulist>
-            <item><p>A namespace URI. This namespace will be used for all unprefixed names appearing
+            <item><p>A namespace URI. This namespace will typically be used for unprefixed names appearing
             where an element or type name is expected.</p></item>
             <item><p>The empty string <code>""</code>. In this case unprefixed names appearing where
               an element or type name is expected are treated as being in no namespace: the
@@ -1084,9 +1084,8 @@ return $node/xx:bing]]>
     </note>
     
     <p>Annotations are <code>(QName, value)</code> pairs. If the EQName of the annotation is a
-        <termref def="dt-qname">lexical QName</termref>, the prefix of the QName is resolved using
-      the statically known namespaces; if no prefix is present, the name is in the
-        <code>http://www.w3.org/2012/xquery</code> namespace.</p>
+        <termref def="dt-qname">lexical QName</termref> then it is expanded using the 
+      <termref def="dt-default-annotation-namespace-rule"/>.</p>
     
     <note><p>The default namespace is a <termref def="dt-reserved-namespaces">reserved namespace</termref>, which means
     that unprefixed names cannot be used for implementation-defined or user-defined
@@ -1185,10 +1184,14 @@ return $node/xx:bing]]>
         expression, is known as a <term>variable binding</term>, and does not make the variable
         visible to an importing module.</p>
     </note>
+    
+    <p>The variable name, if written as a <termref def="dt-qname"/>, is expanded
+      using the <termref def="dt-no-namespace-rule"/>.</p>
+
 
     <p>During static analysis, a variable declaration causes a pair <code>(expanded QName N, type
         T)</code> to be added to the <termref def="dt-in-scope-variables">in-scope
-        variables</termref>. The expanded QName N is the <code>VarName</code>. If N is equal (as
+        variables</termref>. The <termref def="dt-expanded-qname"/> N is the <code>VarName</code>. If N is equal (as
       defined by the eq operator) to the expanded QName of another variable in in-scope variables, a
         <termref def="dt-static-error">static error</termref> is raised <errorref class="ST"
         code="0049"/>.
@@ -1240,9 +1243,7 @@ return $node/xx:bing]]>
       namespace of the library module <errorref class="ST" code="0048"/>.</p>
 
 
-    <p>Variable names that have no namespace prefix are in no namespace. Variable declarations that
-      have no namespace prefix may appear only in a main module.</p>
-
+    
 
     <p>Here are some examples of variable declarations:</p>
 
@@ -1348,7 +1349,7 @@ declare function local:f() { $b }; </eg>
 
     <p>During query evaluation, each variable declaration causes a pair <code>(expanded QName <var>N</var>,
         value <var>V</var>)</code> to be added to the <termref def="dt-variable-values">variable
-        values</termref>. The expanded QName <var>N</var> is the <code>VarName</code>. The value <var>V</var> is as
+        values</termref>. The <termref def="dt-expanded-qname"/> <var>N</var> is the expanded name of the variable. The value <var>V</var> is as
       follows:</p>
 
     <ulist>
@@ -1616,12 +1617,12 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       
       <ulist>
         <item><p>The name of <var>F</var> is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
-          that follows the keyword <code>function</code>.</p></item>
+          that follows the keyword <code>function</code> using the <termref def="dt-default-function-namespace-rule"/>.</p></item>
         <item><p>The parameters of <var>F</var> are derived from the <code>ParamWithDefault</code> entries in the
           <code>ParamListWithDefaults</code>:</p>
           <ulist>
             <item><p>The parameter name is the <termref def="dt-expanded-qname"/> obtained by expanding the <code>EQName</code>
-              that follows the <code>$</code> symbol.</p></item>
+              that follows the <code>$</code> symbol using the <termref def="dt-no-namespace-rule"/>.</p></item>
             <item><p>The required type of the parameter is given by the <code>TypeDeclaration</code>, defaulting to <code>item()*</code>.</p></item>
             <item><p>The default value of the parameter is given by the expression that follows the <code>:=</code> symbol; if there
               is no default value, then the parameter is a required parameter.</p></item>
@@ -1633,7 +1634,7 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         <item><p>The implementation of the function is given by the enclosed expression.</p></item>
       </ulist>
       
-      <p>The static context may include more than one declared function with the same name, but their arity ranges must 
+      <p>The static context may include more than one declared function with the same expanded name, but their arity ranges must 
         not overlap <errorref class="ST" code="0034"/>.</p>
       
       <note diff="add" at="2023-03-24">
@@ -1712,8 +1713,8 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       </p>
       
       <p>If the function name in a function declaration has no namespace prefix, it is considered to be in the
-        <term>default function namespace</term>. This will result in a static error if the default function
-        namespace is a <termref def="dt-reserved-namespaces">reserved namespace</termref>.</p>
+        <termref def="dt-default-function-namespace"/>. This will result in a static error if the default function
+        namespace is a <termref def="dt-reserved-namespaces"/>.</p>
                
       
       <p>In order to allow modules to declare functions for local use within the module without
@@ -1729,7 +1730,7 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       <head>Function Parameters</head>
     
     
-    <p diff="add" at="variadicity">The function declaration includes a list of zero or more function parameters.</p>
+    <p>A function declaration includes a list of zero or more function parameters.</p>
       
       <p>The parameters of a function declaration are considered to be variables whose scope is the
         function body. It is an <termref def="dt-static-error">static error</termref>
@@ -2174,8 +2175,8 @@ local:depth(doc("partlist.xml"))
      
      <ulist>
        <item><p>The function annotations are the annotations on the named record declaration.</p></item>
-       <item><p>The function name is the QName of the named record declaration: an unprefixed name is expanded
-       using the default namespace for elements and types. The resulting QName must be the same as the
+       <item><p>The function name is the QName of the named record declaration, expanded using
+         the <termref def="dt-default-type-namespace-rule"/>. The resulting QName must be the same as the
        module namespace if the declaration appears in a library module, and in any event, it must be in some
        namespace.</p></item>
        <item><p>The parameters of the function declaration are derived from the fields of the named record
@@ -2303,16 +2304,14 @@ return $box?expand(2)?perimeter()</eg>
     <p>Typically, a particular option will be recognized by some implementations and not by others.
       The syntax is designed so that option declarations can be successfully parsed by all
       implementations.</p>
-    <p>If the EQName of an option is a <termref def="dt-qname">lexical QName</termref> with a
-      prefix, it must resolve to a namespace URI and local name, using the <termref
-        def="dt-static-namespaces">statically known namespaces</termref>
-      <errorref class="ST" code="0081"/>.</p>
+    <p>If the EQName of an option is a <termref def="dt-qname">lexical QName</termref> then it is expanded
+    using the <termref def="dt-default-annotation-namespace-rule"/></p>
 
-    <p>If the EQName of an option <phrase diff="add">is a <termref def="dt-qname">lexical QName</termref> that</phrase> does not have a prefix, the <termref def="dt-expanded-qname"
-        >expanded QName</termref> is in the <code>http://www.w3.org/2012/xquery</code> namespace,
+    <note><p>If the name is unprefixed, the <termref def="dt-expanded-qname"
+        >expanded QName</termref> will be in the <code>http://www.w3.org/2012/xquery</code> namespace,
       which is reserved for option declarations defined by the XQuery family of specifications.
       XQuery does not currently define declaration options in this namespace.</p>
-
+</note>
     <p>Each implementation recognizes the <code>http://www.w3.org/2012/xquery</code> namespace URI
       and and all options defined in this namespace in this specification. In addition, each
       implementation recognizes an <termref def="dt-implementation-defined"
@@ -2372,9 +2371,7 @@ Except for <code>parameter-document</code>, each option corresponds to a seriali
                   />. 
 The name of each option is the same as the name of the corresponding serialization parameter element, 
 and the values permitted for each option are the same as the values allowed in the serialization parameter element. 
-For QName values, prefixes are
-expanded to namespace URIs by means of the statically known namespaces, or 
-if unprefixed, the <termref def="dt-default-namespace-elements-and-types"/>.</p>
+QName values are expanded using the <termref def="dt-default-element-namespace-rule"/>.</p>
 
             <p role="xquery"
                >There is no output declaration for <code>use-character-maps</code>, it can be set only by means of a parameter document. 

--- a/specifications/xquery-40/src/query-prolog.xml
+++ b/specifications/xquery-40/src/query-prolog.xml
@@ -1667,7 +1667,12 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
         the <termref def="dt-target-namespace">target namespace</termref> of the library module
         <errorref class="ST" code="0048"/>. </p>
       
-      <p><termdef term="reserved namespaces" id="dt-reserved-namespaces">A <term>reserved namespace</term> is a namespace that must not be used in the name of a function declaration.</termdef>  It is a <termref def="dt-static-error">static error</termref> <errorref class="ST" code="0045"/> if the function name in a function declaration (when expanded) is in a <termref def="dt-reserved-namespaces">reserved namespace</termref>. The following namespaces are reserved namespaces:
+      <p><termdef term="reserved namespaces" id="dt-reserved-namespaces">A <term>reserved namespace</term> is a namespace
+        that must not be used in the name of a function declaration.</termdef>  
+        It is a <termref def="dt-static-error">static error</termref> <errorref class="ST" code="0045"/> 
+        if the function name in a function declaration (when expanded) is 
+        in a <termref def="dt-reserved-namespaces">reserved namespace</termref>. 
+        The following namespaces are reserved namespaces:
         <ulist>
           <item>
             <p>
@@ -1714,7 +1719,7 @@ local:summary(doc("acme_corp.xml")//employee[location = "Denver"])</eg>
       
       <p>If the function name in a function declaration has no namespace prefix, it is considered to be in the
         <termref def="dt-default-function-namespace"/>. This will result in a static error if the default function
-        namespace is a <termref def="dt-reserved-namespaces"/>.</p>
+        namespace is a <termref def="dt-reserved-namespaces">reserved namespace</termref>.</p>
                
       
       <p>In order to allow modules to declare functions for local use within the module without
@@ -2305,7 +2310,7 @@ return $box?expand(2)?perimeter()</eg>
       The syntax is designed so that option declarations can be successfully parsed by all
       implementations.</p>
     <p>If the EQName of an option is a <termref def="dt-qname">lexical QName</termref> then it is expanded
-    using the <termref def="dt-default-annotation-namespace-rule"/></p>
+    using the <termref def="dt-default-annotation-namespace-rule"/>.</p>
 
     <note><p>If the name is unprefixed, the <termref def="dt-expanded-qname"
         >expanded QName</termref> will be in the <code>http://www.w3.org/2012/xquery</code> namespace,


### PR DESCRIPTION
Fix #1985

Editorial.

The main effect is to centralise the descriptions of how to expand unprefixed QNames into a few named rules which can be referenced and reused throughout the spec.