### PR TITLE
Update schema-for-xslt40.xsd

### DIFF
--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -722,14 +722,14 @@ of problems processing the schema using various tools
       <xs:complexContent>
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:attribute name="name" type="xsl:EQName"/>
-          <xs:attribute name="decimal-separator" type="xs:string" default="."/>
-          <xs:attribute name="grouping-separator" type="xs:string" default=","/>
+          <xs:attribute name="decimal-separator" type="xsl:char-optionally-expanded" default="."/>
+          <xs:attribute name="grouping-separator" type="xsl:char-optionally-expanded" default=","/>
           <xs:attribute name="infinity" type="xs:string" default="Infinity"/>
           <xs:attribute name="minus-sign" type="xs:string" default="-"/>
-          <xs:attribute name="exponent-separator" type="xs:string" default="e"/>
+          <xs:attribute name="exponent-separator" type="xsl:char-optionally-expanded" default="e"/>
           <xs:attribute name="NaN" type="xs:string" default="NaN"/>
-          <xs:attribute name="percent" type="xs:string" default="%"/>
-          <xs:attribute name="per-mille" type="xs:string" default="‰"/>
+          <xs:attribute name="percent" type="xsl:char-optionally-expanded" default="%"/>
+          <xs:attribute name="per-mille" type="xsl:char-optionally-expanded" default="‰"/>
           <xs:attribute name="zero-digit" type="xsl:zero-digit" default="0"/>
           <xs:attribute name="digit" type="xsl:char" default="#"/>
           <xs:attribute name="pattern-separator" type="xsl:char" default=";"/>
@@ -2282,8 +2282,24 @@ of problems processing the schema using various tools
       <xs:length value="1"/>
     </xs:restriction>
   </xs:simpleType>
-  
-   <xs:simpleType name="component-kind-type">
+
+           
+  <xs:simpleType name="char-optionally-expanded">
+    <xs:annotation>
+      <xs:documentation>
+        <p>
+           A string containing either a single character, or a single character
+           followed by a colon followed by an arbitrary string
+        </p>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value=".(:.*)?"/>
+    </xs:restriction>
+  </xs:simpleType> 
+
+           
+  <xs:simpleType name="component-kind-type">
     <xs:annotation>
       <xs:documentation>
         <p>

--- a/specifications/xslt-40/src/schema-for-xslt40.xsd
+++ b/specifications/xslt-40/src/schema-for-xslt40.xsd
@@ -543,7 +543,7 @@ of problems processing the schema using various tools
           <xs:attribute name="name" type="xsl:EQName"/>
           <xs:attribute name="streamable" type="xsl:yes-or-no"/>
           <xs:attribute name="use-attribute-sets" type="xsl:EQNames" default=""/>
-          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="visibility" type="xsl:visibility-not-hidden-type"/>
           <xs:attribute name="_name" type="xs:string"/>
           <xs:attribute name="_streamable" type="xs:string"/>
           <xs:attribute name="_use-attribute-sets" type="xs:string"/>
@@ -577,7 +577,7 @@ of problems processing the schema using various tools
     <xs:complexType>
       <xs:complexContent mixed="true">
         <xs:extension base="xsl:sequence-constructor-or-select">
-          <xs:attribute name="errors" type="xs:token" use="optional"/>
+          <xs:attribute name="errors" type="xsl:tokens" use="optional"/>
           <xs:attribute name="_errors" type="xs:string"/>
         </xs:extension>
       </xs:complexContent>
@@ -722,14 +722,14 @@ of problems processing the schema using various tools
       <xs:complexContent>
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:attribute name="name" type="xsl:EQName"/>
-          <xs:attribute name="decimal-separator" type="xsl:char-optionally-expanded" default="."/>
-          <xs:attribute name="grouping-separator" type="xsl:char-optionally-expanded" default=","/>
+          <xs:attribute name="decimal-separator" type="xs:string" default="."/>
+          <xs:attribute name="grouping-separator" type="xs:string" default=","/>
           <xs:attribute name="infinity" type="xs:string" default="Infinity"/>
           <xs:attribute name="minus-sign" type="xs:string" default="-"/>
-          <xs:attribute name="exponent-separator" type="xsl:char-optionally-expanded" default="e"/>
+          <xs:attribute name="exponent-separator" type="xs:string" default="e"/>
           <xs:attribute name="NaN" type="xs:string" default="NaN"/>
-          <xs:attribute name="percent" type="xsl:char-optionally-expanded" default="%"/>
-          <xs:attribute name="per-mille" type="xsl:char-optionally-expanded" default="~"/>
+          <xs:attribute name="percent" type="xs:string" default="%"/>
+          <xs:attribute name="per-mille" type="xs:string" default="‰"/>
           <xs:attribute name="zero-digit" type="xsl:zero-digit" default="0"/>
           <xs:attribute name="digit" type="xsl:char" default="#"/>
           <xs:attribute name="pattern-separator" type="xsl:char" default=";"/>
@@ -782,7 +782,7 @@ of problems processing the schema using various tools
 
   <xs:element name="evaluate" substitutionGroup="xsl:instruction">
     <xs:complexType>
-      <xs:complexContent mixed="true">
+      <xs:complexContent>
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element ref="xsl:with-param"/>
@@ -825,6 +825,9 @@ of problems processing the schema using various tools
           <xs:attribute name="_component" type="xs:string"/>
           <xs:attribute name="_names" type="xs:string"/>
           <xs:attribute name="_visibility" type="xs:string"/>
+          <xs:assert test="exists(@component | @_component)"/>
+          <xs:assert test="exists(@names | @_names)"/>
+          <xs:assert test="exists(@visibility | @_visibility)"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -889,7 +892,7 @@ of problems processing the schema using various tools
           <xs:attribute name="_group-adjacent" type="xs:string"/>
           <xs:attribute name="_group-starting-with" type="xs:string"/>
           <xs:attribute name="_group-ending-with" type="xs:string"/>
-          <xs:attribute name="_split_when" type="xs:string"/>
+          <xs:attribute name="_split-when" type="xs:string"/>
           <xs:attribute name="_composite" type="xs:string"/>
           <xs:attribute name="_collation" type="xs:string"/>
           <xs:assert test="exists(@select | @_select)"/>
@@ -973,7 +976,7 @@ of problems processing the schema using various tools
           <xs:attribute name="name" type="xsl:EQName-in-namespace"/>
           <xs:attribute name="override" type="xsl:yes-or-no" default="yes"/>
           <xs:attribute name="as" type="xsl:sequence-type" default="item()*"/>
-          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="visibility" type="xsl:visibility-not-hidden-type"/>
           <xs:attribute name="streamability" type="xsl:streamability-type"/>
           <xs:attribute name="override-extension-function" type="xsl:yes-or-no"/>
           <xs:attribute name="new-each-time" type="xsl:yes-or-no-or-maybe"/>
@@ -1186,7 +1189,7 @@ of problems processing the schema using various tools
           <xs:attribute name="select" type="xsl:expression"/>
           <xs:attribute name="lang" type="xsl:avt"/>
           <xs:attribute name="order" type="xsl:avt"/>
-          <xs:attribute name="collation" type="xs:anyURI"/>
+          <xs:attribute name="collation" type="xsl:avt"/>
           <xs:attribute name="case-order" type="xsl:avt"/>
           <xs:attribute name="data-type" type="xsl:avt"/>
           <xs:attribute name="_select" type="xs:string"/>
@@ -1258,7 +1261,7 @@ of problems processing the schema using various tools
           <xs:attribute name="name" type="xsl:EQName"/>
           <xs:attribute name="streamable" type="xsl:yes-or-no" default="no"/>
           <xs:attribute name="use-accumulators" type="xsl:accumulator-names"/>
-          <xs:attribute name="on-no-match" type="xsl:on-no-match-type" default="shallow-skip"/>
+          <xs:attribute name="on-no-match" type="xsl:on-no-match-type" default="text-only-copy"/>
           <xs:attribute name="on-multiple-match"
                         type="xsl:on-multiple-match-type"
                         default="use-last"/>
@@ -1322,7 +1325,7 @@ of problems processing the schema using various tools
 
   <xs:element name="next-iteration" substitutionGroup="xsl:instruction">
     <xs:complexType>
-      <xs:complexContent mixed="true">
+      <xs:complexContent>
         <xs:extension base="xsl:element-only-versioned-element-type">
           <xs:sequence>
             <xs:element ref="xsl:with-param" minOccurs="0" maxOccurs="unbounded"/>
@@ -1442,6 +1445,8 @@ of problems processing the schema using various tools
           <xs:attribute name="version" type="xs:NMTOKEN"/>
           <xs:attribute name="_name" type="xs:string"/>
           <xs:attribute name="_method" type="xs:string"/>
+          <xs:attribute name="_allow-duplicate-names" type="xs:string"/>
+          <xs:attribute name="_build-tree" type="xs:string"/>
           <xs:attribute name="_byte-order-mark" type="xs:string"/>
           <xs:attribute name="_cdata-section-elements" type="xs:string"/>
           <xs:attribute name="_doctype-public" type="xs:string"/>
@@ -1453,6 +1458,8 @@ of problems processing the schema using various tools
           <xs:attribute name="_include-content-type" type="xs:string"/>
           <xs:attribute name="_indent" type="xs:string"/>
           <xs:attribute name="_item-separator" type="xs:string"/>
+          <xs:attribute name="_json-lines" type="xs:string"/>
+          <xs:attribute name="_json-node-output-method" type="xs:string"/>
           <xs:attribute name="_media-type" type="xs:string"/>
           <xs:attribute name="_normalization-form" type="xs:string"/>
           <xs:attribute name="_omit-xml-declaration" type="xs:string"/>
@@ -1586,6 +1593,7 @@ of problems processing the schema using various tools
                       maxOccurs="unbounded"/>
           </xs:sequence>
           <xs:attribute name="select" type="xsl:expression"/>
+          <xs:attribute name="_select" type="xs:string"/>
           <xs:assert test="every $e in subsequence(xsl:sort, 2) 
                            satisfies empty($e/(@stable | @_stable))">
             <xs:annotation>
@@ -1667,6 +1675,8 @@ of problems processing the schema using various tools
           <xs:attribute name="_type" type="xs:string"/>
           <xs:attribute name="_validation" type="xs:string"/>
           <xs:attribute name="_method" type="xs:string"/>
+          <xs:attribute name="_allow-duplicate-names" type="xs:string"/>
+          <xs:attribute name="_build-tree" type="xs:string"/>
           <xs:attribute name="_byte-order-mark" type="xs:string"/>
           <xs:attribute name="_cdata-section-elements" type="xs:string"/>
           <xs:attribute name="_doctype-public" type="xs:string"/>
@@ -1678,6 +1688,8 @@ of problems processing the schema using various tools
           <xs:attribute name="_include-content-type" type="xs:string"/>
           <xs:attribute name="_indent" type="xs:string"/>
           <xs:attribute name="_item-separator" type="xs:string"/>
+          <xs:attribute name="_json-lines" type="xs:string"/>
+          <xs:attribute name="_json-node-output-method" type="xs:string"/>
           <xs:attribute name="_media-type" type="xs:string"/>
           <xs:attribute name="_normalization-form" type="xs:string"/>
           <xs:attribute name="_omit-xml-declaration" type="xs:string"/>
@@ -1808,7 +1820,7 @@ of problems processing the schema using various tools
           <xs:attribute name="mode" type="xsl:modes"/>
           <xs:attribute name="name" type="xsl:EQName"/>
           <xs:attribute name="as" type="xsl:sequence-type" default="item()*"/>
-          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="visibility" type="xsl:visibility-not-hidden-type"/>
           <xs:attribute name="_match" type="xs:string"/>
           <xs:attribute name="_priority" type="xs:string"/>
           <xs:attribute name="_mode" type="xs:string"/>
@@ -2030,6 +2042,7 @@ of problems processing the schema using various tools
           <xs:attribute name="package-version" type="xs:string"/>
           <xs:attribute name="_name" type="xs:string"/>
           <xs:attribute name="_package-version" type="xs:string"/>
+          <xs:assert test="exists(@name | @_name)"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
@@ -2066,7 +2079,7 @@ of problems processing the schema using various tools
         <xs:extension base="xsl:sequence-constructor-or-select">
           <xs:attribute name="name" type="xsl:EQName"/>
           <xs:attribute name="as" type="xsl:sequence-type"/>
-          <xs:attribute name="visibility" type="xsl:visibility-type"/>
+          <xs:attribute name="visibility" type="xsl:visibility-not-hidden-type"/>
           <xs:attribute name="static" type="xsl:yes-or-no"/>
           <xs:attribute name="_name" type="xs:string"/>
           <xs:attribute name="_as" type="xs:string"/>
@@ -2173,10 +2186,10 @@ of problems processing the schema using various tools
                   type="xsl:yes-or-no"/>
     <xs:attribute name="extension-element-prefixes" 
                   form="qualified" 
-                  type="xsl:prefixes"/>
+                  type="xsl:prefix-list"/>
     <xs:attribute name="exclude-result-prefixes" 
                   form="qualified" 
-                  type="xsl:prefixes"/>
+                  type="xsl:prefix-list-or-all"/>
     <xs:attribute name="xpath-default-namespace" 
                   form="qualified" 
                   type="xs:anyURI"/>
@@ -2270,20 +2283,6 @@ of problems processing the schema using various tools
     </xs:restriction>
   </xs:simpleType>
   
-  <xs:simpleType name="char-optionally-expanded">
-    <xs:annotation>
-      <xs:documentation>
-        <p>
-           A string containing either a single character, or a single character
-           followed by a colon followed by an arbitrary string
-        </p>
-      </xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:pattern value=".(:.*)?"/>
-    </xs:restriction>
-  </xs:simpleType>
-  
    <xs:simpleType name="component-kind-type">
     <xs:annotation>
       <xs:documentation>
@@ -2362,15 +2361,15 @@ of problems processing the schema using various tools
     </xs:annotation>
     <xs:list>
       <xs:simpleType>
-        <xs:union memberTypes="xsl:fixed-namespaces-type-default xs:NCName xsl:fixed-namespaces-type-prefix-binding xs:anyURI"/>
+        <xs:union memberTypes="xsl:fixed-namespaces-type-standard xs:NCName xsl:fixed-namespaces-type-prefix-binding xs:anyURI"/>
       </xs:simpleType>
     </xs:list>
  
   </xs:simpleType>
   
-  <xs:simpleType name="fixed-namespaces-type-default">
-    <xs:restriction base="xs:string">
-       <xs:enumeration value="#default"/>
+  <xs:simpleType name="fixed-namespaces-type-standard">
+    <xs:restriction base="xs:token">
+       <xs:enumeration value="#standard"/>
     </xs:restriction>
   </xs:simpleType>
   
@@ -2573,10 +2572,6 @@ of problems processing the schema using various tools
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:simpleType name="prefixes">
-    <xs:list itemType="xs:NCName"/>
-  </xs:simpleType>
-
   <xs:simpleType name="prefix-list-or-all">
     <xs:union memberTypes="xsl:prefix-list">
       <xs:simpleType>
@@ -2601,7 +2596,7 @@ of problems processing the schema using various tools
         </p>
       </xs:documentation>
     </xs:annotation>
-    <xs:union>
+    <xs:union memberTypes="xsl:EQName-in-namespace">
       <xs:simpleType>
         <xs:restriction base="xs:token">
           <xs:enumeration value="xml"/>
@@ -2612,7 +2607,6 @@ of problems processing the schema using various tools
           <xs:enumeration value="adaptive"/>
         </xs:restriction>
       </xs:simpleType>
-      <xs:simpleType ref="EQName-in-namespace"/>
     </xs:union>
   </xs:simpleType>
 
@@ -2744,6 +2738,10 @@ of problems processing the schema using various tools
     </xs:union>
   </xs:simpleType>
   
+  <xs:simpleType name="tokens">
+    <xs:list itemType="xs:token"/>
+  </xs:simpleType>
+
   <xs:simpleType name="typed-type">
     <xs:annotation>
       <xs:documentation>


### PR DESCRIPTION
Fixed invalid syntax xs:simpleType/@ref (moved to @memberTypes) in simpleType named method

Based the type fixed-namespaces-type-default on xs:token instead of xs:string to allow for whitespace normalization

Changed collation attribute on xsl:merge-key to be an avt (according to spec)

Changed attributes that were previously of type "xsl:char-optionally-expanded" to just xs:string since the spec says they can be any string.  I couldn't think of a reason they should be limited to one character optionally followed by a colon and more characters, so I assumed this was some sort of artifact from the past.

Changed xsl:next-iteration and xsl:evaluate to not allow mixed content

Corrected _split_when to _split-when

Added missing shadow attributes (in two places) for allow-duplicate-names, build-tree, json-lines and json-node-output-method

Added missing shadow attribute for select on perform-sort

Added assertions for required attributes:
- xsl:use-package - name
- xsl:expose - names, component and visibility

Made the errors attribute a list of tokens instead of just xs:token.  Doesn't affect validation but I think it is more clear.

Changed default value of per-mille from a tilde to ‰

Changed the default value of the on-no-match attribute from shallow-skip to text-only-copy, per the spec

Gave xsl:exclude-result-prefixes the same type as no-namespace exclude-result-prefixes, to allow for #all and #default

Gave xsl:extension-element-prefixes the same type as no-namespace extension-element-prefixes, to allow for #default

Removed the xsl:prefixes and xsl:char-optionally-expanded types since they were no longer used after the above changes

Changed the type of the visibility attribute on xsl:attribute-set, xsl:function, xsl:template and xsl:variable to xsl:visibility-not-hidden-type to exclude "hidden" per the spec

Changed the keyword value of the fixed-namespaces attribute from #default to #standard (and adjusted type names)