### PR TITLE
Map build patch

### DIFF
--- a/specifications/xpath-functions-40/src/function-catalog.xml
+++ b/specifications/xpath-functions-40/src/function-catalog.xml
@@ -25871,6 +25871,18 @@ for-each(
 }</fos:result>
             </fos:test>
             <fos:test>
+               <fos:expression><eg>map:build(1 to 5, {
+  1: ("eins", "one"),
+  4: ("vier", "four")
+})</eg></fos:expression>
+            <fos:result>{
+  "eins": 1,
+  "one": 1,
+  "vier": 4,
+  "four": 4
+}</fos:result>
+            </fos:test>
+            <fos:test>
                <fos:expression><eg>map:build(
   ("apple", "apricot", "banana", "blueberry", "cherry"), 
   substring(?, 1, 1),


### PR DESCRIPTION
Small edits to `map:build`
- fix parameter name
- remove surplus blank lines
- add example with multiple keys returned by key function (a map of sequences)