### PR TITLE
1970 Editorial notes

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -341,10 +341,6 @@
                         <def><p>Absent</p></def>
                      </gitem>
                      <gitem>
-                        <label>Parameter names</label>
-                        <def><p>(<var>$row</var>, <var>$col</var>)</p></def>
-                     </gitem>
-                     <gitem>
                         <label>Signature</label>
                         <def><p><code>(xs:positiveInteger, (xs:positiveInteger | xs:string)) => xs:string</code></p></def>
                      </gitem>
@@ -8206,7 +8202,7 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
                      <function>fn:boolean</function> returns <code>true</code>.</p>
             </item>
             <item>
-               <p>If <code>$input</code> is a singleton value of type <code>xs:boolean</code> or a
+               <p>If <code>$input</code> is a singleton value of type <code>xs:boolean</code> or
                   derived from <code>xs:boolean</code>, <function>fn:boolean</function> returns
                      <code>$input</code>.</p>
             </item>
@@ -13594,7 +13590,7 @@ else QName("", $value)</eg>
       <fos:signatures>
          <fos:proto name="path" return-type="xs:string?">
             <fos:arg name="node" type="node()?" default="." usage="navigation"/>
-            <fos:arg name="options" type="map(*)" default="{}"/>
+            <fos:arg name="options" type="map(*)?" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -18766,7 +18762,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="doc-available" return-type="xs:boolean">
             <fos:arg name="source" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)" default="{}"/>
+            <fos:arg name="options" type="map(*)?" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -19393,7 +19389,7 @@ return $lines[not(position() = last() and . = '')]
    
    <fos:function name="unparsed-binary" prefix="fn">
       <fos:signatures>
-         <fos:proto name="unparsed-binary" return-type="xs:base64Binary">
+         <fos:proto name="unparsed-binary" return-type="xs:base64Binary?">
             <fos:arg name="source" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
@@ -20208,7 +20204,7 @@ return { "width": $int16-at($loc + 5),
         document node or an element node with respect to a supplied schema.</p>
          
          <p>The details of how the schema is assembled, and the way it is used, are defined by the supplied <code>$options</code>.
-            If the <code>$options</code> argument is absent or empty the effect is to use the schema components from the
+            If the <code>$options</code> argument is absent or empty, the effect is to use the schema components from the
             static context of the call on <function>fn:xsd-validator</function>. In the general case, however, the schema 
             used for validation may include components from any or all of the following:</p>
          
@@ -20365,7 +20361,7 @@ return { "width": $int16-at($loc + 5),
             some processors might allow validation using a schema in which an element declaration
             contains a reference to a type declaration that is not present in the schema, provided
             that the element declaration is never needed in the course of a particular validation
-            episods.</p></item>
+            episodes.</p></item>
          </ulist>
          
          <p>Having assembled a schema, the next task is to validate a supplied node (and the subtree
@@ -20449,7 +20445,7 @@ return { "width": $int16-at($loc + 5),
                <p>If the <code>use-xsi-schema-location</code> option is <code>true</code> and a failure
                occurs processing an <code>xsi:schemaLocation</code> or <code>xsi:noNamespaceSchemaLocation</code>
                attribute (for example, because a schema document cannot be retrieved, or because the referenced
-               schema document is invalid, or because it is incompatible with other schema components) 
+               schema document is invalid, or because it is incompatible with other schema components),
                this is treated as an invalidity, not as a dynamic error:
                <var>V</var> returns successfully with <code>is-valid</code> set to <code>false</code>.</p>
             </item>
@@ -21149,7 +21145,7 @@ serialize(
                it might otherwise lead to an incorrect encoding inference.</p>
             </item><item>
                <p>If the type of <code>$html</code> is a sequence of octets (<code>xs:hexBinary</code> or
-                  <code>xs:base64Binary</code>) the encoding of the input byte stream is determined in a
+                  <code>xs:base64Binary</code>), the encoding of the input byte stream is determined in a
                   way consistent with <bibref ref="html5"/> section 13.2.3.2, <emph>Determining the character
                   encoding</emph>:</p>
                <olist>
@@ -22308,11 +22304,6 @@ return fold-right(
             </fos:test>
          </fos:example>-->
       </fos:examples>
-      <fos:changes>
-         <fos:change issue="516" PR="828" date="2023-11-14">
-            <p>The <code>$action</code> callback function accepts an optional position argument.</p>
-         </fos:change>
-      </fos:changes>
    </fos:function>
    
        <!--<fos:function name="chain" prefix="fn">
@@ -24367,7 +24358,7 @@ map:of-pairs(
                      type-ref="key-value-pair" type-ref-occurs="*"
                      usage="inspection"
                      example="{ 'key': 'n','value': false() }, { 'key': 'y','value': true() }"/>
-            <fos:arg name="options" type="map(*)" default="{}"/>
+            <fos:arg name="options" type="map(*)?" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25716,9 +25707,9 @@ map:for-each($map, fn($key, $value) {
       <fos:signatures>
          <fos:proto name="build" return-type="map(*)">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="keys" type="(fn($item as item(), $position as xs:integer) as xs:anyAtomicType*)?" default="fn:identity#1"/>
+            <fos:arg name="key" type="(fn($item as item(), $position as xs:integer) as xs:anyAtomicType*)?" default="fn:identity#1"/>
             <fos:arg name="value" type="(fn($item as item(), $position as xs:integer) as item()*)?" default="fn:identity#1"/>
-            <fos:arg name="options" type="map(*)" default="{}"/>
+            <fos:arg name="options" type="map(*)?" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25732,7 +25723,7 @@ map:for-each($map, fn($key, $value) {
       </fos:summary>
       <fos:rules>
          <p>Informally, the function processes each item in <code>$input</code> in order.
-            It calls the <code>$keys</code> function on that item to obtain a sequence of key values,
+            It calls the <code>$key</code> function on that item to obtain a sequence of key values,
             and the <code>$value</code> function to obtain an associated value.
             Then, for each key value:</p>
          <ulist>
@@ -27373,7 +27364,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
       <fos:signatures>
          <fos:proto name="element-to-map" return-type="map(xs:string, item()?)?">
             <fos:arg name="element" type="element()?"/>
-            <fos:arg name="options" type="map(*)" usage="inspection"  default="map{}"/>
+            <fos:arg name="options" type="map(*)?" usage="inspection"  default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -32945,7 +32936,7 @@ fn($item) {
       </fos:rules>
       <fos:errors>
          <p>If the set of computed keys contains <code>xs:untypedAtomic</code> values that are not 
-            castable to <code>xs:double</code> then 
+            castable to <code>xs:double</code> then the
             operation will fail with a dynamic error (<xerrorref
                spec="FO" class="RG" code="0001"/>).
          </p>
@@ -33300,7 +33291,7 @@ return $item
       </fos:rules>
       <fos:errors>
          <p>If the set of computed keys contains <code>xs:untypedAtomic</code> values that are not 
-            castable to <code>xs:double</code> then 
+            castable to <code>xs:double</code> then the
             operation will fail with a dynamic error (<xerrorref
                spec="FO" class="RG" code="0001"/>).
          </p>
@@ -34725,7 +34716,7 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:equivalent style="xpath-expression">
 for-each(
   $input,
-  fn($item, $pos) { map{ 'item': $item, 'pos': $pos } }
+  fn($item, $pos) { { 'item': $item, 'pos': $pos } }
 )
 => fold-left((), fn($partitions, $pair) {
   if (empty($partitions) or $split-when(foot($partitions)?*, $pair?item, $pair?pos))

--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -341,6 +341,10 @@
                         <def><p>Absent</p></def>
                      </gitem>
                      <gitem>
+                        <label>Parameter names</label>
+                        <def><p>(<var>$row</var>, <var>$col</var>)</p></def>
+                     </gitem>
+                     <gitem>
                         <label>Signature</label>
                         <def><p><code>(xs:positiveInteger, (xs:positiveInteger | xs:string)) => xs:string</code></p></def>
                      </gitem>
@@ -8202,7 +8206,7 @@ satisfies compare($t, replace($token, '^\s*|\s*$', ''), $collation) eq 0
                      <function>fn:boolean</function> returns <code>true</code>.</p>
             </item>
             <item>
-               <p>If <code>$input</code> is a singleton value of type <code>xs:boolean</code> or
+               <p>If <code>$input</code> is a singleton value of type <code>xs:boolean</code> or a
                   derived from <code>xs:boolean</code>, <function>fn:boolean</function> returns
                      <code>$input</code>.</p>
             </item>
@@ -13590,7 +13594,7 @@ else QName("", $value)</eg>
       <fos:signatures>
          <fos:proto name="path" return-type="xs:string?">
             <fos:arg name="node" type="node()?" default="." usage="navigation"/>
-            <fos:arg name="options" type="map(*)?" default="{}"/>
+            <fos:arg name="options" type="map(*)" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties arity="0">
@@ -18762,7 +18766,7 @@ return tokenize(normalize-space($s), ' ')[. castable as xs:IDREF]</eg>
       <fos:signatures>
          <fos:proto name="doc-available" return-type="xs:boolean">
             <fos:arg name="source" type="xs:string?"/>
-            <fos:arg name="options" type="map(*)?" default="{}"/>
+            <fos:arg name="options" type="map(*)" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -19389,7 +19393,7 @@ return $lines[not(position() = last() and . = '')]
    
    <fos:function name="unparsed-binary" prefix="fn">
       <fos:signatures>
-         <fos:proto name="unparsed-binary" return-type="xs:base64Binary?">
+         <fos:proto name="unparsed-binary" return-type="xs:base64Binary">
             <fos:arg name="source" type="xs:string?"/>
          </fos:proto>
       </fos:signatures>
@@ -20204,7 +20208,7 @@ return { "width": $int16-at($loc + 5),
         document node or an element node with respect to a supplied schema.</p>
          
          <p>The details of how the schema is assembled, and the way it is used, are defined by the supplied <code>$options</code>.
-            If the <code>$options</code> argument is absent or empty, the effect is to use the schema components from the
+            If the <code>$options</code> argument is absent or empty the effect is to use the schema components from the
             static context of the call on <function>fn:xsd-validator</function>. In the general case, however, the schema 
             used for validation may include components from any or all of the following:</p>
          
@@ -20361,7 +20365,7 @@ return { "width": $int16-at($loc + 5),
             some processors might allow validation using a schema in which an element declaration
             contains a reference to a type declaration that is not present in the schema, provided
             that the element declaration is never needed in the course of a particular validation
-            episodes.</p></item>
+            episods.</p></item>
          </ulist>
          
          <p>Having assembled a schema, the next task is to validate a supplied node (and the subtree
@@ -20445,7 +20449,7 @@ return { "width": $int16-at($loc + 5),
                <p>If the <code>use-xsi-schema-location</code> option is <code>true</code> and a failure
                occurs processing an <code>xsi:schemaLocation</code> or <code>xsi:noNamespaceSchemaLocation</code>
                attribute (for example, because a schema document cannot be retrieved, or because the referenced
-               schema document is invalid, or because it is incompatible with other schema components),
+               schema document is invalid, or because it is incompatible with other schema components) 
                this is treated as an invalidity, not as a dynamic error:
                <var>V</var> returns successfully with <code>is-valid</code> set to <code>false</code>.</p>
             </item>
@@ -21145,7 +21149,7 @@ serialize(
                it might otherwise lead to an incorrect encoding inference.</p>
             </item><item>
                <p>If the type of <code>$html</code> is a sequence of octets (<code>xs:hexBinary</code> or
-                  <code>xs:base64Binary</code>), the encoding of the input byte stream is determined in a
+                  <code>xs:base64Binary</code>) the encoding of the input byte stream is determined in a
                   way consistent with <bibref ref="html5"/> section 13.2.3.2, <emph>Determining the character
                   encoding</emph>:</p>
                <olist>
@@ -22304,6 +22308,11 @@ return fold-right(
             </fos:test>
          </fos:example>-->
       </fos:examples>
+      <fos:changes>
+         <fos:change issue="516" PR="828" date="2023-11-14">
+            <p>The <code>$action</code> callback function accepts an optional position argument.</p>
+         </fos:change>
+      </fos:changes>
    </fos:function>
    
        <!--<fos:function name="chain" prefix="fn">
@@ -24358,7 +24367,7 @@ map:of-pairs(
                      type-ref="key-value-pair" type-ref-occurs="*"
                      usage="inspection"
                      example="{ 'key': 'n','value': false() }, { 'key': 'y','value': true() }"/>
-            <fos:arg name="options" type="map(*)?" default="{}"/>
+            <fos:arg name="options" type="map(*)" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25707,9 +25716,9 @@ map:for-each($map, fn($key, $value) {
       <fos:signatures>
          <fos:proto name="build" return-type="map(*)">
             <fos:arg name="input" type="item()*"/>
-            <fos:arg name="key" type="(fn($item as item(), $position as xs:integer) as xs:anyAtomicType*)?" default="fn:identity#1"/>
+            <fos:arg name="keys" type="(fn($item as item(), $position as xs:integer) as xs:anyAtomicType*)?" default="fn:identity#1"/>
             <fos:arg name="value" type="(fn($item as item(), $position as xs:integer) as item()*)?" default="fn:identity#1"/>
-            <fos:arg name="options" type="map(*)?" default="{}"/>
+            <fos:arg name="options" type="map(*)" default="{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -25723,7 +25732,7 @@ map:for-each($map, fn($key, $value) {
       </fos:summary>
       <fos:rules>
          <p>Informally, the function processes each item in <code>$input</code> in order.
-            It calls the <code>$key</code> function on that item to obtain a sequence of key values,
+            It calls the <code>$keys</code> function on that item to obtain a sequence of key values,
             and the <code>$value</code> function to obtain an associated value.
             Then, for each key value:</p>
          <ulist>
@@ -27220,7 +27229,7 @@ return json-to-xml($json, $options)]]></eg>
    <fos:function name="element-to-map-plan" prefix="fn">
       <fos:signatures>
          <fos:proto name="element-to-map-plan" return-type="map(xs:string, record(*))">
-            <fos:arg name="input" type="(document-node() | element(*)) *"/>
+            <fos:arg name="input" type="(document-node() | element(*))*"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -27364,7 +27373,7 @@ element-to-map-plan((<a><b/><b/></a>, <a><b/><c/></a>))
       <fos:signatures>
          <fos:proto name="element-to-map" return-type="map(xs:string, item()?)?">
             <fos:arg name="element" type="element()?"/>
-            <fos:arg name="options" type="map(*)?" usage="inspection"  default="{}"/>
+            <fos:arg name="options" type="map(*)" usage="inspection"  default="map{}"/>
          </fos:proto>
       </fos:signatures>
       <fos:properties>
@@ -32936,7 +32945,7 @@ fn($item) {
       </fos:rules>
       <fos:errors>
          <p>If the set of computed keys contains <code>xs:untypedAtomic</code> values that are not 
-            castable to <code>xs:double</code> then the
+            castable to <code>xs:double</code> then 
             operation will fail with a dynamic error (<xerrorref
                spec="FO" class="RG" code="0001"/>).
          </p>
@@ -33291,7 +33300,7 @@ return $item
       </fos:rules>
       <fos:errors>
          <p>If the set of computed keys contains <code>xs:untypedAtomic</code> values that are not 
-            castable to <code>xs:double</code> then the
+            castable to <code>xs:double</code> then 
             operation will fail with a dynamic error (<xerrorref
                spec="FO" class="RG" code="0001"/>).
          </p>
@@ -34716,7 +34725,7 @@ path with an explicit <code>file:</code> scheme.</p>
       <fos:equivalent style="xpath-expression">
 for-each(
   $input,
-  fn($item, $pos) { { 'item': $item, 'pos': $pos } }
+  fn($item, $pos) { map{ 'item': $item, 'pos': $pos } }
 )
 => fold-left((), fn($partitions, $pair) {
   if (empty($partitions) or $split-when(foot($partitions)?*, $pair?item, $pair?pos))

--- a/specifications/xquery-40/src/errors.xml
+++ b/specifications/xquery-40/src/errors.xml
@@ -418,7 +418,7 @@
 
       <error spec="XP" code="0051" class="ST" type="static">
          <p>It is a <termref def="dt-static-error">static error</termref> if an <termref
-               def="dt-expanded-qname"/> used as an <nt def="ItemType"/>
+               def="dt-expanded-qname"/> used as an <nt def="ItemType">ItemType</nt>
                in a <nt def="SequenceType"/> is not defined
             in the <termref def="dt-static-context"/> either as a <termref def="dt-named-item-type"/>
             in the <termref def="dt-in-scope-named-item-types"/>,

--- a/specifications/xquery-40/src/expressions.xml
+++ b/specifications/xquery-40/src/expressions.xml
@@ -7137,7 +7137,7 @@ declare record Particle (
                </change>
                <change issue="980" PR="911" date="2024-01-30">
                   The coercion rules now allow any numeric type to be implicitly converted to any other, for example
-                  an <code>xs:double</code> is accepted where the required type is <code>xs:double</code>.
+                  an <code>xs:double</code> is accepted where the required type is <code>xs:decimal</code>.
                </change>
                <change issue="130 480" PR="815" date="2023-11-07">
                   The coercion rules now allow conversion in either direction between <code>xs:hexBinary</code>
@@ -19400,8 +19400,8 @@ processing with JSON processing.</p>
                   <p>In order to allow the <code>map</code> keyword to be omitted,
                   an incompatible change has been made to XQuery computed element
                   and attribute constructors: if the name of the constructed element
-                  or attribute is a language keyword, it must now be written in quotes,
-                  for example <code>element "div" {}</code>.</p>
+                  or attribute is a language keyword, it must now be written using the
+                  <code>QNameLiteral</code> syntax, for example <code>element #div {}</code>.</p>
                   
                   <p>Although the grammar allows a <nt def="MapConstructor">MapConstructor</nt>
                   to appear within an <nt def="EnclosedExpr">EnclosedExpr</nt> (that is, between
@@ -20491,10 +20491,6 @@ declare function recursive-content($item as item()) as record(key, value)* {
                   at the top level, are included. This means that <code>E??X</code> mirrors the
                   behavior of <code>E//X</code>, in that it includes all items that are one-or-more levels
                   deep in the tree.</p>
-               </note>
-               <note>
-                  <p>The result of the deep lookup operator retains order when processing sequences and
-                  arrays, but not when processing maps.</p>
                </note>
                <note>
                   <p>An expression involving multiple deep lookup operators may return duplicates.


### PR DESCRIPTION
Closes #1970

Editorial. The only controversial change may be to rename the second parameter of `map:build` from `$keys` to `$key`.