### PR TITLE
2017 fn:sort-by: Observations

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -23043,8 +23043,7 @@ return sort($in, $SWEDISH)</eg>
       <fos:signatures>
          <fos:proto name="sort-by" return-type="item()*">
             <fos:arg name="input" type="item()*" usage="navigation"/>
-            <fos:arg name="keys" type="record(key? as (fn(item()) as xs:anyAtomicType*)?, collation? as xs:string?, order? as enum('ascending', 'descending')?)*"
-                     default="()"/>
+            <fos:arg name="keys" type="record(key? as (fn(item()) as xs:anyAtomicType*)?, collation? as xs:string?, order? as enum('ascending', 'descending')?)*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -23177,34 +23176,34 @@ else +1</eg>
          <p>If the sort key for an item evaluates to an empty sequence, the effect of the rules is that this item
             precedes any value for which the key is non-empty. This is equivalent to the effect of the XQuery option 
             <code>empty least</code>. The effect of the option <code>empty greatest</code> can be achieved by adding an
-            extra sort key definition with <code>{'key': fn{empty(K(.)}}</code>: when comparing boolean sort keys,
+            extra sort key definition with <code>{ 'key': fn { empty(K(.) } }</code>: when comparing boolean sort keys,
             <code>false</code> precedes <code>true</code>.</p>
       </fos:notes>
       <fos:examples>
          <fos:example>
             <fos:test>
-               <fos:expression>sort-by((1, 4, 6, 5, 3))</fos:expression>
+               <fos:expression>sort-by((1, 4, 6, 5, 3), ())</fos:expression>
                <fos:result>1, 3, 4, 5, 6</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>sort-by((1, 4, 4e0, 6, 5, 3), {'order' : 'descending'})</fos:expression>
+               <fos:expression>sort-by((1, 4, 4e0, 6, 5, 3), { 'order': 'descending' })</fos:expression>
                <fos:result>6, 5, 4, 4e0, 3, 1</fos:result>
             </fos:test>
             <fos:test>
-               <fos:expression>sort-by((1, -2, 5, 10, -10, 10, 8), {'key':abs#1})</fos:expression>
+               <fos:expression>sort-by((1, -2, 5, 10, -10, 10, 8), { 'key': abs#1 })</fos:expression>
                <fos:result>1, -2, 5, 8, 10, -10, 10</fos:result>
             </fos:test>
          </fos:example>
          <fos:example>
             <p>To sort a set of strings <code>$in</code> using Swedish collation:</p>
             <eg>let $SWEDISH := collation({ 'lang': 'se' })
-return sort-by($in, {'collation':$SWEDISH})</eg>
+return sort-by($in, { 'collation': $SWEDISH })</eg>
          </fos:example>
          <fos:example>
             <p>To sort a sequence of employees by last name as the major sort key and first name as the minor sort key,
                using the default collation:
             </p>
-            <eg>sort-by($employees, {'key':fn { name ! (last, first) }})</eg>
+            <eg>sort-by($employees, { 'key': fn { name ! (last, first) } })</eg>
          </fos:example>
          <fos:example>
             <p>To sort a sequence of employees first by increasing last name (using Swedish collation order)
@@ -23213,7 +23212,7 @@ return sort-by($in, {'collation':$SWEDISH})</eg>
             <eg>sort-by(
   $employees, 
   ({ 'key': fn { name/last }, 'collation': collation({ 'lang': 'se' }) },
-   { 'key': fn { xs:decimal(salary) }, 'order': 'descending'}))</eg>
+   { 'key': fn { xs:decimal(salary) }, 'order': 'descending' }))</eg>
          </fos:example>
       </fos:examples>
       <fos:changes>


### PR DESCRIPTION
Closes #2017