### PR TITLE
1997 Correct nesting of item coercion rules

### DIFF
--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -4410,22 +4410,24 @@ types</term> (such as <code>xs:integer</code>) and function types
                <p>Technically, enumeration types are defined as follows:</p>
                
                <ulist>
-                  <item><p>An enumeration type with a single enumerated value (such as
+                  <item><p><termdef id="dt-singleton-enumeration-type" term="singleton enumeration type">An 
+                     enumeration type with a single enumerated value (such as
                      <code>enum("red")</code>) is an anonymous <termref def="dt-atomic-type"/>
                      derived from <code>xs:string</code> by restriction using an enumeration facet
                      that permits only the value <code>"red"</code>. This is referred to
-                     as a <term>singleton enumeration type</term>. It is equivalent to the XSD-defined type:</p>
+                     as a <term>singleton enumeration type</term>.</termdef> It is equivalent to the XSD-defined type:</p>
                   <eg><![CDATA[
 <xs:simpleType>
   <xs:restriction base="xs:string">
     <xs:enumeration value="red"/>
   </xs:restriction>
 </xs:simpleType>]]></eg></item>
-                  <item><p>Two singleton enumeration types are the same type if and only
+                  <item><p>Two <termref def="dt-singleton-enumeration-type">singleton enumeration types</termref> 
+                     are the same type if and only
                   if they have the same (single) enumerated value, as determined using the Unicode
                   codepoint collation.</p></item>
                   <item><p>An enumeration type with multiple
-                     enumerated values is a union of singleton enumeration types, 
+                     enumerated values is a union of <termref def="dt-singleton-enumeration-type">singleton enumeration types</termref>, 
                      so <code>enum("red", "green", "blue")</code>
                      is equivalent to <code>(enum("red") | enum("green") | enum("blue"))</code>.</p></item>
                   <item><p>In consequence, an enumeration type <var>T</var> is a subtype
@@ -7284,13 +7286,6 @@ declare record Particle (
                               </ulist>
                            </note>
                         
-                           <!--<olist>
-                              <item><p>If the first alternative in <var>R</var> that <var>J</var>
-                              matches is a typed function type (see <specref ref="id-function-test"/>),
-                              then function coercion is applied to coerce <var>J</var> to that
-                              function type, as described in <specref ref="id-function-coercion"/>.</p></item>
-                              <item><p>Otherwise, <var>J</var> is used as is.</p></item>
-                           </olist>-->
                         
                         </item>
 
@@ -7338,137 +7333,124 @@ declare record Particle (
                         <termref def="dt-choice-item-type">choice item types.</termref></p></note>
                   </item>
                   
-                  <!--<item>
-                     <p>If <var>R</var> is an <termref def="dt-atomic-type"/>
-                        and <var>J</var> is not an atomic item,
-                        then <var>J</var> is <termref def="dt-atomization">atomized</termref>. 
-                        The result of atomization is
-                        in general a sequence of atomic items. The item coercion rules
-                        (that is, the rules in this section) are then applied recursively to each of
-                        these atomic items in turn, with the same item type <var>R</var>
-                        as the required type, and the results are concatenated
-                        in order to form the result sequence.</p>
-                  </item>-->
                         
                   <item>
                      <p>If <var>R</var> is an <termref def="dt-atomic-type"/>
                      and <var>J</var> is an <termref def="dt-atomic-item"/>, then:</p>
 
+                     <olist>
+                        <item diff="chg" at="2024-01-04"><p>If <var>J</var> is an instance of 
+                           <var>R</var> then it is used unchanged.</p></item>
+                        <item><p>If <var>J</var> is an instance of type <code>xs:untypedAtomic</code>
+                        then:</p>
                            <olist>
-                              <item diff="chg" at="2024-01-04"><p>If <var>J</var> is an instance of 
-                                 <var>R</var> then it is used unchanged.</p></item>
-                              <item><p>If <var>J</var> is an instance of type <code>xs:untypedAtomic</code>
-                              then:</p>
-                                 <olist>
-                                    <item>
-                                       <p>If <var>R</var> is an 
-                                       <termref def="dt-enumeration-type"/> then
-                                       <var>A</var> is cast to <code>xs:string</code>.</p></item>
-                                    <item>
-                                       <p>If <var>R</var> is <termref
-                                       def="dt-namespace-sensitive">namespace-sensitive</termref> then 
-                                          a <termref def="dt-type-error">type error</termref>
-                                             <errorref class="TY" code="0117"/> is raised.</p></item>
-                                       </olist>
-                                    </item>
-                                    <item><p>Otherwise,  <var>J</var> is cast to type <var>R</var>.</p>
-                                    </item>
-                                 </olist>
+                              
+                              <item>
+                                 <p>If <var>R</var> is <termref
+                                 def="dt-namespace-sensitive">namespace-sensitive</termref> then 
+                                    a <termref def="dt-type-error">type error</termref>
+                                       <errorref class="TY" code="0117"/> is raised.</p></item>
+                             
+                              <item><p>Otherwise,  <var>J</var> is cast to type <var>R</var>.</p>
                               </item>
+                           </olist>
+                        </item>
+                     </olist>
+                  </item>
                               
   
-                              <item><p>If there is an entry (<var>from</var>, <var>to</var>)
-                                 in the following table such that <var>J</var> is an instance of <var>from</var>,
-                                 and <var>to</var> is <var>R</var>, then <var>J</var> is cast to type <var>R</var>.</p>
-                                 
-                                 <table border="1" role="medium">
-                                    <caption>Implicit Casting</caption>
-                                    <thead>
-                                       <tr>
-                                          <th>from</th>
-                                          <th>to</th>
-                                       </tr>
-                                    </thead>
-                                    <tbody>
-                                       <tr><td><code>xs:decimal</code></td><td><code>xs:double</code></td></tr>
-                                       <tr><td><code>xs:double</code></td><td><code>xs:decimal</code></td></tr>
-                                       <tr><td><code>xs:decimal</code></td><td><code>xs:float</code></td></tr>
-                                       <tr><td><code>xs:float</code></td><td><code>xs:decimal</code></td></tr>
-                                       <tr><td><code>xs:float</code></td><td><code>xs:double</code></td></tr>
-                                       <tr><td><code>xs:double</code></td><td><code>xs:float</code></td></tr>
-                                       <tr><td><code>xs:string</code></td><td><code>xs:anyURI</code></td></tr>
-                                       <tr><td><code>xs:anyURI</code></td><td><code>xs:string</code></td></tr>
-                                       <tr><td><code>xs:hexBinary</code></td><td><code>xs:base64Binary</code></td></tr>
-                                       <tr><td><code>xs:base64Binary</code></td><td><code>xs:hexBinary</code></td></tr>
-                                    </tbody>
-                                    
-                                 </table>
-                                 
-                                 <note><p>The item type in the <var>to</var> column must match <var>R</var>
-                                    exactly; however, <var>J</var> may belong to a subtype of the type in the <var>from</var>
-                                    column.</p>
-                                    <p>For example, an <code>xs:NCName</code> will be cast to type <code>xs:anyURI</code>,
-                                    but an <code>xs:anyURI</code> will not be cast to type <code>xs:NCName</code>.</p>
-                                    <p>Similarly, an <code>xs:integer</code> will be cast to type <code>xs:double</code>,
-                                    but an <code>xs:double</code> will not be cast to type <code>xs:integer</code>.</p>
-                                 </note>
-                                 
-                              </item>
-                              <item><p>If <var>R</var> is derived from some primitive atomic type <var>P</var>, 
-                                 then <var>J</var> is <term>relabeled</term> as an instance of <var>R</var> if it satisfies
-                                 all the following conditions:</p> 
-                                 <ulist>
-                                    <item><p><var>J</var> is an instance of <var>P</var>.</p></item>
-                                    <item><p><var>J</var> is not an instance of <var>R</var>.</p></item>
-                                    <item><p>The <xtermref spec="DM40" ref="dt-datum"/> of <var>J</var> is 
-                                       within the value space of <var>R</var>.</p></item>
-                                 </ulist>
-                                 <p>Relabeling an atomic item changes the <termref def="dt-type-annotation"/> but not the 
-                                    <xtermref spec="DM40" ref="dt-datum"/>. For example, the
-                                    <code>xs:integer</code> value 3 can be relabeled as an instance of <code>xs:unsignedByte</code>, because
-                                    the datum is within the value space of <code>xs:unsignedByte</code>.</p>
-                                 <note><p>Relabeling is not the same as casting. For example, the <code>xs:decimal</code> value 10.1
-                                    can be cast to <code>xs:integer</code>, but it cannot be relabeled as <code>xs:integer</code>,
-                                    because its datum not within the value space of <code>xs:integer</code>.</p></note>
-                              
-                                 <note><p>The effect of this rule is that if, for example, a function parameter is declared
-                                    with an expected type of <code>xs:positiveInteger</code>, then a call that supplies the literal
-                                    value 3 will succeed, whereas a call that supplies -3 will fail.</p>
-                                 
-                                    <p>This differs from previous versions of this specification, where both these calls would fail.</p>
-                                    
-                                    <p>This change allows the arguments of existing functions to be defined with a
-                                       
-                                       more precise type. For example, the <code>$position</code> argument of <function>array:get</function>
-                                       
-                                       could be defined as <code>xs:positiveInteger</code> 
-                                       rather than <code>xs:integer</code>.</p>
-                                 </note>
-                                 <note>
-                                    <p>If <var>T</var>
-                                       is a union type with members <code>xs:negativeInteger</code> and 
-                                       <code>xs:positiveInteger)*</code> and the supplied value is the
-                                       sequence <code>(20, -20)</code>, then the effect of these rules 
-                                       is that the first item <code>20</code> is relabeled as type
-                                       <code>xs:positiveInteger</code> and the second item <code>-20</code>is relabeled as type 
-                                       <code>xs:negativeInteger</code>.</p>
-                                    
-                                    
-                                 
-                                 </note>
-                                 
-                                 <note><p>Promotion (for example of <code>xs:float</code> to <code>xs:double</code>)
-                                    occurs only when <var>T</var> is a primitive type.
-                                    Relabeling occurs only when <var>T</var> is a derived type. Promotion and relabeling are therefore
-                                    never combined.</p></note>
-                              
-                                 <note><p>A singleton enumeration type such as <code>enum("green")</code> is treated
-                                 as an atomic type derived by restriction from <code>xs:string</code>; so if the
-                                 <code>xs:string</code> value <code>"green"</code> is supplied in a context where
-                                 the required type is <code>enum("red", "green", "blue")</code>, the value will be
-                                    accepted and will be relabeled as an instance of <code>enum("green")</code>.</p></note>
-                              
-                              </item>
+                  <item><p>If there is an entry (<var>from</var>, <var>to</var>)
+                     in the following table such that <var>J</var> is an instance of <var>from</var>,
+                     and <var>to</var> is <var>R</var>, then <var>J</var> is cast to type <var>R</var>.</p>
+                     
+                     <table border="1" role="medium">
+                        <caption>Implicit Casting</caption>
+                        <thead>
+                           <tr>
+                              <th>from</th>
+                              <th>to</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <tr><td><code>xs:decimal</code></td><td><code>xs:double</code></td></tr>
+                           <tr><td><code>xs:double</code></td><td><code>xs:decimal</code></td></tr>
+                           <tr><td><code>xs:decimal</code></td><td><code>xs:float</code></td></tr>
+                           <tr><td><code>xs:float</code></td><td><code>xs:decimal</code></td></tr>
+                           <tr><td><code>xs:float</code></td><td><code>xs:double</code></td></tr>
+                           <tr><td><code>xs:double</code></td><td><code>xs:float</code></td></tr>
+                           <tr><td><code>xs:string</code></td><td><code>xs:anyURI</code></td></tr>
+                           <tr><td><code>xs:anyURI</code></td><td><code>xs:string</code></td></tr>
+                           <tr><td><code>xs:hexBinary</code></td><td><code>xs:base64Binary</code></td></tr>
+                           <tr><td><code>xs:base64Binary</code></td><td><code>xs:hexBinary</code></td></tr>
+                        </tbody>
+                        
+                     </table>
+                     
+                     <note><p>The item type in the <var>to</var> column must match <var>R</var>
+                        exactly; however, <var>J</var> may belong to a subtype of the type in the <var>from</var>
+                        column.</p>
+                        <p>For example, an <code>xs:NCName</code> will be cast to type <code>xs:anyURI</code>,
+                        but an <code>xs:anyURI</code> will not be cast to type <code>xs:NCName</code>.</p>
+                        <p>Similarly, an <code>xs:integer</code> will be cast to type <code>xs:double</code>,
+                        but an <code>xs:double</code> will not be cast to type <code>xs:integer</code>.</p>
+                     </note>
+                     
+                  </item>
+                  <item><p>If <var>R</var> is derived from some primitive atomic type <var>P</var>, 
+                     then <var>J</var> is <term>relabeled</term> as an instance of <var>R</var> if it satisfies
+                     all the following conditions:</p> 
+                     <ulist>
+                        <item><p><var>J</var> is an instance of <var>P</var>.</p></item>
+                        <item><p><var>J</var> is not an instance of <var>R</var>.</p></item>
+                        <item><p>The <xtermref spec="DM40" ref="dt-datum"/> of <var>J</var> is 
+                           within the value space of <var>R</var>.</p></item>
+                     </ulist>
+                     <p>Relabeling an atomic item changes the <termref def="dt-type-annotation"/> but not the 
+                        <xtermref spec="DM40" ref="dt-datum"/>. For example, the
+                        <code>xs:integer</code> value 3 can be relabeled as an instance of <code>xs:unsignedByte</code>, because
+                        the datum is within the value space of <code>xs:unsignedByte</code>.</p>
+                     <note><p>Relabeling is not the same as casting. For example, the <code>xs:decimal</code> value 10.1
+                        can be cast to <code>xs:integer</code>, but it cannot be relabeled as <code>xs:integer</code>,
+                        because its datum not within the value space of <code>xs:integer</code>.</p></note>
+                  
+                     <note><p>The effect of this rule is that if, for example, a function parameter is declared
+                        with an expected type of <code>xs:positiveInteger</code>, then a call that supplies the literal
+                        value 3 will succeed, whereas a call that supplies -3 will fail.</p>
+                     
+                        <p>This differs from previous versions of this specification, where both these calls would fail.</p>
+                        
+                        <p>This change allows the arguments of existing functions to be defined with a
+                           
+                           more precise type. For example, the <code>$position</code> argument of <function>array:get</function>
+                           
+                           could be defined as <code>xs:positiveInteger</code> 
+                           rather than <code>xs:integer</code>.</p>
+                     </note>
+                     <note>
+                        <p>If <var>T</var>
+                           is a union type with members <code>xs:negativeInteger</code> and 
+                           <code>xs:positiveInteger</code> and the supplied value is the
+                           sequence <code>(20, -20)</code>, then the effect of these rules 
+                           is that the first item <code>20</code> is relabeled as type
+                           <code>xs:positiveInteger</code> and the second item <code>-20</code>is relabeled as type 
+                           <code>xs:negativeInteger</code>.</p>
+                        
+                        
+                     
+                     </note>
+                     
+                     <note><p>Promotion (for example of <code>xs:float</code> to <code>xs:double</code>)
+                        occurs only when <var>T</var> is a primitive type.
+                        Relabeling occurs only when <var>T</var> is a derived type. Promotion and relabeling are therefore
+                        never combined.</p></note>
+                  
+                     <note><p>A <termref def="dt-singleton-enumeration-type"/> such as <code>enum("green")</code> is treated
+                     as an atomic type derived by restriction from <code>xs:string</code>; so if the
+                     <code>xs:string</code> value <code>"green"</code> is supplied in a context where
+                     the required type is <code>enum("red", "green", "blue")</code>, the value will be
+                        accepted and will be relabeled as an instance of <code>enum("green")</code>.</p></note>
+                  
+                  </item>
                               
                   <item diff="add" at="A">
                      <p>If <var>R</var> is an <nt def="ArrayType"


### PR DESCRIPTION
Fix #1997

(A correction to an editorial error that made a substantive difference to the spec.)