### PR TITLE
Hide `MarkedNCName` from XPath spec

### DIFF
--- a/specifications/grammar-40/xpath-grammar.xml
+++ b/specifications/grammar-40/xpath-grammar.xml
@@ -1985,7 +1985,7 @@ VersionDecl ::= "xquery" (("encoding" StringLiteral) | ("version" StringLiteral
     <g:ref name="EQName"/>
   </g:production>
   
-  <g:production name="MarkedNCName" whitespace-spec="explicit">
+  <g:production name="MarkedNCName" if="xquery40" whitespace-spec="explicit">
     <g:string>#</g:string>
     <g:ref name="NCName"/>
   </g:production>


### PR DESCRIPTION
Today's merge of qt4cg/qtspecs#2028 has added the `MarkedNCName` production to both the XQuery and the XPath spec. It is however only used within the XQuery spec.