### PR TITLE
1776: XSLT template rules for maps and array

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -252,7 +252,6 @@ apply.
   </g:production>
   
   <g:production name="LabelPattern" if="xslt40-patterns">
-    <g:string>.</g:string>
     <g:oneOrMore>
       <g:choice>
         <g:string>?</g:string>

--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -59,6 +59,7 @@ apply.
       <g:ref name="PredicatePattern"/>
       <g:ref name="TypePattern"/>
       <g:ref name="NodePattern"/>
+      <g:ref name="LabelPattern"/>
     </g:choice> 
   </g:production>
   
@@ -250,7 +251,29 @@ apply.
     </g:choice>
   </g:production>
   
-  <!-- ] end XSLT 3.0 Patterns -->
+  <g:production name="LabelPattern" if="xslt40-patterns">
+    <g:string>.</g:string>
+    <g:oneOrMore>
+      <g:choice>
+        <g:string>?</g:string>
+        <g:string>??</g:string>
+      </g:choice>
+      <g:ref name="KeySpecifierP"/>
+    </g:oneOrMore>
+  </g:production>
+  
+  <g:production name="KeySpecifierP" if="xslt40-patterns">
+    <g:choice>
+      <g:ref name="NCName"/>
+      <g:ref name="IntegerLiteral"/>
+      <g:ref name="StringLiteral"/>
+      <g:ref name="VarRef"/>
+      <g:ref name="LookupWildcard"/>
+      <g:ref name="TypeSpecifier"/>
+    </g:choice>
+  </g:production>
+  
+  <!-- ] end XSLT 4.0 Patterns -->
 
   <!-- ===================================================================== -->
 

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -35044,17 +35044,30 @@ return $result
          <p>The supplied value of <code>$input</code> must be either a map or an array.</p>
          <p>The result is as follows:</p>
          <olist>
-            <item><p>If <code>$input</code> is a map <var>M</var>, the result is a map <var>M'</var>
-            derived from <var>M</var> as follows:</p>
+            <item><p>We define an auxiliary function <code>pin2($item, $root)</code> which
+            pins an item <code>$item</code> (of any kind) as part of a tree rooted at <code>$root</code>.
+            This function is described in the following rules. The function <code>fn:pin($input)</code>
+            is defined to return <code>pin2($input, $input)</code>: that is, it processes the supplied
+            item as the root of a tree.</p></item>
+            <item><p>If <code>$item</code> is a map <var>M</var>, the result of <code>pin2($item, $root)</code>
+               is a map <var>M'</var> derived from <var>M</var> as follows:</p>
             <olist>
                <item><p>Any existing label on <var>M</var> is discarded.</p></item>
-               <item><p><var>M'</var> acquires a label having the property <code>pinned</code>
-               set to the value <code>true</code>, and the property <code>id</code> set to
+               <item><p><var>M'</var> acquires a label having the following properties:</p>
+                  <olist>
+                     <item><p>Property <code>pinned</code>
+               set to the value <code>true</code>.</p>
+                     </item>
+                     <item><p>Property <code>id</code> set to
                an arbitrary <code>xs:string</code> value that is unique within the execution scope.</p></item>
+                     <item><p>Property <code>root</code> set to <code>$root</code>.</p></item>
+                  </olist>
+               </item>
+            
                <item><p>For every key-value pair (<var>K</var>, <var>V</var>) in <var>M</var>,
                   <var>M'</var> will have a key-value pair (<var>K</var>, <var>V'</var>)
                in which the key <var>K</var> is unchanged, and the value <var>V'</var>
-               is derived from <var>V</var> by applying the function <code>derived-value(M', K, V)</code>,
+               is derived from <var>V</var> by applying the function <code>derived-value(M', K, V, $root)</code>,
                   defined below.</p>
                </item>
                <item><p>The <xtermref spec="DM40" ref="dt-entry-order"/>
@@ -35065,39 +35078,41 @@ return $result
                derived from <var>A</var> as follows:</p>
                <olist>
                   <item><p>Any existing label on <var>A</var> is discarded.</p></item>
-                  <item><p><var>A'</var> acquires a label having the property <code>pinned</code>
-                     set to the value <code>true</code>, and the property <code>id</code> set to
-                     an arbitrary <code>xs:string</code> value that is unique within the execution scope.</p></item>
+                  <item><p><var>A'</var> acquires a label having the following properties:</p>
+                     <olist>
+                        <item><p>Property <code>pinned</code> set to the value <code>true</code>.</p>
+                        </item>
+                        <item><p>Property <code>id</code> set to an arbitrary <code>xs:string</code> 
+                           value that is unique within the execution scope.</p></item>
+                        <item><p>Property <code>root</code> set to <code>$root</code>.</p></item>
+                     </olist>
+                  </item>
                   <item><p>For every member <var>V</var> in <var>A</var>,
                      whose 1-based index position in <var>A</var> is <var>X</var>,
                      <var>A'</var> will have a member <var>V'</var>
-                     derived from <var>V</var> by applying the function <code>derived-value(A', X, V)</code>,
+                     derived from <var>V</var> by applying the function <code>derived-value(A', X, V, $root)</code>,
                      defined below.</p>
                   </item>
                </olist>
             </item>
-            <item><p>The <code>id</code> property described in the previous paragraphs is allocated
-            only to the top-level map or array (the one supplied as an explicit argument to the
-               <function>fn:pin</function> function). The function is <emph>not</emph>
+            <item><p>The <code>id</code> property described in the previous paragraphs identifies
+               an item uniquely within the execution scope. The <code>fn:pin</code> function is <emph>not</emph>
                   <termref def="dt-deterministic">deterministic</termref>: that is, if the function is called
                   twice with the same arguments, it is <termref def="implementation-dependent"
                      >implementation-dependent</termref> whether the same <code>id</code> property is allocated on both
                   occasions.</p></item>
-            <item><p>If <code>$input</code> is anything other than a map or an array, a type
-               error is raised.</p>
-            </item>
-            <item><p>The function <code>derived-value(P, K, V)</code> has the following logic.
+            <!--<item><p>If <code>$input</code> is anything other than a map or an array, a type
+               error is raised.</p>-->
+            <!--</item>-->
+            <item><p>The function <code>derived-value(P, K, V, $root)</code> has the following logic.
                For every item <var>J</var>
-                  in <var>V</var>, <var>V'</var> will contain an item <var>J'</var> that is derived from
+                  in <var>V</var>, the result <var>V'</var> will contain an item <var>J'</var> that is derived from
                      <var>J</var> as follows:</p>
                    <olist>
                       <item>
                          <p>Let <var>TEMP</var> be:</p>
                          <olist>
-                            <item><p>If <var>J</var> is a map or array, then <code>fn:pin(J)</code>.</p>
-                               <note><p>Note however that
-                                  the <code>id</code> property of <var>TEMP</var> is not used, 
-                                  so there is no need to generate it.</p></note></item>
+                            <item><p>If <var>J</var> is a map or array, then <code>pin2(J, $root)</code>.</p> </item> 
                             <item><p>Otherwise, <var>J</var>.</p></item>
                          </olist>
                       </item>
@@ -35109,6 +35124,10 @@ return $result
                                <def><p><code>true</code></p></def>
                             </gitem>
                             <gitem>
+                               <label>id</label>
+                               <def><p>A string that uniquely identifies this item within the tree rooted at <code>$root</code></p></def>
+                            </gitem>
+                            <gitem>
                                <label>key</label>
                                <def><p><var>K</var></p></def>
                             </gitem>
@@ -35118,15 +35137,19 @@ return $result
                             </gitem>
                             <gitem>
                                <label>parent</label>
-                               <def><p><var>P</var></p></def>
+                               <def><p>A zero-arity function delivering <var>P</var>.</p></def>
+                            </gitem>
+                            <gitem>
+                               <label>root</label>
+                               <def><p>A zero-arity function delivering <code>$root</code>.</p></def>
                             </gitem>
                             <gitem>
                                <label>ancestors</label>
-                               <def><p>A zero-arity function item delivering the value of <code>(?parent, ?parent ! label(.)?ancestors())</code>.</p></def>
+                               <def><p>A zero-arity function item delivering the value of <code>(?parent(), ?parent() ! label(.)?ancestors())</code>.</p></def>
                             </gitem>
-                           <gitem>
+                            <gitem>
                               <label>path</label>
-                              <def><p>A zero-arity function item delivering the value of <code>(?parent ! label(.)?path(), ?key)</code>.</p></def>
+                              <def><p>A zero-arity function item delivering the value of <code>(?parent() ! label(.)?path(), ?key)</code>.</p></def>
                            </gitem>
                         </glist>
                       </item>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -13145,6 +13145,11 @@ return $tree =?> depth()]]></eg>
                concatenated retaining the order of the items in
                the sorted sequence. The final concatenated sequence forms the result of the
                   <elcode>xsl:apply-templates</elcode> instruction. </p>
+            
+            <div3 id="applying-templates-to-nodes">
+               <head>Applying Template Rules to Node Trees</head>
+               <p>This section illustrates common techniques used when template
+               rules are used to transform XML documents, represented as node trees.</p>
             <example>
                <head>Applying Template Rules</head>
                <p>Suppose the source document is as follows:</p>
@@ -13293,6 +13298,28 @@ return $tree =?> depth()]]></eg>
                      <code>select=".//div"</code>
                </p>
             </example>
+               
+               <note>
+               <p>The <elcode>xsl:apply-templates</elcode> instruction is most commonly used to
+                  process nodes that are descendants of the context node. Such use of
+                     <elcode>xsl:apply-templates</elcode> cannot result in non-terminating
+                  processing loops. However, when <elcode>xsl:apply-templates</elcode> is used to
+                  process elements that are not descendants of the context node, the possibility
+                  arises of non-terminating loops. For example,</p>
+               <eg role="error" xml:space="preserve">&lt;xsl:template match="foo"&gt;
+  &lt;xsl:apply-templates select="."/&gt;
+&lt;/xsl:template&gt;</eg>
+               <p>Implementations may be able to detect such loops in some cases, but the
+                  possibility exists that a <termref def="dt-stylesheet">stylesheet</termref> may
+                  enter a non-terminating loop that an implementation is unable to detect. This may
+                  present a denial of service security risk.</p>
+            </note>
+               
+            </div3>
+            <div3 id="applying-templates-to-atomic-items">
+               <head>Applying Template Rules to Atomic Items</head>
+               <p>Template rules can also be used to process atomic items.</p>
+            
             <example>
                <head>Applying Templates to Atomic Items</head>
                <p>This example reads a non-XML text file and processes it line-by-line, applying
@@ -13316,21 +13343,8 @@ return $tree =?> depth()]]></eg>
 </eg>
             </example>
             
-            <note>
-               <p>The <elcode>xsl:apply-templates</elcode> instruction is most commonly used to
-                  process nodes that are descendants of the context node. Such use of
-                     <elcode>xsl:apply-templates</elcode> cannot result in non-terminating
-                  processing loops. However, when <elcode>xsl:apply-templates</elcode> is used to
-                  process elements that are not descendants of the context node, the possibility
-                  arises of non-terminating loops. For example,</p>
-               <eg role="error" xml:space="preserve">&lt;xsl:template match="foo"&gt;
-  &lt;xsl:apply-templates select="."/&gt;
-&lt;/xsl:template&gt;</eg>
-               <p>Implementations may be able to detect such loops in some cases, but the
-                  possibility exists that a <termref def="dt-stylesheet">stylesheet</termref> may
-                  enter a non-terminating loop that an implementation is unable to detect. This may
-                  present a denial of service security risk.</p>
-            </note>
+            
+            </div3>
             <div3 id="applying-templates-to-maps-and-arrays">
                <head>Applying Templates to Maps and Arrays</head>
                <changes>
@@ -13342,9 +13356,9 @@ return $tree =?> depth()]]></eg>
                </changes>
                
                <p>A tree of maps and arrays (often derived by parsing JSON) behaves differently from a 
-                  tree of nodes (typically derived by parsing XML). In particular, if a value
+                  tree of nodes (typically derived by parsing XML). If a value
                   is located within a tree of maps and arrays by means of a lookup expression,
-                  the value that is retrieved contains no identifying information. Specifically:</p>
+                  the value that is retrieved contains no intrinsic identifying information. Specifically:</p>
                
                <ulist>
                   <item><p>The value has no name. It might have been selected from a containing map
@@ -13376,6 +13390,26 @@ return $tree =?> depth()]]></eg>
                   is labeled with information about its parent (containing) map or array, together with its key or
                   index within that container. The label is accessible using the <xfunction>label</xfunction>
                   function, but otherwise has no effect on the way the value is processed.</p>
+               
+               <p>More specifically, the rules are as follows:</p>
+               
+               
+               <olist>
+                  <item>
+                     <p>Let <var>C</var> be the context item for evaluation of the <elcode>xsl:apply-templates</elcode>
+                     instruction, and let <var>S</var> be an item selected by the (explicit or implicit)
+                     <code>select</code> expression of the instruction.</p>
+                  </item>
+                  <item>
+                     <p>If <var>C</var> is pinned (that is, it has a label with the property
+                     <code>pinned = true()</code>), and <var>S</var> is pinned, and 
+                        <var>C</var> and <var>S</var> have the same root,
+                        then <var>S</var> is used as is.</p>
+                  </item>
+                  <item><p>Otherwise, <var>S</var> is replaced by <code>fn:pin(<var>S</var>)</code>.</p>
+                  </item>
+
+               </olist>
                
                <note><p>In a practical implementation, it is likely that these labels will be created
                   on-the-fly when a value is actually selected within a containing map or array. There is
@@ -13532,10 +13566,10 @@ return $tree =?> depth()]]></eg>
                (which is always the case with parsed JSON, except when the JSON text includes nulls).
                The technique is less suitable when processing arrays or maps that contain sequences.
                For example, if the context item is the array
-               <code>[1, (2,3), ()}</code>, then <code>?*</code> evaluates to the sequence of three
-               items, <code>1, 2, 3</code>. In such cases it is better to decompose an array using 
+               <code>[1, (2,3), ()]</code>, then <code>?*</code> evaluates to the sequence of three
+               items, <code>1, 2, 3</code>. In such cases it may be better to decompose an array using 
                <code>array:members(.)</code>,
-               or a map using <code>map:pairs(.)</code>. In most such cases it will be more
+               or a map using <code>map:pairs(.)</code>. It will often be more
                convenient to process the resulting values using <elcode>xsl:for-each</elcode>
                rather than <elcode>xsl:apply-templates</elcode>, though both are possible.
                Values extracted using <code>array:members(.)</code> or <code>map:pairs(.)</code>
@@ -13628,7 +13662,9 @@ return $tree =?> depth()]]></eg>
 </xsl:array>]]></eg>
                <p>Such code can become verbose, so XSLT 4.0 offers the alternative of writing it like this:</p>
                <eg><![CDATA[
-<xsl:sequence select="array{ * ! map:build(@*, local-name#1, apply-templates#1) }"/>]]></eg>
+<xsl:select>
+  array{ * ! map:build(@*, local-name#1, apply-templates#1) }
+</xsl:select>]]></eg>
                <p>To make this possible, a subset of the functionality of the <elcode>xsl:apply-templates</elcode>
                instruction is available via the (XSLT-only) <function>apply-templates</function>
                function, whose specification follows.</p>
@@ -14146,12 +14182,7 @@ return $tree =?> depth()]]></eg>
                   <p>If the pattern is a <nt def="TypePattern">TypePattern</nt>, then the priority
                   is 0 (zero).</p></item>
                <item>
-                  <p>If the pattern is a <nt def="LabelPattern">LabelPattern</nt> in which every
-                  one <nt def="KeySpecifierP">KeySpecifierP</nt> is an <xnt def="LookupWildcard">LookupWildcard</xnt>,
-                     then the priority is -0.5.</p>
-               </item>
-               <item>
-                  <p>If the pattern is any other <nt def="LabelPattern">LabelPattern</nt>, 
+                  <p>If the pattern is a <nt def="LabelPattern">LabelPattern</nt>, 
                      then the priority is 0 (zero).</p>
                </item>
                <item>
@@ -15173,7 +15204,7 @@ return $tree =?> depth()]]></eg>
                from the original. The purpose is to allow the processing of selected values within the
                tree to be overridden by explicit user-written template rules. See 
                   <specref ref="shallow-copy-all-overriding"/> for advice on writing overriding 
-               transformation rules for this mode of processing.</p>
+               template rules for this mode of processing.</p>
                
                
                
@@ -15181,10 +15212,10 @@ return $tree =?> depth()]]></eg>
                   <head>Shallow Copy All: Processing Arrays</head>
                
                   <p>The default processing for an array constructs a new array with the same
-                     number of members as the original, each member constructed by applying
+                     number of members as the original, each member being constructed by applying
                      templates to the existing value.</p>
  
-                  <p>The template rule for the first phase is equivalent to the following, 
+                  <p>The template rule is equivalent to the following, 
                      except that this does not show
                      the propagation of template parameters:</p>
                   
@@ -15199,6 +15230,12 @@ return $tree =?> depth()]]></eg>
 </xsl:template>
        ]]></eg>
                   
+                  <note><p>Because the <elcode>xsl:apply-templates</elcode> instruction
+                  selects items that are labeled with the same <code>root</code>
+                  property as the context item, they are not relabeled, and therefore
+                  retain the ability to access their parents and ancestors within the
+                  overall processing.</p></note>
+                  
                   
                </div4>
               
@@ -15208,7 +15245,7 @@ return $tree =?> depth()]]></eg>
                   as the original; the value associated with each key is obtained by applying
                   templates to the original value.</p>
                  
-                  <p>The template rule for the first phase is equivalent to the following, 
+                  <p>The template rule is equivalent to the following, 
                      except that this does not show
                      the propagation of template parameters:</p>
                   
@@ -15217,47 +15254,144 @@ return $tree =?> depth()]]></eg>
       <xsl:for-each select="map:pairs(.)">
          <xsl:map:entry key="?key">
            <xsl:apply-templates select="?value"/>
-         </xsl:map:entry>   
+         </xsl:map-entry>   
       </xsl:for-each>   
    </xsl:map>
 </xsl:template>
        ]]></eg>
+                 
+                 <note><p>Because the <elcode>xsl:apply-templates</elcode> instruction
+                  selects items that are labeled with the same <code>root</code>
+                  property as the context item, they are not relabeled, and therefore
+                  retain the ability to access their parents and ancestors within the
+                  overall processing.</p></note>
                   
                     
               </div4>
-               <div4 id="shallow-copy-all-overriding">
-                  <head>Shallow Copy All: Overriding Template Rules</head>
-                  <p>Most transformations can be achieved by override the processing  
-                  of map entries with a specific known key. Keys can be matched
+  
+               <div4 id="shallow-copy-all-examples">
+                  <head>Shallow Copy All: Examples</head>
+               
+               <example>
+                  <head>Transforming Individual Map Entries</head>
+                  
+                  <p>Many useful transformations can be achieved by overriding the processing  
+                  of map entries that have a specific known key. Keys can be matched
                   using label patterns: see <specref ref="label-patterns"/>. For example:</p>
                   
                   <eg><![CDATA[
 <xsl:template match="?surname">
   <xsl:select>uppercase(.)</xsl:select>
+</xsl:template>
+
+<xsl:template match="?date-of-birth">
+  <xsl:select>format-date(xs:date(.), '[D1] [MNn] [Y0001]')</xsl:select>
 </xsl:template>]]></eg>
                   
-                  <p>This does not work well, however, if the value associated with a key
-                  is not a single item. For example, consider a map containing an entry:</p>
+                  <p>This approach does not work well, however, if the value associated with a key
+                  contains multiple items, or if it is empty. Subsequent examples in this section
+                  illustrate ways of handling this.</p>
                   
-                  <eg>{
-   "type": "cupboard",
-   "material": "oak:,
+               </example>
+               <example>
+                  <head>Deleting Unwanted Entries from Maps</head>
+                  
+                  <p>If any map is to be replaced by a map with a different set of keys, it
+                  is necessary to write an explicit template rule that matches the map.</p>
+                  
+                  <p>For example, to delete <code>"Note"</code> entries from any map in which they
+                  appear, the following stylesheet might be used:</p>
+                  
+                  <eg xml:space="preserve" role="xslt-document"><![CDATA[xsl:stylesheet version="3.0"
+     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+     default-mode="delete-notes">
+				  
+  <xsl:mode name="delete-notes" 
+            on-no-match="shallow-copy-all">
+
+    <xsl:template match="record(Note, *)">
+      <xsl:apply-templates select="map:remove(., 'Note')"/>  
+    </xsl:template>
+    
+  </xsl:mode>
+
+</xsl:stylesheet>]]></eg>
+                  
+                  <p>The way this works is:</p>
+                  
+                  <ulist>
+                     <item><p>By default, all maps and arrays 
+                     are processed using the built-in template rule, which copies them unchanged.</p></item>
+                     
+                     <item><p>A map containing an entry with the key <code>"Note"</code> matches the
+                        pattern <code>record(Note, *)</code> and is therefore processed using a template
+                     rule that removes the <code>"Note"</code> entry and applies templates recursively
+                     to the map that results.</p></item>
+                     
+                  </ulist>
+                  
+                  <p>Note that the <elcode>xsl:apply-templates</elcode> instruction here is processing
+                  a map (the result of the <code>map:remove</code> operation) that is <emph>not</emph>
+                  labeled as belonging to the original processing tree, and it will therefore be labeled
+                  as part of a new tree with a different processing root. This can be avoided by instead
+                  writing:</p>
+                  
+                  <eg><![CDATA[
+<xsl:template match="record(Note, *)">
+   <xsl:map>
+      <xsl:for-each select="map:pair(.)[not(?key = 'Note')]">
+        <xsl:map-entry key="?key">
+          <xsl:apply-templates select="?value"/>
+        </xsl:map-entry>
+      </xsl:for-each>
+   </xsl:map>
+</xsl:template>
+                     ]]></eg>
+                  
+                  <p>This can also be expressed as:</p>
+                  
+                  <eg><![CDATA[
+<xsl:template match="record(Note, *)">
+   <xsl:select>
+     map:build(map:pairs(.)[not(?key = 'Note')], 
+               fn{?key},
+               fn{apply-templates(?value)})
+   </xsl:select>
+</xsl:template>
+                     ]]></eg>
+                  <p>The essential difference with these examples is that they apply templates
+                  to values that were present in the original processing tree, not to a newly constructed
+                  map.</p>
+               </example>
+                  
+               <example>
+                  <head>Processing non-Singleton Values</head>
+                  
+                  <p>The default processing rules apply templates to individual items
+                  within the value of a map entry or the value of an array member. This creates
+                  a challenge when such a value is a sequence of more than one item, and needs to be
+                  processed as a group. This example illustrates such a case.</p>
+                  
+                  <p>Consider the map:</p>
+                  
+                  <eg>
+{  "type": "cupboard",
+   "material": "oak",
    "dimensions": (12.5, 6.2, 8.3)
 }</eg>
                   
-                  <p>where the requirement is to turn this into the entry:</p>
+                  <p>where the requirement is to turn this into:</p>
                   
-                  <eg>{
-   "type": "cupboard",
-   "material": "oak:,
+                  <eg>
+{  "type": "cupboard",
+   "material": "oak",
    "dimensions": {'height': 12.5, 'width': 6.2, 'depth': 8.3}
 }</eg>
                      
- 
-                      
+                 
                   <p>A template rule written with <code>match="?dimensions"</code> will match
-                  each of the three values individually, giving no opportunity to construct
-                  the single map to contain all three.</p>
+                  each of the three decimal values individually, giving no opportunity to construct
+                  a single map to contain all three.</p>
                   
                   <p>A solution to this is to override the processing of the containing map. For example:</p>
                   
@@ -15272,50 +15406,53 @@ return $tree =?> depth()]]></eg>
 </xsl:template>  
   ]]></eg>
                      
-                    <p>An alternative is to process all the map entries using template rules that match
+                    <p>Alternatively, if other entries in the map also need to be transformed,
+                       it is possible is to process all the map entries using template rules that match
                     key-value pairs. For example:</p>
                      
                      <eg><![CDATA[
 <xsl:template match="record(type, material, dimensions, *)">
   <xsl:map>
-    <xsl:apply-templates select="map:pairs(.)" mode="furniture-properties"/>
+    <xsl:apply-templates select="map:entries(.)" 
+                         mode="furniture-properties"/>
   </xsl:map>  
 </xsl:template>
 
 <xsl:mode name="furniture-properties" 
-          as="record(key, value)" 
-          on-no-match="deep-copy">
-   <xsl:template match=".[?key = 'dimensions']">
-     <xsl:map-entry key="'dimensions'">
-       <xsl:select>{ 'height': ?value[1], 
-                     'width':  ?value[2], 
-                     'depth':  ?value[3] }  
-       </xsl:select/>
-     </xsl:map:entry>
+          on-no-match="shallow-copy-all">
+          
+   <xsl:template match="?dimensions'">
+       <xsl:record height="?value[1]" 
+                   width="?value[2]" 
+                   depth="?value[3]"/>
    </xsl:template>
+   
+   <xsl:template match=".">
+       <xsl:apply-templates select="." mode="#unnamed"/>
+   </xsl:template>
+   
 </xsl:mode>  
   ]]></eg>
-               </div4>
-               <div4 id="shallow-copy-all-examples">
-                  <head>Shallow Copy All: Examples</head>
-               
-               
-               <p>The overall effect is best understood with an example.</p>
+                  
+                  <p>In this example the mode <code>furniture-properties</code> is only used
+                  to process singleton maps (maps containing a single entry). If the key
+                  in the singleton map is <code>"dimensions"</code>, then the sequence of
+                  three decimals is replaced by a map with three entries; in all other cases,
+                  processing is delegated back to the original unnamed mode.</p>
+                  
+                  <p>Note that the switching between two different modes does not affect the
+                  labels on any values in the tree. When the context item for a call on
+                     <elcode>xsl:apply-templates</elcode> is labeled with a particular
+                  navigation root, and any items selected by the <elcode>xsl:apply-templates</elcode>
+                  instruction will be labeled with the same navigation root,
+                  even if the processing is in a different mode.</p>
+               </example>   
                
                <example>
                   <head>Modified Identity Transformation of a JSON Document</head>
                   <p>The following stylesheet transforms a supplied JSON document by deleting all properties
                      named <code>"Note"</code>, appearing at any level:</p>
-                  <eg xml:space="preserve" role="xslt-document">&lt;xsl:stylesheet version="3.0"
-     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;
-				  
-&lt;xsl:mode on-no-match="shallow-copy-all"/&gt;
-
-&lt;xsl:template match="record(Note)"&gt;
-  &lt;!-- no action --&gt;
-&lt;/xsl:template&gt;
-
-&lt;/xsl:stylesheet&gt;</eg>
+                  
                   
                   <p>Consider the following JSON input, converted to an array of maps by calling 
                      the function <function>parse-json</function>:</p>

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -15448,78 +15448,7 @@ return $tree =?> depth()]]></eg>
                   even if the processing is in a different mode.</p>
                </example>   
                
-               <example>
-                  <head>Modified Identity Transformation of a JSON Document</head>
-                  <p>The following stylesheet transforms a supplied JSON document by deleting all properties
-                     named <code>"Note"</code>, appearing at any level:</p>
-                  
-                  
-                  <p>Consider the following JSON input, converted to an array of maps by calling 
-                     the function <function>parse-json</function>:</p>
-                  
-                  <eg>[
-  { "Title": "Computer Architecture",
-    "Authors": [ "Enid Blyton", { "Note": "possibly misattributed" } ],
-    "Category": "Computers",
-    "Price": 42.60
-  },
-  { "Title": "Steppenwolf",
-    "Authors": [ "Hermann Hesse" ],
-    "Category": "Fiction",
-    "Price": 12.00,
-    "Note": "out of print"
-  },
-  { "Title": "How to Explore Outer Space with Binoculars",
-    "Authors": [ "Bruce Betts", "Erica Colon" ],
-    "Category": "Science",
-    "Price": 10.40
-  }
-]</eg>
-               <p>The logic proceeds as follows:</p>
-                  
-                  <olist>
-                     <item><p>The outermost array is processed by applying templates to a sequence of value records, 
-                        the first being in the form:</p>
-                        <eg>{ "value": map: { "Title": ..., "Author": ..., ... }</eg>
-                     <p>The result of applying templates to these value records is expected to comprise a new sequence
-                        of value records, which is used to construct the final output array.</p></item>
-                     
-                     <item><p>Each of the value records is processed using the rule for single-entry maps. This rule
-                        produces a new value record by applying templates to the value, that is, to a map of the form
-                        <code>map: { "Title": ..., "Author": ..., ... }</code> representing a book.</p></item>
-                     
-                     <item><p>Each of these books, being represented by a map with more than two entries, is processed by
-                     a template rule that splits the map into its multiple entries, each represented as a singleton
-                     map (a map with one key and one value). One of these single-entry maps, for example, would be
-                     <code>{"Title": "Steppenwolf"}</code>.</p></item>
-                     
-                     <item><p>The default processing for a single-entry map of the form 
-                        <code>{ "Title": "Steppenwolf" }</code> is to return the value unchanged.
-                        This is achieved by applying templates to the string <code>"Steppenwolf"</code>;
-                     the default template rule for strings returns the string unchanged.</p></item>
-                     
-                     <item><p>When a single-entry map in the form <code>{ "Note": "out of print" }</code> is encountered, no output
-                     is produced, meaning that entry in the parent map is effectively dropped. This is because there
-                     is an explicit template rule with <code>match="record(Note)"</code> that matches such single-entry maps.</p></item>
-                     
-                     <item><p>When a single-entry map in the form <code>"Authors": [ "Bruce Betts", "Erica Colon" ]</code> 
-                        is encountered, a new single-entry map is produced; it has the same key (<code>"Authors"</code>),
-                        and a value obtained by applying templates to the array <code>[ "Bruce Betts", "Erica Colon" ]</code>.
-                        The default processing for an array, in which none of the constituents are matched by explicit
-                        template rules, ends up delivering a copy of the array.</p></item>
-                     
-                     <item><p>When the single-entry map <code>"Authors": [ "Enid Blyton", { "Note": "possibly misattributed" } ]</code>
-                        is encountered, the recursive processing results in templates being applied to the map
-                        <code>{ "Note": "possibly misattributed" }</code>. This matches the template rule having
-                        <code>match="record(Note)"</code>, which returns no output, so the entry is effectively deleted.</p>
-                        <note><p>The map entry is deleted, but the map itself remains, so the value becomes
-                           <code>"Authors": [ "Enid Blyton", map: {} ]</code>.</p></note>
-                     
-                     </item>
-                  </olist>
-                  
-
-               </example>
+               
                </div4>
             </div3>
             

--- a/specifications/xslt-40/src/xslt.xml
+++ b/specifications/xslt-40/src/xslt.xml
@@ -10844,23 +10844,36 @@ and <code>version="1.0"</code> otherwise.</p>
                   <prodrecap ref="Pattern40"/>
                </scrap>
                
-               <p diff="add" at="2022-01-01">Patterns fall into three groups:</p>
+               <p>Patterns fall into four groups:</p>
                
-               <ulist diff="add" at="2022-01-01">
+               <ulist>
                   <item><p>A <code>PredicatePattern</code> matches items according to conditions that the item must
                   satisfy: for example <code>.[. castable as xs:integer]</code> matches any value (it might
                   be an atomic item, a node, or an array) that is castable as an integer.</p></item>
+                  
                   <item><p>A <code>TypePattern</code> matches items according to their type. For example
                   <code>type(xs:integer)</code> matches an atomic item that is an instance of <code>xs:integer</code>,
                   while <code>record(longitude, latitude)</code> matches a map that has exactly two entries, with
                   keys <code>"longitude"</code> and <code>"latitude"</code></p></item>
+                  
                   <item><p>A <code>NodePattern</code> matches nodes in a tree, typically by specifying a path that
                   can be used to locate the nodes: for example <code>order</code> matches an element node
                   named <code>order</code>, while <code>billing-address/city</code> matches an element named <code>city</code>
                   whose parent node is an element named <code>billing-address</code>.</p></item>
+                  
+                  <item><p>A <code>LabelPattern</code> matches items according to keys found in their labels.
+                  These arise typically when processing a tree of maps and arrays using 
+                  <elcode>xsl:apply-templates</elcode>.</p></item>
                </ulist>
                
-               <p diff="add" at="2022-01-01">The following sections define the rules for each of these groups.</p>
+               <p diff="add" at="2022-01-01">The following sections define the rules for each of these groups:</p>
+               
+               <slist>
+                  <sitem><specref ref="predicate-patterns"/></sitem>
+                  <sitem><specref ref="type-patterns"/></sitem>
+                  <sitem><specref ref="node-patterns"/></sitem>
+                  <sitem><specref ref="label-patterns"/></sitem>
+               </slist>
                
                <div4 id="predicate-patterns">
                   <head>Predicate Patterns</head>
@@ -11274,6 +11287,77 @@ and <code>version="1.0"</code> otherwise.</p>
                   the complications arise mainly when non-trivial relative paths are used.</p>
                </note>
             </div4>
+               
+               <div4 id="label-patterns">
+                  <head>Label Patterns</head>
+                  
+                  <changes>
+                     <change issue="1776">Label patterns are new in XSLT 4.0. They are used for matching
+                     values occurring within a tree of maps and array, such as occurs as the result of
+                     parsing JSON.</change>
+                  </changes>
+                  
+                  <p>The syntax of a label pattern is:</p>
+                  
+                  <scrap id="Label-Patterns-scrap" >
+                     <prodrecap ref="LabelPattern"/>
+                  </scrap>
+                  
+                  <p>Informally, an item <var>J</var> matches a pattern such as <code>?a?b?c</code>
+                  if there is some containing map or array <var>$C</var> such that <code>$C?a?b?c</code>
+                  returns a result that includes the item <var>J</var>.</p>
+                  
+                  <p>To take a simple example, given the input map</p>
+                  
+                  <eg>[
+  { "Title": "Computer Architecture",
+    "Authors": [ "Enid Blyton"] ,
+    "Category": "Computers",
+    "Price": 42.60
+  },
+  { "Title": "Steppenwolf",
+    "Authors": [ "Hermann Hesse" ],
+    "Category": "Fiction",
+    "Price": 12.00
+  },
+  {  "Title": "How to Explore Outer Space with Binoculars",
+     "Authors": [ "Bruce Betts", "Erica Colon" ],
+     "Category": "Science",
+     "Price": 10.40
+  }
+]</eg>
+                  <ulist>
+                     <item><p>The values <code>42.60</code>, <code>12.00</code>, and <code>10.40</code>
+                     match the pattern <code>?Price</code></p></item>
+                     <item><p>The value <code>12.00</code>
+                     matches the pattern <code>?2?Price</code></p></item>
+                     <item><p>The strings <code>"Enid Blyton"</code>, <code>"Hermann Hesse"</code>,
+                        <code>"Bruce Betts"</code>, and <code>"Erica Colon"</code> all match
+                        the pattern <code>?Authors?*</code></p></item>
+                     <item><p>The strings <code>"Enid Blyton"</code>, <code>"Hermann Hesse"</code>,
+                        and <code>"Bruce Betts"</code> all match
+                        the pattern <code>?Authors?1</code></p></item>
+                     <item><p>The arrays <code>["Enid Blyton"]</code>, <code>["Hermann Hesse"]</code>,
+                        and <code>["Bruce Betts", "Erica Colon"]</code> all match the pattern
+                     <code>?Authors</code></p></item>
+                     <item><p>The values <code>42.60</code>, <code>12.00</code>, and <code>10.40</code>
+                     match the pattern <code>?~record(Title, Author, Category, Price)?Price</code>
+                     (this pattern might be used to distinguish prices of books from prices of other
+                     objects).</p></item>
+                  </ulist>
+                  
+                  <p>These patterns rely on the matched items being labeled, which will automatically
+                  be the case if they are selected in the course of evaluating an 
+                     <elcode>xsl:apply-templates</elcode> instruction applied to a map or array, as
+                  described in <specref ref="applying-templates-to-maps-and-arrays"/>.</p>
+                  
+                  <p>A more precise definition of the semantics of a label pattern <var>LL</var>
+                  is that the pattern matches an item <var>$J</var> if the value of <code>label($J)?ancestors()</code>
+                  includes a map or array <var>$A</var> such that the expression <var>LL</var>, evaluated
+                  with <var>$A</var> as the context item, selects an item <var>$K</var> such that
+                  <code>label($K)?id</code> equals <code>label($J)?id</code>.</p>
+               </div4>
+               
             </div3>
             <div3 id="pattern-errors">
                <head>Errors in Patterns</head>
@@ -13231,7 +13315,233 @@ return $tree =?> depth()]]></eg>
 
 </eg>
             </example>
-            <example>
+            
+            <note>
+               <p>The <elcode>xsl:apply-templates</elcode> instruction is most commonly used to
+                  process nodes that are descendants of the context node. Such use of
+                     <elcode>xsl:apply-templates</elcode> cannot result in non-terminating
+                  processing loops. However, when <elcode>xsl:apply-templates</elcode> is used to
+                  process elements that are not descendants of the context node, the possibility
+                  arises of non-terminating loops. For example,</p>
+               <eg role="error" xml:space="preserve">&lt;xsl:template match="foo"&gt;
+  &lt;xsl:apply-templates select="."/&gt;
+&lt;/xsl:template&gt;</eg>
+               <p>Implementations may be able to detect such loops in some cases, but the
+                  possibility exists that a <termref def="dt-stylesheet">stylesheet</termref> may
+                  enter a non-terminating loop that an implementation is unable to detect. This may
+                  present a denial of service security risk.</p>
+            </note>
+            <div3 id="applying-templates-to-maps-and-arrays">
+               <head>Applying Templates to Maps and Arrays</head>
+               <changes>
+                  <change issue="1776">
+                     When arrays and maps are processed using xsl:apply-templates, they are pinned,
+                     making additional properties (such as the key of a map entry) available within
+                     match patterns.
+                  </change>
+               </changes>
+               
+               <p>A tree of maps and arrays (often derived by parsing JSON) behaves differently from a 
+                  tree of nodes (typically derived by parsing XML). In particular, if a value
+                  is located within a tree of maps and arrays by means of a lookup expression,
+                  the value that is retrieved contains no identifying information. Specifically:</p>
+               
+               <ulist>
+                  <item><p>The value has no name. It might have been selected from a containing map
+                  using its unique key value, but the key is not part of the value in the way that
+                  a node name is part of a node.</p></item>
+                  <item><p>The value has no parent. Having selected a value from a containing map,
+                  there is no way of discovering the containing map. There is no equivalent of the
+                  parent or ancestor axes that are available for nodes.</p></item>
+                  <item><p>The value has no identity. If two values are found using different
+                  selection criteria (for example, finding all employees at a given location and all
+                  employees with a particular job title) there is no way of asking whether the
+                  two values are identical, unless there happens to be a property that is known to be
+                  unique.</p></item>
+               </ulist>
+               
+               <p>These differences create challenges when processing a tree of maps and arrays
+               using recursive-descent rule-based template matching. It makes it difficult to define patterns
+               that can be used to match values and determine what processing to apply, and having
+               matched values, it makes it difficult to use information that is not contained within
+               the value itself, but elsewhere in the containing tree.</p>
+               
+               <p>To address these difficulties, when the <elcode>xsl:apply-templates</elcode>
+               instruction selects a map or array, the map or array is automatically pinned,
+               by applying the <xfunction>pin</xfunction> function; the <elcode>xsl:apply-templates</elcode>
+               logic is then applied to the pinned version of the map or array.</p>
+               
+               <p>When a map or array is pinned, all values within the subtree are labeled with additional
+                  properties. Conceptually, a deep copy of the map or array is created, in which every value
+                  is labeled with information about its parent (containing) map or array, together with its key or
+                  index within that container. The label is accessible using the <xfunction>label</xfunction>
+                  function, but otherwise has no effect on the way the value is processed.</p>
+               
+               <note><p>In a practical implementation, it is likely that these labels will be created
+                  on-the-fly when a value is actually selected within a containing map or array. There is
+                  no need to create labels for values that are never selected for processing.</p>
+               
+                  <p>In the terminology of computer science, a pinned tree of maps and arrays is
+                  a <term>zipper</term> data structure. At a high level of abstraction, navigation
+                  within a zipper structure returns pairs consisting of a data element itself, plus
+                  information about how the data element was reached. In the XDM model these
+                  are referred to as the value and the label.</p>
+                  
+                  <p>Labels are attached only to items, not to sequences.</p>
+               </note>
+               
+               <example>
+                  <head>A Simple JSON-to-HTML Transformation</head>
+               
+               <p>To take a simple example, suppose the input is a map obtained by parsing the
+                  JSON text:</p>
+               
+               <eg>
+{ "first": "John",
+  "last":  "Smith",
+  "dob":   "1995-12-06"
+}</eg>
+               <p>and the stylesheet is to transform this into the HTML:</p>
+               
+               <eg><![CDATA[<table>
+  <tr> <td>First name:</td>    <td>John</td>            </tr>
+  <tr> <td>Last name:</td>     <td>SMITH</td>           </tr>
+  <tr> <td>Date of birth:</td> <td>6 December 1995</td> </tr>
+</table>]]></eg>
+               
+               <p>This can be achieved by writing template rules as follows:</p>
+               
+               <eg><![CDATA[
+<xsl:mode on-no-match="shallow-copy-all"/>
+                  
+<xsl:template match="?first">
+  <tr><td>First name:</td>
+      <td>{.}</td>
+  </tr>
+</xsl:template>
+
+<xsl:template match="?last">
+  <tr><td>First name:</td>
+      <td>{upper-case(.)}</td>
+  </tr>
+</xsl:template>
+
+<xsl:template match="?dob">
+  <tr><td>Date of birth:</td>
+      <td>{format-date(xs:date(.), "[D1] [MNn] [Y0001]")}</td>
+  </tr>
+</xsl:template>
+
+<xsl:template match="xsl:initial-template">
+  <table>
+     <xsl:apply-templates select="parse-json('input.json')"/>
+  </table>
+</xsl:template>  
+   ]]></eg>
+               
+               <p>The way this works is as follows.</p>
+                  
+                  <olist>
+                     <item><p>The <elcode>xsl:apply-templates</elcode> instruction
+                     causes the top-level map to be pinned. This means that the
+                     values (the strings <code>"John"</code>, <code>"Smith"</code>, 
+                     and <code>"1995-12-06"</code>) are labeled with various properties:
+                     the important property for this example is the corresponding key.</p></item>
+                     
+                     <item><p>There is no template rule matching the top-level map.
+                     Therefore the built-in template rule for a mode with
+                     <code>on-no-match="shallow-copy-all"</code> is activated. This
+                     rule effectively does <code>&lt;xsl:apply-templates select="?*"/></code>,
+                     which applies templates to the three values <code>"John"</code>, <code>"Smith"</code>, 
+                     and <code>"1995-12-06"</code>.</p></item>
+                     
+                     <item><p>The match pattern <code>?first</code> matches any value
+                     labeled with the key <code>"first"</code>.</p></item>
+                     
+                     <item><p>Within the template rule having this pattern, the context
+                     item is the string <code>"John"</code> (the string has a label, but
+                     this template rule makes no use of it). The text value template
+                     <code>{.}</code> therefore outputs the string <code>"John"</code>.</p></item>
+                  </olist>
+      
+               </example>
+               
+               <p>Match patterns for matching values by their corresponding key can be
+               more complex than this example illustrates. For further examples, see
+               <specref ref="label-patterns"/>.</p>
+               
+               <p>As well as being useful within match patterns, the properties in a label
+               can also be used within the body of the template rule. The label of a value
+               can be retrieved (as a map) using the <xfunction>label</xfunction> function,
+               and the individual properties can then be accessed using a lookup expression.
+               For example, expressions that might be used within the body of a template rule
+               to access properties of the context item include:</p>
+               
+               <table>
+                  <tr><td><code>label(.)?key</code></td>
+                     <td>The key associated with the value in a map, or the index associated
+                     with the value in an array.</td></tr>
+                  <tr><td><code>label(.)?position</code></td>
+                     <td>The position of an item within a map entry or array member.</td></tr>
+                  <tr><td><code>label(.)?id</code></td>
+                     <td>A system-generated string that uniquely identifies this value
+                        within the subtree of the root map or array..</td></tr>
+                  <tr><td><code>label(.)?parent()</code></td>
+                     <td>The containing map or array.</td></tr>
+                  <tr><td><code>label(.)?ancestors()</code></td>
+                     <td>All containing maps or arrays, back to the 
+                     root map or array, in innermost-to-outermost
+                     order.</td></tr>
+                  <tr><td><code>label(.)?path()</code></td><td>The keys (or array indexes) of
+                     this value and all containing maps and array, back to the 
+                     root map or array, in outermost-to-innermost
+                     order.</td></tr>
+               </table>
+               
+               <p>For example, within the body of a template rule, it is possible to test whether
+               the context item is contained (at any depth) within a map that has the entry
+               <code>"deleted" : true()</code> using the expression:</p>
+               
+               <eg>if (label(.)?ancestors()?deleted) then ...</eg>
+               
+               <p>It is also possible to use such expressions within a predicate in a match
+               pattern.</p>
+               
+               <p>When <elcode>xsl:apply-templates</elcode> selects a map or array that has no label,
+               this map or array is treated as the root of a subtree of values reachable by navigating
+               downwards to the contents of nested maps or arrays. Labeling these values conceptually
+               makes a deep copy, in which all values at any depth are identifiable as belonging
+               to this root.</p>
+               
+               <p>By contrast, when <elcode>xsl:apply-templates</elcode> selects a map or array that 
+                  has an existing label, the label is examined to see if it belongs to the same root
+                  as the current item. If it does, the label is retained: the selected item and its subtree is not
+                  relabeled. If however, the item's label is unrelated, then it is treated in the
+                  same way as an unlabeled item: it is copied and relabeled, with the effect that any existing labels
+                  are discarded.</p>
+               
+               <note><p>Unlike the model for XML-derived nodes, maps and arrays do not have a unique
+               and permanent parent. The item that is returned by the <code>parent()</code> function
+               in the item's label is the container from which the item was selected. Two items
+               selected by different routes will have different values returned by the <code>parent()</code>
+               function. In practice, however, when processing a tree of maps and arrays derived from
+               parsing a JSON text, this is unlikely to be a concern.</p></note>
+               
+               <p>Decomposing a map or array using the expression <code>&lt;xsl:apply-templates select="?*"/></code>
+               works well when the members of the array, or the values in the map, are all single items
+               (which is always the case with parsed JSON, except when the JSON text includes nulls).
+               The technique is less suitable when processing arrays or maps that contain sequences.
+               For example, if the context item is the array
+               <code>[1, (2,3), ()}</code>, then <code>?*</code> evaluates to the sequence of three
+               items, <code>1, 2, 3</code>. In such cases it is better to decompose an array using 
+               <code>array:members(.)</code>,
+               or a map using <code>map:pairs(.)</code>. In most such cases it will be more
+               convenient to process the resulting values using <elcode>xsl:for-each</elcode>
+               rather than <elcode>xsl:apply-templates</elcode>, though both are possible.
+               Values extracted using <code>array:members(.)</code> or <code>map:pairs(.)</code>
+               still have labels, just as items extracted using a lookup expression do.</p>
+               
+               <example>
                <head>Applying Templates to JSON Documents</head>
                <p>This example reads a JSON data file and formats it as XHTML.</p>
                <p>It takes the following JSON data as input:</p>
@@ -13290,23 +13600,47 @@ return $tree =?> depth()]]></eg>
 </xsl:template>
 ]]></eg>
             </example>
-            <note>
-               <p>The <elcode>xsl:apply-templates</elcode> instruction is most commonly used to
-                  process nodes that are descendants of the context node. Such use of
-                     <elcode>xsl:apply-templates</elcode> cannot result in non-terminating
-                  processing loops. However, when <elcode>xsl:apply-templates</elcode> is used to
-                  process elements that are not descendants of the context node, the possibility
-                  arises of non-terminating loops. For example,</p>
-               <eg role="error" xml:space="preserve">&lt;xsl:template match="foo"&gt;
-  &lt;xsl:apply-templates select="."/&gt;
-&lt;/xsl:template&gt;</eg>
-               <p>Implementations may be able to detect such loops in some cases, but the
-                  possibility exists that a <termref def="dt-stylesheet">stylesheet</termref> may
-                  enter a non-terminating loop that an implementation is unable to detect. This may
-                  present a denial of service security risk.</p>
-            </note>
-         </div2>
-         <div2 id="apply-templates-separator" diff="add" at="2022-01-01">
+               
+            </div3>
+            
+            <div3 id="apply-templates-function">
+               <head>The <code>apply-templates</code> Function</head>
+               <changes>
+                  <change issue="2005" PR="2006" date="2025-05-16">A new function <code>fn:apply-templates</code> is introduced.</change>
+               </changes>
+               <p>Sometimes it is useful to be able to apply templates from within an XPath expression.
+               A common example is when using XPath expressions to construct maps and arrays. For example,
+               an array of maps might be constructed by the following code:</p>
+               
+               <eg><![CDATA[
+<xsl:array>
+  <xsl:for-each select="*">
+    <xsl:array-member>
+      <xsl:map>
+        <xsl:for-each select="@*">
+          <xsl:map-entry key="local-name()">
+            <xsl:apply-templates select="."/>
+          </xsl:map-entry>
+        </xsl:for-each>
+      </xsl:map>
+    </xsl:array-member>  
+  </xsl:for-each>
+</xsl:array>]]></eg>
+               <p>Such code can become verbose, so XSLT 4.0 offers the alternative of writing it like this:</p>
+               <eg><![CDATA[
+<xsl:sequence select="array{ * ! map:build(@*, local-name#1, apply-templates#1) }"/>]]></eg>
+               <p>To make this possible, a subset of the functionality of the <elcode>xsl:apply-templates</elcode>
+               instruction is available via the (XSLT-only) <function>apply-templates</function>
+               function, whose specification follows.</p>
+               
+               <div4 id="func-apply-templates">
+                 <head><?function fn:apply-templates?></head>
+               </div4>
+
+            </div3>
+
+
+         <div3 id="apply-templates-separator" diff="add" at="2022-01-01">
             <head>The <code>separator</code> attribute</head>
             
             <p>If the <code>separator</code> attribute of <elcode>xsl:apply-templates</elcode>
@@ -13339,6 +13673,7 @@ return $tree =?> depth()]]></eg>
             <p>If the separator is a zero-length string, then a zero-length text node is inserted into the sequence. (If the
                sequence is used for constructing the value of a node, then zero-length text nodes will be discarded: see
                <specref ref="constructing-simple-content"/> and <specref ref="constructing-complex-content"/>.)</p>
+         </div3>
          </div2>
          <!--<div2 id="template-test" diff="add" at="2022-01-01">
             <head>The <code>test</code> Attribute</head>
@@ -13399,7 +13734,7 @@ return $tree =?> depth()]]></eg>
             <p>When an <elcode>xsl:apply-imports</elcode> or <elcode>xsl:next-match</elcode> instruction is evaluated,
             the values of tunnel parameters may change, and the set of eligible template rules may therefore also change.</p>
          </div2>-->
-            
+       
         
          <div2 id="conflict">
             <head>Conflict Resolution for Template Rules</head>
@@ -13808,8 +14143,17 @@ return $tree =?> depth()]]></eg>
                      −0.5.</p>
                </item>
                <item>
-                  <p diff="add" at="2023-03-15">If the pattern is a <nt def="TypePattern">TypePattern</nt>, then the priority
+                  <p>If the pattern is a <nt def="TypePattern">TypePattern</nt>, then the priority
                   is 0 (zero).</p></item>
+               <item>
+                  <p>If the pattern is a <nt def="LabelPattern">LabelPattern</nt> in which every
+                  one <nt def="KeySpecifierP">KeySpecifierP</nt> is an <xnt def="LookupWildcard">LookupWildcard</xnt>,
+                     then the priority is -0.5.</p>
+               </item>
+               <item>
+                  <p>If the pattern is any other <nt def="LabelPattern">LabelPattern</nt>, 
+                     then the priority is 0 (zero).</p>
+               </item>
                <item>
                   <p>In all other cases, the priority is +0.5.</p>
                </item>
@@ -14232,44 +14576,8 @@ return $tree =?> depth()]]></eg>
                      <elcode>xsl:apply-imports</elcode> and <elcode>xsl:next-match</elcode>
                   instructions (see <specref ref="apply-imports"/>).</p>
             </div3>
-            <!--End of text replaced by erratum E19-->
             
-            <div3 id="apply-templates-function">
-               <head>The <code>apply-templates</code> Function</head>
-               <changes>
-                  <change issue="2005" PR="2006" date="2025-05-16">A new function <code>fn:apply-templates</code> is introduced.</change>
-               </changes>
-               <p>Sometimes it is useful to be able to apply templates from within an XPath expression.
-               A common example is when using XPath expressions to construct maps and arrays. For example,
-               an array of maps might be constructed by the following code:</p>
-               
-               <eg><![CDATA[
-<xsl:array>
-  <xsl:for-each select="*">
-    <xsl:array-member>
-      <xsl:map>
-        <xsl:for-each select="@*">
-          <xsl:map-entry key="local-name()">
-            <xsl:apply-templates select="."/>
-          </xsl:map-entry>
-        </xsl:for-each>
-      </xsl:map>
-    </xsl:array-member>  
-  </xsl:for-each>
-</xsl:array>]]></eg>
-               <p>Such code can become verbose, so XSLT 4.0 offers the alternative of writing it like this:</p>
-               <eg><![CDATA[
-<xsl:sequence select="array{ * ! map:build(@*, local-name#1, apply-templates#1) }"/>]]></eg>
-               <p>To make this possible, a subset of the functionality of the <elcode>xsl:apply-templates</elcode>
-               instruction is available via the (XSLT-only) <function>apply-templates</function>
-               function, whose specification follows.</p>
-               
-               <div4 id="func-apply-templates">
-                 <head><?function fn:apply-templates?></head>
-               </div4>
-
-            </div3>
-
+            
             <div3 id="xsl-mode-typed">
                <head>Declaring the Type of Nodes Processed by a Mode</head>
 
@@ -14847,8 +15155,13 @@ return $tree =?> depth()]]></eg>
 
             </div3>
             
-            <div3 id="built-in-templates-shallow-copy-all" diff="add" at="issue570">
+            <div3 id="built-in-templates-shallow-copy-all">
                <head>Built-in Templates: Shallow Copy All</head>
+               <changes>
+                  <change issue="570">The new value <code>on-no-match="shallow-copy-all"</code>
+                  is designed for processing trees of maps and arrays, such as arise from
+                  parsing JSON.</change>
+               </changes>
                <p>This processing mode is introduced in XSLT 4.0 as a variant of <code>shallow-copy</code>
                to enable recursive descent processing of trees involving maps and arrays, such as might result
                from parsing JSON input.
@@ -14856,60 +15169,136 @@ return $tree =?> depth()]]></eg>
                <p>For all items other than maps and arrays, the effect of <code>shallow-copy-all</code>
                is exactly the same as <code>shallow-copy</code>.</p>
                
-               <p>For arrays, the processing is as follows. A new result array is created, and its content
-                  is populated by decomposing the input array to a sequence of <term>value records</term>
-               using the function <function>array:members</function>. Each of these value records is processed
-                  by a call on <elcode>xsl:apply-templates</elcode> (using the current mode, and passing
-                  on the values of all template parameters); the result of the called template
-                  is expected to be a value record.</p>
+               <p>If an entire tree is processed using the built-in rules, the result will be unchanged
+               from the original. The purpose is to allow the processing of selected values within the
+               tree to be overridden by explicit user-written template rules. See 
+                  <specref ref="shallow-copy-all-overriding"/> for advice on writing overriding 
+               transformation rules for this mode of processing.</p>
                
-               <p>That is, the template rule is equivalent to the following, except that this does not show
-                  the propagation of template parameters:</p>
                
-               <eg><![CDATA[<xsl:array use="?value">
-  <xsl:apply-templates select="array:members(.)" mode="#current"/>
-</xsl:array>  
-    ]]></eg>
                
-               <note><p>A <term>value record</term> is a single-entry map: it has a single key-value pair with the key <code>"value"</code>,
-               the corresponding value being a member of the original array. The default processing for a value
-               record, unless specified otherwise, is to apply templates to the value, as indicated by the rules
-               that follow.</p></note>
+               <div4 id="shallow-copy-all-arrays">
+                  <head>Shallow Copy All: Processing Arrays</head>
                
-               <p>For maps, the processing is as follows:</p>
-               <ulist>
-                  <item><p>If the map contains two or more entries,
-                     then a new result map is created, and its content is populated
-                     by decomposing the input map using the function <function>map:entries</function> to 
-                     produce a sequence of single-entry maps (each containing one key and one value), and then applying
-                     templates to this sequence, using the current mode, and passing
-                     on the values of all template parameters.</p></item>
-                  <item><p>If the map contains a single entry <code>{ <var>K</var> : <var>V/0</var> }</code>, then a new single entry
-                     map <code>{ <var>K</var>: <var>V/1</var> }</code> is constructed in which <var>V/1</var> is the
-                     result of applying templates to <var>V/0</var> (using the current mode, and passing
-                     on the values of all template parameters).</p>
-                     <note><p>This rule has the effect that if the input is a value record, the output will also
-                     be a value record.</p></note>
-                  </item>
-                  <item><p>If the map is empty, the result is an empty map.</p></item>
-               </ulist>
+                  <p>The default processing for an array constructs a new array with the same
+                     number of members as the original, each member constructed by applying
+                     templates to the existing value.</p>
+ 
+                  <p>The template rule for the first phase is equivalent to the following, 
+                     except that this does not show
+                     the propagation of template parameters:</p>
+                  
+                  <eg><![CDATA[<xsl:template match="type(array(*))">
+   <xsl:array>
+     <xsl:for-each select="array:members(.)">
+        <xsl:array-member>
+          <xsl:apply-templates select="?value" mode="#current"/>
+        </xsl:array-member>
+     </xsl:for-each>   
+   </xsl:array>
+</xsl:template>
+       ]]></eg>
+                  
+                  
+               </div4>
+              
+              <div4 id="shallow-copy-all-maps">
+                  <head>Shallow Copy All: Processing Maps</head>
+               <p>The default processing for a map constructs a new map with the same keys
+                  as the original; the value associated with each key is obtained by applying
+                  templates to the original value.</p>
+                 
+                  <p>The template rule for the first phase is equivalent to the following, 
+                     except that this does not show
+                     the propagation of template parameters:</p>
+                  
+                  <eg><![CDATA[<xsl:template match="type(map(*))">
+   <xsl:map>
+      <xsl:for-each select="map:pairs(.)">
+         <xsl:map:entry key="?key">
+           <xsl:apply-templates select="?value"/>
+         </xsl:map:entry>   
+      </xsl:for-each>   
+   </xsl:map>
+</xsl:template>
+       ]]></eg>
+                  
+                    
+              </div4>
+               <div4 id="shallow-copy-all-overriding">
+                  <head>Shallow Copy All: Overriding Template Rules</head>
+                  <p>Most transformations can be achieved by override the processing  
+                  of map entries with a specific known key. Keys can be matched
+                  using label patterns: see <specref ref="label-patterns"/>. For example:</p>
+                  
+                  <eg><![CDATA[
+<xsl:template match="?surname">
+  <xsl:select>uppercase(.)</xsl:select>
+</xsl:template>]]></eg>
+                  
+                  <p>This does not work well, however, if the value associated with a key
+                  is not a single item. For example, consider a map containing an entry:</p>
+                  
+                  <eg>{
+   "type": "cupboard",
+   "material": "oak:,
+   "dimensions": (12.5, 6.2, 8.3)
+}</eg>
+                  
+                  <p>where the requirement is to turn this into the entry:</p>
+                  
+                  <eg>{
+   "type": "cupboard",
+   "material": "oak:,
+   "dimensions": {'height': 12.5, 'width': 6.2, 'depth': 8.3}
+}</eg>
+                     
+ 
+                      
+                  <p>A template rule written with <code>match="?dimensions"</code> will match
+                  each of the three values individually, giving no opportunity to construct
+                  the single map to contain all three.</p>
+                  
+                  <p>A solution to this is to override the processing of the containing map. For example:</p>
+                  
+                  <eg><![CDATA[
+<xsl:template match="record(type, material, dimensions, *)">
+  <xsl:select>
+    map:put(., 
+       'dimensions', {'height': ?dimensions[1], 
+                      'width': ?dimensions[2], 
+                      'depth': ?dimensions[3]})
+  </xsl:select/>
+</xsl:template>  
+  ]]></eg>
+                     
+                    <p>An alternative is to process all the map entries using template rules that match
+                    key-value pairs. For example:</p>
+                     
+                     <eg><![CDATA[
+<xsl:template match="record(type, material, dimensions, *)">
+  <xsl:map>
+    <xsl:apply-templates select="map:pairs(.)" mode="furniture-properties"/>
+  </xsl:map>  
+</xsl:template>
+
+<xsl:mode name="furniture-properties" 
+          as="record(key, value)" 
+          on-no-match="deep-copy">
+   <xsl:template match=".[?key = 'dimensions']">
+     <xsl:map-entry key="'dimensions'">
+       <xsl:select>{ 'height': ?value[1], 
+                     'width':  ?value[2], 
+                     'depth':  ?value[3] }  
+       </xsl:select/>
+     </xsl:map:entry>
+   </xsl:template>
+</xsl:mode>  
+  ]]></eg>
+               </div4>
+               <div4 id="shallow-copy-all-examples">
+                  <head>Shallow Copy All: Examples</head>
                
-               <p>In the first case, the template rule is equivalent to the following, except that this does not show
-                  the propagation of template parameters:</p>
-               
-               <eg><![CDATA[<xsl:map>
-  <xsl:apply-templates select="map:entries(.)" mode="#current"/>
-</xsl:map>]]></eg>
-               
-               <p>In the second case, the template rule is equivalent to the following, except that this does not show
-                  the propagation of template parameters:</p>
-               
-               <eg><![CDATA[<xsl:map-entry key="map:keys(.)">
-  <xsl:apply-templates select="map:items(.)" mode="#current"/>
-</xsl:map-entry>]]></eg>
-               
-               <p>The reason there is a special rule for maps with one entry is to ensure that the process
-               terminates.</p>
                
                <p>The overall effect is best understood with an example.</p>
                
@@ -14994,7 +15383,7 @@ return $tree =?> depth()]]></eg>
                   
 
                </example>
-               
+               </div4>
             </div3>
             
             <div3 id="built-in-templates-deep-skip">


### PR DESCRIPTION
Currently work In progress, committed so that the draft can be reviewed.

Changes in three main areas:

- Pattern syntax: patterns such as `?item` and `?parent?item` are defined to match items in a map by their key
- Built-in template rules for on-no-match="shallow-copy-all". Revisits the built in template rules for this scenario.
- General revision of the processing model for xsl:apply-templates applied to a tree of maps and arrays.