### PR TITLE
2009 Avoid constructing document node when it makes no sense

### DIFF
--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -18174,7 +18174,7 @@ return $tree =?> depth()]]></eg>
          <div2 id="variable-values">
             <head>Values of Variables and Parameters</head>
             <changes>
-               <change issue="2009">
+               <change issue="2009" PR="2015" date="2025-05-20">
                   A variable-binding with no <code>as</code> or <code>select</code> attribute no longer
                   attempts to create an implicit document node if the sequence constructor contains
                   an <elcode>xsl:map</elcode>, <elcode>xsl:array</elcode>, or <elcode>xsl:select</elcode>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -18173,6 +18173,14 @@ return $tree =?> depth()]]></eg>
          </div2>
          <div2 id="variable-values">
             <head>Values of Variables and Parameters</head>
+            <changes>
+               <change issue="2009">
+                  A variable-binding with no <code>as</code> or <code>select</code> attribute no longer
+                  attempts to create an implicit document node if the sequence constructor contains
+                  an <elcode>xsl:map</elcode>, <elcode>xsl:array</elcode>, or <elcode>xsl:select</elcode>
+                  child instruction.
+               </change>
+            </changes>
             <p>A <termref def="dt-variable-binding-element">variable-binding element</termref> may
                specify the <termref def="dt-supplied-value">supplied value</termref> of a <termref def="dt-variable">variable</termref>
                or the default value of a
@@ -18197,11 +18205,20 @@ return $tree =?> depth()]]></eg>
                </item>
                <item>
                   <p>If a <termref def="dt-variable-binding-element">variable-binding
-                        element</termref> has no <code>select</code> attribute and has non-empty
-                     content (that is, the variable-binding element has one or more child nodes),
-                     and has no <code>as</code> attribute, then the content of the variable-binding
+                        element</termref> satisfies all the following conditions:</p>
+                  
+                     <ulist>
+                        <item><p>The element has no <code>select</code> attribute</p></item>
+                        <item><p>The element has no <code>as</code> attribute</p></item>
+                        <item><p>The element has non-empty content (that is, the variable-binding element 
+                           has one or more child nodes)</p></item>
+                        <item><p>There is no <elcode>xsl:map</elcode>, <elcode>xsl:array</elcode>,
+                           or <elcode>xsl:select</elcode> element among the element's children</p></item>
+                     </ulist>
+                     <p>then the content of the variable-binding
                      element specifies the <termref def="dt-supplied-value">supplied
-                     value</termref>. The content of the variable-binding element is a <termref def="dt-sequence-constructor">sequence constructor</termref>; a new document
+                     value</termref>. The content of the variable-binding element is a 
+                     <termref def="dt-sequence-constructor">sequence constructor</termref>; a new document
                      is constructed with a document node having as its children the sequence of
                      nodes that results from evaluating the sequence constructor and then applying
                      the rules given in <specref ref="constructing-complex-content"/>. The value of
@@ -18209,9 +18226,8 @@ return $tree =?> depth()]]></eg>
                      further information, see <specref ref="temporary-trees"/>. </p>
                </item>
                <item>
-                  <p>If a <termref def="dt-variable-binding-element">variable-binding
-                        element</termref> has an <code>as</code> attribute but no
-                        <code>select</code> attribute, then the <termref def="dt-supplied-value">supplied value</termref> is the sequence that results from evaluating the
+                  <p>Otherwise, the <termref def="dt-supplied-value">supplied value</termref> 
+                     is the sequence that results from evaluating the
                      (possibly empty) <termref def="dt-sequence-constructor">sequence
                         constructor</termref> contained within the variable-binding element (see
                         <specref ref="sequence-constructors"/>). </p>
@@ -18245,7 +18261,7 @@ return $tree =?> depth()]]></eg>
                      <td rowspan="1" colspan="1">present</td>
                      <td rowspan="1" colspan="1">empty</td>
                      <td rowspan="1" colspan="1">Value is obtained by evaluating the <code>select</code>
-                        attribute, adjusted to the type required by the <code>as</code>
+                        attribute, coerced to the type required by the <code>as</code>
                         attribute</td>
                   </tr>
                   <tr>
@@ -18276,7 +18292,15 @@ return $tree =?> depth()]]></eg>
                   <tr>
                      <td rowspan="1" colspan="1">absent</td>
                      <td rowspan="1" colspan="1">absent</td>
-                     <td rowspan="1" colspan="1">present</td>
+                     <td rowspan="1" colspan="1">includes <elcode>xsl:map</elcode>, <elcode>xsl:array</elcode>,
+                             or <elcode>xsl:select</elcode></td>
+                     <td rowspan="1" colspan="1">Value is obtained by evaluating the sequence constructor</td>
+                  </tr>
+                  <tr>
+                     <td rowspan="1" colspan="1">absent</td>
+                     <td rowspan="1" colspan="1">absent</td>
+                     <td rowspan="1" colspan="1">present and does not include <elcode>xsl:map</elcode>, <elcode>xsl:array</elcode>,
+                             or <elcode>xsl:select</elcode></td>
                      <td rowspan="1" colspan="1">Value is a document node whose content is obtained by
                         evaluating the sequence constructor</td>
                   </tr>
@@ -18285,13 +18309,14 @@ return $tree =?> depth()]]></eg>
                      <td rowspan="1" colspan="1">present</td>
                      <td rowspan="1" colspan="1">present</td>
                      <td rowspan="1" colspan="1">Value is obtained by evaluating the sequence constructor,
-                        adjusted to the type required by the <code>as</code> attribute</td>
+                        coerced to the type required by the <code>as</code> attribute</td>
                   </tr>
                </tbody>
             </table>
             <p>
                <error spec="XT" type="static" class="SE" code="0620">
-                  <p>It is a <termref def="dt-static-error">static error</termref> if a <termref def="dt-variable-binding-element">variable-binding element</termref> has a
+                  <p>It is a <termref def="dt-static-error">static error</termref> 
+                     if a <termref def="dt-variable-binding-element">variable-binding element</termref> has a
                         <code>select</code> attribute and has non-empty content.</p>
                </error>
             </p>


### PR DESCRIPTION
Fix #2009 

The rules for xsl:variable are changed so there is no attempt to construct an implicit temporary tree when the sequence constructor contains an `xsl:map`. `xsl:array`, or `xsl:select` instruction (perhaps mixed with other instructions).

Compatibility: note that `xsl:array` and `xsl:select` are new in 4.0, while xsl:map inside `xsl:variable` always throws an error in XSLT 3.0.

Justification: 

- a child `xsl:select` element behaves like a `select` attribute
- if the content of xsl:variable is `xsl:map` or `xsl:array` it makes no sense to require the user to add `as=map(*)` or `as=array(*)` because the type is obvious anyway.