### PR TITLE
835 Add built-in named record types to static context

### DIFF
--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -13889,7 +13889,7 @@ ISBN 0 521 77752 6.</bibl>
          <head>Built-in named record types</head>
          
          <changes>
-            <change issue="835" date="2025-05-11">
+            <change issue="835" PR="1991" date="2025-05-11">
                Named record types used in the signatures of built-in functions are now available as standard
                in the static context.
             </change>

--- a/specifications/xpath-functions-40/src/xpath-functions.xml
+++ b/specifications/xpath-functions-40/src/xpath-functions.xml
@@ -13885,6 +13885,26 @@ ISBN 0 521 77752 6.</bibl>
          </error-list>
       </div1>
       
+      <div1 id="id-built-in-named-record-types">
+         <head>Built-in named record types</head>
+         
+         <changes>
+            <change issue="835" date="2025-05-11">
+               Named record types used in the signatures of built-in functions are now available as standard
+               in the static context.
+            </change>
+         </changes>
+         
+         <p>This appendix lists the named record types that are used in function signatures in this function library,
+         and that are available in the static context of every application.</p>
+         
+         <p>These definitions are all in the standard function namespace <code>http://www.w3.org/2005/xpath-functions</code>,
+         which is normally bound to the prefix <code>fn</code>. Because this will not usually be the default namespace for
+         types, the names will usually be written with the prefix <code>fn</code>.</p>
+         
+         <?record-description-index?>
+      </div1>
+      
       <div1 id="schemata">
          <head>Schemas</head>
          

--- a/specifications/xpath-functions-40/style/merge-function-specs.xsl
+++ b/specifications/xpath-functions-40/style/merge-function-specs.xsl
@@ -237,6 +237,17 @@
 		<head>Record fn:{$definition/@id}</head>
 		<xsl:apply-templates select="processing-instruction('record-description')   (:$definition:)"/>
 	</xsl:template>
+	
+	<xsl:template match="processing-instruction('record-description-index')" expand-text="yes">
+		<ulist>
+		<xsl:for-each select="$fosdoc/fos:functions/fos:record-type">
+			<xsl:sort select="@id"/>
+			<item>
+				<p>Record <loc href="#{@id}">{@id}</loc></p>
+			</item>
+		</xsl:for-each>
+		</ulist>
+	</xsl:template>
 
    <xsl:template match="fos:record-type">
    	<xsl:call-template name="show-record-type">

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -549,6 +549,10 @@ The term URI has been retained in preference to IRI to avoid introducing new nam
                <change issue="1495" PR="1496" date="2024-10-29">
                   The context value static type, which was there purely to assist in static typing, has been dropped.
                </change>
+               <change issue="835" PR="1991" date="2025-05-11">
+                  Named record types used in the signatures of built-in functions are now available as standard
+                  in the static context.
+               </change>
             </changes>
             <p>
                <termdef id="dt-static-context" term="static context"

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -864,6 +864,8 @@ inferred by static type inference as discussed in  <specref
                      describing recursive data structures such as lists and trees. For details see
                      <specref ref="id-recursive-record-tests"/>. </p></item>
                   </ulist>
+                  <p>Certain named item types (typically item types used in the signatures of built-in functions)
+                  are always available in the static context. These are defined in <xspecref spec="FO40" ref="id-built-in-named-record-types"/>.</p>
                   <note>
                      <p role="xquery">In XQuery, named item types can be declared in the Query Prolog.</p>
                      <p role="xpath">Named item types can be defined in a <termref def="dt-host-language">host language</termref> 


### PR DESCRIPTION
This PR adds six built-in named record types to the static context of every application:

Record [key-value-pair]
Record [load-xquery-module-record]
Record [parsed-csv-structure-record]
Record [random-number-generator-record]
Record [schema-type-record]
Record [uri-structure-record]

These are now listed in Appendix C of F&O

Issue 835 requests a review of the names of these records; perhaps putting them in one place will make that review easier. Personally, I am happy with the names as currently defined.