### PR TITLE
2045 Context value can be an empty sequence

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -516,7 +516,8 @@
                      class="DY" code="0002" type="type"/>.</p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, 
+                  type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -780,7 +781,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -846,7 +847,7 @@
                      class="DY" code="0002" type="dynamic"/>.</p>
             </item>
             <item>
-               <p>If the context value is not a single item, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>item()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -1054,7 +1055,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -1102,7 +1103,7 @@
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -13145,7 +13146,7 @@ else QName("", $value)</eg>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -13339,7 +13340,7 @@ else QName("", $value)</eg>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -13820,7 +13821,7 @@ else QName("", $value)</eg>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item></ulist>
             
@@ -13967,8 +13968,7 @@ Himmlische, dein Heiligtum.
       </fos:summary>
       <fos:rules>
          <p>If the function is called without an argument, the context value (<code>.</code>) is used
-            as the default argument.<phrase diff="del" at="2022-11-29"> The behavior of the function if the argument is omitted is
-            exactly the same as if the context value had been passed as the argument.</phrase></p>
+            as the default argument.</p>
 
          <p>The function returns the value of the expression
                <code>($arg/ancestor-or-self::node())[1]</code>.</p>
@@ -13983,7 +13983,7 @@ Himmlische, dein Heiligtum.
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -14081,7 +14081,7 @@ let $newi := $o/tool</eg>
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -14486,7 +14486,7 @@ else $node
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>
@@ -19689,7 +19689,7 @@ return { "width": $int16-at($loc + 5),
                      class="DY" code="0002" type="type"/></p>
             </item>
             <item>
-               <p>If the context value is not a single node, type error <xerrorref spec="XP" class="TY"
+               <p>If the context value is not an instance of the sequence type <code>node()?</code>, type error <xerrorref spec="XP" class="TY"
                      code="0004" type="type"/>.</p>
             </item>
          </ulist>


### PR DESCRIPTION
For functions like name(), local-name() etc with `as="node()? default="."` in the signature, allow the context value to be an empty sequence.

Fix #2045