### PR TITLE
675(part): Add XSLT static typing rules for new kinds of XPath expression

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -28547,6 +28547,12 @@ the same group, and the-->
 
          <div2 id="determining-static-type">
             <head>Determining the Static Type of a Construct</head>
+            
+            <changes>
+               <change issue="675">
+                  The static typing rules have been updated to take account of new constructs in XPath 4.0.
+               </change>
+            </changes>
 
             <p><termdef id="dt-static-type" term="static type">The <term>static type</term> of a
                      <termref def="dt-construct">construct</termref> is such that all values
@@ -28644,6 +28650,11 @@ the same group, and the-->
                         <p><code>item()</code> maps to <var>U{*}</var></p>
                      </item>
                      <item>
+                        <p>A choice item type <code>(A | B | C)</code> maps
+                        to the union of the U-types corresponding to <code>A</code>,
+                        <code>B</code>, and <code>C</code>.</p>
+                     </item>
+                     <item>
                         <p><code>AnyKindTest</code> (<code>node()</code>) maps to
                            <var>U{N}</var></p>
                      </item>
@@ -28672,8 +28683,7 @@ the same group, and the-->
                      </item>
                      <item>
                         <p><code>FunctionType</code>, <code>MapType</code>, 
-                           and <phrase diff="del" at="2022-01-01">(if the XPath 3.1 feature
-                           is implemented) </phrase><code>ArrayType</code> 
+                           and <code>ArrayType</code> and <code>RecordType</code> 
                            map to <var>U{fn(*)}</var></p>
                      </item>
                      <item>
@@ -28713,9 +28723,8 @@ the same group, and the-->
             <p>The rules given here are deliberately simple. Implementations may well be able to
                compute a more precise <termref def="dt-static-type"/>, but this will rarely be
                useful for streamability analysis. The item type for each kind of XPath expression is
-               determined by the rules below. In the first column, numbers in square brackets are
-               production numbers from the XPath 3.0 and XPath 3.1 
-                  specifications respectively. In the
+               determined by the rules below. The name in the first column is the name of a production
+               in the XPath grammar. In the
                   second column, the <term>Proforma</term> uses an informal notation used both to
                   provide a reminder of the syntax of the construct in question, and to attach
                   labels to its operand roles so that they can be referred to in the text of the
@@ -28732,57 +28741,66 @@ the same group, and the-->
                </thead>
                <tbody>
                   <tr>
-                     <td rowspan="1" colspan="1">Expr [6,6] </td>
+                     <td rowspan="1" colspan="1">Expr</td>
                      <td rowspan="1" colspan="1"><code>E,F</code></td>
                      <td rowspan="1" colspan="1">the union of the static types of E and F</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">ForExpr [8,8] </td>
+                     <td rowspan="1" colspan="1">ForExpr</td>
                      <td rowspan="1" colspan="1"><code>for $x in S return E</code></td>
                      <td rowspan="1" colspan="1">the static type of E</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">LetExpr [11,11] </td>
+                     <td rowspan="1" colspan="1">LetExpr</td>
                      <td rowspan="1" colspan="1"><code>let $x := S return E</code></td>
                      <td rowspan="1" colspan="1">the static type of E</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">QuantifiedExpr [14,14]</td>
+                     <td rowspan="1" colspan="1">QuantifiedExpr</td>
                      <td rowspan="1" colspan="1"><code>some|every $x in S satisfies C</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:boolean}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">IfExpr [15,15] </td>
+                     <td rowspan="2" colspan="1">IfExpr</td>
                      <td rowspan="1" colspan="1"><code>if (C) then T else E</code></td>
                      <td rowspan="1" colspan="1">the union of the static types of T and E</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">OrExpr [16,16]</td>
+                     <td rowspan="1" colspan="1"><code>if (C) { T }</code></td>
+                     <td rowspan="1" colspan="1">the static type of T</td>
+                  </tr>
+                  <tr>
+                     <td rowspan="1" colspan="1">ConditionalExpr</td>
+                     <td rowspan="1" colspan="1"><code>A otherwise B</code></td>
+                     <td rowspan="1" colspan="1">the union of the static types of A and B</td>
+                  </tr>
+                  <tr>
+                     <td rowspan="1" colspan="1">OrExpr</td>
                      <td rowspan="1" colspan="1"><code>E or F</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:boolean}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">AndExpr [17,17]</td>
+                     <td rowspan="1" colspan="1">AndExpr</td>
                      <td rowspan="1" colspan="1"><code>E and F</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:boolean}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">ComparisonExpr [18,18]</td>
+                     <td rowspan="1" colspan="1">ComparisonExpr</td>
                      <td rowspan="1" colspan="1"><code>E = F, E eq F, E is F</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:boolean}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">StringConcatExpr [19,19]</td>
+                     <td rowspan="1" colspan="1">StringConcatExpr</td>
                      <td rowspan="1" colspan="1"><code>E || F</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:string}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">RangeExpr [20,20]</td>
+                     <td rowspan="1" colspan="1">RangeExpr</td>
                      <td rowspan="1" colspan="1"><code>E to F</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:decimal}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">AdditiveExpr [21,21]</td>
+                     <td rowspan="1" colspan="1">AdditiveExpr</td>
                      <td rowspan="1" colspan="1"><code>E + F</code></td>
                      <td rowspan="1" colspan="1"><var>U{A}</var>. But if the expression
                            is a predicate (that is, if it appears between square brackets in a
@@ -28790,7 +28808,7 @@ the same group, and the-->
                               xs:float}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">MultiplicativeExpr [22,22]</td>
+                     <td rowspan="1" colspan="1">MultiplicativeExpr</td>
                      <td rowspan="1" colspan="1"><code>E * F</code></td>
                      <td rowspan="1" colspan="1"><var>U{A}</var>. But if the expression
                            is a predicate (that is, if it appears between square brackets in a
@@ -28798,12 +28816,12 @@ the same group, and the-->
                               xs:float}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">UnionExpr [23,23] </td>
+                     <td rowspan="1" colspan="1">UnionExpr</td>
                      <td rowspan="1" colspan="1"><code>E | F</code></td>
                      <td rowspan="1" colspan="1">the union of the static types of E and F</td>
                   </tr>
                   <tr>
-                     <td rowspan="2" colspan="1">IntersectExceptExpr [24,24] </td>
+                     <td rowspan="2" colspan="1">IntersectExceptExpr</td>
                      <td rowspan="1" colspan="1"><code>E intersect F</code></td>
                      <td rowspan="1" colspan="1">the intersection of the static types of E and F</td>
                   </tr>
@@ -28812,38 +28830,38 @@ the same group, and the-->
                      <td rowspan="1" colspan="1">the static type of E</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">InstanceOfExpr [25,25]</td>
+                     <td rowspan="1" colspan="1">InstanceOfExpr</td>
                      <td rowspan="1" colspan="1"><code>E instance of T</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:boolean}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">TreatExpr [26,26]</td>
+                     <td rowspan="1" colspan="1">TreatExpr</td>
                      <td rowspan="1" colspan="1"><code>E treat as T</code></td>
                      <td rowspan="1" colspan="1">the U-type corresponding to the SequenceType T</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">CastableExpr [27,27]</td>
+                     <td rowspan="1" colspan="1">CastableExpr</td>
                      <td rowspan="1" colspan="1"><code>E castable as T</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:boolean}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">CastExpr [28,28] </td>
+                     <td rowspan="1" colspan="1">CastExpr</td>
                      <td rowspan="1" colspan="1"><code>E cast as T</code></td>
                      <td rowspan="1" colspan="1">if T is an atomic or pure union type, the corresponding U-type. Otherwise,
                         for example if T is a list type, <var>U{A}</var>.</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">UnaryExpr [29,30]</td>
+                     <td rowspan="1" colspan="1">UnaryExpr</td>
                      <td rowspan="1" colspan="1"><code>-N</code></td>
                      <td rowspan="1" colspan="1"><var>U{xs:decimal, xs:double, xs:float}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">SimpleMapExpr [34,35] </td>
+                     <td rowspan="1" colspan="1">SimpleMapExpr</td>
                      <td rowspan="1" colspan="1"><code>E ! F</code></td>
                      <td rowspan="1" colspan="1">the static type of F</td>
                   </tr>
                   <tr>
-                     <td rowspan="3" colspan="1">PathExpr [35,36] </td>
+                     <td rowspan="3" colspan="1">PathExpr</td>
                      <td rowspan="1" colspan="1"><code>/</code></td>
                      <td rowspan="1" colspan="1"><var>U{document-node()}</var></td>
                   </tr>
@@ -28856,23 +28874,27 @@ the same group, and the-->
                      <td rowspan="1" colspan="1">the static type of P</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">RelativePathExpr [36,37] </td>
+                     <td rowspan="1" colspan="1">RelativePathExpr</td>
                      <td rowspan="1" colspan="1"><code>P/Q, P//Q</code></td>
                      <td rowspan="1" colspan="1">the static type of Q</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">AxisStep [38,39] </td>
+                     <td rowspan="1" colspan="1">AxisStep</td>
                      <td rowspan="1" colspan="1"><code>E[P]</code></td>
                      <td rowspan="1" colspan="1">the static type of E: see <specref ref="static-type-of-steps"/></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">ForwardStep [39,40], ReverseStep [42,43]</td>
+                     <td rowspan="1" colspan="1">ForwardStep, ReverseStep</td>
                      <td rowspan="1" colspan="1"><code>Axis::NodeTest</code></td>
                      <td rowspan="1" colspan="1">See <specref ref="static-type-of-steps"/></td>
                   </tr>
                   <tr>
-                     <td rowspan="2" colspan="1">PostfixExpr [48,49]</td>
-                     <td rowspan="1" colspan="1">Filter Expression <code>E[P]</code></td>
+                     <td rowspan="3" colspan="1">PostfixExpr</td>
+                     <td rowspan="1" colspan="1">FilterExpr <code>E[P]</code></td>
+                     <td rowspan="1" colspan="1">the static type of E</td>
+                  </tr>
+                  <tr>
+                     <td rowspan="1" colspan="1">FilterExprAM <code>E?[P]</code></td>
                      <td rowspan="1" colspan="1">the static type of E</td>
                   </tr>
                   <tr>
@@ -28881,13 +28903,18 @@ the same group, and the-->
                         function signature of F: see below.</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">Literal [53,57]</td>
-                     <td rowspan="1" colspan="1"><code>"pH"</code>, <code>93.7</code></td>
-                     <td rowspan="1" colspan="1"><var>U{xs:string}</var>, <var>U{xs:decimal}</var>, or
-                           <var>U{xs:double}</var>, depending on the form of the literal</td>
+                     <td rowspan="1" colspan="1">Literal</td>
+                     <td rowspan="1" colspan="1"><code>"pH"</code>, <code>93.7</code>, <code>#xml:space</code></td>
+                     <td rowspan="1" colspan="1"><var>U{xs:string}</var>, <var>U{xs:decimal}</var>, 
+                           <var>U{xs:double}</var>, or <var>U{xs:QName}</var> depending on the form of the literal</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">VarRef [55,59]</td>
+                     <td rowspan="1" colspan="1">StringTemplate</td>
+                     <td rowspan="1" colspan="1"><code>`{$x}{$y}`</code></td>
+                     <td rowspan="1" colspan="1"><var>U{xs:string}</var></td>
+                  </tr>
+                  <tr>
+                     <td rowspan="1" colspan="1">VarRef</td>
                      <td rowspan="1" colspan="1"><code>$V</code></td>
                      <td rowspan="1" colspan="1">For a variable declared using <elcode>xsl:variable</elcode> or
                            <elcode>xsl:param</elcode>, and for parameters of inline function
@@ -28897,7 +28924,7 @@ the same group, and the-->
                         the static type of the expression to which the variable is bound.</td>
                   </tr>
                   <tr>
-                     <td rowspan="2" colspan="1">ParenthesizedExpr [57,61]</td>
+                     <td rowspan="2" colspan="1">ParenthesizedExpr</td>
                      <td rowspan="1" colspan="1"><code>(E)</code></td>
                      <td rowspan="1" colspan="1">the type of E</td>
                   </tr>
@@ -28906,12 +28933,12 @@ the same group, and the-->
                      <td rowspan="1" colspan="1"><var>U{}</var> (a type whose only instance is the empty sequence)</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">ContextItemExpr [58,62]</td>
+                     <td rowspan="1" colspan="1">ContextValueRef</td>
                      <td rowspan="1" colspan="1"><code>.</code></td>
                      <td rowspan="1" colspan="1">the context item type: see below</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">FunctionCall [59,63]</td>
+                     <td rowspan="1" colspan="1">FunctionCall</td>
                      <td rowspan="1" colspan="1"><code>F(X, Y)</code></td>
                      <td rowspan="1" colspan="1">In general: the U-type corresponding to
                         the declared result type of function <var>F</var>. But:
@@ -28927,47 +28954,64 @@ the same group, and the-->
                         </ulist></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">NamedFunctionRef [63,67]</td>
+                     <td rowspan="1" colspan="1">Partial Function Application</td>
+                     <td rowspan="1" colspan="1"><code>F(X, ?)</code>, $F(X, ?)</td>
+                     <td rowspan="1" colspan="1"><var>U{fn(*)}</var></td>
+                  </tr>
+                  <tr>
+                     <td rowspan="1" colspan="1">NamedFunctionRef</td>
                      <td rowspan="1" colspan="1"><code>F#n</code></td>
                      <td rowspan="1" colspan="1"><var>U{fn(*)}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">InlineFunctionExpr [64,68] </td>
+                     <td rowspan="1" colspan="1">InlineFunctionExpr</td>
                      <td rowspan="1" colspan="1"><code>fn(P) {E}</code></td>
                      <td rowspan="1" colspan="1"><var>U{fn(*)}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">MapConstructor [,69]</td>
+                     <td rowspan="1" colspan="1">MapConstructor</td>
                      <td rowspan="1" colspan="1"><code>{ "A": E, "B": F }</code></td>
                      <td rowspan="1" colspan="1"><var>U{fn(*)}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">Postfix Lookup [,49]</td>
+                     <td rowspan="1" colspan="1">Postfix Lookup (Shallow)</td>
                      <td rowspan="1" colspan="1"><code>E ? K</code></td>
                      <td rowspan="1" colspan="1">If the type of <var>E</var> is a map type <code>map(K, V)</code> or an
                         array type <code>array(V)</code>, then the U-type corresponding to the item
-                        type of <var>V</var>; otherwise <var>U{*}</var></td>
+                        type of <var>V</var>; otherwise <var>U{*}</var>. An implementation <rfc2119>may</rfc2119>
+                     be able to determine a more precise type when the type of <var>E</var> is a record type.</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">(Unary) Lookup [,53]</td>
+                     <td rowspan="1" colspan="1">Unary Lookup (Shallow)</td>
                      <td rowspan="1" colspan="1"><code>? K</code></td>
                      <td rowspan="1" colspan="1">If the context item type is a map type <code>map(K, V)</code> or an array
                         type <code>array(V)</code>, then the U-type corresponding to the item type
-                        of <var>V</var>; otherwise <var>U{*}</var></td>
+                        of <var>V</var>; otherwise <var>U{*}</var>. An implementation <rfc2119>may</rfc2119>
+                     be able to determine a more precise type when the context item type is a record type.</td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">ArrowExpr [,29]</td>
-                     <td rowspan="1" colspan="1"><code>X =&gt; F(Y, Z)</code></td>
+                     <td rowspan="1" colspan="1">Deep Lookup</td>
+                     <td rowspan="1" colspan="1"><code>?? K</code>, <code>E ?? K</code></td>
+                     <td rowspan="1" colspan="1"><var>U{*}</var></td>
+                  </tr>
+                  <tr>
+                     <td rowspan="1" colspan="1">PipelineExpr</td>
+                     <td rowspan="1" colspan="1"><code>X -&gt; Y</code></td>
+                     <td rowspan="1" colspan="1">The static type of <code>Y</code></td>
+                  </tr> 
+                  <tr>
+                     <td rowspan="1" colspan="1">ArrowExpr</td>
+                     <td rowspan="1" colspan="1"><code>X =&gt; F(Y, Z)</code>, <code>X =!&gt; F(Y, Z)</code></td>
                      <td rowspan="1" colspan="1">The static type of the equivalent static or dynamic function call 
                         <code>F(X, Y, Z)</code></td>
                   </tr>                 
                   <tr>
-                     <td rowspan="1" colspan="1">SquareArrayConstructor [,74]</td>
+                     <td rowspan="1" colspan="1">SquareArrayConstructor</td>
                      <td rowspan="1" colspan="1"><code>[ X, Y, ... ]</code></td>
                      <td rowspan="1" colspan="1"><var>U{fn(*)}</var></td>
                   </tr>
                   <tr>
-                     <td rowspan="1" colspan="1">CurlyArrayConstructor [,75]</td>
+                     <td rowspan="1" colspan="1">CurlyArrayConstructor</td>
                      <td rowspan="1" colspan="1"><code>array {X, Y, ... }</code></td>
                      <td rowspan="1" colspan="1"><var>U{fn(*)}</var></td>
                   </tr>
@@ -29172,7 +29216,8 @@ the same group, and the-->
                this specification or in the XPath specification, describe how the <termref def="dt-focus"/> for evaluating each <termref def="dt-operand"/> of the construct
                is determined. In most cases the focus is the same as that of the parent construct.
                In some cases the focus is determined by evaluating some other expression, for
-               example in the expressions <code>A/B</code>, <code>A!B</code>, or <code>A[B]</code>,
+               example in the expressions <code>A/B</code>, <code>A!B</code>, <code>A[B]</code>, 
+               <code>A?[B]</code>, or <code>A -> B</code>
                the focus for evaluating <var>B</var> is <var>A</var>. More generally:</p>
 
             <ulist>


### PR DESCRIPTION
Updates the static typing rules in XSLT for new kinds of expression introduced in XPath 4.0. These rules are used in streamability analysis, but more work needs to be done to complete the streamability analysis.

Production rules are now referenced by name, as production numbers are no longer available.